### PR TITLE
fix(mir): free multi-interpolation f-string concat intermediates

### DIFF
--- a/examples/v05/checked-mir/golden/hashmap_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/hashmap_ops.raw.mir
@@ -159,6 +159,7 @@ fn main() -> () [conv=default]
     _36 = call string_concat(_34, _35) -> bb23
   bb23:
     drop _35 ty=string fn=release(hew_string_drop)
+    drop _34 ty=string fn=release(hew_string_drop)
     _37 = string_lit " len="
     _38 = call string_concat(_36, _37) -> bb24
   bb24:
@@ -171,6 +172,7 @@ fn main() -> () [conv=default]
     _41 = call string_concat(_38, _40) -> bb27
   bb27:
     drop _40 ty=string fn=release(hew_string_drop)
+    drop _38 ty=string fn=release(hew_string_drop)
     call println_str(_41) -> bb28
   bb28:
     stmt: eval site=SiteId(29) ty=()

--- a/examples/v05/checked-mir/golden/hashset_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/hashset_ops.raw.mir
@@ -100,6 +100,7 @@ fn main() -> () [conv=default]
     _22 = call string_concat(_20, _21) -> bb12
   bb12:
     drop _21 ty=string fn=release(hew_string_drop)
+    drop _20 ty=string fn=release(hew_string_drop)
     _23 = string_lit " removed="
     _24 = call string_concat(_22, _23) -> bb13
   bb13:
@@ -110,6 +111,7 @@ fn main() -> () [conv=default]
     _26 = call string_concat(_24, _25) -> bb15
   bb15:
     drop _25 ty=string fn=release(hew_string_drop)
+    drop _24 ty=string fn=release(hew_string_drop)
     call println_str(_26) -> bb16
   bb16:
     stmt: eval site=SiteId(19) ty=()
@@ -162,6 +164,7 @@ fn main() -> () [conv=default]
     _45 = call string_concat(_43, _44) -> bb28
   bb28:
     drop _44 ty=string fn=release(hew_string_drop)
+    drop _43 ty=string fn=release(hew_string_drop)
     call println_str(_45) -> bb29
   bb29:
     stmt: eval site=SiteId(60) ty=()

--- a/examples/v05/checked-mir/golden/math_intrinsics.raw.mir
+++ b/examples/v05/checked-mir/golden/math_intrinsics.raw.mir
@@ -202,6 +202,7 @@ fn math$clamp(i64, i64, i64) -> i64 [conv=default]
     _11 = call string_concat(_9, _10) -> bb8
   bb8:
     drop _10 ty=string fn=release(hew_string_drop)
+    drop _9 ty=string fn=release(hew_string_drop)
     call panic(_11) -> bb9
   bb9:
     stmt: eval site=SiteId(86) ty=!

--- a/examples/v05/checked-mir/golden/option_result_unwrap.raw.mir
+++ b/examples/v05/checked-mir/golden/option_result_unwrap.raw.mir
@@ -582,6 +582,7 @@ fn main() -> i64 [conv=default]
     _162 = call string_concat(_160, _161) -> bb82
   bb82:
     drop _161 ty=string fn=release(hew_string_drop)
+    drop _160 ty=string fn=release(hew_string_drop)
     call println_str(_162) -> bb83
   bb83:
     stmt: eval site=SiteId(102) ty=()

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -760,6 +760,7 @@ fn fs$read(string) -> string [conv=default]
     _23 = call string_concat(_18, _22) -> bb17
   bb17:
     drop _22 ty=string fn=release(hew_string_drop)
+    drop _18 ty=string fn=release(hew_string_drop)
     call panic(_23) -> bb18
   bb18:
     stmt: eval site=SiteId(228) ty=!
@@ -778,6 +779,7 @@ fn fs$read(string) -> string [conv=default]
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
     drop _29 ty=string fn=release(hew_string_drop)
+    drop _28 ty=string fn=release(hew_string_drop)
     call panic(_30) -> bb24
   bb24:
     stmt: eval site=SiteId(251) ty=!

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -820,6 +820,7 @@ fn fs$read(string) -> string [conv=default]
     _23 = call string_concat(_18, _22) -> bb17
   bb17:
     drop _22 ty=string fn=release(hew_string_drop)
