### PR TITLE
fix(mir): treat post-call return-position variant share as a hand-off

### DIFF
--- a/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
@@ -294,7 +294,6 @@ fn channel$try_new(i64) -> Result<(Sender, Receiver), string> [conv=default]
     stmt: return site=Some(SiteId(88)) ty=Result<(Sender, Receiver), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return

--- a/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
@@ -415,7 +415,6 @@ fn channel$try_new(i64) -> Result<(Sender, Receiver), string> [conv=default]
     stmt: return site=Some(SiteId(127)) ty=Result<(Sender, Receiver), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -855,7 +855,6 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     stmt: use BindingId(24) contents site=SiteId(296) ty=string intent=Read
     _17 = const.i64 0
     mtag16 = move _17
-    string.retain _6
     mvar16.0.0 = move _6
     _18 = move _16
     _13 = move _18
@@ -1764,7 +1763,6 @@ fn stream$try_pipe(i64) -> Result<(Sink<string>, Stream<string>), string> [conv=
     stmt: return site=Some(SiteId(550)) ty=Result<(Sink<string>, Stream<string>), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return
@@ -1950,7 +1948,6 @@ fn stream$try_bytes_pipe(i64) -> Result<(Sink<bytes>, Stream<bytes>), string> [c
     stmt: return site=Some(SiteId(609)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -915,7 +915,6 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     stmt: use BindingId(29) contents site=SiteId(315) ty=string intent=Read
     _17 = const.i64 0
     mtag16 = move _17
-    string.retain _6
     mvar16.0.0 = move _6
     _18 = move _16
     _13 = move _18
@@ -1824,7 +1823,6 @@ fn stream$try_pipe(i64) -> Result<(Sink<string>, Stream<string>), string> [conv=
     stmt: return site=Some(SiteId(569)) ty=Result<(Sink<string>, Stream<string>), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return
@@ -2010,7 +2008,6 @@ fn stream$try_bytes_pipe(i64) -> Result<(Sink<bytes>, Stream<bytes>), string> [c
     stmt: return site=Some(SiteId(628)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -801,7 +801,6 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     stmt: use BindingId(24) contents site=SiteId(283) ty=string intent=Read
     _17 = const.i64 0
     mtag16 = move _17
-    string.retain _6
     mvar16.0.0 = move _6
     _18 = move _16
     _13 = move _18
@@ -1710,7 +1709,6 @@ fn stream$try_pipe(i64) -> Result<(Sink<string>, Stream<string>), string> [conv=
     stmt: return site=Some(SiteId(537)) ty=Result<(Sink<string>, Stream<string>), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return
@@ -1896,7 +1894,6 @@ fn stream$try_bytes_pipe(i64) -> Result<(Sink<bytes>, Stream<bytes>), string> [c
     stmt: return site=Some(SiteId(596)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.raw.mir
@@ -779,7 +779,6 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     stmt: use BindingId(22) contents site=SiteId(276) ty=string intent=Read
     _17 = const.i64 0
     mtag16 = move _17
-    string.retain _6
     mvar16.0.0 = move _6
     _18 = move _16
     _13 = move _18
@@ -1688,7 +1687,6 @@ fn stream$try_pipe(i64) -> Result<(Sink<string>, Stream<string>), string> [conv=
     stmt: return site=Some(SiteId(530)) ty=Result<(Sink<string>, Stream<string>), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return
@@ -1874,7 +1872,6 @@ fn stream$try_bytes_pipe(i64) -> Result<(Sink<bytes>, Stream<bytes>), string> [c
     stmt: return site=Some(SiteId(589)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
     _26 = const.i64 1
     mtag25 = move _26
-    string.retain _18
     mvar25.1.0 = move _18
     ret = move _25
     return

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -388,8 +388,48 @@ pub(super) fn derive_cow_sole_owner(
             }
         }
     }
+    // A variant-payload share is a hand-off (no retain) when the source is
+    // never used afterwards AND the store site cannot re-execute for the same
+    // binding instance — i.e. its block is not on a CFG cycle. The previous
+    // entry-block-only proxy for "executes at most once" misclassified every
+    // post-call return-position constructor (`let v = f(); Ok(v)` — the call
+    // splits the CFG, so the constructor lands in a non-entry block) as a
+    // co-own share. That minted a `StringRetain` while
+    // `derive_returned_aggregate_member_bindings` simultaneously excluded the
+    // binding from its scope-exit drop as a returned-aggregate member (that
+    // authority's contract is a NO-retain byte-copy hand-off), so the payload
+    // gained a reference nothing ever released: one leaked string per call.
+    // Blocks on a cycle keep the retain-on-share posture — a loop body's store
+    // can re-execute for a binding defined outside the loop, where a hand-off
+    // would double-free.
+    // Reachable-from-self is a deliberate OVER-APPROXIMATION of cycle membership,
+    // and that is the fail-closed choice: a straight-line store wrongly judged
+    // loop-carried merely keeps a retain (safe — at worst a missed hand-off), whereas
+    // the dangerous direction is treating a re-executing store as a one-shot hand-off
+    // (a double-free). Cost is O(blocks·(blocks+edges)) per store — fine at MIR
+    // function sizes.
+    let cyclic_blocks: HashSet<u32> = {
+        let succs: HashMap<u32, Vec<u32>> = blocks.iter().map(|b| (b.id, b.successors())).collect();
+        let mut cyclic = HashSet::new();
+        for start in succs.keys().copied() {
+            let mut stack: Vec<u32> = succs.get(&start).cloned().unwrap_or_default();
+            let mut seen: HashSet<u32> = HashSet::new();
+            while let Some(b) = stack.pop() {
+                if b == start {
+                    cyclic.insert(start);
+                    break;
+                }
+                if seen.insert(b) {
+                    if let Some(next) = succs.get(&b) {
+                        stack.extend(next.iter().copied());
+                    }
+                }
+            }
+        }
+        cyclic
+    };
     let share_needs_retain = |local: u32, block: u32, instr_index: usize| {
-        entry_block != Some(block)
+        cyclic_blocks.contains(&block)
             || local_is_used_after(blocks, suspend_kinds, local, block, instr_index)
     };
 


### PR DESCRIPTION
**Summary**: Fix a reference-count leak in MIR temporary-drop lowering. `derive_cow_sole_owner` decided whether a variant-payload store needs a retain by testing whether its block was the entry block — a proxy for "executes at most once." A function call splits the control-flow graph, so a post-call return-position constructor (`let v = f(); Ok(v)`) lands in a non-entry block and was wrongly given a retain, even though the binding is handed off into the returned aggregate with no matching release — leaking one allocation per call. Replace the entry-block proxy with a real re-execution test: a store is a hand-off (no retain) unless its block sits on a control-flow cycle (reachable from itself). Loop-body stores keep their retain; straight-line post-call constructors no longer over-retain.

**Verification**: The leak fixture `call_scrutinee_fresh_forwarder_release` goes from 3 leaked objects to 0 (reproduced with the macOS `leaks --atExit` oracle; the leak returns if the fix is reverted). No double-free introduced — loop-carried stores stay retained, verified on `enum_payload_call_loop_release` and a purpose-built loop fixture. `cargo test -p hew-mir`, the vertical-slice suite (473), and the ASan gate fixtures all pass; clippy and fmt clean. Fixes the nightly Compiled-fixture-ASan regression.

**Out of scope**: The two intermittent `Rust runtime ASan` test flakes in the same nightly run (TMPDIR race + virtual-clock timer) are pre-existing and tracked separately in #2706.