### PR TITLE
fix(mir): close resource-cleanup leaks in enum payloads

### DIFF
--- a/examples/v05/checked-mir/golden/metric_register_record.raw.mir
+++ b/examples/v05/checked-mir/golden/metric_register_record.raw.mir
@@ -189,6 +189,7 @@ fn metrics$counter(string) -> Counter [conv=default]
   bb4:
     _9 = call string_concat(_7, _8) -> bb5
   bb5:
+    drop _8 ty=string fn=release(hew_string_drop)
     _10 = string_lit "`"
     _11 = call string_concat(_9, _10) -> bb6
   bb6:
@@ -293,6 +294,7 @@ fn metrics$gauge(string) -> Gauge [conv=default]
   bb4:
     _9 = call string_concat(_7, _8) -> bb5
   bb5:
+    drop _8 ty=string fn=release(hew_string_drop)
     _10 = string_lit "`"
     _11 = call string_concat(_9, _10) -> bb6
   bb6:
@@ -397,6 +399,7 @@ fn metrics$histogram(string) -> Histogram [conv=default]
   bb4:
     _9 = call string_concat(_7, _8) -> bb5
   bb5:
+    drop _8 ty=string fn=release(hew_string_drop)
     _10 = string_lit "`"
     _11 = call string_concat(_9, _10) -> bb6
   bb6:

--- a/examples/v05/checked-mir/golden/regex_match_literal.raw.mir
+++ b/examples/v05/checked-mir/golden/regex_match_literal.raw.mir
@@ -678,6 +678,7 @@ fn regex$new(string) -> Pattern [conv=default]
   bb6:
     _12 = call string_concat(_10, _11) -> bb7
   bb7:
+    drop _11 ty=string fn=release(hew_string_drop)
     call panic(_12) -> bb8
   bb8:
     stmt: eval site=SiteId(199) ty=!

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -625,6 +625,7 @@ fn fs$last_io_error() -> IoError [conv=default]
   bb3:
     stmt: eval site=SiteId(192) ty=string
     stmt: use BindingId(17) errno site=SiteId(197) ty=i64 intent=Read
+    drop _6 ty=string fn=release(hew_string_drop)
     _8 = const.i64 0
     _9 = const.i64 0
     _10 = icmp.eq _5 _9
@@ -743,6 +744,7 @@ fn fs$read(string) -> string [conv=default]
   bb11:
     _16 = call string_concat(_14, _15) -> bb12
   bb12:
+    drop _15 ty=string fn=release(hew_string_drop)
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
@@ -757,6 +759,7 @@ fn fs$read(string) -> string [conv=default]
   bb16:
     _23 = call string_concat(_18, _22) -> bb17
   bb17:
+    drop _22 ty=string fn=release(hew_string_drop)
     call panic(_23) -> bb18
   bb18:
     stmt: eval site=SiteId(228) ty=!
@@ -764,6 +767,7 @@ fn fs$read(string) -> string [conv=default]
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
   bb20:
+    drop _25 ty=string fn=release(hew_string_drop)
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
@@ -773,6 +777,7 @@ fn fs$read(string) -> string [conv=default]
   bb22:
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
+    drop _29 ty=string fn=release(hew_string_drop)
     call panic(_30) -> bb24
   bb24:
     stmt: eval site=SiteId(251) ty=!
@@ -848,6 +853,7 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
   bb9:
     stmt: eval site=SiteId(288) ty=string
     stmt: use BindingId(26) errno site=SiteId(292) ty=i32 intent=Read
+    drop _12 ty=string fn=release(hew_string_drop)
     _14 = const.i64 0
     _15 = icmp.eq _11 _14
     branch _15 ? bb10 : bb11
@@ -1178,6 +1184,7 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     stmt: eval site=SiteId(383) ty=string
     stmt: use BindingId(42) kind site=SiteId(387) ty=i64 intent=Read
     stmt: use BindingId(43) errno site=SiteId(389) ty=i32 intent=Read
+    drop _11 ty=string fn=release(hew_string_drop)
     _13 = const.i64 1
     mtag12 = move _13
     _14 = cast _7 i32 -> i64
@@ -1434,6 +1441,7 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb4:
     stmt: eval site=SiteId(454) ty=string
     stmt: use BindingId(56) errno site=SiteId(458) ty=i32 intent=Read
+    drop _8 ty=string fn=release(hew_string_drop)
     _10 = const.i64 0
     _11 = icmp.eq _7 _10
     branch _11 ? bb5 : bb6
@@ -2090,6 +2098,7 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     stmt: eval site=SiteId(658) ty=string
     stmt: use BindingId(86) kind site=SiteId(662) ty=i64 intent=Read
     stmt: use BindingId(87) errno site=SiteId(664) ty=i32 intent=Read
+    drop _13 ty=string fn=release(hew_string_drop)
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -2210,6 +2219,7 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     stmt: eval site=SiteId(698) ty=string
     stmt: use BindingId(92) kind site=SiteId(702) ty=i64 intent=Read
     stmt: use BindingId(93) errno site=SiteId(704) ty=i32 intent=Read
+    drop _13 ty=string fn=release(hew_string_drop)
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -685,6 +685,7 @@ fn fs$last_io_error() -> IoError [conv=default]
   bb3:
     stmt: eval site=SiteId(211) ty=string
     stmt: use BindingId(22) errno site=SiteId(216) ty=i64 intent=Read
+    drop _6 ty=string fn=release(hew_string_drop)
     _8 = const.i64 0
     _9 = const.i64 0
     _10 = icmp.eq _5 _9
