### PR TITLE
fix(build): pass sanitizer suppressions by a space-free path (#1889)

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -52,7 +52,14 @@ jobs:
           CARGO_TARGET_DIR: target/sanitizer-runtime-asan
           RUSTFLAGS: -Zsanitizer=address -Cforce-frame-pointers=yes -Cunsafe-allow-abi-mismatch=sanitizer
           ASAN_OPTIONS: detect_leaks=1
-          LSAN_OPTIONS: suppressions=${{ github.workspace }}/hew-runtime/lsan.supp
+          # Bare relative filename, not an absolute ${{ github.workspace }} path:
+          # cargo runs the -p hew-runtime test binary with cwd = hew-runtime/, so
+          # `suppressions=lsan.supp` resolves to hew-runtime/lsan.supp without
+          # embedding the runner's workspace path. A workspace whose absolute
+          # path contains a space (self-hosted runner under /Volumes/Extreme SSD/
+          # ...) would otherwise make the sanitizer parse the space as a
+          # key=value separator and abort with "expected '=' in LSAN_OPTIONS".
+          LSAN_OPTIONS: suppressions=lsan.supp
           ASAN_SYMBOLIZER_PATH: /usr/lib/llvm-${{ env.LLVM_VERSION }}/bin/llvm-symbolizer
         run: |
           # -Cunsafe-allow-abi-mismatch=sanitizer silences the hard ABI-mismatch

--- a/Makefile
+++ b/Makefile
@@ -982,12 +982,20 @@ check-sanitizer-gate:
 # NOTE: GNU make $(sort) is lexicographic, so llvm-9 would rank after llvm-17.
 # Use a shell pipeline with sort -V (version-aware) to find the newest copy.
 ASAN_SYMBOLIZER ?= $(shell ls /usr/lib/llvm-*/bin/llvm-symbolizer 2>/dev/null | sort -V | tail -1)
+# NOTE: the suppressions path is passed RELATIVE, not absolute. The sanitizer
+# runtime parses [LA]SAN_OPTIONS as a space-tolerant key=value:key=value list and
+# treats an embedded space as a separator, so an absolute worktree path
+# containing a space (e.g. /Volumes/Extreme SSD/...) aborts before any test runs
+# with "expected '=' in LSAN_OPTIONS" (hew-lang/hew#1889). cargo runs the
+# hew-runtime test binary with cwd = the package dir (hew-runtime/), so the bare
+# filename `lsan.supp` resolves correctly and never contains a space regardless
+# of the absolute worktree location.
 asan:
 	CARGO_TARGET_DIR=$(RUNTIME_ASAN_TARGET_DIR) \
 	RUSTFLAGS="-Zsanitizer=address -Cforce-frame-pointers=yes" \
 	ASAN_OPTIONS="detect_leaks=1" \
 	ASAN_SYMBOLIZER_PATH=$(ASAN_SYMBOLIZER) \
-	LSAN_OPTIONS="suppressions=$(CURDIR)/hew-runtime/lsan.supp" \
+	LSAN_OPTIONS="suppressions=lsan.supp" \
 	cargo +nightly test --target $(SANITIZER_RUST_TARGET) -p hew-runtime --lib -- --test-threads=1
 
 # ASan gate for compiled .hew fixture binaries (Linux/nightly toolchain required).
@@ -1022,7 +1030,7 @@ ifeq ($(shell uname -sm),Darwin arm64)
 else
 	CARGO_TARGET_DIR=$(RUNTIME_TSAN_TARGET_DIR) \
 	RUSTFLAGS="-Zsanitizer=thread -Cforce-frame-pointers=yes -Cunsafe-allow-abi-mismatch=sanitizer" \
-	TSAN_OPTIONS="halt_on_error=0 suppressions=$(CURDIR)/hew-runtime/tsan.supp" \
+	TSAN_OPTIONS="halt_on_error=0 suppressions=tsan.supp" \
 	cargo +nightly test \
 		--target $(SANITIZER_RUST_TARGET) \
 		-p hew-runtime \

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -115,6 +115,26 @@ ASAN_FIXTURE_TARGET_DIR="${ROOT}/target/sanitizer-fixture-asan"
 WORK_DIR="${ROOT}/.tmp/asan-fixture-out"
 mkdir -p "${WORK_DIR}"
 
+# ── Suppressions staging (hew-lang/hew#1889) ──────────────────────────────
+# The sanitizer runtime parses [LA]SAN_OPTIONS as a space-tolerant
+# key=value:key=value list, so a space inside the suppressions path value
+# (e.g. a worktree on /Volumes/Extreme SSD/...) makes it expect a new
+# key=value and abort with "expected '=' in LSAN_OPTIONS" before any fixture
+# runs. Stage lsan.supp into a mktemp dir (TMPDIR is conventionally space-free
+# on both Linux and macOS) so the value we pass never contains a space,
+# regardless of the absolute worktree location.
+SUPP_STAGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/hew-asan-supp.XXXXXX")"
+cleanup_supp_stage() { rm -rf "${SUPP_STAGE_DIR}"; }
+trap cleanup_supp_stage EXIT
+cp "${ROOT}/hew-runtime/lsan.supp" "${SUPP_STAGE_DIR}/lsan.supp"
+LSAN_SUPP="${SUPP_STAGE_DIR}/lsan.supp"
+if printf '%s' "${LSAN_SUPP}" | grep -q ' '; then
+  echo "asan-fixture-check: staged suppressions path still contains a space:" >&2
+  echo "  ${LSAN_SUPP}" >&2
+  echo "  set TMPDIR to a space-free directory and re-run." >&2
+  exit 1
+fi
+
 # ── Step 1: build ASan-instrumented hew + libhew.a ───────────────────────
 # Build with -Zsanitizer=address so the runtime's malloc/free paths are
 # instrumented.  The resulting hew binary and libhew.a live in the same
@@ -220,7 +240,7 @@ run_asan_fixture() {
 
   ASAN_OPTIONS="detect_leaks=1:log_path=${log_prefix}" \
   ASAN_SYMBOLIZER_PATH="${ASAN_SYMBOLIZER_PATH}" \
-  LSAN_OPTIONS="suppressions=${ROOT}/hew-runtime/lsan.supp" \
+  LSAN_OPTIONS="suppressions=${LSAN_SUPP}" \
   HEW_WORKERS=1 \
     "${bin}" >/dev/null 2>/dev/null || actual_exit=$?
 


### PR DESCRIPTION
## Problem

`make asan`/`make tsan` and `scripts/asan-fixture-check.sh` build the suppressions option value from the **absolute** worktree path:

```make
LSAN_OPTIONS="suppressions=$(CURDIR)/hew-runtime/lsan.supp"
```

The sanitizer runtime parses `[LA]SAN_OPTIONS`/`TSAN_OPTIONS` as a space-tolerant `key=value:key=value` list and treats an embedded space as a separator. A worktree on a spaced volume (e.g. `/Volumes/Extreme SSD/...`) therefore aborts before any test runs with `expected '=' in LSAN_OPTIONS` (SIGABRT). Shell quoting can't help — the space is inside the value. The sanitizer never runs, so it masquerades as a memory error. (Fixes #1889.)

## Fix

- **Makefile `asan`/`tsan`:** cargo runs the `hew-runtime` test binary with cwd = the package dir (`hew-runtime/`), verified empirically, so the value becomes the bare relative filename `lsan.supp` / `tsan.supp` — never contains a space regardless of the absolute worktree location.
  - Note: the issue's suggested value `hew-runtime/lsan.supp` would double-prefix to `hew-runtime/hew-runtime/lsan.supp` under that cwd and fail to read; the bare filename is the correct relative value.
- **`asan-fixture-check.sh`:** runs the compiled fixture binaries from the (possibly spaced) `ROOT` cwd, so a bare filename wouldn't resolve there. Instead it stages `lsan.supp` into a `mktemp` dir under `TMPDIR` (conventionally space-free on Linux and macOS), guards that the staged path is space-free, and cleans it up on `EXIT`.

## Verification

- Empirically confirmed cargo runs the `hew-runtime` test binary with cwd = `hew-runtime/` (so the bare relative filename resolves).
- Reproduced the exact `expected '=' in LSAN_OPTIONS` abort with an absolute spaced path against a standalone ASan leak binary; confirmed both the relative (Makefile) and staged (script) space-free paths parse cleanly and the suppression fires (`Suppressions used: 1`).
- Swept the Makefile + scripts for any remaining absolute-path option construction — only these two sites existed.
- `bash -n scripts/asan-fixture-check.sh` passes.

Harness-only change; no product/runtime/ABI surface touched.