### PR TITLE
refactor(types): centralize shared helpers to single authorities

### DIFF
--- a/hew-analysis/src/signature_help.rs
+++ b/hew-analysis/src/signature_help.rs
@@ -135,7 +135,7 @@ fn extract_fn_name_before(source: &str, paren_pos: usize) -> Option<(String, Opt
 
 fn find_receiver_method_sig(context: &CallContext, tc: &TypeCheckOutput) -> Option<FnSig> {
     let receiver_end = context.receiver_end?;
-    let method = context.callee.rsplit('.').next()?;
+    let method = hew_types::short_name(&context.callee);
     let receiver_ty = find_receiver_type(tc, receiver_end)?;
     lookup_receiver_method_sig(tc, receiver_ty, method)
 }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -75,6 +75,7 @@ use hew_mir::{
     RawMirFunction, RecordLayout, RegexLiteral, SourceOrigin, StateFieldCloneKind,
     SupervisorChildLayout, SupervisorLayout, SuspendKind, Terminator, TrapKind,
 };
+pub(crate) use hew_types::short_name;
 use hew_types::{
     runtime_call::RuntimeCapability, BuiltinType, NumericWidth, ResolvedTy, WireCodecDirection,
     WireLayoutTable, WireTextFormat,
@@ -2585,10 +2586,6 @@ fn emit_const_globals<'ctx>(
         }
     }
     Ok(globals)
-}
-
-pub(crate) fn short_name(name: &str) -> &str {
-    name.rsplit_once('.').map_or(name, |(_, short)| short)
 }
 
 /// True when `ty` names a machine (short-name match against the machine
