### PR TITLE
refactor: carry TCP/DNS blocking-offload as a typed capability

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -27453,45 +27453,6 @@ fn validate_context_markers_for_codegen(func: &RawMirFunction) -> Vec<hew_mir::M
     validate_context_markers(func)
 }
 
-/// Does the module reach a distributed-node authority (`Node::*` builtin)?
-///
-/// The de-globalized node state (`CURRENT_NODE`/`KNOWN_NODES`/`REPLY_TABLE`,
-/// owned by `RuntimeInner::node`) is touched the moment a program calls
-/// `Node::set_transport`/`start`/`connect`/`register`/`lookup`/`shutdown`.
-/// Those builtins lower to `Terminator::Call` with a typed Node family.
-/// Does the module reach a blocking-pool offload authority (net DNS / TCP
-/// connect)?
-///
-/// The deadline-bounded syscall pool (`RuntimeInner::blocking_pool`) was a
-/// process-lifetime `blocking_pool::SHARED_POOL` singleton that worked with no
-/// runtime installed; it is now owned per-runtime and resolved through the
-/// fail-closed `rt_current_opt()` (`blocking_pool::shared_blocking_pool_opt`).
-/// A program that offloads a DNS resolve or a TCP connect from a non-actor
-/// context — e.g. `net.connect(..)` in a bare `main`, with no `spawn`, `Node`,
-/// or metrics use — would otherwise reach the offload with no runtime installed
-/// and fail closed with EINVAL, so the connect never completes. Touching the
-/// pool is therefore an independent reason to install the runtime at program
-/// entry, just like node/metrics.
-///
-/// The offload entrypoints are the connect family (`hew_tcp_connect`,
-/// `hew_tcp_connect_timed`, `hew_tcp_connect_timeout`) and the DNS family
-/// (`hew_dns_resolve*`, `hew_dns_lookup_host*`); every one begins with
-/// `hew_tcp_connect` or `hew_dns_`. Accept/read/write are direct blocking
-/// syscalls that never touch the pool, so they are deliberately not matched.
-/// Extern fns lower to `Terminator::Call` with the extern symbol as the callee
-/// (`hew-mir/src/lower.rs`), so scanning terminators by callee prefix is exact.
-fn module_uses_blocking_offload(raw_mir: &[RawMirFunction]) -> bool {
-    raw_mir.iter().any(|func| {
-        func.blocks.iter().any(|block| {
-            matches!(
-                &block.terminator,
-                Terminator::Call { callee, .. }
-                    if callee.starts_with("hew_tcp_connect") || callee.starts_with("hew_dns_")
-            )
-        })
-    })
-}
-
 /// Lower one function from `raw_mir`, consuming `elaborated_mir.drop_plans`
 /// to emit LIFO close calls before every exit terminator.
 ///
@@ -29769,6 +29730,7 @@ fn build_module_for_target<'ctx>(
     target_machine: Option<&TargetMachine>,
     debug: Option<DebugInput<'_>>,
 ) -> CodegenResult<LlvmModule<'ctx>> {
+    pipeline.debug_assert_capabilities_current();
     let llvm_mod = ctx.create_module(name);
     let emit_wasm_entry_alias = target_machine.is_some_and(|machine| {
         machine
@@ -30465,9 +30427,11 @@ fn build_module_for_target<'ctx>(
     // registration/mutation, the implicit drain epilogue).
     let module_uses_runtime = !pipeline.actor_layouts.is_empty()
         || !pipeline.supervisor_layouts.is_empty()
+        || pipeline
+            .capabilities
+            .contains(RuntimeCapability::BlockingOffload)
         || pipeline.capabilities.contains(RuntimeCapability::Node)
-        || pipeline.capabilities.contains(RuntimeCapability::Metrics)
-        || module_uses_blocking_offload(&pipeline.raw_mir);
+        || pipeline.capabilities.contains(RuntimeCapability::Metrics);
     let machine_step_symbols: HashSet<String> = pipeline
         .raw_mir
         .iter()

--- a/hew-codegen-rs/tests/structural/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/structural/bytes_extern_fail_closed.rs
@@ -152,6 +152,7 @@ fn pipeline_with_extern(
             param_tys,
             return_ty,
             provenance: hew_hir::ExternProvenance::Root,
+            runtime_capability: None,
             malloc_string_return: false,
         }],
         dyn_vtable_registry: vec![],

--- a/hew-codegen-rs/tests/structural/extern_malloc_string_adoption.rs
+++ b/hew-codegen-rs/tests/structural/extern_malloc_string_adoption.rs
@@ -121,6 +121,7 @@ fn pipeline_adopt_extern(malloc_string_return: bool) -> IrPipeline {
             param_tys: vec![],
             return_ty: ResolvedTy::String,
             provenance: hew_hir::ExternProvenance::Root,
+            runtime_capability: None,
             malloc_string_return,
         }],
         dyn_vtable_registry: vec![],