@@ -803,6 +804,7 @@ fn fs$read(string) -> string [conv=default]
   bb11:
     _16 = call string_concat(_14, _15) -> bb12
   bb12:
+    drop _15 ty=string fn=release(hew_string_drop)
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
@@ -817,6 +819,7 @@ fn fs$read(string) -> string [conv=default]
   bb16:
     _23 = call string_concat(_18, _22) -> bb17
   bb17:
+    drop _22 ty=string fn=release(hew_string_drop)
     call panic(_23) -> bb18
   bb18:
     stmt: eval site=SiteId(247) ty=!
@@ -824,6 +827,7 @@ fn fs$read(string) -> string [conv=default]
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
   bb20:
+    drop _25 ty=string fn=release(hew_string_drop)
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
@@ -833,6 +837,7 @@ fn fs$read(string) -> string [conv=default]
   bb22:
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
+    drop _29 ty=string fn=release(hew_string_drop)
     call panic(_30) -> bb24
   bb24:
     stmt: eval site=SiteId(270) ty=!
@@ -908,6 +913,7 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
   bb9:
     stmt: eval site=SiteId(307) ty=string
     stmt: use BindingId(31) errno site=SiteId(311) ty=i32 intent=Read
+    drop _12 ty=string fn=release(hew_string_drop)
     _14 = const.i64 0
     _15 = icmp.eq _11 _14
     branch _15 ? bb10 : bb11
@@ -1238,6 +1244,7 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     stmt: eval site=SiteId(402) ty=string
     stmt: use BindingId(47) kind site=SiteId(406) ty=i64 intent=Read
     stmt: use BindingId(48) errno site=SiteId(408) ty=i32 intent=Read
+    drop _11 ty=string fn=release(hew_string_drop)
     _13 = const.i64 1
     mtag12 = move _13
     _14 = cast _7 i32 -> i64
@@ -1494,6 +1501,7 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb4:
     stmt: eval site=SiteId(473) ty=string
     stmt: use BindingId(61) errno site=SiteId(477) ty=i32 intent=Read
+    drop _8 ty=string fn=release(hew_string_drop)
     _10 = const.i64 0
     _11 = icmp.eq _7 _10
     branch _11 ? bb5 : bb6
@@ -2150,6 +2158,7 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     stmt: eval site=SiteId(677) ty=string
     stmt: use BindingId(91) kind site=SiteId(681) ty=i64 intent=Read
     stmt: use BindingId(92) errno site=SiteId(683) ty=i32 intent=Read
+    drop _13 ty=string fn=release(hew_string_drop)
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -2270,6 +2279,7 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     stmt: eval site=SiteId(717) ty=string
     stmt: use BindingId(97) kind site=SiteId(721) ty=i64 intent=Read
     stmt: use BindingId(98) errno site=SiteId(723) ty=i32 intent=Read
+    drop _13 ty=string fn=release(hew_string_drop)
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -571,6 +571,7 @@ fn fs$last_io_error() -> IoError [conv=default]
   bb3:
     stmt: eval site=SiteId(179) ty=string
     stmt: use BindingId(17) errno site=SiteId(184) ty=i64 intent=Read
+    drop _6 ty=string fn=release(hew_string_drop)
     _8 = const.i64 0
     _9 = const.i64 0
     _10 = icmp.eq _5 _9
@@ -689,6 +690,7 @@ fn fs$read(string) -> string [conv=default]
   bb11:
     _16 = call string_concat(_14, _15) -> bb12
   bb12:
+    drop _15 ty=string fn=release(hew_string_drop)
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
@@ -703,6 +705,7 @@ fn fs$read(string) -> string [conv=default]
   bb16:
     _23 = call string_concat(_18, _22) -> bb17
   bb17:
+    drop _22 ty=string fn=release(hew_string_drop)
     call panic(_23) -> bb18
   bb18:
     stmt: eval site=SiteId(215) ty=!
@@ -710,6 +713,7 @@ fn fs$read(string) -> string [conv=default]
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
   bb20:
+    drop _25 ty=string fn=release(hew_string_drop)
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
@@ -719,6 +723,7 @@ fn fs$read(string) -> string [conv=default]
   bb22:
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
+    drop _29 ty=string fn=release(hew_string_drop)
     call panic(_30) -> bb24
   bb24:
     stmt: eval site=SiteId(238) ty=!
@@ -794,6 +799,7 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
   bb9:
     stmt: eval site=SiteId(275) ty=string
     stmt: use BindingId(26) errno site=SiteId(279) ty=i32 intent=Read
+    drop _12 ty=string fn=release(hew_string_drop)
     _14 = const.i64 0
     _15 = icmp.eq _11 _14
     branch _15 ? bb10 : bb11
@@ -1124,6 +1130,7 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     stmt: eval site=SiteId(370) ty=string
     stmt: use BindingId(42) kind site=SiteId(374) ty=i64 intent=Read
     stmt: use BindingId(43) errno site=SiteId(376) ty=i32 intent=Read
+    drop _11 ty=string fn=release(hew_string_drop)
     _13 = const.i64 1
     mtag12 = move _13
     _14 = cast _7 i32 -> i64
@@ -1380,6 +1387,7 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb4:
     stmt: eval site=SiteId(441) ty=string
     stmt: use BindingId(56) errno site=SiteId(445) ty=i32 intent=Read
+    drop _8 ty=string fn=release(hew_string_drop)
     _10 = const.i64 0
     _11 = icmp.eq _7 _10
     branch _11 ? bb5 : bb6
