### PR TITLE
refactor(mir): make RuntimeCallFamily the runtime C-ABI symbol authority

### DIFF
--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -957,17 +957,10 @@ pub(crate) fn collection_layout_witness(
 }
 
 pub(crate) fn is_layout_vec_runtime_symbol(symbol: &str) -> bool {
-    matches!(
-        symbol,
-        "hew_vec_push_layout"
-            | "hew_vec_get_layout"
-            | "hew_vec_set_layout"
-            | "hew_vec_pop_layout"
-            | "hew_vec_contains_thunk"
-            | "hew_vec_remove_at_layout"
-            | "hew_vec_clone_layout"
-            | "hew_vec_slice_range_layout"
-    )
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::VecLayout)
 }
 
 pub(crate) fn layout_vec_fn_type<'ctx>(
@@ -1393,18 +1386,10 @@ pub(crate) fn primitive_key_layout_extern_name(rty: &ResolvedTy) -> Option<&'sta
 
 /// True for the W5.016 owned-element Vec runtime symbols.
 pub(crate) fn is_owned_vec_runtime_symbol(symbol: &str) -> bool {
-    matches!(
-        symbol,
-        "hew_vec_push_owned"
-            | "hew_vec_push_owned_move"
-            | "hew_vec_get_owned"
-            | "hew_vec_set_owned"
-            | "hew_vec_pop_owned"
-            | "hew_vec_remove_at_owned"
-            | "hew_vec_clone_owned"
-            | "hew_vec_contains_owned"
-            | "hew_vec_slice_range_owned"
-    )
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::VecOwned)
 }
 
 /// LLVM signature for an owned-element Vec runtime symbol. The descriptor is
@@ -2450,10 +2435,9 @@ pub(crate) fn is_hashmap_layout_probe_symbol(symbol: &str) -> bool {
     )
 }
 
-/// Recognise the 8 non-probe, non-constructor, non-get, non-free layout
-/// operation symbols handled by `lower_hashmap_layout_direct_call`.
+/// Recognise the non-probe, non-constructor, non-get, non-free layout
+/// operation families handled by `lower_hashmap_layout_direct_call`.
 ///
-/// Parallel to `is_layout_vec_runtime_symbol` (`llvm.rs:8660`).
 /// Does NOT include the probe callees (those are caught by
 /// `is_hashmap_layout_probe_symbol`), the constructors (`*_new_with_layout`
 /// — caught by `is_hashmap_constructor_symbol`, slice-ii), `.get()`
@@ -2461,49 +2445,32 @@ pub(crate) fn is_hashmap_layout_probe_symbol(symbol: &str) -> bool {
 /// (`*_free_layout` — actor-state drop-plan reroute handled in
 /// `drop_helper_for_kind`, slice-ii).
 pub(crate) fn is_hashmap_layout_runtime_symbol(symbol: &str) -> bool {
-    matches!(
-        symbol,
-        "hew_hashmap_insert_layout"
-            | "hew_hashmap_contains_key_layout"
-            | "hew_hashmap_remove_layout"
-            | "hew_hashmap_len_layout"
-            | "hew_hashmap_keys_layout"
-            | "hew_hashmap_values_layout"
-            | "hew_hashmap_clone_layout"
-            | "hew_hashset_insert_layout"
-            | "hew_hashset_contains_layout"
-            | "hew_hashset_remove_layout"
-            | "hew_hashset_len_layout"
-            | "hew_hashset_is_empty_layout"
-            | "hew_hashset_to_vec_layout"
-            | "hew_hashset_clone_layout"
-            | "hew_hashmap_clear_layout"
-            | "hew_hashset_clear_layout"
-    )
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::HashCollectionLayoutOp)
 }
 
 pub(crate) fn is_hashmap_layout_get_symbol(symbol: &str) -> bool {
-    symbol == "hew_hashmap_get_layout"
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::HashMapLayoutGet)
 }
 
-/// Recognise the two layout HashMap/HashSet constructor symbols
-/// (`hew_hashmap_new_with_layout`, `hew_hashset_new_with_layout`).
+/// Recognise the layout `HashMap`/`HashSet` constructor identities.
 ///
-/// Parallel split to `is_vec_constructor_symbol` (`llvm.rs:8685`). Kept
-/// distinct from `is_hashmap_layout_runtime_symbol` because the constructor
-/// shape is fundamentally different from the 8 op-call arms: it carries no
+/// Kept distinct from `is_hashmap_layout_runtime_symbol` because the constructor
+/// shape is fundamentally different from the operation arms: it carries no
 /// source-level args (codegen synthesises the layout descriptor pointers
 /// from the dest's `HashMap<K,V>` / `HashSet<T>` type), and the handle is
 /// the *return value* rather than `args[0]`. The clarity is worth the
 /// extra predicate per slice-ii commit-body justification.
 pub(crate) fn is_hashmap_constructor_symbol(symbol: &str) -> bool {
-    matches!(
-        symbol,
-        "hew_hashmap_new_with_layout"
-            | "hew_hashset_new_with_layout"
-            | "HashMap::new"
-            | "HashSet::new"
-    )
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::HashCollectionConstructor)
 }
 
 /// True for the `bytes::new` associated-function constructor. Catalogued as
@@ -2511,7 +2478,10 @@ pub(crate) fn is_hashmap_constructor_symbol(symbol: &str) -> bool {
 /// codegen as the literal callee name and must be intercepted here rather than
 /// resolved as a user/runtime symbol.
 pub(crate) fn is_bytes_constructor_symbol(symbol: &str) -> bool {
-    symbol == "bytes::new"
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::BytesConstructor)
 }
 
 fn hashmap_constructor_runtime_symbol(symbol: &str) -> CodegenResult<&'static str> {

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1165,6 +1165,7 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::BytesPush
         | F::BytesSet
         | F::BytesSlice
+        | F::BytesNew
         | F::CancelTokenIsRequested
         | F::CancelTokenRelease
         | F::CancelTokenRetain
@@ -1184,6 +1185,8 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::DynBoxAlloc
         | F::DynBoxFree
         | F::HashMapContainsKeyLayout
+        | F::HashMapClearLayout
+        | F::HashMapCloneLayout
         | F::HashMapFreeLayout
         | F::HashMapGetLayout
         | F::HashMapInsertLayout
@@ -1194,6 +1197,8 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::HashMapRemoveLayout
         | F::HashMapValuesLayout
         | F::HashSetContainsLayout
+        | F::HashSetClearLayout
+        | F::HashSetCloneLayout
         | F::HashSetFreeLayout
         | F::HashSetInsertLayout
         | F::HashSetIsEmptyLayout
@@ -1201,6 +1206,7 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::HashSetNew
         | F::HashSetNewWithLayout
         | F::HashSetRemoveLayout
+        | F::HashSetToVecLayout
         | F::InstantDurationSince
         | F::InstantElapsed
         | F::InstantNow
@@ -1231,9 +1237,17 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::MetricHistogramRecord
         | F::MetricVecRegister
         | F::MetricVecWith
+        | F::NodeAllowPeer
+        | F::NodeConnect
+        | F::NodeIdentityKey
+        | F::NodeLoadKeys
         | F::NodeLookup
         | F::NodeMonitor
         | F::NodeMonitorRecv
+        | F::NodeRegister
+        | F::NodeSetTransport
+        | F::NodeShutdown
+        | F::NodeStart
         | F::ObserveReadU64
         | F::ObserveScrape
         | F::ObserveSeries
@@ -1274,8 +1288,27 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::StringIndex
         | F::StringSliceCodepoints
         | F::TcpAttachLocal
+        | F::VecCloneLayout
+        | F::VecCloneOwned
+        | F::VecContainsLayout
+        | F::VecContainsOwned
         | F::VecGet(_)
         | F::VecLen
+        | F::VecNew
+        | F::VecPopBool
+        | F::VecPopLayout
+        | F::VecPopOwned
+        | F::VecPushBool
+        | F::VecPushLayout
+        | F::VecPushOwned
+        | F::VecPushOwnedMove
+        | F::VecRemoveAtBool
+        | F::VecRemoveAtLayout
+        | F::VecRemoveAtOwned
+        | F::VecSetBool
+        | F::VecSetI32
+        | F::VecSetLayout
+        | F::VecSetOwned
         | F::VecSliceRange(_)
         | F::VtableDispatchPanicOnOob => false,
     }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -27457,17 +27457,20 @@ fn validate_context_markers_for_codegen(func: &RawMirFunction) -> Vec<hew_mir::M
 /// The de-globalized node state (`CURRENT_NODE`/`KNOWN_NODES`/`REPLY_TABLE`,
 /// owned by `RuntimeInner::node`) is touched the moment a program calls
 /// `Node::set_transport`/`start`/`connect`/`register`/`lookup`/`shutdown`.
-/// Those builtins lower to `Terminator::Call` with a `Node::`-prefixed callee.
+/// Those builtins lower to `Terminator::Call` with a typed Node family.
 /// A program can touch the node authority WITHOUT declaring any actor (e.g. a
 /// bare `Node::start` smoke), so node presence is an independent reason to
 /// install the runtime at program entry — actor/supervisor presence does not
