### PR TITLE
fix(mir): release reassigned while-let scrutinee on the loop back-edge

### DIFF
--- a/hew-cli/tests/while_let_reassign_leak_oracle.rs
+++ b/hew-cli/tests/while_let_reassign_leak_oracle.rs
@@ -1,0 +1,124 @@
+//! Leak and exactly-once guards for reassigned `BindingRef` while-let scrutinees.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+fn source(frames: usize, move_payload: bool) -> String {
+    let payload_use = if move_payload {
+        "let moved = s;\n        total = total + moved.len();"
+    } else {
+        "total = total + s.len();"
+    };
+    let payload = if move_payload {
+        "wl-backedge-payload"
+    } else {
+        "while-let-backedge-payload-abcdefghijklmnopqrstuvwxyz"
+    };
+    format!(
+        "enum Packet {{\n\
+         \x20   Payload(string);\n\
+         \x20   Done;\n\
+         }}\n\
+         fn next(i: i64, cap: i64) -> Packet {{\n\
+         \x20   if i < cap {{\n\
+         \x20       Packet::Payload(\"{payload}\".to_upper())\n\
+         \x20   }} else {{\n\
+         \x20       Packet::Done\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var i = 0;\n\
+         \x20   var q = next(i, {frames});\n\
+         \x20   var total = 0;\n\
+         \x20   while let Packet::Payload(s) = q {{\n\
+         \x20       {payload_use}\n\
+         \x20       i = i + 1;\n\
+         \x20       q = next(i, {frames});\n\
+         \x20   }}\n\
+         \x20   if total >= 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+fn fully_bound_source(frames: usize) -> String {
+    source(frames, false)
+}
+
+fn moved_out_source(frames: usize) -> String {
+    source(frames, true)
+}
+
+const EXIT_EDGES_SOURCE: &str = r#"
+enum Packet {
+    Payload(string);
+    Done;
+}
+
+fn next(i: i64, cap: i64) -> Packet {
+    if i < cap {
+        Packet::Payload("while-let-backedge-edge-payload-abcdefghijklmnopqrstuvwxyz".to_upper())
+    } else {
+        Packet::Done
+    }
+}
+
+fn run_break() {
+    var i = 0;
+    var q = next(i, 4);
+    while let Packet::Payload(s) = q {
+        if s.len() > 0 {
+            break;
+        }
+        i = i + 1;
+        q = next(i, 4);
+    }
+}
+
+fn run_tag_false() {
+    var i = 0;
+    var q = next(i, 4);
+    while let Packet::Payload(s) = q {
+        i = i + 1;
+        q = next(i, 4);
+    }
+}
+
+fn main() {
+    run_break();
+    run_tag_false();
+    print("ok");
+}
+"#;
+
+#[test]
+fn while_let_reassigned_fully_bound_payload_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("while_let_reassign_fully_bound", fully_bound_source);
+}
+
+#[test]
+fn while_let_reassigned_moved_out_payload_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("while_let_reassign_moved_out", moved_out_source);
+}
+
+#[test]
+fn while_let_reassigned_break_and_tag_false_release_exactly_once() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("while-let-reassign-scribble-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(EXIT_EDGES_SOURCE, dir.path(), "while_let_reassign_edges");
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "reassigned while-let edge cleanup must not double-free:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "ok");
+}

--- a/hew-mir/src/lower/control_flow.rs
+++ b/hew-mir/src/lower/control_flow.rs
@@ -1,8 +1,10 @@
 use super::{
-    base_local, integer_bit_width, integer_signedness, ActiveIterationOwner, Builder, CmpPred,
-    HashSet, HirExpr, Instr, IntArithOp, IntSignedness, LoopFrame, MirDiagnostic,
+    base_local, binding_reassignment_values_in_block, integer_bit_width, integer_signedness,
+    ty_is_heap_owning_enum_composite, ActiveIterationOwner, Builder, CmpPred, HashSet, HirExpr,
+    HirExprKind, HirStmtKind, Instr, IntArithOp, IntSignedness, LoopFrame, MirDiagnostic,
     MirDiagnosticKind, MirStatement, Place, ProjectedPayloadOrigin, ProjectedPayloadRejectReason,
-    ResolvedTy, Terminator, TrapKind, SYNTHETIC_CALL_SCRUTINEE_NAME,
+    ResolvedRef, ResolvedTy, Terminator, TrapKind, SYNTHETIC_CALL_SCRUTINEE_NAME,
+    SYNTHETIC_WHILE_LET_ITERATION_NAME,
 };
 
 impl Builder {
@@ -399,6 +401,14 @@ impl Builder {
                 return None;
             }
         };