@@ -2036,6 +2044,7 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     stmt: eval site=SiteId(645) ty=string
     stmt: use BindingId(86) kind site=SiteId(649) ty=i64 intent=Read
     stmt: use BindingId(87) errno site=SiteId(651) ty=i32 intent=Read
+    drop _13 ty=string fn=release(hew_string_drop)
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -2156,6 +2165,7 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     stmt: eval site=SiteId(685) ty=string
     stmt: use BindingId(92) kind site=SiteId(689) ty=i64 intent=Read
     stmt: use BindingId(93) errno site=SiteId(691) ty=i32 intent=Read
+    drop _13 ty=string fn=release(hew_string_drop)
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.raw.mir
@@ -549,6 +549,7 @@ fn fs$last_io_error() -> IoError [conv=default]
   bb3:
     stmt: eval site=SiteId(172) ty=string
     stmt: use BindingId(15) errno site=SiteId(177) ty=i64 intent=Read
+    drop _6 ty=string fn=release(hew_string_drop)
     _8 = const.i64 0
     _9 = const.i64 0
     _10 = icmp.eq _5 _9
@@ -667,6 +668,7 @@ fn fs$read(string) -> string [conv=default]
   bb11:
     _16 = call string_concat(_14, _15) -> bb12
   bb12:
+    drop _15 ty=string fn=release(hew_string_drop)
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
@@ -681,6 +683,7 @@ fn fs$read(string) -> string [conv=default]
   bb16:
     _23 = call string_concat(_18, _22) -> bb17
   bb17:
+    drop _22 ty=string fn=release(hew_string_drop)
     call panic(_23) -> bb18
   bb18:
     stmt: eval site=SiteId(208) ty=!
@@ -688,6 +691,7 @@ fn fs$read(string) -> string [conv=default]
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
   bb20:
+    drop _25 ty=string fn=release(hew_string_drop)
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
@@ -697,6 +701,7 @@ fn fs$read(string) -> string [conv=default]
   bb22:
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
+    drop _29 ty=string fn=release(hew_string_drop)
     call panic(_30) -> bb24
   bb24:
     stmt: eval site=SiteId(231) ty=!
@@ -772,6 +777,7 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
   bb9:
     stmt: eval site=SiteId(268) ty=string
     stmt: use BindingId(24) errno site=SiteId(272) ty=i32 intent=Read
+    drop _12 ty=string fn=release(hew_string_drop)
     _14 = const.i64 0
     _15 = icmp.eq _11 _14
     branch _15 ? bb10 : bb11
@@ -1102,6 +1108,7 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     stmt: eval site=SiteId(363) ty=string
     stmt: use BindingId(40) kind site=SiteId(367) ty=i64 intent=Read
     stmt: use BindingId(41) errno site=SiteId(369) ty=i32 intent=Read
+    drop _11 ty=string fn=release(hew_string_drop)
     _13 = const.i64 1
     mtag12 = move _13
     _14 = cast _7 i32 -> i64
@@ -1358,6 +1365,7 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb4:
     stmt: eval site=SiteId(434) ty=string
     stmt: use BindingId(54) errno site=SiteId(438) ty=i32 intent=Read
+    drop _8 ty=string fn=release(hew_string_drop)
     _10 = const.i64 0
     _11 = icmp.eq _7 _10
     branch _11 ? bb5 : bb6
@@ -2014,6 +2022,7 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     stmt: eval site=SiteId(638) ty=string
     stmt: use BindingId(84) kind site=SiteId(642) ty=i64 intent=Read
     stmt: use BindingId(85) errno site=SiteId(644) ty=i32 intent=Read
+    drop _13 ty=string fn=release(hew_string_drop)
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -2134,6 +2143,7 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     stmt: eval site=SiteId(678) ty=string
     stmt: use BindingId(90) kind site=SiteId(682) ty=i64 intent=Read
     stmt: use BindingId(91) errno site=SiteId(684) ty=i32 intent=Read
+    drop _13 ty=string fn=release(hew_string_drop)
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64

