### PR TITLE
feat(types): add build-time stdlib authority loader

### DIFF
--- a/hew-hir/src/builtin_type_classes.rs
+++ b/hew-hir/src/builtin_type_classes.rs
@@ -1,3 +1,16 @@
+//! Lane 0 authority inventory verdicts.
+//!
+//! This table is **C (shrink)**: HIR must seed compiler-known substrate
+//! representation/ownership classes before user declarations are available.
+//! Later lanes can remove stdlib-defined error/data rows as attributed `.hew`
+//! declarations become authoritative, but handle-family ABI/drop anchors remain
+//! irreducible.
+//!
+//! `instant` is also **C**, primitive-level like `duration`: it is an i64-backed
+//! `BuiltinType`, erases to `ResolvedTy::I64`, has dedicated duration/instant
+//! operator typing, uses the i64 Vec element ABI, and has explicit MIR ownership
+//! and LLVM representation arms. It therefore stays out of Lane 6 relocation.
+
 use hew_types::builtin_type::{
     BuiltinHandleFamily, BuiltinType, BuiltinTypeMarker, BuiltinTypeRole as BuiltinRegistrationRole,
 };

--- a/hew-hir/src/lib.rs
+++ b/hew-hir/src/lib.rs
@@ -20,6 +20,7 @@ pub mod verify;
 
 pub use diagnostic::{HirDiagnostic, HirDiagnosticKind, ImportedItemKind};
 pub use dump::dump_hir;
+pub use hew_types::stdlib_authority;
 pub use ids::{BindingId, HirNodeId, ItemId, ResolvedRef, ScopeId, SiteId};
 pub use intent::IntentKind;
 pub use layout_mono::run_layout_mono_pass;

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -981,6 +981,9 @@ pub struct TypeDecl {
     /// Populated by the parser; used by the type checker to validate ownership rules.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub consuming_methods: Vec<String>,
+    /// Lang-item key from `#[lang_item("key")]`, if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lang_item: Option<String>,
 }
 
 impl ResourceMarker {

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -430,6 +430,12 @@ impl<'a> Formatter<'a> {
             self.write_indent();
             self.write("#[opaque]\n");
         }
+        if let Some(lang_item) = &decl.lang_item {
+            self.write_indent();
+            self.write("#[lang_item(\"");
+            self.write(lang_item);
+            self.write("\")]\n");
+        }
         self.write_indent();
         self.write_visibility(decl.visibility);
         if decl.is_indirect {
@@ -541,6 +547,12 @@ impl<'a> Formatter<'a> {
     }
 
     fn format_wire_type_decl(&mut self, decl: &TypeDecl, wire: &WireMetadata) {
+        if let Some(lang_item) = &decl.lang_item {
+            self.write_indent();
+            self.write("#[lang_item(\"");
+            self.write(lang_item);
+            self.write("\")]\n");
+        }
         // Emit type-level naming attributes
         self.format_naming_attr("json", wire.json_case);
         self.format_naming_attr("yaml", wire.yaml_case);

--- a/hew-parser/src/parser/items.rs
+++ b/hew-parser/src/parser/items.rs
@@ -136,13 +136,59 @@ impl Parser<'_> {
             let end = self
                 .expect(&Token::RightBracket)
                 .map_or_else(|| self.peek_span().start, |span| span.end);
-            attrs.push(Attribute {
+            let attr = Attribute {
                 name,
                 args,
                 span: start..end,
-            });
+            };
+            self.validate_authority_attribute_shape(&attr);
+            attrs.push(attr);
         }
         attrs
+    }
+
+    fn validate_authority_attribute_shape(&mut self, attr: &Attribute) {
+        match attr.name.as_str() {
+            "lang_item" | "intrinsic" | "diagnostic_item" => {
+                if !matches!(attr.args.as_slice(), [AttributeArg::Positional(value)] if !value.is_empty())
+                {
+                    self.error_at(
+                        format!(
+                            "`#[{}]` requires exactly one string key, for example \
+                             `#[{}(\"key\")]`",
+                            attr.name, attr.name
+                        ),
+                        attr.span.clone(),
+                    );
+                }
+            }
+            "abi" => {
+                if attr.args.is_empty()
+                    || attr
+                        .args
+                        .iter()
+                        .any(|arg| !matches!(arg, AttributeArg::KeyValue { .. }))
+                {
+                    self.error_at(
+                        "`#[abi]` requires one or more `key = value` arguments".to_string(),
+                        attr.span.clone(),
+                    );
+                }
+
+                let mut seen = std::collections::HashSet::new();
+                for arg in &attr.args {
+                    if let AttributeArg::KeyValue { key, .. } = arg {
+                        if !seen.insert(key.as_str()) {
+                            self.error_at(
+                                format!("duplicate `#[abi]` key `{key}`"),
+                                attr.span.clone(),
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
     /// Parse a visibility modifier.
@@ -314,7 +360,7 @@ impl Parser<'_> {
                         self.parse_fn_with_modifiers(vis, attrs, &doc_comment)?
                     }
                     Some(Token::Indirect) => {
-                        let mut t = self.parse_indirect_enum(vis)?;
+                        let mut t = self.parse_indirect_enum(vis, &attrs)?;
                         t.doc_comment = doc_comment;
                         Item::TypeDecl(t)
                     }
@@ -388,7 +434,7 @@ impl Parser<'_> {
                 self.parse_fn_with_modifiers(Visibility::Private, attrs, &doc_comment)?
             }
             Some(Token::Indirect) => {
-                let mut t = self.parse_indirect_enum(Visibility::Private)?;
+                let mut t = self.parse_indirect_enum(Visibility::Private, &attrs)?;
                 t.doc_comment = doc_comment;
                 Item::TypeDecl(t)
             }
@@ -689,6 +735,10 @@ impl Parser<'_> {
         // post-body (must be an empty-body struct). Representation axis —
         // orthogonal to the `resource_marker` ownership axis.
         let is_opaque = attrs.iter().any(|a| a.name == "opaque");
+        let lang_item = attrs
+            .iter()
+            .find(|a| a.name == "lang_item")
+            .and_then(|a| a.args.first().map(|arg| arg.as_str().to_string()));
 
         let kind = match self.peek() {
             Some(Token::Type) => {
@@ -760,6 +810,7 @@ impl Parser<'_> {
             resource_marker,
             is_opaque,
             consuming_methods,
+            lang_item,
         })
     }
 
@@ -914,6 +965,7 @@ impl Parser<'_> {
             "yaml",
             "deprecated",
             "opaque",
+            "lang_item",
         ];
 
         let mut resource_span: Option<std::ops::Range<usize>> = None;
@@ -967,16 +1019,17 @@ impl Parser<'_> {
         marker
     }
 
-    pub(crate) fn parse_indirect_enum(&mut self, visibility: Visibility) -> Option<TypeDecl> {
+    pub(crate) fn parse_indirect_enum(
+        &mut self,
+        visibility: Visibility,
+        attrs: &[Attribute],
+    ) -> Option<TypeDecl> {
         self.expect(&Token::Indirect)?;
         if self.peek() != Some(&Token::Enum) {
             self.error("'indirect' can only be used with 'enum'".to_string());
             return None;
         }
-        // Indirect enums (recursive boxed enums) do not participate in the
-        // `#[resource]` / `#[linear]` ownership-discipline surface; pass an
-        // empty attribute slice so no marker is extracted.
-        let mut decl = self.parse_struct_or_enum(visibility, &[])?;
+        let mut decl = self.parse_struct_or_enum(visibility, attrs)?;
         decl.is_indirect = true;
         Some(decl)
     }

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -10,6 +10,94 @@ fn parse_simple_function() {
     assert_eq!(result.program.items.len(), 1);
 }
 
+#[test]
+fn parse_stdlib_authority_attributes() {
+    let source = r#"
+#[lang_item("option")]
+pub enum Maybe<T> { Some(T); None; }
+
+#[diagnostic_item("fs")]
+pub fn read_file() {}
+
+#[intrinsic("math.sqrt")]
+pub fn sqrt(x: f64) -> f64;
+
+extern "C" {
+    #[abi(ret = bytes_triple, bytes_param = ptr)]
+    fn hew_read() -> bytes;
+}
+"#;
+    let result = parse(source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let Item::TypeDecl(type_decl) = &result.program.items[0].0 else {
+        panic!("expected type declaration");
+    };
+    assert_eq!(type_decl.lang_item.as_deref(), Some("option"));
+
+    let Item::Function(diagnostic_fn) = &result.program.items[1].0 else {
+        panic!("expected diagnostic function");
+    };
+    assert_eq!(
+        diagnostic_fn.attributes[0].name, "diagnostic_item",
+        "diagnostic attributes remain available to the authority loader"
+    );
+
+    let Item::Function(intrinsic_fn) = &result.program.items[2].0 else {
+        panic!("expected intrinsic function");
+    };
+    assert_eq!(intrinsic_fn.intrinsic.as_deref(), Some("math.sqrt"));
+
+    let Item::ExternBlock(extern_block) = &result.program.items[3].0 else {
+        panic!("expected extern block");
+    };
+    let abi = &extern_block.functions[0].attributes[0];
+    assert_eq!(abi.name, "abi");
+    assert_eq!(
+        abi.args,
+        vec![
+            AttributeArg::KeyValue {
+                key: "ret".to_string(),
+                value: "bytes_triple".to_string(),
+            },
+            AttributeArg::KeyValue {
+                key: "bytes_param".to_string(),
+                value: "ptr".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn malformed_stdlib_authority_attributes_are_rejected() {
+    let source = r#"
+#[lang_item]
+pub trait MissingKey {}
+
+extern "C" {
+    #[abi(bytes_triple)]
+    fn hew_bad();
+}
+"#;
+    let result = parse(source);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|error| error.message.contains("requires exactly one string key")),
+        "missing lang-item key must be diagnosed: {:?}",
+        result.errors
+    );
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|error| error.message.contains("requires one or more `key = value`")),
+        "positional ABI facts must be diagnosed: {:?}",
+        result.errors
+    );
+}
+
 /// Supervisor child declarations accept the module-qualified dotted type
 /// (`child a: bank.Account`), carrying the qualified actor identity
 /// verbatim; bare child types stay the root/local spelling.

--- a/hew-parser/src/parser/wire.rs
+++ b/hew-parser/src/parser/wire.rs
@@ -370,6 +370,10 @@ impl Parser<'_> {
             resource_marker: ResourceMarker::None,
             is_opaque: false,
             consuming_methods: Vec::new(),
+            lang_item: attrs
+                .iter()
+                .find(|a| a.name == "lang_item")
+                .and_then(|a| a.args.first().map(|arg| arg.as_str().to_string())),
         })
     }
 

--- a/hew-types/src/check/tests/collections.rs
+++ b/hew-types/src/check/tests/collections.rs
@@ -1370,6 +1370,7 @@ fn register_type_decl_marks_transitive_handle_bearing_structs() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
     let outer = TypeDecl {
         visibility: Visibility::Private,
@@ -1396,6 +1397,7 @@ fn register_type_decl_marks_transitive_handle_bearing_structs() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
     let plain = TypeDecl {
         visibility: Visibility::Private,
@@ -1422,6 +1424,7 @@ fn register_type_decl_marks_transitive_handle_bearing_structs() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
 
     checker.register_type_decl(&inner);

--- a/hew-types/src/check/tests/handles.rs
+++ b/hew-types/src/check/tests/handles.rs
@@ -447,6 +447,7 @@ fn handle_bearing_refresh_deferred_to_single_fixpoint_pass() {
                 resource_marker: hew_parser::ast::ResourceMarker::None,
                 is_opaque: false,
                 consuming_methods: Vec::new(),
+                lang_item: None,
             };
             checker.register_type_decl(&td);
         }
@@ -507,6 +508,7 @@ fn handle_bearing_registration_scales_linearly_not_quadratically() {
                 resource_marker: hew_parser::ast::ResourceMarker::None,
                 is_opaque: false,
                 consuming_methods: Vec::new(),
+                lang_item: None,
             };
             checker.register_type_decl(&td);
         }

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -103,6 +103,7 @@ fn make_pub_struct(name: &str, field: &str) -> TypeDecl {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     }
 }
 
@@ -833,6 +834,7 @@ fn user_module_registers_types() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
     let import = make_user_import(
         &["myapp", "config"],
@@ -1383,6 +1385,7 @@ fn make_struct_with_field_ty(name: &str, field: &str, field_type: &str) -> TypeD
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     }
 }
 