+    drop _18 ty=string fn=release(hew_string_drop)
     call panic(_23) -> bb18
   bb18:
     stmt: eval site=SiteId(247) ty=!
@@ -838,6 +839,7 @@ fn fs$read(string) -> string [conv=default]
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
     drop _29 ty=string fn=release(hew_string_drop)
+    drop _28 ty=string fn=release(hew_string_drop)
     call panic(_30) -> bb24
   bb24:
     stmt: eval site=SiteId(270) ty=!

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -706,6 +706,7 @@ fn fs$read(string) -> string [conv=default]
     _23 = call string_concat(_18, _22) -> bb17
   bb17:
     drop _22 ty=string fn=release(hew_string_drop)
+    drop _18 ty=string fn=release(hew_string_drop)
     call panic(_23) -> bb18
   bb18:
     stmt: eval site=SiteId(215) ty=!
@@ -724,6 +725,7 @@ fn fs$read(string) -> string [conv=default]
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
     drop _29 ty=string fn=release(hew_string_drop)
+    drop _28 ty=string fn=release(hew_string_drop)
     call panic(_30) -> bb24
   bb24:
     stmt: eval site=SiteId(238) ty=!

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.raw.mir
@@ -684,6 +684,7 @@ fn fs$read(string) -> string [conv=default]
     _23 = call string_concat(_18, _22) -> bb17
   bb17:
     drop _22 ty=string fn=release(hew_string_drop)
+    drop _18 ty=string fn=release(hew_string_drop)
     call panic(_23) -> bb18
   bb18:
     stmt: eval site=SiteId(208) ty=!
@@ -702,6 +703,7 @@ fn fs$read(string) -> string [conv=default]
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
     drop _29 ty=string fn=release(hew_string_drop)
+    drop _28 ty=string fn=release(hew_string_drop)
     call panic(_30) -> bb24
   bb24:
     stmt: eval site=SiteId(231) ty=!

--- a/hew-cli/tests/fstring_interp_temp_leak_oracle.rs
+++ b/hew-cli/tests/fstring_interp_temp_leak_oracle.rs
@@ -131,6 +131,54 @@ fn fstring_gen_yield_interp_loop_source(frames: usize) -> String {
     )
 }
 