--- a/hew-cli/tests/enum_resource_variant_leak_oracle.rs
+++ b/hew-cli/tests/enum_resource_variant_leak_oracle.rs
@@ -1,0 +1,220 @@
+#![cfg(unix)]
+
+mod support;
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::Command;
+
+use support::leak_slope::{compile_to_native, leaks_supported, run_under_malloc_scribble};
+use support::{describe_output, require_codegen};
+
+const RESOURCE_FRAMES: usize = 8;
+
+fn resource_enum_source(frames: usize) -> String {
+    format!(
+        "\
+#[opaque]\n\
+type Dq {{}}\n\
+#[resource]\n\
+type Handle {{ raw: Dq; }}\n\
+impl Handle {{\n\
+    fn value(self) -> i64 {{ 7 }}\n\
+    fn close(self) {{ unsafe {{ hew_deque_free(self.raw) }}; print(\"C\"); }}\n\
+}}\n\
+extern \"C\" {{\n\
+    fn hew_deque_new() -> Dq;\n\
+    fn hew_deque_free(consume dq: Dq);\n\
+}}\n\
+enum Outcome {{ Loaded(Handle); Failed(string); }}\n\
+fn make(ok: bool) -> Outcome {{\n\
+    if ok {{ Outcome::Loaded(Handle {{ raw: unsafe {{ hew_deque_new() }} }}) }}\n\
+    else {{ Outcome::Failed(\"bad\".to_upper()) }}\n\
+}}\n\
+fn main() {{\n\
+    for _ in 0..{frames} {{\n\
+        match make(true) {{\n\
+            Outcome::Loaded(handle) => print(handle.value()),\n\
+            Outcome::Failed(message) => print(message + \"!\"),\n\
+        }}\n\
+        match make(false) {{\n\
+            Outcome::Loaded(handle) => print(handle.value()),\n\
+            Outcome::Failed(message) => print(message + \"!\"),\n\
+        }}\n\
+    }}\n\
+}}\n"
+    )
+}
+
+const XML_STRING_TEMP_SOURCE: &str = "\
+import std::encoding::xml;\n\
+fn parse_result(s: string) -> Result<xml.Node, string> {\n\
+    if xml.is_wellformed(s) { Ok(xml.parse(s)) } else { Err(\"not well-formed\") }\n\
+}\n\
+fn main() {\n\
+    match parse_result(\"<a><b>hi</b></a>\") {\n\
+        Ok(node) => { println(node.to_string()); node.close(); }\n\
+        Err(message) => println(message),\n\
+    }\n\
+}\n";
+
+fn measure_leaks_exact(bin: &Path) -> Option<(usize, usize)> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    for line in report.lines() {
+        let Some(rest) = line.strip_prefix("Process ") else {
+            continue;
+        };
+        if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        let Some(summary) = rest.split_once(": ").map(|(_, summary)| summary) else {
+            continue;
+        };
+        if !summary.contains(" leak") || !summary.contains(" for ") {
+            continue;
+        }
+        let mut words = summary.split_whitespace();
+        let count = words.next()?.parse().ok()?;
+        let _ = words.next();
+        let _ = words.next();
+        let bytes = words.next()?.parse().ok()?;
+        return Some((count, bytes));
+    }
+    None
+}
+
+fn assert_exact_zero_leaks(bin: &Path, shape: &str) {
+    if !leaks_supported(shape) {
+        return;
+    }
+    let Some((count, bytes)) = measure_leaks_exact(bin) else {
+        return;
+    };
+    assert_eq!(
+        (count, bytes),
+        (0, 0),
+        "{shape}: expected `0 leaks for 0 total leaked bytes`, got \
+         {count} leak(s) for {bytes} bytes; re-run with \
+         `MallocStackLogging=1 leaks --atExit -- {}`",
+        bin.display()
+    );
+}
+
+#[test]
+fn resource_record_enum_payload_closes_exactly_once() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("enum-resource-close-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        &resource_enum_source(RESOURCE_FRAMES),
+        dir.path(),
+        "resource_enum",
+    );
+
+    let mut expected = String::new();
+    for _ in 0..RESOURCE_FRAMES {
+        let _ = write!(expected, "7BAD!C");
+    }
+
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "resource enum loop must run clean under the poisoned allocator; a crash \
+         indicates a double-close or use-after-free:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        expected,
+        "each resource payload must be read, then closed exactly once"
+    );
+    assert_exact_zero_leaks(&bin, "resource_record_enum_payload");
+
+    let ll = std::fs::read_to_string(dir.path().join("resource_enum.ll")).expect("read LLVM IR");
+    let enum_drop = function_body(&ll, "@__hew_enum_drop_inplace_Outcome(")
+        .expect("enum drop helper must be defined");
+    assert!(
+        enum_drop.contains("@__hew_record_drop_inplace_Handle"),
+        "enum drop must recurse through the resource record:\n{enum_drop}"
+    );
+    let record_drop = function_body(&ll, "@__hew_record_drop_inplace_Handle(")
+        .expect("resource record drop helper must be defined");
+    assert_eq!(
+        record_drop.matches("@\"Handle::close\"").count(),
+        1,
+        "resource record drop must call close exactly once:\n{record_drop}"
+    );
+    let record_clone = function_body(&ll, "@__hew_record_clone_inplace_Handle(")
+        .expect("resource record clone helper must be defined");
+    assert!(
+        record_clone.contains("step_0_clone:")
+            && record_clone.contains("br label %rb_step_0")
+            && record_clone.contains("step_0_store:")
+            && record_clone.contains("No predecessors!")
+            && !record_clone.contains(" call "),
+        "the opaque field clone step must unconditionally branch to rollback, \
+         leaving its success store unreachable:\n{record_clone}"
+    );
+}
+
+#[test]
+fn xml_string_return_temporary_is_released() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("enum-resource-xml-string-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(XML_STRING_TEMP_SOURCE, dir.path(), "xml_string_temp");
+
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "XML string-return temporary must run clean under the poisoned allocator:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "<a><b>hi</b></a>\n"
+    );
+    assert_exact_zero_leaks(&bin, "xml_string_return_temporary");
+}
+
+fn function_body(ll: &str, needle: &str) -> Option<String> {
+    let mut in_function = false;
+    let mut body = String::new();
+    for line in ll.lines() {
+        if !in_function {
+            if line.starts_with("define") && line.contains(needle) {
+                in_function = true;
+                body.push_str(line);
+                body.push('\n');
+            }
+            continue;
+        }
+        body.push_str(line);
+        body.push('\n');
+        if line == "}" {
+            return Some(body);
+        }
+    }
+    None
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -5809,6 +5809,7 @@ fn emit_actor_state_clone_body<'ctx>(
                 dst,
                 field_idx,
                 kind,
+                false,
                 store_bbs[step_idx],
                 rollback_bbs[step_idx],
                 next_bb,
@@ -5881,6 +5882,7 @@ fn emit_field_clone_step<'ctx>(
     dst: PointerValue<'ctx>,
     field_idx: u32,
     kind: &StateFieldCloneKind,
+    allow_opaque_rollback: bool,
     store_bb: inkwell::basic_block::BasicBlock<'ctx>,
     rollback_bb: inkwell::basic_block::BasicBlock<'ctx>,
     next_bb: inkwell::basic_block::BasicBlock<'ctx>,
@@ -6093,6 +6095,20 @@ fn emit_field_clone_step<'ctx>(
             builder
                 .build_unconditional_branch(next_bb)
                 .llvm_ctx_with(|| format!("closure pair clone store term f{field_idx}"))?;
+            return Ok(());
+        }
+        StateFieldCloneKind::OpaqueHandle { name } if allow_opaque_rollback => {
+            // Opaque handles have no dup helper. Aggregate clone callers must
+            // receive the ordinary rollback/failure result, while the paired
+            // drop helper remains available for drop-only enum/record seeds.
+            let _ = name;
+            builder
+                .build_unconditional_branch(rollback_bb)
+                .llvm_ctx_with(|| format!("opaque handle clone refusal f{field_idx}"))?;
+            builder.position_at_end(store_bb);
+            builder
+                .build_unconditional_branch(next_bb)
+                .llvm_ctx_with(|| format!("opaque handle clone store term f{field_idx}"))?;
             return Ok(());
         }
         StateFieldCloneKind::Resource { name, .. } => {
@@ -6879,7 +6895,7 @@ fn emit_record_clone_inplace_body<'ctx>(
              already has a body — duplicate synthesis is a substrate invariant violation"
         )));
     }
