### PR TITLE
refactor: carry typed math intrinsics into codegen

### DIFF
--- a/examples/v05/checked-mir/golden/math_intrinsics.raw.mir
+++ b/examples/v05/checked-mir/golden/math_intrinsics.raw.mir
@@ -38,97 +38,97 @@ fn main() -> () [conv=default]
     _35: f64
   bb0:
     _0 = const.f64 0x4030000000000000
-    _1 = call sqrt(_0) -> bb1
+    _1 = call sqrt(_0) [builtin=MathIntrinsic(Sqrt)] -> bb1
   bb1:
     call println_f64(_1) -> bb2
   bb2:
     stmt: eval site=SiteId(0) ty=()
     _2 = const.f64 0x4000000000000000
     _3 = const.f64 0x4024000000000000
-    _4 = call pow(_2, _3) -> bb3
+    _4 = call pow(_2, _3) [builtin=MathIntrinsic(Pow)] -> bb3
   bb3:
     call println_f64(_4) -> bb4
   bb4:
     stmt: eval site=SiteId(5) ty=()
     _5 = const.f64 0x400d99999999999a
-    _6 = call floor(_5) -> bb5
+    _6 = call floor(_5) [builtin=MathIntrinsic(Floor)] -> bb5
   bb5:
     call println_f64(_6) -> bb6
   bb6:
     stmt: eval site=SiteId(11) ty=()
     _7 = const.f64 0x400999999999999a
-    _8 = call ceil(_7) -> bb7
+    _8 = call ceil(_7) [builtin=MathIntrinsic(Ceil)] -> bb7
   bb7:
     call println_f64(_8) -> bb8
   bb8:
     stmt: eval site=SiteId(16) ty=()
     _9 = const.f64 0x400c000000000000
-    _10 = call round(_9) -> bb9
+    _10 = call round(_9) [builtin=MathIntrinsic(Round)] -> bb9
   bb9:
     call println_f64(_10) -> bb10
   bb10:
     stmt: eval site=SiteId(21) ty=()
     _11 = const.f64 0x4014000000000000
     _12 = fneg.f64 _11
-    _13 = call abs_f(_12) -> bb11
+    _13 = call abs_f(_12) [builtin=MathIntrinsic(AbsF64)] -> bb11
   bb11:
     call println_f64(_13) -> bb12
   bb12:
     stmt: eval site=SiteId(26) ty=()
     _14 = const.f64 0x4008000000000000
     _15 = const.f64 0x401c000000000000
-    _16 = call min_f(_14, _15) -> bb13
+    _16 = call min_f(_14, _15) [builtin=MathIntrinsic(MinF64)] -> bb13
   bb13:
     call println_f64(_16) -> bb14
   bb14:
     stmt: eval site=SiteId(32) ty=()
     _17 = const.f64 0x4008000000000000
     _18 = const.f64 0x401c000000000000
-    _19 = call max_f(_17, _18) -> bb15
+    _19 = call max_f(_17, _18) [builtin=MathIntrinsic(MaxF64)] -> bb15
   bb15:
     call println_f64(_19) -> bb16
   bb16:
     stmt: eval site=SiteId(38) ty=()
     _20 = const.i64 -5
-    _21 = call abs(_20) -> bb17
+    _21 = call abs(_20) [builtin=MathIntrinsic(AbsI64)] -> bb17
   bb17:
     call println_i64(_21) -> bb18
   bb18:
     stmt: eval site=SiteId(44) ty=()
     _22 = const.i64 3
     _23 = const.i64 7
-    _24 = call min(_22, _23) -> bb19
+    _24 = call min(_22, _23) [builtin=MathIntrinsic(MinI64)] -> bb19
   bb19:
     call println_i64(_24) -> bb20
   bb20:
     stmt: eval site=SiteId(49) ty=()
     _25 = const.i64 3
     _26 = const.i64 7
-    _27 = call max(_25, _26) -> bb21
+    _27 = call max(_25, _26) [builtin=MathIntrinsic(MaxI64)] -> bb21
   bb21:
     call println_i64(_27) -> bb22
   bb22:
     stmt: eval site=SiteId(55) ty=()
     _28 = const.f64 0x0000000000000000
