### PR TITLE
test(runtime): de-flake three test-quality races in the ASan nightly (#2706)

### DIFF
--- a/hew-runtime/src/env.rs
+++ b/hew-runtime/src/env.rs
@@ -918,6 +918,26 @@ mod tests {
 
         let key = CString::new("TMPDIR").unwrap();
 
+        // Toggle TMPDIR only between real, always-present directories.
+        //
+        // WHY: this test mutates the process-wide TMPDIR env var, which
+        // `std::env::temp_dir()` reads. Under the parallel test runner a
+        // sibling test that calls `tempdir()` resolves its base directory from
+        // whatever value TMPDIR holds at that instant. The previous version
+        // toggled TMPDIR to `/tmp/hew_test_{i}` — paths that this test never
+        // creates — so a sibling could observe TMPDIR pointing at a
+        // non-existent directory and its `tempdir()` failed `NotFound`
+        // (the cross-test flake reported in the nightly ASan job). Toggling
+        // only between two directories that always exist keeps the concurrency
+        // stress on `hew_temp_dir`/`ENV_LOCK` (the actual unit under test)
+        // while never exposing a sibling to an unresolvable base. Both are
+        // system temp roots on every supported platform.
+        let real_tmp = std::env::temp_dir();
+        let alt_tmp = real_tmp.join("hew_env_test_stable");
+        std::fs::create_dir_all(&alt_tmp).expect("alt temp root must be creatable");
+        let val_a = CString::new(real_tmp.to_string_lossy().into_owned()).unwrap();
+        let val_b = CString::new(alt_tmp.to_string_lossy().into_owned()).unwrap();
+
         // Snapshot original TMPDIR so we can restore it.
         // SAFETY: key is a valid NUL-terminated C string.
         let orig_ptr = unsafe { hew_env_get(key.as_ptr()) };
@@ -934,18 +954,16 @@ mod tests {
         let barrier = Arc::new(Barrier::new(THREADS * 2));
         let mut handles = Vec::new();
 
-        // Writer threads toggle TMPDIR between two values.
-        for i in 0..THREADS {
+        // Writer threads toggle TMPDIR between two always-present directories.
+        for _ in 0..THREADS {
             let key = key.clone();
+            let val_a = val_a.clone();
+            let val_b = val_b.clone();
             let b = Arc::clone(&barrier);
             handles.push(thread::spawn(move || {
                 b.wait();
                 for j in 0..ITERS {
-                    let val = if j % 2 == 0 {
-                        CString::new(format!("/tmp/hew_test_{i}")).unwrap()
-                    } else {
-                        CString::new("/tmp").unwrap()
-                    };
+                    let val = if j % 2 == 0 { &val_a } else { &val_b };
                     // SAFETY: both pointers are valid NUL-terminated C strings.
                     unsafe { hew_env_set(key.as_ptr(), val.as_ptr()) };
                 }

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -5958,10 +5958,10 @@ mod tests {
         unsafe { reset_globals() };
         hew_sched_init();
         // Pin the virtual clock (wasm32; see VirtualClock) so the wheel's
-        // `current_ms` at creation, the `park_actor_sleep` delay computation,
-        // and the test-driven tick values all share one deterministic `now`. On
-        // the real clock these are three independent reads that drift under load
-        // and intermittently abort this exact-deadline assertion.
+        // `current_ms` at creation and the `park_actor_sleep` delay computation
+        // share one deterministic `now`. Inert on native (the seam is
+        // wasm32-only), where the exact-deadline boundary is instead recovered
+        // from the wheel's own scheduled deadline below.
         let _clock = VirtualClock::pinned_at(VIRTUAL_BASE_MS);
 
         let mut a = stub_actor();
@@ -5969,27 +5969,44 @@ mod tests {
         a.actor_state
             .store(HewActorState::Idle as i32, Ordering::Relaxed);
 
-        // Anchor all deadlines to the clock (pinned on wasm32) so the wheel's
-        // internal current_ms and the test-driven tick values are in the
-        // same numeric space.
         // SAFETY: hew_now_ms has no preconditions (pinned to VIRTUAL_BASE_MS on wasm32).
         let now = unsafe { hew_now_ms() };
 
         // SAFETY: actor valid for duration of test.
         unsafe { park_actor_sleep(a_ptr, now + 1000) };
 
-        // One ms before deadline: nothing wakes.
+        // Recover the actual absolute deadline the wheel scheduled, rather than
+        // re-deriving it from a fresh `hew_now_ms()` read. On native (where the
+        // VirtualClock seam is inert) the wheel's `current_ms` at creation and
+        // `park_actor_sleep`'s delay `now` are two independent monotonic reads,
+        // so the wheel fires the entry at its absolute `deadline_ms`
+        // (`wheel_current_ms + (deadline - park_now)`), which drifts from
+        // `now + 1000` under CPU load and intermittently aborted the
+        // exact-deadline assertion. Ticking to the wheel's own absolute
+        // scheduled deadline makes the wake boundary exact on every platform
+        // with no tolerance and no weakened assertion.
+        // SAFETY: wheel was created by park_actor_sleep and is non-null here.
+        let wheel = unsafe { wasm_timer_wheel_raw() };
+        assert!(
+            !wheel.is_null(),
+            "park_actor_sleep must have created the wheel"
+        );
+        // SAFETY: wheel is a valid, live HewTimerWheel pointer.
+        let deadline = unsafe { crate::timer_wheel::timer_wheel_earliest_abs_deadline_ms(wheel) }
+            .expect("a live sleep entry must have an absolute deadline");
+
+        // One ms before the wheel's scheduled deadline: nothing wakes.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { hew_wasm_timer_tick(now + 999) };
+        let woken = unsafe { hew_wasm_timer_tick(deadline - 1) };
         assert_eq!(woken, 0);
         assert_eq!(
             a.actor_state.load(Ordering::Relaxed),
             HewActorState::Sleeping as i32
         );
 
-        // Exactly at deadline: actor wakes.
+        // Exactly at the wheel's scheduled deadline: actor wakes.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { hew_wasm_timer_tick(now + 1000) };
+        let woken = unsafe { hew_wasm_timer_tick(deadline) };
         assert_eq!(woken, 1);
         assert_eq!(
             a.actor_state.load(Ordering::Relaxed),

--- a/hew-runtime/src/timer_wheel.rs
+++ b/hew-runtime/src/timer_wheel.rs
@@ -756,6 +756,58 @@ pub unsafe extern "C" fn hew_timer_wheel_next_deadline_ms(tw: *mut HewTimerWheel
     }
 }
 
+/// Test-only: return the earliest **absolute** deadline (`deadline_ms`) of any
+/// live entry, or `None` when the wheel is empty.
+///
+/// Unlike [`hew_timer_wheel_next_deadline_ms`], which returns the delay
+/// *relative* to the wheel's `current_ms`, this returns the absolute fire time
+/// an entry was scheduled at. Timer-wheel tests must drive
+/// `hew_wasm_timer_tick` with this absolute value: the wheel fires an entry
+/// only once its `current_ms` reaches the entry's absolute `deadline_ms`, and
+/// on native (where the wasm virtual-clock seam is inert) that value is
+/// `current_ms_at_creation + delay`, which drifts from any freshly re-derived
+/// `now + delay`.
+///
+/// # Safety
+///
+/// `tw` must be null or a valid pointer returned by [`hew_timer_wheel_new`].
+#[cfg(test)]
+pub(crate) unsafe fn timer_wheel_earliest_abs_deadline_ms(tw: *mut HewTimerWheel) -> Option<u64> {
+    if tw.is_null() {
+        return None;
+    }
+    // SAFETY: caller guarantees `tw` is valid.
+    let wheel = unsafe { &*tw };
+    let w = wheel
+        .inner
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut earliest: u64 = u64::MAX;
+    let mut scan = |mut e: *mut HewTimerEntry| {
+        while !e.is_null() {
+            // SAFETY: entries are valid under lock.
+            unsafe {
+                if (*e).cancelled == 0 && (*e).deadline_ms < earliest {
+                    earliest = (*e).deadline_ms;
+                }
+                e = (*e).next;
+            }
+        }
+    };
+    for slot in &w.l0 {
+        scan(*slot);
+    }
+    for slot in &w.l1 {
+        scan(*slot);
+    }
+    scan(w.overflow);
+    if earliest == u64::MAX {
+        None
+    } else {
+        Some(earliest)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -765,40 +817,51 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicI32, Ordering};
 
-    static FIRE_COUNT: AtomicI32 = AtomicI32::new(0);
-
-    unsafe extern "C" fn test_cb(_data: *mut c_void) {
-        FIRE_COUNT.fetch_add(1, Ordering::SeqCst);
+    /// Per-test fire counter passed through the timer callback's `data`
+    /// pointer. Using a callback-local counter instead of a shared `static`
+    /// keeps each test's fire count isolated: the timer callbacks run under a
+    /// parallel test runner, so a module-global counter let a sibling test's
+    /// fire (`schedule_and_tick_immediate`) leak into `cancel_prevents_firing`
+    /// and flip its `== 0` assertion (a pre-existing cross-test race).
+    unsafe extern "C" fn test_cb(data: *mut c_void) {
+        if !data.is_null() {
+            // SAFETY: every scheduler in these tests passes a pointer to a
+            // live `AtomicI32` that outlives the tick that fires the callback.
+            let counter = unsafe { &*data.cast::<AtomicI32>() };
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
     }
 
     #[test]
     fn schedule_and_tick_immediate() {
-        FIRE_COUNT.store(0, Ordering::SeqCst);
+        let fire_count = AtomicI32::new(0);
+        let data = (&raw const fire_count).cast::<c_void>().cast_mut();
         // SAFETY: standard lifecycle calls.
         unsafe {
             let tw = hew_timer_wheel_new();
             assert!(!tw.is_null());
-            hew_timer_wheel_schedule(tw, 1, test_cb, ptr::null_mut());
+            hew_timer_wheel_schedule(tw, 1, test_cb, data);
             // Wait for the 1ms timer to expire.
             std::thread::sleep(std::time::Duration::from_millis(5));
             let fired = hew_timer_wheel_tick(tw);
             assert!(fired >= 1);
-            assert!(FIRE_COUNT.load(Ordering::SeqCst) >= 1);
+            assert!(fire_count.load(Ordering::SeqCst) >= 1);
             hew_timer_wheel_free(tw);
         }
     }
 
     #[test]
     fn cancel_prevents_firing() {
-        FIRE_COUNT.store(0, Ordering::SeqCst);
+        let fire_count = AtomicI32::new(0);
+        let data = (&raw const fire_count).cast::<c_void>().cast_mut();
         // SAFETY: standard lifecycle calls.
         unsafe {
             let tw = hew_timer_wheel_new();
-            let h = hew_timer_wheel_schedule_handle(tw, 0, test_cb, ptr::null_mut());
+            let h = hew_timer_wheel_schedule_handle(tw, 0, test_cb, data);
             hew_timer_wheel_cancel(tw, h.entry, h.generation);
             let fired = hew_timer_wheel_tick(tw);
             assert_eq!(fired, 0);
-            assert_eq!(FIRE_COUNT.load(Ordering::SeqCst), 0);
+            assert_eq!(fire_count.load(Ordering::SeqCst), 0);
             hew_timer_wheel_free(tw);
         }
     }
@@ -1270,7 +1333,8 @@ mod tests {
 
     #[test]
     fn probe_b_stale_cancel_does_not_cancel_reused_entry_address() {
-        FIRE_COUNT.store(0, Ordering::SeqCst);
+        let fire_count = AtomicI32::new(0);
+        let data = (&raw const fire_count).cast::<c_void>().cast_mut();
         // SAFETY: this test reuses one allocation slot with explicit lifetime
         // boundaries to model allocator reuse of E's address for E2.
         unsafe {
@@ -1282,7 +1346,7 @@ mod tests {
                     deadline_ms: 1,
                     generation: 41,
                     cb: Some(test_cb),
-                    data: ptr::null_mut(),
+                    data,
                     cancelled: 0,
                     next: ptr::null_mut(),
                 },
@@ -1297,7 +1361,7 @@ mod tests {
                     deadline_ms: 10,
                     generation: 42,
                     cb: Some(test_cb),
-                    data: ptr::null_mut(),
+                    data,
                     cancelled: 0,
                     next: ptr::null_mut(),
                 },
@@ -1319,22 +1383,23 @@ mod tests {
             if let Some(cb) = expired_entry.cb {
                 cb(expired_entry.data);
             }
-            assert_eq!(FIRE_COUNT.load(Ordering::SeqCst), 1);
+            assert_eq!(fire_count.load(Ordering::SeqCst), 1);
             ptr::drop_in_place(entry);
         }
     }
 
     #[test]
     fn cancel_after_tick_free_is_ignored() {
-        FIRE_COUNT.store(0, Ordering::SeqCst);
+        let fire_count = AtomicI32::new(0);
+        let data = (&raw const fire_count).cast::<c_void>().cast_mut();
         // SAFETY: the stale cancel models a source-completion thread that
         // already captured the timer entry before the deadline thread fired it.
         unsafe {
             let tw = make_timer_wheel(0);
-            let h = hew_timer_wheel_schedule_handle(tw, 1, test_cb, ptr::null_mut());
+            let h = hew_timer_wheel_schedule_handle(tw, 1, test_cb, data);
 
             assert_eq!(timer_wheel_tick_to(tw, 1), 1);
-            assert_eq!(FIRE_COUNT.load(Ordering::SeqCst), 1);
+            assert_eq!(fire_count.load(Ordering::SeqCst), 1);
 
             hew_timer_wheel_cancel(tw, h.entry, h.generation);
             hew_timer_wheel_free(tw);


### PR DESCRIPTION
Fixes #2706.

Root-causes the two flakes the issue names, plus a third pre-existing sibling in the same file that flakes on clean `main` and would keep the same nightly job intermittently red. All three are test-quality/isolation defects (not memory-safety findings); **no product code is touched** — every change is inside a test module or a `#[cfg(test)]`-gated accessor.

## 1. `env::tests::temp_dir_concurrent_with_env_set` — TMPDIR cross-test race
The test mutated the process-wide `TMPDIR` env var to `/tmp/hew_test_{i}` — paths it never creates. Under the parallel runner a sibling test's `tempdir()` could resolve its base from that value and fail `NotFound` (the reported `encryption.rs:522` panic class). Now it toggles `TMPDIR` only between two directories that **always exist** (the system temp root and a `create_dir_all`'d stable subdir), keeping the concurrency stress on `hew_temp_dir`/`ENV_LOCK` (the unit under test) while never exposing a sibling to an unresolvable base.

## 2. `scheduler_wasm::tests::timer_tick_wakes_at_exact_deadline` — clock drift
The `VirtualClock` pin is wasm32-only and **inert on native** (where the ASan job runs), so the wheel's `current_ms` captured at creation and `park_actor_sleep`'s delay `now` are two independent monotonic reads. The entry fires at its absolute `deadline_ms` (`wheel_current_ms + delay`), which drifts from a freshly re-derived `now + 1000` under load and aborted the exact-deadline assertion. The test now drives the tick off the wheel's **own absolute scheduled deadline** via a new `#[cfg(test)]` `timer_wheel_earliest_abs_deadline_ms` accessor — exact on every platform, no tolerance, no weakened assertion.

## 3. `timer_wheel::tests::cancel_prevents_firing` (+ siblings) — shared-global race
These tests shared one module-level `static FIRE_COUNT`; the timer callbacks run under the parallel runner, so `schedule_and_tick_immediate`'s fire leaked into `cancel_prevents_firing`'s `== 0` assertion (**reproduced 2–3/5 in-suite on clean `main`**). The fix threads a per-test `AtomicI32` through the callback's `data` pointer, eliminating the shared global entirely.

## Verification
- Full `hew-runtime` lib suite: **2111 passed, 0 failed**.
- `timer_wheel::tests` and `env::tests`: **10/10 clean in-suite under full-core saturation** (was 2–3/5 failing before).
- `cargo fmt` + `cargo clippy -p hew-runtime --tests`: clean.