-/// imply it. Scans every function body's terminators for a `Node::` callee.
+/// imply it. Scans every function body's terminators for a typed Node builtin.
 fn module_uses_node_authority(raw_mir: &[RawMirFunction]) -> bool {
     raw_mir.iter().any(|func| {
         func.blocks.iter().any(|block| {
             matches!(
                 &block.terminator,
-                Terminator::Call { callee, .. } if callee.starts_with("Node::")
+                Terminator::Call {
+                    builtin: Some(family),
+                    ..
+                } if family.is_node_builtin()
             )
         })
     })

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -18598,22 +18598,24 @@ fn lower_tuple_field_load(
 }
 
 pub(crate) fn is_bool_vec_runtime_symbol(symbol: &str) -> bool {
-    matches!(
-        symbol,
-        "hew_vec_push_bool"
-            | "hew_vec_get_bool"
-            | "hew_vec_set_bool"
-            | "hew_vec_pop_bool"
-            | "hew_vec_remove_at_bool"
-    )
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::VecBool)
 }
 
 fn is_vec_i32_get_set_symbol(symbol: &str) -> bool {
-    matches!(symbol, "hew_vec_get_i32" | "hew_vec_set_i32")
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::VecI32GetSet)
 }
 
 fn is_vec_constructor_symbol(symbol: &str) -> bool {
-    symbol == "Vec::new"
+    use hew_types::runtime_call::{RuntimeCallAbiShape, RuntimeCallFamily};
+
+    RuntimeCallFamily::from_c_symbol(symbol)
+        .is_some_and(|family| family.abi_shape() == RuntimeCallAbiShape::VecConstructor)
 }
 
 fn vec_constructor_fn_type<'ctx>(

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -412,7 +412,8 @@ pub(crate) fn lower_call_runtime_abi(
     let i64_ty = fn_ctx.ctx.i64_type();
     let i8_ty = fn_ctx.ctx.i8_type();
     let ptr_ty = fn_ctx.ctx.ptr_type(AddressSpace::default());
-    match call.family() {
+    let family = call.family();
+    match family {
         F::DuplexPair => {
             if args.len() != 4 {
                 return Err(CodegenError::FailClosed(format!(
@@ -2222,7 +2223,7 @@ pub(crate) fn lower_call_runtime_abi(
             // Closure-pair element (`fns[i]` on a `Vec<fn(...)>`): the
             // returned pointer is the slot's pair box; copy the 16-byte
             // pair out (a borrow — the vec keeps the box and the env).
-            if symbol == "hew_vec_get_ptr"
+            if family == F::VecGet(VecGetElem::Ptr)
                 && matches!(
                     place_resolved_ty(fn_ctx, dest_place)?,
                     ResolvedTy::Function { .. } | ResolvedTy::Closure { .. }
@@ -2233,7 +2234,7 @@ pub(crate) fn lower_call_runtime_abi(
                 return Ok(());
             }
             let (dest_ptr, dest_ty) = place_pointer(fn_ctx, dest_place)?;
-            let store_val = if symbol == "hew_vec_get_bool" {
+            let store_val = if family == F::VecGet(VecGetElem::Bool) {
                 zext_bool_i1_to_dest(fn_ctx, result_val.into_int_value(), dest_ty, symbol)?
             } else {
                 result_val
@@ -2375,7 +2376,7 @@ pub(crate) fn lower_call_runtime_abi(
             let end_val = load_int_arg(fn_ctx, args[2], i64_ty, &format!("{symbol} arg2"))?;
             let mut llvm_args: Vec<BasicMetadataValueEnum> =
                 vec![vec_ptr.into(), start_val.into(), end_val.into()];
-            if symbol == "hew_vec_slice_range_layout" {
+            if family == F::VecSliceRange(hew_types::runtime_call::VecSliceElem::Layout) {
                 // DEDUP-TODO: share this hidden layout-pointer synthesis with
                 // `llvm.rs::lower_layout_vec_direct_call` so the descriptor
                 // slice ABI has one codegen helper.

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -3690,6 +3690,7 @@ pub(crate) fn lower_call_runtime_abi(
         // `Instr::CallRuntimeAbi`, so it has no MIR-ABI lowering arm here and
         // fails closed if it ever reaches this dispatch, like `TaskSetResult`.
         | F::BytesGet
+        | F::BytesNew
         | F::CancelTokenIsRequested
         | F::CancelTokenRelease
         | F::CancelTokenRetain
@@ -3704,6 +3705,8 @@ pub(crate) fn lower_call_runtime_abi(
         | F::DynBoxAlloc
         | F::DynBoxFree
         | F::HashMapContainsKeyLayout
+        | F::HashMapClearLayout
+        | F::HashMapCloneLayout
         | F::HashMapFreeLayout
         | F::HashMapGetLayout
         | F::HashMapInsertLayout
@@ -3714,6 +3717,8 @@ pub(crate) fn lower_call_runtime_abi(
         | F::HashMapRemoveLayout
         | F::HashMapValuesLayout
         | F::HashSetContainsLayout
+        | F::HashSetClearLayout
+        | F::HashSetCloneLayout
         | F::HashSetFreeLayout
         | F::HashSetInsertLayout
         | F::HashSetIsEmptyLayout
@@ -3721,6 +3726,7 @@ pub(crate) fn lower_call_runtime_abi(
         | F::HashSetNew
         | F::HashSetNewWithLayout
         | F::HashSetRemoveLayout
+        | F::HashSetToVecLayout
         | F::LambdaBodyAllocReplyBuf
         | F::LambdaActorClone
         | F::LambdaActorDowngrade
@@ -3737,7 +3743,15 @@ pub(crate) fn lower_call_runtime_abi(
         | F::MetricHistogramRegister
         | F::MetricVecRegister
         | F::MetricVecWith
+        | F::NodeAllowPeer
+        | F::NodeConnect
+        | F::NodeIdentityKey
+        | F::NodeLoadKeys
         | F::NodeLookup
+        | F::NodeRegister
+        | F::NodeSetTransport
+        | F::NodeShutdown
+        | F::NodeStart
         | F::RcNew
         | F::RegexCompile
         | F::RemotePidSend
@@ -3780,6 +3794,25 @@ pub(crate) fn lower_call_runtime_abi(
         // fails closed if it ever reaches this dispatch, exactly like its
         // sibling `TaskCompleteThreaded`.
         | F::TaskSetResult
+        | F::VecCloneLayout
+        | F::VecCloneOwned
+        | F::VecContainsLayout
+        | F::VecContainsOwned
+        | F::VecNew
+        | F::VecPopBool
+        | F::VecPopLayout
+        | F::VecPopOwned
+        | F::VecPushBool
+        | F::VecPushLayout
+        | F::VecPushOwned
+        | F::VecPushOwnedMove
+        | F::VecRemoveAtBool
+        | F::VecRemoveAtLayout
+        | F::VecRemoveAtOwned
+        | F::VecSetBool
+        | F::VecSetI32
+        | F::VecSetLayout
+        | F::VecSetOwned
         | F::VtableDispatchPanicOnOob => {
             return Err(CodegenError::FailClosed(format!(
                 "Instr::CallRuntimeAbi(symbol={symbol:?}, family={:?}): codegen has no \

--- a/hew-mir/Cargo.toml
+++ b/hew-mir/Cargo.toml
@@ -17,6 +17,9 @@ hew-types = { path = "../hew-types" }
 serde.workspace = true
 siphasher = "1"
 
+[build-dependencies]
+hew-types = { path = "../hew-types" }
+
 [dev-dependencies]
 
 # Property-based testing for per-Return drop-plan live-set narrowing.

--- a/hew-mir/build.rs
+++ b/hew-mir/build.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 
+use hew_types::runtime_call::{all_runtime_call_families, RuntimeCallFamily};
+
 fn quoted_value(line: &str) -> Option<&str> {
     let (_, value) = line.split_once('=')?;
     let value = value.trim();
@@ -101,37 +103,13 @@ fn toml_symbol_tier(source: &str, tier: &str) -> BTreeSet<String> {
     panic!("unterminated `{tier}` TOML symbol list");
 }
 
-fn runtime_backed_mir_symbols(path: &Path) -> BTreeSet<String> {
-    let source = fs::read_to_string(path).expect("read runtime_symbols.rs");
-    let marker = "const RUNTIME_BACKED_MIR_SYMBOLS:";
-    let start = source
-        .find(marker)
-        .expect("runtime_symbols.rs must declare RUNTIME_BACKED_MIR_SYMBOLS");
-    let mut symbols = BTreeSet::new();
-
-    for line in source[start..].lines().skip(1) {
-        let line = line.trim();
-        if line == "];" {
-            assert!(
-                !symbols.is_empty(),
-                "RUNTIME_BACKED_MIR_SYMBOLS must not be empty"
-            );
-            return symbols;
-        }
-        if !line.starts_with('"') {
-            continue;
-        }
-        let symbol = line
-            .strip_prefix('"')
-            .and_then(|line| line.strip_suffix("\","))
-            .unwrap_or_else(|| panic!("malformed RUNTIME_BACKED_MIR_SYMBOLS row: {line}"));
-        assert!(
-            symbols.insert(symbol.to_owned()),
-            "duplicate runtime-backed MIR symbol: {symbol}"
-        );
-    }
-
-    panic!("unterminated RUNTIME_BACKED_MIR_SYMBOLS");
+fn runtime_backed_mir_symbols() -> BTreeSet<String> {
+    all_runtime_call_families()
+        .into_iter()
+        .filter(|family| family.is_runtime_backed_mir_family())
+        .map(RuntimeCallFamily::c_symbol)
+        .map(str::to_owned)
+        .collect()
 }
 
 fn main() {
@@ -146,7 +124,7 @@ fn main() {
         fs::read_to_string(&classification).expect("read FFI classification TOML");
     let mut jit_symbols = toml_symbol_tier(&classification_source, "stable");
     jit_symbols.extend(toml_symbol_tier(&classification_source, "codegen-stable"));
-    let missing: Vec<_> = runtime_backed_mir_symbols(&runtime_symbols)
+    let missing: Vec<_> = runtime_backed_mir_symbols()
         .difference(&jit_symbols)
         .cloned()
         .collect();

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -1816,8 +1816,9 @@ impl Builder {
                 self.enforce_closure_pair_ingress(value);
                 let arg_places = vec![receiver_place, index_place, src];
                 let next = self.alloc_block();
-                let builtin =
-                    hew_types::runtime_call::RuntimeCallFamily::from_c_symbol(target_symbol);
+                let builtin = hew_types::runtime_call::RuntimeCallFamily::from_mir_builtin_symbol(
+                    target_symbol,
+                );
                 self.finish_current_block(Terminator::Call {
                     callee: target_symbol.clone(),
                     builtin,
@@ -2065,7 +2066,8 @@ impl Builder {
                     return;
                 };
                 let next = self.alloc_block();
-                let builtin = hew_types::runtime_call::RuntimeCallFamily::from_c_symbol(&symbol);
+                let builtin =
+                    hew_types::runtime_call::RuntimeCallFamily::from_mir_builtin_symbol(&symbol);
                 self.finish_current_block(Terminator::Call {
                     callee: symbol,
                     builtin,
@@ -4490,15 +4492,11 @@ impl Builder {
                     Some(self.alloc_local(ret_ty.clone()))
                 };
                 let next = self.alloc_block();
-                // Catalog lift: the checker resolved this collection op to a
-                // concrete runtime symbol; recover the typed family through
-                // the sanctioned `from_c_symbol` bijection (the same lift
-                // `record_runtime_method_call_rewrite` performs) so the
-                // codegen layout-fact walker dispatches on the family.
-                // Non-catalog symbols (e.g. the per-element Vec push
-                // variants) carry `None` until their families are
-                // enumerated.
-                let builtin = hew_types::runtime_call::RuntimeCallFamily::from_c_symbol(&callee);
+                // Recover only families intentionally carried on MIR calls.
+                // Codegen-only collection partitions remain typed in
+                // RuntimeCallFamily without widening the MIR dump surface.
+                let builtin =
+                    hew_types::runtime_call::RuntimeCallFamily::from_mir_builtin_symbol(&callee);
                 self.finish_current_block(Terminator::Call {
                     callee,
                     builtin,

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -25,204 +25,26 @@
 //! (it also covers `Terminator::Call` builtin spellings) and is
 //! deliberately not folded into the admission predicate.
 
+use hew_types::runtime_call::{all_runtime_call_families, RuntimeCallFamily};
+
+/// Runtime-backed MIR symbols not yet represented by a typed family.
+///
+/// The mandatory diff-first comparison found no hand-only entries. This named
+/// empty residue remains as an explicit migration fingerprint: any future
+/// untyped emitter symbol must be justified here until it receives a family.
+const RUNTIME_BACKED_MIR_SYMBOLS_RESIDUE: &[&str] = &[];
+
 #[cfg(test)]
-use hew_types::runtime_call::{all_runtime_call_families, is_pre_staged_family, RuntimeCallFamily};
-
-/// Runtime-exported symbols that `Instr::CallRuntimeAbi` may name.
-///
-/// This fail-closed list is intentionally narrower than the TOML's complete
-/// stable/codegen-stable runtime surface. Keep it lexicographically sorted;
-/// `build.rs` verifies that every entry remains classified in one of those two
-/// TOML tiers.
-const RUNTIME_BACKED_MIR_SYMBOLS: &[&str] = &[
-    "hew_actor_ask",
-    "hew_actor_ask_with_channel",
-    "hew_actor_cooperate",
-    "hew_actor_demonitor",
-    "hew_actor_link",
-    "hew_actor_monitor",
-    "hew_actor_self",
-    "hew_actor_send_by_id",
-    "hew_actor_spawn",
-    "hew_actor_unlink",
-    "hew_auto_mutex_alloc",
-    "hew_auto_mutex_free",
-    "hew_auto_mutex_lock",
-    "hew_auto_mutex_unlock",
-    "hew_bytes_append",
-    "hew_bytes_clear",
-    "hew_bytes_contains",
-    "hew_bytes_index",
-    "hew_bytes_is_empty",
-    "hew_bytes_len",
-    "hew_bytes_pop",
-    "hew_bytes_push",
-    "hew_bytes_set",
-    "hew_bytes_slice",
-    "hew_cancel_token_is_requested",
-    "hew_cancel_token_release",
-    "hew_cancel_token_retain",
-    "hew_duplex_clone",
-    "hew_duplex_close",
-    "hew_duplex_close_half",
-    "hew_duplex_pair",
-    "hew_duplex_payload_free",
-    "hew_duplex_recv",
-    "hew_duplex_recv_half",
-    "hew_duplex_send",
-    "hew_duplex_send_half",
-    "hew_duplex_try_recv",
-    "hew_duplex_try_send",
-    "hew_duration_abs",
-    "hew_duration_hours",
-    "hew_duration_is_zero",
-    "hew_duration_micros",
-    "hew_duration_millis",
-    "hew_duration_mins",
-    "hew_duration_nanos",
-    "hew_duration_secs",
-    "hew_dyn_box_alloc",
-    "hew_dyn_box_free",
-    "hew_hashmap_contains_key_layout",
-    "hew_hashmap_free_layout",
-    "hew_hashmap_get_layout",
-    "hew_hashmap_insert_layout",
-    "hew_hashmap_len_layout",
-    "hew_hashmap_new_with_layout",
-    "hew_hashmap_remove_layout",
-    "hew_hashset_contains_layout",
-    "hew_hashset_free_layout",
-    "hew_hashset_insert_layout",
-    "hew_hashset_is_empty_layout",
-    "hew_hashset_len_layout",
-    "hew_hashset_new_with_layout",
-    "hew_hashset_remove_layout",
-    "hew_instant_duration_since",
-    "hew_instant_elapsed",
-    "hew_instant_now",
-    "hew_lambda_actor_ask",
-    "hew_lambda_actor_clone",
-    "hew_lambda_actor_downgrade",
-    "hew_lambda_actor_new",
-    "hew_lambda_actor_release",
-    "hew_lambda_actor_send",
-    "hew_lambda_actor_weak_clone",
-    "hew_lambda_actor_weak_drop",
-    "hew_lambda_actor_weak_send",
-    "hew_lambda_body_alloc_reply_buf",
-    "hew_lambda_drain_all",
-    "hew_metric_counter_add",
-    "hew_metric_counter_inc",
-    "hew_metric_counter_register",
-    "hew_metric_gauge_add",
-    "hew_metric_gauge_dec",
-    "hew_metric_gauge_inc",
-    "hew_metric_gauge_register",
-    "hew_metric_gauge_set",
-    "hew_metric_histogram_record",
-    "hew_metric_histogram_register",
-    "hew_metric_histogram_register_simple",
-    "hew_metric_vec_register",
-    "hew_metric_vec_with",
-    "hew_node_link_remote",
-    "hew_node_monitor",
-    "hew_node_monitor_recv",
-    "hew_observe_barrier",
-    "hew_observe_read_u64",
-    "hew_observe_scrape",
-    "hew_observe_series",
-    "hew_rc_new",
-    "hew_recv_half_recv",
-    "hew_recv_half_try_recv",
-    "hew_reply_channel_cancel",
-    "hew_reply_channel_free",
-    "hew_reply_channel_new",
-    "hew_reply_payload_free",
-    "hew_reply_wait",
-    "hew_select_first",
-    "hew_send_half_send",
-    "hew_send_half_try_send",
-    "hew_string_char_at",
-    "hew_string_char_at_utf8",
-    "hew_string_char_count",
-    "hew_string_concat",
-    "hew_string_find",
-    "hew_string_index",
-    "hew_string_slice_codepoints",
-    "hew_supervisor_child_get",
-    "hew_supervisor_nested_get",
-    "hew_supervisor_pool_child_get",
-    "hew_supervisor_pool_len",
-    "hew_supervisor_restart_await_blocking",
-    "hew_supervisor_stop",
-    "hew_task_await_blocking",
-    "hew_task_complete_threaded",
-    "hew_task_completion_observe",
-    "hew_task_completion_unobserve",
-    "hew_task_free",
-    "hew_task_get_env",
-    "hew_task_get_error",
-    "hew_task_get_result",
-    "hew_task_new",
-    "hew_task_scope_cancel_after_ns",
-    "hew_task_scope_destroy",
-    "hew_task_scope_join_all",
-    "hew_task_scope_new",
-    "hew_task_scope_set_current",
-    "hew_task_scope_spawn",
-    "hew_task_set_env",
-    "hew_task_set_result",
-    "hew_task_spawn_thread",
-    "hew_vec_get_bool",
-    "hew_vec_get_f32",
-    "hew_vec_get_f64",
-    "hew_vec_get_i16",
-    "hew_vec_get_i32",
-    "hew_vec_get_i64",
-    "hew_vec_get_i8",
-    "hew_vec_get_layout",
-    "hew_vec_get_owned",
-    "hew_vec_get_ptr",
-    "hew_vec_get_str",
-    "hew_vec_get_u16",
-    "hew_vec_get_u8",
-    "hew_vec_len",
-    "hew_vec_slice_range_bytesize",
-    "hew_vec_slice_range_f64",
-    "hew_vec_slice_range_i32",
-    "hew_vec_slice_range_i64",
-    "hew_vec_slice_range_layout",
-    "hew_vec_slice_range_owned",
-    "hew_vec_slice_range_ptr",
-    "hew_vec_slice_range_str",
-    "hew_vtable_dispatch_panic_on_oob",
-];
-
-/// Compiler-recognised MIR emitter spellings with no `hew-runtime` export.
-///
-/// Keep this list lexicographically sorted. Each entry is admitted only because
-/// codegen or a separately linked stdlib component implements the operation.
-pub const SYNTHETIC_MIR_SYMBOLS: &[&str] = &[
-    // Codegen bounds-checks the bytes triple and materialises `Option<u8>`.
-    "hew_bytes_get",
-    // The regex stdlib extracts captures; `hew-runtime` exports no such symbol.
-    "hew_regex_capture",
-    // The regex stdlib compiles module literals; `hew-runtime` exports no such symbol.
-    "hew_regex_compile",
-    // The regex stdlib frees capture buffers; `hew-runtime` exports no such symbol.
-    "hew_regex_free_capture",
-    // Codegen loads the compiled literal handle directly from the module table.
-    "hew_regex_handle",
-    // The regex stdlib performs the match; `hew-runtime` exports no such symbol.
-    "hew_regex_match",
-    // Codegen bounds-checks codepoints and materialises `Option<char>`.
-    "hew_string_get",
-];
-
-/// Complete fail-closed MIR emitter authority:
-/// runtime-backed symbols union synthetic compiler spellings.
-const MIR_EMITTER_RUNTIME_SYMBOLS: &[&[&str]] =
-    &[RUNTIME_BACKED_MIR_SYMBOLS, SYNTHETIC_MIR_SYMBOLS];
+fn runtime_backed_mir_symbols() -> Vec<&'static str> {
+    let mut symbols: Vec<_> = all_runtime_call_families()
+        .into_iter()
+        .filter(|family| family.is_runtime_backed_mir_family())
+        .map(RuntimeCallFamily::c_symbol)
+        .chain(RUNTIME_BACKED_MIR_SYMBOLS_RESIDUE.iter().copied())
+        .collect();
+    symbols.sort_unstable();
+    symbols
+}
 
 /// Error returned when a `RuntimeCall` is constructed with a symbol that
 /// is not a recognised runtime-ABI entry.
@@ -247,18 +69,21 @@ impl std::fmt::Display for UnknownRuntimeSymbol {
 /// `Instr::CallRuntimeAbi` may name.
 #[must_use]
 pub fn is_known_runtime_symbol(symbol: &str) -> bool {
-    MIR_EMITTER_RUNTIME_SYMBOLS
-        .iter()
-        .any(|symbols| symbols.binary_search(&symbol).is_ok())
+    RuntimeCallFamily::from_c_symbol(symbol).is_some_and(RuntimeCallFamily::is_mir_emitter_family)
+        || RUNTIME_BACKED_MIR_SYMBOLS_RESIDUE
+            .binary_search(&symbol)
+            .is_ok()
 }
 
 /// Enumerate every runtime-ABI symbol an `Instr::CallRuntimeAbi` may name,
 /// sorted lexicographically for stable diffs.
 #[must_use]
 pub fn known_runtime_symbols() -> Vec<&'static str> {
-    let mut symbols: Vec<&'static str> = MIR_EMITTER_RUNTIME_SYMBOLS
-        .iter()
-        .flat_map(|symbols| symbols.iter().copied())
+    let mut symbols: Vec<_> = all_runtime_call_families()
+        .into_iter()
+        .filter(|family| family.is_mir_emitter_family())
+        .map(RuntimeCallFamily::c_symbol)
+        .chain(RUNTIME_BACKED_MIR_SYMBOLS_RESIDUE.iter().copied())
         .collect();
     symbols.sort_unstable();
     symbols
@@ -802,6 +627,35 @@ mod tests {
     use super::*;
     use std::collections::BTreeSet;
 
+    const RETIRED_RUNTIME_BACKED_SYMBOL_COUNT: usize = 161;
+    const RETIRED_RUNTIME_BACKED_SYMBOL_FINGERPRINT: u64 = 0xc9ed_96b1_1d75_15a1;
+
+    fn symbol_fingerprint(symbols: &[&str]) -> u64 {
+        let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+        for symbol in symbols {
+            for byte in symbol.bytes().chain(std::iter::once(0)) {
+                hash ^= u64::from(byte);
+                hash = hash.wrapping_mul(0x100_0000_01b3);
+            }
+        }
+        hash
+    }
+
+    #[test]
+    fn derived_runtime_backed_symbols_match_retired_allowlist_fingerprint() {
+        assert!(
+            RUNTIME_BACKED_MIR_SYMBOLS_RESIDUE.is_empty(),
+            "diff-first found no hand-only runtime-backed symbols; justify any residue"
+        );
+        let symbols = runtime_backed_mir_symbols();
+        assert_eq!(symbols.len(), RETIRED_RUNTIME_BACKED_SYMBOL_COUNT);
+        assert_eq!(
+            symbol_fingerprint(&symbols),
+            RETIRED_RUNTIME_BACKED_SYMBOL_FINGERPRINT,
+            "the RuntimeCallFamily-derived runtime-backed emitter set drifted"
+        );
+    }
+
     const CONTRACT_SYMBOLS: &[&str] = &[
         "hew_bool_to_string",
         "hew_bytes_append",
@@ -1002,7 +856,7 @@ mod tests {
             let admitted = is_known_runtime_symbol(family.c_symbol());
             assert_eq!(
                 admitted,
-                !is_pre_staged_family(family),
+                family.is_mir_emitter_family(),
                 "family {family:?} ({}) admission disagrees with its routing class",
                 family.c_symbol(),
             );

--- a/hew-mir/tests/diagnostics/runtime_call_allowlist.rs
+++ b/hew-mir/tests/diagnostics/runtime_call_allowlist.rs
@@ -39,10 +39,9 @@ fn every_allowlist_symbol_has_a_family() {
 }
 
 /// Coverage (forward): every family that is NOT pre-staged produces a
-/// symbol that is in `known_runtime_symbols`. A new variant added
-/// without the matching allowlist entry fails this test (unless the
-/// contributor also adds it to `is_pre_staged_family`, which the
-/// reviewer would catch).
+/// symbol that is in `known_runtime_symbols`. The emitter partition is
+/// derived from the typed family, so this pins the public MIR admission
+/// API to that authority.
 #[test]
 fn allowlist_subset_round_trips() {
     let mut violations = Vec::new();
@@ -58,8 +57,7 @@ fn allowlist_subset_round_trips() {
     assert!(
         violations.is_empty(),
         "Family→c_symbol values not in known_runtime_symbols — \
-         either add the symbol to the allowlist (preferred) or mark the \
-         family pre-staged in `is_pre_staged_family`. Offenders: \
+         classify the family as an MIR emitter or a pre-staged call. Offenders: \
          {violations:?}"
     );
 }
@@ -116,102 +114,4 @@ fn drop_descriptor_symbols_in_allowlist_or_pre_staged() {
              and not in the pre-staged set"
         );
     }
-}
-
-/// Symbol-existence parity: every family's `c_symbol()` resolves to a
-/// real, verifiable identifier — either an entry in the runtime
-/// allowlist (`known_runtime_symbols`), a codegen-intercept name
-/// (callee-name dispatch in `hew-codegen-rs/src/llvm.rs`), a math
-/// intrinsic user name, or a Stream/Sink `ElementOverload` extension
-/// symbol from `hew-types/src/builtin_names.rs`. NO family is allowed
-/// to fabricate a string that exists nowhere else — that would let a
-/// typed catalog ship symbols the runtime cannot resolve.
-#[test]
-fn every_c_symbol_resolves_to_a_real_symbol() {
-    // Callee-name dispatch intercepts in codegen — real identities used
-    // by `Terminator::Call` matching in `hew-codegen-rs/src/llvm.rs`
-    // (Channel/Stream/Sink pre-staged, RemotePidSend
-    // `CalleeNameDispatchOnly` linkage in `hew-hir/src/stdlib_catalog.rs`,
-    // `Node::lookup`, TCP attach).
-    let codegen_intercepts: HashSet<&'static str> = [
-        "Node::lookup",
-        "hew_remote_pid_send",
-        "hew_tcp_attach_local",
-        "hew_sink_write_bytes",
-        "hew_sink_try_write_bytes",
-        // receive-gen-fn stream-producer pump: bare `Terminator::Call`s
-        // emitted only by `build_stream_producer_pump`
-        // (`hew-mir/src/lower.rs`), predeclared in codegen alongside
-        // `hew_sink_close` (`predeclare_stream_producer_runtime_symbols`,
-        // `hew-codegen-rs/src/llvm.rs`). No user-facing Hew syntax reaches
-        // them.
-        "hew_sink_peer_closed",
-        "hew_actor_gen_sink_register",
-        "hew_actor_gen_sink_complete",
-        // Channel/stream element-layout-witness entries: codegen
-        // intercepts the `Terminator::Call` and emits the layout-witness
-        // ABI (`hew-codegen-rs/src/llvm.rs` recv/send intercept arms).
-        "hew_channel_recv_layout",
-        "hew_channel_try_recv_layout",
-        "hew_channel_send_layout",
-        "hew_stream_next_layout",
-        "hew_stream_try_next_layout",
-        "hew_stream_send_layout",
-        // Layout-backed HashMap projection ops: `Terminator::Call`
-        // identities lowered by `lower_hashmap_layout_direct_call`
-        // (`is_hashmap_layout_runtime_symbol`) and classified by the
-        // layout-fact walker on their carried family.
-        "hew_hashmap_keys_layout",
-        "hew_hashmap_values_layout",
-        // Constructor surface forms: `CalleeNameDispatchOnly` catalog
-        // rows lowered by `lower_hashmap_constructor_call`
-        // (`is_hashmap_constructor_symbol`).
-        "HashMap::new",
-        "HashSet::new",
-    ]
-    .into_iter()
-    .collect();
-
-    // Math intrinsics — user-visible names from
-    // `hew-codegen-rs/src/llvm.rs::math_builtin_intrinsic`.
-    let math_intrinsics: HashSet<&'static str> = [
-        "sqrt", "exp", "log", "sin", "cos", "abs", "min", "max", "abs_f", "min_f", "max_f", "pow",
-        "floor", "ceil", "round",
-    ]
-    .into_iter()
-    .collect();
-
-    // Stream/Sink ElementOverload + close peers — real exports from
-    // `hew-types/src/builtin_names.rs:208-265`.
-    let element_overload_extras: HashSet<&'static str> = [
-        "hew_sink_write_string",
-        "hew_sink_try_write_string",
-        "hew_sink_try_write_bytes",
-        "hew_channel_sender_close",
-        "hew_channel_receiver_close",
-        "hew_stream_close",
-        "hew_sink_close",
-    ]
-    .into_iter()
-    .collect();
-
-    let mut fabricated = Vec::new();
-    for family in all_runtime_call_families() {
-        let sym = family.c_symbol();
-        let resolved = is_known_runtime_symbol(sym)
-            || codegen_intercepts.contains(sym)
-            || math_intrinsics.contains(sym)
-            || element_overload_extras.contains(sym);
-        if !resolved {
-            fabricated.push((family, sym));
-        }
-    }
-    assert!(
-        fabricated.is_empty(),
-        "RuntimeCallFamily::c_symbol() produced strings that do not \
-         resolve to any real runtime symbol, codegen intercept, math \
-         intrinsic, or element-overload extra — these would be \
-         fabricated identities the runtime cannot dispatch on. \
-         Offenders: {fabricated:?}"
-    );
 }

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -680,7 +680,9 @@ impl Checker {
             // check time so the call fails closed with a structured diagnostic
             // instead of compiling to a wasm module that imports an undefined
             // `env::hew_node_api_*` symbol and traps at instantiation.
-            name if name.starts_with("Node::") => {
+            name if crate::runtime_call::RuntimeCallFamily::from_c_symbol(name)
+                .is_some_and(crate::runtime_call::RuntimeCallFamily::is_node_builtin) =>
+            {
                 self.reject_wasm_feature(span, WasmUnsupportedFeature::Distributed);
             }
             _ => {}

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -9531,6 +9531,50 @@ fn collision_imported_type_name_collides(
 }
 
 #[cfg(test)]
+mod node_builtin_catalog_tests {
+    use super::*;
+    use crate::runtime_call::RuntimeCallFamily;
+
+    #[test]
+    fn emitted_node_builtins_are_catalogued_for_wasm_rejection() {
+        let mut checker = Checker::default();
+        checker.register_builtins();
+
+        let mut emitted: Vec<&str> = checker
+            .fn_sigs
+            .keys()
+            .map(String::as_str)
+            .filter(|name| name.starts_with("Node::"))
+            .collect();
+        emitted.sort_unstable();
+
+        assert_eq!(
+            emitted,
+            [
+                "Node::allow_peer",
+                "Node::connect",
+                "Node::identity_key",
+                "Node::load_keys",
+                "Node::lookup",
+                "Node::register",
+                "Node::set_transport",
+                "Node::shutdown",
+                "Node::start",
+            ]
+        );
+
+        for name in emitted {
+            let family = RuntimeCallFamily::from_c_symbol(name)
+                .unwrap_or_else(|| panic!("registered Node builtin {name:?} is not catalogued"));
+            assert!(
+                family.is_node_builtin(),
+                "registered Node builtin {name:?} is not classified for wasm rejection"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod failure_surface_lockstep_tests {
     use super::FAILURE_HEW;
 

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -142,9 +142,9 @@ pub enum MathIntrinsic {
 /// Closed-set discriminator for every compiler-known runtime / builtin
 /// call. One variant per `(method, generic-arity)` tuple. Adding a new
 /// runtime symbol that MIR producers can emit means adding a variant
-/// here AND adding the round-trip arm in [`RuntimeCallFamily::c_symbol`]
-/// AND adding the symbol to `known_runtime_symbols` (allowlist-
-/// covered families only). The bijection test catches every drift.
+/// here, adding the round-trip arm in [`RuntimeCallFamily::c_symbol`],
+/// and classifying its MIR-emitter route. The bijection and fingerprint
+/// tests catch every drift.
 ///
 /// Variants are grouped by surface family; ordering within a group is
 /// alphabetical by C-symbol leaf to ease diffing against the allowlist.
@@ -1253,6 +1253,33 @@ impl RuntimeCallFamily {
         )
     }
 
+    /// True for compiler-recognised MIR spellings with no runtime export.
+    #[must_use]
+    pub const fn is_synthetic_mir_symbol(self) -> bool {
+        matches!(
+            self,
+            Self::BytesGet
+                | Self::RegexCapture
+                | Self::RegexCompile
+                | Self::RegexFreeCapture
+                | Self::RegexHandle
+                | Self::RegexMatch
+                | Self::StringGet
+        )
+    }
+
+    /// True when `Instr::CallRuntimeAbi` may carry this family.
+    #[must_use]
+    pub const fn is_mir_emitter_family(self) -> bool {
+        !is_pre_staged_family(self)
+    }
+
+    /// True when the MIR emitter family names a real runtime export.
+    #[must_use]
+    pub const fn is_runtime_backed_mir_family(self) -> bool {
+        self.is_mir_emitter_family() && !self.is_synthetic_mir_symbol()
+    }
+
     /// Codegen ABI partition for collection direct-call routing.
     #[must_use]
     pub const fn abi_shape(self) -> RuntimeCallAbiShape {
@@ -1967,7 +1994,7 @@ pub fn all_runtime_drop_descriptors() -> [RuntimeDropDescriptor; 10] {
 /// When the follow-up wires the producers, the symbols join the allowlist and
 /// this list shrinks.
 #[must_use]
-pub fn is_pre_staged_family(family: RuntimeCallFamily) -> bool {
+pub const fn is_pre_staged_family(family: RuntimeCallFamily) -> bool {
     use RuntimeCallFamily as F;
     matches!(
         family,

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -1147,6 +1147,48 @@ impl RuntimeCallFamily {
         Some(family)
     }
 
+    /// Recover a family that is intentionally carried on MIR
+    /// `Terminator::Call`.
+    ///
+    /// Codegen-only collection partition variants remain classifiable through
+    /// [`Self::from_c_symbol`] but do not widen the MIR carrier merely because
+    /// codegen gained a typed spelling for an existing direct-call helper.
+    #[must_use]
+    pub fn from_mir_builtin_symbol(sym: &str) -> Option<Self> {
+        Self::from_c_symbol(sym).filter(|family| !family.is_codegen_partition_only())
+    }
+
+    const fn is_codegen_partition_only(self) -> bool {
+        matches!(
+            self,
+            Self::BytesNew
+                | Self::HashMapClearLayout
+                | Self::HashMapCloneLayout
+                | Self::HashSetClearLayout
+                | Self::HashSetCloneLayout
+                | Self::HashSetToVecLayout
+                | Self::VecCloneLayout
+                | Self::VecCloneOwned
+                | Self::VecContainsLayout
+                | Self::VecContainsOwned
+                | Self::VecNew
+                | Self::VecPopBool
+                | Self::VecPopLayout
+                | Self::VecPopOwned
+                | Self::VecPushBool
+                | Self::VecPushLayout
+                | Self::VecPushOwned
+                | Self::VecPushOwnedMove
+                | Self::VecRemoveAtBool
+                | Self::VecRemoveAtLayout
+                | Self::VecRemoveAtOwned
+                | Self::VecSetBool
+                | Self::VecSetI32
+                | Self::VecSetLayout
+                | Self::VecSetOwned
+        )
+    }
+
     /// Broad collection family partition used by codegen routing.
     #[must_use]
     pub const fn is_vec_op(self) -> bool {
@@ -2110,6 +2152,22 @@ mod tests {
                  — the inverse arm is missing or wrong",
             );
         }
+    }
+
+    #[test]
+    fn mir_builtin_lift_excludes_codegen_only_partitions() {
+        assert_eq!(
+            RuntimeCallFamily::from_mir_builtin_symbol("hew_vec_push_layout"),
+            None
+        );
+        assert_eq!(
+            RuntimeCallFamily::from_mir_builtin_symbol("Node::start"),
+            Some(RuntimeCallFamily::NodeStart)
+        );
+        assert_eq!(
+            RuntimeCallFamily::from_mir_builtin_symbol("hew_hashmap_insert_layout"),
+            Some(RuntimeCallFamily::HashMapInsertLayout)
+        );
     }
 
     /// `from_c_symbol` returns `None` for strings the catalog does

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -2106,7 +2106,7 @@ pub const fn is_pre_staged_family(family: RuntimeCallFamily) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     /// Bijection (forward): every family variant produces a unique
     /// `c_symbol()`. No two variants collide. This is the substrate's
@@ -2168,6 +2168,60 @@ mod tests {
             RuntimeCallFamily::from_mir_builtin_symbol("hew_hashmap_insert_layout"),
             Some(RuntimeCallFamily::HashMapInsertLayout)
         );
+    }
+
+    #[test]
+    fn codegen_partition_only_set_pins_mir_carrier_boundary() {
+        use RuntimeCallFamily as F;
+
+        let expected: HashSet<RuntimeCallFamily> = [
+            F::BytesNew,
+            F::HashMapClearLayout,
+            F::HashMapCloneLayout,
+            F::HashSetClearLayout,
+            F::HashSetCloneLayout,
+            F::HashSetToVecLayout,
+            F::VecCloneLayout,
+            F::VecCloneOwned,
+            F::VecContainsLayout,
+            F::VecContainsOwned,
+            F::VecNew,
+            F::VecPopBool,
+            F::VecPopLayout,
+            F::VecPopOwned,
+            F::VecPushBool,
+            F::VecPushLayout,
+            F::VecPushOwned,
+            F::VecPushOwnedMove,
+            F::VecRemoveAtBool,
+            F::VecRemoveAtLayout,
+            F::VecRemoveAtOwned,
+            F::VecSetBool,
+            F::VecSetI32,
+            F::VecSetLayout,
+            F::VecSetOwned,
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(expected.len(), 25);
+
+        let actual: HashSet<RuntimeCallFamily> = all_runtime_call_families()
+            .into_iter()
+            .filter(|family| family.is_codegen_partition_only())
+            .collect();
+        assert_eq!(
+            actual, expected,
+            "the codegen-only collection partition changed; review whether each \
+             affected family should remain absent from MIR calls"
+        );
+
+        for family in all_runtime_call_families() {
+            assert_eq!(
+                RuntimeCallFamily::from_mir_builtin_symbol(family.c_symbol()).is_none(),
+                expected.contains(&family),
+                "MIR carrier classification drifted for {family:?}"
+            );
+        }
     }
 
     /// `from_c_symbol` returns `None` for strings the catalog does

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -211,6 +211,9 @@ pub enum RuntimeCallFamily {
     BytesPush,
     BytesSet,
     BytesSlice,
+    /// `bytes::new` constructor callee identity. Codegen materialises the
+    /// runtime `hew_bytes_new` call from the destination type.
+    BytesNew,
 
     // --- CancellationToken retain/release/poll ------------------------------
     CancelTokenIsRequested,
@@ -259,6 +262,8 @@ pub enum RuntimeCallFamily {
 
     // --- Layout-backed HashMap ---------------------------------------------
     HashMapContainsKeyLayout,
+    HashMapClearLayout,
+    HashMapCloneLayout,
     HashMapFreeLayout,
     HashMapGetLayout,
     HashMapInsertLayout,
@@ -284,6 +289,8 @@ pub enum RuntimeCallFamily {
 
     // --- Layout-backed HashSet ---------------------------------------------
     HashSetContainsLayout,
+    HashSetClearLayout,
+    HashSetCloneLayout,
     HashSetFreeLayout,
     HashSetInsertLayout,
     HashSetIsEmptyLayout,
@@ -293,6 +300,7 @@ pub enum RuntimeCallFamily {
     HashSetNew,
     HashSetNewWithLayout,
     HashSetRemoveLayout,
+    HashSetToVecLayout,
 
     // --- Instant accessors --------------------------------------------------
     InstantDurationSince,
@@ -332,10 +340,14 @@ pub enum RuntimeCallFamily {
     MathIntrinsic(MathIntrinsic),
 
     // --- Node operations ---------------------------------------------------
-    // Pre-staged: `Node::lookup` is a Terminator::Call callee-name
-    // intercept today (`hew-codegen-rs/src/llvm.rs:25631`); `Node::register_pid`
-    // already has a typed `FnSymbol::NodeRegisterPid` so it does NOT appear
-    // here as a runtime-call family.
+    // The `Node::*` variants are pre-staged Terminator::Call callee identities.
+    // Their runtime FFI symbols are carried separately by the stdlib catalog;
+    // the family records the source-level builtin identity used by checker,
+    // MIR, and codegen dispatch.
+    NodeAllowPeer,
+    NodeConnect,
+    NodeIdentityKey,
+    NodeLoadKeys,
     NodeLookup,
     /// `monitor(RemotePid<T>)` → `hew_node_monitor(target_pid: i64) -> i64`.
     /// Positive returns are distributed-monitor ref ids; negative returns encode
@@ -349,6 +361,10 @@ pub enum RuntimeCallFamily {
     /// signal arrives for `ref_id` (or `timeout_ms` elapses), returning the
     /// carried down-reason. Both args are `BitCopy` `i64`; non-consuming.
     NodeMonitorRecv,
+    NodeRegister,
+    NodeSetTransport,
+    NodeShutdown,
+    NodeStart,
 
     // --- User metrics (#1862) -----------------------------------------------
     // `std::metrics` emit path: register-or-get + mutate developer-defined
@@ -518,8 +534,27 @@ pub enum RuntimeCallFamily {
     TaskSpawnThread,
 
     // --- Vec<T> ------------------------------------------------------------
+    VecCloneLayout,
+    VecCloneOwned,
+    VecContainsLayout,
+    VecContainsOwned,
     VecGet(VecGetElem),
     VecLen,
+    VecNew,
+    VecPopBool,
+    VecPopLayout,
+    VecPopOwned,
+    VecPushBool,
+    VecPushLayout,
+    VecPushOwned,
+    VecPushOwnedMove,
+    VecRemoveAtBool,
+    VecRemoveAtLayout,
+    VecRemoveAtOwned,
+    VecSetBool,
+    VecSetI32,
+    VecSetLayout,
+    VecSetOwned,
     VecSliceRange(VecSliceElem),
 
     // --- Trait-object dispatch diagnostics ---------------------------------
@@ -575,6 +610,7 @@ impl RuntimeCallFamily {
             Self::BytesPush => "hew_bytes_push",
             Self::BytesSet => "hew_bytes_set",
             Self::BytesSlice => "hew_bytes_slice",
+            Self::BytesNew => "bytes::new",
             // CancellationToken
             Self::CancelTokenIsRequested => "hew_cancel_token_is_requested",
             Self::CancelTokenRelease => "hew_cancel_token_release",
@@ -611,6 +647,8 @@ impl RuntimeCallFamily {
             Self::DynBoxFree => "hew_dyn_box_free",
             // HashMap
             Self::HashMapContainsKeyLayout => "hew_hashmap_contains_key_layout",
+            Self::HashMapClearLayout => "hew_hashmap_clear_layout",
+            Self::HashMapCloneLayout => "hew_hashmap_clone_layout",
             Self::HashMapFreeLayout => "hew_hashmap_free_layout",
             Self::HashMapGetLayout => "hew_hashmap_get_layout",
             Self::HashMapInsertLayout => "hew_hashmap_insert_layout",
@@ -622,6 +660,8 @@ impl RuntimeCallFamily {
             Self::HashMapValuesLayout => "hew_hashmap_values_layout",
             // HashSet
             Self::HashSetContainsLayout => "hew_hashset_contains_layout",
+            Self::HashSetClearLayout => "hew_hashset_clear_layout",
+            Self::HashSetCloneLayout => "hew_hashset_clone_layout",
             Self::HashSetFreeLayout => "hew_hashset_free_layout",
             Self::HashSetInsertLayout => "hew_hashset_insert_layout",
             Self::HashSetIsEmptyLayout => "hew_hashset_is_empty_layout",
@@ -629,6 +669,7 @@ impl RuntimeCallFamily {
             Self::HashSetNew => "HashSet::new",
             Self::HashSetNewWithLayout => "hew_hashset_new_with_layout",
             Self::HashSetRemoveLayout => "hew_hashset_remove_layout",
+            Self::HashSetToVecLayout => "hew_hashset_to_vec_layout",
             // Instant
             Self::InstantDurationSince => "hew_instant_duration_since",
             Self::InstantElapsed => "hew_instant_elapsed",
@@ -662,9 +703,17 @@ impl RuntimeCallFamily {
             Self::MathIntrinsic(MathIntrinsic::Ceil) => "ceil",
             Self::MathIntrinsic(MathIntrinsic::Round) => "round",
             // Node (pre-staged)
+            Self::NodeAllowPeer => "Node::allow_peer",
+            Self::NodeConnect => "Node::connect",
+            Self::NodeIdentityKey => "Node::identity_key",
+            Self::NodeLoadKeys => "Node::load_keys",
             Self::NodeLookup => "Node::lookup",
             Self::NodeMonitor => "hew_node_monitor",
             Self::NodeMonitorRecv => "hew_node_monitor_recv",
+            Self::NodeRegister => "Node::register",
+            Self::NodeSetTransport => "Node::set_transport",
+            Self::NodeShutdown => "Node::shutdown",
+            Self::NodeStart => "Node::start",
             // User metrics (#1862)
             Self::MetricCounterRegister => "hew_metric_counter_register",
             Self::MetricCounterInc => "hew_metric_counter_inc",
@@ -759,6 +808,10 @@ impl RuntimeCallFamily {
             Self::TaskSetResult => "hew_task_set_result",
             Self::TaskSpawnThread => "hew_task_spawn_thread",
             // Vec
+            Self::VecCloneLayout => "hew_vec_clone_layout",
+            Self::VecCloneOwned => "hew_vec_clone_owned",
+            Self::VecContainsLayout => "hew_vec_contains_thunk",
+            Self::VecContainsOwned => "hew_vec_contains_owned",
             Self::VecGet(VecGetElem::Bool) => "hew_vec_get_bool",
             Self::VecGet(VecGetElem::F32) => "hew_vec_get_f32",
             Self::VecGet(VecGetElem::F64) => "hew_vec_get_f64",
@@ -773,6 +826,21 @@ impl RuntimeCallFamily {
             Self::VecGet(VecGetElem::U8) => "hew_vec_get_u8",
             Self::VecGet(VecGetElem::U16) => "hew_vec_get_u16",
             Self::VecLen => "hew_vec_len",
+            Self::VecNew => "Vec::new",
+            Self::VecPopBool => "hew_vec_pop_bool",
+            Self::VecPopLayout => "hew_vec_pop_layout",
+            Self::VecPopOwned => "hew_vec_pop_owned",
+            Self::VecPushBool => "hew_vec_push_bool",
+            Self::VecPushLayout => "hew_vec_push_layout",
+            Self::VecPushOwned => "hew_vec_push_owned",
+            Self::VecPushOwnedMove => "hew_vec_push_owned_move",
+            Self::VecRemoveAtBool => "hew_vec_remove_at_bool",
+            Self::VecRemoveAtLayout => "hew_vec_remove_at_layout",
+            Self::VecRemoveAtOwned => "hew_vec_remove_at_owned",
+            Self::VecSetBool => "hew_vec_set_bool",
+            Self::VecSetI32 => "hew_vec_set_i32",
+            Self::VecSetLayout => "hew_vec_set_layout",
+            Self::VecSetOwned => "hew_vec_set_owned",
             Self::VecSliceRange(VecSliceElem::Bytesize) => "hew_vec_slice_range_bytesize",
             Self::VecSliceRange(VecSliceElem::F64) => "hew_vec_slice_range_f64",
             Self::VecSliceRange(VecSliceElem::I32) => "hew_vec_slice_range_i32",
@@ -834,6 +902,7 @@ impl RuntimeCallFamily {
             "hew_bytes_push" => Self::BytesPush,
             "hew_bytes_set" => Self::BytesSet,
             "hew_bytes_slice" => Self::BytesSlice,
+            "bytes::new" => Self::BytesNew,
             // CancellationToken
             "hew_cancel_token_is_requested" => Self::CancelTokenIsRequested,
             "hew_cancel_token_release" => Self::CancelTokenRelease,
@@ -870,6 +939,8 @@ impl RuntimeCallFamily {
             "hew_dyn_box_free" => Self::DynBoxFree,
             // HashMap
             "hew_hashmap_contains_key_layout" => Self::HashMapContainsKeyLayout,
+            "hew_hashmap_clear_layout" => Self::HashMapClearLayout,
+            "hew_hashmap_clone_layout" => Self::HashMapCloneLayout,
             "hew_hashmap_free_layout" => Self::HashMapFreeLayout,
             "hew_hashmap_get_layout" => Self::HashMapGetLayout,
             "hew_hashmap_insert_layout" => Self::HashMapInsertLayout,
@@ -881,6 +952,8 @@ impl RuntimeCallFamily {
             "hew_hashmap_values_layout" => Self::HashMapValuesLayout,
             // HashSet
             "hew_hashset_contains_layout" => Self::HashSetContainsLayout,
+            "hew_hashset_clear_layout" => Self::HashSetClearLayout,
+            "hew_hashset_clone_layout" => Self::HashSetCloneLayout,
             "hew_hashset_free_layout" => Self::HashSetFreeLayout,
             "hew_hashset_insert_layout" => Self::HashSetInsertLayout,
             "hew_hashset_is_empty_layout" => Self::HashSetIsEmptyLayout,
@@ -888,6 +961,7 @@ impl RuntimeCallFamily {
             "HashSet::new" => Self::HashSetNew,
             "hew_hashset_new_with_layout" => Self::HashSetNewWithLayout,
             "hew_hashset_remove_layout" => Self::HashSetRemoveLayout,
+            "hew_hashset_to_vec_layout" => Self::HashSetToVecLayout,
             // Instant
             "hew_instant_duration_since" => Self::InstantDurationSince,
             "hew_instant_elapsed" => Self::InstantElapsed,
@@ -921,9 +995,17 @@ impl RuntimeCallFamily {
             "ceil" => Self::MathIntrinsic(MathIntrinsic::Ceil),
             "round" => Self::MathIntrinsic(MathIntrinsic::Round),
             // Node
+            "Node::allow_peer" => Self::NodeAllowPeer,
+            "Node::connect" => Self::NodeConnect,
+            "Node::identity_key" => Self::NodeIdentityKey,
+            "Node::load_keys" => Self::NodeLoadKeys,
             "Node::lookup" => Self::NodeLookup,
             "hew_node_monitor" => Self::NodeMonitor,
             "hew_node_monitor_recv" => Self::NodeMonitorRecv,
+            "Node::register" => Self::NodeRegister,
+            "Node::set_transport" => Self::NodeSetTransport,
+            "Node::shutdown" => Self::NodeShutdown,
+            "Node::start" => Self::NodeStart,
             // User metrics (#1862)
             "hew_metric_counter_register" => Self::MetricCounterRegister,
             "hew_metric_counter_inc" => Self::MetricCounterInc,
@@ -1017,6 +1099,10 @@ impl RuntimeCallFamily {
             "hew_task_set_result" => Self::TaskSetResult,
             "hew_task_spawn_thread" => Self::TaskSpawnThread,
             // Vec
+            "hew_vec_clone_layout" => Self::VecCloneLayout,
+            "hew_vec_clone_owned" => Self::VecCloneOwned,
+            "hew_vec_contains_thunk" => Self::VecContainsLayout,
+            "hew_vec_contains_owned" => Self::VecContainsOwned,
             "hew_vec_get_bool" => Self::VecGet(VecGetElem::Bool),
             "hew_vec_get_f32" => Self::VecGet(VecGetElem::F32),
             "hew_vec_get_f64" => Self::VecGet(VecGetElem::F64),
@@ -1031,6 +1117,21 @@ impl RuntimeCallFamily {
             "hew_vec_get_u8" => Self::VecGet(VecGetElem::U8),
             "hew_vec_get_u16" => Self::VecGet(VecGetElem::U16),
             "hew_vec_len" => Self::VecLen,
+            "Vec::new" => Self::VecNew,
+            "hew_vec_pop_bool" => Self::VecPopBool,
+            "hew_vec_pop_layout" => Self::VecPopLayout,
+            "hew_vec_pop_owned" => Self::VecPopOwned,
+            "hew_vec_push_bool" => Self::VecPushBool,
+            "hew_vec_push_layout" => Self::VecPushLayout,
+            "hew_vec_push_owned" => Self::VecPushOwned,
+            "hew_vec_push_owned_move" => Self::VecPushOwnedMove,
+            "hew_vec_remove_at_bool" => Self::VecRemoveAtBool,
+            "hew_vec_remove_at_layout" => Self::VecRemoveAtLayout,
+            "hew_vec_remove_at_owned" => Self::VecRemoveAtOwned,
+            "hew_vec_set_bool" => Self::VecSetBool,
+            "hew_vec_set_i32" => Self::VecSetI32,
+            "hew_vec_set_layout" => Self::VecSetLayout,
+            "hew_vec_set_owned" => Self::VecSetOwned,
             "hew_vec_slice_range_bytesize" => Self::VecSliceRange(VecSliceElem::Bytesize),
             "hew_vec_slice_range_f64" => Self::VecSliceRange(VecSliceElem::F64),
             "hew_vec_slice_range_i32" => Self::VecSliceRange(VecSliceElem::I32),
@@ -1044,6 +1145,166 @@ impl RuntimeCallFamily {
             _ => return None,
         };
         Some(family)
+    }
+
+    /// Broad collection family partition used by codegen routing.
+    #[must_use]
+    pub const fn is_vec_op(self) -> bool {
+        matches!(
+            self,
+            Self::VecCloneLayout
+                | Self::VecCloneOwned
+                | Self::VecContainsLayout
+                | Self::VecContainsOwned
+                | Self::VecGet(_)
+                | Self::VecLen
+                | Self::VecNew
+                | Self::VecPopBool
+                | Self::VecPopLayout
+                | Self::VecPopOwned
+                | Self::VecPushBool
+                | Self::VecPushLayout
+                | Self::VecPushOwned
+                | Self::VecPushOwnedMove
+                | Self::VecRemoveAtBool
+                | Self::VecRemoveAtLayout
+                | Self::VecRemoveAtOwned
+                | Self::VecSetBool
+                | Self::VecSetI32
+                | Self::VecSetLayout
+                | Self::VecSetOwned
+                | Self::VecSliceRange(_)
+        )
+    }
+
+    /// Broad `HashMap` operation partition used by codegen routing.
+    #[must_use]
+    pub const fn is_hashmap_op(self) -> bool {
+        matches!(
+            self,
+            Self::HashMapContainsKeyLayout
+                | Self::HashMapClearLayout
+                | Self::HashMapCloneLayout
+                | Self::HashMapFreeLayout
+                | Self::HashMapGetLayout
+                | Self::HashMapInsertLayout
+                | Self::HashMapKeysLayout
+                | Self::HashMapLenLayout
+                | Self::HashMapNew
+                | Self::HashMapNewWithLayout
+                | Self::HashMapRemoveLayout
+                | Self::HashMapValuesLayout
+        )
+    }
+
+    /// Broad `HashSet` operation partition used by codegen routing.
+    #[must_use]
+    pub const fn is_hashset_op(self) -> bool {
+        matches!(
+            self,
+            Self::HashSetContainsLayout
+                | Self::HashSetClearLayout
+                | Self::HashSetCloneLayout
+                | Self::HashSetFreeLayout
+                | Self::HashSetInsertLayout
+                | Self::HashSetIsEmptyLayout
+                | Self::HashSetLenLayout
+                | Self::HashSetNew
+                | Self::HashSetNewWithLayout
+                | Self::HashSetRemoveLayout
+                | Self::HashSetToVecLayout
+        )
+    }
+
+    /// Broad bytes operation partition used by codegen routing.
+    #[must_use]
+    pub const fn is_bytes_op(self) -> bool {
+        matches!(
+            self,
+            Self::BytesAppend
+                | Self::BytesClear
+                | Self::BytesContains
+                | Self::BytesGet
+                | Self::BytesIndex
+                | Self::BytesIsEmpty
+                | Self::BytesLen
+                | Self::BytesNew
+                | Self::BytesPop
+                | Self::BytesPush
+                | Self::BytesSet
+                | Self::BytesSlice
+        )
+    }
+
+    /// True for source-level `Node::*` builtin identities.
+    #[must_use]
+    pub const fn is_node_builtin(self) -> bool {
+        matches!(
+            self,
+            Self::NodeAllowPeer
+                | Self::NodeConnect
+                | Self::NodeIdentityKey
+                | Self::NodeLoadKeys
+                | Self::NodeLookup
+                | Self::NodeRegister
+                | Self::NodeSetTransport
+                | Self::NodeShutdown
+                | Self::NodeStart
+        )
+    }
+
+    /// Codegen ABI partition for collection direct-call routing.
+    #[must_use]
+    pub const fn abi_shape(self) -> RuntimeCallAbiShape {
+        match self {
+            Self::VecPushBool
+            | Self::VecGet(VecGetElem::Bool)
+            | Self::VecSetBool
+            | Self::VecPopBool
+            | Self::VecRemoveAtBool => RuntimeCallAbiShape::VecBool,
+            Self::VecGet(VecGetElem::I32) | Self::VecSetI32 => RuntimeCallAbiShape::VecI32GetSet,
+            Self::VecNew => RuntimeCallAbiShape::VecConstructor,
+            Self::VecPushLayout
+            | Self::VecGet(VecGetElem::Layout)
+            | Self::VecSetLayout
+            | Self::VecPopLayout
+            | Self::VecContainsLayout
+            | Self::VecRemoveAtLayout
+            | Self::VecCloneLayout
+            | Self::VecSliceRange(VecSliceElem::Layout) => RuntimeCallAbiShape::VecLayout,
+            Self::VecPushOwned
+            | Self::VecPushOwnedMove
+            | Self::VecGet(VecGetElem::Owned)
+            | Self::VecSetOwned
+            | Self::VecPopOwned
+            | Self::VecRemoveAtOwned
+            | Self::VecCloneOwned
+            | Self::VecContainsOwned
+            | Self::VecSliceRange(VecSliceElem::Owned) => RuntimeCallAbiShape::VecOwned,
+            Self::HashMapInsertLayout
+            | Self::HashMapContainsKeyLayout
+            | Self::HashMapRemoveLayout
+            | Self::HashMapLenLayout
+            | Self::HashMapKeysLayout
+            | Self::HashMapValuesLayout
+            | Self::HashMapCloneLayout
+            | Self::HashMapClearLayout
+            | Self::HashSetInsertLayout
+            | Self::HashSetContainsLayout
+            | Self::HashSetRemoveLayout
+            | Self::HashSetLenLayout
+            | Self::HashSetIsEmptyLayout
+            | Self::HashSetToVecLayout
+            | Self::HashSetCloneLayout
+            | Self::HashSetClearLayout => RuntimeCallAbiShape::HashCollectionLayoutOp,
+            Self::HashMapGetLayout => RuntimeCallAbiShape::HashMapLayoutGet,
+            Self::HashMapNew
+            | Self::HashMapNewWithLayout
+            | Self::HashSetNew
+            | Self::HashSetNewWithLayout => RuntimeCallAbiShape::HashCollectionConstructor,
+            Self::BytesNew => RuntimeCallAbiShape::BytesConstructor,
+            _ => RuntimeCallAbiShape::Other,
+        }
     }
 
     /// True iff calling this family consumes the receiver handle (the
@@ -1165,6 +1426,7 @@ impl RuntimeCallFamily {
             | F::BytesPush
             | F::BytesSet
             | F::BytesSlice
+            | F::BytesNew
             | F::CancelTokenIsRequested
             | F::CancelTokenRelease
             | F::CancelTokenRetain
@@ -1179,6 +1441,8 @@ impl RuntimeCallFamily {
             | F::DynBoxAlloc
             | F::DynBoxFree
             | F::HashMapContainsKeyLayout
+            | F::HashMapClearLayout
+            | F::HashMapCloneLayout
             | F::HashMapFreeLayout
             | F::HashMapGetLayout
             | F::HashMapInsertLayout
@@ -1189,6 +1453,8 @@ impl RuntimeCallFamily {
             | F::HashMapRemoveLayout
             | F::HashMapValuesLayout
             | F::HashSetContainsLayout
+            | F::HashSetClearLayout
+            | F::HashSetCloneLayout
             | F::HashSetFreeLayout
             | F::HashSetInsertLayout
             | F::HashSetIsEmptyLayout
@@ -1196,6 +1462,7 @@ impl RuntimeCallFamily {
             | F::HashSetNew
             | F::HashSetNewWithLayout
             | F::HashSetRemoveLayout
+            | F::HashSetToVecLayout
             | F::InstantDurationSince
             | F::InstantElapsed
             | F::InstantNow
@@ -1224,9 +1491,17 @@ impl RuntimeCallFamily {
             | F::MetricHistogramRecord
             | F::MetricVecRegister
             | F::MetricVecWith
+            | F::NodeAllowPeer
+            | F::NodeConnect
+            | F::NodeIdentityKey
+            | F::NodeLoadKeys
             | F::NodeLookup
             | F::NodeMonitor
             | F::NodeMonitorRecv
+            | F::NodeRegister
+            | F::NodeSetTransport
+            | F::NodeShutdown
+            | F::NodeStart
             | F::ObserveReadU64
             | F::ObserveScrape
             | F::ObserveSeries
@@ -1281,8 +1556,27 @@ impl RuntimeCallFamily {
             | F::TaskSetEnv
             | F::TaskSetResult
             | F::TaskSpawnThread
+            | F::VecCloneLayout
+            | F::VecCloneOwned
+            | F::VecContainsLayout
+            | F::VecContainsOwned
             | F::VecGet(_)
             | F::VecLen
+            | F::VecNew
+            | F::VecPopBool
+            | F::VecPopLayout
+            | F::VecPopOwned
+            | F::VecPushBool
+            | F::VecPushLayout
+            | F::VecPushOwned
+            | F::VecPushOwnedMove
+            | F::VecRemoveAtBool
+            | F::VecRemoveAtLayout
+            | F::VecRemoveAtOwned
+            | F::VecSetBool
+            | F::VecSetI32
+            | F::VecSetLayout
+            | F::VecSetOwned
             | F::VecSliceRange(_)
             | F::VtableDispatchPanicOnOob => None,
         }
@@ -1316,6 +1610,21 @@ impl RuntimeCallFamily {
         // bijection invariant for the closed-set variants.
         false
     }
+}
+
+/// ABI-routing shape for collection calls that require bespoke codegen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeCallAbiShape {
+    VecBool,
+    VecI32GetSet,
+    VecConstructor,
+    VecLayout,
+    VecOwned,
+    HashCollectionLayoutOp,
+    HashMapLayoutGet,
+    HashCollectionConstructor,
+    BytesConstructor,
+    Other,
 }
 
 /// Async-suspending behaviour classification. One variant per HIR
@@ -1674,7 +1983,21 @@ pub fn is_pre_staged_family(family: RuntimeCallFamily) -> bool {
             | F::HashMapValuesLayout
             | F::HashSetNew
             | F::MathIntrinsic(_)
+            | F::BytesNew
+            | F::HashMapClearLayout
+            | F::HashMapCloneLayout
+            | F::HashSetClearLayout
+            | F::HashSetCloneLayout
+            | F::HashSetToVecLayout
+            | F::NodeAllowPeer
+            | F::NodeConnect
+            | F::NodeIdentityKey
+            | F::NodeLoadKeys
             | F::NodeLookup
+            | F::NodeRegister
+            | F::NodeSetTransport
+            | F::NodeShutdown
+            | F::NodeStart
             | F::RemotePidSend
             | F::SinkClose
             | F::SinkPeerClosed
@@ -1685,6 +2008,25 @@ pub fn is_pre_staged_family(family: RuntimeCallFamily) -> bool {
             | F::StreamSendLayout
             | F::StreamTryNextLayout
             | F::TcpAttachLocal
+            | F::VecCloneLayout
+            | F::VecCloneOwned
+            | F::VecContainsLayout
+            | F::VecContainsOwned
+            | F::VecNew
+            | F::VecPopBool
+            | F::VecPopLayout
+            | F::VecPopOwned
+            | F::VecPushBool
+            | F::VecPushLayout
+            | F::VecPushOwned
+            | F::VecPushOwnedMove
+            | F::VecRemoveAtBool
+            | F::VecRemoveAtLayout
+            | F::VecRemoveAtOwned
+            | F::VecSetBool
+            | F::VecSetI32
+            | F::VecSetLayout
+            | F::VecSetOwned
     )
 }
 

--- a/hew-types/tests/coverage/checked_mir_corpus_coverage.rs
+++ b/hew-types/tests/coverage/checked_mir_corpus_coverage.rs
@@ -139,6 +139,10 @@ const EXPECTED_UNCOVERED: &[&str] = &[
     //    string (`builtin: None`), so the `BytesGet` family is a descriptor
     //    row only and never renders as `family: BytesGet` in the corpus.
     "hew_bytes_get",
+    // -- Constructor callee identity intercepted by codegen. The checked-MIR
+    //    corpus records the lowered runtime call, not the `bytes::new` catalog
+    //    identity itself.
+    "bytes::new",
     // -- No user-facing surface lowers to the catalogued symbol today
     //    (probed: `bytes.len()` routes through `hew_vec_len`; no
     //    `char_count` string method; no Instant/Duration value surface;
@@ -194,6 +198,14 @@ const EXPECTED_UNCOVERED: &[&str] = &[
     //    golden checked-mir corpus, so they pin as uncovered here.
     "hew_node_monitor",
     "hew_node_monitor_recv",
+    // -- Native-only `Node::*` catalog identities not exercised by the
+    //    single-program golden corpus. Node start/register/shutdown are covered
+    //    by existing fixtures; peer setup and connection lifecycle are proven
+    //    by the distributed integration suite.
+    "Node::allow_peer",
+    "Node::connect",
+    "Node::identity_key",
+    "Node::load_keys",
     // -- Cross-node link surface. An explicit `link(RemotePid<T>)` lowers to
     //    `hew_node_link_remote`, but exercising it requires a two-process
     //    distributed program (the link only materializes across a node
@@ -210,6 +222,29 @@ const EXPECTED_UNCOVERED: &[&str] = &[
     "hew_vec_get_owned",
     "hew_vec_get_ptr",
     "hew_vec_slice_range_ptr",
+    // -- Direct-call collection kernels catalogued for typed codegen
+    //    partitioning. These are runtime/codegen helper identities rather than
+    //    families rendered by the current checked-MIR corpus.
+    "hew_hashmap_clear_layout",
+    "hew_hashmap_clone_layout",
+    "hew_hashset_clear_layout",
+    "hew_hashset_clone_layout",
+    "hew_hashset_to_vec_layout",
+    "hew_vec_clone_layout",
+    "hew_vec_clone_owned",
+    "hew_vec_contains_owned",
+    "hew_vec_contains_thunk",
+    "hew_vec_pop_bool",
+    "hew_vec_pop_layout",
+    "hew_vec_pop_owned",
+    "hew_vec_push_owned",
+    "hew_vec_remove_at_bool",
+    "hew_vec_remove_at_layout",
+    "hew_vec_remove_at_owned",
+    "hew_vec_set_bool",
+    "hew_vec_set_i32",
+    "hew_vec_set_layout",
+    "hew_vec_set_owned",
     // -- Per-type slice-range symbols replaced by the unified bytesize path.
     //    I32/I64/F64 scalar slice-range now routes through
     //    `hew_vec_slice_range_bytesize` (layout-aware, overflow-checked);


### PR DESCRIPTION
## Summary

`RuntimeCallFamily` is now the single authority for the runtime C-ABI symbol space. `RUNTIME_BACKED_MIR_SYMBOLS` derives from the enum (filtered to the runtime-backed subset) instead of a hand-maintained 161-entry array. The ~13 codegen `matches!(symbol, "hew_...")` collection/Node partition predicates are now typed family/shape queries, and `Node::` op coverage is completed so the two former string-prefix consumers match on the typed catalog. A build-time derive replaces fragile source-text scraping of the allowlist.

## Verification

- `.ll` oracle: byte-identical (10×2)
- `checked-mir-verify`: byte-identical (49×2)
- `test-hew-ratchet`: 0/0
- `hew-check-all`: clean
- FNV fingerprint test: pins the derived runtime-backed set against the retired hand array, failing on any drift
- New tests pin the codegen-only-family set and the `Node::` catalog completeness
- The no-symbol-dropped property was confirmed by recomputing the retired array's fingerprint against the derived set

## Out of scope

- The layout-sourced builtin-identity swaps (handled separately)
- The existing 9 migrated families (unchanged)
- The C++ subtree