+/// Multi-interpolation f-string in statement position: `interps` copies of the
+/// loop counter interpolated into ONE f-string per iteration
+/// (`f"a={i} b={i} c={i}"` for `interps == 3`). Each interpolation adds a
+/// `to_string_i64` conversion (a block-terminating `Terminator::Call` that
+/// SPLITS the concat chain) plus a `hew_string_concat` join. #2726: the
+/// intermediate concat result whose consuming concat lands in the NEXT block
+/// (past the `to_string` split) was never admitted by
+/// `collect_nested_fresh_string_temp_drops` — the instruction-use concat-chain
+/// branch required def and use in the SAME block, so every `to_string`-split
+/// intermediate leaked. 1–2 interpolations stay in one block (clean); 3+
+/// cross a split and leaked pre-fix, at a rate that scales with `interps`.
+fn fstring_multi_interp_loop_source(interps: usize, frames: usize) -> String {
+    let expected_total: usize = (0..frames).sum();
+    let fstr = (0..interps)
+        .map(|j| format!("s{j}={{i}}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        "fn main() -> i64 {{\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       println(f\"{fstr}\");\n\
+         \x20       total = total + i;\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total != {expected_total} {{ return 94; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+fn fstring_one_interp_loop_source(frames: usize) -> String {
+    fstring_multi_interp_loop_source(1, frames)
+}
+fn fstring_two_interp_loop_source(frames: usize) -> String {
+    fstring_multi_interp_loop_source(2, frames)
+}
+fn fstring_three_interp_loop_source(frames: usize) -> String {
+    fstring_multi_interp_loop_source(3, frames)
+}
+fn fstring_four_interp_loop_source(frames: usize) -> String {
+    fstring_multi_interp_loop_source(4, frames)
+}
+fn fstring_five_interp_loop_source(frames: usize) -> String {
+    fstring_multi_interp_loop_source(5, frames)
+}
+
 // -- correctness pins --------------------------------------------------------
 
 /// Run `source` to native, execute under the poisoned-allocator triple, and
@@ -194,4 +242,55 @@ fn fstring_scalar_interp_gen_yield_freed_exactly_once_under_malloc_scribble() {
         "fstring_scalar_gen_df",
         &fstring_gen_yield_interp_loop_source(200),
     );
+}
+
+// -- #2726 multi-interpolation concat-chain oracles --------------------------
+
+/// No-regression slope pins: 1- and 2-interpolation f-strings keep the whole
+/// concat chain in one block (no `to_string` split between an intermediate and
+/// its consuming concat), so they were always clean. Pin them flat so a future
+/// change to the admission cannot silently regress the already-correct cases.
+#[test]
+fn fstring_one_interp_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("fstring_1interp", fstring_one_interp_loop_source);
+}
+#[test]
+fn fstring_two_interp_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("fstring_2interp", fstring_two_interp_loop_source);
+}
+
+/// Teeth (#2726): 3-, 4-, and 5-interpolation f-strings. Each interpolation
+/// past the second splits the concat chain across a `to_string` terminator, so
+/// the intermediate concat result consumed in the next block leaked once per
+/// split per iteration pre-fix — a positive slope that scales with the
+/// interpolation count (3→~1, 4→~3, 5→~4 leaked nodes/iteration). With the
+/// cross-block domination admission the slope is flat.
+#[test]
+fn fstring_three_interp_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("fstring_3interp", fstring_three_interp_loop_source);
+}
+#[test]
+fn fstring_four_interp_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("fstring_4interp", fstring_four_interp_loop_source);
+}
+#[test]
+fn fstring_five_interp_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("fstring_5interp", fstring_five_interp_loop_source);
+}
+
+/// No-double-free pins (#2726): the intermediate concat results release EXACTLY
+/// once across 200 iterations for 3-, 4-, and 5-interpolation f-strings. A
+/// second owner (an over-eager cross-block drop that double-frees) aborts under
+/// the poisoned-allocator triple; a scribbled read miscomputes the total.
+#[test]
+fn fstring_three_interp_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free("fstring_3interp_df", &fstring_three_interp_loop_source(200));
+}
+#[test]
+fn fstring_four_interp_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free("fstring_4interp_df", &fstring_four_interp_loop_source(200));
+}
+#[test]
+fn fstring_five_interp_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free("fstring_5interp_df", &fstring_five_interp_loop_source(200));
 }

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -1517,6 +1517,46 @@ fn is_borrowing_string_concat_instr_use(instr: &Instr, t: u32) -> bool {
         && crate::runtime_symbols::callee_ownership_contract(call.symbol())
             .borrows_string_call_args()
 }
+/// `true` when control flows from `start` to `use_block` along a chain of
+/// single-predecessor `Call`-terminated blocks — so reaching `use_block`
+/// implies the block that produced `start` ran exactly once, and every block on
+/// the chain (including `use_block`) has that single predecessor.
+///
+/// `start` is the def producer's `Call` continuation (the `next` of a
+/// terminator-def, or the def instruction's own block terminator's `next`).
+/// A single-step chain (`start == use_block`, `pred_count[use_block] == 1`) is
+/// the shape the terminator-def domination check historically proved directly.
+/// The multi-step walk is the #2726 f-string case: a `to_string_*` conversion
+/// lowers to a block-terminating `Call` that SPLITS the concat chain, so the
+/// concat consuming an intermediate result is separated from the concat that
+/// produced it by that conversion block. Each intervening block is itself a
+/// single-predecessor `Call` continuation, so the whole span is straight-line —
+/// no branch merges in, so reaching the use implies the def ran once.
+///
+/// The walk is bounded by the block count: a single-predecessor chain cannot
+/// revisit a block (a revisited block would have a second predecessor), so the
+/// bound is a belt-and-braces guard, never a real limit.
+fn dominates_use_via_single_pred_chain(
+    blocks: &[BasicBlock],
+    start: u32,
+    use_block: u32,
+    pred_count: &HashMap<u32, usize>,
+) -> bool {
+    let mut cur = start;
+    for _ in 0..blocks.len() {
+        if pred_count.get(&cur).copied().unwrap_or(0) != 1 {
+            return false;
+        }
+        if cur == use_block {
+            return true;
+        }
+        match block_by_id(blocks, cur).and_then(|b| call_terminator_next(&b.terminator)) {
+            Some(n) => cur = n,
+            None => return false,
+        }
+    }
+    false
+}
 /// W5.011 P3 — `true` when an instruction transfers ownership of a fresh-owned
 /// `string` `local` out of its slot, so a scope-exit drop of `local` would be a
 /// double-free (over-decrement of the shared refcount).