-    emit_aggregate_clone_inplace_body(ctx, llvm_mod, f, record_struct, kinds, w)
+    emit_aggregate_clone_inplace_body(ctx, llvm_mod, f, record_struct, kinds, true, w)
 }
 
 /// Emit the per-field clone+rollback body into a pre-declared
@@ -6895,6 +6911,7 @@ pub(crate) fn emit_aggregate_clone_inplace_body<'ctx>(
     f: FunctionValue<'ctx>,
     record_struct: StructType<'ctx>,
     kinds: &[StateFieldCloneKind],
+    allow_opaque_rollback: bool,
     w: &DropSynthWitnesses<'_, 'ctx>,
 ) -> CodegenResult<()> {
     let i32_ty = ctx.i32_type();
@@ -6953,6 +6970,7 @@ pub(crate) fn emit_aggregate_clone_inplace_body<'ctx>(
                 dst,
                 field_idx,
                 kind,
+                allow_opaque_rollback,
                 store_bbs[step_idx],
                 rollback_bbs[step_idx],
                 next_bb,
@@ -8807,6 +8825,7 @@ fn emit_enum_clone_inplace_body<'ctx>(
                 dst_payload,
                 field_idx,
                 kind,
+                true,
                 store_bbs[step_idx],
                 rollback_bbs[step_idx],
                 next_bb,
@@ -18757,7 +18776,7 @@ fn emit_tuple_kind_inplace_thunk_bodies<'ctx>(
 ) -> CodegenResult<()> {
     let clone_fn = get_or_declare_tuple_clone_inplace(ctx, llvm_mod, tuple_key);
     if clone_fn.count_basic_blocks() == 0 {
-        emit_aggregate_clone_inplace_body(ctx, llvm_mod, clone_fn, tuple_struct, kinds, w)?;
+        emit_aggregate_clone_inplace_body(ctx, llvm_mod, clone_fn, tuple_struct, kinds, false, w)?;
     }
     let drop_fn = get_or_declare_tuple_drop_inplace(ctx, llvm_mod, tuple_key);
     if drop_fn.count_basic_blocks() == 0 {

--- a/hew-codegen-rs/src/thunks.rs
+++ b/hew-codegen-rs/src/thunks.rs
@@ -1028,7 +1028,15 @@ pub(crate) fn emit_tuple_inplace_thunk_bodies<'ctx>(
 
     let clone_fn = get_or_declare_tuple_clone_inplace(ctx, llvm_mod, tuple_key);
     if clone_fn.count_basic_blocks() == 0 {
-        emit_aggregate_clone_inplace_body(ctx, llvm_mod, clone_fn, tuple_struct, &kinds, &w)?;
+        emit_aggregate_clone_inplace_body(
+            ctx,
+            llvm_mod,
+            clone_fn,
+            tuple_struct,
+            &kinds,
+            false,
+            &w,
+        )?;
     }
     let drop_fn = get_or_declare_tuple_drop_inplace(ctx, llvm_mod, tuple_key);
     if drop_fn.count_basic_blocks() == 0 {

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -3599,6 +3599,9 @@ pub(super) fn binder_read_is_borrow_safe_terminator(
 pub(super) fn binder_read_is_borrow_safe_instr(instr: &Instr, binder: u32) -> bool {
     if let Instr::CallRuntimeAbi(call) = instr {
         let contract = crate::runtime_symbols::callee_ownership_contract(call.symbol());
+        if contract.borrows_string_call_args() {
+            return true;
+        }
         if contract.borrows_collection_binder_receiver() || contract.borrows_bytes_receiver() {
             return !call
                 .args()

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -1389,14 +1389,22 @@ fn fresh_string_producer_dest(instr: &Instr) -> Option<Place> {
 /// getter `hew_vec_get_str` lower to block-terminating calls, not `Instr`s).
 fn fresh_string_producer_term_dest(term: &Terminator) -> Option<Place> {
     match term {
-        Terminator::Call { callee, dest, .. }
-            if crate::runtime_symbols::callee_ownership_contract(callee)
-                .produces_fresh_owned_string() =>
-        {
-            *dest
-        }
+        Terminator::Call {
+            callee,
+            builtin: None,
+            dest,
+            ..
+        } if fresh_string_producer_term_admissible(callee) => *dest,
         _ => None,
     }
+}
+fn fresh_string_producer_term_admissible(callee: &str) -> bool {
+    let contract = crate::runtime_symbols::callee_ownership_contract(callee);
+    if contract.returns_receiver_interior_alias() {
+        return false;
+    }
+    !crate::runtime_symbols::is_known_runtime_symbol(callee)
+        || contract.produces_fresh_owned_string()
 }
 /// The dest of a `string`-typed record/tuple/closure-env field load — a fresh
 /// `+1` owner once codegen retains it (`retain_string_field_load`,

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -60,6 +60,10 @@
 #       match-arm destructured call-result payload released exactly once per
 #       loop back-edge. A refcount underflow in any would double-free a
 #       String/Bytes header — invisible to macOS `leaks`, caught here by ASan.
+#   resource-in-enum shapes (#2641)
+#       A match-consumed resource payload with heap-owning sibling variants and
+#       an actor-state resource enum overwritten Loaded→Broken. Both must remain
+#       leak- and double-free-clean through recursive enum/record drop thunks.
 #
 # SHIM: Linux-only gate.  On macOS the leak oracle is the `leaks --atExit`
 # path in hew-cli/tests/*_leak_oracle.rs; ASan + LSan on Darwin does not
@@ -364,6 +368,8 @@ ENUM_PAYLOAD_LOOP_SRC="${ROOT}/tests/vertical-slice/accept/enum_payload_call_loo
 # synthetic owner over the call temp; a double-mint would double-free the payload
 # header — invisible to macOS `leaks`, caught here by ASan. Exits 0, clean.
 CALL_SCRUTINEE_FRESH_SRC="${ROOT}/tests/vertical-slice/accept/call_scrutinee_fresh_forwarder_release.hew"
+ENUM_RESOURCE_MATCH_SRC="${ROOT}/tests/vertical-slice/accept/enum_resource_heap_sibling_asan.hew"
+ENUM_RESOURCE_STATE_SRC="${ROOT}/tests/vertical-slice/accept/enum_resource_state_overwrite_asan.hew"
 
 # ── Step 3: compile the Hew fixtures ─────────────────────────────────────
 echo ""
@@ -409,6 +415,12 @@ compile_asan_fixture "match-scrutinee enum payload (call loop)" "${ENUM_PAYLOAD_
 
 CALL_SCRUTINEE_FRESH_BIN="${WORK_DIR}/call_scrutinee_fresh_forwarder_release"
 compile_asan_fixture "admitted fresh-producer call scrutinee (#2648)" "${CALL_SCRUTINEE_FRESH_SRC}" "${CALL_SCRUTINEE_FRESH_BIN}"
+
+ENUM_RESOURCE_MATCH_BIN="${WORK_DIR}/enum_resource_heap_sibling_asan"
+compile_asan_fixture "resource enum match-consume (#2641)" "${ENUM_RESOURCE_MATCH_SRC}" "${ENUM_RESOURCE_MATCH_BIN}"
+
+ENUM_RESOURCE_STATE_BIN="${WORK_DIR}/enum_resource_state_overwrite_asan"
+compile_asan_fixture "resource enum actor-state overwrite (#2641)" "${ENUM_RESOURCE_STATE_SRC}" "${ENUM_RESOURCE_STATE_BIN}"
 
 # ── Step 3c: compile and link the clean probe via the CLI flag path ───────
 # Uses HEW_SANITIZE_ADDRESS=1 hew build (full link, not --emit-obj) to exercise
@@ -528,6 +540,18 @@ fi
 # admit path is leak-clean under ASan; a double-mint (the #2648 double-free) would
 # surface here as a heap-use-after-free on the payload header.
 if run_asan_fixture "admitted fresh-producer call scrutinee (#2648)" "${CALL_SCRUTINEE_FRESH_BIN}" 0; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+if run_asan_fixture "resource enum match-consume (#2641)" "${ENUM_RESOURCE_MATCH_BIN}" 0; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+if run_asan_fixture "resource enum actor-state overwrite (#2641)" "${ENUM_RESOURCE_STATE_BIN}" 0; then
   pass=$((pass + 1))
 else
   fail=$((fail + 1))

--- a/std/encoding/xml/xml.hew
+++ b/std/encoding/xml/xml.hew
@@ -109,17 +109,7 @@ impl Node {
 /// Parse an XML string into a `Node` tree.
 ///
 /// Panics with the parser's reason if `s` is not well-formed XML.
-///
-/// A non-panicking `try_parse` counterpart returning `Result<Node, string>`
-/// is not offered: `Node` is `#[resource]`-wrapped around an `#[opaque]`
-/// handle, and constructing any enum (`Result` or user-defined) that pairs
-/// that payload with a second, heap-owning variant (e.g. `string`) hits an
-/// unrelated codegen limitation (`OpaqueHandle` has no dup/clone helper,
-/// which today's enum-construction path requires unconditionally for every
-/// variant, not just the active one). Confirmed with minimal repros: a
-/// plain scalar second variant (`i64`) compiles, but any heap-owning
-/// second variant (`string`, or a record wrapping `string`) does not.
-/// Callers that must not panic can guard with `xml.is_wellformed(s)` first.
+/// Use `try_parse(s)` when malformed input should be returned as an error.
 pub fn parse(s: string) -> Node {
     unsafe {
         let handle = hew_xml_parse(s);
@@ -130,10 +120,24 @@ pub fn parse(s: string) -> Node {
     }
 }
 
+/// Parse an XML string without panicking.
+///
+/// Returns the parsed `Node` on success or the parser's error message when
+/// `s` is not well-formed XML.
+pub fn try_parse(s: string) -> Result<Node, string> {
+    unsafe {
+        let handle = hew_xml_parse(s);
+        if hew_xml_is_element(handle) < 0 {
+            Err(hew_xml_last_error())
+        } else {
+            Ok(Node { handle: handle })
+        }
+    }
+}
+
 /// Report whether `s` is well-formed XML, without constructing a `Node`.
 ///
-/// Use this to guard a call to `parse(s)` when the input's well-formedness
-/// is not already known, avoiding the panic.
+/// Prefer `try_parse(s)` when the parsed node or error message is needed.
 pub fn is_wellformed(s: string) -> bool {
     unsafe {
         let handle = hew_xml_parse(s);

--- a/std/option.hew
+++ b/std/option.hew
@@ -4,10 +4,8 @@
 //! operations.  They use `match` on the built-in `Option` type and avoid
 //! FFI calls entirely for the supported element types.
 //!
-//! v0.5 supports user functions returning `Option<T>` for bitcopy payloads
-//! (i64, f64, bool, and other non-heap-owning types). Composite returns of
-//! heap-owning payloads (e.g. `Option<string>`) are rejected at compile time
-//! until tag-aware drop is implemented.
+//! Options may carry both bitcopy and heap-owning payloads. Heap-owning values
+//! are released through tag-aware drop glue when the option remains owned.
 //!
 //! # Examples
 //!

--- a/std/result.hew
+++ b/std/result.hew
@@ -4,10 +4,8 @@
 //! operations.  They use `match` on the built-in `Result` type and avoid
 //! FFI calls entirely for the supported element types.
 //!
-//! v0.5 supports user functions returning `Result<T, E>` for bitcopy payloads
-//! (i64, f64, bool, and other non-heap-owning types). Composite returns of
-//! heap-owning payloads (e.g. `Result<string, string>`) are rejected at compile
-//! time until tag-aware drop is implemented.
+//! Results may carry both bitcopy and heap-owning payloads. Heap-owning values
+//! are released through tag-aware drop glue when the result remains owned.
 //!
 //! # Examples
 //!

--- a/tests/hew/enum_resource_heap_sibling_test.hew
+++ b/tests/hew/enum_resource_heap_sibling_test.hew
@@ -1,0 +1,81 @@
+import std::encoding::xml;
+import std::testing;
+
+type ParseError {
+    message: string;
+    offset: i64;
+}
+
+enum ParseOutcome {
+    Parsed(xml.Node);
+    Failed(ParseError);
+    Skipped(string);
+}
+
+enum ScalarSibling {
+    Loaded(xml.Node);
+    Count(i64);
+}
+
+fn classify(s: string) -> ParseOutcome {
+    if s == "" {
+        ParseOutcome::Skipped("empty".to_upper())
+    } else {
+        match xml.try_parse(s) {
+            Ok(node) => ParseOutcome::Parsed(node),
+            Err(message) => ParseOutcome::Failed(ParseError { message: message, offset: 0 }),
+        }
+    }
+}
+
+#[test]
+fn result_resource_and_string_variants() {
+    match xml.try_parse("<a/>") {
+        Ok(node) => testing.assert_eq_str(node.get_tag(), "a"),
+        Err(_) => testing.assert_true(false),
+    }
+    match xml.try_parse("<a>") {
+        Ok(node) => {
+            node.close();
+            testing.assert_true(false);
+        }
+        Err(message) => testing.assert_true(message.starts_with("xml:")),
+    }
+}
+
+#[test]
+fn user_enum_resource_and_heap_siblings() {
+    match classify("<doc/>") {
+        ParseOutcome::Parsed(node) => testing.assert_eq_str(node.get_tag(), "doc"),
+        ParseOutcome::Failed(_) => testing.assert_true(false),
+        ParseOutcome::Skipped(_) => testing.assert_true(false),
+    }
+    match classify("<doc>") {
+        ParseOutcome::Parsed(node) => {
+            node.close();
+            testing.assert_true(false);
+        }
+        ParseOutcome::Failed(error) => {
+            testing.assert_eq(error.offset, 0);
+            testing.assert_true(error.message.starts_with("xml:"));
+        }
+        ParseOutcome::Skipped(_) => testing.assert_true(false),
+    }
+    match classify("") {
+        ParseOutcome::Parsed(node) => {
+            node.close();
+            testing.assert_true(false);
+        }
+        ParseOutcome::Failed(_) => testing.assert_true(false),
+        ParseOutcome::Skipped(message) => testing.assert_eq_str(message, "EMPTY"),
+    }
+}
+
+#[test]
+fn scalar_sibling_control() {
+    let value = ScalarSibling::Loaded(xml.parse("<x/>"));
+    match value {
+        ScalarSibling::Loaded(node) => testing.assert_eq_str(node.get_tag(), "x"),
+        ScalarSibling::Count(_) => testing.assert_true(false),
+    }
+}

--- a/tests/hew/enum_resource_heap_sibling_test.hew
+++ b/tests/hew/enum_resource_heap_sibling_test.hew
@@ -1,4 +1,5 @@
 import std::encoding::xml;
+
 import std::testing;
 
 type ParseError {
@@ -38,7 +39,7 @@ fn result_resource_and_string_variants() {
         Ok(node) => {
             node.close();
             testing.assert_true(false);
-        }
+        },
         Err(message) => testing.assert_true(message.starts_with("xml:")),
     }
 }
@@ -54,18 +55,18 @@ fn user_enum_resource_and_heap_siblings() {
         ParseOutcome::Parsed(node) => {
             node.close();
             testing.assert_true(false);
-        }
+        },
         ParseOutcome::Failed(error) => {
             testing.assert_eq(error.offset, 0);
             testing.assert_true(error.message.starts_with("xml:"));
-        }
+        },
         ParseOutcome::Skipped(_) => testing.assert_true(false),
     }
     match classify("") {
         ParseOutcome::Parsed(node) => {
             node.close();
             testing.assert_true(false);
-        }
+        },
         ParseOutcome::Failed(_) => testing.assert_true(false),
         ParseOutcome::Skipped(message) => testing.assert_eq_str(message, "EMPTY"),
     }

--- a/tests/hew/xml_try_parse_test.hew
+++ b/tests/hew/xml_try_parse_test.hew
@@ -1,0 +1,21 @@
+import std::encoding::xml;
+import std::testing;
+
+#[test]
+fn try_parse_returns_node() {
+    match xml.try_parse("<root><child/></root>") {
+        Ok(node) => testing.assert_eq_str(node.get_tag(), "root"),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn try_parse_returns_parser_error() {
+    match xml.try_parse("<root>") {
+        Ok(node) => {
+            node.close();
+            testing.assert_true(false);
+        }
+        Err(message) => testing.assert_true(message.starts_with("xml:")),
+    }
+}

--- a/tests/hew/xml_try_parse_test.hew
+++ b/tests/hew/xml_try_parse_test.hew
@@ -1,4 +1,5 @@
 import std::encoding::xml;
+
 import std::testing;
 
 #[test]
@@ -15,7 +16,7 @@ fn try_parse_returns_parser_error() {
         Ok(node) => {
             node.close();
             testing.assert_true(false);
-        }
+        },
         Err(message) => testing.assert_true(message.starts_with("xml:")),
     }
 }

--- a/tests/vertical-slice/accept/enum_resource_heap_sibling_asan.hew
+++ b/tests/vertical-slice/accept/enum_resource_heap_sibling_asan.hew
@@ -1,0 +1,27 @@
+import std::encoding::xml;
+
+type ParseError {
+    message: string;
+    offset: i64;
+}
+
+enum ParseOutcome {
+    Parsed(xml.Node);
+    Failed(ParseError);
+    Skipped(string);
+}
+
+fn classify(s: string) -> ParseOutcome {
+    match xml.try_parse(s) {
+        Ok(node) => ParseOutcome::Parsed(node),
+        Err(message) => ParseOutcome::Failed(ParseError { message: message, offset: 0 }),
+    }
+}
+
+fn main() {
+    match classify("<root/>") {
+        ParseOutcome::Parsed(node) => println(node.get_tag()),
+        ParseOutcome::Failed(error) => println(error.message),
+        ParseOutcome::Skipped(message) => println(message),
+    }
+}

--- a/tests/vertical-slice/accept/enum_resource_state_overwrite_asan.hew
+++ b/tests/vertical-slice/accept/enum_resource_state_overwrite_asan.hew
@@ -11,8 +11,12 @@ actor DocHolder {
 
     receive fn load(s: string) -> i64 {
         match xml.try_parse(s) {
-            Ok(node) => { doc = DocState::Loaded(node); },
-            Err(message) => { doc = DocState::Broken(message); },
+            Ok(node) => {
+                doc = DocState::Loaded(node);
+            },
+            Err(message) => {
+                doc = DocState::Broken(message);
+            },
         }
         1
     }

--- a/tests/vertical-slice/accept/enum_resource_state_overwrite_asan.hew
+++ b/tests/vertical-slice/accept/enum_resource_state_overwrite_asan.hew
@@ -1,0 +1,26 @@
+import std::encoding::xml;
+
+enum DocState {
+    Empty;
+    Loaded(xml.Node);
+    Broken(string);
+}
+
+actor DocHolder {
+    var doc: DocState;
+
+    receive fn load(s: string) -> i64 {
+        match xml.try_parse(s) {
+            Ok(node) => { doc = DocState::Loaded(node); },
+            Err(message) => { doc = DocState::Broken(message); },
+        }
+        1
+    }
+}
+
+fn main() -> i64 {
+    let holder = spawn DocHolder(doc: DocState::Empty);
+    let first = (await holder.load("<doc/>")).unwrap_or(0);
+    let second = (await holder.load("<doc>")).unwrap_or(0);
+    first + second - 2
+}


### PR DESCRIPTION
## Summary

I close two resource-cleanup leaks in enum payloads. A `Result<Node, string>` (or any enum carrying a resource-typed variant) returned from a call over-retained and leaked its heap payload (~48B), and an RAII-scoped resource returned as part of an aggregate leaked its whole tree (~464B across 5 objects) because the paired drop helper was never emitted. I now mint the drop helper from the typed descriptor and close the string call-temporaries. I also add `xml.try_parse`, a single-parse validate-or-error entry point that avoids the double parse that `is_wellformed` + `parse` incurs. Resource-bearing enums that would need supervisor-restart cloning are now refused at compile time rather than miscompiled, since that clone path is not yet implemented.

## Verification

- Fail-without-fix leak oracle: neutering the MIR drop-plan fix returns both leaks; neutering the LLVM side fails closed at compile time.
- Two ASan fixtures for resource enums: 0-leak.
- `make lint`: green.
- `make test-hew-ratchet`: green.
- `make checked-mir-verify`: green.

## Out of scope

- A separate, pre-existing actor string-reply leak (~48B via `alloc_cstring_data`, which reproduces even with a resource-free scalar variant) is tracked in #2717 and not touched here.

Fixes #2641