+        let binding_iteration_owner_ty =
+            match self.classify_while_let_binding_iteration_owner(label, scrutinee, body) {
+                Ok(owner_ty) => owner_ty,
+                Err(diag) => {
+                    self.diagnostics.push(*diag);
+                    return None;
+                }
+            };
         // Fail-closed: a `while let` over an enum variant that leaves an OWNED
         // payload field unaccounted for (a `..` rest or a bare `_` sibling)
         // cannot release that field's heap on the loop back-edge. The header
@@ -469,6 +479,22 @@ impl Builder {
             scrutinee,
             scrutinee_local,
         );
+        let binding_iteration_owner = binding_iteration_owner_ty.map(|ty| {
+            let snapshot_place = self.alloc_local(ty.clone());
+            let Place::Local(snapshot_local) = snapshot_place else {
+                unreachable!("alloc_local returns Place::Local");
+            };
+            self.push_instr(Instr::Move {
+                dest: snapshot_place,
+                src: Place::Local(scrutinee_local),
+            });
+            let binding =
+                self.register_while_let_iteration_owner(scrutinee, snapshot_local, ty.clone());
+            (binding, ty, snapshot_local)
+        });
+        let pattern_scrutinee_local = binding_iteration_owner
+            .as_ref()
+            .map_or(scrutinee_local, |(_, _, snapshot_local)| *snapshot_local);
         let false_cleanup_bb = scrutinee_owner.as_ref().map(|_| self.alloc_block());
 
         // Load the variant tag into a fresh i64 local, mirroring