@@ -2094,13 +2134,27 @@ fn nested_fresh_string_temp_drop(
                 return None;
             }
             let def_dominates = match def {
-                // Instruction def in the use's own block precedes the terminator.
-                NestedDefSite::Instr { block, .. } => block == ub,
-                // Terminator def `Call(next = U)`: a single-predecessor `U` is
-                // reached only from the def block, so the def ran.
+                // Instruction def in the use's own block precedes the terminator;
+                // otherwise the def block's `Call` continuation must reach the
+                // use block along a single-predecessor chain (see below).
+                NestedDefSite::Instr { block, .. } => {
+                    block == ub
+                        || block_by_id(blocks, block)
+                            .and_then(|b| call_terminator_next(&b.terminator))
+                            .is_some_and(|start| {
+                                dominates_use_via_single_pred_chain(blocks, start, ub, pred_count)
+                            })
+                }
+                // Terminator def `Call(next = U)`: `U` (and every block up to the
+                // use) is reached only from the def block along a
+                // single-predecessor chain, so the def ran. The multi-step chain
+                // is the #2726 f-string case, where a `to_string_*` conversion
+                // block splits the concat chain between the producing and
+                // consuming concats.
                 NestedDefSite::Term { block } => {
-                    call_terminator_next(&block_by_id(blocks, block)?.terminator) == Some(ub)
-                        && pred_count.get(&ub).copied().unwrap_or(0) == 1
+                    call_terminator_next(&block_by_id(blocks, block)?.terminator).is_some_and(
+                        |start| dominates_use_via_single_pred_chain(blocks, start, ub, pred_count),
+                    )
                 }
             };
             def_dominates.then_some((*next, 0, drop_place, drop_ty))
@@ -2124,15 +2178,37 @@ fn nested_fresh_string_temp_drop(
                 return None;
             }
             let def_dominates = match def {
-                // Instruction def must be an EARLIER instruction in the use's
-                // own block: same-block straight-line execution means reaching
-                // the use (which reads `t`) implies the def ran.
-                NestedDefSite::Instr { block, idx } => block == ub && idx < *ui,
-                // Terminator def `Call(next = U)`: a single-predecessor `U` is
-                // reached only from the def block, so the def ran before the use.
+                // Instruction def dominates the use when EITHER:
+                //   * it is an EARLIER instruction in the use's own block —
+                //     same-block straight-line execution means reaching the use
+                //     (which reads `t`) implies the def ran; OR
+                //   * the def block's terminator is a `Call` whose sole
+                //     continuation is the use block, and the use block has that
+                //     single predecessor. The def is an instruction in the def
+                //     block, which runs straight-line to its terminator; the
+                //     terminator's normal edge reaches the use block, whose only
+                //     predecessor is the def block — so reaching the use implies
+                //     the def ran. This is the multi-interpolation f-string
+                //     shape (#2726): a `to_string_*` conversion lowers to a
+                //     block-terminating `Call` that SPLITS the concat chain, so
+                //     the concat consuming an intermediate result lands one
+                //     block past that split. Same single-step domination the
+                //     terminator-def arm below already proves.
+                NestedDefSite::Instr { block, idx } => {
+                    (block == ub && idx < *ui)
+                        || block_by_id(blocks, block)
+                            .and_then(|b| call_terminator_next(&b.terminator))
+                            .is_some_and(|start| {
+                                dominates_use_via_single_pred_chain(blocks, start, ub, pred_count)
+                            })
+                }
+                // Terminator def `Call(next = U)`: `U` (and every block up to the
+                // use) is reached only from the def block along a
+                // single-predecessor chain, so the def ran before the use.
                 NestedDefSite::Term { block } => {
-                    call_terminator_next(&block_by_id(blocks, block)?.terminator) == Some(ub)
-                        && pred_count.get(&ub).copied().unwrap_or(0) == 1
+                    call_terminator_next(&block_by_id(blocks, block)?.terminator).is_some_and(
+                        |start| dominates_use_via_single_pred_chain(blocks, start, ub, pred_count),
+                    )
                 }
             };
             // Drop immediately after the compare instruction (straight-line in
