### PR TITLE
refactor(runtime): centralize mailbox header into shared module

### DIFF
--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -689,6 +689,8 @@ pub mod deque;
 pub mod mailbox;
 /// Mailbox envelope payload classification and cross-node send guards.
 pub mod mailbox_envelope;
+/// Target-independent in-process mailbox message-header bit logic.
+pub mod mailbox_header;
 #[cfg(any(target_arch = "wasm32", test))]
 pub mod mailbox_wasm;
 #[cfg(not(target_arch = "wasm32"))]

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -30,9 +30,18 @@ use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 
 use crate::internal::types::{HewError, HewOverflowPolicy};
+use crate::mailbox_header::{header_validate, normalize_coalesce_fallback};
 use crate::scheduler::{MESSAGES_RECEIVED, MESSAGES_SENT};
 use crate::set_last_error;
 use crate::tracing::HewTraceContext;
+
+pub use crate::mailbox_header::{
+    HEW_MSG_ENVELOPE_ALIAS_ACTIVE, HEW_MSG_ENVELOPE_ARENA_BACKED,
+    HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER, HEW_MSG_ENVELOPE_FORKED,
+    HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK, HEW_MSG_ENVELOPE_RESERVED_DELTA_A,
+    HEW_MSG_ENVELOPE_RESERVED_DELTA_B, HEW_MSG_ENVELOPE_RESERVED_GAMMA_A,
+    HEW_MSG_ENVELOPE_RESERVED_GAMMA_B, HEW_MSG_ENVELOPE_SHARED_FROZEN,
+};
 
 /// Re-export of [`HewOverflowPolicy`] for the public mailbox API.
 pub use crate::internal::types::HewOverflowPolicy as OverflowPolicy;
@@ -159,30 +168,8 @@ pub struct HewMsgNode {
 // send for non-`Copy` types, so a runtime fork only fires for the
 // narrow corner cases the static analysis cannot prove safe.
 //
-// This commit lands the envelope FFI surface and reserved header bits.
-// No call site calls into the envelope path yet; codegen flips selected
-// sites in a later commit.
-
-/// Header bit: ≥2 observers hold this envelope (sender + receiver).
-pub const HEW_MSG_ENVELOPE_ALIAS_ACTIVE: u32 = 1 << 0;
-/// Header bit: payload is `Frozen`; never forks (γ uses).
-pub const HEW_MSG_ENVELOPE_SHARED_FROZEN: u32 = 1 << 1;
-/// Header bit: payload was bumped from a per-dispatch arena (δ uses).
-pub const HEW_MSG_ENVELOPE_ARENA_BACKED: u32 = 1 << 2;
-/// Header bit: a fork-on-write has fired (diagnostic / metric).
-pub const HEW_MSG_ENVELOPE_FORKED: u32 = 1 << 3;
-/// Header bit: payload is a §12 capability transfer; alias forbidden.
-pub const HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER: u32 = 1 << 4;
-/// Reserved for γ (captured by ≥2 `task_scope` children).
-pub const HEW_MSG_ENVELOPE_RESERVED_GAMMA_A: u32 = 1 << 5;
-/// Reserved for γ aux.
-pub const HEW_MSG_ENVELOPE_RESERVED_GAMMA_B: u32 = 1 << 6;
-/// Reserved for δ aux.
-pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_A: u32 = 1 << 7;
-/// Reserved for δ aux.
-pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_B: u32 = 1 << 8;
-/// All bits ≥ 9 must read zero on every envelope load (fail-closed).
-pub const HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK: u32 = !((1u32 << 9) - 1);
+// The cross-target header assignments and pure bit logic live in
+// `crate::mailbox_header`; native allocation and scheduling remain here.
 
 /// Drop glue invoked when an envelope's refcount drops to zero.
 ///
@@ -236,23 +223,6 @@ unsafe impl Send for HewMsgEnvelope {}
 // SAFETY: see the `Send` impl above; concurrent reads are read-only,
 // concurrent refcount/header mutations go through atomics.
 unsafe impl Sync for HewMsgEnvelope {}
-
-/// Validate that bits 9..31 of `bits` are zero; panic on mismatch.
-///
-/// This is the `serializer-fail-closed` invariant for the envelope
-/// header: any forwards-incompatible bit set by a future runtime
-/// would otherwise be interpreted as zero by today's release path,
-/// silently dropping a contract. Loud panic instead.
-#[inline]
-fn header_validate(bits: u32) -> u32 {
-    assert!(
-        bits & HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK == 0,
-        "hew_msg_envelope: reserved header bits set (bits = {bits:#x}); \
-         this runtime does not understand the envelope's contract — \
-         refusing to proceed (fail-closed)"
-    );
-    bits
-}
 
 /// Allocate a fresh envelope wrapping `payload`.
 ///
@@ -1287,13 +1257,6 @@ pub unsafe extern "C" fn hew_mailbox_new_coalesce(capacity: u32) -> *mut HewMail
         high_water_mark: AtomicI64::new(0),
         use_slow_path: true,
     }))