@@ -1465,6 +1468,7 @@ fn import_alias_in_enum_payload_resolves_to_source_identity() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
     let output = check_items(vec![
         (Item::Import(import), 0..0),
@@ -1695,6 +1699,7 @@ fn local_type_impl_no_orphan_warning() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
     let impl_decl = ImplDecl {
         type_params: None,
@@ -1845,6 +1850,7 @@ fn test_file_import_private_items_not_visible() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     });
 
     let resolved: Vec<Spanned<Item>> = vec![

--- a/hew-types/src/check/tests/infer.rs
+++ b/hew-types/src/check/tests/infer.rs
@@ -636,6 +636,7 @@ mod non_root_module_inference_scope {
             resource_marker: hew_parser::ast::ResourceMarker::None,
             is_opaque: false,
             consuming_methods: Vec::new(),
+            lang_item: None,
         };
         let impl_decl = ImplDecl {
             type_params: None,

--- a/hew-types/src/check/tests/modules.rs
+++ b/hew-types/src/check/tests/modules.rs
@@ -236,6 +236,7 @@ fn module_graph_body_private_local_type_is_available() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
 
     let ok_fn = FnDecl {

--- a/hew-types/src/check/tests/records.rs
+++ b/hew-types/src/check/tests/records.rs
@@ -37,6 +37,7 @@ mod cross_module_same_name {
             resource_marker: hew_parser::ast::ResourceMarker::None,
             is_opaque: false,
             consuming_methods: vec![],
+            lang_item: None,
         }
     }
 

--- a/hew-types/src/lang_items.rs
+++ b/hew-types/src/lang_items.rs
@@ -23,13 +23,145 @@
 
 use std::collections::HashMap;
 
+/// Closed compiler-recognised lang-item key vocabulary.
+///
+/// The stdlib may move these attributes between declarations, but adding a new
+/// semantic hook requires a compiler change so misspelled keys fail closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LangItem {
+    Index,
+    IndexGet,
+    IndexAt,
+    Display,
+    DisplayFmt,
+    Option,
+    OptionIsSome,
+    OptionIsNone,
+    OptionUnwrap,
+    OptionUnwrapOr,
+    Result,
+    ResultIsOk,
+    ResultIsErr,
+    ResultUnwrap,
+    ResultUnwrapOr,
+    VecIterState,
+    Iterator,
+    IteratorNext,
+    CollectionNew,
+    MarkerSend,
+    MarkerSync,
+    MarkerFrozen,
+    MarkerCopy,
+    MarkerClone,
+    MarkerEq,
+    MarkerPartialOrd,
+    MarkerOrd,
+    MarkerNum,
+    MarkerHash,
+    MarkerDebug,
+    MarkerDrop,
+    MarkerDecode,
+    MarkerEncode,
+    MarkerSerializable,
+    MarkerRcFree,
+    MarkerResource,
+}
+
+impl LangItem {
+    pub const ALL: [Self; 36] = [
+        Self::Index,
+        Self::IndexGet,
+        Self::IndexAt,
+        Self::Display,
+        Self::DisplayFmt,
+        Self::Option,
+        Self::OptionIsSome,
+        Self::OptionIsNone,
+        Self::OptionUnwrap,
+        Self::OptionUnwrapOr,
+        Self::Result,
+        Self::ResultIsOk,
+        Self::ResultIsErr,
+        Self::ResultUnwrap,
+        Self::ResultUnwrapOr,
+        Self::VecIterState,
+        Self::Iterator,
+        Self::IteratorNext,
+        Self::CollectionNew,
+        Self::MarkerSend,
+        Self::MarkerSync,
+        Self::MarkerFrozen,
+        Self::MarkerCopy,
+        Self::MarkerClone,
+        Self::MarkerEq,
+        Self::MarkerPartialOrd,
+        Self::MarkerOrd,
+        Self::MarkerNum,
+        Self::MarkerHash,
+        Self::MarkerDebug,
+        Self::MarkerDrop,
+        Self::MarkerDecode,
+        Self::MarkerEncode,
+        Self::MarkerSerializable,
+        Self::MarkerRcFree,
+        Self::MarkerResource,
+    ];
+
+    #[must_use]
+    pub const fn key(self) -> &'static str {
+        match self {
+            Self::Index => "index",
+            Self::IndexGet => "index_get",
+            Self::IndexAt => "index_at",
+            Self::Display => "display",
+            Self::DisplayFmt => "display_fmt",
+            Self::Option => "option",
+            Self::OptionIsSome => "option.is_some",
+            Self::OptionIsNone => "option.is_none",
+            Self::OptionUnwrap => "option.unwrap",
+            Self::OptionUnwrapOr => "option.unwrap_or",
+            Self::Result => "result",
+            Self::ResultIsOk => "result.is_ok",
+            Self::ResultIsErr => "result.is_err",
+            Self::ResultUnwrap => "result.unwrap",
+            Self::ResultUnwrapOr => "result.unwrap_or",
+            Self::VecIterState => "vec.iter_state",
+            Self::Iterator => "iterator",
+            Self::IteratorNext => "iterator.next",
+            Self::CollectionNew => "collection.new",
+            Self::MarkerSend => "marker.send",
+            Self::MarkerSync => "marker.sync",
+            Self::MarkerFrozen => "marker.frozen",
+            Self::MarkerCopy => "marker.copy",
+            Self::MarkerClone => "marker.clone",
+            Self::MarkerEq => "marker.eq",
+            Self::MarkerPartialOrd => "marker.partial_ord",
+            Self::MarkerOrd => "marker.ord",
+            Self::MarkerNum => "marker.num",
+            Self::MarkerHash => "marker.hash",
+            Self::MarkerDebug => "marker.debug",
+            Self::MarkerDrop => "marker.drop",
+            Self::MarkerDecode => "marker.decode",
+            Self::MarkerEncode => "marker.encode",
+            Self::MarkerSerializable => "marker.serializable",
+            Self::MarkerRcFree => "marker.rc_free",
+            Self::MarkerResource => "marker.resource",
+        }
+    }
+
+    #[must_use]
+    pub fn from_key(key: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|item| item.key() == key)
+    }
+}
+
 /// Well-known lang-item key for the trait through which f-string
 /// interpolation dispatches.