-    _29 = call sin(_28) -> bb23
+    _29 = call sin(_28) [builtin=MathIntrinsic(Sin)] -> bb23
   bb23:
     call println_f64(_29) -> bb24
   bb24:
     stmt: eval site=SiteId(61) ty=()
     _30 = const.f64 0x0000000000000000
-    _31 = call cos(_30) -> bb25
+    _31 = call cos(_30) [builtin=MathIntrinsic(Cos)] -> bb25
   bb25:
     call println_f64(_31) -> bb26
   bb26:
     stmt: eval site=SiteId(66) ty=()
     _32 = const.f64 0x3ff0000000000000
-    _33 = call exp(_32) -> bb27
+    _33 = call exp(_32) [builtin=MathIntrinsic(Exp)] -> bb27
   bb27:
     call println_f64(_33) -> bb28
   bb28:
     stmt: eval site=SiteId(71) ty=()
     _34 = const.f64 0x3ff0000000000000
-    _35 = call log(_34) -> bb29
+    _35 = call log(_34) [builtin=MathIntrinsic(Log)] -> bb29
   bb29:
     call println_f64(_35) -> bb30
   bb30:

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -77,8 +77,8 @@ use hew_mir::{
 };
 pub(crate) use hew_types::short_name;
 use hew_types::{
-    runtime_call::RuntimeCapability, BuiltinType, NumericWidth, ResolvedTy, WireCodecDirection,
-    WireLayoutTable, WireTextFormat,
+    runtime_call::{MathIntrinsic, RuntimeCapability},
+    BuiltinType, NumericWidth, ResolvedTy, WireCodecDirection, WireLayoutTable, WireTextFormat,
 };
 // Single source of truth for the trap discriminants codegen emits. Importing
 // these from the runtime makes a renumber on either side a build error rather