-}
-
-fn normalize_coalesce_fallback(policy: HewOverflowPolicy) -> HewOverflowPolicy {
-    match policy {
-        HewOverflowPolicy::Coalesce => HewOverflowPolicy::DropOld,
-        other => other,
-    }
 }
 
 unsafe fn coalesce_message_key(
@@ -3785,24 +3748,6 @@ mod tests {
     }
 
     // ── Phase-α envelope tests ──────────────────────────────────────
-
-    /// Reserved-bit layout is documented and tested. Any reordering
-    /// here will be caught at compile-time on the constants and at
-    /// run-time on the assertion.
-    #[test]
-    fn envelope_header_bits_layout_locked() {
-        assert_eq!(HEW_MSG_ENVELOPE_ALIAS_ACTIVE, 1u32 << 0);
-        assert_eq!(HEW_MSG_ENVELOPE_SHARED_FROZEN, 1u32 << 1);
-        assert_eq!(HEW_MSG_ENVELOPE_ARENA_BACKED, 1u32 << 2);
-        assert_eq!(HEW_MSG_ENVELOPE_FORKED, 1u32 << 3);
-        assert_eq!(HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER, 1u32 << 4);
-        assert_eq!(HEW_MSG_ENVELOPE_RESERVED_GAMMA_A, 1u32 << 5);
-        assert_eq!(HEW_MSG_ENVELOPE_RESERVED_GAMMA_B, 1u32 << 6);
-        assert_eq!(HEW_MSG_ENVELOPE_RESERVED_DELTA_A, 1u32 << 7);
-        assert_eq!(HEW_MSG_ENVELOPE_RESERVED_DELTA_B, 1u32 << 8);
-        // Bits 9..31 are reserved-zero.
-        assert_eq!(HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK, 0xFFFF_FE00);
-    }
 
     /// Drop-glue probe used by envelope tests; bumps a counter so the
     /// test can assert that the final release fires `drop_glue` exactly

--- a/hew-runtime/src/mailbox_header.rs
+++ b/hew-runtime/src/mailbox_header.rs
@@ -1,0 +1,45 @@
+//! Target-independent mailbox message-header bit logic.
+//!
+//! These bits describe in-process COW message payloads and must remain identical
+//! across native and WASM mailboxes. They are unrelated to the cross-node CBOR
+//! wire envelope.
+
+/// Header bit: at least two observers hold this message payload.
+pub const HEW_MSG_ENVELOPE_ALIAS_ACTIVE: u32 = 1 << 0;
+/// Header bit: payload is `Frozen`; never forks.
+pub const HEW_MSG_ENVELOPE_SHARED_FROZEN: u32 = 1 << 1;
+/// Header bit: payload was bumped from a per-dispatch arena.
+pub const HEW_MSG_ENVELOPE_ARENA_BACKED: u32 = 1 << 2;
+/// Header bit: a fork-on-write has fired.
+pub const HEW_MSG_ENVELOPE_FORKED: u32 = 1 << 3;
+/// Header bit: payload is a capability transfer; aliasing is forbidden.
+pub const HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER: u32 = 1 << 4;
+/// Reserved for captured payloads shared by multiple task-scope children.
+pub const HEW_MSG_ENVELOPE_RESERVED_GAMMA_A: u32 = 1 << 5;
+/// Reserved for an additional shared-task payload contract.
+pub const HEW_MSG_ENVELOPE_RESERVED_GAMMA_B: u32 = 1 << 6;
+/// Reserved for an arena-backed payload contract.
+pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_A: u32 = 1 << 7;
+/// Reserved for an additional arena-backed payload contract.
+pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_B: u32 = 1 << 8;
+/// All bits at or above bit 9 must read zero on every header load.
+pub const HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK: u32 = !((1u32 << 9) - 1);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bit_layout_fingerprint() {
+        assert_eq!(HEW_MSG_ENVELOPE_ALIAS_ACTIVE, 0x0000_0001);
+        assert_eq!(HEW_MSG_ENVELOPE_SHARED_FROZEN, 0x0000_0002);
+        assert_eq!(HEW_MSG_ENVELOPE_ARENA_BACKED, 0x0000_0004);
+        assert_eq!(HEW_MSG_ENVELOPE_FORKED, 0x0000_0008);
+        assert_eq!(HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER, 0x0000_0010);
+        assert_eq!(HEW_MSG_ENVELOPE_RESERVED_GAMMA_A, 0x0000_0020);
+        assert_eq!(HEW_MSG_ENVELOPE_RESERVED_GAMMA_B, 0x0000_0040);
+        assert_eq!(HEW_MSG_ENVELOPE_RESERVED_DELTA_A, 0x0000_0080);
+        assert_eq!(HEW_MSG_ENVELOPE_RESERVED_DELTA_B, 0x0000_0100);
+        assert_eq!(HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK, 0xffff_fe00);
+    }
+}