-pub const LANG_ITEM_DISPLAY: &str = "display";
+pub const LANG_ITEM_DISPLAY: &str = LangItem::Display.key();
 
 /// Well-known lang-item key for the method on the `display` trait used to
 /// render an interpolant to a `string`.
-pub const LANG_ITEM_DISPLAY_FMT: &str = "display_fmt";
+pub const LANG_ITEM_DISPLAY_FMT: &str = LangItem::DisplayFmt.key();
 
 /// One resolved lang-item entry: the trait that owns the tag plus, for
 /// method-level tags, the method's surface name.

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -25,6 +25,7 @@ pub mod resolved_ty;
 pub mod runtime_call;
 pub mod runtime_calling_convention;
 pub mod stdlib;
+pub mod stdlib_authority;
 pub mod stdlib_loader;
 pub mod traits;
 pub mod ty;
@@ -58,7 +59,9 @@ pub use extern_symbol::{
     ExternSymbolSpec, ExternSymbolTemplate, PlaceholderName, TemplateError, TemplateExpansionError,
     TemplateSegment,
 };
-pub use lang_items::{LangItemBinding, LangItemRegistry, LANG_ITEM_DISPLAY, LANG_ITEM_DISPLAY_FMT};
+pub use lang_items::{
+    LangItem, LangItemBinding, LangItemRegistry, LANG_ITEM_DISPLAY, LANG_ITEM_DISPLAY_FMT,
+};
 pub use lowering_facts::{
     assert_lowering_facts_consistent, hashmap_layout_key_fact,
     hashmap_layout_key_layout_value_fact, hashset_layout_element_admissible, hashset_layout_fact,
@@ -73,6 +76,12 @@ pub use runtime_call::{
     RuntimeDropDescriptor, StreamElementKind, VecGetElem, VecSliceElem,
 };
 pub use runtime_calling_convention::RuntimeCallingConvention;
+pub use stdlib_authority::{
+    authority as stdlib_authority, AuthorityBinding, AuthorityDeclarationKind, AuthorityError,
+    AuthorityErrorKind, AuthoritySource, DiagnosticItem, EnumVariantOrder, ExternAbiEntry,
+    ExternAbiFact, Intrinsic, OverloadGroup, PreludeExport, PreludeExportKind, StdlibAuthority,
+    StdlibRoot, STDLIB_AUTHORITY, SUBSTRATE_SOURCES,
+};
 pub use ty::{TraitObjectBound, Ty};
 pub use type_descriptor::TypeDescriptor;
 pub use vec_authority::VecElementToken;

--- a/hew-types/src/stdlib_authority.rs
+++ b/hew-types/src/stdlib_authority.rs
@@ -968,3 +968,188 @@ fn error(
         kind,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_substrate_populates_existing_authorities() {
+        let authority = load_stdlib_authority(SUBSTRATE_SOURCES)
+            .expect("embedded stdlib authority sources must load");
+
+        for key in [
+            LangItem::Index,
+            LangItem::IndexGet,
+            LangItem::IndexAt,
+            LangItem::Display,
+            LangItem::DisplayFmt,
+        ] {
+            assert!(
+                authority.lang_items().contains_key(&key),
+                "missing existing lang item {}",
+                key.key()
+            );
+        }
+        assert!(
+            authority
+                .enum_variant_orders()
+                .contains_key("builtins::SendError"),
+            "builtins enum orders must be collected"
+        );
+        assert!(
+            authority
+                .enum_variant_orders()
+                .contains_key("failure::CrashAction"),
+            "failure enum orders must be collected"
+        );
+    }
+
+    #[test]
+    fn synthetic_sources_populate_every_registry() {
+        let sources = [
+            AuthoritySource::embedded(
+                StdlibRoot::Builtins,
+                "std/builtins.hew",
+                r#"
+#[lang_item("option")]
+pub enum Maybe<T> { Some(T); None; }
+
+#[intrinsic("math.sqrt")]
+pub fn sqrt(x: f64) -> f64;
+
+#[diagnostic_item("fs")]
+pub fn read_file() {}
+
+#[overload("println")]
+pub fn println_i64(value: i64) {}
+
+extern "C" {
+    #[abi(ret = bytes_triple, bytes_param = ptr, drop = cow_null_tolerant)]
+    fn hew_bytes();
+}
+"#,
+            ),
+            AuthoritySource::embedded(
+                StdlibRoot::Prelude,
+                "std/prelude.hew",
+                "import std::builtins::{ Maybe as Option };\n",
+            ),
+        ];
+
+        let authority =
+            load_stdlib_authority(&sources).expect("synthetic authority sources must load");
+        assert_eq!(
+            authority.lang_items()[&LangItem::Option].declaration,
+            "Maybe"
+        );
+        assert_eq!(
+            authority.intrinsics()[&Intrinsic::MathSqrt].declaration,
+            "sqrt"
+        );
+        assert_eq!(
+            authority.diagnostic_items()[&DiagnosticItem::Fs].declaration,
+            "read_file"
+        );
+        assert_eq!(
+            authority.overload_groups()[&OverloadGroup::Println][0].declaration,
+            "println_i64"
+        );
+        assert_eq!(
+            authority.extern_abi()["builtins::hew_bytes"].facts,
+            vec![
+                ExternAbiFact::ReturnBytesTriple,
+                ExternAbiFact::BytesParamPointer,
+                ExternAbiFact::CowDropNullTolerant,
+            ]
+        );
+        assert_eq!(
+            authority.enum_variant_orders()["builtins::Maybe"].variants,
+            vec!["Some".to_string(), "None".to_string()]
+        );
+        assert_eq!(
+            authority.prelude_exports(),
+            &[PreludeExport {
+                module: "std::builtins".to_string(),
+                name: Some("Maybe".to_string()),
+                alias: Some("Option".to_string()),
+                kind: PreludeExportKind::Item,
+            }]
+        );
+    }
+
+    #[test]
+    fn unknown_lang_item_key_is_a_pointed_build_error() {
+        let source = AuthoritySource::embedded(
+            StdlibRoot::Builtins,
+            "std/builtins.hew",
+            r#"#[lang_item("display_typo")] pub trait Display {}"#,
+        );
+        let error =
+            load_stdlib_authority(&[source]).expect_err("unknown lang-item keys must fail closed");
+
+        assert_eq!(error.source_path, "std/builtins.hew");
+        assert_eq!(error.declaration.as_deref(), Some("Display"));
+        assert_eq!(
+            error.kind,
+            AuthorityErrorKind::UnknownLangItem {
+                key: "display_typo".to_string(),
+            }
+        );
+        assert!(
+            error.to_string().contains("display_typo"),
+            "build error must name the rejected key: {error}"
+        );
+    }
+
+    #[test]
+    fn unknown_abi_key_is_a_pointed_build_error() {
+        let source = AuthoritySource::embedded(
+            StdlibRoot::Io,
+            "std/io.hew",
+            r#"
+extern "C" {
+    #[abi(byte_param = ptr)]
+    fn hew_write(data: bytes);
+}
+"#,
+        );
+        let error =
+            load_stdlib_authority(&[source]).expect_err("unknown ABI keys must fail closed");
+
+        assert_eq!(error.declaration.as_deref(), Some("hew_write"));
+        assert_eq!(
+            error.kind,
+            AuthorityErrorKind::UnknownAbiKey {
+                key: "byte_param".to_string(),
+            }
+        );
+        assert!(
+            error.to_string().contains("byte_param"),
+            "build error must name the rejected ABI key: {error}"
+        );
+    }
+
+    #[test]
+    fn authority_attribute_outside_std_roots_is_rejected() {
+        let source = AuthoritySource::external(
+            "src/main.hew",
+            r#"#[diagnostic_item("fs")] pub fn read_file() {}"#,
+        );
+        let error = load_stdlib_authority(&[source])
+            .expect_err("authority attributes outside std roots must fail closed");
+
+        assert_eq!(error.source_path, "src/main.hew");
+        assert_eq!(error.declaration.as_deref(), Some("read_file"));
+        assert_eq!(
+            error.kind,
+            AuthorityErrorKind::AttributeOutsideStdRoot {
+                attribute: "diagnostic_item".to_string(),
+            }
+        );
+        assert!(
+            error.to_string().contains("substrate-only"),
+            "outside-root error must explain the privilege boundary: {error}"
+        );
+    }
+}

--- a/hew-types/src/stdlib_authority.rs
+++ b/hew-types/src/stdlib_authority.rs
@@ -1,0 +1,970 @@
+//! Build-time authority extracted from the closed stdlib substrate surface.
+//!
+//! The compiler binary embeds the substrate sources with [`include_str!`].
+//! [`STDLIB_AUTHORITY`] parses them lazily with `hew_parser`, validates the
+//! compiler-recognised attribute vocabularies, and exposes typed facts without
+//! changing any existing consumer in this foundation lane.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::LazyLock;
+
+use hew_parser::ast::{
+    Attribute, AttributeArg, FnDecl, ImportSpec, Item, TraitItem, TypeBodyItem, TypeDeclKind,
+    TypeExpr,
+};
+
+use crate::LangItem;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StdlibRoot {
+    Builtins,
+    Option,
+    Result,
+    Failure,
+    LinkMonitor,
+    String,
+    Io,
+    Prelude,
+}
+
+impl StdlibRoot {
+    #[must_use]
+    pub const fn module_name(self) -> &'static str {
+        match self {
+            Self::Builtins => "builtins",
+            Self::Option => "option",
+            Self::Result => "result",
+            Self::Failure => "failure",
+            Self::LinkMonitor => "link_monitor",
+            Self::String => "string",
+            Self::Io => "io",
+            Self::Prelude => "prelude",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AuthoritySource<'a> {
+    pub root: Option<StdlibRoot>,
+    pub path: &'a str,
+    pub source: &'a str,
+}
+
+impl<'a> AuthoritySource<'a> {
+    #[must_use]
+    pub const fn embedded(root: StdlibRoot, path: &'a str, source: &'a str) -> Self {
+        Self {
+            root: Some(root),
+            path,
+            source,
+        }
+    }
+
+    #[must_use]
+    pub const fn external(path: &'a str, source: &'a str) -> Self {
+        Self {
+            root: None,
+            path,
+            source,
+        }
+    }
+}
+
+pub const SUBSTRATE_SOURCES: &[AuthoritySource<'static>] = &[
+    AuthoritySource::embedded(
+        StdlibRoot::Builtins,
+        "std/builtins.hew",
+        include_str!("../../std/builtins.hew"),
+    ),
+    AuthoritySource::embedded(
+        StdlibRoot::Option,
+        "std/option.hew",
+        include_str!("../../std/option.hew"),
+    ),
+    AuthoritySource::embedded(
+        StdlibRoot::Result,
+        "std/result.hew",
+        include_str!("../../std/result.hew"),
+    ),
+    AuthoritySource::embedded(
+        StdlibRoot::Failure,
+        "std/failure.hew",
+        include_str!("../../std/failure.hew"),
+    ),
+    AuthoritySource::embedded(
+        StdlibRoot::LinkMonitor,
+        "std/link_monitor.hew",
+        include_str!("../../std/link_monitor.hew"),
+    ),
+    AuthoritySource::embedded(
+        StdlibRoot::String,
+        "std/string.hew",
+        include_str!("../../std/string.hew"),
+    ),
+    AuthoritySource::embedded(
+        StdlibRoot::Io,
+        "std/io.hew",
+        include_str!("../../std/io.hew"),
+    ),
+    AuthoritySource::embedded(
+        StdlibRoot::Prelude,
+        "std/prelude.hew",
+        include_str!("../../std/prelude.hew"),
+    ),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AuthorityDeclarationKind {
+    Type,
+    Trait,
+    TraitMethod,
+    Function,
+    Method,
+    ExternFunction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorityBinding {
+    pub root: StdlibRoot,
+    pub declaration: String,
+    pub kind: AuthorityDeclarationKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Intrinsic {
+    MathExp,
+    MathLog,
+    MathSqrt,
+    MathSin,
+    MathCos,
+    MathFloor,
+    MathCeil,
+    MathAbs,
+    MathTanh,
+    MathLog2,
+    MathLog10,
+    MathExp2,
+    MathPow,
+    MathMax,
+    MathMin,
+    MathPi,
+    MathE,
+    MemAlloc,
+    MemRealloc,
+    MemDealloc,
+    MemPtrOffset,
+    MemPtrCopy,
+}
+
+impl Intrinsic {
+    pub const ALL: [Self; 22] = [
+        Self::MathExp,
+        Self::MathLog,
+        Self::MathSqrt,
+        Self::MathSin,
+        Self::MathCos,
+        Self::MathFloor,
+        Self::MathCeil,
+        Self::MathAbs,
+        Self::MathTanh,
+        Self::MathLog2,
+        Self::MathLog10,
+        Self::MathExp2,
+        Self::MathPow,
+        Self::MathMax,
+        Self::MathMin,
+        Self::MathPi,
+        Self::MathE,
+        Self::MemAlloc,
+        Self::MemRealloc,
+        Self::MemDealloc,
+        Self::MemPtrOffset,
+        Self::MemPtrCopy,
+    ];
+
+    #[must_use]
+    pub const fn key(self) -> &'static str {
+        match self {
+            Self::MathExp => "math.exp",
+            Self::MathLog => "math.log",
+            Self::MathSqrt => "math.sqrt",
+            Self::MathSin => "math.sin",
+            Self::MathCos => "math.cos",
+            Self::MathFloor => "math.floor",
+            Self::MathCeil => "math.ceil",
+            Self::MathAbs => "math.abs",
+            Self::MathTanh => "math.tanh",
+            Self::MathLog2 => "math.log2",
+            Self::MathLog10 => "math.log10",
+            Self::MathExp2 => "math.exp2",
+            Self::MathPow => "math.pow",
+            Self::MathMax => "math.max",
+            Self::MathMin => "math.min",
+            Self::MathPi => "math.pi",
+            Self::MathE => "math.e",
+            Self::MemAlloc => "mem.alloc",
+            Self::MemRealloc => "mem.realloc",
+            Self::MemDealloc => "mem.dealloc",
+            Self::MemPtrOffset => "mem.ptr_offset",
+            Self::MemPtrCopy => "mem.ptr_copy",
+        }
+    }
+
+    #[must_use]
+    pub fn from_key(key: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|intrinsic| intrinsic.key() == key)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternAbiFact {
+    ReturnBytesTriple,
+    BytesParamPointer,
+    CowDropNullTolerant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternAbiEntry {
+    pub binding: AuthorityBinding,
+    pub facts: Vec<ExternAbiFact>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum OverloadGroup {
+    Println,
+    Print,
+    ToString,
+    AssertEq,
+    AssertNe,
+    Len,
+}
+
+impl OverloadGroup {
+    pub const ALL: [Self; 6] = [
+        Self::Println,
+        Self::Print,
+        Self::ToString,
+        Self::AssertEq,
+        Self::AssertNe,
+        Self::Len,
+    ];
+
+    #[must_use]
+    pub const fn key(self) -> &'static str {
+        match self {
+            Self::Println => "println",
+            Self::Print => "print",
+            Self::ToString => "to_string",
+            Self::AssertEq => "assert_eq",
+            Self::AssertNe => "assert_ne",
+            Self::Len => "len",
+        }
+    }
+
+    #[must_use]
+    pub fn from_key(key: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|group| group.key() == key)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiagnosticItem {
+    Fs,
+    Json,
+}
+
+impl DiagnosticItem {
+    pub const ALL: [Self; 2] = [Self::Fs, Self::Json];
+
+    #[must_use]
+    pub const fn key(self) -> &'static str {
+        match self {
+            Self::Fs => "fs",
+            Self::Json => "json",
+        }
+    }
+
+    #[must_use]
+    pub fn from_key(key: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|item| item.key() == key)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumVariantOrder {
+    pub root: StdlibRoot,
+    pub declaration: String,
+    pub variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreludeExportKind {
+    Module,
+    Glob,
+    Item,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreludeExport {
+    pub module: String,
+    pub name: Option<String>,
+    pub alias: Option<String>,
+    pub kind: PreludeExportKind,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StdlibAuthority {
+    lang_items: BTreeMap<LangItem, AuthorityBinding>,
+    intrinsics: BTreeMap<Intrinsic, AuthorityBinding>,
+    extern_abi: BTreeMap<String, ExternAbiEntry>,
+    overload_groups: BTreeMap<OverloadGroup, Vec<AuthorityBinding>>,
+    diagnostic_items: BTreeMap<DiagnosticItem, AuthorityBinding>,
+    enum_variant_orders: BTreeMap<String, EnumVariantOrder>,
+    prelude_exports: Vec<PreludeExport>,
+}
+
+impl StdlibAuthority {
+    #[must_use]
+    pub fn lang_items(&self) -> &BTreeMap<LangItem, AuthorityBinding> {
+        &self.lang_items
+    }
+
+    #[must_use]
+    pub fn intrinsics(&self) -> &BTreeMap<Intrinsic, AuthorityBinding> {
+        &self.intrinsics
+    }
+
+    #[must_use]
+    pub fn extern_abi(&self) -> &BTreeMap<String, ExternAbiEntry> {
+        &self.extern_abi
+    }
+
+    #[must_use]
+    pub fn overload_groups(&self) -> &BTreeMap<OverloadGroup, Vec<AuthorityBinding>> {
+        &self.overload_groups
+    }
+
+    #[must_use]
+    pub fn diagnostic_items(&self) -> &BTreeMap<DiagnosticItem, AuthorityBinding> {
+        &self.diagnostic_items
+    }
+
+    #[must_use]
+    pub fn enum_variant_orders(&self) -> &BTreeMap<String, EnumVariantOrder> {
+        &self.enum_variant_orders
+    }
+
+    #[must_use]
+    pub fn prelude_exports(&self) -> &[PreludeExport] {
+        &self.prelude_exports
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorityErrorKind {
+    Parse { diagnostics: Vec<String> },
+    AttributeOutsideStdRoot { attribute: String },
+    InvalidAttributePlacement { attribute: String },
+    MalformedAttribute { attribute: String },
+    UnknownLangItem { key: String },
+    UnknownIntrinsic { key: String },
+    UnknownAbiKey { key: String },
+    UnknownAbiValue { key: String, value: String },
+    UnknownOverloadGroup { key: String },
+    UnknownDiagnosticItem { key: String },
+    DuplicateBinding { family: String, key: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorityError {
+    pub source_path: String,
+    pub declaration: Option<String>,
+    pub kind: AuthorityErrorKind,
+}
+
+impl fmt::Display for AuthorityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "stdlib authority error in {}", self.source_path)?;
+        if let Some(declaration) = &self.declaration {
+            write!(f, " at `{declaration}`")?;
+        }
+        write!(f, ": ")?;
+        match &self.kind {
+            AuthorityErrorKind::Parse { diagnostics } => {
+                write!(f, "source failed to parse: {}", diagnostics.join("; "))
+            }
+            AuthorityErrorKind::AttributeOutsideStdRoot { attribute } => write!(
+                f,
+                "`#[{attribute}]` is substrate-only and cannot be declared outside a known stdlib root"
+            ),
+            AuthorityErrorKind::InvalidAttributePlacement { attribute } => {
+                write!(f, "`#[{attribute}]` is not valid on this declaration form")
+            }
+            AuthorityErrorKind::MalformedAttribute { attribute } => {
+                write!(f, "`#[{attribute}]` has an invalid argument shape")
+            }
+            AuthorityErrorKind::UnknownLangItem { key } => {
+                write!(f, "unknown `#[lang_item]` key `{key}`")
+            }
+            AuthorityErrorKind::UnknownIntrinsic { key } => {
+                write!(f, "unknown `#[intrinsic]` key `{key}`")
+            }
+            AuthorityErrorKind::UnknownAbiKey { key } => {
+                write!(f, "unknown `#[abi]` key `{key}`")
+            }
+            AuthorityErrorKind::UnknownAbiValue { key, value } => {
+                write!(f, "unknown `#[abi]` value `{value}` for key `{key}`")
+            }
+            AuthorityErrorKind::UnknownOverloadGroup { key } => {
+                write!(f, "unknown `#[overload]` group `{key}`")
+            }
+            AuthorityErrorKind::UnknownDiagnosticItem { key } => {
+                write!(f, "unknown `#[diagnostic_item]` key `{key}`")
+            }
+            AuthorityErrorKind::DuplicateBinding { family, key } => {
+                write!(f, "duplicate {family} binding for key `{key}`")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AuthorityError {}
+
+pub static STDLIB_AUTHORITY: LazyLock<StdlibAuthority> = LazyLock::new(|| {
+    load_stdlib_authority(SUBSTRATE_SOURCES)
+        .unwrap_or_else(|error| panic!("failed to build stdlib authority: {error}"))
+});
+
+#[must_use]
+pub fn authority() -> &'static StdlibAuthority {
+    &STDLIB_AUTHORITY
+}
+
+/// Parse and validate a set of authority sources.
+///
+/// Recognised authority attributes on an [`AuthoritySource::external`] input
+/// are rejected before their payload is considered.
+///
+/// # Errors
+///
+/// Returns an [`AuthorityError`] when a source does not parse, an authority
+/// attribute is outside the known stdlib roots, or a recognised key/value is
+/// malformed, unknown, misplaced, or duplicated.
+pub fn load_stdlib_authority(
+    sources: &[AuthoritySource<'_>],
+) -> Result<StdlibAuthority, AuthorityError> {
+    let mut authority = StdlibAuthority::default();
+    for source in sources {
+        load_source(&mut authority, *source)?;
+    }
+    Ok(authority)
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "the exhaustive AST declaration walk keeps attribute placement rules together"
+)]
+fn load_source(
+    authority: &mut StdlibAuthority,
+    source: AuthoritySource<'_>,
+) -> Result<(), AuthorityError> {
+    let parsed = hew_parser::parse(source.source);
+    if !parsed.errors.is_empty() {
+        return Err(error(
+            source,
+            None,
+            AuthorityErrorKind::Parse {
+                diagnostics: parsed
+                    .errors
+                    .into_iter()
+                    .map(|diagnostic| diagnostic.message)
+                    .collect(),
+            },
+        ));
+    }
+
+    for (item, _) in parsed.program.items {
+        match item {
+            Item::TypeDecl(decl) => {
+                if let Some(key) = decl.lang_item.as_deref() {
+                    ensure_known_root(source, &decl.name, "lang_item")?;
+                    let type_binding =
+                        make_binding(source, decl.name.clone(), AuthorityDeclarationKind::Type)?;
+                    register_lang_item(authority, source, &type_binding, key)?;
+                }
+                if let (TypeDeclKind::Enum, Some(root)) = (decl.kind, source.root) {
+                    let variants = decl
+                        .body
+                        .iter()
+                        .filter_map(|item| match item {
+                            TypeBodyItem::Variant(variant) => Some(variant.name.clone()),
+                            _ => None,
+                        })
+                        .collect();
+                    let qualified = qualified(source, &decl.name);
+                    authority.enum_variant_orders.insert(
+                        qualified,
+                        EnumVariantOrder {
+                            root,
+                            declaration: decl.name.clone(),
+                            variants,
+                        },
+                    );
+                }
+                for item in decl.body {
+                    if let TypeBodyItem::Method(method) = item {
+                        let declaration = format!("{}::{}", decl.name, method.name);
+                        load_function_attributes(
+                            authority,
+                            source,
+                            &method,
+                            declaration,
+                            AuthorityDeclarationKind::Method,
+                            false,
+                        )?;
+                    }
+                }
+            }
+            Item::Trait(decl) => {
+                if let Some(key) = decl.lang_item.as_deref() {
+                    ensure_known_root(source, &decl.name, "lang_item")?;
+                    let trait_binding =
+                        make_binding(source, decl.name.clone(), AuthorityDeclarationKind::Trait)?;
+                    register_lang_item(authority, source, &trait_binding, key)?;
+                }
+                for item in decl.items {
+                    if let TraitItem::Method(method) = item {
+                        if let Some(key) = method.lang_item.as_deref() {
+                            let declaration = format!("{}::{}", decl.name, method.name);
+                            ensure_known_root(source, &declaration, "lang_item")?;
+                            let method_binding = make_binding(
+                                source,
+                                declaration,
+                                AuthorityDeclarationKind::TraitMethod,
+                            )?;
+                            register_lang_item(authority, source, &method_binding, key)?;
+                        }
+                    }
+                }
+            }
+            Item::Impl(decl) => {
+                let owner = type_name(&decl.target_type.0);
+                for method in decl.methods {
+                    let declaration = format!("{owner}::{}", method.name);
+                    load_function_attributes(
+                        authority,
+                        source,
+                        &method,
+                        declaration,
+                        AuthorityDeclarationKind::Method,
+                        false,
+                    )?;
+                }
+            }
+            Item::Function(function) => {
+                let declaration = function.name.clone();
+                load_function_attributes(
+                    authority,
+                    source,
+                    &function,
+                    declaration,
+                    AuthorityDeclarationKind::Function,
+                    true,
+                )?;
+            }
+            Item::ExternBlock(block) => {
+                for function in block.functions {
+                    let declaration = function.name.clone();
+                    for attr in &function.attributes {
+                        ensure_substrate_attribute(source, &declaration, attr)?;
+                        match attr.name.as_str() {
+                            "abi" => {
+                                let facts = parse_abi_facts(source, &declaration, attr)?;
+                                let binding = make_binding(
+                                    source,
+                                    declaration.clone(),
+                                    AuthorityDeclarationKind::ExternFunction,
+                                )?;
+                                let key = qualified(source, &declaration);
+                                if authority
+                                    .extern_abi
+                                    .insert(key.clone(), ExternAbiEntry { binding, facts })
+                                    .is_some()
+                                {
+                                    return Err(error(
+                                        source,
+                                        Some(declaration),
+                                        AuthorityErrorKind::DuplicateBinding {
+                                            family: "extern ABI".to_string(),
+                                            key,
+                                        },
+                                    ));
+                                }
+                            }
+                            "lang_item" | "intrinsic" | "diagnostic_item" | "overload" => {
+                                return Err(error(
+                                    source,
+                                    Some(declaration),
+                                    AuthorityErrorKind::InvalidAttributePlacement {
+                                        attribute: attr.name.clone(),
+                                    },
+                                ));
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            Item::Import(import) if source.root == Some(StdlibRoot::Prelude) => {
+                collect_prelude_export(&mut authority.prelude_exports, import);
+            }
+            Item::Import(_)
+            | Item::Const(_)
+            | Item::TypeAlias(_)
+            | Item::Actor(_)
+            | Item::Supervisor(_)
+            | Item::Machine(_)
+            | Item::Record(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn load_function_attributes(
+    authority: &mut StdlibAuthority,
+    source: AuthoritySource<'_>,
+    function: &FnDecl,
+    declaration: String,
+    kind: AuthorityDeclarationKind,
+    top_level: bool,
+) -> Result<(), AuthorityError> {
+    for attr in &function.attributes {
+        ensure_substrate_attribute(source, &declaration, attr)?;
+    }
+    if source.root.is_none() {
+        return Ok(());
+    }
+    let binding = make_binding(source, declaration.clone(), kind)?;
+    for attr in &function.attributes {
+        match attr.name.as_str() {
+            "lang_item" => {
+                let key = positional_key(source, &declaration, attr)?;
+                register_lang_item(authority, source, &binding, key)?;
+            }
+            "intrinsic" => {
+                if !top_level {
+                    return Err(error(
+                        source,
+                        Some(declaration),
+                        AuthorityErrorKind::InvalidAttributePlacement {
+                            attribute: attr.name.clone(),
+                        },
+                    ));
+                }
+                let key = positional_key(source, &declaration, attr)?;
+                let intrinsic = Intrinsic::from_key(key).ok_or_else(|| {
+                    error(
+                        source,
+                        Some(declaration.clone()),
+                        AuthorityErrorKind::UnknownIntrinsic {
+                            key: key.to_string(),
+                        },
+                    )
+                })?;
+                insert_unique(
+                    &mut authority.intrinsics,
+                    intrinsic,
+                    binding.clone(),
+                    source,
+                    &declaration,
+                    "intrinsic",
+                    key,
+                )?;
+            }
+            "diagnostic_item" => {
+                let key = positional_key(source, &declaration, attr)?;
+                let diagnostic = DiagnosticItem::from_key(key).ok_or_else(|| {
+                    error(
+                        source,
+                        Some(declaration.clone()),
+                        AuthorityErrorKind::UnknownDiagnosticItem {
+                            key: key.to_string(),
+                        },
+                    )
+                })?;
+                insert_unique(
+                    &mut authority.diagnostic_items,
+                    diagnostic,
+                    binding.clone(),
+                    source,
+                    &declaration,
+                    "diagnostic item",
+                    key,
+                )?;
+            }
+            "overload" => {
+                let key = positional_key(source, &declaration, attr)?;
+                let group = OverloadGroup::from_key(key).ok_or_else(|| {
+                    error(
+                        source,
+                        Some(declaration.clone()),
+                        AuthorityErrorKind::UnknownOverloadGroup {
+                            key: key.to_string(),
+                        },
+                    )
+                })?;
+                authority
+                    .overload_groups
+                    .entry(group)
+                    .or_default()
+                    .push(binding.clone());
+            }
+            "abi" => {
+                return Err(error(
+                    source,
+                    Some(declaration),
+                    AuthorityErrorKind::InvalidAttributePlacement {
+                        attribute: attr.name.clone(),
+                    },
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn register_lang_item(
+    authority: &mut StdlibAuthority,
+    source: AuthoritySource<'_>,
+    binding: &AuthorityBinding,
+    key: &str,
+) -> Result<(), AuthorityError> {
+    let item = LangItem::from_key(key).ok_or_else(|| {
+        error(
+            source,
+            Some(binding.declaration.clone()),
+            AuthorityErrorKind::UnknownLangItem {
+                key: key.to_string(),
+            },
+        )
+    })?;
+    insert_unique(
+        &mut authority.lang_items,
+        item,
+        binding.clone(),
+        source,
+        &binding.declaration,
+        "lang item",
+        key,
+    )
+}
+
+fn parse_abi_facts(
+    source: AuthoritySource<'_>,
+    declaration: &str,
+    attr: &Attribute,
+) -> Result<Vec<ExternAbiFact>, AuthorityError> {
+    if attr.args.is_empty() {
+        return Err(error(
+            source,
+            Some(declaration.to_string()),
+            AuthorityErrorKind::MalformedAttribute {
+                attribute: attr.name.clone(),
+            },
+        ));
+    }
+
+    let mut facts = Vec::with_capacity(attr.args.len());
+    for arg in &attr.args {
+        let AttributeArg::KeyValue { key, value } = arg else {
+            return Err(error(
+                source,
+                Some(declaration.to_string()),
+                AuthorityErrorKind::MalformedAttribute {
+                    attribute: attr.name.clone(),
+                },
+            ));
+        };
+        let fact = match (key.as_str(), value.as_str()) {
+            ("ret", "bytes_triple") => ExternAbiFact::ReturnBytesTriple,
+            ("bytes_param", "ptr") => ExternAbiFact::BytesParamPointer,
+            ("drop", "cow_null_tolerant") => ExternAbiFact::CowDropNullTolerant,
+            ("ret" | "bytes_param" | "drop", _) => {
+                return Err(error(
+                    source,
+                    Some(declaration.to_string()),
+                    AuthorityErrorKind::UnknownAbiValue {
+                        key: key.clone(),
+                        value: value.clone(),
+                    },
+                ));
+            }
+            _ => {
+                return Err(error(
+                    source,
+                    Some(declaration.to_string()),
+                    AuthorityErrorKind::UnknownAbiKey { key: key.clone() },
+                ));
+            }
+        };
+        facts.push(fact);
+    }
+    Ok(facts)
+}
+
+fn positional_key<'a>(
+    source: AuthoritySource<'_>,
+    declaration: &str,
+    attr: &'a Attribute,
+) -> Result<&'a str, AuthorityError> {
+    match attr.args.as_slice() {
+        [AttributeArg::Positional(key)] if !key.is_empty() => Ok(key),
+        _ => Err(error(
+            source,
+            Some(declaration.to_string()),
+            AuthorityErrorKind::MalformedAttribute {
+                attribute: attr.name.clone(),
+            },
+        )),
+    }
+}
+
+fn ensure_substrate_attribute(
+    source: AuthoritySource<'_>,
+    declaration: &str,
+    attr: &Attribute,
+) -> Result<(), AuthorityError> {
+    if source.root.is_none()
+        && matches!(
+            attr.name.as_str(),
+            "lang_item" | "abi" | "intrinsic" | "diagnostic_item" | "overload"
+        )
+    {
+        return Err(error(
+            source,
+            Some(declaration.to_string()),
+            AuthorityErrorKind::AttributeOutsideStdRoot {
+                attribute: attr.name.clone(),
+            },
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_known_root(
+    source: AuthoritySource<'_>,
+    declaration: &str,
+    attribute: &str,
+) -> Result<(), AuthorityError> {
+    if source.root.is_none() {
+        return Err(error(
+            source,
+            Some(declaration.to_string()),
+            AuthorityErrorKind::AttributeOutsideStdRoot {
+                attribute: attribute.to_string(),
+            },
+        ));
+    }
+    Ok(())
+}
+
+fn insert_unique<K: Ord>(
+    map: &mut BTreeMap<K, AuthorityBinding>,
+    key: K,
+    binding: AuthorityBinding,
+    source: AuthoritySource<'_>,
+    declaration: &str,
+    family: &str,
+    display_key: &str,
+) -> Result<(), AuthorityError> {
+    if map.insert(key, binding).is_some() {
+        return Err(error(
+            source,
+            Some(declaration.to_string()),
+            AuthorityErrorKind::DuplicateBinding {
+                family: family.to_string(),
+                key: display_key.to_string(),
+            },
+        ));
+    }
+    Ok(())
+}
+
+fn make_binding(
+    source: AuthoritySource<'_>,
+    declaration: String,
+    kind: AuthorityDeclarationKind,
+) -> Result<AuthorityBinding, AuthorityError> {
+    let root = source.root.ok_or_else(|| {
+        error(
+            source,
+            Some(declaration.clone()),
+            AuthorityErrorKind::AttributeOutsideStdRoot {
+                attribute: "authority".to_string(),
+            },
+        )
+    })?;
+    Ok(AuthorityBinding {
+        root,
+        declaration,
+        kind,
+    })
+}
+
+fn qualified(source: AuthoritySource<'_>, declaration: &str) -> String {
+    source.root.map_or_else(
+        || declaration.to_string(),
+        |root| format!("{}::{declaration}", root.module_name()),
+    )
+}
+
+fn type_name(ty: &TypeExpr) -> String {
+    match ty {
+        TypeExpr::Named { name, .. } => name.clone(),
+        _ => "<unnamed>".to_string(),
+    }
+}
+
+fn collect_prelude_export(exports: &mut Vec<PreludeExport>, import: hew_parser::ast::ImportDecl) {
+    let module = import.path.join("::");
+    match import.spec {
+        None => exports.push(PreludeExport {
+            module,
+            name: None,
+            alias: import.module_alias,
+            kind: PreludeExportKind::Module,
+        }),
+        Some(ImportSpec::Glob) => exports.push(PreludeExport {
+            module,
+            name: None,
+            alias: None,
+            kind: PreludeExportKind::Glob,
+        }),
+        Some(ImportSpec::Names(names)) => {
+            for name in names {
+                exports.push(PreludeExport {
+                    module: module.clone(),
+                    name: Some(name.name),
+                    alias: name.alias,
+                    kind: PreludeExportKind::Item,
+                });
+            }
+        }
+    }
+}
+
+fn error(
+    source: AuthoritySource<'_>,
+    declaration: Option<String>,
+    kind: AuthorityErrorKind,
+) -> AuthorityError {
+    AuthorityError {
+        source_path: source.path.to_string(),
+        declaration,
+        kind,
+    }
+}

--- a/hew-types/tests/registry_core/module_system_test.rs
+++ b/hew-types/tests/registry_core/module_system_test.rs
@@ -425,6 +425,7 @@ fn test_pub_type_accessible_qualified() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
     let import = make_user_import(
         &["myapp", "config"],
@@ -470,6 +471,7 @@ fn test_pub_type_import_coexists_with_local_same_name() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
     let imported_type = TypeDecl {
         visibility: Visibility::Pub,
@@ -484,6 +486,7 @@ fn test_pub_type_import_coexists_with_local_same_name() {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     };
     let import = make_user_import(
         &["myapp", "config"],
@@ -536,6 +539,7 @@ fn pub_struct(name: &str) -> TypeDecl {
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     }
 }
 
@@ -747,6 +751,7 @@ fn pub_struct_with_scalar_field(name: &str, field: &str, scalar: &str) -> TypeDe
         resource_marker: hew_parser::ast::ResourceMarker::None,
         is_opaque: false,
         consuming_methods: Vec::new(),
+        lang_item: None,
     }
 }
 

--- a/std/prelude.hew
+++ b/std/prelude.hew
@@ -1,0 +1,5 @@
+//! Compiler-embedded prelude authority manifest.
+//!
+//! Lane 0 reserves the single manifest path and parses it with the other
+//! substrate sources. It remains intentionally empty until the prelude
+//! publication migration, so this foundation does not change name resolution.


### PR DESCRIPTION
## Summary

The stdlib source is now able to be the authority for stdlib facts, rather than hardcoded Rust lists. This adds a build-time `stdlib_authority` loader that generalizes the existing `vec_authority.rs` parse-at-build-time pattern into a reusable API: it `include_str!`s the closed substrate `.hew` set, parses it, walks declaration attributes, and exposes typed registries (lang items, intrinsics, extern ABI, overload groups, diagnostic items, enum variant orders, prelude exports) via a `LazyLock` — build-time, no runtime cost, no bootstrap circularity.

Alongside it, the parser attribute grammar is widened: `#[lang_item]` is extended to more declaration forms, and `#[abi]` and `#[diagnostic_item]` are added. All of these attributes are substrate-only and fail closed — they are a hard error outside the std roots.

This is behaviourally inert: the registries are only re-exported, with no pipeline consumer wired yet. It builds the foundation without changing compiler output.

## Verification

- `cargo build -p hew-cli`: clean.
- `cargo fmt --check` and `make lint`: clean.
- `make test-hew-ratchet`: unchanged at 0 expected / 0 actual failures — confirms behavioural inertness (no consumer forces the loader).
- Loader fail-closed negative tests assert the exact error kind and that the diagnostic names the rejected key: unknown lang-item key, unknown ABI key, and an authority attribute placed outside the std roots.
- Parser negative tests assert specific diagnostics for a missing lang-item key and malformed positional ABI facts.
- `hew fmt` round-trip is idempotent across the full `.hew` corpus (attribute emission round-trips without double-emission).
- Loading against the real substrate `.hew` files succeeds (proves no parse/validation panic on the actual stdlib).

## Out of scope

- Consuming the registries — deleting the duplicate hardcoded Rust lists and making the loader the single source of truth — is deliberately deferred to follow-up changes. This change only builds and tests the foundation.
- No codegen consumes the `#[abi]` ExternAbiFact modelling yet; wiring ABI facts into codegen is separate future work.