### PR TITLE
refactor(codegen): use carried BuiltinType as collection-identity authority

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -23641,9 +23641,7 @@ fn recv_dest_option_elem_ty(
         ))
     })?;
     match dest_ty {
-        ResolvedTy::Named { args, .. }
-            if dest_ty.is_builtin(BuiltinType::Option) && args.len() == 1 =>
-        {
+        ResolvedTy::Named { name, args, .. } if name == "Option" && args.len() == 1 => {
             Ok(args[0].clone())
         }
         other => Err(CodegenError::FailClosed(format!(
@@ -37779,17 +37777,8 @@ mod tests {
         let ctx = Context::create();
         let llvm_mod = ctx.create_module("cow_heap_release_test");
         let harness = build_harness(&ctx, &[], &[]);
-        let mut fn_ctx = make_test_fn_ctx(&ctx, &llvm_mod, &harness, "cow_heap_release_probe");
+        let fn_ctx = make_test_fn_ctx(&ctx, &llvm_mod, &harness, "cow_heap_release_probe");
 
-        fn_ctx.local_tys.insert(
-            0,
-            ResolvedTy::Named {
-                name: "Option".to_string(),
-                args: vec![ResolvedTy::I64],
-                builtin: None,
-                is_opaque: false,
-            },
-        );
         let sym =
             |ty: &ResolvedTy| resolved_ty_cow_heap_release(&fn_ctx, ty).map(|r| r.release_symbol());
 
@@ -37806,11 +37795,6 @@ mod tests {
                 "user type `{name}` must not resolve to a runtime collection release"
             );
         }
-
-        assert!(
-            recv_dest_option_elem_ty(&fn_ctx, 0, "hew_channel_recv_layout").is_err(),
-            "user `Option<T>` must not be accepted as the runtime receive result"
-        );
 
         // The genuine builtin Vec of a string element: `string` takes its own
         // ElemKind path, so the Vec releases via the plain `hew_vec_free`.

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -38306,8 +38306,8 @@ mod tests {
         );
     }
 
-    /// C1a positive guard: layout-sourced genuine builtins can still carry
-    /// `builtin: None` and must continue through the runtime layout ABI.
+    /// Positive guard: layout-sourced genuine builtins can carry `builtin: None`
+    /// and must stay on the runtime layout ABI.
     #[test]
     fn hashmap_layout_ops_get_emits_clone_call_and_option_branches() {
         let ctx = Context::create();

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -23641,7 +23641,9 @@ fn recv_dest_option_elem_ty(
         ))
     })?;
     match dest_ty {
-        ResolvedTy::Named { name, args, .. } if name == "Option" && args.len() == 1 => {
+        ResolvedTy::Named { args, .. }
+            if dest_ty.is_builtin(BuiltinType::Option) && args.len() == 1 =>
+        {
             Ok(args[0].clone())
         }
         other => Err(CodegenError::FailClosed(format!(
@@ -37770,33 +37772,46 @@ mod tests {
         finish_test_fn(&fn_ctx);
     }
 
-    /// W5.011 P3 (Fix #2.2): `resolved_ty_cow_heap_release` dispatches on the
-    /// `builtin` discriminant, NOT the `name` string. A user-defined type
-    /// named "Vec" with `builtin: None` must NOT be routed to `hew_vec_free`
-    /// (which would free a non-Vec layout). The resolved release's symbol reads
-    /// the single `CowHeapRelease::release_symbol` authority.
+    /// Checker-stamped runtime collection dispatch must use the `builtin`
+    /// discriminant, not a colliding user type's name.
     #[test]
-    fn resolved_ty_cow_heap_release_ignores_user_named_collision() {
+    fn checker_stamped_collection_dispatch_ignores_user_name_collisions() {
         let ctx = Context::create();
         let llvm_mod = ctx.create_module("cow_heap_release_test");
         let harness = build_harness(&ctx, &[], &[]);
-        let fn_ctx = make_test_fn_ctx(&ctx, &llvm_mod, &harness, "cow_heap_release_probe");
+        let mut fn_ctx = make_test_fn_ctx(&ctx, &llvm_mod, &harness, "cow_heap_release_probe");
 
+        fn_ctx.local_tys.insert(
+            0,
+            ResolvedTy::Named {
+                name: "Option".to_string(),
+                args: vec![ResolvedTy::I64],
+                builtin: None,
+                is_opaque: false,
+            },
+        );
         let sym =
             |ty: &ResolvedTy| resolved_ty_cow_heap_release(&fn_ctx, ty).map(|r| r.release_symbol());
 
-        // User type literally named "Vec" but not the builtin.
-        let user_vec = ResolvedTy::Named {
-            name: "Vec".to_string(),
-            args: vec![],
-            builtin: None,
-            is_opaque: false,
-        };
-        assert_eq!(
-            sym(&user_vec),
-            None,
-            "a user `Named {{ name: \"Vec\", builtin: None }}` must not resolve to hew_vec_free"
+        for name in ["Vec", "HashMap", "HashSet"] {
+            let user_ty = ResolvedTy::Named {
+                name: name.to_string(),
+                args: vec![],
+                builtin: None,
+                is_opaque: false,
+            };
+            assert_eq!(
+                sym(&user_ty),
+                None,
+                "user type `{name}` must not resolve to a runtime collection release"
+            );
+        }
+
+        assert!(
+            recv_dest_option_elem_ty(&fn_ctx, 0, "hew_channel_recv_layout").is_err(),
+            "user `Option<T>` must not be accepted as the runtime receive result"
         );
+
         // The genuine builtin Vec of a string element: `string` takes its own
         // ElemKind path, so the Vec releases via the plain `hew_vec_free`.
         let builtin_vec = ResolvedTy::Named {
@@ -38307,6 +38322,8 @@ mod tests {
         );
     }
 
+    /// C1a positive guard: layout-sourced genuine builtins can still carry
+    /// `builtin: None` and must continue through the runtime layout ABI.
     #[test]
     fn hashmap_layout_ops_get_emits_clone_call_and_option_branches() {
         let ctx = Context::create();

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -33,6 +33,13 @@ use crate::layout::{
 #[allow(unused_imports)]
 use crate::llvm::*;
 
+fn stamped_vec_element_ty(ty: &ResolvedTy) -> Option<&ResolvedTy> {
+    let ResolvedTy::Named { args, .. } = ty else {
+        return None;
+    };
+    (ty.is_builtin(BuiltinType::Vec) && args.len() == 1).then(|| &args[0])
+}
+
 /// Decode a setup ABI whose positive return is an internal ref id and whose
 /// negative return encodes an error enum as `-(variant + 1)`.
 ///
@@ -2381,19 +2388,14 @@ pub(crate) fn lower_call_runtime_abi(
                 // `llvm.rs::lower_layout_vec_direct_call` so the descriptor
                 // slice ABI has one codegen helper.
                 let vec_resolved_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
-                let elem_hew_ty = match &vec_resolved_ty {
-                    ResolvedTy::Named {
-                        args: vec_args,
-                        ..
-                    } if vec_resolved_ty.is_builtin(BuiltinType::Vec) && vec_args.len() == 1 => {
-                        vec_args[0].clone()
-                    }
-                    other => {
-                        return Err(CodegenError::FailClosed(format!(
-                            "hew_vec_slice_range_layout: arg0 must be Vec<T>, got {other:?}"
-                        )));
-                    }
-                };
+                let elem_hew_ty = stamped_vec_element_ty(&vec_resolved_ty)
+                    .cloned()
+                    .ok_or_else(|| {
+                        CodegenError::FailClosed(format!(
+                            "hew_vec_slice_range_layout: arg0 must be Vec<T>, got \
+                             {vec_resolved_ty:?}"
+                        ))
+                    })?;
                 let layout_elem_ty = layout_vec_element_needs_descriptor(fn_ctx, &elem_hew_ty)?
                     .ok_or_else(|| {
                         CodegenError::FailClosed(format!(
@@ -6348,4 +6350,28 @@ pub(crate) fn predeclare_extern_decls<'ctx>(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stamped_vec_element_ignores_user_name_collision() {
+        let user_vec = ResolvedTy::Named {
+            name: "Vec".to_string(),
+            args: vec![ResolvedTy::I64],
+            builtin: None,
+            is_opaque: false,
+        };
+        assert_eq!(stamped_vec_element_ty(&user_vec), None);
+
+        let builtin_vec = ResolvedTy::Named {
+            name: "Vec".to_string(),
+            args: vec![ResolvedTy::I64],
+            builtin: Some(BuiltinType::Vec),
+            is_opaque: false,
+        };
+        assert_eq!(stamped_vec_element_ty(&builtin_vec), Some(&ResolvedTy::I64));
+    }
 }

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -24,7 +24,7 @@ use inkwell::{AddressSpace, IntPredicate};
 
 use hew_hir::stdlib_catalog::{self, BuiltinEntry, BuiltinLinkage, BuiltinTy};
 use hew_mir::Place;
-use hew_types::ResolvedTy;
+use hew_types::{BuiltinType, ResolvedTy};
 
 use crate::layout::{
     get_or_declare_bool_vec_runtime, get_or_declare_owned_vec_runtime,
@@ -2383,10 +2383,11 @@ pub(crate) fn lower_call_runtime_abi(
                 let vec_resolved_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
                 let elem_hew_ty = match &vec_resolved_ty {
                     ResolvedTy::Named {
-                        name,
                         args: vec_args,
                         ..
-                    } if name == "Vec" && vec_args.len() == 1 => vec_args[0].clone(),
+                    } if vec_resolved_ty.is_builtin(BuiltinType::Vec) && vec_args.len() == 1 => {
+                        vec_args[0].clone()
+                    }
                     other => {
                         return Err(CodegenError::FailClosed(format!(
                             "hew_vec_slice_range_layout: arg0 must be Vec<T>, got {other:?}"

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -2043,7 +2043,8 @@ impl Builder {
             }
             // `xs[i] = v` over a `Vec<T>` lowers to the same runtime call that
             // `xs.set(i, v)` emits.
-            HirExprKind::Index { container, index } if matches!(&self.subst_ty(&container.ty), ResolvedTy::Named { name, .. } if name == "Vec") =>
+            HirExprKind::Index { container, index }
+                if self.subst_ty(&container.ty).is_builtin(BuiltinType::Vec) =>
             {
                 let Some(vec_place) = self.lower_value(container) else {
                     return;
@@ -2084,7 +2085,10 @@ impl Builder {
             // accepted this target with value type `V`, so `src` already holds
             // a `V`-typed value. The container/index were NOT pre-lowered (the
             // outer `assign` only lowered `value`), so lower them here.
-            HirExprKind::Index { container, index } if matches!(&self.subst_ty(&container.ty), ResolvedTy::Named { name, .. } if name == "HashMap") =>
+            HirExprKind::Index { container, index }
+                if self
+                    .subst_ty(&container.ty)
+                    .is_builtin(BuiltinType::HashMap) =>
             {
                 let Some(map_place) = self.lower_value(container) else {
                     return;
@@ -4069,7 +4073,7 @@ impl Builder {
                     // aborts with IndexOutOfBounds on a miss (the map analogue of
                     // `v[i]` OOB). `m.get(k) -> Option<V>` is the non-aborting
                     // form and takes the `ResolvedImplCall` get path.
-                    ResolvedTy::Named { name, .. } if name == "HashMap" => {
+                    ty if ty.is_builtin(BuiltinType::HashMap) => {
                         self.lower_hashmap_index_trap(container, index, &elem_ty, expr.site)
                     }
                     _ => self.lower_vec_index(container, index, &elem_ty, expr.site),
@@ -6891,7 +6895,9 @@ impl Builder {
         // Resolve element type from the result Vec<T> for runtime dispatch.
         let result_ty = self.subst_ty(result_ty);
         let elem_ty = match &result_ty {
-            ResolvedTy::Named { name, args, .. } if name == "Vec" && !args.is_empty() => {
+            ResolvedTy::Named { args, .. }
+                if result_ty.is_builtin(BuiltinType::Vec) && !args.is_empty() =>
+            {
                 args[0].clone()
             }
             other => {

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -267,6 +267,18 @@ impl fmt::Display for BoundaryError {
 impl std::error::Error for BoundaryError {}
 
 impl ResolvedTy {
+    /// Returns whether this type carries the checker-stamped builtin identity.
+    #[must_use]
+    pub fn is_builtin(&self, expected: BuiltinType) -> bool {
+        matches!(
+            self,
+            Self::Named {
+                builtin: Some(actual),
+                ..
+            } if *actual == expected
+        )
+    }
+
     /// Returns `true` for every concrete integer type admitted by the checker.
     /// `Bool` and `Char` are deliberately excluded: `bool` participates in
     /// explicit casts only through the checker-owned bool<->integer rules, and
@@ -939,6 +951,26 @@ pub fn mangle_impl_self_name(name: &str, type_args: &[ResolvedTy]) -> Option<Str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn builtin_identity_uses_the_carried_discriminant() {
+        let builtin_vec = ResolvedTy::Named {
+            name: "Vec".into(),
+            args: vec![ResolvedTy::I64],
+            builtin: Some(BuiltinType::Vec),
+            is_opaque: false,
+        };
+        assert!(builtin_vec.is_builtin(BuiltinType::Vec));
+        assert!(!builtin_vec.is_builtin(BuiltinType::HashMap));
+
+        let user_vec = ResolvedTy::Named {
+            name: "Vec".into(),
+            args: vec![],
+            builtin: None,
+            is_opaque: false,
+        };
+        assert!(!user_vec.is_builtin(BuiltinType::Vec));
+    }
 
     #[test]
     fn integer_literal_match_scrutinee_admits_all_integer_widths_only() {


### PR DESCRIPTION
## Summary

Collection identity is now decided by the `builtin: Option<BuiltinType>` discriminant already carried on `ResolvedTy::Named`, at the sites where the checker reliably stamps it, instead of bare name-string comparisons (`name == "Vec"`, etc.). This closes a shadow-type hazard: a user-defined type named `Vec`, `HashMap`, or `Option` no longer misroutes to the runtime container ABI. Layout-sourced sites that can legitimately carry a null stamp for a genuine builtin are deliberately left name-based for now (threading the stamp there is a separate change), and a guard commit keeps those on the safe path.

## Verification

- `make ll-diff` (LLVM IR oracle): byte-identical, 10×2.
- `make checked-mir-verify`: byte-identical, 49×2.
- `make test-hew-ratchet`: 0 failures.
- `make hew-check-all`: clean.
- Shadow-type negative test: a user-defined `Vec` compiles and does NOT route to the container ABI (fails against the old name-based code, passes here).
- Layout-sourced positive test: a genuine builtin still routes correctly.
- The stamped-element helper fail-closes rather than misroutes if a stamp is ever unexpectedly absent.
- Preflight: ready-to-push.

## Out of scope

- Threading the discriminant through layout-sourced sites (a follow-on change) — those sites remain name-based for now, guarded onto the safe path.
- The C++ subtree.