@@ -2303,6 +2379,56 @@ mod nested_fresh_string_temp_drop_admission {
             vec![(1, 1, Place::Local(2), ResolvedTy::String)],
             "a proven fresh terminator-produced operand used once by borrowing concat \
              must be dropped immediately after that concat"
+        );
+    }
+
+    fn concat_term(lhs: u32, rhs: u32, dest: u32, next: u32) -> Terminator {
+        Terminator::Call {
+            callee: "hew_string_concat".to_string(),
+            builtin: None,
+            args: vec![Place::Local(lhs), Place::Local(rhs)],
+            dest: Some(Place::Local(dest)),
+            next,
+        }
+    }
+
+    // #2726: a multi-interpolation f-string lowers the concat chain as
+    // block-terminating `Call`s, and each `to_string_*` conversion is itself a
+    // terminator that SPLITS the chain. The intermediate concat result (t2)
+    // produced in bb0 is consumed by the concat in bb2, one block past the
+    // `to_string` split (bb1). Its producing and consuming concats are in
+    // DIFFERENT blocks, so the single-step domination check missed it and it
+    // leaked. The single-predecessor-chain walk proves bb0's continuation
+    // reaches the use block bb2 straight-line, so t2 earns exactly one drop.
+    #[test]
+    fn cross_block_concat_intermediate_split_by_conversion_gets_one_drop() {
+        let blocks = vec![
+            // t2 = concat(t0, t1); the intermediate result.
+            block(0, vec![], concat_term(0, 1, 2, 1)),
+            // t3 = to_string(..); the conversion terminator that splits the chain.
+            block(1, vec![], fresh_string_call("hew_i64_to_string", 3, 2)),
+            // t4 = concat(t2, t3); consumes the cross-block intermediate t2.
+            block(2, vec![], concat_term(2, 3, 4, 3)),
+            ret_block(3),
+        ];
+        // t4 is the final result (a let/print binding); exclude it so the
+        // assertion isolates the intermediate temps t2 and t3.
+        let binding_locals: HashMap<BindingId, Place> =
+            [(BindingId(44), Place::Local(4))].into_iter().collect();
+
+        let mut drops = collect(&blocks, &locals_with(&[]), &binding_locals);
+        drops.sort_by_key(|(_, _, place, _)| base_local(*place));
+
+        assert_eq!(
+            drops,
+            vec![
+                (3, 0, Place::Local(2), ResolvedTy::String),
+                (3, 0, Place::Local(3), ResolvedTy::String),
+            ],
+            "the cross-block intermediate concat result (t2) and the conversion \
+             temp (t3) are each fresh owners borrowed exactly once by the \
+             consuming concat; both must be released once, at the front of the \
+             consuming concat's continuation"
         );
     }
 


### PR DESCRIPTION
## Summary

I fix a leak where an f-string with 3 or more interpolations leaked its intermediate concatenation buffers (~1 per extra interpolation). The f-string lowers to a chain of string-concat calls, and each `to_string` conversion is a call that splits the chain across basic blocks; the intermediate-concat temporary's drop was only admitted when the consumer sat in the producer's own block or one call-continuation, so a consumer one block past a conversion split never got its drop. I generalise the domination check to walk a bounded chain of single-predecessor call-terminated blocks, so a straight-line span across conversion splits now frees each intermediate exactly once. Branch merges stay fail-closed (the drop is not admitted where a block has multiple predecessors), so there is no double-free.

## Verification

- A leak oracle over 3/4/5-interpolation f-strings runs at flat 0-leak slopes (and returns the leak when the fix is neutered).
- A branch-merge test confirms no drop is admitted across a merge.
- A poisoned-allocator pass confirms exactly-once with no double-free.
- `checked-mir-verify` is byte-identical after an additive-only golden refresh.
- `test-hew-ratchet`, `test-vertical-slice`, and `hew-check-all` are green.

Closes #2726.