### PR TITLE
feat(mir): support self-recursive enum/record collection elements via the move path

### DIFF
--- a/hew-codegen-rs/tests/structural.rs
+++ b/hew-codegen-rs/tests/structural.rs
@@ -34,6 +34,8 @@ mod resolved_impl_call_hashmap_layout_descriptor_materialisation;
 mod scalar_discard_guard;
 #[path = "structural/state_clone_generic_enum_pipeline.rs"]
 mod state_clone_generic_enum_pipeline;
+#[path = "structural/state_clone_recursive_collection_pipeline.rs"]
+mod state_clone_recursive_collection_pipeline;
 #[path = "structural/state_clone_synthesis.rs"]
 mod state_clone_synthesis;
 #[path = "structural/supervised_handler_name_registration.rs"]

--- a/hew-codegen-rs/tests/structural/state_clone_recursive_collection_pipeline.rs
+++ b/hew-codegen-rs/tests/structural/state_clone_recursive_collection_pipeline.rs
@@ -1,0 +1,132 @@
+//! Recursive-collection element thunk synthesis — REAL end-to-end pipeline
+//! coverage for a self-recursive enum whose self-edge passes through a `Vec`
+//! payload (`enum Reply { Nil; Num(i64); Arr([Reply]) }`, the Redis/JSON reply
+//! shape).
+//!
+//! The MIR state-clone classifier breaks the value cycle at the collection
+//! boundary (a `Vec` is a heap indirection, so re-encountering the enum on the
+//! far side of the buffer is finite). This test proves the downstream codegen
+//! synthesises the enum's per-element drop thunk and that the thunk recurses
+//! through the inner `Vec<Reply>` via the owned-collection release ABI
+//! (`hew_vec_free_owned`) — the runtime recursion boundary. The synthesis is
+//! lazy (`get_or_declare_*` + body-exists guard), so the self-referential thunk
+//! cycle is representable without non-termination.
+//!
+//! Driven entirely by the real parse → check → HIR → MIR → LLVM path, never a
+//! hand-fed registry.
+//!
+//! LESSONS applied:
+//! - `recursive-admission-needs-indirection-witness` (P0): the admitted
+//!   self-edge is through the container indirection; the thunk releases the
+//!   element via the inner collection's own owned-release symbol.
+//! - `vec-element-width-symmetric-abi` (P0): the element release routes through
+//!   the single `collection_layout_witness` owned-Vec family the constructor
+//!   and free agree on.
+
+use std::path::Path;
+
+use hew_codegen_rs::{emit_module, EmitOptions};
+use hew_hir::{lower_program, ResolutionCtx};
+use hew_types::{module_registry::ModuleRegistry, Checker};
+
+/// Run the full parse → check → HIR → MIR → LLVM pipeline on `source` and
+/// return the emitted textual LLVM IR. Asserts each intermediate step is free
+/// of blocking diagnostics so a regression in the lowering path surfaces here
+/// rather than as a confusing IR-shape mismatch.
+fn emit_ll(source: &str, module_name: &str) -> String {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(
+        tc_output.errors.is_empty(),
+        "type-check errors: {:#?}",
+        tc_output.errors
+    );
+    let lowered = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(
+        lowered.diagnostics.is_empty(),
+        "HIR diagnostics: {:#?}",
+        lowered.diagnostics
+    );
+    let pipeline = hew_mir::lower_hir_module(&lowered.module);
+    use hew_mir::MirDiagnosticKind;
+    let blocking: Vec<_> = pipeline
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            matches!(
+                d.kind,
+                MirDiagnosticKind::NotYetImplemented { .. }
+                    | MirDiagnosticKind::UnresolvedPlace { .. }
+                    | MirDiagnosticKind::ActorStateCloneClassificationFailed { .. }
+            )
+        })
+        .collect();
+    assert!(
+        blocking.is_empty(),
+        "blocking MIR diagnostics: {blocking:#?}"
+    );
+    let tmp = std::env::temp_dir().join(format!("hew-recursive-collection-{module_name}"));
+    std::fs::create_dir_all(&tmp).expect("create out_dir");
+    let options = EmitOptions {
+        module_name,
+        out_dir: &tmp,
+        native: false,
+        wasm: false,
+        target_triple: None,
+        debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
+        source_path: None,
+    };
+    let artefacts = emit_module(&pipeline, &options).expect("pipeline must emit successfully");
+    let ll_path: &Path = artefacts
+        .ll_path
+        .as_deref()
+        .expect("emit_module must populate ll_path");
+    std::fs::read_to_string(ll_path).expect("read emitted .ll")
+}
+
+/// A self-recursive enum built and dropped through an owned `Vec<Reply>` forces
+/// synthesis of the enum's per-element drop thunk, whose body must recurse into
+/// the inner `Vec<Reply>` payload through the owned-collection release symbol.
+/// Before the MIR cycle-break this program failed classification with
+/// `RecordCycle`; the assertion pins that it now flows to real recursive
+/// release code, not a fail-closed trap.
+#[test]
+fn self_recursive_enum_through_vec_synthesises_recursive_drop_thunk() {
+    let source = r#"
+enum Reply { Nil; Num(i64); Arr([Reply]); }
+
+fn main() -> i64 {
+    let xs = [Reply::Num(7), Reply::Arr([Reply::Nil, Reply::Num(9)])];
+    let n = xs.len();
+    n
+}
+"#;
+    let ir = emit_ll(source, "recursive-enum-drop");
+
+    // The self-recursive enum's per-element drop thunk is synthesised.
+    assert!(
+        ir.contains("__hew_enum_drop_inplace_Reply"),
+        "expected the self-recursive enum drop thunk to be synthesised; IR:\n{ir}"
+    );
+    // The recursion boundary: the element release runs through the owned-Vec
+    // free symbol (the inner Vec<Reply> payload), which in turn invokes the
+    // per-element enum thunk at runtime. Without the cycle-break this program
+    // never reached codegen.
+    assert!(
+        ir.contains("hew_vec_free_owned"),
+        "expected the recursive drop to release the inner Vec<Reply> via the \
+         owned-collection release ABI; IR:\n{ir}"
+    );
+}

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -1079,6 +1079,65 @@ fn classify_state_field_full_impl(
 /// the single `model::ty_contains_unclonable_opaque` authority so `Vec` /
 /// `Option` / `Result` / `HashMap` / nested containers / record-with-opaque-field
 /// / enum-payload all fail closed through one decision, not per-shape patches.
+/// Classify a container's element/value type, breaking a self-recursion cycle
+/// at the container boundary.
+///
+/// A `Vec`/`HashMap`/`HashSet` is a heap-pointer indirection: an element type
+/// already on the active recursion stack (`visited`) is reached through the
+/// container's heap buffer, so a value cycle that passes through it is FINITE —
+/// re-encountering an inline ancestor on the far side of the container pointer
+/// is not the infinite-inline-layout cycle that [`classify_enum`] /
+/// [`classify_user_record`] reject with [`ClassificationError::RecordCycle`].
+/// This mirrors the `indirect enum` heap-boundary handling in `classify_enum`.
+///
+/// When the element resolves to a record/enum whose layout name is already
+/// `visited`, return the name-only kind directly WITHOUT re-descending: the
+/// runtime recursion runs through the inner collection's OWN per-element
+/// clone/drop thunks (`hew_vec_{clone,free}_owned` etc.), which invoke the
+/// element type's `__hew_{record,enum}_{clone,drop}_inplace_*` thunk per slot.
+/// A directly self-referential record/enum WITHOUT a container indirection
+/// never reaches this helper (its field recursion goes straight through
+/// `classify_state_field_full_impl`), so it still fails closed with
+/// `RecordCycle` — the container indirection is the sole admitted recursion
+/// boundary (`recursive-admission-needs-indirection-witness`).
+fn classify_container_element(
+    elem: &ResolvedTy,
+    record_layouts: &[RecordLayout],
+    enum_layouts: &[EnumLayout],
+    opaque_handle_names: &[String],
+    resource_close: &[(String, String)],
+    visited: &mut HashSet<String>,
+) -> Result<StateFieldCloneKind, ClassificationError> {
+    if let ResolvedTy::Named { name, args, .. } = elem {
+        // Enum on the active stack — reached through this container's heap
+        // buffer. (Indirect enums carry a `\0ind\0` marker rather than their
+        // bare name in `visited`, so `layout.name` is absent for them and they
+        // fall through to normal recursion, where `classify_enum`'s indirect
+        // arm handles the boundary.)
+        if let Some(layout) = lookup_enum_layout(name, args, enum_layouts) {
+            if visited.contains(&layout.name) {
+                return Ok(StateFieldCloneKind::Enum {
+                    name: layout.name.clone(),
+                });
+            }
+        } else if let Some(layout) = lookup_record_layout(name, args, record_layouts) {
+            if visited.contains(&layout.name) {
+                return Ok(StateFieldCloneKind::UserRecord {
+                    name: layout.name.clone(),
+                });
+            }
+        }
+    }
+    classify_state_field_full_impl(
+        elem,
+        record_layouts,
+        enum_layouts,
+        opaque_handle_names,
+        resource_close,
+        visited,
+    )
+}
+
 fn reject_unclonable_opaque_container(
     outer: &str,
     elem: &ResolvedTy,
@@ -1338,7 +1397,7 @@ fn classify_named(
             // The single transitive authority covers Vec<json.Value>,
             // Vec<Option<json.Value>>, Vec<RecordWithOpaqueField>, etc.
             reject_unclonable_opaque_container("Vec", elem, record_layouts, enum_layouts)?;
-            let elem_kind = classify_state_field_full_impl(
+            let elem_kind = classify_container_element(
                 elem,
                 record_layouts,
                 enum_layouts,
@@ -1364,6 +1423,10 @@ fn classify_named(
             // Fail closed on either an opaque key or an opaque value.
             reject_unclonable_opaque_container("HashMap", key, record_layouts, enum_layouts)?;
             reject_unclonable_opaque_container("HashMap", val, record_layouts, enum_layouts)?;
+            // The key position is not a self-recursion boundary (a hashable key
+            // does not recurse through the map); classify it directly. The value
+            // position IS a container-indirected boundary, so it takes the
+            // cycle-break helper.
             let key_kind = classify_state_field_full_impl(
                 key,
                 record_layouts,
@@ -1372,7 +1435,7 @@ fn classify_named(
                 resource_close,
                 visited,
             )?;
-            let val_kind = classify_state_field_full_impl(
+            let val_kind = classify_container_element(
                 val,
                 record_layouts,
                 enum_layouts,
@@ -1392,7 +1455,7 @@ fn classify_named(
                     rendered: format!("Named {{ name: \"HashSet\", args: {args:?} }}"),
                 })?;
             reject_unclonable_opaque_container("HashSet", elem, record_layouts, enum_layouts)?;
-            let elem_kind = classify_state_field_full_impl(
+            let elem_kind = classify_container_element(
                 elem,
                 record_layouts,
                 enum_layouts,
@@ -2175,6 +2238,107 @@ mod tests {
         assert!(
             matches!(result, Err(ClassificationError::RecordCycle { ref name }) if name == "Node"),
             "expected RecordCycle on `Node`, got {result:?}",
+        );
+    }
+
+    /// A self-recursive enum whose self-edge passes THROUGH a `Vec` payload
+    /// (`enum Reply { Nil; Num(i64); Arr([Reply]) }`) classifies as `Enum`
+    /// rather than failing closed with `RecordCycle`. The `Vec` is a heap
+    /// indirection, so the value cycle is finite — the runtime recursion runs
+    /// through the inner Vec's own per-element clone/drop thunks.
+    #[test]
+    fn self_recursive_enum_through_vec_classifies() {
+        let enums = vec![EnumLayout {
+            name: "Reply".to_string(),
+            tag_width: 1,
+            variants: vec![
+                MachineVariantLayout {
+                    name: "Nil".to_string(),
+                    field_tys: vec![],
+                    field_names: vec![],
+                },
+                MachineVariantLayout {
+                    name: "Num".to_string(),
+                    field_tys: vec![ResolvedTy::I64],
+                    field_names: vec![],
+                },
+                MachineVariantLayout {
+                    name: "Arr".to_string(),
+                    field_tys: vec![builtin(
+                        hew_types::BuiltinType::Vec,
+                        vec![named("Reply", vec![])],
+                    )],
+                    field_names: vec![],
+                },
+            ],
+            is_indirect: false,
+        }];
+        let mut v = HashSet::new();
+        let result =
+            classify_state_field_with_enum_layouts(&named("Reply", vec![]), &[], &enums, &mut v)
+                .unwrap();
+        assert_eq!(
+            result,
+            StateFieldCloneKind::Enum {
+                name: "Reply".to_string(),
+            },
+        );
+        assert!(v.is_empty(), "recursion guard must unwind cleanly");
+    }
+
+    /// A self-recursive record whose self-edge passes through a `Vec` field
+    /// (`type Tree { children: [Tree] }`) classifies as `UserRecord`, not
+    /// `RecordCycle` — the container-indirection cycle-break covers records too.
+    #[test]
+    fn self_recursive_record_through_vec_classifies() {
+        let records = vec![RecordLayout {
+            name: "Tree".to_string(),
+            field_tys: vec![builtin(
+                hew_types::BuiltinType::Vec,
+                vec![named("Tree", vec![])],
+            )],
+            field_names: vec![],
+        }];
+        let mut v = HashSet::new();
+        let result =
+            classify_state_field_with_enum_layouts(&named("Tree", vec![]), &records, &[], &mut v)
+                .unwrap();
+        assert_eq!(
+            result,
+            StateFieldCloneKind::UserRecord {
+                name: "Tree".to_string(),
+            },
+        );
+        assert!(v.is_empty());
+    }
+
+    /// A self-recursive enum whose self-edge is DIRECT (an inline payload with
+    /// no container indirection) must still fail closed with `RecordCycle`: the
+    /// container indirection is the sole admitted recursion boundary
+    /// (`recursive-admission-needs-indirection-witness`). A real such enum is
+    /// `indirect` (heap-boxed); an inline one is an infinite-layout bug.
+    #[test]
+    fn self_recursive_enum_direct_still_cycles() {
+        let enums = vec![EnumLayout {
+            name: "BadDirect".to_string(),
+            tag_width: 1,
+            variants: vec![MachineVariantLayout {
+                name: "Wrap".to_string(),
+                field_tys: vec![named("BadDirect", vec![])],
+                field_names: vec![],
+            }],
+            is_indirect: false,
+        }];
+        let mut v = HashSet::new();
+        let result = classify_state_field_with_enum_layouts(
+            &named("BadDirect", vec![]),
+            &[],
+            &enums,
+            &mut v,
+        );
+        assert!(
+            matches!(result, Err(ClassificationError::RecordCycle { ref name }) if name == "BadDirect"),
+            "direct (non-container) self-reference must still fail closed, got {result:?}",
         );
     }
 


### PR DESCRIPTION
## Summary

A self-recursive value type whose variant holds a growable collection of itself — e.g. `enum Reply { Arr([Reply]) }` — now compiles and runs when built by an array literal (the move path). The state-clone classifier previously rejected this as an unbreakable cycle; I add a container-boundary rule: when a type name is re-entered through a `Vec`/`HashMap`-value/`HashSet` payload, the heap indirection breaks the cycle and it classifies as name-only (a direct, non-indirected self-reference still correctly rejects). The synthesized recursive drop thunk frees each node's collection buffer and every nested element exactly once. Copying such a value into a collection by `.push` of a live owned lvalue remains rejected with a diagnostic — that clone-path cleanup is not yet synthesized — so only the move path newly compiles.

## Verification

- Codegen pipeline test: pins that `__hew_enum_drop_inplace_Reply` recurses through `hew_vec_free_owned`.
- Move-path program: runs at 0 leaks / 0 bytes under a leak checker and a poisoned allocator with no double-free.
- `checked-mir-verify`: byte-identical (49 fixtures × 2 stages).
- `make test-hew-ratchet`: green.

## Out of scope

- Copy-in-clone `.push` of a live owned collection-bearing value stays fail-closed; its drop synthesis is separate follow-on work.
