### PR TITLE
fix(mir): drop owned by-value record/tuple/enum params at the caller

### DIFF
--- a/hew-cli/tests/nested_projection_chain_leak_oracle.rs
+++ b/hew-cli/tests/nested_projection_chain_leak_oracle.rs
@@ -883,11 +883,15 @@ fn escaped_return_record_excludes_the_owner_composite() {
     );
 }
 
-/// Owner-consumed control: the alias `mid` emits no drop and the consumed
-/// owner `o` emits no scope-exit composite drop in the caller (the consumer
-/// `sink` owns it) — so `run_cycle` emits zero `record_in_place` drops.
+/// Proven-borrow owner control: `sink(o: Outer)` only reads `o`, so it is a
+/// proven-borrowing helper that registers no callee-side drop. Under the
+/// copy-on-write borrow model the caller therefore RETAINS the owner and frees
+/// it exactly once at its own scope exit: `run_cycle` emits exactly ONE
+/// `record_in_place` drop — the owner `o`'s composite. The alias `mid` (a
+/// Read-projection of `o.mid`) never owns, so it emits none. Exactly-once is
+/// the invariant: two owner drops would be a double-free, zero would be a leak.
 #[test]
-fn owner_consumed_control_emits_no_alias_or_owner_drop() {
+fn owner_consumed_control_emits_single_owner_drop_no_alias_drop() {
     let dump = elab_dump(
         &owner_consumed_control_source(4),
         "chain-owner-consumed-mir-",
@@ -896,11 +900,24 @@ fn owner_consumed_control_emits_no_alias_or_owner_drop() {
         .split("fn ")
         .find(|section| section.starts_with("run_cycle"))
         .expect("run_cycle section present in dump");
+    // Teeth 1: the owner frees exactly once — one composite in-place drop, the
+    // outer root's. Zero here is the leak (proven-borrow callee freed nothing);
+    // two is the double-free (caller AND callee both freed).
+    let composites = record_in_place_locals(run_cycle);
     assert_eq!(
-        run_cycle.matches("kind=record_in_place").count(),
-        0,
-        "the alias emits no drop and the consumed owner is freed by the \
-         callee, so the caller emits no composite drop;\n{run_cycle}"
+        composites.len(),
+        1,
+        "the proven-borrowing `sink` frees nothing, so the caller retains the \
+         owner and frees it exactly once; got {composites:?}\n{run_cycle}"
+    );
+    // Teeth 2: the single composite is the OWNER's (`ty=Outer`), never the
+    // alias `mid` (a Read-projection into the owner's subtree, `ty=Mid`). A
+    // `Mid` composite here would be the alias wrongly re-freeing the shared
+    // subtree — a double-free of the owner's payload.
+    assert!(
+        !run_cycle.contains("ty=Mid kind=record_in_place"),
+        "the alias `mid` must emit no composite drop; a `ty=Mid` in-place drop \
+         means the alias re-freed the owner's shared subtree;\n{run_cycle}"
     );
 }
 

--- a/hew-cli/tests/owned_param_reuse_leak_oracle.rs
+++ b/hew-cli/tests/owned_param_reuse_leak_oracle.rs
@@ -1,0 +1,157 @@
+//! Leak oracle for caller-side owned by-value param drop under REUSE.
+//!
+//! An owned composite (record / tuple / enum) bound to a `let` and passed BY
+//! VALUE to TWO borrowing free functions in sequence (`let r = …; f(r); g(r);`)
+//! is borrowed by each call, not consumed: under the copy-on-write borrow model
+//! the CALLER retains ownership and drops the value exactly ONCE at its own
+//! scope exit — not once per call (which would double-free), and not zero times
+//! (which would leak per iteration).
+//!
+//! This pins the reuse edge of the record/tuple/enum caller-side drop:
+//! reuse-across-two-borrowing-calls was previously untested, and this oracle
+//! closes that gap. It is the composite-param twin of
+//! `owned_vec_cross_function_release_leak_oracle` (the shipped collection
+//! precedent).
+//!
+//! Two independent signals per shape:
+//! - the per-iteration leak SLOPE stays flat (`leaks --atExit`, LOW vs HIGH
+//!   frame counts under the poisoned-allocator triple) — no per-call/per-iter
+//!   leak; and
+//! - the poisoned allocator (`MallocScribble`+`MallocPreScribble`+
+//!   `MallocGuardEdges`) does not abort — the value is released exactly once, so
+//!   the second borrowing call never reads freed storage and scope-exit never
+//!   double-frees.
+//!
+//! The enum shape uses non-consuming (borrow) callee bodies: a `match`
+//! scrutinee and a method receiver of an owned enum param are classified CONSUME
+//! by the parameter-body summary (destructure / receiver intent), so the
+//! caller-side proven-borrow shape for an enum is a callee that does not consume
+//! it. Reads of an enum payload via `match`/method receivers are a separate
+//! (summary / callee-side) concern, out of scope for this caller-side oracle.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+/// Record reused across two borrowing free calls. `f`/`g` read `r.s.len()` — a
+/// field projection is a borrow, so `r` is proven-borrow to both and the caller
+/// drops it once per iteration. `r.s == "ab"` (len 2), so each iteration adds 4.
+fn record_reuse_source(frames: usize) -> String {
+    format!(
+        "type Rec {{ s: string }}\n\
+         \n\
+         fn f(r: Rec) -> i64 {{ r.s.len() }}\n\
+         fn g(r: Rec) -> i64 {{ r.s.len() }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       let r = Rec {{ s: \"a\" + \"b\" }};\n\
+         \x20       let a = f(r);\n\
+         \x20       let b = g(r);\n\
+         \x20       total = total + a + b;\n\
+         \x20   }}\n\
+         \x20   if total != {frames} * 4 {{ return 71; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Tuple reused across two borrowing free calls. `tf`/`tg` read `t.0`/`t.1`
+/// (element projections = borrows), so `t` is proven-borrow to both and the
+/// caller drops it once. `t.0 == "ab"` (2) + `t.1 == "cde"` (3) → 5 per iter.
+fn tuple_reuse_source(frames: usize) -> String {
+    format!(
+        "fn tf(t: (string, string)) -> i64 {{ t.0.len() }}\n\
+         fn tg(t: (string, string)) -> i64 {{ t.1.len() }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       let t = (\"a\" + \"b\", \"c\" + \"de\");\n\
+         \x20       let a = tf(t);\n\
+         \x20       let b = tg(t);\n\
+         \x20       total = total + a + b;\n\
+         \x20   }}\n\
+         \x20   if total != {frames} * 5 {{ return 72; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Enum reused across two borrowing free calls. `ef`/`eg` do not consume their
+/// param (non-consuming body = the proven-borrow enum shape), so `e` is
+/// proven-borrow to both and the caller drops it once. The heap payload
+/// (`Ok("ab")`) must be released exactly once per iteration.
+fn enum_reuse_source(frames: usize) -> String {
+    format!(
+        "fn ef(e: Result<string, string>) -> i64 {{ 2 }}\n\
+         fn eg(e: Result<string, string>) -> i64 {{ 3 }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       let e: Result<string, string> = Ok(\"a\" + \"b\");\n\
+         \x20       let a = ef(e);\n\
+         \x20       let b = eg(e);\n\
+         \x20       total = total + a + b;\n\
+         \x20   }}\n\
+         \x20   if total != {frames} * 5 {{ return 73; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Poisoned-allocator no-double-free pin: an over-eager caller drop (freeing the
+/// value after the first borrowing call, or twice at scope exit) reads/aborts
+/// under the scribbled allocator. A clean exit means exactly-once release.
+fn assert_no_double_free(shape_name: &str, source: &str) {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("owned-param-reuse-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), shape_name);
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "{shape_name}: an owned by-value param reused across two borrowing calls \
+         must be released exactly once at caller scope exit;\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn record_param_reuse_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("owned_param_reuse_record", record_reuse_source);
+}
+
+#[test]
+fn tuple_param_reuse_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("owned_param_reuse_tuple", tuple_reuse_source);
+}
+
+#[test]
+fn enum_param_reuse_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("owned_param_reuse_enum", enum_reuse_source);
+}
+
+#[test]
+fn record_param_reuse_does_not_double_free() {
+    assert_no_double_free("record_reuse_df", &record_reuse_source(50));
+}
+
+#[test]
+fn tuple_param_reuse_does_not_double_free() {
+    assert_no_double_free("tuple_reuse_df", &tuple_reuse_source(50));
+}
+
+#[test]
+fn enum_param_reuse_does_not_double_free() {
+    assert_no_double_free("enum_reuse_df", &enum_reuse_source(50));
+}

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -846,6 +846,41 @@ fn compute_escaped_chain_sibling_drops(
     }
     vec![(esc_block, esc_idx + 1, siblings)]
 }
+/// The base locals passed as WHOLE-VALUE arguments at the proven-borrow
+/// positions of this block's terminating direct call.
+///
+/// A user-function call borrows exactly the argument positions the module
+/// parameter-body summary proved never escape (`compute_call_param_consumption`
+/// projected into `builder.proven_borrow_call_args`, keyed block-id → borrowed
+/// arg-index set, stamped in `lower_direct_call`). Such a by-value composite
+/// argument is a transient borrow: the callee releases nothing, so the CALLER
+/// retains the value and keeps its scope-exit composite drop — the caller-side
+/// owned-param completion for by-value record / tuple / enum params. This
+/// mirrors the arm `derive_local_collection_drop_allowed` already applies to
+/// `Vec` / map handles.
+///
+/// Shared verbatim by the record / tuple / enum sole-owner escape scans so the
+/// exemption is one authority and cannot drift between the sibling derivations.
+/// Only WHOLE-value arg reads are exempted here: a field / element / payload
+/// binder passed by value (`f(r.field)`) is a distinct local whose escape each
+/// scan's own binder branch still records — this set never touches it, so those
+/// discharges stay fail-closed.
+pub(super) fn proven_borrow_whole_arg_locals(
+    block: &BasicBlock,
+    proven_borrow_call_args: &HashMap<u32, HashSet<usize>>,
+) -> HashSet<u32> {
+    let Terminator::Call { args, .. } = &block.terminator else {
+        return HashSet::new();
+    };
+    let Some(borrowed) = proven_borrow_call_args.get(&block.id) else {
+        return HashSet::new();
+    };
+    args.iter()
+        .enumerate()
+        .filter(|(index, _)| borrowed.contains(index))
+        .filter_map(|(_, p)| base_local(*p))
+        .collect()
+}
 /// W5.020 — fail-closed sole-owner derivation for **heap-owning enum
 /// composite** bindings (`Result<T, string>`, `Option<string>`, any user
 /// `enum` whose active variant owns heap). Returns the subset of
@@ -921,6 +956,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
     local_tys: &[ResolvedTy],
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
     enum_layouts: &[crate::model::EnumLayout],
+    proven_borrow_call_args: &HashMap<u32, HashSet<usize>>,
 ) -> HashSet<BindingId> {
     // A local carries a heap-owning value (string/Bytes/owning aggregate or a
     // nested heap-owning enum) iff its registered type says so. Bitcopy payload
@@ -1344,6 +1380,12 @@ pub(super) fn derive_enum_composite_drop_allowed(
                 if crate::runtime_symbols::callee_ownership_contract(callee)
                     .is_vec_copy_in_element_store()
         );
+        // Caller-side owned-param completion: a whole enum composite passed by
+        // value at a proven-borrow call position is a transient borrow, so the
+        // caller keeps its `EnumInPlace` scope-exit drop. Payload binders
+        // (`f(p.field)`) are unaffected — this set holds only whole-value args.
+        let proven_borrow_arg_locals =
+            proven_borrow_whole_arg_locals(block, proven_borrow_call_args);
         // Terminator reads. A return value / send / ask payload escapes; a
         // branch cond is bitcopy and harmless. A `print`/`println` call
         // BORROWS its string argument (it does not take ownership), so a
@@ -1355,6 +1397,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
                 if !copy_in_elem_store
                     && alias_of.contains_key(&l)
                     && matches!(p, Place::Local(_) | Place::ReturnSlot)
+                    && !proven_borrow_arg_locals.contains(&l)
                 {
                     // A whole composite passed to a borrowing print sink is
                     // not how composites are consumed, but apply the same
@@ -1470,6 +1513,7 @@ pub(super) fn derive_owned_record_drop_allowed(
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
     enum_layouts: &[crate::model::EnumLayout],
     alias_field_binders: &[(u32, u32)],
+    proven_borrow_call_args: &HashMap<u32, HashSet<usize>>,
 ) -> HashSet<BindingId> {
     // A local carries a heap-owning value iff its registered type says so. Used
     // to decide whether a `RecordFieldLoad` dest is an owned-field binder (a
@@ -1869,6 +1913,13 @@ pub(super) fn derive_owned_record_drop_allowed(
                 if crate::runtime_symbols::callee_ownership_contract(callee)
                     .is_vec_copy_in_element_store()
         );
+        // Caller-side owned-param completion: a whole record passed by value at a
+        // proven-borrow call position is a transient borrow, so the caller keeps
+        // its `RecordInPlace` scope-exit drop. Field binders (`f(r.field)`) are a
+        // distinct local excluded by the field-escape branch below unchanged —
+        // this set holds only whole-value args.
+        let proven_borrow_arg_locals =
+            proven_borrow_whole_arg_locals(block, proven_borrow_call_args);
         // Terminator reads. A return / send / ask of a whole record or an owned
         // field binder escapes. `print`/`println` borrows its string arg, and a
         // collection-borrow call (`.len()` / `.get(i)`) borrows its receiver, so
@@ -1879,6 +1930,7 @@ pub(super) fn derive_owned_record_drop_allowed(
                 if !copy_in_elem_store
                     && alias_of.contains_key(&l)
                     && matches!(p, Place::Local(_) | Place::ReturnSlot)
+                    && !proven_borrow_arg_locals.contains(&l)
                     && !binder_read_is_borrow_safe_terminator(
                         &block.terminator,
                         suspend_kinds.get(&block.id),
@@ -2732,6 +2784,7 @@ pub(super) fn derive_tuple_composite_drop_allowed(
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
     enum_layouts: &[crate::model::EnumLayout],
     alias_field_binders: &[(u32, u32)],
+    proven_borrow_call_args: &HashMap<u32, HashSet<usize>>,
 ) -> HashSet<BindingId> {
     // A local carries a heap-owning value iff its registered type says so. Used
     // to decide whether a `TupleFieldLoad` dest is an owned-element binder (a
@@ -3111,6 +3164,13 @@ pub(super) fn derive_tuple_composite_drop_allowed(
                 }
             }
         }
+        // Caller-side owned-param completion: a whole tuple passed by value at a
+        // proven-borrow call position is a transient borrow, so the caller keeps
+        // its `TupleInPlace` scope-exit drop. Element binders (`f(t.0)`) are a
+        // distinct local excluded by the element-escape branch below unchanged —
+        // this set holds only whole-value args.
+        let proven_borrow_arg_locals =
+            proven_borrow_whole_arg_locals(block, proven_borrow_call_args);
         // Terminator reads. A return / send / ask of a whole tuple or an owned
         // element binder escapes. `print`/`println` borrows its string arg, and a
         // collection-borrow call (`.len()` / `.get(i)`) borrows its receiver, so
@@ -3120,6 +3180,7 @@ pub(super) fn derive_tuple_composite_drop_allowed(
             if let Some(l) = base_local(p) {
                 if alias_of.contains_key(&l)
                     && matches!(p, Place::Local(_) | Place::ReturnSlot)
+                    && !proven_borrow_arg_locals.contains(&l)
                     && !binder_read_is_borrow_safe_terminator(
                         &block.terminator,
                         suspend_kinds.get(&block.id),
@@ -4957,6 +5018,7 @@ mod owned_record_drop_derivation {
             &record_field_orders,
             &[],
             &[],
+            &HashMap::new(),
         )
     }
 
@@ -4979,6 +5041,144 @@ mod owned_record_drop_derivation {
         assert!(
             allowed.contains(&b),
             "an untouched owned record is its own sole owner and must be admitted"
+        );
+    }
+
+    /// `derive` variant that seeds the per-block proven-borrow arg-index map —
+    /// the caller-side owned-param completion input.
+    fn derive_with_pbca(
+        blocks: &[BasicBlock],
+        owned: &[(BindingId, String, ResolvedTy)],
+        binding_locals: &HashMap<BindingId, Place>,
+        local_tys: &[ResolvedTy],
+        proven_borrow_call_args: &HashMap<u32, HashSet<usize>>,
+    ) -> HashSet<BindingId> {
+        let mut record_field_orders: HashMap<String, Vec<(String, ResolvedTy)>> = HashMap::new();
+        record_field_orders.insert(
+            "Rec".to_string(),
+            vec![("label".to_string(), ResolvedTy::String)],
+        );
+        derive_owned_record_drop_allowed(
+            blocks,
+            &HashMap::new(),
+            owned,
+            binding_locals,
+            local_tys,
+            &is_rec,
+            &record_field_orders,
+            &[],
+            &[],
+            proven_borrow_call_args,
+        )
+    }
+
+    /// A single-block user call `foo(r)` reading the WHOLE record as its sole
+    /// argument. Returns `(binding, block)` so a test can drive the derivation
+    /// with and without a proven-borrow verdict for arg-index 0.
+    fn whole_record_arg_call_block() -> (BindingId, Vec<BasicBlock>) {
+        let b = BindingId(1);
+        let blk = vec![block(
+            0,
+            vec![],
+            Terminator::Call {
+                callee: "foo".to_string(),
+                builtin: None,
+                args: vec![Place::Local(0)],
+                dest: None,
+                next: 1,
+            },
+        )];
+        (b, blk)
+    }
+
+    /// Caller-side owned-param completion: a whole record passed by value at a
+    /// call position the module summary PROVED borrow-only is a transient borrow
+    /// — the caller retains it and keeps its `RecordInPlace` scope-exit drop.
+    #[test]
+    fn proven_borrow_whole_record_arg_is_admitted() {
+        let (b, blocks) = whole_record_arg_call_block();
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals: HashMap<BindingId, Place> =
+            [(b, Place::Local(0))].into_iter().collect();
+        let local_tys = vec![rec_ty()];
+        // Block 0's arg-index 0 is proven borrow.
+        let pbca: HashMap<u32, HashSet<usize>> = [(0u32, [0usize].into_iter().collect())]
+            .into_iter()
+            .collect();
+
+        let allowed = derive_with_pbca(&blocks, &owned, &binding_locals, &local_tys, &pbca);
+        assert!(
+            allowed.contains(&b),
+            "a proven-borrow whole-record call arg is a transient borrow; the \
+             caller must keep its RecordInPlace drop; allowed: {allowed:?}"
+        );
+    }
+
+    /// Fail-closed direction: the SAME call with NO proven-borrow verdict is an
+    /// ownership escape (the callee may store/return/send the record), so the
+    /// record root stays excluded — leak, never double-free.
+    #[test]
+    fn unproven_whole_record_arg_is_excluded() {
+        let (b, blocks) = whole_record_arg_call_block();
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals: HashMap<BindingId, Place> =
+            [(b, Place::Local(0))].into_iter().collect();
+        let local_tys = vec![rec_ty()];
+
+        let allowed = derive_with_pbca(
+            &blocks,
+            &owned,
+            &binding_locals,
+            &local_tys,
+            &HashMap::new(),
+        );
+        assert!(
+            !allowed.contains(&b),
+            "an unproven whole-record call arg may escape into the callee; it \
+             must stay excluded (fail-closed leak); allowed: {allowed:?}"
+        );
+    }
+
+    /// A mixed-args call `foo(a, b)` where ONLY arg-index 0 is proven borrow:
+    /// `a` is admitted, `b`'s root stays excluded. The exemption is per-arg, not
+    /// per-call.
+    #[test]
+    fn mixed_args_call_admits_only_proven_arg() {
+        let a = BindingId(1);
+        let bb = BindingId(2);
+        let owned = vec![
+            (a, "a".to_string(), rec_ty()),
+            (bb, "b".to_string(), rec_ty()),
+        ];
+        let binding_locals: HashMap<BindingId, Place> =
+            [(a, Place::Local(0)), (bb, Place::Local(1))]
+                .into_iter()
+                .collect();
+        let local_tys = vec![rec_ty(), rec_ty()];
+        let blocks = vec![block(
+            0,
+            vec![],
+            Terminator::Call {
+                callee: "foo".to_string(),
+                builtin: None,
+                args: vec![Place::Local(0), Place::Local(1)],
+                dest: None,
+                next: 1,
+            },
+        )];
+        // Only arg-index 0 is proven borrow.
+        let pbca: HashMap<u32, HashSet<usize>> = [(0u32, [0usize].into_iter().collect())]
+            .into_iter()
+            .collect();
+
+        let allowed = derive_with_pbca(&blocks, &owned, &binding_locals, &local_tys, &pbca);
+        assert!(
+            allowed.contains(&a),
+            "the proven-borrow arg must be admitted; allowed: {allowed:?}"
+        );
+        assert!(
+            !allowed.contains(&bb),
+            "the un-proven arg may escape and must stay excluded; allowed: {allowed:?}"
         );
     }
 
@@ -6304,6 +6504,7 @@ mod tuple_composite_field_drop_exclusion {
             &HashMap::new(),
             &[],
             &[],
+            &HashMap::new(),
         );
         (b, allowed)
     }
@@ -6382,6 +6583,7 @@ mod tuple_composite_field_drop_exclusion {
             &HashMap::new(),
             &[],
             &[],
+            &HashMap::new(),
         );
         assert!(
             !allowed.contains(&b),
@@ -6462,6 +6664,7 @@ mod enum_composite_field_drop_exemption {
             &local_tys,
             &record_field_orders,
             &enum_layouts,
+            &HashMap::new(),
         );
         (b, allowed)
     }

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -309,6 +309,7 @@ pub(super) fn elaborate(
         &builder.locals,
         &builder.record_field_orders,
         &builder.enum_layouts,
+        &builder.proven_borrow_call_args,
     );
 
     // W5.016 — owned-element `Vec<T>` scope-exit drop allow-set. An owned Vec
@@ -626,6 +627,7 @@ pub(super) fn elaborate(
         &builder.record_field_orders,
         &builder.enum_layouts,
         &alias_field_binders,
+        &builder.proven_borrow_call_args,
     );
 
     // W5.021 — fail-closed sole-owner allow-set for heap-owning **tuple**
@@ -647,6 +649,7 @@ pub(super) fn elaborate(
         &builder.record_field_orders,
         &builder.enum_layouts,
         &alias_field_binders,
+        &builder.proven_borrow_call_args,
     );
 
     // W5.021 (defect #1) — owned members the caller now owns via a returned

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -4142,6 +4142,7 @@ pub(crate) fn lower_function(
         &builder.record_field_orders,
         &builder.enum_layouts,
         &alias_field_binders,
+        &builder.proven_borrow_call_args,
     );
     let is_owned_record = |ty: &ResolvedTy| builder.is_owned_aggregate_record_ty(ty);
     let owned_record_drop_allowed = derive_owned_record_drop_allowed(
@@ -4154,6 +4155,7 @@ pub(crate) fn lower_function(
         &builder.record_field_orders,
         &builder.enum_layouts,
         &alias_field_binders,
+        &builder.proven_borrow_call_args,
     );
     let mut composite_drop_allowed = tuple_composite_drop_allowed;
     composite_drop_allowed.extend(owned_record_drop_allowed);

--- a/tests/mir-baselines/funcupdate-reassign/manifest.tsv
+++ b/tests/mir-baselines/funcupdate-reassign/manifest.tsv
@@ -6,6 +6,12 @@
 #   are now Read/retain, so the source binding keeps a scope-exit drop and every
 #   shared heap-string local drops via the cow_heap(hew_string_drop) destructor.
 #   The two owned-record fixtures are byte-identical across both revisions.)
+#   Refreshed for the caller-side by-value-param drop: owned by-value
+#   record/tuple/enum params now carry a scope-exit `record_in_place` drop at
+#   the caller. Only var_record_reassign_ownership_test.elab.mir shifted, and
+#   purely additively — every hunk replaces a `(none)` scope-exit slot with a
+#   `drop _N ty=<record/tuple> kind=record_in_place`, no CFG/terminator/value
+#   change. The other three baselines remain byte-identical.
 # dump-mode: hew compile --dump-mir elab <fixture>   (run from the repo root)
 # normalization: two run-variance normalizations — (1) the dump's function
 #   ORDER is nondeterministic (map iteration), so the harness splits both

--- a/tests/mir-baselines/funcupdate-reassign/var_record_reassign_ownership_test.elab.mir
+++ b/tests/mir-baselines/funcupdate-reassign/var_record_reassign_ownership_test.elab.mir
@@ -119,17 +119,17 @@ fn test_var_reassign_through_aliasing_fn_is_exact -> ()
     branch[bb6: bb7/bb8] ->
       (none)
     panic[bb7] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     call[bb8 testing$assert_eq -> bb9] ->
       (none)
     branch[bb9: bb10/bb11] ->
       (none)
     panic[bb10] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     call[bb11 testing$assert_eq -> bb12] ->
       (none)
     return[bb12] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
 
 fn test_loop_reassignment_accumulates_exact_elements -> ()
   statements:
@@ -166,17 +166,17 @@ fn test_loop_reassignment_accumulates_exact_elements -> ()
     call[bb5 testing$assert_eq -> bb10] ->
       (none)
     panic[bb6] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     goto[bb7->bb2] ->
       (none)
     cancel[bb7] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     goto[bb8->bb4] ->
       (none)
     cancel[bb8] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     panic[bb9] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     call[bb10 hew_vec_len -> bb11] ->
       (none)
     call[bb11 testing$assert_eq -> bb12] ->
@@ -184,23 +184,23 @@ fn test_loop_reassignment_accumulates_exact_elements -> ()
     branch[bb12: bb13/bb14] ->
       (none)
     panic[bb13] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     call[bb14 testing$assert_eq -> bb15] ->
       (none)
     branch[bb15: bb16/bb17] ->
       (none)
     panic[bb16] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     call[bb17 testing$assert_eq -> bb18] ->
       (none)
     branch[bb18: bb19/bb20] ->
       (none)
     panic[bb19] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     call[bb20 testing$assert_eq -> bb21] ->
       (none)
     return[bb21] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
 
 fn test_two_vec_record_reassignment_is_exact -> ()
   statements:
@@ -253,29 +253,29 @@ fn test_two_vec_record_reassignment_is_exact -> ()
     branch[bb9: bb10/bb11] ->
       (none)
     panic[bb10] ->
-      (none)
+      drop _1 ty=Pair kind=record_in_place
     call[bb11 testing$assert_eq -> bb12] ->
       (none)
     branch[bb12: bb13/bb14] ->
       (none)
     panic[bb13] ->
-      (none)
+      drop _1 ty=Pair kind=record_in_place
     call[bb14 testing$assert_eq -> bb15] ->
       (none)
     branch[bb15: bb16/bb17] ->
       (none)
     panic[bb16] ->
-      (none)
+      drop _1 ty=Pair kind=record_in_place
     call[bb17 testing$assert_eq -> bb18] ->
       (none)
     branch[bb18: bb19/bb20] ->
       (none)
     panic[bb19] ->
-      (none)
+      drop _1 ty=Pair kind=record_in_place
     call[bb20 testing$assert_eq -> bb21] ->
       (none)
     return[bb21] ->
-      (none)
+      drop _1 ty=Pair kind=record_in_place
 
 fn test_reassignment_from_fresh_returning_fn_resets -> ()
   statements:
@@ -326,11 +326,11 @@ fn test_reassignment_from_fresh_returning_fn_resets -> ()
     branch[bb10: bb11/bb12] ->
       (none)
     panic[bb11] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
     call[bb12 testing$assert_eq -> bb13] ->
       (none)
     return[bb13] ->
-      (none)
+      drop _1 ty=S kind=record_in_place
 
 fn test_conditional_reassignment_join_is_exact -> ()
   statements:
@@ -378,7 +378,8 @@ fn test_conditional_reassignment_join_is_exact -> ()
     goto[bb6->bb5] ->
       (none)
     cancel[bb6] ->
-      (none)
+      drop _3 ty=S kind=record_in_place
+      drop _1 ty=S kind=record_in_place
     call[bb7 grow -> bb10] ->
       (none)
     goto[bb8->bb9] ->
@@ -388,7 +389,8 @@ fn test_conditional_reassignment_join_is_exact -> ()
     goto[bb10->bb9] ->
       (none)
     cancel[bb10] ->
-      (none)
+      drop _3 ty=S kind=record_in_place
+      drop _1 ty=S kind=record_in_place
     call[bb11 hew_vec_len -> bb12] ->
       (none)
     call[bb12 testing$assert_eq -> bb13] ->
@@ -396,7 +398,8 @@ fn test_conditional_reassignment_join_is_exact -> ()
     branch[bb13: bb14/bb15] ->
       (none)
     panic[bb14] ->
-      (none)
+      drop _3 ty=S kind=record_in_place
+      drop _1 ty=S kind=record_in_place
     call[bb15 testing$assert_eq -> bb16] ->
       (none)
     call[bb16 testing$assert_eq -> bb17] ->
@@ -406,7 +409,8 @@ fn test_conditional_reassignment_join_is_exact -> ()
     call[bb18 testing$assert_eq -> bb19] ->
       (none)
     return[bb19] ->
-      (none)
+      drop _3 ty=S kind=record_in_place
+      drop _1 ty=S kind=record_in_place
 
 fn test_literal_rhs_embedding_own_projection_is_exact -> ()
   statements:


### PR DESCRIPTION
## Summary

I fix a pervasive leak: an owned record, tuple, or enum passed by value to a function that reads but doesn't return it was dropped by neither side. Under the copy-on-write borrow-by-default model a by-value parameter is a borrow — the caller keeps the value and drops it at its own scope exit (reuse across calls and value-receiver chains stay legal). I thread the existing proven-borrow-argument analysis into the record/tuple/enum whole-composite alias-escape scans so the caller emits the scope-exit drop for a value it still owns after a borrowing call; a parameter that is returned, forwarded into a consuming call, stored, sent, or captured is already classified as consumed by the existing analysis, so it gets no caller drop and there is no double-free. A pushed or passed extracted field (`f(r.field)`) is unaffected (only the whole-composite branch is threaded).

## Verification

- Leak oracles over record/tuple/enum by-value params run 0-leak, and the leak returns when the admission is neutered (record ~160k, tuple/enum ~80k frames).
- A reuse oracle (`f(r); g(r)` loop-scaled) confirms the value is dropped exactly once at caller scope-exit with no double-free under a poisoned allocator.
- `cargo test -p hew-mir`: 369 passed, 0 failed.
- `cargo test -p hew-cli --test owned_param_reuse_leak_oracle`: 6 passed, 0 failed.
- `make checked-mir-verify`: OK, 49 fixtures × 2 stages byte-identical.
- `make test-hew-ratchet`: green.

## Out of scope

- A separate pre-existing callee-side enum-consume-drop leak (`fn f(e: E){ match e }`) is tracked in #2732.
- String and bytes by-value params are a separate follow-on.