@@ -478,7 +504,7 @@ impl Builder {
         let tag_local = self.alloc_local(ResolvedTy::I64);
         self.push_instr(Instr::Move {
             dest: tag_local,
-            src: Place::EnumTag(scrutinee_local),
+            src: Place::EnumTag(pattern_scrutinee_local),
         });
 
         // Compare tag against the continue-arm variant index.
@@ -513,7 +539,7 @@ impl Builder {
         for pvp in payload_variant_predicates {
             self.emit_payload_variant_predicate_checks(
                 pvp,
-                scrutinee_local,
+                pattern_scrutinee_local,
                 variant_idx,
                 false_cleanup_bb.unwrap_or(exit_bb),
                 scrutinee.site,
@@ -550,7 +576,7 @@ impl Builder {
             self.push_instr(Instr::Move {
                 dest,
                 src: Place::MachineVariant {
-                    local: scrutinee_local,
+                    local: pattern_scrutinee_local,
                     variant_idx,
                     field_idx: binding.field_idx,
                 },
@@ -566,7 +592,7 @@ impl Builder {
                 binding.binding,
                 &binding.name,
                 Place::MachineVariant {
-                    local: scrutinee_local,
+                    local: pattern_scrutinee_local,
                     variant_idx,
                     field_idx: binding.field_idx,
                 },
@@ -663,6 +689,14 @@ impl Builder {
                 ty,
             );
         }
+        if let Some((binding, ty, _)) = &binding_iteration_owner {
+            self.record_iteration_owner_drop(
+                *binding,
+                SYNTHETIC_WHILE_LET_ITERATION_NAME,
+                scrutinee.site,
+                ty,
+            );
+        }
         // Record this block as a loop-body back-edge so `enumerate_exits`
         // populates its `Goto` `DropPlan` with per-iteration releases for
         // heap-owning bindings declared in `body.scope` (including the
@@ -700,6 +734,461 @@ impl Builder {
         // Exit: subsequent lowering continues here.
         self.start_block(exit_bb);
         None
+    }
+
+    fn classify_while_let_binding_iteration_owner(
+        &self,
+        label: Option<&str>,
+        scrutinee: &HirExpr,
+        body: &hew_hir::HirBlock,
+    ) -> Result<Option<ResolvedTy>, Box<MirDiagnostic>> {
+        let HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(binding),
+            ..
+        } = &scrutinee.kind
+        else {
+            return Ok(None);
+        };
+        let ty = self.subst_ty(&scrutinee.ty);
+        if !ty_is_heap_owning_enum_composite(&ty, &self.record_field_orders, &self.enum_layouts) {
+            return Ok(None);
+        }
+
+        let nested_reassignments = binding_reassignment_values_in_block(body, *binding);
+        if nested_reassignments.is_empty() {
+            return Ok(None);
+        }
+        let top_level_reassignments: Vec<(usize, &HirExpr)> = body
+            .statements
+            .iter()
+            .enumerate()
+            .filter_map(|(index, stmt)| match &stmt.kind {
+                HirStmtKind::Assign { target, value }
+                    if matches!(
+                        &target.kind,
+                        HirExprKind::BindingRef {
+                            resolved: ResolvedRef::Binding(target_binding),
+                            ..
+                        } if target_binding == binding
+                    ) =>
+                {
+                    Some((index, value.as_ref()))
+                }
+                _ => None,
+            })
+            .collect();
+
+        if nested_reassignments.len() != 1 || top_level_reassignments.len() != 1 {
+            return Err(Box::new(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "while-let scrutinee conditionally reassigned in loop body"
+                        .to_string(),
+                    site: scrutinee.site,
+                },
+                note: "a heap-owning while-let scrutinee binding may currently be reassigned \
+                       exactly once by an unconditional top-level statement; move the \
+                       reassignment out of nested control flow"
+                    .to_string(),
+            }));
+        }
+        if self.while_let_body_contains_targeting_continue(body, label, 0) {
+            return Err(Box::new(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "while-let reassigned scrutinee with continue".to_string(),
+                    site: scrutinee.site,
+                },
+                note: "a continue edge may bypass the unconditional fresh reassignment; \
+                       rewrite the body without continue before using a reassigned \
+                       heap-owning while-let scrutinee"
+                    .to_string(),
+            }));
+        }
+        let (reassignment_index, reassignment_value) = top_level_reassignments[0];
+        if self.while_let_body_has_exit_after_reassignment(body, label, reassignment_index) {
+            return Err(Box::new(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "while-let reassigned scrutinee with post-reassignment exit"
+                        .to_string(),
+                    site: scrutinee.site,
+                },
+                note: "break or return after the reassignment would bypass the back-edge-only \
+                       snapshot release; move the exit before the reassignment"
+                    .to_string(),
+            }));
+        }
+        if !self.while_let_reassignment_provably_fresh(reassignment_value) {
+            return Err(Box::new(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "while-let scrutinee reassigned from non-fresh value".to_string(),
+                    site: scrutinee.site,
+                },
+                note: "the reassignment must produce a proven-fresh value; assigning from a \
+                       re-readable binding or projection could alias the iteration snapshot"
+                    .to_string(),
+            }));
+        }
+        Ok(Some(ty))
+    }
+
+    fn while_let_reassignment_provably_fresh(&self, value: &HirExpr) -> bool {
+        if matches!(value.kind, HirExprKind::Call { .. }) {
+            return self
+                .classify_call_scrutinee_admission(value)
+                .is_ok_and(|admission| {
+                    !matches!(
+                        admission,
+                        crate::return_provenance::CallScrutineeAdmission::NotApplicable
+                    )
+                });
+        }
+        self.scrutinee_arg_provably_fresh(value)
+    }
+
+    fn while_let_body_has_exit_after_reassignment(
+        &self,
+        body: &hew_hir::HirBlock,
+        label: Option<&str>,
+        reassignment_index: usize,
+    ) -> bool {
+        body.statements[reassignment_index + 1..]
+            .iter()
+            .any(|stmt| match &stmt.kind {
+                HirStmtKind::Return(_) => true,
+                HirStmtKind::Let(_, init) => init
+                    .as_ref()
+                    .is_some_and(|expr| self.while_let_expr_has_unsafe_exit(expr, label, 0)),
+                HirStmtKind::Assign { target, value } => {
+                    self.while_let_expr_has_unsafe_exit(target, label, 0)
+                        || self.while_let_expr_has_unsafe_exit(value, label, 0)
+                }
+                HirStmtKind::Expr(expr) => self.while_let_expr_has_unsafe_exit(expr, label, 0),
+                HirStmtKind::Defer { body, .. } => {
+                    self.while_let_expr_has_unsafe_exit(body, label, 0)
+                }
+                HirStmtKind::LetElse {
+                    scrutinee,
+                    success_prelude,
+                    else_body,
+                    ..
+                } => {
+                    self.while_let_expr_has_unsafe_exit(scrutinee, label, 0)
+                        || success_prelude.iter().any(|stmt| {
+                            if let HirStmtKind::Let(_, Some(value)) = &stmt.kind {
+                                self.while_let_expr_has_unsafe_exit(value, label, 0)
+                            } else {
+                                false
+                            }
+                        })
+                        || self.while_let_block_has_unsafe_exit(else_body, label, 0)
+                }
+            })
+            || body
+                .tail
+                .as_ref()
+                .is_some_and(|tail| self.while_let_expr_has_unsafe_exit(tail, label, 0))
+    }
+
+    fn while_let_block_has_unsafe_exit(
+        &self,
+        block: &hew_hir::HirBlock,
+        label: Option<&str>,
+        nested_loop_depth: usize,
+    ) -> bool {
+        block.statements.iter().any(|stmt| match &stmt.kind {
+            HirStmtKind::Return(_) => true,
+            HirStmtKind::Let(_, init) => init.as_ref().is_some_and(|expr| {
+                self.while_let_expr_has_unsafe_exit(expr, label, nested_loop_depth)
+            }),
+            HirStmtKind::Assign { target, value } => {
+                self.while_let_expr_has_unsafe_exit(target, label, nested_loop_depth)
+                    || self.while_let_expr_has_unsafe_exit(value, label, nested_loop_depth)
+            }
+            HirStmtKind::Expr(expr) => {
+                self.while_let_expr_has_unsafe_exit(expr, label, nested_loop_depth)
+            }
+            HirStmtKind::Defer { body, .. } => {
+                self.while_let_expr_has_unsafe_exit(body, label, nested_loop_depth)
+            }
+            HirStmtKind::LetElse {
+                scrutinee,
+                success_prelude,
+                else_body,
+                ..
+            } => {
+                self.while_let_expr_has_unsafe_exit(scrutinee, label, nested_loop_depth)
+                    || success_prelude.iter().any(|stmt| {
+                        if let HirStmtKind::Let(_, Some(value)) = &stmt.kind {
+                            self.while_let_expr_has_unsafe_exit(value, label, nested_loop_depth)
+                        } else {
+                            false
+                        }
+                    })
+                    || self.while_let_block_has_unsafe_exit(else_body, label, nested_loop_depth)
+            }
+        }) || block
+            .tail
+            .as_ref()
+            .is_some_and(|tail| self.while_let_expr_has_unsafe_exit(tail, label, nested_loop_depth))
+    }
+
+    fn while_let_expr_has_unsafe_exit(
+        &self,
+        expr: &HirExpr,
+        label: Option<&str>,
+        nested_loop_depth: usize,
+    ) -> bool {
+        match &expr.kind {
+            HirExprKind::Return { .. } => true,
+            HirExprKind::Break {
+                label: break_label, ..
+            } => break_label
+                .as_deref()
+                .map_or(nested_loop_depth == 0, |name| label == Some(name)),
+            HirExprKind::Block(block) | HirExprKind::Scope { body: block } => {
+                self.while_let_block_has_unsafe_exit(block, label, nested_loop_depth)
+            }
+            HirExprKind::If {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.while_let_expr_has_unsafe_exit(condition, label, nested_loop_depth)
+                    || self.while_let_expr_has_unsafe_exit(then_expr, label, nested_loop_depth)
+                    || else_expr.as_ref().is_some_and(|else_expr| {
+                        self.while_let_expr_has_unsafe_exit(else_expr, label, nested_loop_depth)
+                    })
+            }
+            HirExprKind::Match { scrutinee, arms } => {
+                self.while_let_expr_has_unsafe_exit(scrutinee, label, nested_loop_depth)
+                    || arms.iter().any(|arm| {
+                        arm.guard.as_ref().is_some_and(|guard| {
+                            self.while_let_expr_has_unsafe_exit(guard, label, nested_loop_depth)
+                        }) || self.while_let_expr_has_unsafe_exit(
+                            &arm.body,
+                            label,
+                            nested_loop_depth,
+                        )
+                    })
+            }
+            HirExprKind::IfLet {
+                scrutinee,
+                body,
+                else_body,
+                ..
+            } => {
+                self.while_let_expr_has_unsafe_exit(scrutinee, label, nested_loop_depth)
+                    || self.while_let_block_has_unsafe_exit(body, label, nested_loop_depth)
+                    || else_body.as_ref().is_some_and(|else_body| {
+                        self.while_let_block_has_unsafe_exit(else_body, label, nested_loop_depth)
+                    })
+            }
+            HirExprKind::While {
+                condition, body, ..
+            } => {
+                self.while_let_expr_has_unsafe_exit(condition, label, nested_loop_depth)
+                    || self.while_let_block_has_unsafe_exit(body, label, nested_loop_depth + 1)
+            }
+            HirExprKind::ForRange {
+                start,
+                end,
+                step,
+                body,
+                ..
+            } => {
+                self.while_let_expr_has_unsafe_exit(start, label, nested_loop_depth)
+                    || self.while_let_expr_has_unsafe_exit(end, label, nested_loop_depth)
+                    || self.while_let_expr_has_unsafe_exit(step, label, nested_loop_depth)
+                    || self.while_let_block_has_unsafe_exit(body, label, nested_loop_depth + 1)
+            }
+            HirExprKind::WhileLet {
+                scrutinee, body, ..
+            } => {
+                self.while_let_expr_has_unsafe_exit(scrutinee, label, nested_loop_depth)
+                    || self.while_let_block_has_unsafe_exit(body, label, nested_loop_depth + 1)
+            }
+            HirExprKind::Loop { body, .. } => {
+                self.while_let_block_has_unsafe_exit(body, label, nested_loop_depth + 1)
+            }
+            _ => false,
+        }
+    }
+
+    fn while_let_body_contains_targeting_continue(
+        &self,
+        block: &hew_hir::HirBlock,
+        label: Option<&str>,
+        nested_loop_depth: usize,
+    ) -> bool {
+        block.statements.iter().any(|stmt| {
+            let expr_has_continue = |expr: &HirExpr| {
+                self.while_let_expr_contains_targeting_continue(expr, label, nested_loop_depth)
+            };
+            match &stmt.kind {
+                HirStmtKind::Let(_, init) => init.as_ref().is_some_and(expr_has_continue),
+                HirStmtKind::Assign { target, value } => {
+                    expr_has_continue(target) || expr_has_continue(value)
+                }
+                HirStmtKind::Expr(expr) | HirStmtKind::Return(Some(expr)) => {
+                    expr_has_continue(expr)
+                }
+                HirStmtKind::Return(None) => false,
+                HirStmtKind::Defer { body, .. } => expr_has_continue(body),
+                HirStmtKind::LetElse {
+                    scrutinee,
+                    success_prelude,
+                    else_body,
+                    ..
+                } => {
+                    expr_has_continue(scrutinee)
+                        || success_prelude.iter().any(|stmt| {
+                            if let HirStmtKind::Let(_, Some(value)) = &stmt.kind {
+                                expr_has_continue(value)
+                            } else {
+                                false
+                            }
+                        })
+                        || self.while_let_body_contains_targeting_continue(
+                            else_body,
+                            label,
+                            nested_loop_depth,
+                        )
+                }
+            }
+        }) || block.tail.as_ref().is_some_and(|tail| {
+            self.while_let_expr_contains_targeting_continue(tail, label, nested_loop_depth)
+        })
+    }
+
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the recursive control-flow scan keeps every loop and branch shape visible so a \
+                  newly admitted continue path cannot silently bypass the snapshot release"
+    )]
+    fn while_let_expr_contains_targeting_continue(
+        &self,
+        expr: &HirExpr,
+        label: Option<&str>,
+        nested_loop_depth: usize,
+    ) -> bool {
+        match &expr.kind {
+            HirExprKind::Continue {
+                label: continue_label,
+            } => continue_label
+                .as_deref()
+                .map_or(nested_loop_depth == 0, |name| label == Some(name)),
+            HirExprKind::Block(block) | HirExprKind::Scope { body: block } => {
+                self.while_let_body_contains_targeting_continue(block, label, nested_loop_depth)
+            }
+            HirExprKind::If {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.while_let_expr_contains_targeting_continue(condition, label, nested_loop_depth)
+                    || self.while_let_expr_contains_targeting_continue(
+                        then_expr,
+                        label,
+                        nested_loop_depth,
+                    )
+                    || else_expr.as_ref().is_some_and(|else_expr| {
+                        self.while_let_expr_contains_targeting_continue(
+                            else_expr,
+                            label,
+                            nested_loop_depth,
+                        )
+                    })
+            }
+            HirExprKind::Match { scrutinee, arms } => {
+                self.while_let_expr_contains_targeting_continue(scrutinee, label, nested_loop_depth)
+                    || arms.iter().any(|arm| {
+                        arm.guard.as_ref().is_some_and(|guard| {
+                            self.while_let_expr_contains_targeting_continue(
+                                guard,
+                                label,
+                                nested_loop_depth,
+                            )
+                        }) || self.while_let_expr_contains_targeting_continue(
+                            &arm.body,
+                            label,
+                            nested_loop_depth,
+                        )
+                    })
+            }
+            HirExprKind::IfLet {
+                scrutinee,
+                body,
+                else_body,
+                ..
+            } => {
+                self.while_let_expr_contains_targeting_continue(scrutinee, label, nested_loop_depth)
+                    || self.while_let_body_contains_targeting_continue(
+                        body,
+                        label,
+                        nested_loop_depth,
+                    )
+                    || else_body.as_ref().is_some_and(|else_body| {
+                        self.while_let_body_contains_targeting_continue(
+                            else_body,
+                            label,
+                            nested_loop_depth,
+                        )
+                    })
+            }
+            HirExprKind::While {
+                condition, body, ..
+            } => {
+                self.while_let_expr_contains_targeting_continue(condition, label, nested_loop_depth)
+                    || self.while_let_body_contains_targeting_continue(
+                        body,
+                        label,
+                        nested_loop_depth + 1,
+                    )
+            }
+            HirExprKind::ForRange {
+                start,
+                end,
+                step,
+                body,
+                ..
+            } => {
+                self.while_let_expr_contains_targeting_continue(start, label, nested_loop_depth)
+                    || self.while_let_expr_contains_targeting_continue(
+                        end,
+                        label,
+                        nested_loop_depth,
+                    )
+                    || self.while_let_expr_contains_targeting_continue(
+                        step,
+                        label,
+                        nested_loop_depth,
+                    )
+                    || self.while_let_body_contains_targeting_continue(
+                        body,
+                        label,
+                        nested_loop_depth + 1,
+                    )
+            }
+            HirExprKind::WhileLet {
+                scrutinee, body, ..
+            } => {
+                self.while_let_expr_contains_targeting_continue(scrutinee, label, nested_loop_depth)
+                    || self.while_let_body_contains_targeting_continue(
+                        body,
+                        label,
+                        nested_loop_depth + 1,
+                    )
+            }
+            HirExprKind::Loop { body, .. } => {
+                self.while_let_body_contains_targeting_continue(body, label, nested_loop_depth + 1)
+            }
+            HirExprKind::Break {
+                value: Some(value), ..
+            }
+            | HirExprKind::Return { value: Some(value) } => {
+                self.while_let_expr_contains_targeting_continue(value, label, nested_loop_depth)
+            }
+            _ => false,
+        }
     }
 
     /// Detect a `while let` enum-variant pattern that leaves an OWNED payload

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -226,6 +226,9 @@ pub(super) fn elaborate(
     // ledger carried richer facts, in the same declaration order.
     let owned_locals_snapshot = builder.owned_locals_snapshot();
     for (binding, name, ty) in owned_locals_snapshot.iter().rev() {
+        if builder.back_edge_only_iteration_owners.contains(binding) {
+            continue;
+        }
         elaborated_statements.push(MirStatement::Drop {
             binding: *binding,
             name: name.clone(),
@@ -757,9 +760,19 @@ pub(super) fn elaborate(
         &builder.resource_drop_flags,
         &builder.collection_drop_flags,
     );
+    let ordinary_lifo_drops: Vec<ElabDrop> = lifo_drops
+        .iter()
+        .filter(|drop| {
+            !builder
+                .back_edge_only_iteration_owners
+                .iter()
+                .any(|binding| builder.binding_locals.get(binding).copied() == Some(drop.place))
+        })
+        .cloned()
+        .collect();
     let (elab_blocks, mut drop_plans) = enumerate_exits(
         &checked.blocks,
-        &lifo_drops,
+        &ordinary_lifo_drops,
         &dataflow_result.exit_states,
         &dataflow_result.entry_states,
         &builder.binding_locals,

--- a/hew-mir/src/lower/facts.rs
+++ b/hew-mir/src/lower/facts.rs
@@ -207,6 +207,23 @@ fn collect_binding_defs_in_block<'f>(
         collect_binding_defs_in_expr(tail, defs, let_ids);
     }
 }
+
+/// Every whole-binding reassignment of `binding` nested within `block`.
+///
+/// Binding ids are function-unique, so the existing exhaustive definition
+/// collector can be reused here: the queried binding was declared outside the
+/// while-let body, and therefore every definition found inside the body is an
+/// assignment rather than a shadowing `let`.
+pub(crate) fn binding_reassignment_values_in_block(
+    block: &HirBlock,
+    binding: BindingId,
+) -> Vec<&HirExpr> {
+    let mut defs = HashMap::new();
+    let mut let_ids = HashSet::new();
+    collect_binding_defs_in_block(block, &mut defs, &mut let_ids);
+    defs.remove(&binding).unwrap_or_default()
+}
+
 /// Recurse into every sub-expression and nested block of `expr` so
 /// `collect_binding_defs_in_block` reaches every `let`/`=` in inner scopes.
 /// Mirrors the sealed `HirExprKind` surface (cf.

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -263,6 +263,7 @@ const SENTINEL_RECV_GEN_COMPANION_BINDING: BindingId = BindingId(u32::MAX - 4);
 const SYNTHETIC_OWNED_TEMP_BINDING_BASE: u32 = u32::MAX - 64;
 
 const SYNTHETIC_CALL_SCRUTINEE_NAME: &str = "__hew_call_scrutinee";
+const SYNTHETIC_WHILE_LET_ITERATION_NAME: &str = "__hew_while_let_iteration";
 const SYNTHETIC_DISCARDED_CALL_RESULT_NAME: &str = "__hew_discarded_call_result";
 
 /// Prefix of the synthetic for-iteration cursor binding minted by the HIR
@@ -683,6 +684,11 @@ struct Builder {
     /// Each binding is also marked consumed in the source block's statement
     /// stream, so the target's later function exit cannot release it again.
     pub(crate) iteration_owner_drop_blocks: HashMap<u32, Vec<BindingId>>,
+    /// Header snapshot owners whose drop template is valid only on a recorded
+    /// loop back-edge. Ordinary exit plans exclude these bindings because the
+    /// source binding still owns the same value on tag-false and pre-reassign
+    /// break/return edges.
+    pub(crate) back_edge_only_iteration_owners: HashSet<BindingId>,
     /// Diagnostics collected during MIR building (e.g., Unsupported HIR nodes).
     pub(crate) diagnostics: Vec<MirDiagnostic>,
     /// Per-function de-duplication for W3.029 user-aggregate value-class

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -10,6 +10,7 @@ use super::{
     Projection, ResolvedRef, ResolvedTy, ResourceMarker, SiteId, Strategy, Terminator, ValueClass,
     ValueOwnership, ValueProvenance, SYNTHETIC_CALL_SCRUTINEE_NAME,
     SYNTHETIC_DISCARDED_CALL_RESULT_NAME, SYNTHETIC_OWNED_TEMP_BINDING_BASE,
+    SYNTHETIC_WHILE_LET_ITERATION_NAME,
 };
 
 impl Builder {
@@ -415,6 +416,21 @@ impl Builder {
             ty.clone(),
         );
         Some((binding, ty))
+    }
+    pub(crate) fn register_while_let_iteration_owner(
+        &mut self,
+        scrutinee: &HirExpr,
+        snapshot_local: u32,
+        ty: ResolvedTy,
+    ) -> BindingId {
+        let binding = self.register_synthetic_owned_local(
+            SYNTHETIC_WHILE_LET_ITERATION_NAME,
+            scrutinee.site,
+            snapshot_local,
+            ty,
+        );
+        self.back_edge_only_iteration_owners.insert(binding);
+        binding
     }
     pub(crate) fn discarded_call_result_owned_ty(&self, expr: &HirExpr) -> Option<ResolvedTy> {
         if let Some(ty) = self.call_scrutinee_owned_ty(expr) {

--- a/hew-mir/tests/lowering_expr.rs
+++ b/hew-mir/tests/lowering_expr.rs
@@ -74,6 +74,8 @@ mod unary_lowering;
 mod vec_slice_range;
 #[path = "lowering_expr/vertical.rs"]
 mod vertical;
+#[path = "lowering_expr/while_let_reassign_owner.rs"]
+mod while_let_reassign_owner;
 #[path = "lowering_expr/while_let_skipped_owned.rs"]
 mod while_let_skipped_owned;
 #[path = "lowering_expr/wrapping_lowering.rs"]

--- a/hew-mir/tests/lowering_expr/while_let_reassign_owner.rs
+++ b/hew-mir/tests/lowering_expr/while_let_reassign_owner.rs
@@ -1,0 +1,250 @@
+//! Back-edge-only ownership for a reassigned `BindingRef` while-let scrutinee.
+
+use hew_hir::{lower_program, ResolutionCtx};
+use hew_mir::{
+    lower_hir_module, DropKind, ExitPath, Instr, IrPipeline, MirDiagnosticKind, MirStatement, Place,
+};
+use hew_types::{module_registry::ModuleRegistry, Checker};
+
+const ITERATION_OWNER_NAME: &str = "__hew_while_let_iteration";
+
+fn pipeline(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(
+        tc_output.errors.is_empty(),
+        "type errors: {:#?}",
+        tc_output.errors
+    );
+    let output = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "HIR diagnostics: {:#?}",
+        output.diagnostics
+    );
+    lower_hir_module(&output.module)
+}
+
+const REASSIGNED_WITH_BREAK: &str = r#"
+enum Packet {
+    Payload(string);
+    Done;
+}
+
+fn next(i: i64, cap: i64) -> Packet {
+    if i < cap {
+        Packet::Payload("while-let-backedge-payload-abcdefghijklmnopqrstuvwxyz".to_upper())
+    } else {
+        Packet::Done
+    }
+}
+
+fn probe(cap: i64) -> i64 {
+    var i = 0;
+    var q = next(i, cap);
+    var total = 0;
+    while let Packet::Payload(s) = q {
+        if i == 2 {
+            break;
+        }
+        total = total + s.len();
+        i = i + 1;
+        q = next(i, cap);
+    }
+    total
+}
+"#;
+
+fn snapshot_and_source_locals(pipeline: &IrPipeline) -> (u32, u32, u32) {
+    let raw = pipeline
+        .raw_mir
+        .iter()
+        .find(|function| function.name == "probe")
+        .expect("probe raw MIR");
+    let header = raw
+        .blocks
+        .iter()
+        .find(|block| {
+            block.statements.iter().any(|statement| {
+                matches!(
+                    statement,
+                    MirStatement::Bind { name, .. } if name == ITERATION_OWNER_NAME
+                )
+            })
+        })
+        .expect("while-let header with iteration owner");
+    let snapshot_local = header
+        .instructions
+        .iter()
+        .find_map(|instruction| match instruction {
+            Instr::Move {
+                src: Place::EnumTag(local),
+                ..
+            } => Some(*local),
+            _ => None,
+        })
+        .expect("tag read from snapshot local");
+    let source_local = header
+        .instructions
+        .iter()
+        .find_map(|instruction| match instruction {
+            Instr::Move {
+                dest: Place::Local(dest),
+                src: Place::Local(src),
+            } if *dest == snapshot_local => Some(*src),
+            _ => None,
+        })
+        .expect("source binding copied into snapshot");
+    (header.id, snapshot_local, source_local)
+}
+
+#[test]
+fn reassigned_binding_snapshot_drops_once_on_back_edge_only() {
+    let pipeline = pipeline(REASSIGNED_WITH_BREAK);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "MIR diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    let (header_id, snapshot_local, source_local) = snapshot_and_source_locals(&pipeline);
+    let function = pipeline
+        .elaborated_mir
+        .iter()
+        .find(|function| function.name == "probe")
+        .expect("probe elaborated MIR");
+
+    let mut back_edge_snapshot_drops = 0;
+    let mut other_snapshot_drops = 0;
+    let mut return_source_drops = 0;
+    for (exit, plan) in &function.drop_plans {
+        for drop in &plan.drops {
+            if drop.place == Place::Local(snapshot_local)
+                && matches!(drop.kind, DropKind::EnumInPlace)
+            {
+                if matches!(exit, ExitPath::Goto { target, .. } if *target == header_id) {
+                    back_edge_snapshot_drops += 1;
+                } else {
+                    other_snapshot_drops += 1;
+                }
+            }
+            if drop.place == Place::Local(source_local)
+                && matches!(drop.kind, DropKind::EnumInPlace)
+                && matches!(exit, ExitPath::Return { .. })
+            {
+                return_source_drops += 1;
+            }
+        }
+    }
+
+    assert_eq!(
+        back_edge_snapshot_drops, 1,
+        "the discarded iteration composite must have one back-edge release"
+    );
+    assert_eq!(
+        other_snapshot_drops, 0,
+        "break, tag-false, and function-exit plans must not release the aliasing snapshot"
+    );
+    assert_eq!(
+        return_source_drops, 1,
+        "the binding's final value must retain exactly one scope-exit release"
+    );
+}
+
+fn reject_count(pipeline: &IrPipeline, construct: &str) -> usize {
+    pipeline
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(
+                &diagnostic.kind,
+                MirDiagnosticKind::NotYetImplemented {
+                    construct: actual,
+                    ..
+                } if actual == construct
+            )
+        })
+        .count()
+}
+
+#[test]
+fn conditional_reassignment_fails_closed() {
+    let source = REASSIGNED_WITH_BREAK.replace(
+        "        q = next(i, cap);",
+        "        if i < cap {\n            q = next(i, cap);\n        }",
+    );
+    let pipeline = pipeline(&source);
+    assert_eq!(
+        reject_count(
+            &pipeline,
+            "while-let scrutinee conditionally reassigned in loop body"
+        ),
+        1,
+        "diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+#[test]
+fn non_fresh_reassignment_fails_closed() {
+    let source = REASSIGNED_WITH_BREAK.replace(
+        "var total = 0;",
+        "var other = next(0, cap);\n    var total = 0;",
+    );
+    let source = source.replace("        q = next(i, cap);", "        q = other;");
+    let pipeline = pipeline(&source);
+    assert_eq!(
+        reject_count(
+            &pipeline,
+            "while-let scrutinee reassigned from non-fresh value"
+        ),
+        1,
+        "diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+#[test]
+fn continue_with_reassignment_fails_closed() {
+    let source = REASSIGNED_WITH_BREAK.replace(
+        "        q = next(i, cap);",
+        "        q = next(i, cap);\n        continue;",
+    );
+    let pipeline = pipeline(&source);
+    assert_eq!(
+        reject_count(&pipeline, "while-let reassigned scrutinee with continue"),
+        1,
+        "diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+#[test]
+fn post_reassignment_break_fails_closed() {
+    let source = REASSIGNED_WITH_BREAK
+        .replace("        if i == 2 {\n            break;\n        }\n", "")
+        .replace(
+            "        q = next(i, cap);",
+            "        q = next(i, cap);\n        break;",
+        );
+    let pipeline = pipeline(&source);
+    assert_eq!(
+        reject_count(
+            &pipeline,
+            "while-let reassigned scrutinee with post-reassignment exit"
+        ),
+        1,
+        "diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+}


### PR DESCRIPTION
## Summary

`while let` loops silently leaked memory when the scrutinee was a fully-bound binding reassigned each iteration. The previous iteration's owned payload was never released, leaking ~80B/iteration for the scrutinee's heap payload and ~48B/iteration for a moved-out composite box, with no diagnostic. I mint a back-edge snapshot-drop owner for the reassigned binding so the prior value is released exactly once on the loop back-edge and never double-dropped on any exit (break, tag-false, or normal fall-through). The admission is deliberately narrow — a single unconditional top-level reassignment of a provably-fresh value; conditional or multi-reassignment loop-carried scrutinees are refused at compile time with `NotYetImplemented` rather than miscompiled.

## Verification

- Leak oracle (fail-without-fix): neutering the owner-minting returns both leaks; with the fix, both hold at zero across 50 iterations under a poisoned allocator with no double-free.
- MIR lowering tests: pin exactly one back-edge drop and zero drops on other exit edges, plus the four fail-closed refuse shapes (conditional, non-fresh, continue-with-reassignment, post-reassignment break).
- `make lint`: green.
- `make checked-mir-verify`: green (byte-identical).
- `make test-hew-ratchet`: green.

## Out of scope

- Widening the admission to conditional or multi-reassignment loop-carried scrutinees — these stay fail-closed (`NotYetImplemented`) for now; a later change can widen the admission safely.