### PR TITLE
feat(wire): admit heap-owning record/enum Vec elements through the CBOR codec

### DIFF
--- a/hew-cli/tests/wire_cbor_codec_leak_oracle.rs
+++ b/hew-cli/tests/wire_cbor_codec_leak_oracle.rs
@@ -80,16 +80,25 @@
 //!
 //! ## Error-path under-free disposition
 //!
-//! `.decode()` traps (SIGTRAP/SIGILL) on a malformed stream — it does not
-//! return a `Result` — so `leaks --atExit` (which needs a normal exit to run
-//! its hook) cannot snapshot the failing decode for an UNDER-free slope. The
-//! error-path under-free guarantee is instead established structurally: the
-//! `fail_bb` calls `emit_de_drop_owned(dst)` over the SAME null-safe drop
-//! helpers (`hew_string_drop`, `hew_vec_free`, `__hew_record_drop_inplace_*`)
-//! that the success-path slope proves leak-free, walking every field of the
-//! zero-initialised shell (unwritten fields are null and short-circuit) before
-//! `free(dst)`. The no-DOUBLE-free half is proven dynamically here under the
-//! poisoned-allocator triple.
+//! `.decode()` traps (SIGTRAP/SIGILL) on a malformed stream in `fn main` — it
+//! does not return a `Result` — so `leaks --atExit` (which needs a normal exit
+//! to run its hook) cannot snapshot THAT process for an UNDER-free slope. The
+//! `assert_decode_failure_traps_no_double_free` oracles therefore prove only the
+//! no-DOUBLE-free half (the poisoned-allocator triple aborts on an over-free).
+//!
+//! The UNDER-free half is proven dynamically by
+//! `vec_owned_{struct,enum}_decode_failure_frees_partials_no_under_free`: they
+//! run the SAME failing decode inside an actor `receive` handler, where the
+//! supervisor's crash-recovery `siglongjmp` catches each trap and keeps the
+//! process alive to a normal exit `leaks --atExit` can snapshot. A `fail_bb`
+//! that skipped `emit_de_drop_owned(dst)` leaks the already-decoded owned Vec +
+//! its element strings on every failed message; a DIFFERENTIAL slope against an
+//! in-range (successful-decode) baseline cancels the per-spawn actor-cell floor
+//! and the success-path owned-Vec drop, leaving the `fail_bb`'s own under-free —
+//! which must be ~0. `emit_de_drop_owned` walks the zero-initialised shell over
+//! the SAME null-safe drop helpers (`hew_string_drop`, `hew_vec_free`,
+//! `__hew_record_drop_inplace_*`) the success-path slope proves leak-free
+//! (unwritten fields are null and short-circuit) before `free(dst)`.
 //!
 //! ## Slope methodology + skip behaviour
 //!
@@ -493,6 +502,154 @@ fn actor_in_range_enum_decode_source(frames: usize) -> String {
     actor_enum_decode_source(frames, "Narrow::B(1)")
 }
 