@@ -1969,35 +1969,6 @@ impl<'ctx> FnSymbol<'ctx> {
 /// check). One declaration per symbol per module — repeat references at
 /// multiple call sites share the same LLVM `declare` line.
 pub(crate) type RuntimeDeclMap<'ctx> = HashMap<String, FunctionValue<'ctx>>;
-
-#[derive(Debug, Clone, Copy)]
-enum MathBuiltinIntrinsic {
-    UnaryF64(&'static str),
-    BinaryF64(&'static str),
-    AbsI64,
-    BinaryI64(&'static str),
-}
-
-fn math_builtin_intrinsic(callee: &str) -> Option<MathBuiltinIntrinsic> {
-    match callee {
-        "sqrt" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.sqrt.f64")),
-        "exp" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.exp.f64")),
-        "log" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.log.f64")),
-        "sin" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.sin.f64")),
-        "cos" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.cos.f64")),
-        "abs" => Some(MathBuiltinIntrinsic::AbsI64),
-        "min" => Some(MathBuiltinIntrinsic::BinaryI64("llvm.smin.i64")),
-        "max" => Some(MathBuiltinIntrinsic::BinaryI64("llvm.smax.i64")),
-        "abs_f" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.fabs.f64")),
-        "min_f" => Some(MathBuiltinIntrinsic::BinaryF64("llvm.minnum.f64")),
-        "max_f" => Some(MathBuiltinIntrinsic::BinaryF64("llvm.maxnum.f64")),
-        "pow" => Some(MathBuiltinIntrinsic::BinaryF64("llvm.pow.f64")),
-        "floor" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.floor.f64")),
-        "ceil" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.ceil.f64")),
-        "round" => Some(MathBuiltinIntrinsic::UnaryF64("llvm.round.f64")),
-        _ => None,
-    }
-}
 
 /// The C `size_t`/`usize` integer type for the module's target.
 ///
@@ -23411,10 +23382,10 @@ fn emit_tcp_attach_local_call<'ctx>(fn_ctx: &FnCtx<'_, 'ctx>, args: &[Place]) ->
     Ok(())
 }
 
-fn emit_math_builtin_intrinsic_call<'ctx>(
+fn emit_math_intrinsic_call<'ctx>(
     fn_ctx: &FnCtx<'_, 'ctx>,
     callee: &str,
-    intrinsic: MathBuiltinIntrinsic,
+    intrinsic: MathIntrinsic,
     args: &[Place],
     dest: Option<&Place>,
     next: u32,
@@ -23429,19 +23400,39 @@ fn emit_math_builtin_intrinsic_call<'ctx>(
     let i64_ty = fn_ctx.ctx.i64_type();
     let i1_ty = fn_ctx.ctx.bool_type();
 
-    // `UnaryF64` / `BinaryF64` float intrinsics are resolved via
-    // `add_function`; they carry no integer-only attributes and their
+    // Float intrinsics are resolved via `add_function`; they carry no
+    // integer-only attributes and their
     // `IntrNoMem` / `Speculatable` markers are preserved through the
     // external-linkage declaration.
     //
-    // `AbsI64` and `BinaryI64` (abs / smin / smax / umin / umax) are
+    // Integer intrinsics (abs / smin / smax) are
     // resolved via `Intrinsic::find` + `get_declaration` so LLVM
     // attaches the `IntrNoMem`, `Speculatable`, and `willreturn`
     // attributes that `add_function(..., External)` would strip.
     // These attributes enable InstCombine folding and LICM on
     // abs/min/max calls.
     match intrinsic {
-        MathBuiltinIntrinsic::UnaryF64(name) => {
+        MathIntrinsic::Sqrt
+        | MathIntrinsic::Exp
+        | MathIntrinsic::Log
+        | MathIntrinsic::Sin
+        | MathIntrinsic::Cos
+        | MathIntrinsic::AbsF64
+        | MathIntrinsic::Floor
+        | MathIntrinsic::Ceil
+        | MathIntrinsic::Round => {
+            let name = match intrinsic {
+                MathIntrinsic::Sqrt => "llvm.sqrt.f64",
+                MathIntrinsic::Exp => "llvm.exp.f64",
+                MathIntrinsic::Log => "llvm.log.f64",
+                MathIntrinsic::Sin => "llvm.sin.f64",
+                MathIntrinsic::Cos => "llvm.cos.f64",
+                MathIntrinsic::AbsF64 => "llvm.fabs.f64",
+                MathIntrinsic::Floor => "llvm.floor.f64",
+                MathIntrinsic::Ceil => "llvm.ceil.f64",
+                MathIntrinsic::Round => "llvm.round.f64",
+                _ => unreachable!("outer match admits only unary f64 intrinsics"),
+            };
             let [arg] = args else {
                 return Err(CodegenError::FailClosed(format!(
                     "math builtin `{callee}` expects 1 argument, got {}",
@@ -23479,7 +23470,13 @@ fn emit_math_builtin_intrinsic_call<'ctx>(
                 .build_store(dest_ptr, result)
                 .llvm_ctx_with(|| format!("{callee} intrinsic store"))?;
         }
-        MathBuiltinIntrinsic::BinaryF64(name) => {
+        MathIntrinsic::MinF64 | MathIntrinsic::MaxF64 | MathIntrinsic::Pow => {
+            let name = match intrinsic {
+                MathIntrinsic::MinF64 => "llvm.minnum.f64",
+                MathIntrinsic::MaxF64 => "llvm.maxnum.f64",
+                MathIntrinsic::Pow => "llvm.pow.f64",
+                _ => unreachable!("outer match admits only binary f64 intrinsics"),
+            };
             let [lhs, rhs] = args else {
                 return Err(CodegenError::FailClosed(format!(
                     "math builtin `{callee}` expects 2 arguments, got {}",
@@ -23518,7 +23515,7 @@ fn emit_math_builtin_intrinsic_call<'ctx>(
                 .build_store(dest_ptr, result)
                 .llvm_ctx_with(|| format!("{callee} intrinsic store"))?;
         }
-        MathBuiltinIntrinsic::AbsI64 => {
+        MathIntrinsic::AbsI64 => {
             let [arg] = args else {
                 return Err(CodegenError::FailClosed(format!(
                     "math builtin `{callee}` expects 1 argument, got {}",
@@ -23566,7 +23563,12 @@ fn emit_math_builtin_intrinsic_call<'ctx>(
                 .build_store(dest_ptr, result)
                 .llvm_ctx_with(|| "abs intrinsic store".to_owned())?;
         }
-        MathBuiltinIntrinsic::BinaryI64(name) => {
+        MathIntrinsic::MinI64 | MathIntrinsic::MaxI64 => {
+            let name = match intrinsic {
+                MathIntrinsic::MinI64 => "llvm.smin.i64",
+                MathIntrinsic::MaxI64 => "llvm.smax.i64",
+                _ => unreachable!("outer match admits only binary i64 intrinsics"),
+            };
             let [lhs, rhs] = args else {
                 return Err(CodegenError::FailClosed(format!(
                     "math builtin `{callee}` expects 2 arguments, got {}",
@@ -25367,18 +25369,9 @@ fn lower_terminator<'ctx>(
                     }
                 }
             }
-            if let Some(intrinsic) = math_builtin_intrinsic(callee) {
-                if !fn_symbols.contains_key(callee) {
-                    emit_math_builtin_intrinsic_call(
-                        fn_ctx,
-                        callee,
-                        intrinsic,
-                        args,
-                        dest.as_ref(),
-                        *next,
-                    )?;
-                    return Ok(());
-                }
+            if let Some(RtFamily::MathIntrinsic(intrinsic)) = *builtin {
+                emit_math_intrinsic_call(fn_ctx, callee, intrinsic, args, dest.as_ref(), *next)?;
+                return Ok(());
             }
             // Closure-pair Vec element marshalling: a `Vec<fn(...)>` rides
             // the pointer-element runtime ABI with each slot holding a

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -7329,26 +7329,26 @@ impl LowerCtx {
             // so MIR threads the typed family onto the call and codegen
             // dispatches on it, never on the callee string. Deliberately
             // narrow: only the families whose intercepts are family-keyed
-            // today (`Node::lookup` and the `HashMap::new` / `HashSet::new`
-            // constructor surface forms — `pid.send` / `conn.attach` and
-            // the channel/stream layout entries arrive typed through the
-            // checker's method-call rewrites instead). Widening this to
-            // every catalog-named row (e.g. the math intrinsic names)
-            // changes their value-position acceptance and belongs to the
-            // math-intercept migration, not this seam.
+            // today (math intrinsics, `Node::lookup`, and the `HashMap::new` /
+            // `HashSet::new` constructor surface forms — `pid.send` /
+            // `conn.attach` and the channel/stream layout entries arrive typed
+            // through the checker's method-call rewrites instead).
             //
             // The lift must NOT apply to the `runtime_symbol()` alias
             // insert below: the alias callee name (e.g.
             // `hew_node_api_lookup`) is a different callee identity than
             // the family's `c_symbol()`, and carrying the family there
             // would break the `Terminator::Call` builtin↔callee invariant.
-            let primary_family = hew_types::runtime_call::RuntimeCallFamily::from_c_symbol(
-                builtin.name,
-            )
-            .filter(|family| {
-                use hew_types::runtime_call::RuntimeCallFamily as F;
-                matches!(family, F::NodeLookup | F::HashMapNew | F::HashSetNew)
-            });
+            let primary_family =
+                match hew_types::runtime_call::RuntimeCallFamily::from_c_symbol(builtin.name) {
+                    Some(
+                        family @ (hew_types::runtime_call::RuntimeCallFamily::MathIntrinsic(_)
+                        | hew_types::runtime_call::RuntimeCallFamily::NodeLookup
+                        | hew_types::runtime_call::RuntimeCallFamily::HashMapNew
+                        | hew_types::runtime_call::RuntimeCallFamily::HashSetNew),
+                    ) => Some(family),
+                    _ => None,
+                };
             self.fn_registry.insert(
                 builtin.name.to_string(),
                 FnEntry {
@@ -8999,7 +8999,11 @@ impl LowerCtx {
         let resolved_ref = self
             .fn_registry
             .get(&symbol)
-            .map_or(ResolvedRef::Unresolved, |entry| ResolvedRef::Item(entry.id));
+            .map_or(ResolvedRef::Unresolved, |entry| {
+                entry
+                    .builtin_family
+                    .map_or(ResolvedRef::Item(entry.id), ResolvedRef::Builtin)
+            });
         let callee_ty = ResolvedTy::Function {
             params: Vec::new(),
             ret: Box::new(ret_ty.clone()),
@@ -21889,10 +21893,14 @@ impl LowerCtx {
                         ResolvedTy::Unit,
                     );
                 };
-                let resolved_ref = self
-                    .fn_registry
-                    .get(symbol)
-                    .map_or(ResolvedRef::Unresolved, |entry| ResolvedRef::Item(entry.id));
+                let resolved_ref =
+                    self.fn_registry
+                        .get(symbol)
+                        .map_or(ResolvedRef::Unresolved, |entry| {
+                            entry
+                                .builtin_family
+                                .map_or(ResolvedRef::Item(entry.id), ResolvedRef::Builtin)
+                        });
                 let callee_ty = ResolvedTy::Function {
                     params: Vec::new(),
                     ret: Box::new(ret_ty.clone()),

--- a/hew-hir/tests/lowering_calls/math_builtin_lower.rs
+++ b/hew-hir/tests/lowering_calls/math_builtin_lower.rs
@@ -1,14 +1,21 @@
 use hew_hir::{lower_program, verify_hir, HirExprKind, HirItem, ResolutionCtx};
-use hew_types::{module_registry::ModuleRegistry, Checker};
+use hew_types::{
+    module_registry::ModuleRegistry, runtime_call::MathIntrinsic, Checker, RuntimeCallFamily,
+};
 
 fn lower(source: &str) -> hew_hir::LowerOutput {
-    let parsed = hew_parser::parse(source);
+    let source = format!("import std::math;\n{source}");
+    let parsed = hew_parser::parse(&source);
     assert!(
         parsed.errors.is_empty(),
         "parse errors: {:?}",
         parsed.errors
     );
-    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("hew-hir crate must live below repo root")
+        .to_path_buf();
+    let mut checker = Checker::new(ModuleRegistry::new(vec![repo_root]));
     let tc_output = checker.check_program(&parsed.program);
     assert!(
         tc_output.errors.is_empty(),
@@ -31,7 +38,7 @@ fn lower(source: &str) -> hew_hir::LowerOutput {
     output
 }
 
-fn assert_main_tail_call_resolves(source: &str, expected: &str) {
+fn assert_main_tail_call_resolves(source: &str, expected: &str, expected_intrinsic: MathIntrinsic) {
     let output = lower(source);
     let main_fn = output
         .module
@@ -50,38 +57,92 @@ fn assert_main_tail_call_resolves(source: &str, expected: &str) {
         panic!("callee must be a binding ref, got {callee:#?}");
     };
     assert_eq!(name, expected);
-    assert!(
-        matches!(resolved, hew_hir::ResolvedRef::Item(_)),
-        "{expected} must resolve to a synthetic stdlib item, got {resolved:?}"
+    assert_eq!(
+        *resolved,
+        hew_hir::ResolvedRef::Builtin(RuntimeCallFamily::MathIntrinsic(expected_intrinsic)),
+        "{expected} must resolve to its typed math intrinsic"
     );
 }
 
 #[test]
-fn free_math_builtins_resolve_to_hir_items() {
-    for (name, source) in [
-        ("sqrt", "fn main() -> f64 { sqrt(9.0) }"),
-        ("abs", "fn main() -> i64 { abs(-9) }"),
-        ("min", "fn main() -> i64 { min(7, 3) }"),
-        ("max", "fn main() -> i64 { max(7, 3) }"),
-        ("pow", "fn main() -> f64 { pow(2, 10) }"),
-        ("floor", "fn main() -> f64 { floor(2.75) }"),
-        ("ceil", "fn main() -> f64 { ceil(2.25) }"),
-        ("round", "fn main() -> f64 { round(2.5) }"),
+fn math_builtin_identifiers_resolve_to_typed_intrinsics() {
+    for (name, intrinsic, source) in [
+        (
+            "sqrt",
+            MathIntrinsic::Sqrt,
+            "fn main() -> f64 { math.sqrt(9.0) }",
+        ),
+        (
+            "exp",
+            MathIntrinsic::Exp,
+            "fn main() -> f64 { math.exp(1.0) }",
+        ),
+        (
+            "log",
+            MathIntrinsic::Log,
+            "fn main() -> f64 { math.log(1.0) }",
+        ),
+        (
+            "sin",
+            MathIntrinsic::Sin,
+            "fn main() -> f64 { math.sin(1.0) }",
+        ),
+        (
+            "cos",
+            MathIntrinsic::Cos,
+            "fn main() -> f64 { math.cos(1.0) }",
+        ),
+        (
+            "abs",
+            MathIntrinsic::AbsI64,
+            "fn main() -> i64 { math.abs(-9) }",
+        ),
+        (
+            "min",
+            MathIntrinsic::MinI64,
+            "fn main() -> i64 { math.min(7, 3) }",
+        ),
+        (
+            "max",
+            MathIntrinsic::MaxI64,
+            "fn main() -> i64 { math.max(7, 3) }",
+        ),
+        (
+            "abs_f",
+            MathIntrinsic::AbsF64,
+            "fn main() -> f64 { math.abs(-9.0) }",
+        ),
+        (
+            "min_f",
+            MathIntrinsic::MinF64,
+            "fn main() -> f64 { math.min(7.0, 3.0) }",
+        ),
+        (
+            "max_f",
+            MathIntrinsic::MaxF64,
+            "fn main() -> f64 { math.max(7.0, 3.0) }",
+        ),
+        (
+            "pow",
+            MathIntrinsic::Pow,
+            "fn main() -> f64 { math.pow(2.0, 10.0) }",
+        ),
+        (
+            "floor",
+            MathIntrinsic::Floor,
+            "fn main() -> f64 { math.floor(2.75) }",
+        ),
+        (
+            "ceil",
+            MathIntrinsic::Ceil,
+            "fn main() -> f64 { math.ceil(2.25) }",
+        ),
+        (
+            "round",
+            MathIntrinsic::Round,
+            "fn main() -> f64 { math.round(2.5) }",
+        ),
     ] {
-        assert_main_tail_call_resolves(source, name);
-    }
-}
-
-#[test]
-fn generic_math_module_calls_dispatch_to_concrete_intrinsics() {
-    for (expected, source) in [
-        ("abs", "fn main() -> i64 { math.abs(-9) }"),
-        ("abs_f", "fn main() -> f64 { math.abs(-9.0) }"),
-        ("min", "fn main() -> i64 { math.min(7, 3) }"),
-        ("min_f", "fn main() -> f64 { math.min(7.0, 3.0) }"),
-        ("max", "fn main() -> i64 { math.max(7, 3) }"),
-        ("max_f", "fn main() -> f64 { math.max(7.0, 3.0) }"),
-    ] {
-        assert_main_tail_call_resolves(source, expected);
+        assert_main_tail_call_resolves(source, name, intrinsic);
     }
 }

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -110,11 +110,10 @@ pub enum StreamElementKind {
     String,
 }
 
-/// Math-intrinsic family discriminator. Mirrors the user-visible
-/// callee names dispatched in `hew-codegen-rs::llvm::math_builtin_intrinsic`
-/// today (the names appear as `BindingRef.name` in HIR — `"sqrt"`, `"sin"`,
-/// …). Pre-staged: a follow-up migrates the callee-name match in codegen
-/// onto a typed `RuntimeCallFamily::MathIntrinsic(...)`.
+/// Math-intrinsic family discriminator. HIR resolves the user-visible
+/// identifiers (`"sqrt"`, `"sin"`, …) onto
+/// `RuntimeCallFamily::MathIntrinsic(...)`; MIR carries that family on the
+/// call so codegen never re-derives the intrinsic from the callee string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, EnumIter)]
 pub enum MathIntrinsic {
     #[default]
@@ -334,9 +333,8 @@ pub enum RuntimeCallFamily {
     LambdaActorWeakSend,
 
     // --- Math intrinsics ---------------------------------------------------
-    // Pre-staged: dispatched today by user-visible callee name
-    // (`"sqrt"`, `"sin"`, …) via codegen's `math_builtin_intrinsic`
-    // lookup; not in `known_runtime_symbols`.
+    // User-visible callee identities carried on MIR `Terminator::Call`; not
+    // runtime C-ABI symbols and therefore absent from `known_runtime_symbols`.
     MathIntrinsic(MathIntrinsic),
 
     // --- Node operations ---------------------------------------------------
@@ -693,7 +691,7 @@ impl RuntimeCallFamily {
             Self::LambdaActorWeakClone => "hew_lambda_actor_weak_clone",
             Self::LambdaActorWeakDrop => "hew_lambda_actor_weak_drop",
             Self::LambdaActorWeakSend => "hew_lambda_actor_weak_send",
-            // Math intrinsics (pre-staged; user-visible callee names)
+            // Math intrinsics (user-visible callee names)
             Self::MathIntrinsic(MathIntrinsic::Sqrt) => "sqrt",
             Self::MathIntrinsic(MathIntrinsic::Exp) => "exp",
             Self::MathIntrinsic(MathIntrinsic::Log) => "log",

--- a/std/math/math.hew
+++ b/std/math/math.hew
@@ -87,10 +87,10 @@ pub fn sign(x: i64) -> i64 {
 #[intrinsic("math.sqrt")]
 pub fn sqrt(x: f64) -> f64 {}
 
-// WHY the stub body: codegen intercepts calls to these four functions by name
-// via `math_builtin_intrinsic` (hew-codegen-rs/src/llvm.rs) and emits the
-// corresponding LLVM intrinsic (`llvm.pow.f64`, `llvm.floor.f64`, etc.)
-// directly at the call site, bypassing the body entirely. This is the
+// WHY the stub body: HIR resolves these functions to a typed math intrinsic
+// carried through MIR; codegen emits the corresponding LLVM intrinsic
+// (`llvm.pow.f64`, `llvm.floor.f64`, etc.) directly at the call site,
+// bypassing the body entirely. This is the
 // call-site interception path, distinct from the `#[intrinsic]` attribute
 // path used by `sqrt`, `exp`, `log`, `sin`, and `cos`. The `0.0` body is
 // never executed; it satisfies the type-checker only.
@@ -99,22 +99,22 @@ pub fn pow(base: f64, exp: f64) -> f64 {
     0.0
 }
 
-// WHY the stub body: call-site interception via `math_builtin_intrinsic` emits
-// `llvm.floor.f64`. See comment on `pow` above for the full explanation.
+// WHY the stub body: typed call-site interception emits `llvm.floor.f64`.
+// See comment on `pow` above for the full explanation.
 /// Return the largest integer value less than or equal to `x`.
 pub fn floor(x: f64) -> f64 {
     0.0
 }
 
-// WHY the stub body: call-site interception via `math_builtin_intrinsic` emits
-// `llvm.ceil.f64`. See comment on `pow` above for the full explanation.
+// WHY the stub body: typed call-site interception emits `llvm.ceil.f64`.
+// See comment on `pow` above for the full explanation.
 /// Return the smallest integer value greater than or equal to `x`.
 pub fn ceil(x: f64) -> f64 {
     0.0
 }
 
-// WHY the stub body: call-site interception via `math_builtin_intrinsic` emits
-// `llvm.round.f64`. See comment on `pow` above for the full explanation.
+// WHY the stub body: typed call-site interception emits `llvm.round.f64`.
+// See comment on `pow` above for the full explanation.
 /// Round to the nearest integer, with ties rounding away from zero.
 pub fn round(x: f64) -> f64 {
     0.0
@@ -123,7 +123,7 @@ pub fn round(x: f64) -> f64 {
 // ── Transcendental functions ──────────────────────────────────────────
 // These lower to LLVM math intrinsics via `#[intrinsic]` the same way
 // `sqrt` does. The empty body satisfies the type-checker; codegen routes
-// through `emit_math_builtin_intrinsic_call` using the `llvm.*.f64` name.
+// through `emit_math_intrinsic_call` using the `llvm.*.f64` name.
 /// Return e raised to the power `x`.
 #[intrinsic("math.exp")]
 pub fn exp(x: f64) -> f64 {}


### PR DESCRIPTION
## Summary

`runtime_call::MathIntrinsic` is now the single authority for math-builtin dispatch. Codegen previously carried a duplicate local `MathBuiltinIntrinsic` enum and dispatched math builtins by re-matching the raw source identifier string; that enum and its string match are deleted, and identifier→intrinsic resolution now happens once upstream in HIR (via the same catalog family-lift used for the node/collection builtins). Codegen dispatches on the typed intrinsic carried on the call.

## Verification

- All fifteen math builtins map 1:1 to the same LLVM intrinsic as before (a coverage test asserts every typed variant).
- `.ll` oracle byte-identical (11 fixtures × 2 targets).
- checked-mir byte-identical apart from the intended `[builtin=MathIntrinsic(...)]` annotation now carried on each math call; control flow and args unchanged.
- `test-hew-ratchet` and `hew-check-all` clean.
- `make lint` (clippy + fmt + hew-fmt-check) clean.
- The `std/math/math.hew` change is a comment retarget only.

## Out of scope

- `stdlib_authority::Intrinsic` — a different vocabulary, deliberately not unified.
- The MIR producer-side drop-descriptor string-lift, which needs a deeper reshape and is tracked in #2714.