### PR TITLE
refactor(codegen): source collection identity from builtin stamp in layout paths

### DIFF
--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -3787,11 +3787,11 @@ pub(crate) fn lower_layout_vec_direct_call(
             // Derive the LLVM element type from the Vec<T> resolved type.
             let vec_resolved_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
             let elem_hew_ty = match &vec_resolved_ty {
-                ResolvedTy::Named {
-                    name,
-                    args: vec_args,
-                    ..
-                } if name == "Vec" && vec_args.len() == 1 => vec_args[0].clone(),
+                ResolvedTy::Named { args: vec_args, .. }
+                    if vec_resolved_ty.is_builtin(BuiltinType::Vec) && vec_args.len() == 1 =>
+                {
+                    vec_args[0].clone()
+                }
                 other => {
                     return Err(CodegenError::FailClosed(format!(
                         "hew_vec_clone_layout: arg0 must be Vec<T>, got {other:?}"
@@ -3847,11 +3847,11 @@ pub(crate) fn lower_layout_vec_direct_call(
             )?;
             let vec_resolved_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
             let elem_hew_ty = match &vec_resolved_ty {
-                ResolvedTy::Named {
-                    name,
-                    args: vec_args,
-                    ..
-                } if name == "Vec" && vec_args.len() == 1 => vec_args[0].clone(),
+                ResolvedTy::Named { args: vec_args, .. }
+                    if vec_resolved_ty.is_builtin(BuiltinType::Vec) && vec_args.len() == 1 =>
+                {
+                    vec_args[0].clone()
+                }
                 other => {
                     return Err(CodegenError::FailClosed(format!(
                         "hew_vec_slice_range_layout: arg0 must be Vec<T>, got {other:?}"
@@ -4531,12 +4531,12 @@ pub(crate) fn lower_hashmap_get_layout_call(
     })?;
 
     let map_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
-    let val_resolved = match map_ty {
-        ResolvedTy::Named {
-            name,
-            args: ty_args,
-            ..
-        } if name == "HashMap" && ty_args.len() == 2 => ty_args[1].clone(),
+    let val_resolved = match &map_ty {
+        ResolvedTy::Named { args: ty_args, .. }
+            if map_ty.is_builtin(BuiltinType::HashMap) && ty_args.len() == 2 =>
+        {
+            ty_args[1].clone()
+        }
         other => {
             return Err(CodegenError::FailClosed(format!(
                 "hew_hashmap_get_layout arg0 must be HashMap<K,V>, got {other:?}"
@@ -4545,11 +4545,10 @@ pub(crate) fn lower_hashmap_get_layout_call(
     };
     let dest_ty = place_resolved_ty(fn_ctx, *dest_place)?.clone();
     match &dest_ty {
-        ResolvedTy::Named {
-            name,
-            args: ty_args,
-            ..
-        } if name == "Option" && ty_args.len() == 1 && ty_args[0] == val_resolved => {}
+        ResolvedTy::Named { args: ty_args, .. }
+            if dest_ty.is_builtin(BuiltinType::Option)
+                && ty_args.len() == 1
+                && ty_args[0] == val_resolved => {}
         other => {
             return Err(CodegenError::FailClosed(format!(
                 "hew_hashmap_get_layout dest must be Option<{val_resolved:?}>, got {other:?}"
@@ -4666,12 +4665,12 @@ pub(crate) fn lower_hashmap_remove_take_call(
     })?;
 
     let map_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
-    let val_resolved = match map_ty {
-        ResolvedTy::Named {
-            name,
-            args: ty_args,
-            ..
-        } if name == "HashMap" && ty_args.len() == 2 => ty_args[1].clone(),
+    let val_resolved = match &map_ty {
+        ResolvedTy::Named { args: ty_args, .. }
+            if map_ty.is_builtin(BuiltinType::HashMap) && ty_args.len() == 2 =>
+        {
+            ty_args[1].clone()
+        }
         other => {
             return Err(CodegenError::FailClosed(format!(
                 "hew_hashmap_remove_take_layout arg0 must be HashMap<K,V>, got {other:?}"
@@ -4680,11 +4679,10 @@ pub(crate) fn lower_hashmap_remove_take_call(
     };
     let dest_ty = place_resolved_ty(fn_ctx, *dest_place)?.clone();
     match &dest_ty {
-        ResolvedTy::Named {
-            name,
-            args: ty_args,
-            ..
-        } if name == "Option" && ty_args.len() == 1 && ty_args[0] == val_resolved => {}
+        ResolvedTy::Named { args: ty_args, .. }
+            if dest_ty.is_builtin(BuiltinType::Option)
+                && ty_args.len() == 1
+                && ty_args[0] == val_resolved => {}
         other => {
             return Err(CodegenError::FailClosed(format!(
                 "hew_hashmap_remove_take_layout dest must be Option<{val_resolved:?}>, \
@@ -4810,12 +4808,12 @@ pub(crate) fn lower_hashmap_index_trap_call(
     })?;
 
     let map_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
-    let val_resolved = match map_ty {
-        ResolvedTy::Named {
-            name,
-            args: ty_args,
-            ..
-        } if name == "HashMap" && ty_args.len() == 2 => ty_args[1].clone(),
+    let val_resolved = match &map_ty {
+        ResolvedTy::Named { args: ty_args, .. }
+            if map_ty.is_builtin(BuiltinType::HashMap) && ty_args.len() == 2 =>
+        {
+            ty_args[1].clone()
+        }
         other => {
             return Err(CodegenError::FailClosed(format!(
                 "hew_hashmap_get_clone_layout (m[k] trap) arg0 must be HashMap<K,V>, got {other:?}"
@@ -4936,12 +4934,12 @@ pub(crate) fn lower_vec_get_clone_call(
     })?;
 
     let vec_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
-    let elem_resolved = match vec_ty {
-        ResolvedTy::Named {
-            name,
-            args: ty_args,
-            ..
-        } if name == "Vec" && ty_args.len() == 1 => ty_args[0].clone(),
+    let elem_resolved = match &vec_ty {
+        ResolvedTy::Named { args: ty_args, .. }
+            if vec_ty.is_builtin(BuiltinType::Vec) && ty_args.len() == 1 =>
+        {
+            ty_args[0].clone()
+        }
         other => {
             return Err(CodegenError::FailClosed(format!(
                 "hew_vec_get_clone arg0 must be Vec<T>, got {other:?}"
@@ -4950,11 +4948,13 @@ pub(crate) fn lower_vec_get_clone_call(
     };
     let dest_ty = place_resolved_ty(fn_ctx, *dest_place)?.clone();
     let dest_is_option = match &dest_ty {
-        ResolvedTy::Named {
-            name,
-            args: ty_args,
-            ..
-        } if name == "Option" && ty_args.len() == 1 && ty_args[0] == elem_resolved => true,
+        ResolvedTy::Named { args: ty_args, .. }
+            if dest_ty.is_builtin(BuiltinType::Option)
+                && ty_args.len() == 1
+                && ty_args[0] == elem_resolved =>
+        {
+            true
+        }
         ty if ty == &elem_resolved => false,
         other => {
             return Err(CodegenError::FailClosed(format!(

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -8192,11 +8192,13 @@ fn collect_vec_owned_element_seeds(
                 // channel (string-bearing records were masked by the
                 // direct-string record seed). Carrier names may be
                 // module-qualified (`channel.Receiver`) — compare short.
-                if name == "Vec" || matches!(short_name(name), "Sender" | "Receiver" | "Stream") {
+                if ty.is_builtin(BuiltinType::Vec)
+                    || matches!(short_name(name), "Sender" | "Receiver" | "Stream")
+                {
                     if let Some(elem) = args.first() {
                         on_vec_elem(elem);
                     }
-                } else if name == "HashMap" || short_name(name) == "HashMap" {
+                } else if ty.is_builtin(BuiltinType::HashMap) {
                     // Seed BOTH the value (heap-owning V drop thunk) AND the key
                     // (managed-record-key drop thunk). A `string`-bearing record
                     // key is owned by the map and dropped via its per-record
@@ -8330,24 +8332,22 @@ fn collect_wire_value_owned_vec_element_seeds(
         match &ty {
             ResolvedTy::Named { name, args, .. } => {
                 let short = short_name(name);
-                if name == "Vec" || matches!(short, "Sender" | "Receiver" | "Stream") {
+                if ty.is_builtin(BuiltinType::Vec)
+                    || matches!(short, "Sender" | "Receiver" | "Stream")
+                {
                     if let Some(elem) = args.first() {
                         consider_elem(elem, &mut record_seeds, &mut enum_seeds);
                         stack.push(elem.clone());
                     }
                     continue;
                 }
-                if name == "HashMap"
-                    || short == "HashMap"
-                    || name == "HashSet"
-                    || short == "HashSet"
-                {
+                if ty.is_builtin(BuiltinType::HashMap) || ty.is_builtin(BuiltinType::HashSet) {
                     for a in args {
                         stack.push(a.clone());
                     }
                     continue;
                 }
-                if matches!(short, "Option" | "Result" | "Range") {
+                if ty.is_builtin(BuiltinType::Option) || matches!(short, "Result" | "Range") {
                     for a in args {
                         stack.push(a.clone());
                     }
@@ -38342,6 +38342,59 @@ mod tests {
             !ir.contains("llvm.memcpy"),
             "HashMap::get must not memcpy a borrowed slot into owned Option<V>; got IR:\n{ir}"
         );
+    }
+
+    #[test]
+    fn hashmap_layout_ops_reject_user_named_collision() {
+        let ctx = Context::create();
+        let m = ctx.create_module("hashmap_get_user_collision_test");
+        let harness = build_harness(
+            &ctx,
+            &[fixture_point_layout()],
+            &[fixture_option_i64_layout()],
+        );
+        let mut fn_ctx = make_test_fn_ctx(&ctx, &m, &harness, "drv");
+        let user_map_ty = ResolvedTy::Named {
+            name: "HashMap".to_string(),
+            args: vec![
+                ResolvedTy::Named {
+                    name: "Point".to_string(),
+                    args: vec![],
+                    builtin: None,
+                    is_opaque: false,
+                },
+                ResolvedTy::I64,
+            ],
+            builtin: None,
+            is_opaque: false,
+        };
+        let point_ty = ResolvedTy::Named {
+            name: "Point".to_string(),
+            args: vec![],
+            builtin: None,
+            is_opaque: false,
+        };
+        let option_i64_ty = ResolvedTy::named_builtin(
+            BuiltinType::Option.canonical_name(),
+            BuiltinType::Option,
+            vec![ResolvedTy::I64],
+        );
+        alloc_local(&mut fn_ctx, 0, user_map_ty);
+        alloc_local(&mut fn_ctx, 1, point_ty);
+        alloc_local(&mut fn_ctx, 2, option_i64_ty);
+
+        let err = lower_hashmap_get_layout_call(
+            &fn_ctx,
+            &[Place::Local(0), Place::Local(1)],
+            Some(&Place::Local(2)),
+            1,
+        )
+        .expect_err("a user type named HashMap must not route to the runtime map ABI");
+        assert!(
+            matches!(&err, CodegenError::FailClosed(message) if message.contains("arg0 must be HashMap<K,V>")),
+            "unexpected error: {err:?}"
+        );
+        finish_test_fn(&fn_ctx);
     }
 
     // ---- emit_result_ok ----------------------------------------------------

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -35350,12 +35350,11 @@ mod tests {
             params: vec![],
             locals: vec![
                 // local_0: Option<i64> — must resolve via mangled key
-                ResolvedTy::Named {
-                    name: "Option".to_string(),
-                    args: vec![ResolvedTy::I64],
-                    builtin: None,
-                    is_opaque: false,
-                },
+                ResolvedTy::named_builtin(
+                    BuiltinType::Option.canonical_name(),
+                    BuiltinType::Option,
+                    vec![ResolvedTy::I64],
+                ),
                 // local_1: i64 — return value
                 ResolvedTy::I64,
             ],
@@ -38266,8 +38265,8 @@ mod tests {
         );
     }
 
-    /// Positive guard: layout-sourced genuine builtins can carry `builtin: None`
-    /// and must stay on the runtime layout ABI.
+    /// Positive guard: layout-sourced genuine builtins carry their discriminant
+    /// and stay on the runtime layout ABI.
     #[test]
     fn hashmap_layout_ops_get_emits_clone_call_and_option_branches() {
         let ctx = Context::create();
@@ -38278,9 +38277,10 @@ mod tests {
             &[fixture_option_i64_layout()],
         );
         let mut fn_ctx = make_test_fn_ctx(&ctx, &m, &harness, "drv");
-        let map_ty = ResolvedTy::Named {
-            name: "HashMap".to_string(),
-            args: vec![
+        let map_ty = ResolvedTy::named_builtin(
+            BuiltinType::HashMap.canonical_name(),
+            BuiltinType::HashMap,
+            vec![
                 ResolvedTy::Named {
                     name: "Point".to_string(),
                     args: vec![],
@@ -38289,21 +38289,20 @@ mod tests {
                 },
                 ResolvedTy::I64,
             ],
-            builtin: None,
-            is_opaque: false,
-        };
+        );
         let point_ty = ResolvedTy::Named {
             name: "Point".to_string(),
             args: vec![],
             builtin: None,
             is_opaque: false,
         };
-        let option_i64_ty = ResolvedTy::Named {
-            name: "Option".to_string(),
-            args: vec![ResolvedTy::I64],
-            builtin: None,
-            is_opaque: false,
-        };
+        let option_i64_ty = ResolvedTy::named_builtin(
+            BuiltinType::Option.canonical_name(),
+            BuiltinType::Option,
+            vec![ResolvedTy::I64],
+        );
+        assert!(map_ty.is_builtin(BuiltinType::HashMap));
+        assert!(option_i64_ty.is_builtin(BuiltinType::Option));
         alloc_local(&mut fn_ctx, 0, map_ty);
         alloc_local(&mut fn_ctx, 1, point_ty);
         alloc_local(&mut fn_ctx, 2, option_i64_ty);

--- a/hew-codegen-rs/tests/emission/hashmap_layout_emission.rs
+++ b/hew-codegen-rs/tests/emission/hashmap_layout_emission.rs
@@ -36,7 +36,7 @@ fn vec_of(elem: ResolvedTy) -> ResolvedTy {
     ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![elem],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     }
 }

--- a/hew-codegen-rs/tests/emission/vec_index_emission.rs
+++ b/hew-codegen-rs/tests/emission/vec_index_emission.rs
@@ -46,7 +46,7 @@ fn vec_index_i64_pipeline() -> IrPipeline {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![ResolvedTy::I64],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
 
@@ -214,7 +214,7 @@ fn vec_index_bool_pipeline() -> IrPipeline {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![ResolvedTy::Bool],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
 
@@ -378,7 +378,7 @@ fn vec_index_char_pipeline() -> IrPipeline {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![ResolvedTy::Char],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
 

--- a/hew-codegen-rs/tests/emission/vec_layout_emission.rs
+++ b/hew-codegen-rs/tests/emission/vec_layout_emission.rs
@@ -148,7 +148,7 @@ fn vec_layout_new_constructs_with_descriptor() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -177,7 +177,7 @@ fn vec_bitcopy_tuple_new_constructs_with_plain_descriptor() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![tuple_ty],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -211,7 +211,7 @@ fn vec_non_bitcopy_tuple_new_constructor_routes_to_owned_abi() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![tuple_ty],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -267,7 +267,7 @@ fn vec_payload_free_enum_new_routes_bitcopy_not_owned() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![enum_ty.clone()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -337,7 +337,7 @@ fn vec_scalar_payload_enum_new_routes_bitcopy_not_owned() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![enum_ty.clone()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -389,7 +389,7 @@ fn vec_layout_push_synthesizes_descriptor_and_data_pointer() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -421,7 +421,7 @@ fn vec_layout_get_loads_returned_element_pointer_into_dest() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -461,7 +461,7 @@ fn vec_layout_set_synthesizes_descriptor_index_and_data_pointer() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -500,7 +500,7 @@ fn vec_layout_pop_traps_when_runtime_reports_empty() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -538,7 +538,7 @@ fn vec_layout_contains_thunk_emits_per_type_equality_function() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -600,7 +600,7 @@ fn vec_layout_contains_thunk_dedups_by_structured_type() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let return_block = BasicBlock {
@@ -759,7 +759,7 @@ fn vec_layout_contains_thunk_enum_tag_dispatches_not_byte_compares() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![enum_ty.clone()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -843,7 +843,7 @@ fn vec_layout_contains_thunk_emits_for_wasm_target() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {
@@ -907,7 +907,7 @@ fn vec_layout_clone_synthesizes_descriptor_and_returns_new_vec() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let cloned_vec_ty = vec_ty.clone();
@@ -966,7 +966,7 @@ fn vec_layout_remove_synthesizes_descriptor_index_and_out_slot() {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![point_ty()],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
     let block = BasicBlock {

--- a/hew-codegen-rs/tests/emission/vec_slice_emission.rs
+++ b/hew-codegen-rs/tests/emission/vec_slice_emission.rs
@@ -41,7 +41,7 @@ fn vec_slice_i64_pipeline() -> IrPipeline {
     let vec_ty = ResolvedTy::Named {
         name: "Vec".to_string(),
         args: vec![ResolvedTy::I64],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Vec),
         is_opaque: false,
     };
 

--- a/hew-codegen-rs/tests/structural/composite_return.rs
+++ b/hew-codegen-rs/tests/structural/composite_return.rs
@@ -43,7 +43,7 @@ fn option_some_pipeline() -> IrPipeline {
     let option_ty = ResolvedTy::Named {
         name: "Option".to_string(),
         args: vec![ResolvedTy::I64],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Option),
         is_opaque: false,
     };
     let enum_layout = EnumLayout {
@@ -152,7 +152,7 @@ fn option_string_pipeline() -> IrPipeline {
     let option_ty = ResolvedTy::Named {
         name: "Option".to_string(),
         args: vec![ResolvedTy::String],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::Option),
         is_opaque: false,
     };
     let enum_layout = EnumLayout {

--- a/hew-codegen-rs/tests/structural/hashmap_layout_ops.rs
+++ b/hew-codegen-rs/tests/structural/hashmap_layout_ops.rs
@@ -314,7 +314,7 @@ fn hashmap_ty(key: ResolvedTy, val: ResolvedTy) -> ResolvedTy {
     ResolvedTy::Named {
         name: "HashMap".to_string(),
         args: vec![key, val],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::HashMap),
         is_opaque: false,
     }
 }
@@ -323,7 +323,7 @@ fn hashset_ty(elem: ResolvedTy) -> ResolvedTy {
     ResolvedTy::Named {
         name: "HashSet".to_string(),
         args: vec![elem],
-        builtin: None,
+        builtin: Some(hew_types::BuiltinType::HashSet),
         is_opaque: false,
     }
 }

--- a/hew-codegen-rs/tests/structural/state_clone_synthesis.rs
+++ b/hew-codegen-rs/tests/structural/state_clone_synthesis.rs
@@ -254,7 +254,7 @@ fn state_clone_chatroom_string_and_vec_clone_with_rollback() {
             ResolvedTy::Named {
                 name: "Vec".into(),
                 args: vec![ResolvedTy::I32],
-                builtin: None,
+                builtin: Some(hew_types::BuiltinType::Vec),
                 is_opaque: false,
             },
         ],
@@ -272,7 +272,7 @@ fn state_clone_chatroom_string_and_vec_clone_with_rollback() {
             ResolvedTy::Named {
                 name: "Vec".into(),
                 args: vec![ResolvedTy::I32],
-                builtin: None,
+                builtin: Some(hew_types::BuiltinType::Vec),
                 is_opaque: false,
             },
         ],
@@ -358,19 +358,19 @@ fn state_clone_router_three_vecs_full_rollback_chain() {
             ResolvedTy::Named {
                 name: "Vec".into(),
                 args: vec![ResolvedTy::I64],
-                builtin: None,
+                builtin: Some(hew_types::BuiltinType::Vec),
                 is_opaque: false,
             },
             ResolvedTy::Named {
                 name: "Vec".into(),
                 args: vec![ResolvedTy::I64],
-                builtin: None,
+                builtin: Some(hew_types::BuiltinType::Vec),
                 is_opaque: false,
             },
             ResolvedTy::Named {
                 name: "Vec".into(),
                 args: vec![ResolvedTy::I64],
-                builtin: None,
+                builtin: Some(hew_types::BuiltinType::Vec),
                 is_opaque: false,
             },
         ],
@@ -422,7 +422,7 @@ fn state_clone_workspace_nested_user_record_synthesizes_record_helper() {
             ResolvedTy::Named {
                 name: "Vec".into(),
                 args: vec![ResolvedTy::I32],
-                builtin: None,
+                builtin: Some(hew_types::BuiltinType::Vec),
                 is_opaque: false,
             }, // payload
         ],
@@ -588,7 +588,7 @@ fn state_clone_alloc_fail_per_field_rollback_cardinality_and_order() {
             ResolvedTy::Named {
                 name: "Vec".into(),
                 args: vec![ResolvedTy::I32],
-                builtin: None,
+                builtin: Some(hew_types::BuiltinType::Vec),
                 is_opaque: false,
             },
             ResolvedTy::String,

--- a/hew-hir/src/monomorph.rs
+++ b/hew-hir/src/monomorph.rs
@@ -911,10 +911,15 @@ mod tests {
         // Option<T> where T is the structural TypeParam variant -> Option<i64>.
         let params = vec!["T".to_string()];
         let args = vec![ResolvedTy::I64];
-        let ty = ResolvedTy::named_user("Option", vec![ResolvedTy::TypeParam { name: "T".into() }]);
+        let builtin = hew_types::BuiltinType::Option;
+        let ty = ResolvedTy::named_builtin(
+            builtin.canonical_name(),
+            builtin,
+            vec![ResolvedTy::TypeParam { name: "T".into() }],
+        );
         assert_eq!(
             substitute_type_params(&ty, &params, &args),
-            ResolvedTy::named_user("Option", vec![ResolvedTy::I64])
+            ResolvedTy::named_builtin(builtin.canonical_name(), builtin, vec![ResolvedTy::I64])
         );
     }
 

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -1744,6 +1744,10 @@ mod tests {
         ResolvedTy::named_user(name, args)
     }
 
+    fn builtin(kind: hew_types::BuiltinType, args: Vec<ResolvedTy>) -> ResolvedTy {
+        ResolvedTy::named_builtin(kind.canonical_name(), kind, args)
+    }
+
     /// Build a `Named` type carrying the `#[opaque]` discriminator, as
     /// `lower_type` stamps for an opaque-handle reference (e.g. `json.Value`).
     fn named_opaque(name: &str, args: Vec<ResolvedTy>) -> ResolvedTy {
@@ -1833,12 +1837,7 @@ mod tests {
     #[test]
     fn vec_of_primitive_recurses_to_bitcopy_element() {
         let mut v = HashSet::new();
-        let ty = ResolvedTy::Named {
-            name: "Vec".to_string(),
-            args: vec![ResolvedTy::I32],
-            builtin: None,
-            is_opaque: false,
-        };
+        let ty = builtin(hew_types::BuiltinType::Vec, vec![ResolvedTy::I32]);
         assert_eq!(
             classify_state_field(&ty, &no_records(), &mut v).unwrap(),
             StateFieldCloneKind::Vec {
@@ -1850,12 +1849,7 @@ mod tests {
     #[test]
     fn vec_of_string_recurses_to_string_element() {
         let mut v = HashSet::new();
-        let ty = ResolvedTy::Named {
-            name: "Vec".to_string(),
-            args: vec![ResolvedTy::String],
-            builtin: None,
-            is_opaque: false,
-        };
+        let ty = builtin(hew_types::BuiltinType::Vec, vec![ResolvedTy::String]);
         assert_eq!(
             classify_state_field(&ty, &no_records(), &mut v).unwrap(),
             StateFieldCloneKind::Vec {
@@ -2006,17 +2000,15 @@ mod tests {
         // Connection-in-container and emit the codegen-time FailClosed
         // at supervisor sites.
         let mut v = HashSet::new();
-        let ty = ResolvedTy::Named {
-            name: "Vec".to_string(),
-            args: vec![ResolvedTy::Named {
+        let ty = builtin(
+            hew_types::BuiltinType::Vec,
+            vec![ResolvedTy::Named {
                 name: "Connection".to_string(),
                 args: vec![],
                 builtin: None,
                 is_opaque: false,
             }],
-            builtin: None,
-            is_opaque: false,
-        };
+        );
         assert_eq!(
             classify_state_field(&ty, &no_records(), &mut v).unwrap(),
             StateFieldCloneKind::Vec {
@@ -2030,12 +2022,10 @@ mod tests {
     #[test]
     fn hashmap_recurses_into_both_key_and_value() {
         let mut v = HashSet::new();
-        let ty = ResolvedTy::Named {
-            name: "HashMap".to_string(),
-            args: vec![ResolvedTy::String, ResolvedTy::I64],
-            builtin: None,
-            is_opaque: false,
-        };
+        let ty = builtin(
+            hew_types::BuiltinType::HashMap,
+            vec![ResolvedTy::String, ResolvedTy::I64],
+        );
         assert_eq!(
             classify_state_field(&ty, &no_records(), &mut v).unwrap(),
             StateFieldCloneKind::HashMap {
@@ -2055,17 +2045,15 @@ mod tests {
             RecordLayout {
                 name: "Workspace".to_string(),
                 field_tys: vec![
-                    ResolvedTy::Named {
-                        name: "Vec".to_string(),
-                        args: vec![ResolvedTy::Named {
+                    builtin(
+                        hew_types::BuiltinType::Vec,
+                        vec![ResolvedTy::Named {
                             name: "Entry".to_string(),
                             args: vec![],
                             builtin: None,
                             is_opaque: false,
                         }],
-                        builtin: None,
-                        is_opaque: false,
-                    },
+                    ),
                     ResolvedTy::String,
                 ],
                 field_names: vec![],
@@ -2074,12 +2062,7 @@ mod tests {
                 name: "Entry".to_string(),
                 field_tys: vec![
                     ResolvedTy::String,
-                    ResolvedTy::Named {
-                        name: "Vec".to_string(),
-                        args: vec![ResolvedTy::I32],
-                        builtin: None,
-                        is_opaque: false,
-                    },
+                    builtin(hew_types::BuiltinType::Vec, vec![ResolvedTy::I32]),
                 ],
                 field_names: vec![],
             },
@@ -2489,12 +2472,7 @@ mod tests {
         // mangled `Option$$string`) and return `Enum`, NOT fail closed as
         // `MissingRecordLayout`.
         let layouts = vec![option_string_layout()];
-        let ty = ResolvedTy::Named {
-            name: "Option".to_string(),
-            args: vec![ResolvedTy::String],
-            builtin: None,
-            is_opaque: false,
-        };
+        let ty = builtin(hew_types::BuiltinType::Option, vec![ResolvedTy::String]);
         let mut v = HashSet::new();
         let result =
             classify_state_field_with_enum_layouts(&ty, &no_records(), &layouts, &mut v).unwrap();
@@ -2626,12 +2604,7 @@ mod tests {
         // `MissingRecordLayout`. This pins that the additive enum-aware API
         // does not silently change the legacy call sites (llvm.rs record /
         // dyn-trait classification) that pass no enum layouts.
-        let ty = ResolvedTy::Named {
-            name: "Option".to_string(),
-            args: vec![ResolvedTy::String],
-            builtin: None,
-            is_opaque: false,
-        };
+        let ty = builtin(hew_types::BuiltinType::Option, vec![ResolvedTy::String]);
         let mut v = HashSet::new();
         let result = classify_state_field(&ty, &no_records(), &mut v);
         assert!(
@@ -2965,7 +2938,10 @@ mod tests {
         // this classified as `Vec { OpaqueHandle }` and codegen cloned the vec
         // handle with a plain element witness — the UAF.
         let mut v = HashSet::new();
-        let ty = ResolvedTy::named_user("Vec", vec![named_opaque("Value", vec![])]);
+        let ty = builtin(
+            hew_types::BuiltinType::Vec,
+            vec![named_opaque("Value", vec![])],
+        );
         assert_opaque_in_container(classify_state_field_full(
             &ty,
             &no_records(),
@@ -2979,7 +2955,10 @@ mod tests {
     #[test]
     fn hashset_of_opaque_handle_fails_closed() {
         let mut v = HashSet::new();
-        let ty = ResolvedTy::named_user("HashSet", vec![named_opaque("Value", vec![])]);
+        let ty = builtin(
+            hew_types::BuiltinType::HashSet,
+            vec![named_opaque("Value", vec![])],
+        );
         assert_opaque_in_container(classify_state_field_full(
             &ty,
             &no_records(),
@@ -2992,8 +2971,8 @@ mod tests {
     #[test]
     fn hashmap_with_opaque_value_fails_closed() {
         let mut v = HashSet::new();
-        let ty = ResolvedTy::named_user(
-            "HashMap",
+        let ty = builtin(
+            hew_types::BuiltinType::HashMap,
             vec![ResolvedTy::String, named_opaque("Value", vec![])],
         );
         assert_opaque_in_container(classify_state_field_full(
@@ -3008,8 +2987,8 @@ mod tests {
     #[test]
     fn hashmap_with_opaque_key_fails_closed() {
         let mut v = HashSet::new();
-        let ty = ResolvedTy::named_user(
-            "HashMap",
+        let ty = builtin(
+            hew_types::BuiltinType::HashMap,
             vec![named_opaque("Value", vec![]), ResolvedTy::I64],
         );
         assert_opaque_in_container(classify_state_field_full(
@@ -3027,8 +3006,11 @@ mod tests {
         // transitive authority recurses through the `Option<T>` type-arg, so the
         // outer Vec fails closed even though its immediate element is an enum.
         let mut v = HashSet::new();
-        let inner_opt = ResolvedTy::named_user("Option", vec![named_opaque("Value", vec![])]);
-        let ty = ResolvedTy::named_user("Vec", vec![inner_opt]);
+        let inner_opt = builtin(
+            hew_types::BuiltinType::Option,
+            vec![named_opaque("Value", vec![])],
+        );
+        let ty = builtin(hew_types::BuiltinType::Vec, vec![inner_opt]);
         assert_opaque_in_container(classify_state_field_full(
             &ty,
             &no_records(),
@@ -3049,7 +3031,10 @@ mod tests {
             field_names: vec![],
         }];
         let mut v = HashSet::new();
-        let ty = ResolvedTy::named_user("Vec", vec![ResolvedTy::named_user("Holder", vec![])]);
+        let ty = builtin(
+            hew_types::BuiltinType::Vec,
+            vec![ResolvedTy::named_user("Holder", vec![])],
+        );
         assert_opaque_in_container(classify_state_field_full(&ty, &records, &[], &[], &mut v));
     }
 
@@ -3067,7 +3052,7 @@ mod tests {
         }];
         let opaque_names = vec!["Value".to_string()];
         let mut v = HashSet::new();
-        let ty = ResolvedTy::named_user("Vec", vec![named("Value", vec![])]); // is_opaque: false
+        let ty = builtin(hew_types::BuiltinType::Vec, vec![named("Value", vec![])]); // is_opaque: false
         let result = classify_state_field_full(&ty, &records, &[], &opaque_names, &mut v).unwrap();
         assert_eq!(
             result,


### PR DESCRIPTION
## Summary

The carried `builtin` discriminant on `ResolvedTy::Named` is now the exclusive collection-identity authority at the layout element-extractor sites, replacing the remaining bare-`name`-string checks (`name == "Vec"` and friends) in codegen's layout paths and the owned-Vec-element seed walks. The checker already threads the stamp into these place types, so this is a safe swap: a user-defined type named `Vec`/`HashMap`/`Option` that carries no builtin stamp now fails closed instead of misrouting to the runtime container ABI.

## Verification

- `make ll-diff`: `.ll` oracle byte-identical (11×2, including the owned-Vec cross-function drop-routing fixture) — the swap changes zero emitted routing.
- `hashmap_layout_ops_reject_user_named_collision` (new negative test): pass — a user type literally named `HashMap` is now rejected rather than routed to the container ABI.
- `hashmap_layout_ops_get_emits_clone_call_and_option_branches` (existing positive test): pass — a genuine `HashMap` still emits its clone-call plus Option branches.
- checked-mir byte-identical; hew-check-all clean.
- Preflight: ready-to-push.

## Out of scope

- The already-stamped-safe extractor sites, changed in a prior step.
- The checker's stamping itself, which already flows the discriminant into these place types.