@@ -19084,8 +19081,8 @@ fn resolve_drop_fn<'ctx>(
             // first and this fallback never crosses two distinct bodies; if
             // neither spelling is registered the drop still fails closed below.
             let bare_fallback = name.split_once("::").and_then(|(ty, method)| {
-                ty.rsplit_once('.')
-                    .map(|(_, short)| format!("{short}::{method}"))
+                let short = short_name(ty);
+                (short != ty).then(|| format!("{short}::{method}"))
             });
             let resolved: &str = match bare_fallback.as_deref() {
                 Some(bare) if !fn_symbols.contains_key(name) && fn_symbols.contains_key(bare) => {
@@ -20333,10 +20330,7 @@ fn record_inplace_drop_name(ty: &ResolvedTy) -> CodegenResult<String> {
             // The type checker qualifies imported record names with their module
             // prefix (e.g. `"process.CommandOutput"`). The synthesized helper is
             // keyed by the bare type name (`"CommandOutput"`), so strip the prefix.
-            Ok(name
-                .rsplit_once('.')
-                .map_or(name.as_str(), |(_, bare)| bare)
-                .to_string())
+            Ok(short_name(name).to_string())
         }
         ResolvedTy::Named {
             name,
@@ -20353,9 +20347,7 @@ fn record_inplace_drop_name(ty: &ResolvedTy) -> CodegenResult<String> {
             // the drop call resolves the body that was emitted. Strip the module
             // prefix from the origin name first (the mangler keys on the short
             // name) so an imported generic record matches its registered layout.
-            let short = name
-                .rsplit_once('.')
-                .map_or(name.as_str(), |(_, bare)| bare);
+            let short = short_name(name);
             Ok(mangle_with_shortened_args(short, args))
         }
         // M-5: a builtin owned-aggregate record (today only `CrashInfo`, which

--- a/hew-codegen-rs/src/wire.rs
+++ b/hew-codegen-rs/src/wire.rs
@@ -73,7 +73,7 @@ fn xnode_registry_key(
     records: &[RecordLayout],
     enums: &[EnumLayout],
 ) -> String {
-    let short = name.rsplit_once('.').map_or(name, |(_, s)| s);
+    let short = short_name(name);
     if args.is_empty() {
         // Prefer an exact registered name; else the short form.
         if records.iter().any(|r| r.name == name) || enums.iter().any(|e| e.name == name) {
@@ -312,7 +312,7 @@ fn cbor_field_key(
         return tag;
     }
     // Records are usually keyed by the short name; try it if the key was qualified.
-    let short = record_key.rsplit_once('.').map_or(record_key, |(_, s)| s);
+    let short = short_name(record_key);
     if short != record_key {
         if let Some(tag) = probe(short) {
             return tag;
@@ -1162,7 +1162,7 @@ fn cbor_variant_tag(
     if let Some(tag) = probe(enum_key) {
         return tag;
     }
-    let short = enum_key.rsplit_once('.').map_or(enum_key, |(_, s)| s);
+    let short = short_name(enum_key);
     if short != enum_key {
         if let Some(tag) = probe(short) {
             return tag;

--- a/hew-hir/src/dispatch.rs
+++ b/hew-hir/src/dispatch.rs
@@ -139,7 +139,7 @@ pub fn lookup_trait_impl_entry<'a, S: std::hash::BuildHasher>(
             return Some(entry);
         }
         // Also try bare-leaf of the mangled name for module-qualified receivers.
-        let bare_mangled = mangled.rsplit('.').next().unwrap_or(&mangled);
+        let bare_mangled = hew_types::short_name(&mangled);
         if bare_mangled != mangled {
             let bare_concrete_key = (
                 declaring_trait.to_string(),
@@ -161,7 +161,7 @@ pub fn lookup_trait_impl_entry<'a, S: std::hash::BuildHasher>(
     if let Some(entry) = index.get(&key) {
         return Some(entry);
     }
-    let bare = self_type_name.rsplit('.').next().unwrap_or(self_type_name);
+    let bare = hew_types::short_name(self_type_name);
     if bare == self_type_name {
         return None;
     }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -11155,7 +11155,7 @@ impl LowerCtx {
         let module_scoped_key = self
             .current_module_name
             .as_deref()
-            .and_then(|module| module.rsplit('.').next())
+            .map(hew_types::short_name)
             .map(|leaf| format!("{leaf}.{}", decl.name));
         let protocol_descriptor = module_scoped_key
             .as_deref()
@@ -14398,11 +14398,9 @@ impl LowerCtx {
                                 builtin: None,
                                 ..
                             } if recorded.contains('.') => {
-                                recorded.rsplit_once('.').and_then(|(_, short)| {
-                                    (short == name.as_str()
-                                        || self.record_registry.contains_key(short))
+                                let short = hew_types::short_name(recorded);
+                                (short == name.as_str() || self.record_registry.contains_key(short))
                                     .then(|| recorded.clone())
-                                })
                             }
                             _ => None,
                         })
@@ -15846,8 +15844,7 @@ impl LowerCtx {
                         ..
                     } if args.len() == 1
                         && (matches!(builtin, Some(hew_types::BuiltinType::Receiver))
-                            || name.rsplit_once('.').map_or(name.as_str(), |(_, s)| s)
-                                == "Receiver") =>
+                            || hew_types::short_name(name) == "Receiver") =>
                     {
                         args[0].clone()
                     }
@@ -18604,9 +18601,7 @@ impl LowerCtx {
     /// already-lowered generic arguments. Split out of `lower_type` to keep
     /// that dispatcher under the line budget.
     fn resolve_named_type_ref(&self, name: &str, args: Vec<ResolvedTy>) -> ResolvedTy {
-        let type_name = name
-            .rsplit_once('.')
-            .map_or(name, |(_, unqualified)| unqualified);
+        let type_name = hew_types::short_name(name);
         if args.is_empty() {
             let canonical = self.canonical_current_module_record_name(name);
             if canonical != name && !self.resolves_to_opaque_handle(&canonical, type_name) {
@@ -18770,7 +18765,7 @@ impl LowerCtx {
             if let Some(module_short) = self
                 .current_module_name
                 .as_deref()
-                .and_then(|module| module.rsplit('.').next())
+                .map(hew_types::short_name)
             {
                 let qualified = format!("{module_short}.{name}");
                 if self.record_registry.contains_key(&qualified) {
@@ -18796,9 +18791,10 @@ impl LowerCtx {
         else {
             return symbol.to_string();
         };
-        let Some((_, receiver_short)) = receiver_name.rsplit_once('.') else {
+        let receiver_short = hew_types::short_name(receiver_name);
+        if receiver_short == receiver_name {
             return symbol.to_string();
-        };
+        }
         if receiver_short != symbol_type {
             return symbol.to_string();
         }

--- a/hew-hir/src/monomorph.rs
+++ b/hew-hir/src/monomorph.rs
@@ -156,9 +156,7 @@ pub fn shorten_named_arg_qualifiers(ty: ResolvedTy) -> ResolvedTy {
             builtin,
             is_opaque,
         } => ResolvedTy::Named {
-            name: name
-                .rsplit_once('.')
-                .map_or(name.clone(), |(_, short)| short.to_string()),
+            name: hew_types::short_name(&name).to_string(),
             args: args.into_iter().map(shorten_named_arg_qualifiers).collect(),
             builtin,
             is_opaque,
@@ -203,10 +201,7 @@ pub fn shorten_named_arg_qualifiers(ty: ResolvedTy) -> ResolvedTy {
             traits: traits
                 .into_iter()
                 .map(|b| hew_types::ResolvedTraitBound {
-                    trait_name: b
-                        .trait_name
-                        .rsplit_once('.')
-                        .map_or(b.trait_name.clone(), |(_, short)| short.to_string()),
+                    trait_name: hew_types::short_name(&b.trait_name).to_string(),
                     args: b
                         .args
                         .into_iter()

--- a/hew-hir/src/value_class.rs
+++ b/hew-hir/src/value_class.rs
@@ -44,13 +44,14 @@ pub fn lookup_type_marker(name: &str, type_classes: &TypeClassTable) -> Option<R
         .map(|registration| registration.marker)
         .or_else(|| {
             let exact = type_classes.get(name).map(|(marker, _)| *marker);
-            match (exact, name.rsplit_once('.')) {
-                (Some(ResourceMarker::None), Some((_, short))) => {
+            let short = hew_types::short_name(name);
+            match (exact, short != name) {
+                (Some(ResourceMarker::None), true) => {
                     type_classes.get(short).map(|(marker, _)| *marker).or(exact)
                 }
                 (Some(marker), _) => Some(marker),
-                (None, Some((_, short))) => type_classes.get(short).map(|(marker, _)| *marker),
-                (None, None) => None,
+                (None, true) => type_classes.get(short).map(|(marker, _)| *marker),
+                (None, false) => None,
             }
         })
 }
@@ -96,13 +97,14 @@ pub fn lookup_type_marker_for_ty(
     }
 
     let exact = type_classes.get(name).map(|(marker, _)| *marker);
-    match (exact, name.rsplit_once('.')) {
-        (Some(ResourceMarker::None), Some((_, short))) => {
+    let short = hew_types::short_name(name);
+    match (exact, short != name.as_str()) {
+        (Some(ResourceMarker::None), true) => {
             type_classes.get(short).map(|(marker, _)| *marker).or(exact)
         }
         (Some(marker), _) => Some(marker),
-        (None, Some((_, short))) => type_classes.get(short).map(|(marker, _)| *marker),
-        (None, None) => None,
+        (None, true) => type_classes.get(short).map(|(marker, _)| *marker),
+        (None, false) => None,
     }
 }
 

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -1552,7 +1552,7 @@ impl Worker {
         // find_definition_in_ast doesn't find the full dot-qualified name...
         assert!(find_definition_in_ast(source, &lo, &parse_result, &word).is_none());
         // ...but the method part alone finds the receive method definition.
-        let method = word.rsplit('.').next().unwrap();
+        let method = hew_types::short_name(&word);
         let found = find_definition_in_ast(source, &lo, &parse_result, method);
         assert!(found.is_some(), "should find receive method definition");
     }

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -47,10 +47,11 @@ pub fn drop_kind_for_test(
 }
 pub use dump::{dump_mir, DumpStage};
 pub use hew_hir::sanitize_for_symbol;
+pub use hew_types::short_name;
 pub use model::{
     call_arg_source_escapes, callee_param_is_borrow, classify_extern_string_ownership,
     container_ingress_is_copy_in, machine_enum_view, machine_enum_views,
-    mangle_dyn_drop_in_place_symbol, mangle_dyn_thunk_symbol, mangle_dyn_vtable_symbol, short_name,
+    mangle_dyn_drop_in_place_symbol, mangle_dyn_thunk_symbol, mangle_dyn_vtable_symbol,
     ty_contains_closure_value, ty_contains_heap_owning, ty_contains_unclonable_opaque,
     ty_contains_unclonable_opaque_with_names, ty_heap_ownership, ty_owns_heap, ty_owns_heap_mir,
     validate_context_markers, ActorHandlerKind, ActorHandlerLayout, ActorLayout,

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -1483,11 +1483,11 @@ pub(super) fn ty_is_heap_owning_enum_composite(
     // not an opaque/builtin handle). Indirect (heap-boxed) enums route their
     // payload drop through the boxed-storage release path, not this in-place
     // helper, so they are excluded here.
-    let short = crate::model::short_name(name);
+    let short = hew_types::short_name(name);
     let layout = if args.is_empty() {
         enum_layouts
             .iter()
-            .find(|el| el.name == *name || crate::model::short_name(&el.name) == short)
+            .find(|el| el.name == *name || hew_types::short_name(&el.name) == short)
     } else {
         let mangled = mangle_layout_key(short, args);
         enum_layouts

--- a/hew-mir/src/lower/facts.rs
+++ b/hew-mir/src/lower/facts.rs
@@ -2,10 +2,10 @@
 use super::*;
 #[cfg(not(test))]
 use super::{
-    named_type_names, BindingId, Builder, BuiltinType, HashMap, HashSet, HirBlock, HirExpr,
-    HirExprKind, HirFn, HirItem, HirStmtKind, Instr, IntentKind, LayoutReadiness, MirDiagnostic,
-    MirDiagnosticKind, MirStatement, ParamOwnershipFacts, Place, ResolvedRef, ResolvedTy,
-    ResourceMarker, ScanCtx, Strategy, ValueClass,
+    named_type_names, short_name, BindingId, Builder, BuiltinType, HashMap, HashSet, HirBlock,
+    HirExpr, HirExprKind, HirFn, HirItem, HirStmtKind, Instr, IntentKind, LayoutReadiness,
+    MirDiagnostic, MirDiagnosticKind, MirStatement, ParamOwnershipFacts, Place, ResolvedRef,
+    ResolvedTy, ResourceMarker, ScanCtx, Strategy, ValueClass,
 };
 
 /// Flow-insensitive prescan deciding, for every binding in `func`, whether a
@@ -2432,10 +2432,7 @@ fn push_unknown_type_diagnostic(
 pub(super) fn machine_layout_name_matches(layout_names: &HashSet<String>, name: &str) -> bool {
     layout_names
         .iter()
-        .any(|known| known == name || short_name(known) == short_name(name))
-}
-pub(super) fn short_name(name: &str) -> &str {
-    name.rsplit_once('.').map_or(name, |(_, short)| short)
+        .any(|known| known == name || hew_types::short_name(known) == hew_types::short_name(name))
 }
 #[cfg(test)]
 mod runtime_callee_ownership_contract_parity {

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -24,7 +24,7 @@ use hew_hir::{
 };
 use hew_parser::ast::{BinaryOp, UnaryOp};
 use hew_types::{
-    BuiltinType, ChildKind, ChildSlot, ExecutionContextReader, NumericMethodFamily,
+    short_name, BuiltinType, ChildKind, ChildSlot, ExecutionContextReader, NumericMethodFamily,
     NumericMethodOp, NumericSignedness, ResolvedTy,
 };
 
@@ -2245,7 +2245,7 @@ pub fn lower_hir_module_with_facts(
     for layout in &actor_layouts {
         if layout.defining_module.is_some() {
             *module_short_name_counts
-                .entry(crate::model::short_name(&layout.name))
+                .entry(short_name(&layout.name))
                 .or_insert(0) += 1;
         }
     }
@@ -2253,7 +2253,7 @@ pub fn lower_hir_module_with_facts(
         if layout.defining_module.is_none() {
             continue;
         }
-        let short = crate::model::short_name(&layout.name);
+        let short = short_name(&layout.name);
         if module_short_name_counts.get(short) == Some(&1) && !actor_layout_map.contains_key(short)
         {
             actor_layout_map.insert(short.to_string(), layout.clone());

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -952,7 +952,8 @@ impl Builder {
             return Some(order);
         }
         // Fallback: strip the module prefix and try the bare type name.
-        if let Some(bare) = type_name.rsplit_once('.').map(|(_, bare)| bare) {
+        let bare = hew_types::short_name(type_name);
+        if bare != type_name {
             if let Some(order) = self.record_field_orders.get(bare) {
                 return Some(order);
             }
@@ -1878,10 +1879,10 @@ impl Builder {
                     )
             }
             ResolvedTy::Named { name, args, .. } => {
-                let short = crate::model::short_name(name);
+                let short = hew_types::short_name(name);
                 let layout = if args.is_empty() {
                     self.enum_layouts.iter().find(|layout| {
-                        layout.name == *name || crate::model::short_name(&layout.name) == short
+                        layout.name == *name || hew_types::short_name(&layout.name) == short
                     })
                 } else {
                     let mangled = mangle_layout_key(short, args);

--- a/hew-mir/src/lower/task.rs
+++ b/hew-mir/src/lower/task.rs
@@ -1533,8 +1533,7 @@ impl Builder {
                             ..
                         } if args.len() == 1
                             && (matches!(builtin, Some(hew_types::BuiltinType::Receiver))
-                                || name.rsplit_once('.').map_or(name.as_str(), |(_, s)| s)
-                                    == "Receiver") =>
+                                || hew_types::short_name(&name) == "Receiver") =>
                         {
                             args.remove(0)
                         }

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use hew_hir::{sanitize_for_symbol, BindingId, IntentKind, ItemId, SiteId, ValueClass};
-use hew_types::{NumericWidth, ResolvedTy, TryConversionKind, WireCodecDirection, WireLayoutTable};
+use hew_types::{
+    short_name, NumericWidth, ResolvedTy, TryConversionKind, WireCodecDirection, WireLayoutTable,
+};
 
 pub use crate::runtime_symbols::UnknownRuntimeSymbol;
 
@@ -1470,14 +1472,6 @@ pub fn machine_enum_view(layout: &MachineLayout) -> EnumLayout {
 #[must_use]
 pub fn machine_enum_views(machine_layouts: &[MachineLayout]) -> Vec<EnumLayout> {
     machine_layouts.iter().map(machine_enum_view).collect()
-}
-
-/// Unqualified tail of a possibly module-qualified type name
-/// (`"mod.Expr"` → `"Expr"`). The single short-name authority shared by
-/// the MIR drop elaborator and the codegen layout lookup.
-#[must_use]
-pub fn short_name(name: &str) -> &str {
-    name.rsplit_once('.').map_or(name, |(_, short)| short)
 }
 
 /// THE single enum-layout lookup authority for this module.

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -1164,7 +1164,7 @@ fn classify_named(
     // qualified (`regex.Pattern`) while the registry key is the unqualified
     // decl name (`Pattern`); match both spellings, mirroring the opaque
     // name-set fallback below.
-    let resource_short = name.rsplit_once('.').map_or(name, |(_, s)| s);
+    let resource_short = hew_types::short_name(name);
     if let Some((_, close_symbol)) = resource_close
         .iter()
         .find(|(n, _)| n == name || n == resource_short)
@@ -1251,7 +1251,7 @@ fn classify_named(
     // carries the unqualified decl name (`"Value"`); use sites may carry the
     // qualified form (`"json.Value"`), so match both the full name and the
     // short suffix.
-    let short = name.rsplit_once('.').map_or(name, |(_, s)| s);
+    let short = hew_types::short_name(name);
     if opaque_handle_names.iter().any(|n| n == name || n == short) {
         return Ok(StateFieldCloneKind::OpaqueHandle {
             name: name.to_string(),
@@ -1464,7 +1464,7 @@ fn lookup_enum_layout<'a>(
     args: &[ResolvedTy],
     enum_layouts: &'a [EnumLayout],
 ) -> Option<&'a EnumLayout> {
-    let short = name.rsplit_once('.').map_or(name, |(_, s)| s);
+    let short = hew_types::short_name(name);
     if args.is_empty() {
         enum_layouts
             .iter()
@@ -1505,7 +1505,7 @@ fn lookup_record_layout<'a>(
     args: &[ResolvedTy],
     record_layouts: &'a [RecordLayout],
 ) -> Option<&'a RecordLayout> {
-    let short = name.rsplit_once('.').map_or(name, |(_, s)| s);
+    let short = hew_types::short_name(name);
     if args.is_empty() {
         record_layouts
             .iter()

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -1311,9 +1311,7 @@ impl Checker {
                     let acc_module = self.current_module.as_deref();
                     if !visibility::access_allowed(decl_module, acc_module, vis) {
                         // Extract just the function name (last segment after '.').
-                        let symbol = resolved_fn_name
-                            .rsplit_once('.')
-                            .map_or(resolved_fn_name.as_str(), |(_, n)| n);
+                        let symbol = crate::short_name(&resolved_fn_name);
                         let decl_span = self
                             .fn_def_spans
                             .get(&resolved_fn_name)

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -2951,9 +2951,8 @@ impl Checker {
                 && expected_args.is_empty()
                 && !name.contains('.')
                 && !name.contains("::")
-                && expected_name
-                    .rsplit_once('.')
-                    .is_some_and(|(_, short)| short == name.as_str())
+                && expected_name.contains('.')
+                && crate::short_name(expected_name) == name
                 && self.lookup_type_def(expected_name).is_some_and(|td| {
                     td.type_params.is_empty()
                         && matches!(td.kind, TypeDefKind::Struct | TypeDefKind::Record)
@@ -3000,9 +2999,8 @@ impl Checker {
                 && !expected_args.is_empty()
                 && !name.contains('.')
                 && !name.contains("::")
-                && expected_name
-                    .rsplit_once('.')
-                    .is_some_and(|(_, short)| short == name.as_str())
+                && expected_name.contains('.')
+                && crate::short_name(expected_name) == name
                 && self.lookup_type_def(expected_name).is_some_and(|td| {
                     !td.type_params.is_empty()
                         && matches!(td.kind, TypeDefKind::Struct | TypeDefKind::Record)

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1964,9 +1964,7 @@ impl Checker {
     /// `std.net.websocket`). Returns `None` at the root / flat namespace, where
     /// type names are unqualified.
     pub(super) fn current_module_short(&self) -> Option<&str> {
-        self.current_module
-            .as_deref()
-            .map(|m| m.rsplit('.').next().unwrap_or(m))
+        self.current_module.as_deref().map(crate::short_name)
     }
 
     /// Resolve a bare actor reference to its registered checker identity.
@@ -7828,9 +7826,7 @@ impl Checker {
                         || self.dyn_trait_method_calls.contains_key(&span_key)
                         || self.resolved_calls.contains_key(&span_key);
                     if !already_rewritten {
-                        let method_owner = name
-                            .rsplit_once('.')
-                            .map_or(name.as_str(), |(_, unqualified)| unqualified);
+                        let method_owner = crate::short_name(name);
                         let method_key = format!("{method_owner}::{method}");
                         // Wire codec instance serialize methods on a `#[wire]`
                         // struct or enum. `encode` is the binary CBOR path

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6201,11 +6201,7 @@ impl Checker {
         //     spelled in a DECLARING module is never the importer's local trait of
         //     the same name; gating this on `Current` is the H11 scope correctness.
         if matches!(scope, TraitRefScope::Current) && self.local_trait_defs.contains(name) {
-            if let Some(module) = self
-                .current_module
-                .as_deref()
-                .and_then(|current| current.rsplit('.').next())
-            {
+            if let Some(module) = self.current_module.as_deref().map(crate::short_name) {
                 let qualified = format!("{module}.{name}");
                 if self.trait_defs.contains_key(&qualified) {
                     return self.identity_from_trait_defs_key(&qualified);
@@ -6264,7 +6260,7 @@ impl Checker {
                         || self
                             .current_module
                             .as_deref()
-                            .is_some_and(|current| current.rsplit('.').next() == Some(*module)))
+                            .is_some_and(|current| crate::short_name(current) == *module))
             })
             .collect();
         owners.sort_unstable();

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -143,7 +143,7 @@ impl Checker {
         }
         if let Some((module, short)) = name.rsplit_once('.') {
             let current = self.current_module.as_deref();
-            let current_short = current.map(|m| m.rsplit_once('.').map_or(m, |(_, s)| s));
+            let current_short = current.map(crate::short_name);
             if current == Some(module) || current_short == Some(module) {
                 return short.to_string();
             }
@@ -283,8 +283,8 @@ impl Checker {
         if a_qualified == b_qualified {
             return false;
         }
-        let a_bare = a.rsplit_once('.').map_or(a, |(_, bare)| bare);
-        let b_bare = b.rsplit_once('.').map_or(b, |(_, bare)| bare);
+        let a_bare = crate::short_name(a);
+        let b_bare = crate::short_name(b);
         a_bare == b_bare && crate::lookup_builtin_type(a_bare).is_some()
     }
 
@@ -1314,7 +1314,7 @@ impl Checker {
                     // way it does in the defining module (`per-module-type-identity`:
                     // the qualifier is an outer-identity concern, not part of the
                     // impl-binding key).
-                    let bare_name = name.rsplit('.').next().unwrap_or(name.as_str());
+                    let bare_name = crate::short_name(name);
                     let key = (name.clone(), trait_name.to_string(), assoc_name.to_string());
                     let binding = self.impl_assoc_type_bindings.get(&key).or_else(|| {
                         if bare_name == name.as_str() {
@@ -1855,9 +1855,7 @@ impl Checker {
                     .known_types
                     .iter()
                     .filter(|qualified| {
-                        qualified
-                            .rsplit_once('.')
-                            .is_some_and(|(_, short)| short == name)
+                        qualified.contains('.') && crate::short_name(qualified) == name
                     })
                     .cloned()
                     .collect();
@@ -1965,9 +1963,7 @@ impl Checker {
                                 .reported_type_visibility_violations
                                 .insert(resolved_name.clone())
                             {
-                                let symbol = resolved_name
-                                    .rsplit_once('.')
-                                    .map_or(resolved_name.as_str(), |(_, n)| n);
+                                let symbol = crate::short_name(&resolved_name);
                                 let decl_span = self
                                     .type_def_spans
                                     .get(&resolved_name)

--- a/hew-types/src/lang_items.rs
+++ b/hew-types/src/lang_items.rs
@@ -23,11 +23,13 @@
 
 use std::collections::HashMap;
 
+use strum::{EnumIter, IntoEnumIterator};
+
 /// Closed compiler-recognised lang-item key vocabulary.
 ///
 /// The stdlib may move these attributes between declarations, but adding a new
 /// semantic hook requires a compiler change so misspelled keys fail closed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, EnumIter)]
 pub enum LangItem {
     Index,
     IndexGet,
@@ -68,45 +70,6 @@ pub enum LangItem {
 }
 
 impl LangItem {
-    pub const ALL: [Self; 36] = [
-        Self::Index,
-        Self::IndexGet,
-        Self::IndexAt,
-        Self::Display,
-        Self::DisplayFmt,
-        Self::Option,
-        Self::OptionIsSome,
-        Self::OptionIsNone,
-        Self::OptionUnwrap,
-        Self::OptionUnwrapOr,
-        Self::Result,
-        Self::ResultIsOk,
-        Self::ResultIsErr,
-        Self::ResultUnwrap,
-        Self::ResultUnwrapOr,
-        Self::VecIterState,
-        Self::Iterator,
-        Self::IteratorNext,
-        Self::CollectionNew,
-        Self::MarkerSend,
-        Self::MarkerSync,
-        Self::MarkerFrozen,
-        Self::MarkerCopy,
-        Self::MarkerClone,
-        Self::MarkerEq,
-        Self::MarkerPartialOrd,
-        Self::MarkerOrd,
-        Self::MarkerNum,
-        Self::MarkerHash,
-        Self::MarkerDebug,
-        Self::MarkerDrop,
-        Self::MarkerDecode,
-        Self::MarkerEncode,
-        Self::MarkerSerializable,
-        Self::MarkerRcFree,
-        Self::MarkerResource,
-    ];
-
     #[must_use]
     pub const fn key(self) -> &'static str {
         match self {
@@ -151,7 +114,7 @@ impl LangItem {
 
     #[must_use]
     pub fn from_key(key: &str) -> Option<Self> {
-        Self::ALL.into_iter().find(|item| item.key() == key)
+        Self::iter().find(|item| item.key() == key)
     }
 }
 
@@ -239,5 +202,17 @@ impl LangItemRegistry {
     /// Iterate registered (key, binding) pairs in arbitrary order.
     pub fn iter(&self) -> impl Iterator<Item = (&String, &LangItemBinding)> {
         self.entries.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_lang_item_key_round_trips() {
+        for item in LangItem::iter() {
+            assert_eq!(LangItem::from_key(item.key()), Some(item));
+        }
     }
 }

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -86,6 +86,12 @@ pub use ty::{TraitObjectBound, Ty};
 pub use type_descriptor::TypeDescriptor;
 pub use vec_authority::VecElementToken;
 
+/// Return the final segment of a dot-qualified name.
+#[must_use]
+pub fn short_name(name: &str) -> &str {
+    name.rsplit_once('.').map_or(name, |(_, short)| short)
+}
+
 /// Native-only stdlib module short-names that are rejected on the wasm32 target
 /// and in the browser sandbox.
 ///
@@ -112,3 +118,14 @@ pub const NATIVE_ONLY_WASM_MODULES: &[&str] = &[
     "http_client",
     "smtp",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::short_name;
+
+    #[test]
+    fn short_name_uses_the_final_qualified_segment() {
+        assert_eq!(short_name("a.b.c"), "c");
+        assert_eq!(short_name("Name"), "Name");
+    }
+}

--- a/hew-types/src/method_resolution.rs
+++ b/hew-types/src/method_resolution.rs
@@ -37,11 +37,9 @@ fn lookup_user_type_def<'a>(
     type_defs: &'a HashMap<String, TypeDef>,
     type_name: &str,
 ) -> Option<&'a TypeDef> {
-    type_defs.get(type_name).or_else(|| {
-        type_name
-            .rsplit_once('.')
-            .and_then(|(_, short)| type_defs.get(short))
-    })
+    type_defs
+        .get(type_name)
+        .or_else(|| type_defs.get(crate::short_name(type_name)))
 }
 
 fn lookup_user_fn_sig<'a>(fn_sigs: &'a HashMap<String, FnSig>, key: &str) -> Option<&'a FnSig> {
@@ -49,7 +47,10 @@ fn lookup_user_fn_sig<'a>(fn_sigs: &'a HashMap<String, FnSig>, key: &str) -> Opt
         .get(key)
         .or_else(|| {
             let (type_name, method_name) = key.split_once("::")?;
-            let (_, short) = type_name.rsplit_once('.')?;
+            let short = crate::short_name(type_name);
+            if short == type_name {
+                return None;
+            }
             fn_sigs.get(&format!("{short}::{method_name}"))
         })
         .or_else(|| {
@@ -112,9 +113,10 @@ fn named_receiver_parts(ty: &Ty) -> Option<(&str, &[Ty])> {
 
 fn scoped_method_name<'a>(sig_name: &'a str, type_name: &str) -> Option<&'a str> {
     let scoped_prefix = format!("{type_name}::");
-    sig_name
-        .rsplit_once('.')
-        .and_then(|(_, unqualified)| unqualified.strip_prefix(&scoped_prefix))
+    let unqualified = crate::short_name(sig_name);
+    (unqualified != sig_name)
+        .then(|| unqualified.strip_prefix(&scoped_prefix))
+        .flatten()
 }
 
 fn lookup_collection_clone_method_sig(receiver_ty: &Ty, method: &str) -> Option<FnSig> {
@@ -337,9 +339,8 @@ pub fn collect_method_sigs_for_named_type(
     }
 
     let exact_prefix = format!("{type_name}::");
-    let short_prefix = type_name
-        .rsplit_once('.')
-        .map(|(_, short)| format!("{short}::"));
+    let short = crate::short_name(type_name);
+    let short_prefix = (short != type_name).then(|| format!("{short}::"));
     for (sig_name, sig) in fn_sigs {
         let method_name = sig_name
             .strip_prefix(&exact_prefix)

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -383,7 +383,7 @@ impl ModuleRegistry {
     pub fn qualify_handle_type(&self, name: &str) -> Option<String> {
         self.handle_types
             .iter()
-            .find(|ht| ht.rsplit('.').next() == Some(name))
+            .find(|ht| crate::short_name(ht) == name)
             .cloned()
     }
 
@@ -714,11 +714,7 @@ mod tests {
         reg.load("std::encoding::json").unwrap();
         let info = reg.get("std::encoding::json").unwrap();
         if let Some(hm) = info.handle_methods.first() {
-            let short = hm
-                .type_name
-                .rsplit('.')
-                .next()
-                .expect("qualified handle type should have short name");
+            let short = crate::short_name(&hm.type_name);
             let c_sym = reg.resolve_handle_method(short, &hm.method_name);
             assert_eq!(
                 c_sym.as_deref(),

--- a/hew-types/src/stdlib_authority.rs
+++ b/hew-types/src/stdlib_authority.rs
@@ -117,6 +117,14 @@ pub const SUBSTRATE_SOURCES: &[AuthoritySource<'static>] = &[
     ),
 ];
 
+const RESERVED_SUBSTRATE_ATTRIBUTES: &[&str] = &[
+    "lang_item",
+    "abi",
+    "intrinsic",
+    "diagnostic_item",
+    "overload",
+];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AuthorityDeclarationKind {
     Type,
@@ -814,12 +822,7 @@ fn ensure_substrate_attribute(
     declaration: &str,
     attr: &Attribute,
 ) -> Result<(), AuthorityError> {
-    if source.root.is_none()
-        && matches!(
-            attr.name.as_str(),
-            "lang_item" | "abi" | "intrinsic" | "diagnostic_item" | "overload"
-        )
-    {
+    if source.root.is_none() && RESERVED_SUBSTRATE_ATTRIBUTES.contains(&attr.name.as_str()) {
         return Err(error(
             source,
             Some(declaration.to_string()),
@@ -1133,6 +1136,49 @@ extern "C" {
         assert!(
             error.to_string().contains("substrate-only"),
             "outside-root error must explain the privilege boundary: {error}"
+        );
+    }
+
+    #[test]
+    fn abi_on_non_extern_declaration_is_rejected() {
+        let source = AuthoritySource::embedded(
+            StdlibRoot::Io,
+            "std/io.hew",
+            r"#[abi(ret = bytes_triple)] pub fn hew_bytes() -> bytes {}",
+        );
+        let error = load_stdlib_authority(&[source])
+            .expect_err("ABI facts must only decorate extern declarations");
+
+        assert_eq!(error.declaration.as_deref(), Some("hew_bytes"));
+        assert_eq!(
+            error.kind,
+            AuthorityErrorKind::InvalidAttributePlacement {
+                attribute: "abi".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn abi_outside_std_roots_is_rejected() {
+        let source = AuthoritySource::external(
+            "src/main.hew",
+            r#"
+extern "C" {
+    #[abi(ret = bytes_triple)]
+    fn hew_bytes() -> bytes;
+}
+"#,
+        );
+        let error = load_stdlib_authority(&[source])
+            .expect_err("ABI facts outside std roots must fail closed");
+
+        assert_eq!(error.source_path, "src/main.hew");
+        assert_eq!(error.declaration.as_deref(), Some("hew_bytes"));
+        assert_eq!(
+            error.kind,
+            AuthorityErrorKind::AttributeOutsideStdRoot {
+                attribute: "abi".to_string(),
+            }
         );
     }
 }

--- a/hew-types/src/stdlib_authority.rs
+++ b/hew-types/src/stdlib_authority.rs
@@ -13,6 +13,7 @@ use hew_parser::ast::{
     Attribute, AttributeArg, FnDecl, ImportSpec, Item, TraitItem, TypeBodyItem, TypeDeclKind,
     TypeExpr,
 };
+use strum::{EnumIter, IntoEnumIterator};
 
 use crate::LangItem;
 
@@ -133,7 +134,7 @@ pub struct AuthorityBinding {
     pub kind: AuthorityDeclarationKind,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, EnumIter)]
 pub enum Intrinsic {
     MathExp,
     MathLog,
@@ -160,31 +161,6 @@ pub enum Intrinsic {
 }
 
 impl Intrinsic {
-    pub const ALL: [Self; 22] = [
-        Self::MathExp,
-        Self::MathLog,
-        Self::MathSqrt,
-        Self::MathSin,
-        Self::MathCos,
-        Self::MathFloor,
-        Self::MathCeil,
-        Self::MathAbs,
-        Self::MathTanh,
-        Self::MathLog2,
-        Self::MathLog10,
-        Self::MathExp2,
-        Self::MathPow,
-        Self::MathMax,
-        Self::MathMin,
-        Self::MathPi,
-        Self::MathE,
-        Self::MemAlloc,
-        Self::MemRealloc,
-        Self::MemDealloc,
-        Self::MemPtrOffset,
-        Self::MemPtrCopy,
-    ];
-
     #[must_use]
     pub const fn key(self) -> &'static str {
         match self {
@@ -215,9 +191,7 @@ impl Intrinsic {
 
     #[must_use]
     pub fn from_key(key: &str) -> Option<Self> {
-        Self::ALL
-            .into_iter()
-            .find(|intrinsic| intrinsic.key() == key)
+        Self::iter().find(|intrinsic| intrinsic.key() == key)
     }
 }
 
@@ -974,6 +948,13 @@ fn error(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_intrinsic_key_round_trips() {
+        for intrinsic in Intrinsic::iter() {
+            assert_eq!(Intrinsic::from_key(intrinsic.key()), Some(intrinsic));
+        }
+    }
 
     #[test]
     fn embedded_substrate_populates_existing_authorities() {

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -409,18 +409,15 @@ pub(crate) fn resource_wrapper_shadowing_handle<'a>(
     handle_types: &'a HashSet<String>,
     resource_wrapper_types: &'a HashSet<String>,
 ) -> Option<(&'a str, &'a str)> {
-    // A free fn (not a closure) so the "return lifetime = input lifetime"
-    // relationship is expressible for both the map keys and the lookup argument.
-    fn short_name(qualified: &str) -> &str {
-        qualified.rsplit('.').next().unwrap_or(qualified)
-    }
     let handle_by_short: HashMap<&str, &str> = handle_types
         .iter()
-        .map(|h| (short_name(h), h.as_str()))
+        .map(|h| (crate::short_name(h), h.as_str()))
         .collect();
-    resource_wrapper_types
-        .iter()
-        .find_map(|w| handle_by_short.get(short_name(w)).map(|h| (w.as_str(), *h)))
+    resource_wrapper_types.iter().find_map(|w| {
+        handle_by_short
+            .get(crate::short_name(w))
+            .map(|h| (w.as_str(), *h))
+    })
 }
 
 /// Resolve an `impl` block's target type to its fully-qualified name,
@@ -1031,7 +1028,7 @@ fn wrapper_constructor_call_from_expr(
             fields,
             base: None,
             ..
-        } if name.rsplit('.').next() == Some(wrapper_simple_name)
+        } if crate::short_name(name) == wrapper_simple_name
             && fields.len() == 1
             && field_names.len() == 1 =>
         {
@@ -1076,7 +1073,7 @@ fn extract_handle_methods(
     // so nothing it registers can feed the `is_handle_type`-gated rewrite.
     let wrapper_field_names = wrapper_resource_fields.get(&type_name);
     let is_resource_wrapper = wrapper_field_names.is_some();
-    let wrapper_simple_name = type_name.rsplit('.').next().unwrap_or(type_name.as_str());
+    let wrapper_simple_name = crate::short_name(&type_name);
 
     for method in &impl_decl.methods {
         // A fieldless `#[resource]` handle (e.g. process.Child) IS a handle
@@ -1110,12 +1107,9 @@ fn extract_handle_methods(
             } else {
                 format!("{module_short}.{name}")
             };
-            wrapper_resource_fields.get(&qualified).map(|field_names| {
-                (
-                    name.rsplit('.').next().unwrap_or(name.as_str()),
-                    field_names,
-                )
-            })
+            wrapper_resource_fields
+                .get(&qualified)
+                .map(|field_names| (crate::short_name(name), field_names))
         });
         let extracted = extract_call_target(&method.body)
             .map(|target| (target, false))

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -324,18 +324,16 @@ impl TraitRegistry {
 
     /// Look up `RcFree` members by exact or module-qualified/unqualified name.
     fn rc_free_members_any(&self, name: &str) -> Option<&Vec<Ty>> {
-        self.rc_free_members.get(name).or_else(|| {
-            name.rsplit_once('.')
-                .and_then(|(_, unqualified)| self.rc_free_members.get(unqualified))
-        })
+        self.rc_free_members
+            .get(name)
+            .or_else(|| self.rc_free_members.get(crate::short_name(name)))
     }
 
     /// Look up `Serializable` members by exact or module-qualified/unqualified name.
     fn serializable_members_any(&self, name: &str) -> Option<&Vec<Ty>> {
-        self.serializable_members.get(name).or_else(|| {
-            name.rsplit_once('.')
-                .and_then(|(_, unqualified)| self.serializable_members.get(unqualified))
-        })
+        self.serializable_members
+            .get(name)
+            .or_else(|| self.serializable_members.get(crate::short_name(name)))
     }
 
     fn combine_rc_free_status<I>(&self, tys: I, visiting: &mut HashSet<String>) -> RcFreeStatus
@@ -562,7 +560,7 @@ impl TraitRegistry {
             || self
                 .handle_types
                 .iter()
-                .any(|ht| ht.rsplit('.').next() == Some(name))
+                .any(|ht| crate::short_name(ht) == name)
     }
 
     /// Check if a name is a drop type (qualified or unqualified).
@@ -571,7 +569,7 @@ impl TraitRegistry {
             || self
                 .drop_types
                 .iter()
-                .any(|dt| dt.rsplit('.').next() == Some(name))
+                .any(|dt| crate::short_name(dt) == name)
     }
 
     /// Register a `#[resource]` type by its declared (bare) name.
@@ -633,7 +631,7 @@ impl TraitRegistry {
         if self.resource_types.contains(name) {
             return true;
         }
-        let unqualified = name.rsplit_once('.').map_or(name, |(_, suffix)| suffix);
+        let unqualified = crate::short_name(name);
         self.resource_types.contains(unqualified)
     }
 
@@ -644,7 +642,7 @@ impl TraitRegistry {
         if self.linear_types.contains(name) {
             return true;
         }
-        let unqualified = name.rsplit_once('.').map_or(name, |(_, suffix)| suffix);
+        let unqualified = crate::short_name(name);
         self.linear_types.contains(unqualified)
     }
 


### PR DESCRIPTION
## Summary

Collapse three shallow duplications to single authorities. The qualified-name `short_name` helper (previously ~4 standalone copies plus dozens of inline `rsplit`/`rsplit_once` variants that had begun to drift) is now one function in hew-types, pinned to final-segment extraction. The `LangItem` and `Intrinsic` closed sets drop their hand-maintained `[Self; N]` arrays in favour of a `strum::EnumIter`-derived key lookup, so a new variant can't silently go missing from the lookup. The reserved substrate-attribute vocabulary becomes one named constant read by the placement gate.

## Verification

- `.ll` oracle: byte-identical (11×2)
- checked-mir: byte-identical
- `test-hew-ratchet`: 0/0
- `hew-check-all` and `lint`: clean
- New tests: `short_name` pinned on a multi-dot name; round-trip completeness for every LangItem/Intrinsic key; two `#[abi]` placement tests (non-extern → InvalidAttributePlacement, outside a std root → AttributeOutsideStdRoot)
- The `short_name` behaviour was verified identical at every migrated caller, including the diagnostic, registry-key, and method-resolution paths
- Preflight: ready-to-push

## Out of scope

- The other `Self::ALL` closed-set enums are unchanged.
- The extern-block attribute-rejection subset is a purpose-specific subset, not the reserved vocabulary, and is left as-is.