+// ── under-free (leak) teeth for the decode-failure `fail_bb` ─────────────────
+//
+// The `assert_decode_failure_traps_no_double_free` oracles run the failing
+// decode in `fn main`, where the null-return TRAPS the process. That trap
+// catches OVER-free (the scribbled double-free aborts with the cabi guard) but
+// is BLIND to UNDER-free: a `fail_bb` that never dropped the partial owned
+// fields still exits via the same trap, and `leaks --atExit` cannot snapshot a
+// signal-terminated process. Removing `emit_de_drop_owned` therefore leaves the
+// trap-based oracles green while the error path leaks every already-decoded
+// owned element.
+//
+// These fixtures give that path under-free teeth by running the SAME failing
+// decode inside an actor `receive` handler. The supervisor's crash-recovery
+// `siglongjmp` catches each trap and keeps the PROCESS alive, so the leak of a
+// missing `fail_bb` drop ACCUMULATES across frames and survives to a normal
+// exit that `leaks --atExit` can snapshot — the same survive-the-trap mechanism
+// `actor_oob_enum_tag_decode_frees_reader_and_shell_no_excess_slope` relies on.
+// A DIFFERENTIAL slope against an in-range baseline (same spawn-per-frame shape,
+// same owned-Vec decode allocation, but a matching layout that decodes
+// SUCCESSFULLY) cancels the codec-independent per-spawn actor-cell leak; the
+// remainder is the `fail_bb`'s own per-message under-free, which must be ~0.
+// Drop `emit_de_drop_owned` and the failure slope jumps by the owned Vec + its
+// element strings per frame — the teeth these fixtures require.
+
+/// Actor-context owned-Vec-element STRUCT decode, parameterised by whether the
+/// encoded layout MISMATCHES the decode layout. Both shapes decode a
+/// `BatchBad { items: Vec<Item> @1; tail: i64 @2 }` (an owned-string-per-element
+/// Vec) inside the actor handler, spawning one `Decoder` per frame:
+///
+///   * `mismatch = true`: the frame encodes a `BatchGood` (`tail: string`), so
+///     the decode fills the full owned Vec then latches on the `i64`-where-text
+///     tail, driving the `fail_bb`. The actor traps; the supervisor recovers.
+///     A `fail_bb` missing its owned-Vec drop leaks the Vec + every element
+///     string per frame.
+///   * `mismatch = false`: the frame encodes a `BatchBad` directly, so the
+///     decode succeeds; the handler reads only the scalar `bad.tail` keep-alive
+///     and the value drop releases the owned Vec at scope exit (the success-path
+///     drop the round-trip slope oracle already proves leak-free). This isolates
+///     the shared per-spawn actor-cell floor.
+fn actor_vec_owned_struct_decode_source(frames: usize, mismatch: bool) -> String {
+    let build = if mismatch {
+        "let g = BatchGood { items: xs, tail: \"owned-tail-value\" };"
+    } else {
+        "let g = BatchBad { items: xs, tail: 7 };"
+    };
+    format!(
+        "#[wire]\n\
+         type Item {{ name: string @1; }}\n\
+         #[wire]\n\
+         type BatchGood {{ items: Vec<Item> @1; tail: string @2; }}\n\
+         #[wire]\n\
+         type BatchBad {{ items: Vec<Item> @1; tail: i64 @2; }}\n\
+         \n\
+         actor Decoder {{\n\
+         \x20   let seq: i64;\n\
+         \x20   receive fn decode_it(raw: bytes) -> i64 {{\n\
+         \x20       let bad = BatchBad.decode(raw);\n\
+         \x20       bad.tail\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let xs: Vec<Item> = Vec::new();\n\
+         \x20       xs.push(Item {{ name: \"alpha-owned-element\" }});\n\
+         \x20       xs.push(Item {{ name: \"beta-owned-element\" }});\n\
+         \x20       {build}\n\
+         \x20       let raw = g.encode();\n\
+         \x20       let a = spawn Decoder(seq: i);\n\
+         \x20       let r = await a.decode_it(raw);\n\
+         \x20       match r {{ Ok(v) => {{ total = total + v; }}, Err(_) => {{ total = total + 1; }}, }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Mismatch (failure) branch of the owned-Vec-element struct actor fixture.
+fn actor_vec_owned_struct_decode_failure_source(frames: usize) -> String {
+    actor_vec_owned_struct_decode_source(frames, true)
+}
+
+/// In-range baseline of the owned-Vec-element struct actor fixture.
+fn actor_vec_owned_struct_decode_baseline_source(frames: usize) -> String {
+    actor_vec_owned_struct_decode_source(frames, false)
+}
+
+/// Actor-context owned-Vec-element ENUM decode, parameterised by mismatch. The
+/// element is a `#[wire]` enum whose `Full` variant owns a `string`, so each
+/// decoded element allocates through `__hew_enum_clone_inplace_Payload`. On the
+/// `mismatch = true` failure the `fail_bb` must drop the owned enum Vec exactly
+/// once (each `Full` element releasing its string); the `mismatch = false`
+/// baseline decodes successfully and drops the owned Vec on the value drop.
+fn actor_vec_owned_enum_decode_source(frames: usize, mismatch: bool) -> String {
+    let build = if mismatch {
+        "let g = BagGood { items: xs, tail: \"owned-tail-value\" };"
+    } else {
+        "let g = BagBad { items: xs, tail: 7 };"
+    };
+    format!(
+        "#[wire]\n\
+         enum Payload {{ Empty; Full(string); }}\n\
+         #[wire]\n\
+         type BagGood {{ items: Vec<Payload> @1; tail: string @2; }}\n\
+         #[wire]\n\
+         type BagBad {{ items: Vec<Payload> @1; tail: i64 @2; }}\n\
+         \n\
+         actor Decoder {{\n\
+         \x20   let seq: i64;\n\
+         \x20   receive fn decode_it(raw: bytes) -> i64 {{\n\
+         \x20       let bad = BagBad.decode(raw);\n\
+         \x20       bad.tail\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let xs: Vec<Payload> = Vec::new();\n\
+         \x20       xs.push(Payload::Full(\"first-owned-element\"));\n\
+         \x20       xs.push(Payload::Empty);\n\
+         \x20       xs.push(Payload::Full(\"second-owned-element\"));\n\
+         \x20       {build}\n\
+         \x20       let raw = g.encode();\n\
+         \x20       let a = spawn Decoder(seq: i);\n\
+         \x20       let r = await a.decode_it(raw);\n\
+         \x20       match r {{ Ok(v) => {{ total = total + v; }}, Err(_) => {{ total = total + 1; }}, }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Mismatch (failure) branch of the owned-Vec-element enum actor fixture.
+fn actor_vec_owned_enum_decode_failure_source(frames: usize) -> String {
+    actor_vec_owned_enum_decode_source(frames, true)
+}
+
+/// In-range baseline of the owned-Vec-element enum actor fixture.
+fn actor_vec_owned_enum_decode_baseline_source(frames: usize) -> String {
+    actor_vec_owned_enum_decode_source(frames, false)
+}
+
 // ── leak measurement plumbing (same shape as bytes_drop_leak_oracle) ────────
 
 /// Compile `source` to a native binary via `hew compile --emit-dir` and return
@@ -688,6 +845,52 @@ fn assert_frame_leaks_exactly_zero(
          high_leaks={high_leaks}. The fresh codec temp (encode buffer / to_json \
          string) is not released after the borrowing decode/parse — re-run a \
          standalone build under `MallocStackLogging=1 leaks --atExit -- <bin>`."
+    );
+}
+
+/// Differential leak-slope teeth for a decode-FAILURE `fail_bb`. Compiles the
+/// failure shape (mismatched layout — traps, caught by the actor supervisor)
+/// and an in-range baseline (matching layout — decodes successfully) at LOW and
+/// HIGH frames, measures each leak-node slope, and asserts the failure slope
+/// does not exceed the baseline slope by more than `SLOPE_TOLERANCE`. Both
+/// shapes spawn one `Decoder` per frame and allocate the same owned Vec on
+/// decode, so subtracting the baseline cancels the per-spawn actor-cell floor
+/// AND the success-path owned-Vec drop; the remainder is the `fail_bb`'s own
+/// per-message under-free, which must be ~0. Dropping `emit_de_drop_owned`
+/// leaks the owned Vec + its element strings per failed frame — an ~N/frame
+/// slope this catches. Skips (logs `skip:`) when the host cannot run `leaks(1)`.
+fn assert_decode_failure_no_underfree_slope(
+    fail_shape: &str,
+    fail_source_fn: fn(usize) -> String,
+    base_shape: &str,
+    base_source_fn: fn(usize) -> String,
+) {
+    let Some((fail_low, fail_high)) =
+        frame_leak_counts(fail_shape, fail_source_fn, LOW_FRAMES, HIGH_FRAMES)
+    else {
+        return;
+    };
+    let Some((base_low, base_high)) =
+        frame_leak_counts(base_shape, base_source_fn, LOW_FRAMES, HIGH_FRAMES)
+    else {
+        return;
+    };
+
+    let fail_slope = fail_high.saturating_sub(fail_low);
+    let base_slope = base_high.saturating_sub(base_low);
+    eprintln!(
+        "{fail_shape} under-free differential: fail_slope={fail_slope} \
+         (fail_low={fail_low} fail_high={fail_high}) base_slope={base_slope} \
+         (base_low={base_low} base_high={base_high}) tolerance={SLOPE_TOLERANCE}"
+    );
+    assert!(
+        fail_slope <= base_slope + SLOPE_TOLERANCE,
+        "{fail_shape}: the decode-failure path leaks (UNDER-frees) per malformed message — \
+         failure slope {fail_slope} exceeds the in-range baseline slope {base_slope} by {} nodes \
+         (tolerance {SLOPE_TOLERANCE}). The `fail_bb` is not dropping every already-decoded owned \
+         field (the owned Vec + its element strings) before freeing the shell — check that \
+         `emit_de_drop_owned` still walks this shape's owned fields on the error path.",
+        fail_slope.saturating_sub(base_slope + SLOPE_TOLERANCE),
     );
 }
 
@@ -891,6 +1094,38 @@ fn vec_owned_enum_decode_failure_frees_partials_no_double_free() {
     assert_decode_failure_traps_no_double_free(
         "wire_cbor_vec_owned_enum_decode_failure",
         VEC_OWNED_ENUM_DECODE_FAILURE_SOURCE,
+    );
+}
+
+/// UNDER-free teeth for the owned-Vec-element STRUCT decode-failure path. The
+/// `no_double_free` sibling above traps in `fn main` and so is blind to a
+/// leak; this runs the same failing decode inside an actor handler (the
+/// supervisor survives each trap) and asserts the accumulated leak slope stays
+/// at the in-range baseline. Removing `emit_de_drop_owned` from the deserialize
+/// thunk's `fail_bb` leaks the owned Vec + element strings per frame and fails
+/// this — the direction the `no_double_free` oracle cannot see.
+#[test]
+fn vec_owned_struct_decode_failure_frees_partials_no_under_free() {
+    assert_decode_failure_no_underfree_slope(
+        "wire_cbor_vec_owned_struct_decode_failure_underfree",
+        actor_vec_owned_struct_decode_failure_source,
+        "wire_cbor_vec_owned_struct_decode_baseline",
+        actor_vec_owned_struct_decode_baseline_source,
+    );
+}
+
+/// UNDER-free teeth for the owned-Vec-element ENUM decode-failure path — the
+/// `Vec<#[wire] enum>` sibling of the struct under-free oracle above. Each
+/// already-decoded `Full` element owns a `string`; a `fail_bb` that skips the
+/// owned enum Vec drop leaks those strings per malformed message, which the
+/// actor-survived differential slope catches.
+#[test]
+fn vec_owned_enum_decode_failure_frees_partials_no_under_free() {
+    assert_decode_failure_no_underfree_slope(
+        "wire_cbor_vec_owned_enum_decode_failure_underfree",
+        actor_vec_owned_enum_decode_failure_source,
+        "wire_cbor_vec_owned_enum_decode_baseline",
+        actor_vec_owned_enum_decode_baseline_source,
     );
 }
 

--- a/hew-cli/tests/wire_cbor_codec_leak_oracle.rs
+++ b/hew-cli/tests/wire_cbor_codec_leak_oracle.rs
@@ -53,27 +53,13 @@
 //!     must be ~0. Pre-fix the unknown-tag path took an inline trap that unwound
 //!     past the thunk's reader + shell free (~5 nodes/frame).
 //!
-//! ## Isolating the codec from two pre-existing, out-of-scope drop confounds
+//! ## Isolating the codec from a pre-existing, out-of-scope drop confound
 //!
-//! Both fixtures are written to measure ONLY the codec's own drop glue. Two
-//! unrelated, pre-existing leak/suppression behaviours would otherwise mask or
-//! forge a codec result:
+//! The round-trip fixtures are written to measure ONLY the codec's own drop
+//! glue. One unrelated, pre-existing suppression behaviour would otherwise mask
+//! or forge a codec result:
 //!
-//!   1. **Unnamed `bytes` temporary scope-exit drop.** A `bytes` value produced
-//!      by a call and consumed as an UNNAMED temporary (e.g.
-//!      `T.decode(v.encode())` or the unrelated `"x".to_bytes().len()`) is not
-//!      released at the end of its statement — one leaked buffer per frame.
-//!      This reproduces on a clean base build with `.to_bytes()` (no codec on
-//!      the path), so it is a general MIR temporary-drop derivation gap, NOT a
-//!      codec defect: the existing `derive_local_bytes_drop_allowed` admission
-//!      in `hew-mir/src/lower.rs` covers NAMED bytes locals (see
-//!      `bytes_drop_leak_oracle::bytes_local_loop_no_per_frame_leak_slope`) but
-//!      not anonymous temporaries. The round-trip fixture therefore BINDS the
-//!      encoded bytes to a named local (`let raw = p.encode();`) so the buffer
-//!      drops on the loop back-edge and the slope reflects only the decoded
-//!      value's drop.
-//!
-//!   2. **Managed-aggregate field-read drop suppression** (the `string_field_load`
+//!   1. **Managed-aggregate field-read drop suppression** (the `string_field_load`
 //!      confound). Reading an owned field OUT of an owned aggregate suppresses
 //!      that aggregate's own in-place field drop (documented out-of-scope in
 //!      `string_field_load_leak_oracle`). The fixture therefore reads ONLY a
@@ -133,10 +119,12 @@ const SLOPE_TOLERANCE: usize = 5;
 /// Round-trip fixture: build a struct carrying an owned `string`, an owned
 /// `Vec<string>` (with owned elements), an owned nested `#[wire]` struct (with
 /// an owned nested string), plus a scalar `seq` field. Encode it to a NAMED
-/// bytes local (so the encoded buffer drops on the back-edge — see confound 1),
-/// decode it back, and read ONLY the scalar `back.seq` keep-alive (so the
-/// decoded value is held live to scope exit without the field-read drop
-/// suppression — see confound 2). The decoded value's owned string / Vec /
+/// bytes local (the binding path — its scope-exit drop releases the encoded
+/// buffer on the back-edge), decode it back, and read ONLY the scalar
+/// `back.seq` keep-alive (so the decoded value is held live to scope exit
+/// without the field-read drop suppression — see confound 1). The anonymous
+/// form (`Packet.decode(p.encode())`) is now also released — see
+/// `anonymous_encode_temp_round_trip_leaks_exactly_zero`. The decoded value's owned string / Vec /
 /// nested fields must be released by the synthesised value drop on every frame;
 /// a missing drop is a >= 1 leak/frame slope.
 fn round_trip_source(frames: usize) -> String {
@@ -177,10 +165,11 @@ fn round_trip_source(frames: usize) -> String {
 ///
 /// The decoded value is held live by reading the SCALAR sibling field `seq`
 /// (not the `items` Vec) — reading the Vec field itself (`.len()` / `[i]`)
-/// triggers the pre-existing field-read drop-suppression confound that the
-/// existing `round_trip` oracle dodges the same way (it reads `back.seq`, never
-/// `back.tags`). The `raw` encode buffer is a NAMED local so the anonymous-bytes
-/// temporary confound (confound 1) does not add its own per-frame node.
+/// triggers the pre-existing field-read drop-suppression confound (confound 1)
+/// that the existing `round_trip` oracle dodges the same way (it reads
+/// `back.seq`, never `back.tags`). The `raw` encode buffer is a NAMED local
+/// (the binding path); the anonymous form is covered by
+/// `anonymous_encode_temp_round_trip_leaks_exactly_zero`.
 fn vec_struct_round_trip_source(frames: usize) -> String {
     format!(
         "#[wire]\n\
@@ -200,6 +189,95 @@ fn vec_struct_round_trip_source(frames: usize) -> String {
          \x20       let raw = c.encode();\n\
          \x20       let back = Container.decode(raw);\n\
          \x20       total = total + back.seq;\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Anchor-2 fixture — the ANONYMOUS encode temporary. The round-trip binds the
+/// encode result inline (`Packet.decode(p.encode())`) with NO `let raw`, so the
+/// fresh CBOR buffer is a bare temporary consumed only as the decode operand.
+/// Before the fresh-temp-drop admission this leaked exactly one buffer per frame
+/// (Probe B: 50 leaks/50 frames); the named-binding control measured 0, proving
+/// 0 is the real floor — so this asserts an EXACT `== 0` at both frame counts,
+/// not a slope tolerance (a slope form would pass a constant-leak regression).
+fn anonymous_encode_temp_round_trip_source(frames: usize) -> String {
+    format!(
+        "#[wire]\n\
+         type Packet {{ label: string @1; seq: i64 @2; }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let p = Packet {{ label: \"payload-label-value\", seq: i }};\n\
+         \x20       let back = Packet.decode(p.encode());\n\
+         \x20       total = total + back.seq;\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Anchor-2 fixture — the `mk()` CALL-producer encode temporary. A helper
+/// returns fresh `bytes`; `Packet.decode(mk())` consumes the anonymous call
+/// result straight into the decode. The producer is a `Terminator::Call` (not a
+/// `WireCodec` instruction), so the collector admits it through the terminator-def
+/// path; the decode still borrows the operand. Must leak EXACTLY 0 per frame.
+fn call_producer_temp_round_trip_source(frames: usize) -> String {
+    format!(
+        "#[wire]\n\
+         type Packet {{ label: string @1; seq: i64 @2; }}\n\
+         \n\
+         fn mk(n: i64) -> bytes {{\n\
+         \x20   let p = Packet {{ label: \"payload-label-value\", seq: n }};\n\
+         \x20   p.encode()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let back = Packet.decode(mk(i));\n\
+         \x20       total = total + back.seq;\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Anchor-2 fixture — the STRING-side anonymous temporary. `to_json` mints a
+/// fresh `string`; `Scalar.from_json(p.to_json())` consumes it inline as the
+/// parse operand. The fresh JSON string is a C-heap allocation visible to
+/// `leaks`, so a missing drop of the `to_json` temp shows up as one leaked
+/// buffer per frame. Must leak EXACTLY 0 per frame (the string collector's
+/// `WireCodec` extension).
+///
+/// The wire type is SCALAR-ONLY (no owned fields) on purpose: the JSON *decode*
+/// path does not yet release a decoded value's owned `string` fields (a
+/// pre-existing text-codec drop gap, distinct from this anchor and independent
+/// of the anonymous-temp admission — a NAMED `let s = p.to_json()` control leaks
+/// identically). A scalar-only decoded value owns no heap, so the ONLY per-frame
+/// owned allocation is the `to_json` string this collector must release — the
+/// isolated measurement of the string-collector extension.
+fn anonymous_to_json_temp_round_trip_source(frames: usize) -> String {
+    format!(
+        "#[wire]\n\
+         type Scalar {{ seq: i64 @1; flag: bool @2; }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let p = Scalar {{ seq: i, flag: true }};\n\
+         \x20       match Scalar.from_json(p.to_json()) {{\n\
+         \x20           Ok(back) => {{ total = total + back.seq; }},\n\
+         \x20           Err(_) => {{ total = total + 0; }},\n\
+         \x20       }}\n\
          \x20       i = i + 1;\n\
          \x20   }}\n\
          \x20   total\n\
@@ -235,11 +313,10 @@ const DECODE_FAILURE_SOURCE: &str = "#[wire]\n\
 ///
 /// The decoded value is held live to scope exit by a wildcard `match` (which
 /// neither moves an owned field out — avoiding the field-read drop suppression
-/// confound — nor reads a scalar that does not exist on an enum). The owned
-/// payload must be released by the enum value drop on every frame; a missing
-/// variant-field drop is a >= 1 leak/frame slope. The encoded buffer is bound
-/// to a NAMED local (`raw`) so the anonymous-bytes-temporary confound does not
-/// add its own per-frame node (see confound 1).
+/// confound (confound 1) — nor reads a scalar that does not exist on an enum).
+/// The owned payload must be released by the enum value drop on every frame; a
+/// missing variant-field drop is a >= 1 leak/frame slope. The encoded buffer is
+/// bound to a NAMED local (`raw`, the binding path).
 fn enum_owned_payload_round_trip_source(frames: usize) -> String {
     format!(
         "#[wire]\n\
@@ -520,6 +597,34 @@ fn assert_frame_slope_below_tolerance(
     );
 }
 
+/// Build the shape at `low_frames` and `high_frames`, measure leak NODE counts,
+/// and assert BOTH are EXACTLY zero. Used for the anonymous codec-temporary
+/// shapes whose named-binding control measured a 0-leak floor: a slope tolerance
+/// would silently pass a constant per-frame leak, so the exact form is the one
+/// with teeth.
+fn assert_frame_leaks_exactly_zero(
+    shape_name: &str,
+    source_fn: fn(usize) -> String,
+    low_frames: usize,
+    high_frames: usize,
+) {
+    let Some((low_leaks, high_leaks)) =
+        frame_leak_counts(shape_name, source_fn, low_frames, high_frames)
+    else {
+        return;
+    };
+    assert_eq!(
+        (low_leaks, high_leaks),
+        (0, 0),
+        "{shape_name}: an anonymous codec temporary leaked — expected EXACTLY 0 \
+         leaks at both {low_frames} and {high_frames} frames (the named-binding \
+         control proves 0 is the floor), got low_leaks={low_leaks} \
+         high_leaks={high_leaks}. The fresh codec temp (encode buffer / to_json \
+         string) is not released after the borrowing decode/parse — re-run a \
+         standalone build under `MallocStackLogging=1 leaks --atExit -- <bin>`."
+    );
+}
+
 // ── oracles ───────────────────────────────────────────────────────────────
 
 /// Decode-owned field drop: round-tripping a struct with an owned `string`,
@@ -547,6 +652,48 @@ fn vec_struct_round_trip_no_per_frame_leak_slope() {
     assert_frame_slope_below_tolerance(
         "wire_cbor_vec_struct_round_trip",
         vec_struct_round_trip_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Anchor 2 — the anonymous encode temporary round-trips with EXACTLY zero
+/// leaks. `Packet.decode(p.encode())` with no `let raw`: the fresh CBOR buffer
+/// is a bare temporary released once after the borrowing decode. Probe B leaked
+/// exactly one buffer per frame here before the fresh-temp-drop admission; the
+/// named-binding control measured 0, so this asserts an exact `== 0`.
+#[test]
+fn anonymous_encode_temp_round_trip_leaks_exactly_zero() {
+    assert_frame_leaks_exactly_zero(
+        "wire_cbor_anon_encode_temp",
+        anonymous_encode_temp_round_trip_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Anchor 2 — the `mk()` call-producer encode temporary round-trips with
+/// EXACTLY zero leaks. `Packet.decode(mk(i))`: the anonymous `Terminator::Call`
+/// bytes result is borrowed by the decode and released once after it.
+#[test]
+fn call_producer_encode_temp_round_trip_leaks_exactly_zero() {
+    assert_frame_leaks_exactly_zero(
+        "wire_cbor_call_producer_temp",
+        call_producer_temp_round_trip_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Anchor 2 (string side) — the anonymous `to_json` temporary round-trips with
+/// EXACTLY zero leaks. `Packet.from_json(p.to_json())`: the fresh JSON string is
+/// borrowed by the parse and released once after it. Pins the string collector's
+/// `WireCodec` extension (the JSON codec's C-heap allocs are `leaks`-visible).
+#[test]
+fn anonymous_to_json_temp_round_trip_leaks_exactly_zero() {
+    assert_frame_leaks_exactly_zero(
+        "wire_cbor_anon_to_json_temp",
+        anonymous_to_json_temp_round_trip_source,
         LOW_FRAMES,
         HIGH_FRAMES,
     );

--- a/hew-cli/tests/wire_cbor_codec_leak_oracle.rs
+++ b/hew-cli/tests/wire_cbor_codec_leak_oracle.rs
@@ -42,6 +42,16 @@
 //!     once (no double-free) and that the shell free does not race the field
 //!     drop.
 //!
+//!   * **Owned-Vec-element decode-failure partial free-on-error**
+//!     (`vec_owned_struct_decode_failure_frees_partials_no_double_free` and its
+//!     enum sibling `vec_owned_enum_decode_failure_frees_partials_no_double_free`):
+//!     the headline path of the owned-Vec-element codec change. A container whose
+//!     field 1 is a `Vec<owned>` decodes the full owned Vec (allocating each
+//!     element's heap) before a trailing scalar field latches failure, so the
+//!     `fail_bb` must drop the whole owned Vec — releasing every already-decoded
+//!     element via the vec's per-element `drop_fn` — exactly once before the
+//!     shell free. Same poisoned-allocator trap + no-double-free assertion.
+//!
 //!   * **Out-of-range enum-tag decode free (actor context)**
 //!     (`actor_oob_enum_tag_decode_frees_reader_and_shell_no_excess_slope`): an
 //!     unknown enum wire tag traps fail-closed; inside an actor `receive`
@@ -365,6 +375,62 @@ const ENUM_DECODE_FAILURE_SOURCE: &str = "#[wire]\n\
      \x20   let raw = p.encode();\n\
      \x20   let bad = PayloadBad.decode(raw);\n\
      \x20   match bad { PayloadBad::Empty => 0, PayloadBad::Full(_, n, _) => n, }\n\
+     }\n";
+
+/// Decode-failure fixture for a `Vec<#[wire] struct>` whose ELEMENT owns heap
+/// (a `string` field). Encode a `{ items: Vec<Item> @1; tail: string @2 }`
+/// value, then decode the SAME bytes against a `{ items: Vec<Item> @1; tail:
+/// i64 @2 }` layout. Field 1 (`items`) decodes fully — allocating the owned Vec
+/// plus each element's owned `string` — then field 2 reads an `i64` where the
+/// stream holds a CBOR text head, latching reader failure and driving the
+/// `fail_bb`. The partial shell now holds a fully-decoded owned Vec, so
+/// `fail_bb` must drop that Vec (releasing every already-decoded element string
+/// via the vec's per-element `drop_fn`) exactly once before freeing the shell.
+/// This is the owned-Vec-element half of the error path the headline codec
+/// change admits — distinct from the scalar-string `fail_bb` the sibling
+/// `decode_failure_frees_partials_no_double_free` pins.
+const VEC_OWNED_STRUCT_DECODE_FAILURE_SOURCE: &str = "#[wire]\n\
+     type Item { name: string @1; }\n\
+     #[wire]\n\
+     type BatchGood { items: Vec<Item> @1; tail: string @2; }\n\
+     #[wire]\n\
+     type BatchBad { items: Vec<Item> @1; tail: i64 @2; }\n\
+     \n\
+     fn main() -> i64 {\n\
+     \x20   let xs: Vec<Item> = Vec::new();\n\
+     \x20   xs.push(Item { name: \"alpha-owned-element\" });\n\
+     \x20   xs.push(Item { name: \"beta-owned-element\" });\n\
+     \x20   let g = BatchGood { items: xs, tail: \"owned-tail-value\" };\n\
+     \x20   let raw = g.encode();\n\
+     \x20   let bad = BatchBad.decode(raw);\n\
+     \x20   bad.tail\n\
+     }\n";
+
+/// Decode-failure fixture for a `Vec<#[wire] enum>` whose ELEMENT is an
+/// owned-payload enum (a `string`-bearing variant). Encode a `{ items:
+/// Vec<Payload> @1; tail: string @2 }` value, then decode the SAME bytes against
+/// a `{ items: Vec<Payload> @1; tail: i64 @2 }` layout. Field 1 decodes the full
+/// owned Vec — each `Full` element allocates its owned `string` through
+/// `__hew_enum_clone_inplace_Payload` — then field 2 latches on the `i64`-where-
+/// text mismatch, driving the `fail_bb`. The partial shell's owned enum Vec must
+/// be dropped exactly once (each element's variant drop releasing its owned
+/// string) before the shell free — the owned-enum-element error path.
+const VEC_OWNED_ENUM_DECODE_FAILURE_SOURCE: &str = "#[wire]\n\
+     enum Payload { Empty; Full(string); }\n\
+     #[wire]\n\
+     type BagGood { items: Vec<Payload> @1; tail: string @2; }\n\
+     #[wire]\n\
+     type BagBad { items: Vec<Payload> @1; tail: i64 @2; }\n\
+     \n\
+     fn main() -> i64 {\n\
+     \x20   let xs: Vec<Payload> = Vec::new();\n\
+     \x20   xs.push(Payload::Full(\"first-owned-element\"));\n\
+     \x20   xs.push(Payload::Empty);\n\
+     \x20   xs.push(Payload::Full(\"second-owned-element\"));\n\
+     \x20   let g = BagGood { items: xs, tail: \"owned-tail-value\" };\n\
+     \x20   let raw = g.encode();\n\
+     \x20   let bad = BagBad.decode(raw);\n\
+     \x20   bad.tail\n\
      }\n";
 
 /// Actor-context out-of-range enum-tag fixture, parameterised by the message
@@ -796,6 +862,35 @@ fn enum_owned_payload_decode_failure_frees_partials_no_double_free() {
     assert_decode_failure_traps_no_double_free(
         "wire_cbor_enum_decode_failure",
         ENUM_DECODE_FAILURE_SOURCE,
+    );
+}
+
+/// Owned-Vec-element struct decode-failure free-on-error. Decoding a
+/// `{ items: Vec<Item> @1; tail: string @2 }` value against a `{ items:
+/// Vec<Item> @1; tail: i64 @2 }` layout decodes the full owned Vec (allocating
+/// each element's owned string) then latches on the `i64`-where-text tail,
+/// driving the `fail_bb`. Must trap fail-closed with no cabi double-free of any
+/// already-decoded owned element — proving the owned Vec (and its per-element
+/// strings) is dropped exactly once before the shell free. This is the headline
+/// owned-Vec-element error path the CBOR Vec codec change admits.
+#[test]
+fn vec_owned_struct_decode_failure_frees_partials_no_double_free() {
+    assert_decode_failure_traps_no_double_free(
+        "wire_cbor_vec_owned_struct_decode_failure",
+        VEC_OWNED_STRUCT_DECODE_FAILURE_SOURCE,
+    );
+}
+
+/// Owned-Vec-element ENUM decode-failure free-on-error. The `Vec<Payload>`
+/// element sibling: the owned-payload enum Vec decodes fully (each `Full`
+/// element allocating its owned string) before the `i64`-where-text tail latches
+/// failure. The `fail_bb` must drop the owned enum Vec exactly once — each
+/// element's variant drop releasing its owned string — with no cabi double-free.
+#[test]
+fn vec_owned_enum_decode_failure_frees_partials_no_double_free() {
+    assert_decode_failure_traps_no_double_free(
+        "wire_cbor_vec_owned_enum_decode_failure",
+        VEC_OWNED_ENUM_DECODE_FAILURE_SOURCE,
     );
 }
 

--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -1083,20 +1083,29 @@ pub(crate) fn layout_descriptor_ptr<'ctx>(
 ///
 /// Fails closed for any element with no resolvable thunk path — the owned ABI
 /// must never reference a non-existent thunk (`boundary-fail-closed`).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "narrowed off FnCtx so the wire codec (no per-function FnCtx) can \
+              reach the same owned-descriptor authority; the raw ctx/llvm_mod/\
+              target_data + the three-registry borrow replace the single FnCtx arg"
+)]
 pub(crate) fn owned_elem_layout_descriptor_ptr<'ctx>(
-    fn_ctx: &FnCtx<'_, 'ctx>,
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    target_data: &TargetData,
+    regs: OwnedElemRegistries<'_, 'ctx>,
     elem_resolved_ty: &ResolvedTy,
     elem_llvm_ty: BasicTypeEnum<'ctx>,
     label: &str,
 ) -> CodegenResult<PointerValue<'ctx>> {
-    let Some((kind, key)) = crate::thunks::owned_elem_thunk_key(fn_ctx, elem_resolved_ty) else {
+    let Some((kind, key)) = crate::thunks::owned_elem_thunk_key(regs, elem_resolved_ty) else {
         return Err(CodegenError::FailClosed(format!(
             "owned Vec element `{elem_resolved_ty:?}` has no resolvable record/enum \
              in-place thunk path at `{label}`; the checker must not route a \
              non-thunkable element through the owned ABI"
         )));
     };
-    let (size, align) = abi_size_align(elem_llvm_ty, Some(fn_ctx.target_data))?;
+    let (size, align) = abi_size_align(elem_llvm_ty, Some(target_data))?;
     let kind_tag = match kind {
         OwnedElemThunkKind::Record => "rec",
         OwnedElemThunkKind::Enum => "enum",
@@ -1104,17 +1113,17 @@ pub(crate) fn owned_elem_layout_descriptor_ptr<'ctx>(
         OwnedElemThunkKind::Collection => "coll",
     };
     let global_name = format!("__hew_vec_elem_layout_{kind_tag}_{key}_{size}_{align}");
-    if let Some(g) = fn_ctx.llvm_mod.get_global(&global_name) {
+    if let Some(g) = llvm_mod.get_global(&global_name) {
         return Ok(g.as_pointer_value());
     }
     let (clone_fn, drop_fn) = match kind {
         OwnedElemThunkKind::Record => (
-            get_or_declare_record_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
-            get_or_declare_record_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+            get_or_declare_record_clone_inplace(ctx, llvm_mod, &key),
+            get_or_declare_record_drop_inplace(ctx, llvm_mod, &key),
         ),
         OwnedElemThunkKind::Enum => (
-            get_or_declare_enum_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
-            get_or_declare_enum_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+            get_or_declare_enum_clone_inplace(ctx, llvm_mod, &key),
+            get_or_declare_enum_drop_inplace(ctx, llvm_mod, &key),
         ),
         OwnedElemThunkKind::Tuple => {
             // The tuple thunk BODY is synthesized eagerly here (it has no
@@ -1131,10 +1140,17 @@ pub(crate) fn owned_elem_layout_descriptor_ptr<'ctx>(
                     )));
                 }
             };
-            crate::thunks::emit_tuple_inplace_thunk_bodies(fn_ctx, &key, elems, elem_llvm_ty)?;
+            crate::thunks::emit_tuple_inplace_thunk_bodies(
+                ctx,
+                llvm_mod,
+                regs,
+                &key,
+                elems,
+                elem_llvm_ty,
+            )?;
             (
-                get_or_declare_tuple_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
-                get_or_declare_tuple_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+                get_or_declare_tuple_clone_inplace(ctx, llvm_mod, &key),
+                get_or_declare_tuple_drop_inplace(ctx, llvm_mod, &key),
             )
         }
         OwnedElemThunkKind::Collection => {
@@ -1142,23 +1158,24 @@ pub(crate) fn owned_elem_layout_descriptor_ptr<'ctx>(
             // here (like the tuple thunk — no registry-driven seeding): a
             // collection element is referenced only through this descriptor.
             // Idempotent: the emitter no-ops if the body already exists.
-            let (clone_sym, drop_sym) = collection_elem_clone_drop_syms(fn_ctx, elem_resolved_ty)
+            let (clone_sym, drop_sym) = collection_elem_clone_drop_syms(elem_resolved_ty)
                 .ok_or_else(|| {
-                CodegenError::FailClosed(format!(
-                    "owned collection descriptor at `{label}`: element \
+                    CodegenError::FailClosed(format!(
+                        "owned collection descriptor at `{label}`: element \
                          {elem_resolved_ty:?} has no canonical clone/free primitive \
                          (closure-pair Vec elements are a separate lane)"
-                ))
-            })?;
-            crate::thunks::emit_collection_handle_thunk_bodies(fn_ctx, &key, clone_sym, drop_sym)?;
+                    ))
+                })?;
+            crate::thunks::emit_collection_handle_thunk_bodies(
+                ctx, llvm_mod, &key, clone_sym, drop_sym,
+            )?;
             (
-                get_or_declare_collection_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
-                get_or_declare_collection_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+                get_or_declare_collection_clone_inplace(ctx, llvm_mod, &key),
+                get_or_declare_collection_drop_inplace(ctx, llvm_mod, &key),
             )
         }
     };
-    let ctx = fn_ctx.ctx;
-    let usize_ty = crate::llvm::runtime_size_ty(ctx, fn_ctx.llvm_mod);
+    let usize_ty = crate::llvm::runtime_size_ty(ctx, llvm_mod);
     let i8_ty = ctx.i8_type();
     let ptr_ty = ctx.ptr_type(AddressSpace::default());
     let layout_ty = ctx.struct_type(
@@ -1179,7 +1196,7 @@ pub(crate) fn owned_elem_layout_descriptor_ptr<'ctx>(
         clone_fn.as_global_value().as_pointer_value().into(),
         drop_fn.as_global_value().as_pointer_value().into(),
     ]);
-    let g = fn_ctx.llvm_mod.add_global(layout_ty, None, &global_name);
+    let g = llvm_mod.add_global(layout_ty, None, &global_name);
     g.set_constant(true);
     g.set_linkage(Linkage::Private);
     g.set_initializer(&init);
@@ -1291,7 +1308,15 @@ pub(crate) fn channel_elem_layout_witness_ptr<'ctx>(
                 elem_ty,
                 fn_ctx.record_layouts,
             )?;
-            owned_elem_layout_descriptor_ptr(fn_ctx, elem_ty, elem_llvm_ty, label)
+            owned_elem_layout_descriptor_ptr(
+                fn_ctx.ctx,
+                fn_ctx.llvm_mod,
+                fn_ctx.target_data,
+                fn_ctx.owned_elem_registries(),
+                elem_ty,
+                elem_llvm_ty,
+                label,
+            )
         }
         _ => {
             // Plain: scalars (i8..i64, u8..u64, f32/f64, bool, char) and
@@ -1872,7 +1897,7 @@ fn hashmap_key_layout_descriptor_ptr<'ctx>(
         .is_some_and(|rty| resolved_ty_contains_heap_leaf(fn_ctx, rty, &mut HashSet::new()))
     {
         let rty = resolved_ty.expect("heap-leaf check requires a resolved type");
-        match crate::thunks::owned_elem_thunk_key(fn_ctx, rty) {
+        match crate::thunks::owned_elem_thunk_key(fn_ctx.owned_elem_registries(), rty) {
             Some((OwnedElemThunkKind::Record, record_key)) => Some(
                 get_or_declare_record_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &record_key),
             ),
@@ -2022,7 +2047,9 @@ fn hashmap_owned_value_layout_descriptor_ptr<'ctx>(
     val_resolved_ty: &ResolvedTy,
     val_llvm_ty: BasicTypeEnum<'ctx>,
 ) -> CodegenResult<PointerValue<'ctx>> {
-    let Some((kind, key)) = crate::thunks::owned_elem_thunk_key(fn_ctx, val_resolved_ty) else {
+    let Some((kind, key)) =
+        crate::thunks::owned_elem_thunk_key(fn_ctx.owned_elem_registries(), val_resolved_ty)
+    else {
         return Err(CodegenError::FailClosed(format!(
             "owned HashMap value `{val_resolved_ty:?}` has no resolvable clone/drop \
              thunk path; checker admission must reject non-POD values without a \
@@ -2060,21 +2087,34 @@ fn hashmap_owned_value_layout_descriptor_ptr<'ctx>(
                     )));
                 }
             };
-            crate::thunks::emit_tuple_inplace_thunk_bodies(fn_ctx, &key, elems, val_llvm_ty)?;
+            crate::thunks::emit_tuple_inplace_thunk_bodies(
+                fn_ctx.ctx,
+                fn_ctx.llvm_mod,
+                fn_ctx.owned_elem_registries(),
+                &key,
+                elems,
+                val_llvm_ty,
+            )?;
             (
                 get_or_declare_tuple_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
                 get_or_declare_tuple_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
             )
         }
         OwnedElemThunkKind::Collection => {
-            let (clone_sym, drop_sym) = collection_elem_clone_drop_syms(fn_ctx, val_resolved_ty)
+            let (clone_sym, drop_sym) = collection_elem_clone_drop_syms(val_resolved_ty)
                 .ok_or_else(|| {
                     CodegenError::FailClosed(format!(
                         "owned HashMap collection value `{val_resolved_ty:?}` has no canonical \
                          clone/free primitive"
                     ))
                 })?;
-            crate::thunks::emit_collection_handle_thunk_bodies(fn_ctx, &key, clone_sym, drop_sym)?;
+            crate::thunks::emit_collection_handle_thunk_bodies(
+                fn_ctx.ctx,
+                fn_ctx.llvm_mod,
+                &key,
+                clone_sym,
+                drop_sym,
+            )?;
             (
                 get_or_declare_collection_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
                 get_or_declare_collection_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
@@ -3364,7 +3404,10 @@ pub(crate) fn lower_vec_constructor_call(
         }
         VecCtor::Owned(elem_llvm_ty) => {
             let layout_ptr = crate::layout::owned_elem_layout_descriptor_ptr(
-                fn_ctx,
+                fn_ctx.ctx,
+                fn_ctx.llvm_mod,
+                fn_ctx.target_data,
+                fn_ctx.owned_elem_registries(),
                 elem_ty,
                 elem_llvm_ty,
                 "new",
@@ -3905,7 +3948,7 @@ fn emit_insert_overwrite_key_release(
     let release = match key_ty {
         ResolvedTy::String => Some(KeyRelease::StringPtr),
         rty if resolved_ty_contains_heap_leaf(fn_ctx, rty, &mut HashSet::new()) => {
-            match crate::thunks::owned_elem_thunk_key(fn_ctx, rty) {
+            match crate::thunks::owned_elem_thunk_key(fn_ctx.owned_elem_registries(), rty) {
                 Some((OwnedElemThunkKind::Record, record_key)) => Some(KeyRelease::RecordInPlace(
                     get_or_declare_record_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &record_key),
                 )),

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1526,6 +1526,23 @@ pub(crate) struct CoroState<'ctx> {
     pub(crate) is_generator: bool,
 }
 
+/// The exact set of module-wide registries the owned-Vec-element thunk-key
+/// resolver and descriptor builder need — the THREE lookups `owned_elem_thunk_key`
+/// consults (enum layouts, machine layouts, the codegen record field-type table).
+///
+/// Threading this narrow borrow instead of a full `FnCtx` lets the wire CBOR
+/// codec — which emits in the module pass with no per-function `FnCtx` — call the
+/// SAME owned-descriptor authority `Vec::new` uses. That single authority is what
+/// makes the codec's `__hew_vec_elem_layout_*` descriptor global dedup-collapse
+/// onto `Vec::new`'s for the same element type; a mirrored builder would mint a
+/// second descriptor and break the runtime's layout-equality check.
+#[derive(Clone, Copy)]
+pub(crate) struct OwnedElemRegistries<'a, 'ctx> {
+    pub(crate) enum_layouts: &'a [EnumLayout],
+    pub(crate) machine_layouts: &'a MachineLayoutMap<'ctx>,
+    pub(crate) record_field_resolved_tys: &'a HashMap<String, Vec<ResolvedTy>>,
+}
+
 pub(crate) struct FnCtx<'a, 'ctx> {
     pub(crate) ctx: &'ctx Context,
     pub(crate) llvm_mod: &'a LlvmModule<'ctx>,
@@ -18094,7 +18111,6 @@ fn emit_tuple_kind_drop_inplace_body<'ctx>(
 /// Vec's constructor uses (`resolved_ty_element_owns_heap_for_owned_vec`), so
 /// the clone primitive can never disagree with the inner Vec's actual ABI.
 pub(crate) fn collection_elem_clone_drop_syms(
-    _fn_ctx: &FnCtx<'_, '_>,
     elem_ty: &ResolvedTy,
 ) -> Option<(&'static str, &'static str)> {
     match elem_ty {
@@ -18173,7 +18189,7 @@ fn tuple_field_clone_kind(
 /// (owned-Vec element path) and the drop-only emitter (W5.021 owned-tuple drop
 /// spine), so both consume the same classification authority.
 pub(crate) fn tuple_inplace_field_kinds<'ctx>(
-    fn_ctx: &FnCtx<'_, 'ctx>,
+    regs: OwnedElemRegistries<'_, 'ctx>,
     tuple_key: &str,
     elems: &[ResolvedTy],
     tuple_llvm_ty: BasicTypeEnum<'ctx>,
@@ -18186,7 +18202,7 @@ pub(crate) fn tuple_inplace_field_kinds<'ctx>(
     // Needs the MIR record/enum layout slices; codegen carries the LLVM record
     // map, so reconstruct a minimal RecordLayout slice from the resolved-field
     // table for the classifier.
-    let record_layouts: Vec<hew_mir::RecordLayout> = fn_ctx
+    let record_layouts: Vec<hew_mir::RecordLayout> = regs
         .record_field_resolved_tys
         .iter()
         .map(|(name, tys)| hew_mir::RecordLayout {
@@ -18201,7 +18217,7 @@ pub(crate) fn tuple_inplace_field_kinds<'ctx>(
         kinds.push(tuple_field_clone_kind(
             elem,
             &record_layouts,
-            fn_ctx.enum_layouts,
+            regs.enum_layouts,
         )?);
     }
     Ok((tuple_struct, kinds))
@@ -18228,7 +18244,12 @@ pub(crate) fn emit_tuple_drop_inplace_body_only<'ctx>(
     if drop_fn.count_basic_blocks() > 0 {
         return Ok(());
     }
-    let (tuple_struct, kinds) = tuple_inplace_field_kinds(fn_ctx, tuple_key, elems, tuple_llvm_ty)?;
+    let (tuple_struct, kinds) = tuple_inplace_field_kinds(
+        fn_ctx.owned_elem_registries(),
+        tuple_key,
+        elems,
+        tuple_llvm_ty,
+    )?;
     emit_aggregate_drop_inplace_body(ctx, llvm_mod, drop_fn, tuple_struct, &kinds)
 }
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -8024,6 +8024,146 @@ fn collect_vec_owned_element_seeds(
     (record_seeds, enum_seeds)
 }
 
+/// Seed the owned-Vec ELEMENT record/enum keys reachable through a wire type's
+/// LAYOUT (its record fields / enum payloads) — the decode-only reachability
+/// gap. A wire type materialised ONLY by the CBOR codec (`Batch.decode(bytes)`
+/// with no Hew-side construction) has its `Vec<Item>` field type in no MIR local,
+/// so [`collect_vec_owned_element_seeds`] (which scans MIR function types) never
+/// sees the element. The decode-side owned descriptor
+/// (`owned_elem_layout_descriptor_ptr`) references the element's
+/// `__hew_{record,enum}_{clone,drop}_inplace_<key>` thunk, so without this seed
+/// that thunk is declared-but-undefined and LLVM verify rejects the module (a
+/// loud link-time failure, but this pass converts it to a supported feature).
+///
+/// Walks each wire value type's fields/payloads transitively (expanding records
+/// and enums via their layouts, cycle-guarded on the layout name) and seeds every
+/// `Vec<E>` element `E` that resolves to a registered record/enum — the same
+/// resolution [`collect_vec_owned_element_seeds`] applies to MIR-local Vec types.
+fn collect_wire_value_owned_vec_element_seeds(
+    wire_types: &[ResolvedTy],
+    record_layouts: &[RecordLayout],
+    enum_layouts: &[EnumLayout],
+) -> (Vec<String>, Vec<String>) {
+    let mut record_seeds: Vec<String> = Vec::new();
+    let mut enum_seeds: Vec<String> = Vec::new();
+    let mut rec_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut enum_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Resolve a `Vec` element to its registered record/enum key and seed it —
+    // enum-first, mirroring `owned_elem_thunk_key` / `collect_vec_owned_element_seeds`.
+    let mut consider_elem =
+        |elem: &ResolvedTy, record_seeds: &mut Vec<String>, enum_seeds: &mut Vec<String>| {
+            let ResolvedTy::Named { name, args, .. } = elem else {
+                return;
+            };
+            let short = short_name(name);
+            let enum_key = if args.is_empty() {
+                enum_layouts
+                    .iter()
+                    .find(|el| el.name == *name || short_name(&el.name) == short)
+                    .map(|el| el.name.clone())
+            } else {
+                let mangled = mangle_with_shortened_args(short, args);
+                enum_layouts
+                    .iter()
+                    .find(|el| el.name == mangled || el.name == *name)
+                    .map(|el| el.name.clone())
+            };
+            if let Some(key) = enum_key {
+                if enum_seen.insert(key.clone()) {
+                    enum_seeds.push(key);
+                }
+                return;
+            }
+            let rec_key = if args.is_empty() {
+                record_layouts
+                    .iter()
+                    .find(|rl| rl.name == *name || short_name(&rl.name) == short)
+                    .map(|rl| rl.name.clone())
+            } else {
+                let mangled = mangle_with_shortened_args(short, args);
+                record_layouts
+                    .iter()
+                    .find(|rl| rl.name == mangled || rl.name == *name)
+                    .map(|rl| rl.name.clone())
+            };
+            if let Some(key) = rec_key {
+                if rec_seen.insert(key.clone()) {
+                    record_seeds.push(key);
+                }
+            }
+        };
+
+    // Worklist over the wire types' layouts: expand user records/enums into their
+    // field/payload types, seed every `Vec<E>` element, and keep walking through
+    // nested aggregates so a `Vec<Vec<owned>>` or a record-of-record-of-Vec is
+    // reached. Cycle-guarded on the expanded layout name.
+    let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut stack: Vec<ResolvedTy> = wire_types.to_vec();
+    while let Some(ty) = stack.pop() {
+        match &ty {
+            ResolvedTy::Named { name, args, .. } => {
+                let short = short_name(name);
+                if name == "Vec" || matches!(short, "Sender" | "Receiver" | "Stream") {
+                    if let Some(elem) = args.first() {
+                        consider_elem(elem, &mut record_seeds, &mut enum_seeds);
+                        stack.push(elem.clone());
+                    }
+                    continue;
+                }
+                if name == "HashMap"
+                    || short == "HashMap"
+                    || name == "HashSet"
+                    || short == "HashSet"
+                {
+                    for a in args {
+                        stack.push(a.clone());
+                    }
+                    continue;
+                }
+                if matches!(short, "Option" | "Result" | "Range") {
+                    for a in args {
+                        stack.push(a.clone());
+                    }
+                    continue;
+                }
+                // A user record / enum: expand its fields / variant payloads once.
+                if !visited.insert(name.clone()) {
+                    continue;
+                }
+                if let Some(el) = enum_layouts
+                    .iter()
+                    .find(|el| el.name == *name || short_name(&el.name) == short)
+                {
+                    for v in &el.variants {
+                        for ft in &v.field_tys {
+                            stack.push(ft.clone());
+                        }
+                    }
+                } else if let Some(rl) = record_layouts
+                    .iter()
+                    .find(|rl| rl.name == *name || short_name(&rl.name) == short)
+                {
+                    for ft in &rl.field_tys {
+                        stack.push(ft.clone());
+                    }
+                }
+            }
+            ResolvedTy::Tuple(elems) => {
+                for e in elems {
+                    stack.push(e.clone());
+                }
+            }
+            ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
+                stack.push((**inner).clone());
+            }
+            _ => {}
+        }
+    }
+
+    (record_seeds, enum_seeds)
+}
+
 /// Compute the transitive set of user records AND user enums reachable
 /// through any classified actor's state fields, plus monomorphic
 /// direct-string records (and, recursively, through nested record fields and
@@ -29600,6 +29740,28 @@ fn build_module_for_target<'ctx>(
             vec_owned_record_seeds.push(xnode_rec_seed);
         }
     }
+    // decode-only owned-Vec ELEMENT capstone — a wire type materialised only by
+    // the CBOR codec (`Batch.decode(bytes)`, never constructed) has its
+    // `Vec<Item>` field type in no MIR local, so `collect_vec_owned_element_seeds`
+    // never seeds `Item`. The decode-side owned descriptor references
+    // `__hew_record_drop_inplace_Item`, so seed every owned-Vec element reachable
+    // through a wire value type's layout here or that thunk dangles at LLVM verify.
+    let (wire_vec_elem_record_seeds, wire_vec_elem_enum_seeds) =
+        collect_wire_value_owned_vec_element_seeds(
+            &wire_codec_value_types,
+            &pipeline.record_layouts,
+            &synthesis_enum_layouts,
+        );
+    for enum_seed in wire_vec_elem_enum_seeds {
+        if !enum_inplace_drop_seeds.contains(&enum_seed) {
+            enum_inplace_drop_seeds.push(enum_seed);
+        }
+    }
+    for record_seed in wire_vec_elem_record_seeds {
+        if !vec_owned_record_seeds.contains(&record_seed) {
+            vec_owned_record_seeds.push(record_seed);
+        }
+    }
     // D2 — seed every record/enum that appears as a `dyn Trait` CONCRETE so
     // `emit_state_clone_drop_synthesis` (immediately below) emits its
     // `__hew_{record,enum}_drop_inplace_<key>` body BEFORE
@@ -37169,18 +37331,17 @@ mod tests {
         finish_test_fn(&fn_ctx);
     }
 
-    /// Pin `cbor_vec_elem_kind` over every REACHABLE element shape so the
-    /// retire of the parallel `cbor_ty_owns_heap` walker (now a sealed
-    /// shim over `hew_mir::ty_owns_heap`) is byte-identical: scalars stay
+    /// Pin `cbor_vec_elem_kind` over every REACHABLE element shape: scalars stay
     /// `Plain`, `string` stays `Str`, a heap-free user record stays
-    /// `LayoutBitCopy` (the `Vec<#[wire] struct>` shape), a heap-owning record
-    /// stays `Defer`, `Option<T>` mirrors its payload, and every non-`Option`
-    /// builtin stays `Defer` (the retired walker's coarse `_ => true` rule,
-    /// preserved at the caller rather than routed through the finer authority).
+    /// `LayoutBitCopy` (the `Vec<#[wire] struct>` shape), a heap-OWNING record
+    /// whose thunk key resolves is `Owned` (the new owned-element ABI), a nested
+    /// `Vec` element is `Owned`, `Option<T>` mirrors its payload, and the
+    /// remaining builtins (`HashMap` / `Result` / …) stay `Defer`.
     #[test]
     fn cbor_vec_elem_kind_pins_reachable_classification() {
         let no_recs: Vec<RecordLayout> = vec![];
         let no_enums: Vec<EnumLayout> = vec![];
+        let no_machines: MachineLayoutMap = std::collections::HashMap::new();
 
         // Scalars → Plain (generic, null-layout vec).
         for s in [
@@ -37192,14 +37353,14 @@ mod tests {
             ResolvedTy::Duration,
         ] {
             assert_eq!(
-                cbor_vec_elem_kind(&s, &no_recs, &no_enums),
+                cbor_vec_elem_kind(&s, &no_recs, &no_enums, &no_machines),
                 CborVecElemKind::Plain,
                 "{s:?} must be a Plain element"
             );
         }
         // `string` → Str.
         assert_eq!(
-            cbor_vec_elem_kind(&ResolvedTy::String, &no_recs, &no_enums),
+            cbor_vec_elem_kind(&ResolvedTy::String, &no_recs, &no_enums, &no_machines),
             CborVecElemKind::Str
         );
 
@@ -37213,21 +37374,29 @@ mod tests {
             cbor_vec_elem_kind(
                 &ResolvedTy::named_user("Inner", vec![]),
                 &[inner],
-                &no_enums
+                &no_enums,
+                &no_machines
             ),
             CborVecElemKind::LayoutBitCopy,
             "a heap-free record element is the layout-aware BitCopy vec `Vec::new` builds"
         );
-        // A heap-OWNING user record (a `string` field) → Defer.
+        // A heap-OWNING user record (a `string` field) whose thunk key resolves
+        // (it is a registered record) → Owned, the new owned-element ABI matching
+        // `Vec::new`'s `VecCtor::Owned`.
         let owns = RecordLayout {
             name: "Owns".to_string(),
             field_tys: vec![ResolvedTy::String],
             field_names: vec!["s".to_string()],
         };
         assert_eq!(
-            cbor_vec_elem_kind(&ResolvedTy::named_user("Owns", vec![]), &[owns], &no_enums),
-            CborVecElemKind::Defer,
-            "a string-bearing record element needs the owned Vec ABI → fail closed"
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_user("Owns", vec![]),
+                std::slice::from_ref(&owns),
+                &no_enums,
+                &no_machines
+            ),
+            CborVecElemKind::Owned,
+            "a string-bearing record element rides the owned Vec ABI (thunk key resolves)"
         );
 
         // `Option<scalar>` → LayoutBitCopy; `Option<string>` → Defer (the payload
@@ -37236,7 +37405,8 @@ mod tests {
             cbor_vec_elem_kind(
                 &ResolvedTy::named_builtin("Option", BuiltinType::Option, vec![ResolvedTy::I64]),
                 &no_recs,
-                &no_enums
+                &no_enums,
+                &no_machines
             ),
             CborVecElemKind::LayoutBitCopy
         );
@@ -37244,17 +37414,30 @@ mod tests {
             cbor_vec_elem_kind(
                 &ResolvedTy::named_builtin("Option", BuiltinType::Option, vec![ResolvedTy::String]),
                 &no_recs,
-                &no_enums
+                &no_enums,
+                &no_machines
             ),
             CborVecElemKind::Defer
         );
 
-        // Non-`Option` builtins → Defer, preserving the retired walker's coarse
-        // rule. `Result<i64, i64>` is genuinely heap-free, yet stays Defer here
-        // (the authority's finer recursion that would admit it as BitCopy is
-        // deferred to a future consolidation, gated on matching codec support).
+        // A nested `Vec<E>` element stays fail-closed: an owned Vec of collections
+        // needs the base language's recursive owned clone/drop thunk synthesis,
+        // which is NYI (a direct `Vec<Vec<string>>` aborts at runtime even outside
+        // the codec, and the checker already rejects the analogous
+        // `Vec<record-with-a-collection-field>`).
+        assert_eq!(
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![ResolvedTy::I64]),
+                &no_recs,
+                &no_enums,
+                &no_machines
+            ),
+            CborVecElemKind::Defer,
+            "a nested Vec element fails closed until the base owned nested-Vec ABI lands"
+        );
+        // `HashMap` (no CBOR value arm) and every other non-`Option` builtin stay
+        // fail-closed.
         for b in [
-            ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![ResolvedTy::I64]),
             ResolvedTy::named_builtin(
                 "HashMap",
                 BuiltinType::HashMap,
@@ -37267,37 +37450,39 @@ mod tests {
             ),
         ] {
             assert_eq!(
-                cbor_vec_elem_kind(&b, &no_recs, &no_enums),
+                cbor_vec_elem_kind(&b, &no_recs, &no_enums, &no_machines),
                 CborVecElemKind::Defer,
-                "{b:?} must fail closed (coarse non-Option builtin rule)"
+                "{b:?} must fail closed (no CBOR value arm / no owned-vec support)"
             );
         }
     }
 
-    /// G6: routing the CBOR element probe through the single
-    /// `hew_mir::ty_owns_heap` authority fixes a latent under-drop leak. A user
-    /// record whose field is a `CancellationToken` (an owned runtime handle) was
-    /// classified heap-FREE by the retired `cbor_ty_owns_heap` walker — its
-    /// `_ => false` arm did not recognise the `CancellationToken` own-variant —
-    /// so the codec BitCopied (and leaked) the handle as a `LayoutBitCopy`
-    /// element. The authority recognises `CancellationToken` as a leaf, so the
-    /// record owns heap and the codec correctly fails closed (`Defer`).
+    /// A heap-owning record element whose thunk key resolves rides the OWNED Vec
+    /// ABI (`ownership_kind = LayoutManaged`), so the codec never BitCopies (and
+    /// leaks) an owned handle. A `CancellationToken`-bearing record classifies
+    /// `Owned` — the backing vec has a real per-element `drop_fn`, so there is no
+    /// BitCopy leak; the token field itself has no CBOR value arm, so the codec
+    /// fails closed downstream at `emit_ser_value_cbor` (and the checker's
+    /// Serializable gate rejects such a `#[wire]` type up front for real code).
     #[test]
-    fn cbor_retire_fixes_latent_cancellation_token_leak() {
+    fn cbor_owning_record_element_rides_owned_abi_never_bitcopy_leak() {
         let rec = RecordLayout {
             name: "WithTok".to_string(),
             field_tys: vec![ResolvedTy::CancellationToken],
             field_names: vec!["tok".to_string()],
         };
         let no_enums: Vec<EnumLayout> = vec![];
+        let no_machines: MachineLayoutMap = std::collections::HashMap::new();
         assert_eq!(
             cbor_vec_elem_kind(
                 &ResolvedTy::named_user("WithTok", vec![]),
-                &[rec],
-                &no_enums
+                std::slice::from_ref(&rec),
+                &no_enums,
+                &no_machines
             ),
-            CborVecElemKind::Defer,
-            "a CancellationToken-bearing record element must fail closed, not BitCopy-leak the handle"
+            CborVecElemKind::Owned,
+            "a CancellationToken-bearing record rides the owned ABI (real drop_fn, no \
+             BitCopy leak); the unencodable token field fails closed downstream"
         );
     }
 
@@ -37338,6 +37523,7 @@ mod tests {
             is_indirect: true,
         };
         let no_recs: Vec<RecordLayout> = vec![];
+        let no_machines: MachineLayoutMap = std::collections::HashMap::new();
 
         // The indirect enum itself → Defer (NOT LayoutBitCopy).
         assert_eq!(
@@ -37345,6 +37531,7 @@ mod tests {
                 &ResolvedTy::named_user("Node", vec![]),
                 &no_recs,
                 std::slice::from_ref(&indirect),
+                &no_machines,
             ),
             CborVecElemKind::Defer,
             "an indirect-enum element is a heap-owned pointer — must fail closed, not BitCopy"
@@ -37361,6 +37548,7 @@ mod tests {
                 &ResolvedTy::named_user("Wrapper", vec![]),
                 std::slice::from_ref(&wrapper),
                 std::slice::from_ref(&indirect),
+                &no_machines,
             ),
             CborVecElemKind::Defer,
             "a record transitively containing an indirect enum must fail closed"
@@ -37392,6 +37580,7 @@ mod tests {
                 &ResolvedTy::named_user("Flat", vec![]),
                 &no_recs,
                 std::slice::from_ref(&direct),
+                &no_machines,
             ),
             CborVecElemKind::LayoutBitCopy,
             "a heap-free direct enum must stay BitCopy — the fix must not over-defer"

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -5260,6 +5260,18 @@ pub(crate) fn intern_runtime_decl<'ctx>(
 }
 
 impl<'a, 'ctx> FnCtx<'a, 'ctx> {
+    /// Borrow the three module-wide registries the owned-Vec-element thunk-key
+    /// resolver / descriptor builder need, as an [`OwnedElemRegistries`]. Lets a
+    /// per-function `FnCtx` caller hand the same authority the wire codec reaches
+    /// via the raw registries.
+    pub(crate) fn owned_elem_registries(&self) -> OwnedElemRegistries<'a, 'ctx> {
+        OwnedElemRegistries {
+            enum_layouts: self.enum_layouts,
+            machine_layouts: self.machine_layouts,
+            record_field_resolved_tys: self.record_field_resolved_tys,
+        }
+    }
+
     /// Declare-then-call the runtime symbol `sym`, returning the raw
     /// `CallSiteValue`. This is the single seam that collapses the canonical
     /// runtime-call idiom

--- a/hew-codegen-rs/src/thunks.rs
+++ b/hew-codegen-rs/src/thunks.rs
@@ -842,13 +842,12 @@ pub(crate) fn tuple_thunk_key(elems: &[ResolvedTy]) -> String {
 /// The drop thunk loads the slot's handle and frees it (the free primitives
 /// no-op on null, so a moved-out/cleared slot is safe).
 pub(crate) fn emit_collection_handle_thunk_bodies<'ctx>(
-    fn_ctx: &FnCtx<'_, 'ctx>,
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
     key: &str,
     clone_sym: &'static str,
     drop_sym: &'static str,
 ) -> CodegenResult<()> {
-    let ctx = fn_ctx.ctx;
-    let llvm_mod = fn_ctx.llvm_mod;
     let ptr_ty = ctx.ptr_type(AddressSpace::default());
     let i32_ty = ctx.i32_type();
 
@@ -934,14 +933,14 @@ pub(crate) fn emit_collection_handle_thunk_bodies<'ctx>(
 /// the bodies already exist (a tuple shape may be referenced by multiple owned
 /// Vecs).
 pub(crate) fn emit_tuple_inplace_thunk_bodies<'ctx>(
-    fn_ctx: &FnCtx<'_, 'ctx>,
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    regs: OwnedElemRegistries<'_, 'ctx>,
     tuple_key: &str,
     elems: &[ResolvedTy],
     tuple_llvm_ty: BasicTypeEnum<'ctx>,
 ) -> CodegenResult<()> {
-    let ctx = fn_ctx.ctx;
-    let llvm_mod = fn_ctx.llvm_mod;
-    let (tuple_struct, kinds) = tuple_inplace_field_kinds(fn_ctx, tuple_key, elems, tuple_llvm_ty)?;
+    let (tuple_struct, kinds) = tuple_inplace_field_kinds(regs, tuple_key, elems, tuple_llvm_ty)?;
 
     let clone_fn = get_or_declare_tuple_clone_inplace(ctx, llvm_mod, tuple_key);
     if clone_fn.count_basic_blocks() == 0 {
@@ -964,7 +963,7 @@ pub(crate) fn emit_tuple_inplace_thunk_bodies<'ctx>(
 /// thunk body is synthesized on demand). Returns `None` for any shape with no
 /// in-place thunk path (primitives, builtins) — the caller must fail closed.
 pub(crate) fn owned_elem_thunk_key(
-    fn_ctx: &FnCtx<'_, '_>,
+    regs: OwnedElemRegistries<'_, '_>,
     elem_ty: &ResolvedTy,
 ) -> Option<(OwnedElemThunkKind, String)> {
     // Tuple element (W5.016 F2): no registry entry — synthesize a structural
@@ -991,7 +990,7 @@ pub(crate) fn owned_elem_thunk_key(
             ),
             ..
         }
-    ) && collection_elem_clone_drop_syms(fn_ctx, elem_ty).is_some()
+    ) && collection_elem_clone_drop_syms(elem_ty).is_some()
     {
         return Some((
             OwnedElemThunkKind::Collection,
@@ -1004,15 +1003,13 @@ pub(crate) fn owned_elem_thunk_key(
     // Enum-first: an owned-payload / recursive enum is the F3/F4 shape.
     let short = short_name(name);
     let enum_key = if args.is_empty() {
-        fn_ctx
-            .enum_layouts
+        regs.enum_layouts
             .iter()
             .find(|el| el.name == *name || short_name(&el.name) == short)
             .map(|el| el.name.clone())
     } else {
         let mangled = mangle_with_shortened_args(short, args);
-        fn_ctx
-            .enum_layouts
+        regs.enum_layouts
             .iter()
             .find(|el| el.name == mangled || el.name == *name)
             .map(|el| el.name.clone())
@@ -1027,7 +1024,7 @@ pub(crate) fn owned_elem_thunk_key(
     // the same short-name registration `resolve_ty`'s fallback resolves the
     // element struct through. State-side machine entries are distinguished
     // from event companions / plain enums by their state-name table.
-    if fn_ctx
+    if regs
         .machine_layouts
         .get(short)
         .is_some_and(|m| m.state_name_table.is_some())
@@ -1042,13 +1039,13 @@ pub(crate) fn owned_elem_thunk_key(
     } else {
         mangle_with_shortened_args(short_name(name), args)
     };
-    if fn_ctx
+    if regs
         .record_field_resolved_tys
         .contains_key(lookup_key.as_str())
     {
         return Some((OwnedElemThunkKind::Record, lookup_key));
     }
-    if fn_ctx.record_field_resolved_tys.contains_key(short) {
+    if regs.record_field_resolved_tys.contains_key(short) {
         return Some((OwnedElemThunkKind::Record, short.to_string()));
     }
     None

--- a/hew-codegen-rs/src/wire.rs
+++ b/hew-codegen-rs/src/wire.rs
@@ -1604,11 +1604,61 @@ pub(crate) enum CborVecElemKind {
     /// (`Vec layout-aware operation is not implemented`). The descriptor is a
     /// thunk-less `{size, align, ownership_kind=0}` matching `layout_descriptor_ptr`.
     LayoutBitCopy,
-    /// Owned-compound element (bytes / heap-owning record / nested collection):
-    /// the standalone emitter cannot synthesise the owned clone/drop descriptor
-    /// the backing vec would need, so the codec fails closed (a failable
-    /// sub-shape, not a silent partial).
+    /// Heap-owning record / enum element that resolves an owned clone/drop thunk
+    /// key: an OWNED (thunk-bearing) Vec (`hew_vec_new_with_elem_layout` /
+    /// `hew_vec_push_owned_move` / `hew_vec_get_owned`,
+    /// `ownership_kind = LayoutManaged`). This is the SAME ABI `Vec::new` builds
+    /// for a `Vec<owned>` (`VecCtor::Owned`), and the descriptor global
+    /// dedup-collapses onto the constructor's via the single
+    /// `owned_elem_layout_descriptor_ptr` authority. `hew_vec_free` walks the
+    /// per-element `drop_fn`, so a partially decoded vec releases exactly once.
+    /// Nested-collection elements (`Vec<Vec<…>>`) are excluded — that base ABI is
+    /// NYI (see the `Defer` arm) — so this covers records/enums with owned scalar
+    /// leaf fields (`string` today).
+    Owned,
+    /// Element outside the supported wire-body floor (bytes / indirect enum /
+    /// `Option`-with-heap / nested collection `Vec<Vec>`/`Vec<HashMap>`/
+    /// `Vec<HashSet>` / no resolvable owned thunk key): the codec fails closed
+    /// (a failable sub-shape, not a silent partial).
     Defer,
+}
+
+/// Owns the record field-type table the wire codec reconstructs from the
+/// threaded `pipeline_records`, so an [`OwnedElemRegistries`] borrow can be handed
+/// to the single owned-descriptor authority (`owned_elem_thunk_key` /
+/// `owned_elem_layout_descriptor_ptr`). The reconstructed map is byte-identical to
+/// the one `build_module` gives `FnCtx` (both are `pipeline.record_layouts` keyed
+/// by name), so the codec's owned-element resolution can never disagree with the
+/// constructor's.
+struct CborOwnedElemRegistries<'a, 'ctx> {
+    record_field_resolved_tys: std::collections::HashMap<String, Vec<ResolvedTy>>,
+    enum_layouts: &'a [EnumLayout],
+    machine_layouts: &'a MachineLayoutMap<'ctx>,
+}
+
+impl<'ctx> CborOwnedElemRegistries<'_, 'ctx> {
+    fn registries(&self) -> OwnedElemRegistries<'_, 'ctx> {
+        OwnedElemRegistries {
+            enum_layouts: self.enum_layouts,
+            machine_layouts: self.machine_layouts,
+            record_field_resolved_tys: &self.record_field_resolved_tys,
+        }
+    }
+}
+
+fn cbor_owned_elem_registries<'a, 'ctx>(
+    pipeline_records: &[RecordLayout],
+    enum_layouts: &'a [EnumLayout],
+    machine_layouts: &'a MachineLayoutMap<'ctx>,
+) -> CborOwnedElemRegistries<'a, 'ctx> {
+    CborOwnedElemRegistries {
+        record_field_resolved_tys: pipeline_records
+            .iter()
+            .map(|r| (r.name.clone(), r.field_tys.clone()))
+            .collect(),
+        enum_layouts,
+        machine_layouts,
+    }
 }
 
 /// Classify a CBOR Vec element type into the backing-store kind its codec needs.
@@ -1620,7 +1670,12 @@ pub(crate) fn cbor_vec_elem_kind(
     elem: &ResolvedTy,
     pipeline_records: &[RecordLayout],
     enum_layouts: &[EnumLayout],
+    machine_layouts: &MachineLayoutMap<'_>,
 ) -> CborVecElemKind {
+    // Reach the single owned-descriptor authority via the same registries
+    // `Vec::new` uses (reconstructed from the threaded `pipeline_records`).
+    let owned_regs = cbor_owned_elem_registries(pipeline_records, enum_layouts, machine_layouts);
+    let regs = owned_regs.registries();
     match elem {
         ResolvedTy::Bool
         | ResolvedTy::I8
@@ -1638,24 +1693,49 @@ pub(crate) fn cbor_vec_elem_kind(
         | ResolvedTy::F32
         | ResolvedTy::F64 => CborVecElemKind::Plain,
         ResolvedTy::String => CborVecElemKind::Str,
-        // Non-`Option` builtins (`Vec` / `HashMap` / `HashSet` / `Generator` /
-        // `Result` / `Range` / `Rc` / …) need the owned (thunk-bearing) Vec ABI
-        // the standalone codec cannot synthesise: fail closed. This preserves the
-        // retired `cbor_ty_owns_heap` walker's coarse `_ => true` builtin rule
-        // EXACTLY. The single authority's finer arg-recursion (which would admit
-        // a heap-free `Result<i64, i64>` as BitCopy) is intentionally NOT applied
-        // here: enabling those element shapes needs matching codec support and is
-        // deferred to a future consolidation, so reachable behaviour stays byte-identical.
+        // Non-`Option` builtins stay fail-closed. A nested collection element
+        // (`Vec<Vec<…>>`, `Vec<HashMap>`, `Vec<HashSet>`) would need the base
+        // language's recursive owned clone/drop thunk synthesis for a
+        // collection-of-collections, which is NOT implemented yet: the checker
+        // already rejects the analogous `Vec<record-with-a-collection-field>` with
+        // "recursive owned clone/drop thunk synthesis … not implemented yet", and a
+        // direct `Vec<Vec<string>>` (which the checker does not yet gate) aborts at
+        // runtime with a missing element-layout descriptor even OUTSIDE the codec.
+        // Admitting it here would emit codec code that runtime-panics rather than
+        // fails closed, so the codec keeps `Defer` until the base owned nested-Vec
+        // ABI lands. `HashMap`/`HashSet` values additionally have no
+        // `emit_ser_value_cbor` arm; every other builtin (`Generator` / `Result` /
+        // `Range` / `Rc` / …) has no codec support.
         ResolvedTy::Named {
             builtin: Some(b), ..
         } if !matches!(b, BuiltinType::Option) => CborVecElemKind::Defer,
-        // `Option<T>` and user record / enum elements: route the heap-ownership
-        // question through the single `hew_mir::ty_owns_heap` authority (was the
-        // parallel `cbor_ty_owns_heap` walker). A heap-owning element needs the
-        // owned (thunk-bearing) Vec ABI the standalone codec cannot synthesise →
-        // fail closed; a heap-free record/enum element is the layout-aware
-        // BitCopy vec `Vec::new` constructs (`hew_vec_new_with_layout`), so the
-        // codec MUST round-trip it through the layout-aware accessors.
+        // `Option<T>` element: a heap-free payload (`Option<i64>`) is the
+        // layout-aware BitCopy vec; a heap-owning payload (`Option<string>`) stays
+        // fail-closed. Option resolves an enum thunk key (it lowers to an enum),
+        // but its null-encoding + owned-element ABI is a distinct, unproven shape —
+        // out of scope for this floor, so it does NOT take the `Owned` path the
+        // user-record/enum arm below does.
+        ResolvedTy::Named {
+            builtin: Some(BuiltinType::Option),
+            ..
+        } => {
+            #[allow(deprecated)]
+            let owns_heap = cbor_ty_owns_heap(elem, pipeline_records, enum_layouts);
+            if owns_heap {
+                CborVecElemKind::Defer
+            } else {
+                CborVecElemKind::LayoutBitCopy
+            }
+        }
+        // User record / enum elements: route the heap-ownership question through
+        // the single `hew_mir::ty_owns_heap` authority (was the parallel
+        // `cbor_ty_owns_heap` walker). A heap-free record/enum element is the
+        // layout-aware BitCopy vec `Vec::new` constructs (`hew_vec_new_with_layout`).
+        // A heap-OWNING record/enum element takes the OWNED (thunk-bearing) Vec ABI
+        // — the same authority `Vec::new`'s `VecCtor::Owned` uses — provided it
+        // resolves an owned thunk key; a heap-owning element with no resolvable key
+        // (and every indirect enum, whose pointer ABI is a separate store family)
+        // stays fail-closed.
         ResolvedTy::Named { .. } => {
             // SEALED retired-walker seam: the sole sanctioned caller.
             #[allow(deprecated)]
@@ -1666,12 +1746,18 @@ pub(crate) fn cbor_vec_elem_kind(
             // element is nonetheless a heap-owned pointer — the `Vec` constructor
             // and the CBOR decoder both use pointer ABI for it — so fail closed
             // for any element that IS or transitively contains one, never
-            // BitCopying a heap-owned node.
+            // BitCopying (or owned-ABI-mishandling) a heap-owned node.
             let mut visiting = std::collections::HashSet::new();
             let contains_indirect_enum =
                 cbor_ty_contains_indirect_enum(elem, pipeline_records, enum_layouts, &mut visiting);
-            if owns_heap || contains_indirect_enum {
+            if contains_indirect_enum {
                 CborVecElemKind::Defer
+            } else if owns_heap {
+                if crate::thunks::owned_elem_thunk_key(regs, elem).is_some() {
+                    CborVecElemKind::Owned
+                } else {
+                    CborVecElemKind::Defer
+                }
             } else {
                 CborVecElemKind::LayoutBitCopy
             }
@@ -1739,14 +1825,16 @@ fn emit_ser_vec_cbor<'ctx>(
     enum_layouts: &[EnumLayout],
     target_data: &TargetData,
 ) -> CodegenResult<()> {
-    let kind = cbor_vec_elem_kind(elem_ty, pipeline_records, enum_layouts);
+    let kind = cbor_vec_elem_kind(elem_ty, pipeline_records, enum_layouts, machine_layouts);
     if kind == CborVecElemKind::Defer {
         return Err(CodegenError::FailClosed(format!(
-            "wire CBOR serialize: Vec<{elem_ty:?}> has an owned-compound element \
-             (bytes / heap-owning record / nested collection) outside the \
-             supported wire-body floor"
+            "wire CBOR serialize: Vec<{elem_ty:?}> has an element outside the \
+             supported wire-body floor (bytes / indirect enum / Option-with-heap / \
+             nested collection / HashMap or HashSet element / no resolvable owned \
+             thunk key)"
         )));
     }
+    let owned = kind == CborVecElemKind::Owned;
     let ptr_ty = ctx.ptr_type(AddressSpace::default());
     let void_ty = ctx.void_type();
     let i64_ty = ctx.i64_type();
@@ -1768,6 +1856,27 @@ fn emit_ser_vec_cbor<'ctx>(
     } else {
         None
     };
+
+    // An owned (heap-owning) element rides an OWNED vec
+    // (`ownership_kind = LayoutManaged`), whose slots are borrowed through
+    // `hew_vec_get_owned`. Build the owned descriptor via the SAME single
+    // authority `Vec::new` uses so the global dedup-collapses onto the
+    // constructor's (and it validates the element resolves an owned thunk key at
+    // encode too, symmetric with decode). The element is encoded in place from
+    // its borrowed slot exactly as the LayoutBitCopy arm does.
+    if owned {
+        let elem_llvm = resolve_ty(ctx, target_data, elem_ty, record_layouts)?;
+        let regs = cbor_owned_elem_registries(pipeline_records, enum_layouts, machine_layouts);
+        crate::layout::owned_elem_layout_descriptor_ptr(
+            ctx,
+            llvm_mod,
+            target_data,
+            regs.registries(),
+            elem_ty,
+            elem_llvm,
+            "wire_vec",
+        )?;
+    }
 
     let vec_ptr = builder
         .build_load(ptr_ty, value_ptr, "cbor_ser_vec_ptr")
@@ -1824,7 +1933,28 @@ fn emit_ser_vec_cbor<'ctx>(
         .llvm_ctx("cbor ser vec head br")?;
 
     builder.position_at_end(body_bb);
-    let elem_ptr = if let Some(layout_ptr) = layout_ptr {
+    let elem_ptr = if owned {
+        // Owned vec: borrow the element slot (`hew_vec_get_owned` returns the slot
+        // pointer without transferring ownership) and encode it in place. The
+        // slot's heap owners stay with the vec — the codec never frees them.
+        let get_owned = declare_codec_prim(
+            ctx,
+            llvm_mod,
+            "hew_vec_get_owned",
+            ptr_ty.fn_type(&[ptr_ty.into(), i64_ty.into()], false),
+        );
+        builder
+            .build_call(
+                get_owned,
+                &[vec_ptr.into(), i_cur.into()],
+                "cbor_ser_vec_get_owned",
+            )
+            .llvm_ctx("cbor ser vec get_owned")?
+            .try_as_basic_value()
+            .basic()
+            .ok_or_else(|| CodegenError::FailClosed("hew_vec_get_owned void".into()))?
+            .into_pointer_value()
+    } else if let Some(layout_ptr) = layout_ptr {
         let get_layout = declare_codec_prim(
             ctx,
             llvm_mod,
@@ -1917,14 +2047,16 @@ fn emit_de_vec_cbor<'ctx>(
     enum_layouts: &[EnumLayout],
     target_data: &TargetData,
 ) -> CodegenResult<()> {
-    let kind = cbor_vec_elem_kind(elem_ty, pipeline_records, enum_layouts);
+    let kind = cbor_vec_elem_kind(elem_ty, pipeline_records, enum_layouts, machine_layouts);
     if kind == CborVecElemKind::Defer {
         return Err(CodegenError::FailClosed(format!(
-            "wire CBOR deserialize: Vec<{elem_ty:?}> has an owned-compound element \
-             (bytes / heap-owning record / nested collection) outside the \
-             supported wire-body floor"
+            "wire CBOR deserialize: Vec<{elem_ty:?}> has an element outside the \
+             supported wire-body floor (bytes / indirect enum / Option-with-heap / \
+             nested collection / HashMap or HashSet element / no resolvable owned \
+             thunk key)"
         )));
     }
+    let owned = kind == CborVecElemKind::Owned;
     let ptr_ty = ctx.ptr_type(AddressSpace::default());
     let void_ty = ctx.void_type();
     let i64_ty = ctx.i64_type();
@@ -1941,6 +2073,28 @@ fn emit_de_vec_cbor<'ctx>(
             ctx,
             llvm_mod,
             target_data,
+            elem_llvm,
+            "wire_vec",
+        )?)
+    } else {
+        None
+    };
+
+    // A heap-owning element is reconstructed into an OWNED vec
+    // (`ownership_kind = LayoutManaged`), matching `Vec::new` → `VecCtor::Owned`,
+    // so element indexing and scope-exit `hew_vec_free` (which walks the per-
+    // element `drop_fn`) see the same ABI a directly-constructed `Vec<owned>`
+    // has. Built via the SAME single authority `Vec::new` uses, so the descriptor
+    // global dedup-collapses onto the constructor's.
+    let owned_layout_ptr = if owned {
+        let elem_llvm = resolve_ty(ctx, target_data, elem_ty, record_layouts)?;
+        let regs = cbor_owned_elem_registries(pipeline_records, enum_layouts, machine_layouts);
+        Some(crate::layout::owned_elem_layout_descriptor_ptr(
+            ctx,
+            llvm_mod,
+            target_data,
+            regs.registries(),
+            elem_ty,
             elem_llvm,
             "wire_vec",
         )?)
@@ -1996,6 +2150,30 @@ fn emit_de_vec_cbor<'ctx>(
                 .try_as_basic_value()
                 .basic()
                 .ok_or_else(|| CodegenError::FailClosed("hew_vec_new_with_layout void".into()))?
+                .into_pointer_value()
+        }
+        CborVecElemKind::Owned => {
+            let owned_layout_ptr = owned_layout_ptr.ok_or_else(|| {
+                CodegenError::FailClosed("owned Vec decode missing owned descriptor".into())
+            })?;
+            let new_owned = declare_codec_prim(
+                ctx,
+                llvm_mod,
+                "hew_vec_new_with_elem_layout",
+                ptr_ty.fn_type(&[ptr_ty.into()], false),
+            );
+            builder
+                .build_call(
+                    new_owned,
+                    &[owned_layout_ptr.into()],
+                    "cbor_de_vec_new_owned",
+                )
+                .llvm_ctx("cbor de vec new_with_elem_layout")?
+                .try_as_basic_value()
+                .basic()
+                .ok_or_else(|| {
+                    CodegenError::FailClosed("hew_vec_new_with_elem_layout void".into())
+                })?
                 .into_pointer_value()
         }
         CborVecElemKind::Defer => unreachable!("Defer handled above"),
@@ -2164,6 +2342,55 @@ fn emit_de_vec_cbor<'ctx>(
                     "cbor_de_vec_push_layout",
                 )
                 .llvm_ctx("cbor de vec push_layout")?;
+        }
+        CborVecElemKind::Owned => {
+            let elem_llvm = resolve_ty(ctx, target_data, elem_ty, record_layouts)?;
+            let temp = builder
+                .build_alloca(elem_llvm, "cbor_de_vec_elem_owned")
+                .llvm_ctx("cbor de vec owned elem alloca")?;
+            // Zero the slot BEFORE decoding so a fail-closed partial element is a
+            // defined value whose unwritten heap fields are null — the owned
+            // `drop_fn` short-circuits on null, giving exactly-once on the failure
+            // path.
+            builder
+                .build_store(temp, elem_llvm.const_zero())
+                .llvm_ctx("cbor de vec owned elem zero")?;
+            emit_de_value_cbor(
+                ctx,
+                llvm_mod,
+                builder,
+                func,
+                elem_ty,
+                temp,
+                reader,
+                wire_layouts,
+                record_layouts,
+                machine_layouts,
+                pipeline_records,
+                enum_layouts,
+                target_data,
+            )?;
+            // MOVE the decoded element into the vec UNCONDITIONALLY — including on
+            // a latched-failure iteration. `hew_vec_push_owned_move` byte-copies
+            // the temp's heap owners into the vec slot (the temp goes dead, no
+            // clone). On the failure path the thunk's `fail_bb` then frees the vec
+            // via `hew_vec_free`, whose owned drop walks `drop_fn` per element and
+            // short-circuits the zeroed-null partial fields — exactly-once on BOTH
+            // success and failure, with no separate temp drop (which would
+            // double-free the moved-out heap).
+            let push_owned = declare_codec_prim(
+                ctx,
+                llvm_mod,
+                "hew_vec_push_owned_move",
+                void_ty.fn_type(&[ptr_ty.into(), ptr_ty.into()], false),
+            );
+            builder
+                .build_call(
+                    push_owned,
+                    &[vec_ptr.into(), temp.into()],
+                    "cbor_de_vec_push_owned",
+                )
+                .llvm_ctx("cbor de vec push_owned_move")?;
         }
         CborVecElemKind::Defer => unreachable!("Defer handled above"),
     }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -42103,6 +42103,30 @@ fn string_field_load_producer_dest(instr: &Instr, locals: &[ResolvedTy]) -> Opti
     }
 }
 
+/// The dest of a wire-codec text serialize (`value.to_json()` / `value.to_yaml()`
+/// → `string`) — a fresh, solely-owned `string` the caller owes exactly one
+/// `hew_string_drop`. Discriminate by the DEST TYPE (`string`), not by direction:
+/// `ToJson`/`ToYaml` are the only text-serialize directions whose dest is a leaf
+/// `string` (`From*`'s dest is `Result<T, string>`, `Encode`'s is `bytes`,
+/// `Decode`'s is the value type). `Packet.from_json(p.to_json())` leaked the
+/// `to_json` temp before this admission.
+fn wire_codec_string_producer_dest(instr: &Instr, locals: &[ResolvedTy]) -> Option<Place> {
+    match instr {
+        Instr::WireCodec { dest, .. } if string_place_is_typed(*dest, locals) => Some(*dest),
+        _ => None,
+    }
+}
+
+/// `true` when `instr` is a wire-codec deserialize (`Type.from_json(s)` /
+/// `Type.from_yaml(s)`) whose `operand` BORROWS the leaf-`string` temp `t`:
+/// codegen's `lower_wire_codec_instr` loads the operand pointer to feed the text
+/// parser and never frees it (model.rs: "The `operand` is borrowed"). So a fresh
+/// `string` temp read only as a `from_json`/`from_yaml` operand keeps its single
+/// drop obligation and is released once, immediately after the parse.
+fn is_wire_codec_borrowing_string_use(instr: &Instr, t: u32) -> bool {
+    matches!(instr, Instr::WireCodec { operand, .. } if place_refs_local(*operand, t))
+}
+
 /// `true` when `instr` is a string comparison (`==`/`!=`/`<`/`<=`/`>`/`>=`)
 /// that **borrows** the leaf-`string` temp `t` as an operand. String compares
 /// lower to `Instr::IntCmp { pred, lhs, rhs }` (see `lower_binary`); codegen
@@ -42657,6 +42681,7 @@ fn collect_nested_fresh_string_temp_drops(
             // load is never seeded.
             if let Some(dest) = fresh_string_producer_dest(instr)
                 .or_else(|| string_field_load_producer_dest(instr, locals))
+                .or_else(|| wire_codec_string_producer_dest(instr, locals))
             {
                 if let Some(t) = base_local(dest) {
                     defs.push((
@@ -42798,6 +42823,7 @@ fn nested_fresh_string_temp_drop(
             let ub = *ub;
             let use_instr = block_by_id(blocks, ub)?.instructions.get(*ui)?;
             let borrowing_use = is_borrowing_string_cmp_instr(use_instr, t)
+                || is_wire_codec_borrowing_string_use(use_instr, t)
                 || (is_fresh_string_producer_def(def, blocks, locals, t)
                     && is_borrowing_string_concat_instr_use(use_instr, t));
             if !borrowing_use {
@@ -43055,16 +43081,16 @@ mod nested_fresh_string_temp_drop_admission {
     }
 
     #[test]
-    fn concat_temp_read_only_by_wire_from_json_is_not_discard_dropped() {
+    fn concat_temp_read_only_by_wire_from_json_gets_drop_after_the_parse() {
         // `Packet.from_json(a + b)`: the fresh concat temp's ONLY reader is
-        // `Instr::WireCodec` (FromJson operand) — a borrow-excluded read that
-        // `instr_source_places` hides. A source-places-based use table
-        // registered ZERO uses, took the discard branch, and spliced
-        // `hew_string_drop` immediately after the concat — the parse then read
-        // a freed buffer (silent wrong-result `Err`, while the named
-        // `let joined = a + b` sibling was correct). The reads-based table
-        // sees the WireCodec use-site; it is not an admissible borrowing use,
-        // so the temp fails CLOSED to the leak direction: NO drop is spliced.
+        // `Instr::WireCodec` (FromJson operand), a borrowing use — codegen loads
+        // the operand pointer to feed the text parser and never frees it. The
+        // temp keeps its single drop obligation past the parse, so it is released
+        // exactly once immediately AFTER the WireCodec (idx 2), never at the
+        // discard site (idx 1) before the parse reads it — that ordering is the
+        // UAF this collector must never produce. Before this admission the temp
+        // leaked one buffer per call (the confound the leak oracle worked around
+        // by naming `let raw = …`).
         let blocks = vec![block(
             0,
             vec![
@@ -43079,11 +43105,98 @@ mod nested_fresh_string_temp_drop_admission {
             Terminator::Return,
         )];
         let locals = locals_with(&[(5, user_record_ty())]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(0, 2, Place::Local(2), ResolvedTy::String)],
+            "a fresh string temp borrowed once by a from_json parse must be \
+             dropped exactly once immediately after the parse, never before it"
+        );
+    }
+
+    #[test]
+    fn to_json_temp_read_only_by_from_json_gets_drop_after_the_parse() {
+        // `Packet.from_json(p.to_json())`: `to_json` is a WireCodec text
+        // serialize producing a fresh `string`; `from_json` borrows it. The
+        // producer temp gains exactly one drop after the parse.
+        let blocks = vec![block(
+            0,
+            vec![
+                Instr::WireCodec {
+                    dest: Place::Local(2),
+                    operand: Place::Local(0),
+                    direction: hew_types::WireCodecDirection::ToJson,
+                    value_ty: user_record_ty(),
+                },
+                Instr::WireCodec {
+                    dest: Place::Local(5),
+                    operand: Place::Local(2),
+                    direction: hew_types::WireCodecDirection::FromJson,
+                    value_ty: user_record_ty(),
+                },
+            ],
+            Terminator::Return,
+        )];
+        let locals = locals_with(&[(0, user_record_ty()), (5, user_record_ty())]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(0, 2, Place::Local(2), ResolvedTy::String)],
+            "the to_json temp is a fresh owned string borrowed once by from_json; \
+             it must be dropped once immediately after the parse"
+        );
+    }
+
+    #[test]
+    fn discarded_to_json_temp_dropped_right_after_producer() {
+        // `p.to_json();` — a discarded text-serialize temp (zero uses) drops
+        // immediately after the producer instruction.
+        let blocks = vec![block(
+            0,
+            vec![Instr::WireCodec {
+                dest: Place::Local(2),
+                operand: Place::Local(0),
+                direction: hew_types::WireCodecDirection::ToJson,
+                value_ty: user_record_ty(),
+            }],
+            Terminator::Return,
+        )];
+        let locals = locals_with(&[(0, user_record_ty())]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(0, 1, Place::Local(2), ResolvedTy::String)],
+            "a discarded to_json string temp is dropped right after its producer"
+        );
+    }
+
+    #[test]
+    fn named_to_json_binding_stays_out_of_string_collector() {
+        // `let s = p.to_json(); Packet.from_json(s)` — the to_json result is a
+        // binding local, released by scope-exit derivation; the bare-temp
+        // collector must not double-claim it.
+        let blocks = vec![block(
+            0,
+            vec![
+                Instr::WireCodec {
+                    dest: Place::Local(2),
+                    operand: Place::Local(0),
+                    direction: hew_types::WireCodecDirection::ToJson,
+                    value_ty: user_record_ty(),
+                },
+                Instr::WireCodec {
+                    dest: Place::Local(5),
+                    operand: Place::Local(2),
+                    direction: hew_types::WireCodecDirection::FromJson,
+                    value_ty: user_record_ty(),
+                },
+            ],
+            Terminator::Return,
+        )];
+        let locals = locals_with(&[(0, user_record_ty()), (5, user_record_ty())]);
+        let binding_locals: HashMap<BindingId, Place> =
+            [(BindingId(2), Place::Local(2))].into_iter().collect();
         assert!(
-            collect(&blocks, &locals, &HashMap::new()).is_empty(),
-            "a string temp whose only reader is a WireCodec parse must not take \
-             the discard drop — an immediate post-producer hew_string_drop \
-             would free the buffer before the parse reads it"
+            collect(&blocks, &locals, &binding_locals).is_empty(),
+            "a to_json result bound to a let belongs to scope-exit drop \
+             derivation, not the bare-temp collector"
         );
     }
 
@@ -43476,6 +43589,15 @@ fn fresh_bytes_producer_instr_dest(instr: &Instr) -> Option<Place> {
         {
             call.dest()
         }
+        // A wire-codec serialize hands the caller a fresh, solely-owned CBOR
+        // buffer (`value.encode() -> bytes`, rc==1, one `hew_bytes_drop` owed).
+        // Discriminate by the DEST TYPE at the caller's `bytes_place_is_typed`
+        // gate rather than by direction: `Encode` is the only direction whose
+        // dest is `bytes` (`Decode`'s dest is the value type, `ToJson`/`ToYaml`'s
+        // is `string`, `From*`'s is `Result`), so a bytes-typed WireCodec dest is
+        // exactly the fresh-owned CBOR temp. `Packet.decode(p.encode())` /
+        // `p.encode();` leaked this buffer before this admission.
+        Instr::WireCodec { dest, .. } => Some(*dest),
         _ => None,
     }
 }
@@ -43655,6 +43777,14 @@ fn bytes_temp_instr_use_is_borrow_only(instr: &Instr, t: u32) -> bool {
         Instr::CallRuntimeAbi(call) => {
             bytes_temp_call_use_is_borrow_only(call.symbol(), call.args(), t)
         }
+        // A wire-codec deserialize BORROWS its `operand` bytes: codegen's
+        // `lower_wire_codec_instr` loads the operand pointer to feed
+        // `__hew_deserialize_<key>(data, len, ..)` and never frees it (model.rs:
+        // "The `operand` is borrowed"). So a fresh bytes temp read only as a
+        // decode operand keeps its single drop obligation and is released once
+        // here, immediately after the decode. `Packet.decode(mk())` /
+        // `Packet.decode(p.encode())` leaked the operand before this admission.
+        Instr::WireCodec { operand, .. } => place_refs_local(*operand, t),
         _ => false,
     }
 }
@@ -44123,16 +44253,16 @@ mod nested_fresh_bytes_temp_drop_admission {
     }
 
     #[test]
-    fn usercall_result_read_only_by_wire_decode_is_not_discard_dropped() {
+    fn usercall_result_read_only_by_wire_decode_gets_drop_after_the_decode() {
         // `Packet.decode(mk())`: the fresh bytes temp's ONLY reader is
-        // `Instr::WireCodec` (decode operand). `instr_source_places` deliberately
-        // excludes that read (a borrow-exclusion so NAMED bindings keep their
-        // scope-exit drop) — a source-places-based use table would register ZERO
-        // uses, take the discard branch, and splice `hew_bytes_drop` at the
-        // front of the continuation BEFORE the decode reads the buffer (the
-        // reproduced use-after-free). The reads-based table sees the WireCodec
-        // use-site; it is not an admissible borrowing bytes runtime op, so the
-        // temp fails CLOSED to the leak direction: NO drop is spliced.
+        // `Instr::WireCodec` (decode operand), a borrowing use — codegen loads
+        // the operand pointer to feed `__hew_deserialize_<key>` and never frees
+        // it. The temp keeps its single drop obligation past the decode, so it is
+        // released exactly once immediately AFTER the WireCodec (front of the
+        // single-predecessor continuation, at idx 1), never at a discard site
+        // before the decode reads the buffer — that ordering would be the
+        // use-after-free this collector must never produce. Before this admission
+        // the temp leaked one CBOR buffer per call.
         let blocks = vec![
             block(0, vec![], user_call("mk", 2, 1)),
             block(
@@ -44147,11 +44277,106 @@ mod nested_fresh_bytes_temp_drop_admission {
             ),
         ];
         let locals = bytes_locals_with(&[(5, ResolvedTy::named_user("Packet", vec![]))]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(1, 1, Place::Local(2), ResolvedTy::Bytes)],
+            "a bytes temp borrowed once by a WireCodec decode must be dropped \
+             exactly once immediately after the decode, never before it"
+        );
+    }
+
+    #[test]
+    fn encode_then_decode_anonymous_temp_gets_drop_after_the_decode() {
+        // `Packet.decode(p.encode())`: `p.encode()` is a WireCodec serialize
+        // producing a fresh CBOR bytes temp (_2), immediately borrowed as the
+        // `Packet.decode(_2)` operand in the SAME block. The temp is released once
+        // right after the decode instruction (idx 2). This is the anonymous
+        // round-trip shape the leak oracle measures at exact-zero.
+        let blocks = vec![block(
+            0,
+            vec![
+                Instr::WireCodec {
+                    dest: Place::Local(2),
+                    operand: Place::Local(0),
+                    direction: hew_types::WireCodecDirection::Encode,
+                    value_ty: ResolvedTy::named_user("Packet", vec![]),
+                },
+                Instr::WireCodec {
+                    dest: Place::Local(5),
+                    operand: Place::Local(2),
+                    direction: hew_types::WireCodecDirection::Decode,
+                    value_ty: ResolvedTy::named_user("Packet", vec![]),
+                },
+            ],
+            Terminator::Return,
+        )];
+        let locals = bytes_locals_with(&[
+            (0, ResolvedTy::named_user("Packet", vec![])),
+            (5, ResolvedTy::named_user("Packet", vec![])),
+        ]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(0, 2, Place::Local(2), ResolvedTy::Bytes)],
+            "the encode temp is a fresh owned CBOR buffer borrowed once by decode; \
+             it must be dropped once immediately after the decode"
+        );
+    }
+
+    #[test]
+    fn discarded_encode_temp_dropped_right_after_producer() {
+        // `p.encode();` — a discarded WireCodec serialize temp (zero uses) drops
+        // immediately after the producer instruction (straight-line).
+        let blocks = vec![block(
+            0,
+            vec![Instr::WireCodec {
+                dest: Place::Local(2),
+                operand: Place::Local(0),
+                direction: hew_types::WireCodecDirection::Encode,
+                value_ty: ResolvedTy::named_user("Packet", vec![]),
+            }],
+            Terminator::Return,
+        )];
+        let locals = bytes_locals_with(&[(0, ResolvedTy::named_user("Packet", vec![]))]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(0, 1, Place::Local(2), ResolvedTy::Bytes)],
+            "a discarded encode CBOR temp is dropped right after its producer"
+        );
+    }
+
+    #[test]
+    fn named_encode_binding_stays_out_of_bytes_collector() {
+        // `let raw = p.encode(); Packet.decode(raw)` — the encode result is a
+        // binding local, released by the scope-exit `derive_local_bytes_drop_allowed`
+        // path; the bare-temp collector must not double-claim it.
+        let blocks = vec![block(
+            0,
+            vec![
+                Instr::WireCodec {
+                    dest: Place::Local(2),
+                    operand: Place::Local(0),
+                    direction: hew_types::WireCodecDirection::Encode,
+                    value_ty: ResolvedTy::named_user("Packet", vec![]),
+                },
+                Instr::WireCodec {
+                    dest: Place::Local(5),
+                    operand: Place::Local(2),
+                    direction: hew_types::WireCodecDirection::Decode,
+                    value_ty: ResolvedTy::named_user("Packet", vec![]),
+                },
+            ],
+            Terminator::Return,
+        )];
+        let locals = bytes_locals_with(&[
+            (0, ResolvedTy::named_user("Packet", vec![])),
+            (5, ResolvedTy::named_user("Packet", vec![])),
+        ]);
+        let binding_locals: HashMap<BindingId, Place> =
+            [(BindingId(2), Place::Local(2))].into_iter().collect();
         assert!(
-            collect(&blocks, &locals, &HashMap::new()).is_empty(),
-            "a bytes temp whose only reader is a WireCodec decode must not take \
-             the discard drop — a front-of-continuation hew_bytes_drop would free \
-             the buffer before the decode reads it (use-after-free)"
+            collect(&blocks, &locals, &binding_locals).is_empty(),
+            "a named `let raw = p.encode()` binding is released by scope-exit \
+             derivation, not the bare-temp collector"
         );
     }
 

--- a/tests/vertical-slice/accept/wire_cbor_vec_owned_decode_only.hew
+++ b/tests/vertical-slice/accept/wire_cbor_vec_owned_decode_only.hew
@@ -1,0 +1,24 @@
+// Validation: the decode-only owned-Vec-element seeding path. `main` NEVER
+// constructs a `Vec<Item>` local — it only decodes `Batch` from bytes produced
+// by a helper. The decode-side owned descriptor references
+// `__hew_record_drop_inplace_Item`; that thunk body is seeded by walking the
+// wire value type's LAYOUT (`collect_wire_value_owned_vec_element_seeds`), not
+// by scanning MIR locals. Without that seed the thunk would be
+// declared-but-undefined and LLVM verify would reject the module. Exit 11 proves
+// the decode-only program links and round-trips.
+#[wire]
+type Item { name: string @1; }
+#[wire]
+type Batch { items: Vec<Item> @1; seq: i64 @2; }
+
+fn source_bytes() -> bytes {
+    let xs: Vec<Item> = Vec::new();
+    xs.push(Item { name: "seeded-element" });
+    let b = Batch { items: xs, seq: 11 };
+    b.encode()
+}
+
+fn main() -> i64 {
+    let back = Batch.decode(source_bytes());
+    back.seq
+}

--- a/tests/vertical-slice/accept/wire_cbor_vec_owned_enum.hew
+++ b/tests/vertical-slice/accept/wire_cbor_vec_owned_enum.hew
@@ -1,0 +1,30 @@
+// Validation: a `Vec<#[wire] enum>` whose ELEMENT is an owned-payload enum
+// (a `string`-bearing variant) round-trips through the CBOR body codec on the
+// OWNED vec ABI. The enum element's clone/drop route through
+// `__hew_enum_{clone,drop}_inplace_<Payload>`, seeded via the owned descriptor,
+// so `hew_vec_free` releases each decoded variant's owned string. Exit 2 (the
+// count of `Full` payloads) proves the array round-trips with the right shape.
+#[wire]
+enum Payload { Empty; Full(string); }
+#[wire]
+type Bag { items: Vec<Payload> @1; n: i64 @2; }
+
+fn main() -> i64 {
+    let xs: Vec<Payload> = Vec::new();
+    xs.push(Payload::Full("first-owned"));
+    xs.push(Payload::Empty);
+    xs.push(Payload::Full("second-owned"));
+    let b = Bag { items: xs, n: 3 };
+    let back = Bag.decode(b.encode());
+    if back.items.len() != 3 { return 100; }
+    var full: i64 = 0;
+    var i: i64 = 0;
+    while i < 3 {
+        match back.items[i] {
+            Payload::Full(_) => { full = full + 1; }
+            Payload::Empty => {}
+        }
+        i = i + 1;
+    }
+    full
+}

--- a/tests/vertical-slice/accept/wire_cbor_vec_owned_struct.hew
+++ b/tests/vertical-slice/accept/wire_cbor_vec_owned_struct.hew
@@ -1,0 +1,21 @@
+// Validation: a `Vec<#[wire] struct>` whose ELEMENT owns heap (a `string`
+// field) round-trips through the CBOR body codec. The element vec is an OWNED
+// vec (`ownership_kind = LayoutManaged`) — the same ABI `Vec::new` builds for a
+// `Vec<owned>` — so the codec reads slots with `hew_vec_get_owned` on encode and
+// reconstructs via `hew_vec_new_with_elem_layout` + `hew_vec_push_owned_move` on
+// decode. The decoded elements' owned strings are released by the vec's per-
+// element `drop_fn`. Exit 7 (the scalar `seq`) proves the round-trip; the
+// element strings are verified by the leak oracle's no-per-frame-leak slope.
+#[wire]
+type Item { name: string @1; }
+#[wire]
+type Batch { items: Vec<Item> @1; seq: i64 @2; }
+
+fn main() -> i64 {
+    let xs: Vec<Item> = Vec::new();
+    xs.push(Item { name: "alpha-owned" });
+    xs.push(Item { name: "beta-owned" });
+    let b = Batch { items: xs, seq: 7 };
+    let back = Batch.decode(b.encode());
+    back.seq
+}

--- a/tests/vertical-slice/reject/wire_cbor_vec_nested_rejected.hew
+++ b/tests/vertical-slice/reject/wire_cbor_vec_nested_rejected.hew
@@ -1,0 +1,21 @@
+// Reject: a `Vec` whose element is itself a heap-owning collection
+// (`Vec<Vec<string>>`) is outside the supported wire-body floor. Heap-owning
+// record / enum elements ride the owned Vec ABI, but an owned Vec OF collections
+// needs the base language's recursive owned clone/drop thunk synthesis, which is
+// not implemented yet: a direct `Vec<Vec<string>>` aborts at runtime with a
+// missing element-layout descriptor even outside the codec, and the checker
+// already rejects the analogous `Vec<record-with-a-collection-field>`. The CBOR
+// codec fails closed at codegen-front validation rather than emitting an element
+// codec that would runtime-panic on the owned nested-Vec ABI.
+#[wire]
+type Grid {
+    rows: Vec<Vec<string>> @1,
+    n: i64 @2,
+}
+
+fn main() -> i64 {
+    let rows: Vec<Vec<string>> = Vec::new();
+    let g = Grid { rows: rows, n: 5 };
+    let back = Grid.decode(g.encode());
+    back.n
+}

--- a/tests/vertical-slice/reject/wire_cbor_vec_owned_compound_rejected.hew
+++ b/tests/vertical-slice/reject/wire_cbor_vec_owned_compound_rejected.hew
@@ -1,20 +1,18 @@
-// Reject: a `Vec` whose element owns heap (here a nested `#[wire]` struct with a
-// `string` field) is outside the supported wire-body floor. The CBOR codec
-// fails closed at codegen-front validation rather than emitting an element
-// codec that could leak or mis-free the owned element heap on a malformed
-// decode. Scalar and heap-free-record `Vec` elements are supported.
-#[wire]
-type Inner {
-    name: string @1,
-}
-
+// Reject: a `Vec` whose element is an `Option` with a heap-owning payload
+// (`Option<string>`) is outside the supported wire-body floor. Heap-owning
+// record / enum / nested-collection elements now ride the owned Vec ABI, but the
+// `Option` null-encoding combined with an owned-element backing store is a
+// distinct, unproven shape — the CBOR codec fails closed at codegen-front
+// validation rather than emitting an element codec that could mis-free the owned
+// payload on a malformed decode. (bytes, indirect-enum, and HashMap/HashSet
+// elements remain rejected the same way.)
 #[wire]
 type Holder {
-    xs: Vec<Inner> @1,
+    xs: Vec<Option<string>> @1,
 }
 
 fn main() -> i64 {
-    let xs: Vec<Inner> = Vec::new();
+    let xs: Vec<Option<string>> = Vec::new();
     let h = Holder { xs: xs };
     let back = Holder.decode(h.encode());
     back.xs.len()

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4493,6 +4493,11 @@ run_accept_expect_status "wire_cbor_option_none" 42
 run_accept_expect_status "wire_cbor_vec_int" 42
 run_accept_expect_status "wire_cbor_vec_struct" 42
 run_accept_expect_status "wire_cbor_vec_string" 42
+# Owned-element Vec bodies (heap-owning record / enum) ride the owned Vec ABI
+# through the CBOR codec.
+run_accept_expect_status "wire_cbor_vec_owned_struct" 7
+run_accept_expect_status "wire_cbor_vec_owned_enum" 2
+run_accept_expect_status "wire_cbor_vec_owned_decode_only" 11
 run_accept_expect_status "wire_cbor_empty_collections" 42
 run_accept_expect_status "wire_cbor_nested_struct" 42
 run_accept_expect_status "wire_cbor_enum_unit" 42
@@ -4527,8 +4532,12 @@ expect_check_fail_contains \
     "wire_cbor_option_option_rejected"
 expect_check_fail_contains \
     "${ROOT}/tests/vertical-slice/reject/wire_cbor_vec_owned_compound_rejected.hew" \
-    "owned-compound element" \
+    "outside the supported wire-body floor" \
     "wire_cbor_vec_owned_compound_rejected"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/wire_cbor_vec_nested_rejected.hew" \
+    "outside the supported wire-body floor" \
+    "wire_cbor_vec_nested_rejected"
 
 # ---------------------------------------------------------------------------
 # Reserved-name shadowing.


### PR DESCRIPTION
## Summary

`Vec` elements that own heap data — records and enums with string or other heap-bearing fields — now round-trip through the CBOR codec. They are routed through the owned, thunk-bearing `Vec` ABI so each element's heap payload is decoded, pushed, and reclaimed through a single layout authority. Anonymous fresh temporaries minted by the codec (an intermediate encode/decode value that was never bound to a name) are now released instead of leaked. On a mid-decode failure the partially built `Vec` is freed exactly once — no element is double-freed, and no element is left unfreed.

## Verification

- Full workspace `cargo nextest`: 11588 passed
- Vertical-slice oracle suite: 473 passed
- ll-diff golden gate: byte-identical
- Wire leak oracle (`wire_cbor_codec_leak_oracle`): 13/13, including two decode-failure oracles that fail if the partial-free drop is removed and pass when it is restored
- Union / ownership oracles: if-let 8/8, let-else 5/5, channel-send element oracles 13/13
- Accept fixtures round-trip: owned-record `Vec`, owned-enum `Vec`, and decode-only paths all produce their expected exit values

## Out of scope

- `Vec<bytes>` and nested-collection wire elements (for example `Vec<Vec<string>>`) are deliberately not admitted here. They fail closed at codegen-front with an honest "outside the supported wire-body floor" diagnostic rather than emitting a codec path that would abort at runtime. First-class collection elements are handled by the collections wire work.