--- a/hew-codegen-rs/tests/structural/scalar_discard_guard.rs
+++ b/hew-codegen-rs/tests/structural/scalar_discard_guard.rs
@@ -144,6 +144,7 @@ fn pipeline_discard_extern_owned(
             param_tys,
             return_ty: extern_return_ty,
             provenance: hew_hir::ExternProvenance::Root,
+            runtime_capability: None,
             malloc_string_return,
         }],
         dyn_vtable_registry: vec![],

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -3430,6 +3430,8 @@ pub fn lower_program_with_mono_cap(
                         "extern fn",
                         &func.span,
                     );
+                    let provenance = extern_provenance(ctx.current_module_name.as_deref());
+                    let runtime_capability = extern_runtime_capability(&provenance, &func.name);
                     items.push(HirItem::ExternFn(crate::node::HirExternFn {
                         id: ctx.ids.item(),
                         node: ctx.ids.node(),
@@ -3444,7 +3446,8 @@ pub fn lower_program_with_mono_cap(
                         // `Some(dotted)` a file-import module. Threaded to MIR so
                         // C-ABI string-return ownership is classified from a proven
                         // fact, not `diagnostic_source_modules` absence.
-                        provenance: extern_provenance(ctx.current_module_name.as_deref()),
+                        provenance,
+                        runtime_capability,
                         span: func.span.clone(),
                     }));
                 }
@@ -3718,6 +3721,10 @@ pub fn lower_program_with_mono_cap(
                                     "extern fn",
                                     &func.span,
                                 );
+                                let provenance =
+                                    extern_provenance(ctx.current_module_name.as_deref());
+                                let runtime_capability =
+                                    extern_runtime_capability(&provenance, &func.name);
                                 items.push(HirItem::ExternFn(crate::node::HirExternFn {
                                     id: ctx.ids.item(),
                                     node: ctx.ids.node(),
@@ -3733,9 +3740,8 @@ pub fn lower_program_with_mono_cap(
                                     // above so a std vs. user/package extern is
                                     // classified identically regardless of which
                                     // pass emitted it.
-                                    provenance: extern_provenance(
-                                        ctx.current_module_name.as_deref(),
-                                    ),
+                                    provenance,
+                                    runtime_capability,
                                     span: func.span.clone(),
                                 }));
                             }
@@ -4581,6 +4587,16 @@ fn extern_provenance(current_module_name: Option<&str>) -> ExternProvenance {
         None => ExternProvenance::Root,
         Some(name) => ExternProvenance::Module(name.to_string()),
     }
+}
+
+fn extern_runtime_capability(
+    provenance: &ExternProvenance,
+    declaration: &str,
+) -> Option<hew_types::ExternRuntimeCapability> {
+    let ExternProvenance::Module(module_name) = provenance else {
+        return None;
+    };
+    hew_types::stdlib_authority().extern_runtime_capability(module_name, declaration)
 }
 
 fn record_source_modules_for_items(

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -346,6 +346,8 @@ pub struct HirExternFn {
     /// classification downstream as a proven fact rather than an absence
     /// inference — see [`ExternProvenance`].
     pub provenance: ExternProvenance,
+    /// Typed runtime authority declared on this stdlib extern, if any.
+    pub runtime_capability: Option<hew_types::ExternRuntimeCapability>,
     pub span: Span,
 }
 

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -3386,6 +3386,7 @@ pub fn lower_hir_module_with_facts(
             param_tys: ef.param_tys.clone(),
             return_ty: ef.return_ty.clone(),
             provenance: ef.provenance.clone(),
+            runtime_capability: ef.runtime_capability,
             malloc_string_return,
         });
     }
@@ -3465,7 +3466,7 @@ pub fn lower_hir_module_with_facts(
         })
         .collect();
 
