### PR TITLE
test(exec): warm the hew binary once instead of a cold in-deadline cargo run (#1887)

### DIFF
--- a/hew-codegen-rs/tests/exec/bytes_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/bytes_index_exec.rs
@@ -48,12 +48,11 @@ fn hew_command(repo: &Path) -> Command {
         return Command::new(bin);
     }
 
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/ffi_int_width_exec.rs
+++ b/hew-codegen-rs/tests/exec/ffi_int_width_exec.rs
@@ -27,12 +27,12 @@ fn repo_root() -> PathBuf {
 }
 
 fn hew_command(repo: &Path) -> Command {
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    let _ = repo;
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/float_return_exec.rs
+++ b/hew-codegen-rs/tests/exec/float_return_exec.rs
@@ -13,12 +13,12 @@ fn repo_root() -> PathBuf {
 }
 
 fn hew_command(repo: &Path) -> Command {
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    let _ = repo;
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/for_in_vec_string_exec.rs
+++ b/hew-codegen-rs/tests/exec/for_in_vec_string_exec.rs
@@ -56,12 +56,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/generator_exec.rs
+++ b/hew-codegen-rs/tests/exec/generator_exec.rs
@@ -49,12 +49,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/hashmap_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/hashmap_index_exec.rs
@@ -52,12 +52,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/if_let_exec.rs
+++ b/hew-codegen-rs/tests/exec/if_let_exec.rs
@@ -47,12 +47,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/machine_exec.rs
+++ b/hew-codegen-rs/tests/exec/machine_exec.rs
@@ -148,12 +148,11 @@ fn hew_command(repo: &Path) -> Command {
         return Command::new(bin);
     }
 
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/match_literal_guard_default_exec.rs
+++ b/hew-codegen-rs/tests/exec/match_literal_guard_default_exec.rs
@@ -51,12 +51,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/primitive_trait_bound_exec.rs
+++ b/hew-codegen-rs/tests/exec/primitive_trait_bound_exec.rs
@@ -36,12 +36,11 @@ fn hew_command(repo: &Path) -> Command {
         return Command::new(bin);
     }
 
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/structural_eq_exec.rs
+++ b/hew-codegen-rs/tests/exec/structural_eq_exec.rs
@@ -33,12 +33,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/vec_enum_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_enum_index_exec.rs
@@ -48,12 +48,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/vec_i32_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_i32_index_exec.rs
@@ -36,12 +36,11 @@ fn hew_command(repo: &Path) -> Command {
         return Command::new(bin);
     }
 
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/vec_owned_element_routing_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_owned_element_routing_exec.rs
@@ -54,12 +54,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/vec_record_contains_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_record_contains_exec.rs
@@ -33,12 +33,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/vec_record_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_record_index_exec.rs
@@ -45,12 +45,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/exec/wasm_generator_exec.rs
+++ b/hew-codegen-rs/tests/exec/wasm_generator_exec.rs
@@ -97,12 +97,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 #[test]

--- a/hew-codegen-rs/tests/exec/wasm_try_to_platform_width_exec.rs
+++ b/hew-codegen-rs/tests/exec/wasm_try_to_platform_width_exec.rs
@@ -162,12 +162,11 @@ fn hew_command(repo: &Path) -> Command {
     if bin.exists() {
         return Command::new(bin);
     }
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) -> bool {

--- a/hew-codegen-rs/tests/machine_lifecycle.rs
+++ b/hew-codegen-rs/tests/machine_lifecycle.rs
@@ -33,12 +33,11 @@ fn hew_command(repo: &Path) -> Command {
         return Command::new(bin);
     }
 
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
-    command
-        .current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    command
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {

--- a/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
+++ b/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
@@ -35,11 +35,12 @@ fn ensure_hew_runtime_lib(repo: &Path) {
 }
 
 fn hew_command(repo: &Path) -> Command {
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut cmd = Command::new(cargo);
-    cmd.current_dir(repo)
-        .args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"]);
-    cmd
+    let _ = repo;
+    // Cold `target/`: build `hew` once under the shared serialized build
+    // lock, OUTSIDE any per-test deadline, so a concurrent build-lock holder
+    // cannot make a `cargo run` fallback burn the bounded budget and produce
+    // a false timeout (hew-lang/hew#1887).
+    Command::new(hew_testutil::ensure_hew_bin_built().expect("build hew binary"))
 }
 
 /// Write `source` to a temp file and run `hew run <file>`.

--- a/hew-testutil/src/lib.rs
+++ b/hew-testutil/src/lib.rs
@@ -645,6 +645,85 @@ fn hew_lib_name() -> &'static str {
     }
 }
 
+/// Serialize `cargo build -p hew-cli --bin hew` across all parallel nextest
+/// processes and return the resolved `hew` binary path.
+///
+/// This mirrors [`ensure_hew_lib_built`] for the compiler-driver binary that the
+/// `*_exec` integration tests invoke. Without it, a cold `target/` lets the
+/// per-test `hew_command` fall back to a `cargo run` INSIDE the bounded
+/// deadline; if a concurrent `cargo`/`nextest` invocation holds the build-lock,
+/// that fallback blocks on `Blocking waiting for file lock on build directory`
+/// and burns the whole budget, producing a false timeout (hew-lang/hew#1887).
+/// Building the binary once here — outside any per-test deadline, under the same
+/// `fd_lock` + `NEXTEST_RUN_ID` stamp serialization — makes the exec corpus
+/// robust to shared-`target/` contention.
+///
+/// # Errors
+///
+/// Returns `Err` if the lock file cannot be opened/locked, if
+/// `cargo build -p hew-cli --bin hew` fails or cannot be spawned, or if the
+/// expected binary artifact is missing after a successful build.
+pub fn ensure_hew_bin_built() -> Result<PathBuf, String> {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")) // = <repo>/hew-testutil
+        .parent()
+        .ok_or("hew-testutil must live under the workspace root")?
+        .to_path_buf();
+    let (target_dir, profile) = target_dir_and_profile();
+    let bin_path = target_dir.join(&profile).join(hew_bin_name());
+    ensure_built_serialized(&target_dir, &profile, &bin_path, |td, prof| {
+        run_cargo_build_hew_bin(&repo_root, td, prof)
+    })?;
+    Ok(bin_path)
+}
+
+fn hew_bin_name() -> &'static str {
+    if cfg!(windows) {
+        "hew.exe"
+    } else {
+        "hew"
+    }
+}
+
+fn run_cargo_build_hew_bin(
+    repo_root: &Path,
+    target_dir: &Path,
+    profile: &str,
+) -> Result<(), String> {
+    let mut cmd = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+    cmd.args(["build", "-q", "-p", "hew-cli", "--bin", "hew"])
+        .env("CARGO_TARGET_DIR", target_dir)
+        .current_dir(repo_root);
+    match profile {
+        // dev/test both land in target/debug
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]); // e.g. CI release-lib
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let dep = std::env::var("MACOSX_DEPLOYMENT_TARGET")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "13.0".to_string());
+        cmd.env("MACOSX_DEPLOYMENT_TARGET", dep);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| format!("spawn cargo build -p hew-cli --bin hew: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "cargo build -p hew-cli --bin hew failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    Ok(())
+}
+
 /// Testable core: `build_fn` is injected so the unit test can stub `cargo`.
 ///
 /// The stamp read, the build, the artifact presence check, and the stamp
@@ -810,6 +889,63 @@ mod hew_lib_bootstrap_tests {
             "build stub should run exactly once across concurrent callers"
         );
         assert!(artifact.is_file(), "stub artifact should be present");
+    }
+
+    /// The `hew` binary bootstrap (hew-lang/hew#1887) shares the exact
+    /// serialization spine as the library bootstrap: concurrent callers racing
+    /// a bin-named artifact must still build exactly once, and every later
+    /// caller must take the stamped fast path rather than re-running the build
+    /// inside a per-test deadline. Guarding this with its own artifact name
+    /// keeps the bin path from silently regressing to a per-call rebuild if the
+    /// stamp/lock wiring is ever changed.
+    #[test]
+    fn concurrent_bin_callers_build_exactly_once() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let target_dir = dir.path().to_path_buf();
+        let artifact = target_dir.join(hew_bin_name());
+        let build_count = AtomicUsize::new(0);
+
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    let target_dir = &target_dir;
+                    let artifact = &artifact;
+                    let build_count = &build_count;
+                    scope.spawn(move || {
+                        ensure_built_serialized(target_dir, "debug", artifact, |_td, _prof| {
+                            build_count.fetch_add(1, Ordering::SeqCst);
+                            fs::write(artifact, b"stub hew binary")
+                                .map_err(|e| format!("write stub binary: {e}"))
+                        })
+                    })
+                })
+                .collect();
+            for handle in handles {
+                handle
+                    .join()
+                    .expect("bin bootstrap thread should not panic")
+                    .expect("bin bootstrap thread should succeed");
+            }
+        });
+
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            1,
+            "bin build stub should run exactly once across concurrent callers"
+        );
+        assert!(artifact.is_file(), "stub bin artifact should be present");
+
+        // A fresh caller after the winner stamped must not rebuild.
+        ensure_built_serialized(&target_dir, "debug", &artifact, |_td, _prof| {
+            build_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("post-stamp caller should short-circuit");
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            1,
+            "a caller after the stamp must take the fast path, not rebuild"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #1887.

## Problem

The ~20 `*_exec` integration tests in `hew-codegen-rs/tests/` resolve the `hew` driver through a copy-pasted `hew_command(repo)` helper. On a cold `target/` (no `target/debug/hew`), it falls back to:

```rust
Command::new(cargo).args(["run", "--quiet", "-p", "hew-cli", "--bin", "hew", "--"])
```

which is then run **inside** the per-test `run_command_bounded(..., 60s)` deadline. When a concurrent `cargo`/`nextest` invocation shares the same `target/` and holds the build lock, that fallback blocks on `Blocking waiting for file lock on build directory` and burns the entire budget → the test presents as `exceeded 60s wall-clock deadline; process tree was killed`, i.e. a false timeout rather than an assertion failure. With a warm `target/debug/hew` the same fixture runs in ~0.14s and passes. This is the structural mechanism behind the "cold target is a false red" flakes.

## Fix

Add `hew_testutil::ensure_hew_bin_built()`, mirroring the existing `ensure_hew_lib_built()`: it builds `-p hew-cli --bin hew` **exactly once** per nextest run under the same `fd_lock` + `NEXTEST_RUN_ID` stamp serialization already used for `libhew.a`, and crucially **outside** any per-test deadline. Each `hew_command` now warms through this helper on the cold path instead of shelling a deadline-bounded `cargo run`. The warm fast-path (direct exec of an existing `target/debug/hew`) is unchanged, so steady-state latency is identical.

This also folds the cold-fallback duplication across the ~20 files into the single shared helper.

## Regression

`hew_testutil::hew_lib_bootstrap_tests::concurrent_bin_callers_build_exactly_once`: 8 threads race the bin bootstrap on one tempdir; the injected build stub must run exactly once (proving the `fd_lock` serializes writers and the stamp short-circuits the rest), and a post-stamp caller must take the fast path rather than rebuild. It fails if the bin bootstrap ever regresses to a per-call build.

## Verification

- `cargo test -p hew-testutil --lib` — green (incl. the new test).
- `cargo test -p hew-codegen-rs --test exec` — **118 passed; 0 failed**.
- `cargo fmt --check` + `cargo clippy --tests` clean on `hew-testutil` and `hew-codegen-rs` (only a pre-existing unrelated `hew-runtime` warning remains).

Harness-only change: no product code touched.