--- a/hew-runtime/src/mailbox_header.rs
+++ b/hew-runtime/src/mailbox_header.rs
@@ -4,6 +4,8 @@
 //! across native and WASM mailboxes. They are unrelated to the cross-node CBOR
 //! wire envelope.
 
+use crate::internal::types::HewOverflowPolicy;
+
 /// Header bit: at least two observers hold this message payload.
 pub const HEW_MSG_ENVELOPE_ALIAS_ACTIVE: u32 = 1 << 0;
 /// Header bit: payload is `Frozen`; never forks.
@@ -24,6 +26,30 @@ pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_A: u32 = 1 << 7;
 pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_B: u32 = 1 << 8;
 /// All bits at or above bit 9 must read zero on every header load.
 pub const HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK: u32 = !((1u32 << 9) - 1);
+
+/// Validate that reserved header bits are zero.
+///
+/// A newer runtime assigning one of these bits would otherwise let an older
+/// runtime silently drop an in-process payload contract.
+#[inline]
+pub(crate) fn header_validate(bits: u32) -> u32 {
+    assert!(
+        bits & HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK == 0,
+        "hew_msg_envelope: reserved header bits set (bits = {bits:#x}); \
+         this runtime does not understand the envelope's contract — \
+         refusing to proceed (fail-closed)"
+    );
+    bits
+}
+
+/// Prevent a coalescing mailbox from recursively selecting coalescing as its
+/// fallback policy.
+pub(crate) fn normalize_coalesce_fallback(policy: HewOverflowPolicy) -> HewOverflowPolicy {
+    match policy {
+        HewOverflowPolicy::Coalesce => HewOverflowPolicy::DropOld,
+        other => other,
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/hew-runtime/src/mailbox_wasm.rs
+++ b/hew-runtime/src/mailbox_wasm.rs
@@ -22,7 +22,16 @@ use std::ptr;
 use std::sync::atomic::AtomicPtr;
 
 use crate::internal::types::{HewError, HewOverflowPolicy};
+use crate::mailbox_header::{header_validate, normalize_coalesce_fallback};
 use crate::set_last_error;
+
+pub use crate::mailbox_header::{
+    HEW_MSG_ENVELOPE_ALIAS_ACTIVE, HEW_MSG_ENVELOPE_ARENA_BACKED,
+    HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER, HEW_MSG_ENVELOPE_FORKED,
+    HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK, HEW_MSG_ENVELOPE_RESERVED_DELTA_A,
+    HEW_MSG_ENVELOPE_RESERVED_DELTA_B, HEW_MSG_ENVELOPE_RESERVED_GAMMA_A,
+    HEW_MSG_ENVELOPE_RESERVED_GAMMA_B, HEW_MSG_ENVELOPE_SHARED_FROZEN,
+};
 
 /// Key extractor used by coalescing mailboxes.
 pub type HewCoalesceKeyFn = unsafe extern "C" fn(i32, *mut c_void, usize) -> u64;
@@ -245,26 +254,8 @@ const _: () = {
 // contract (refcount-based COW, fail-closed reserved bits) is identical
 // so codegen-emitted calls resolve transparently on both targets.
 
-/// Header bit: ≥2 observers hold this envelope (WASM parity).
-pub const HEW_MSG_ENVELOPE_ALIAS_ACTIVE: u32 = 1 << 0;
-/// Header bit: payload is `Frozen`; never forks (γ uses).
-pub const HEW_MSG_ENVELOPE_SHARED_FROZEN: u32 = 1 << 1;
-/// Header bit: payload was bumped from a per-dispatch arena (δ uses).
-pub const HEW_MSG_ENVELOPE_ARENA_BACKED: u32 = 1 << 2;
-/// Header bit: a fork-on-write has fired (diagnostic / metric).
-pub const HEW_MSG_ENVELOPE_FORKED: u32 = 1 << 3;
-/// Header bit: payload is a §12 capability transfer; alias forbidden.
-pub const HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER: u32 = 1 << 4;
-/// Reserved for γ.
-pub const HEW_MSG_ENVELOPE_RESERVED_GAMMA_A: u32 = 1 << 5;
-/// Reserved for γ aux.
-pub const HEW_MSG_ENVELOPE_RESERVED_GAMMA_B: u32 = 1 << 6;
-/// Reserved for δ aux.
-pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_A: u32 = 1 << 7;
-/// Reserved for δ aux.
-pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_B: u32 = 1 << 8;
-/// All bits ≥ 9 must read zero on every envelope load (fail-closed).
-pub const HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK: u32 = !((1u32 << 9) - 1);
+// The cross-target header assignments and pure bit logic live in
+// `crate::mailbox_header`; WASM allocation and scheduling remain here.
 
 /// Drop glue invoked when an envelope's refcount drops to zero.
 pub type HewMsgEnvelopeDropFn = unsafe extern "C" fn(*mut c_void);
@@ -300,17 +291,6 @@ unsafe impl Send for HewMsgEnvelope {}
 // SAFETY: see the `Send` impl above; concurrent reads are read-only,
 // concurrent refcount/header mutations go through atomics.
 unsafe impl Sync for HewMsgEnvelope {}
-
-#[inline]
-fn header_validate(bits: u32) -> u32 {
-    assert!(
-        bits & HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK == 0,
-        "hew_msg_envelope: reserved header bits set (bits = {bits:#x}); \
-         this runtime does not understand the envelope's contract — \
-         refusing to proceed (fail-closed)"
-    );
-    bits
-}
 
 // On native builds the WASM envelope must layout-match the native one
 // so codegen treats them interchangeably across targets.
@@ -623,13 +603,6 @@ pub struct HewMailboxWasm {
 fn update_high_water_mark(mb: &mut HewMailboxWasm) {
     if mb.count > mb.high_water_mark {
         mb.high_water_mark = mb.count;
-    }
-}
-
-fn normalize_coalesce_fallback(policy: HewOverflowPolicy) -> HewOverflowPolicy {
-    match policy {
-        HewOverflowPolicy::Coalesce => HewOverflowPolicy::DropOld,
-        other => other,
     }
 }
 

--- a/hew-runtime/src/wasm_parity_tests.rs
+++ b/hew-runtime/src/wasm_parity_tests.rs
@@ -547,59 +547,6 @@ unsafe fn wasm_snapshot(
     }
 }
 
-// ── Constants parity ─────────────────────────────────────────────────────────
-
-/// Header-bit constants in `mailbox_wasm` must equal those in `mailbox`.
-///
-/// This is documentation-as-test: if a constant moves in either module the
-/// test fails loudly instead of silently allowing the two surfaces to drift.
-#[test]
-fn envelope_header_bit_constants_match_native_and_wasm() {
-    use crate::mailbox as native;
-    use crate::mailbox_wasm as wasm;
-
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_ALIAS_ACTIVE,
-        wasm::HEW_MSG_ENVELOPE_ALIAS_ACTIVE
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_SHARED_FROZEN,
-        wasm::HEW_MSG_ENVELOPE_SHARED_FROZEN
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_ARENA_BACKED,
-        wasm::HEW_MSG_ENVELOPE_ARENA_BACKED
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_FORKED,
-        wasm::HEW_MSG_ENVELOPE_FORKED
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER,
-        wasm::HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_RESERVED_GAMMA_A,
-        wasm::HEW_MSG_ENVELOPE_RESERVED_GAMMA_A
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_RESERVED_GAMMA_B,
-        wasm::HEW_MSG_ENVELOPE_RESERVED_GAMMA_B
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_RESERVED_DELTA_A,
-        wasm::HEW_MSG_ENVELOPE_RESERVED_DELTA_A
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_RESERVED_DELTA_B,
-        wasm::HEW_MSG_ENVELOPE_RESERVED_DELTA_B
-    );
-    assert_eq!(
-        native::HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK,
-        wasm::HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK
-    );
-}
-
 // ── Refcount + alias bit parity ──────────────────────────────────────────────
 
 /// `hew_msg_envelope_new` starts at refcount=1, alias bit clear, on both


### PR DESCRIPTION
## Summary

The mailbox message-header logic — `header_validate`, the coalesce-fallback normalization, and the `HEW_MSG_ENVELOPE_*` bit constants — was copy-pasted byte-for-byte between the native `mailbox.rs` and the WASM `mailbox_wasm.rs`. This extracts it into one target-independent `mailbox_header.rs` that both consume, so the cross-target wire-layout invariant holds by construction instead of by discipline. This is the in-process mailbox header, distinct from the CBOR wire envelope.

## Verification

- `cargo test -p hew-runtime` mailbox suite: 125 passed, 0 failed.
- `mailbox_header::tests::bit_layout_fingerprint`: passed — pins the exact `HEW_MSG_ENVELOPE_*` constant values so a future bit reassignment is a conscious, fail-closed change.
- `cargo fmt --check`: clean.
- The two copies were confirmed byte-identical before extraction; the now-redundant "constants match across native/WASM" parity test is retired (there is one source now).
- No scheduling/wakeup logic (which is legitimately target-specific) was touched.

## Out of scope

- The CBOR wire envelope and its CDDL schema.
- Target-specific mailbox scheduling.