-    let capabilities = crate::model::ModuleCapabilities::from_raw_mir(&raw_mir);
+    let capabilities = crate::model::ModuleCapabilities::from_raw_mir(&raw_mir, &extern_decls);
 
     IrPipeline {
         thir,

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -368,22 +368,29 @@ pub struct ModuleCapabilities(u8);
 
 impl ModuleCapabilities {
     pub const EMPTY: Self = Self(0);
-    const METRICS: u8 = 1 << 0;
-    const NODE: u8 = 1 << 1;
+    const BLOCKING_OFFLOAD: u8 = 1 << 0;
+    const METRICS: u8 = 1 << 1;
+    const NODE: u8 = 1 << 2;
 
-    pub(crate) fn insert_family(&mut self, family: hew_types::runtime_call::RuntimeCallFamily) {
+    fn insert(&mut self, capability: hew_types::runtime_call::RuntimeCapability) {
         use hew_types::runtime_call::RuntimeCapability;
 
-        self.0 |= match family.runtime_capability() {
-            Some(RuntimeCapability::Metrics) => Self::METRICS,
-            Some(RuntimeCapability::Node) => Self::NODE,
-            None => 0,
+        self.0 |= match capability {
+            RuntimeCapability::BlockingOffload => Self::BLOCKING_OFFLOAD,
+            RuntimeCapability::Metrics => Self::METRICS,
+            RuntimeCapability::Node => Self::NODE,
         };
     }
 
-    /// Collect module capabilities from typed runtime-call identities in MIR.
+    pub(crate) fn insert_family(&mut self, family: hew_types::runtime_call::RuntimeCallFamily) {
+        if let Some(capability) = family.runtime_capability() {
+            self.insert(capability);
+        }
+    }
+
+    /// Collect module capabilities from typed runtime-call and extern identities.
     #[must_use]
-    pub fn from_raw_mir(raw_mir: &[RawMirFunction]) -> Self {
+    pub fn from_raw_mir(raw_mir: &[RawMirFunction], extern_decls: &[ExternDecl]) -> Self {
         let mut capabilities = Self::default();
         for function in raw_mir {
             for block in &function.blocks {
@@ -393,11 +400,20 @@ impl ModuleCapabilities {
                     }
                 }
                 if let Terminator::Call {
-                    builtin: Some(family),
-                    ..
+                    callee, builtin, ..
                 } = &block.terminator
                 {
-                    capabilities.insert_family(*family);
+                    if let Some(family) = builtin {
+                        capabilities.insert_family(*family);
+                    }
+                    if extern_decls.iter().any(|decl| {
+                        decl.name == *callee
+                            && decl.runtime_capability
+                                == Some(hew_types::ExternRuntimeCapability::BlockingOffload)
+                    }) {
+                        capabilities
+                            .insert(hew_types::runtime_call::RuntimeCapability::BlockingOffload);
+                    }
                 }
             }
         }
@@ -410,6 +426,7 @@ impl ModuleCapabilities {
         use hew_types::runtime_call::RuntimeCapability;
 
         let bit = match capability {
+            RuntimeCapability::BlockingOffload => Self::BLOCKING_OFFLOAD,
             RuntimeCapability::Metrics => Self::METRICS,
             RuntimeCapability::Node => Self::NODE,
         };
@@ -437,6 +454,16 @@ pub struct MirLint {
 }
 
 impl IrPipeline {
+    /// Assert that the capability snapshot still matches the final raw MIR and
+    /// its typed extern declarations.
+    pub fn debug_assert_capabilities_current(&self) {
+        debug_assert_eq!(
+            self.capabilities,
+            ModuleCapabilities::from_raw_mir(&self.raw_mir, &self.extern_decls),
+            "module capabilities are stale after raw MIR mutation"
+        );
+    }
+
     /// Clone the checker-authored layout-backed `HashMap`/`HashSet`
     /// lowering facts from `tco` into this pipeline (W3.003).
     ///
@@ -487,6 +514,8 @@ pub struct ExternDecl {
     /// C-ABI string return's ownership ([`ExternDecl::malloc_string_return`]),
     /// carried here as a proven fact so codegen never re-derives it by absence.
     pub provenance: hew_hir::ExternProvenance,
+    /// Typed runtime authority declared on this stdlib extern, if any.
+    pub runtime_capability: Option<hew_types::ExternRuntimeCapability>,
     /// True only for a raw root/package `extern "C" -> string` whose C ABI
     /// transfers a plain malloc-owned pointer that codegen must copy into Hew's
     /// header-aware refcounted domain and then `free`. Standard-library modules

--- a/hew-mir/tests/lowering_calls/extern_string_ownership.rs
+++ b/hew-mir/tests/lowering_calls/extern_string_ownership.rs
@@ -67,6 +67,7 @@ fn extern_item(
         param_consume: vec![],
         return_ty,
         provenance,
+        runtime_capability: None,
         span: 0..0,
     })
 }

--- a/hew-mir/tests/lowering_expr/runtime_abi_instr.rs
+++ b/hew-mir/tests/lowering_expr/runtime_abi_instr.rs
@@ -390,7 +390,77 @@ fn module_capabilities_collect_typed_metric_and_node_calls() {
         instr_spans: ::std::collections::BTreeMap::new(),
     };
 
-    let capabilities = ModuleCapabilities::from_raw_mir(&[function]);
+    let capabilities = ModuleCapabilities::from_raw_mir(&[function], &[]);
     assert!(capabilities.contains(RuntimeCapability::Metrics));
     assert!(capabilities.contains(RuntimeCapability::Node));
+}
+
+#[test]
+fn module_capabilities_set_and_clear_blocking_offload_from_tagged_extern_calls() {
+    use hew_mir::{
+        BasicBlock, ExternDecl, ModuleCapabilities, RawMirFunction, SourceOrigin, Terminator,
+    };
+    use hew_types::runtime_call::RuntimeCapability;
+    use hew_types::ExternRuntimeCapability;
+
+    let function_calling = |callee: &str| RawMirFunction {
+        source_origin: SourceOrigin::Unknown,
+        name: format!("calls_{callee}"),
+        return_ty: ResolvedTy::Unit,
+        call_conv: hew_mir::FunctionCallConv::Default,
+        params: vec![],
+        locals: vec![],
+        local_names: vec![],
+        local_scopes: vec![],
+        local_decl_bytes: vec![],
+        scope_table: vec![],
+        blocks: vec![
+            BasicBlock {
+                id: 0,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Call {
+                    callee: callee.to_string(),
+                    builtin: None,
+                    args: vec![],
+                    dest: None,
+                    next: 1,
+                },
+            },
+            BasicBlock {
+                id: 1,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Return,
+            },
+        ],
+        decisions: vec![],
+        intrinsic_id: None,
+        await_deadline_ns: std::collections::HashMap::new(),
+        suspend_kinds: std::collections::HashMap::new(),
+        lambda_actor_user_param_locals: Vec::new(),
+        span: None,
+        instr_spans: std::collections::BTreeMap::new(),
+    };
+    let tagged_connect = ExternDecl {
+        name: "hew_tcp_connect".to_string(),
+        abi: "C".to_string(),
+        param_tys: vec![ResolvedTy::String],
+        return_ty: ResolvedTy::Unit,
+        provenance: hew_hir::ExternProvenance::Module("std.net".to_string()),
+        runtime_capability: Some(ExternRuntimeCapability::BlockingOffload),
+        malloc_string_return: false,
+    };
+
+    let set = ModuleCapabilities::from_raw_mir(
+        &[function_calling("hew_tcp_connect")],
+        std::slice::from_ref(&tagged_connect),
+    );
+    assert!(set.contains(RuntimeCapability::BlockingOffload));
+
+    let clear = ModuleCapabilities::from_raw_mir(
+        &[function_calling("hew_tcp_accept")],
+        std::slice::from_ref(&tagged_connect),
+    );
+    assert!(!clear.contains(RuntimeCapability::BlockingOffload));
 }

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -79,8 +79,9 @@ pub use runtime_calling_convention::RuntimeCallingConvention;
 pub use stdlib_authority::{
     authority as stdlib_authority, AuthorityBinding, AuthorityDeclarationKind, AuthorityError,
     AuthorityErrorKind, AuthoritySource, DiagnosticItem, EnumVariantOrder, ExternAbiEntry,
-    ExternAbiFact, Intrinsic, OverloadGroup, PreludeExport, PreludeExportKind, StdlibAuthority,
-    StdlibRoot, STDLIB_AUTHORITY, SUBSTRATE_SOURCES,
+    ExternAbiFact, ExternRuntimeCapability, ExternRuntimeCapabilityEntry, Intrinsic, OverloadGroup,
+    PreludeExport, PreludeExportKind, StdlibAuthority, StdlibRoot, STDLIB_AUTHORITY,
+    SUBSTRATE_SOURCES,
 };
 pub use ty::{TraitObjectBound, Ty};
 pub use type_descriptor::TypeDescriptor;

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -564,6 +564,7 @@ pub enum RuntimeCallFamily {
 /// Module-level runtime authorities implied by typed runtime-call families.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RuntimeCapability {
+    BlockingOffload,
     Metrics,
     Node,
 }

--- a/hew-types/src/stdlib_authority.rs
+++ b/hew-types/src/stdlib_authority.rs
@@ -28,6 +28,8 @@ pub enum StdlibRoot {
     LinkMonitor,
     String,
     Io,
+    Net,
+    NetDns,
     Prelude,
 }
 
@@ -42,6 +44,8 @@ impl StdlibRoot {
             Self::LinkMonitor => "link_monitor",
             Self::String => "string",
             Self::Io => "io",
+            Self::Net => "net",
+            Self::NetDns => "net::dns",
             Self::Prelude => "prelude",
         }
     }
@@ -111,6 +115,16 @@ pub const SUBSTRATE_SOURCES: &[AuthoritySource<'static>] = &[
         include_str!("../../std/io.hew"),
     ),
     AuthoritySource::embedded(
+        StdlibRoot::Net,
+        "std/net/net.hew",
+        include_str!("../../std/net/net.hew"),
+    ),
+    AuthoritySource::embedded(
+        StdlibRoot::NetDns,
+        "std/net/dns/dns.hew",
+        include_str!("../../std/net/dns/dns.hew"),
+    ),
+    AuthoritySource::embedded(
         StdlibRoot::Prelude,
         "std/prelude.hew",
         include_str!("../../std/prelude.hew"),
@@ -123,6 +137,7 @@ const RESERVED_SUBSTRATE_ATTRIBUTES: &[&str] = &[
     "intrinsic",
     "diagnostic_item",
     "overload",
+    "runtime_capability",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -216,6 +231,34 @@ pub struct ExternAbiEntry {
     pub facts: Vec<ExternAbiFact>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternRuntimeCapabilityEntry {
+    pub binding: AuthorityBinding,
+    pub capability: ExternRuntimeCapability,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternRuntimeCapability {
+    BlockingOffload,
+}
+
+impl ExternRuntimeCapability {
+    #[must_use]
+    pub const fn key(self) -> &'static str {
+        match self {
+            Self::BlockingOffload => "blocking_offload",
+        }
+    }
+
+    #[must_use]
+    pub fn from_key(key: &str) -> Option<Self> {
+        match key {
+            "blocking_offload" => Some(Self::BlockingOffload),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum OverloadGroup {
     Println,
@@ -304,6 +347,7 @@ pub struct StdlibAuthority {
     lang_items: BTreeMap<LangItem, AuthorityBinding>,
     intrinsics: BTreeMap<Intrinsic, AuthorityBinding>,
     extern_abi: BTreeMap<String, ExternAbiEntry>,
+    extern_runtime_capabilities: BTreeMap<String, ExternRuntimeCapabilityEntry>,
     overload_groups: BTreeMap<OverloadGroup, Vec<AuthorityBinding>>,
     diagnostic_items: BTreeMap<DiagnosticItem, AuthorityBinding>,
     enum_variant_orders: BTreeMap<String, EnumVariantOrder>,
@@ -324,6 +368,11 @@ impl StdlibAuthority {
     #[must_use]
     pub fn extern_abi(&self) -> &BTreeMap<String, ExternAbiEntry> {
         &self.extern_abi
+    }
+
+    #[must_use]
+    pub fn extern_runtime_capabilities(&self) -> &BTreeMap<String, ExternRuntimeCapabilityEntry> {
+        &self.extern_runtime_capabilities
     }
 
     #[must_use]
@@ -357,6 +406,7 @@ pub enum AuthorityErrorKind {
     UnknownIntrinsic { key: String },
     UnknownAbiKey { key: String },
     UnknownAbiValue { key: String, value: String },
+    UnknownRuntimeCapability { key: String },
     UnknownOverloadGroup { key: String },
     UnknownDiagnosticItem { key: String },
     DuplicateBinding { family: String, key: String },
@@ -401,6 +451,9 @@ impl fmt::Display for AuthorityError {
             }
             AuthorityErrorKind::UnknownAbiValue { key, value } => {
                 write!(f, "unknown `#[abi]` value `{value}` for key `{key}`")
+            }
+            AuthorityErrorKind::UnknownRuntimeCapability { key } => {
+                write!(f, "unknown `#[runtime_capability]` key `{key}`")
             }
             AuthorityErrorKind::UnknownOverloadGroup { key } => {
                 write!(f, "unknown `#[overload]` group `{key}`")
@@ -588,6 +641,45 @@ fn load_source(
                                     ));
                                 }
                             }
+                            "runtime_capability" => {
+                                let key = positional_key(source, &declaration, attr)?;
+                                let capability = ExternRuntimeCapability::from_key(key)
+                                    .ok_or_else(|| {
+                                        error(
+                                            source,
+                                            Some(declaration.clone()),
+                                            AuthorityErrorKind::UnknownRuntimeCapability {
+                                                key: key.to_string(),
+                                            },
+                                        )
+                                    })?;
+                                let binding = make_binding(
+                                    source,
+                                    declaration.clone(),
+                                    AuthorityDeclarationKind::ExternFunction,
+                                )?;
+                                let qualified = qualified(source, &declaration);
+                                if authority
+                                    .extern_runtime_capabilities
+                                    .insert(
+                                        qualified.clone(),
+                                        ExternRuntimeCapabilityEntry {
+                                            binding,
+                                            capability,
+                                        },
+                                    )
+                                    .is_some()
+                                {
+                                    return Err(error(
+                                        source,
+                                        Some(declaration),
+                                        AuthorityErrorKind::DuplicateBinding {
+                                            family: "extern runtime capability".to_string(),
+                                            key: qualified,
+                                        },
+                                    ));
+                                }
+                            }
                             "lang_item" | "intrinsic" | "diagnostic_item" | "overload" => {
                                 return Err(error(
                                     source,
@@ -706,7 +798,7 @@ fn load_function_attributes(
                     .or_default()
                     .push(binding.clone());
             }
-            "abi" => {
+            "abi" | "runtime_capability" => {
                 return Err(error(
                     source,
                     Some(declaration),
@@ -989,6 +1081,20 @@ mod tests {
                 .contains_key("failure::CrashAction"),
             "failure enum orders must be collected"
         );
+        for symbol in [
+            "net::hew_tcp_connect",
+            "net::hew_tcp_connect_timeout",
+            "net::dns::hew_dns_resolve",
+            "net::dns::hew_dns_lookup_host",
+            "net::dns::hew_dns_resolve_timed",
+            "net::dns::hew_dns_lookup_host_timed",
+        ] {
+            assert_eq!(
+                authority.extern_runtime_capabilities()[symbol].capability,
+                ExternRuntimeCapability::BlockingOffload,
+                "missing blocking-offload capability on {symbol}"
+            );
+        }
     }
 
     #[test]
@@ -1013,6 +1119,9 @@ pub fn println_i64(value: i64) {}
 extern "C" {
     #[abi(ret = bytes_triple, bytes_param = ptr, drop = cow_null_tolerant)]
     fn hew_bytes();
+
+    #[runtime_capability("blocking_offload")]
+    fn hew_connect();
 }
 "#,
             ),
@@ -1048,6 +1157,10 @@ extern "C" {
                 ExternAbiFact::BytesParamPointer,
                 ExternAbiFact::CowDropNullTolerant,
             ]
+        );
+        assert_eq!(
+            authority.extern_runtime_capabilities()["builtins::hew_connect"].capability,
+            ExternRuntimeCapability::BlockingOffload
         );
         assert_eq!(
             authority.enum_variant_orders()["builtins::Maybe"].variants,
@@ -1178,6 +1291,71 @@ extern "C" {
             error.kind,
             AuthorityErrorKind::AttributeOutsideStdRoot {
                 attribute: "abi".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_capability_on_non_extern_declaration_is_rejected() {
+        let source = AuthoritySource::embedded(
+            StdlibRoot::Net,
+            "std/net/net.hew",
+            r#"#[runtime_capability("blocking_offload")] pub fn connect() {}"#,
+        );
+        let error = load_stdlib_authority(&[source])
+            .expect_err("runtime capabilities must only decorate extern declarations");
+
+        assert_eq!(error.declaration.as_deref(), Some("connect"));
+        assert_eq!(
+            error.kind,
+            AuthorityErrorKind::InvalidAttributePlacement {
+                attribute: "runtime_capability".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_capability_outside_std_roots_is_rejected() {
+        let source = AuthoritySource::external(
+            "src/main.hew",
+            r#"
+extern "C" {
+    #[runtime_capability("blocking_offload")]
+    fn connect();
+}
+"#,
+        );
+        let error = load_stdlib_authority(&[source])
+            .expect_err("runtime capabilities outside std roots must fail closed");
+
+        assert_eq!(error.declaration.as_deref(), Some("connect"));
+        assert_eq!(
+            error.kind,
+            AuthorityErrorKind::AttributeOutsideStdRoot {
+                attribute: "runtime_capability".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_runtime_capability_is_rejected() {
+        let source = AuthoritySource::embedded(
+            StdlibRoot::Net,
+            "std/net/net.hew",
+            r#"
+extern "C" {
+    #[runtime_capability("blocking_forever")]
+    fn connect();
+}
+"#,
+        );
+        let error = load_stdlib_authority(&[source])
+            .expect_err("unknown runtime capabilities must fail closed");
+
+        assert_eq!(
+            error.kind,
+            AuthorityErrorKind::UnknownRuntimeCapability {
+                key: "blocking_forever".to_string(),
             }
         );
     }

--- a/hew-types/src/stdlib_authority.rs
+++ b/hew-types/src/stdlib_authority.rs
@@ -376,6 +376,21 @@ impl StdlibAuthority {
     }
 
     #[must_use]
+    pub fn extern_runtime_capability(
+        &self,
+        module_name: &str,
+        declaration: &str,
+    ) -> Option<ExternRuntimeCapability> {
+        let relative_module = module_name
+            .strip_prefix("std.")
+            .or_else(|| module_name.strip_prefix("std::"))?;
+        let qualified = format!("{}::{declaration}", relative_module.replace('.', "::"));
+        self.extern_runtime_capabilities
+            .get(&qualified)
+            .map(|entry| entry.capability)
+    }
+
+    #[must_use]
     pub fn overload_groups(&self) -> &BTreeMap<OverloadGroup, Vec<AuthorityBinding>> {
         &self.overload_groups
     }
@@ -1174,6 +1189,25 @@ extern "C" {
                 alias: Some("Option".to_string()),
                 kind: PreludeExportKind::Item,
             }]
+        );
+    }
+
+    #[test]
+    fn extern_runtime_capability_lookup_accepts_dotted_and_scoped_std_modules() {
+        let authority = load_stdlib_authority(SUBSTRATE_SOURCES)
+            .expect("embedded stdlib authority sources must load");
+
+        assert_eq!(
+            authority.extern_runtime_capability("std.net", "hew_tcp_connect"),
+            Some(ExternRuntimeCapability::BlockingOffload)
+        );
+        assert_eq!(
+            authority.extern_runtime_capability("std::net::dns", "hew_dns_resolve"),
+            Some(ExternRuntimeCapability::BlockingOffload)
+        );
+        assert_eq!(
+            authority.extern_runtime_capability("user.net", "hew_tcp_connect"),
+            None
         );
     }
 

--- a/scripts/codegen-carried-identity-gate.sh
+++ b/scripts/codegen-carried-identity-gate.sh
@@ -4,11 +4,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-pattern='contains\("__recv__"\)|split_once\("__recv__"\)|strip_suffix\("__step"\)|starts_with\("hew_metric_"\)|actor_name_from_handler_symbol|actor_layout_key_from_handler_symbol|is_machine_step_symbol'
+pattern='contains\("__recv__"\)|split_once\("__recv__"\)|strip_suffix\("__step"\)|starts_with\("hew_metric_"\)|hew_tcp_connect|hew_dns_|actor_name_from_handler_symbol|actor_layout_key_from_handler_symbol|is_machine_step_symbol|module_uses_blocking_offload'
 
-# Deliberately not gated here: the TCP/DNS blocking-offload capability still
-# uses module_uses_blocking_offload's hew_tcp_connect/hew_dns_ scan. A follow-up
-# change will carry that identity from stdlib externs via a capability attribute.
 if rg -n "$pattern" hew-codegen-rs/src; then
     echo "error: codegen reintroduced a string consumer for MIR-carried identity" >&2
     exit 1

--- a/std/net/dns/dns.hew
+++ b/std/net/dns/dns.hew
@@ -116,8 +116,12 @@ pub fn lookup_host_timed(hostname: string, deadline_ms: i64) -> string {
 
 // ── FFI bindings ──────────────────────────────────────────────────────
 extern "C" {
+    #[runtime_capability("blocking_offload")]
     fn hew_dns_resolve(hostname: string) -> Vec<string>;
+    #[runtime_capability("blocking_offload")]
     fn hew_dns_lookup_host(hostname: string) -> string;
+    #[runtime_capability("blocking_offload")]
     fn hew_dns_resolve_timed(hostname: string, deadline_ms: i64) -> Vec<string>;
+    #[runtime_capability("blocking_offload")]
     fn hew_dns_lookup_host_timed(hostname: string, deadline_ms: i64) -> string;
 }

--- a/std/net/dns/dns.hew
+++ b/std/net/dns/dns.hew
@@ -116,12 +116,12 @@ pub fn lookup_host_timed(hostname: string, deadline_ms: i64) -> string {
 
 // ── FFI bindings ──────────────────────────────────────────────────────
 extern "C" {
-    #[runtime_capability("blocking_offload")]
+    #[runtime_capability(blocking_offload)]
     fn hew_dns_resolve(hostname: string) -> Vec<string>;
-    #[runtime_capability("blocking_offload")]
+    #[runtime_capability(blocking_offload)]
     fn hew_dns_lookup_host(hostname: string) -> string;
-    #[runtime_capability("blocking_offload")]
+    #[runtime_capability(blocking_offload)]
     fn hew_dns_resolve_timed(hostname: string, deadline_ms: i64) -> Vec<string>;
-    #[runtime_capability("blocking_offload")]
+    #[runtime_capability(blocking_offload)]
     fn hew_dns_lookup_host_timed(hostname: string, deadline_ms: i64) -> string;
 }

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -679,9 +679,9 @@ pub type StreamPair {
 extern "C" {
     fn hew_tcp_listen(addr: string) -> Listener;
     fn hew_tcp_accept(listener: Listener) -> Connection;
-    #[runtime_capability("blocking_offload")]
+    #[runtime_capability(blocking_offload)]
     fn hew_tcp_connect(addr: string) -> Connection;
-    #[runtime_capability("blocking_offload")]
+    #[runtime_capability(blocking_offload)]
     fn hew_tcp_connect_timeout(host: string, port: i32, timeout_ms: i32) -> Connection;
     fn hew_tcp_read(conn: Connection) -> bytes;
     // Returns the byte count written (>= 0) on success, or -1 on failure with

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -679,7 +679,9 @@ pub type StreamPair {
 extern "C" {
     fn hew_tcp_listen(addr: string) -> Listener;
     fn hew_tcp_accept(listener: Listener) -> Connection;
+    #[runtime_capability("blocking_offload")]
     fn hew_tcp_connect(addr: string) -> Connection;
+    #[runtime_capability("blocking_offload")]
     fn hew_tcp_connect_timeout(host: string, port: i32, timeout_ms: i32) -> Connection;
     fn hew_tcp_read(conn: Connection) -> bytes;
     // Returns the byte count written (>= 0) on success, or -1 on failure with


### PR DESCRIPTION
## Summary

Carry the TCP/DNS blocking-offload capability as a typed fact instead of re-scanning C-symbol prefixes at the end of codegen. The connect-family and DNS-family stdlib externs get a `#[runtime_capability("blocking_offload")]` attribute at their declaration; MIR lowering records the capability on the module when a call resolves to a tagged extern; codegen reads the typed capability alongside the metrics/node capabilities. This deletes `module_uses_blocking_offload` and its `hew_tcp_connect`/`hew_dns_` string scan, so a renamed or added offload entrypoint can no longer silently drop the pool-init capability.

## Verification

- The tagged extern set exactly matches what the old string scan caught (the six connect/resolve/lookup symbols; accept/read/listen correctly excluded).
- `make ll-diff`: `.ll` oracle byte-identical (11 fixtures × 2 targets); a `net.connect` program still emits the runtime-init call and a pure-computation program still emits none.
- A MIR test proves the capability sets on a tagged call and clears on an untagged one (keyed on call resolution, not declaration presence); attribute-placement tests reject the attribute off-extern, outside a std root, and on an unknown key.
- The carried-identity gate is extended to forbid the offload string scan in codegen.
- Completes the runtime-capability migration begun with the metrics/node facts.
- Preflight: ready-to-push

## Out of scope

- The metrics/node/actor capabilities (already carried).
- A runtime-call family for these stdlib externs — the attribute is the right mechanism.
