### PR TITLE
fix(mir): complete drop lowering for nested-collection payloads

### DIFF
--- a/hew-cli/tests/actor_mailbox_record_collection_leak_oracle.rs
+++ b/hew-cli/tests/actor_mailbox_record_collection_leak_oracle.rs
@@ -1,0 +1,116 @@
+//! Actor mailbox record-with-collection-field drop canary (hew-lang/hew#2722).
+//!
+//! ## The shape
+//!
+//! A record whose field is a collection (`type Boxed { payload: [i64] }`) is sent
+//! to an actor by value; the receive handler reads the collection field:
+//!
+//! ```text
+//! actor Sink { receive fn take(b: Boxed) { for v in b.payload { … } } }
+//! sink.take(Boxed { payload: [i, i + 1, i + 2] });
+//! ```
+//!
+//! #2722 reported this leaking the record's collection field ~2 nodes/message:
+//! the mailbox delivery path did not recurse through the collection field.
+//!
+//! ## Status on the Stage-1 tip (`882ff31d9`)
+//!
+//! The collection-field delivery path is CLEAN on `882ff31d9` — the by-value
+//! receive-handler param's recursive teardown frees the record and its
+//! collection field(s) once per delivered message. This is a CANARY that locks
+//! that behaviour: the plain single-collection-field record and a two-collection
+//! -field record both hold a flat per-message leak slope.
+//!
+//! Out of scope (a DISTINCT root, not collection-field recursion): a
+//! mailbox-delivered record carrying a `string` field still leaks its string
+//! header — the `alloc_cstring_data` actor-mailbox class of #2717, tracked
+//! separately. This oracle deliberately uses collection-only records so it pins
+//! exactly the #2722 collection-recursion behaviour.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::assert_frame_slope_below_tolerance;
+
+/// PRIMARY #2722 shape: a `Boxed { payload: [i64] }` sent per message; the
+/// handler iterates `b.payload`. A final `await` synchronises so every message
+/// is delivered and dropped before the `leaks` snapshot.
+fn mailbox_record_collection_loop_source(frames: usize) -> String {
+    format!(
+        "type Boxed {{ payload: [i64] }}\n\
+         \n\
+         actor Sink {{\n\
+         \x20   var seen: i64;\n\
+         \x20   receive fn take(b: Boxed) {{\n\
+         \x20       var s: i64 = 0;\n\
+         \x20       for v in b.payload {{ s = s + v; }}\n\
+         \x20       seen = seen + s;\n\
+         \x20   }}\n\
+         \x20   receive fn total() -> i64 {{ seen }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let sink = spawn Sink(seen: 0);\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let b = Boxed {{ payload: [i, i + 1, i + 2] }};\n\
+         \x20       sink.take(b);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   match await sink.total() {{\n\
+         \x20       Ok(v) => {{ if v < 0 {{ 74 }} else {{ 0 }} }},\n\
+         \x20       Err(_e) => 1,\n\
+         \x20   }}\n\
+         }}\n"
+    )
+}
+
+/// Two-collection-field record: both `payload` and `extra` must be freed per
+/// delivered message.
+fn mailbox_record_two_collections_loop_source(frames: usize) -> String {
+    format!(
+        "type Boxed {{ payload: [i64]; extra: [i64] }}\n\
+         \n\
+         actor Sink {{\n\
+         \x20   var seen: i64;\n\
+         \x20   receive fn take(b: Boxed) {{\n\
+         \x20       var s: i64 = 0;\n\
+         \x20       for v in b.payload {{ s = s + v; }}\n\
+         \x20       for v in b.extra {{ s = s + v; }}\n\
+         \x20       seen = seen + s;\n\
+         \x20   }}\n\
+         \x20   receive fn total() -> i64 {{ seen }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let sink = spawn Sink(seen: 0);\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let b = Boxed {{ payload: [i, i + 1, i + 2], extra: [i * 2, i * 3] }};\n\
+         \x20       sink.take(b);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   match await sink.total() {{\n\
+         \x20       Ok(v) => {{ if v < 0 {{ 75 }} else {{ 0 }} }},\n\
+         \x20       Err(_e) => 1,\n\
+         \x20   }}\n\
+         }}\n"
+    )
+}
+
+#[test]
+fn mailbox_record_collection_field_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "mailbox_record_collection",
+        mailbox_record_collection_loop_source,
+    );
+}
+
+#[test]
+fn mailbox_record_two_collections_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "mailbox_record_two_collections",
+        mailbox_record_two_collections_loop_source,
+    );
+}

--- a/hew-cli/tests/for_in_matched_enum_payload_leak_oracle.rs
+++ b/hew-cli/tests/for_in_matched_enum_payload_leak_oracle.rs
@@ -1,0 +1,187 @@
+//! `for it in <matched enum collection payload>` drop oracle (hew-lang/hew#2725, site b).
+//!
+//! ## The shape
+//!
+//! An enum with a collection-carrying variant is matched, and the destructured
+//! payload binder is iterated by a `for`-in:
+//!
+//! ```text
+//! enum Msg { Empty; Batch([i64]) }
+//! match m { Batch(items) => { for it in items { … } }, Empty => {} }
+//! ```
+//!
+//! `items` is a match-projected payload binder that CowShare-borrows the enum's
+//! payload buffer; `for it in items` lowers it into a `VecIter { vec: items, idx }`
+//! cursor that iterates the shared buffer without freeing it. The scrutinee `m`
+//! is NOT consumed (the match reads the payload), so `m` retains sole ownership
+//! and its scope-exit `EnumInPlace` composite drop is the single freer of the
+//! payload; the borrowing cursor frees nothing.
+//!
+//! ## What regressed (pre-fix, reproduced on the Stage-1 tip `882ff31d9`)
+//!
+//! The enum-composite escape scan (`derive_enum_composite_drop_allowed`) read the
+//! cursor's `record_init VecIter { vec: items }` ingress of the payload binder as
+//! a payload ESCAPE and excluded `m` from its `EnumInPlace` drop — as if the
+//! payload left the composite. The place-source cursor borrows (it is never
+//! registered for a handle drop), so with `m` excluded NOTHING freed the payload:
+//! **2 leak nodes / frame** (the `Vec<i64>` header + buffer), on `882ff31d9`.
+//! The sibling INDEX read `items[j]` of the same payload was already clean (its
+//! receiver-borrow is exempt), so the gap was specific to the for-in cursor
+//! ingress.
+//!
+//! ## The fix
+//!
+//! A payload binder read as the `vec` field of a `record_init VecIter` cursor is
+//! a borrow — exempt it from the payload-escape scan, mirroring the cursor-ingress
+//! exemption `derive_local_collection_drop_allowed` already applies and the
+//! `items[j]` / `.len()` receiver-borrow exemptions. `m` is re-admitted and its
+//! `EnumInPlace` frees the payload exactly once.
+//!
+//! ## What this oracle pins
+//!
+//! * a flat per-iteration leak SLOPE across the LOW/HIGH frame delta — the enum
+//!   payload buffer is freed every frame (was ~2 nodes/frame);
+//! * no double-free / use-after-free under the poisoned allocator: the handler
+//!   alternates the `Batch`/`Empty` variants so both the composite `EnumInPlace`
+//!   drop and the empty-variant no-op run every iteration; a cursor that also
+//!   freed the shared buffer would abort here.
+//! * the INDEX-read sibling (`items[j]`) stays flat — the canary the pre-fix
+//!   report cited as already-clean, guarding against the fix over-reaching.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+/// PRIMARY #2725b shape: `for it in items` over a matched `Batch([i64])` payload.
+/// Alternates `Batch`/`Empty` so both the composite drop and the empty no-op run.
+fn for_in_matched_payload_loop_source(frames: usize) -> String {
+    format!(
+        "enum Msg {{ Empty; Batch([i64]) }}\n\
+         \n\
+         fn frame(n: i64) -> i64 {{\n\
+         \x20   let m: Msg = if n % 2 == 0 {{ Msg::Batch([n, n + 1, n + 2]) }} else {{ Msg::Empty }};\n\
+         \x20   var sum: i64 = 0;\n\
+         \x20   match m {{\n\
+         \x20       Msg::Batch(items) => {{ for it in items {{ sum = sum + it; }} }},\n\
+         \x20       Msg::Empty => {{ sum = sum + 1; }},\n\
+         \x20   }}\n\
+         \x20   sum\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total < 0 {{ 73 }} else {{ 0 }}\n\
+         }}\n"
+    )
+}
+
+/// INDEX-read canary: `items[j]` of the same matched payload was already clean
+/// pre-fix (receiver-borrow exempt). Pinned flat so the for-in fix does not
+/// regress the sibling read.
+fn index_read_matched_payload_loop_source(frames: usize) -> String {
+    format!(
+        "enum Msg {{ Empty; Batch([i64]) }}\n\
+         \n\
+         fn frame(n: i64) -> i64 {{\n\
+         \x20   let m: Msg = if n % 2 == 0 {{ Msg::Batch([n, n + 1, n + 2]) }} else {{ Msg::Empty }};\n\
+         \x20   var sum: i64 = 0;\n\
+         \x20   match m {{\n\
+         \x20       Msg::Batch(items) => {{ sum = sum + items[0] + items.len(); }},\n\
+         \x20       Msg::Empty => {{ sum = sum + 1; }},\n\
+         \x20   }}\n\
+         \x20   sum\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total < 0 {{ 74 }} else {{ 0 }}\n\
+         }}\n"
+    )
+}
+
+/// Deterministic exact-contents / no-double-free source: match a `Batch` payload,
+/// sum it via for-in, print the sum. Under the poisoned allocator a cursor that
+/// freed the shared buffer double-frees against the composite `EnumInPlace`.
+const FOR_IN_PAYLOAD_EXACT_SOURCE: &str = "enum Msg { Empty; Batch([i64]) }\n\
+     \n\
+     fn main() {\n\
+     \x20   let m: Msg = Msg::Batch([10, 20, 30]);\n\
+     \x20   var sum: i64 = 0;\n\
+     \x20   match m {\n\
+     \x20       Msg::Batch(items) => { for it in items { sum = sum + it; } },\n\
+     \x20       Msg::Empty => {},\n\
+     \x20   }\n\
+     \x20   println(f\"{sum}\");\n\
+     }\n";
+
+const FOR_IN_PAYLOAD_EXACT_EXPECTED: &str = "60\n";
+
+fn assert_exact_under_malloc_scribble(name: &str, source: &str, expected: &str) {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("for-in-matched-payload-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{name} must run clean under the poisoned allocator — a crash indicates the borrowing \
+         for-in cursor freed the payload buffer the composite EnumInPlace also frees (#2725b \
+         over-eager cursor free);\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        expected,
+        "{name} must sum the matched payload verbatim under the poisoned allocator;\n{}",
+        describe_output(&output)
+    );
+}
+
+/// PRIMARY #2725b regression: the for-in-over-matched-payload loop must hold a
+/// flat leak slope. Reverting the cursor-ingress exemption excludes the enum
+/// composite drop and strands the payload buffer (~2 nodes/frame).
+#[test]
+fn for_in_matched_payload_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "for_in_matched_enum_payload",
+        for_in_matched_payload_loop_source,
+    );
+}
+
+/// INDEX-read canary: the sibling `items[j]` read stays flat.
+#[test]
+fn index_read_matched_payload_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "index_read_matched_enum_payload",
+        index_read_matched_payload_loop_source,
+    );
+}
+
+/// Exact-contents / no-double-free pin under the poisoned allocator.
+#[test]
+fn for_in_matched_payload_exact_contents_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "for_in_payload_exact",
+        FOR_IN_PAYLOAD_EXACT_SOURCE,
+        FOR_IN_PAYLOAD_EXACT_EXPECTED,
+    );
+}

--- a/hew-cli/tests/nested_vec_field_push_leak_oracle.rs
+++ b/hew-cli/tests/nested_vec_field_push_leak_oracle.rs
@@ -1,0 +1,146 @@
+//! Nested-`Vec` field-push drop oracle (hew-lang/hew#2721).
+//!
+//! ## The shape
+//!
+//! A record whose field is itself a collection (`type Rec { field: [i64] }`)
+//! has that field pushed into a `Vec<Vec<i64>>` by COPY-IN:
+//!
+//! ```text
+//! let r = Rec { field: [n, n + 1, n + 2] };
+//! xs.push(r.field);            // hew_vec_push_owned — DEEP-CLONES the field
+//! ```
+//!
+//! `hew_vec_push_owned` deep-clones its element operand into the slot, so `xs`
+//! owns a DISJOINT clone and `r` keeps sole ownership of the ORIGINAL field
+//! buffer. Two owners, two buffers, each freed exactly once: the container's
+//! element drop-thunk frees the clone, and `r`'s scope-exit `RecordInPlace`
+//! composite drop frees the original.
+//!
+//! ## What regressed (pre-fix, reproduced on the Stage-1 tip `882ff31d9`)
+//!
+//! The composite field-binder escape scan (`note_field_escape`) treated the
+//! pushed field binder as a whole escape and excluded `r`'s composite drop —
+//! as if the push CONSUMED the field. But copy-in clones, so excluding `r`
+//! stranded the ORIGINAL field buffer: **2 leak nodes / frame** (one `Vec<i64>`
+//! header + buffer) rooted at `hew_vec_new_with_elem_size`, on `882ff31d9`.
+//! (Historically — pre the caller-side owned-param drop — the same mis-accounting
+//! surfaced as a double-free; the caller-drop widening turned it into a leak, so
+//! the anchor fix is now a missing-drop, not a wrong-drop.)
+//!
+//! ## The fix
+//!
+//! A field binder read as the operand of a COPY-IN element store is deep-cloned,
+//! not consumed, so it is exempt from `note_field_escape` — mirroring the
+//! whole-record copy-in alias-escape exemption already present. `r` is re-admitted
+//! and its `RecordInPlace` frees the original field exactly once. The MOVE variant
+//! (`hew_vec_push_owned_move`) stays non-exempt (it consumes its source).
+//!
+//! ## What this oracle pins
+//!
+//! * a flat per-iteration leak SLOPE across the LOW/HIGH frame delta — the
+//!   original field buffer is freed every frame (was ~2 nodes/frame);
+//! * no double-free / use-after-free under the poisoned allocator: an over-eager
+//!   re-admission that ALSO freed the clone-source's original through a second
+//!   owner would abort here. The exact-contents read-back proves the clone in
+//!   `xs` is a disjoint deep copy, not an alias of the freed original.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+/// Per-frame build-push-read-drop shape for the leak slope. Each iteration
+/// builds a fresh `Rec { field: [i, i+1, i+2] }`, pushes the field copy-in into
+/// a fresh `Vec<Vec<i64>>`, reads both the clone (via `xs`) and the retained
+/// original (via `r.field`), then lets both go out of scope on the back-edge.
+/// Post-fix the clone (container drop) AND the original (record composite drop)
+/// are freed each frame, so the leak count is flat.
+fn field_push_drop_loop_source(frames: usize) -> String {
+    format!(
+        "type Rec {{ field: [i64] }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let xs: [[i64]] = [];\n\
+         \x20       let r = Rec {{ field: [i, i + 1, i + 2] }};\n\
+         \x20       xs.push(r.field);\n\
+         \x20       total = total + xs[0].len() + r.field.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Deterministic exact-contents source: push a known field copy-in, then read
+/// BOTH the clone (`xs[0][k]`) and the retained original (`r.field[k]`) and sum
+/// them. If the fix mis-shares the clone and the original one buffer, the
+/// scribbled allocator poisons the second read or aborts on the double-free.
+const FIELD_PUSH_EXACT_SOURCE: &str = "type Rec { field: [i64] }\n\
+     \n\
+     fn main() {\n\
+     \x20   let xs: [[i64]] = [];\n\
+     \x20   let r = Rec { field: [10, 20, 30] };\n\
+     \x20   xs.push(r.field);\n\
+     \x20   let clone_sum = xs[0][0] + xs[0][1] + xs[0][2];\n\
+     \x20   let orig_sum = r.field[0] + r.field[1] + r.field[2];\n\
+     \x20   println(f\"{clone_sum},{orig_sum}\");\n\
+     }\n";
+
+/// Both the disjoint clone in `xs` and the retained original in `r` must read
+/// back 60 (10+20+30) under the poisoned allocator.
+const FIELD_PUSH_EXACT_EXPECTED: &str = "60,60\n";
+
+/// Compile `source`, run under the poisoned-allocator triple, assert clean exit
+/// with `expected` stdout.
+fn assert_exact_under_malloc_scribble(name: &str, source: &str, expected: &str) {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("nested-vec-field-push-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{name} must run clean under the poisoned allocator — a crash indicates the pushed \
+         copy-in clone and the record's retained original share one buffer that is freed twice \
+         (#2721 over-eager re-admission);\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        expected,
+        "{name} must read the disjoint clone AND the retained original verbatim — a differing \
+         value indicates the clone aliased the original buffer instead of a deep copy;\n{}",
+        describe_output(&output)
+    );
+}
+
+/// PRIMARY #2721 regression: the field-push build-drop loop must hold a flat
+/// leak slope. Reverting the copy-in field-binder exemption strands the record's
+/// original field buffer (~2 nodes/frame) and this fails.
+#[test]
+fn field_push_drop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("nested_vec_field_push", field_push_drop_loop_source);
+}
+
+/// Exact-contents / no-double-free pin: the deep-cloned element in `xs` and the
+/// record's retained original are disjoint owners; both read back 60 and neither
+/// double-frees under the poisoned allocator.
+#[test]
+fn field_push_exact_contents_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "field_push_exact",
+        FIELD_PUSH_EXACT_SOURCE,
+        FIELD_PUSH_EXACT_EXPECTED,
+    );
+}

--- a/hew-cli/tests/nested_vec_get_clone_leak_oracle.rs
+++ b/hew-cli/tests/nested_vec_get_clone_leak_oracle.rs
@@ -1,0 +1,90 @@
+//! Nested-`Vec` index-read (`hew_vec_get_clone`) drop canary (hew-lang/hew#2725, site a).
+//!
+//! ## The shape
+//!
+//! Indexing a `Vec<Vec<i64>>` binds a fresh clone of the inner collection:
+//!
+//! ```text
+//! let vv: [[i64]] = [];  vv.push([1, 2, 3]);  vv.push([4, 5, 6]);
+//! let inner = vv[i];     // hew_vec_get_clone — deep-clones the inner Vec
+//! ```
+//!
+//! #2725 site (a) reported the caller-side fresh transient from `hew_vec_get_clone`
+//! never recursing drop through the cloned inner buffer — 4 leaks/frame on the
+//! issue's base `dac280f36`.
+//!
+//! ## Status on the Stage-1 tip (`882ff31d9`)
+//!
+//! CLEAN on `882ff31d9` — the index-read transient of a collection-bearing
+//! element is freed at transient scope exit across bind-and-len, bind-and-index,
+//! and bind-and-for-in uses. This is a CANARY locking that behaviour with a flat
+//! per-frame leak slope; the emitted code routes through `hew_vec_get_clone`
+//! (asserted by the pre-fix issue and confirmed in the `.ll` for these shapes).
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::assert_frame_slope_below_tolerance;
+
+/// `let inner = vv[i]` then iterate the clone (for-in consumes the transient).
+fn get_clone_for_in_loop_source(frames: usize) -> String {
+    format!(
+        "fn frame() -> i64 {{\n\
+         \x20   let vv: [[i64]] = [];\n\
+         \x20   vv.push([1, 2, 3]);\n\
+         \x20   vv.push([4, 5, 6]);\n\
+         \x20   let inner = vv[0];\n\
+         \x20   var sum: i64 = 0;\n\
+         \x20   for v in inner {{ sum = sum + v; }}\n\
+         \x20   sum\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total < 0 {{ 72 }} else {{ 0 }}\n\
+         }}\n"
+    )
+}
+
+/// `let inner = vv[i]` then read `inner.len()` — the clone is bound and read but
+/// not iterated; the transient must still be freed at scope exit.
+fn get_clone_bind_len_loop_source(frames: usize) -> String {
+    format!(
+        "fn frame() -> i64 {{\n\
+         \x20   let vv: [[i64]] = [];\n\
+         \x20   vv.push([1, 2, 3]);\n\
+         \x20   vv.push([4, 5, 6]);\n\
+         \x20   let inner = vv[1];\n\
+         \x20   inner.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total < 0 {{ 72 }} else {{ 0 }}\n\
+         }}\n"
+    )
+}
+
+#[test]
+fn get_clone_for_in_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("nested_vec_get_clone_for_in", get_clone_for_in_loop_source);
+}
+
+#[test]
+fn get_clone_bind_len_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "nested_vec_get_clone_bind_len",
+        get_clone_bind_len_loop_source,
+    );
+}

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -1179,6 +1179,21 @@ pub(super) fn derive_enum_composite_drop_allowed(
             excluded.insert(root);
         }
     };
+    // A payload binder read as the `vec` field of a `record_init VecIter` cursor
+    // is a BORROW: a `for it in items` over a matched collection payload
+    // (`match m { Batch(items) => for it in items }`) lowers the payload binder
+    // into `VecIter { vec: items, idx: 0 }`, which ITERATES the shared buffer
+    // without freeing it (a CowShare place source). The composite still solely
+    // owns the payload and keeps its `EnumInPlace` drop — mirroring
+    // `derive_local_collection_drop_allowed`'s cursor-ingress exemption and the
+    // `items[i]` / `.len()` receiver-borrow exemptions below. The place-source
+    // cursor is never registered for a handle drop
+    // (`vec_iter_let_cursor_owns_handle` = false), so the composite's single free
+    // is exactly-once, never a double-free. Left unexempted the cursor ingress
+    // read wrongly excluded the composite and leaked the payload buffer (#2725b).
+    let vec_iter_cursor_ingress_of = |instr: &Instr, local: u32| -> bool {
+        vec_iter_record_init_vec_source(instr).and_then(base_local) == Some(local)
+    };
     for block in blocks {
         for instr in &block.instructions {
             // COPY-IN element store (`hew_vec_push_owned` / `hew_vec_set_owned`)
@@ -1355,6 +1370,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
                         if payload_binders.contains_key(&l)
                             && !place_is_tag_read(p)
                             && !binder_read_is_borrow_safe_instr(instr, l)
+                            && !vec_iter_cursor_ingress_of(instr, l)
                         {
                             note_payload_escape(
                                 &payload_binders,

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -1775,12 +1775,15 @@ pub(super) fn derive_owned_record_drop_allowed(
             // `RecordInPlace` drop (#1722 `container-ingress-ownership-is-per-
             // container` COPY-IN retain, the record analogue of the exemption
             // `derive_local_collection_drop_allowed` already applies for the Vec
-            // handle). This exempts ONLY the whole-record alias escape below; a
-            // pushed owned FIELD BINDER (`xs.push(r.field)`) still excludes its
-            // composite via the field-escape scan, because that discharge path
-            // double-frees if relaxed (`vec_copy_in_tail_split...`). The MOVE
-            // variant (`hew_vec_push_owned_move`) is deliberately NOT exempt — it
-            // consumes its source, which must then be excluded.
+            // handle). This exempts BOTH the whole-record alias escape AND the
+            // field-escape scan below: a pushed owned FIELD BINDER
+            // (`xs.push(r.field)`) is DEEP-CLONED into the slot, so the origin
+            // record keeps sole ownership of the ORIGINAL field and must retain
+            // its composite drop — excluding it leaks the original buffer
+            // (#2721; the container's element drop-thunk owns the disjoint
+            // clone). The MOVE variant (`hew_vec_push_owned_move`) is
+            // deliberately NOT exempt — it consumes its source, which must then
+            // be excluded.
             let copy_in_elem_store = matches!(instr, Instr::CallRuntimeAbi(call)
                 if crate::runtime_symbols::callee_ownership_contract(call.symbol())
                     .is_vec_copy_in_element_store());
@@ -1892,7 +1895,10 @@ pub(super) fn derive_owned_record_drop_allowed(
                         {
                             note_alias_escape(l, &mut excluded_roots);
                         }
-                        if is_escape_binder(l) && !binder_read_is_borrow_safe_instr(instr, l) {
+                        if !copy_in_elem_store
+                            && is_escape_binder(l)
+                            && !binder_read_is_borrow_safe_instr(instr, l)
+                        {
                             note_field_escape(l, &mut excluded_roots);
                         }
                     }
@@ -1903,10 +1909,13 @@ pub(super) fn derive_owned_record_drop_allowed(
         // `Terminator::Call { callee: hew_vec_push_owned, args: [xs, src] }`):
         // a WHOLE owned record source is deep-cloned, not consumed, so it retains
         // its `RecordInPlace` drop and the borrowed receiver is not a candidate
-        // record. Exempt ONLY the whole-record alias escape below — a pushed
-        // FIELD BINDER (`xs.push(r.field)`) still excludes its composite via the
-        // field-escape scan (relaxing that discharge double-frees). This closes
-        // the copy-in `.push(src)` leak of `src`'s owned collection field.
+        // record. Exempt BOTH the whole-record alias escape AND the field-escape
+        // scan below — a pushed FIELD BINDER (`xs.push(r.field)`) is deep-cloned,
+        // so the origin record keeps sole ownership of the ORIGINAL field and
+        // must retain its composite drop (#2721; the container's element
+        // drop-thunk owns the clone). This closes the copy-in `.push(src)` leak
+        // of `src`'s owned collection field AND the field-push leak of the
+        // record's original field buffer.
         let copy_in_elem_store = matches!(
             &block.terminator,
             Terminator::Call { callee, .. }
@@ -1939,7 +1948,8 @@ pub(super) fn derive_owned_record_drop_allowed(
                 {
                     note_alias_escape(l, &mut excluded_roots);
                 }
-                if is_escape_binder(l)
+                if !copy_in_elem_store
+                    && is_escape_binder(l)
                     && !binder_read_is_borrow_safe_terminator(
                         &block.terminator,
                         suspend_kinds.get(&block.id),
@@ -5372,11 +5382,16 @@ mod owned_record_drop_derivation {
         );
     }
 
-    /// `hew_vec_push_owned` / `hew_vec_set_owned` copy their element into the
-    /// destination Vec. The collection-local prover exempts that element operand,
-    /// while composite binder scans still treat the tail operand as an escape.
+    /// `hew_vec_push_owned` / `hew_vec_set_owned` DEEP-CLONE their element
+    /// operand into the destination Vec, so the source keeps sole ownership of
+    /// its own heap. Both the collection-local prover AND the composite binder
+    /// scans therefore retain their candidate: a field binder pushed copy-in
+    /// (`xs.push(r.field)`) leaves `r` owning the ORIGINAL field buffer, so the
+    /// record retains its `RecordInPlace` composite drop (the container's
+    /// element drop-thunk owns the disjoint clone). Excluding the composite
+    /// here leaked the original field buffer (#2721).
     #[test]
-    fn vec_copy_in_tail_split_keeps_local_candidate_but_excludes_composite_binder() {
+    fn vec_copy_in_tail_split_retains_local_candidate_and_composite_binder() {
         let callee = "hew_vec_push_owned";
         let call_builtin = hew_types::runtime_call::RuntimeCallFamily::from_c_symbol(callee);
 
@@ -5408,9 +5423,11 @@ mod owned_record_drop_derivation {
             &record_local_tys,
         );
         assert!(
-            !record_allowed.contains(&record),
-            "a composite field binder used as the copy-in element operand is a \
-             tail read and must exclude the composite; allowed: {record_allowed:?}"
+            record_allowed.contains(&record),
+            "a composite field binder used as the copy-in element operand is \
+             DEEP-CLONED, not consumed, so the record keeps sole ownership of \
+             the original field and must retain its composite drop; excluding \
+             it leaks the original buffer (#2721); allowed: {record_allowed:?}"
         );
 
         let elem = BindingId(11);


### PR DESCRIPTION
## Summary

Two drop-plan gaps left nested collections leaking. When a record field is pushed into another collection as a copy-in element, the origin record still owns that field and must run its `RecordInPlace` drop — the element push is now a deep clone, so both the pushed copy and the retained field are freed independently. Separately, a `for-in` over a matched-enum payload reads the payload through a `VecIter` cursor, which is a borrow, so the enum keeps its `EnumInPlace` drop instead of having ownership silently transferred to the loop.

## Verification

- Leak oracles report zero leaks with the fix and reproduce the leak when the drop is neutered (`nested_vec_field_push_leak_oracle`, `for_in_matched_enum_payload_leak_oracle`, `nested_vec_get_clone_leak_oracle`, `actor_mailbox_record_collection_leak_oracle`).
- Poisoned-allocator runs under `MallocScribble`/`GuardEdges` with exact-content pins confirm no double-free in either direction (disjoint deep-clone, 60/60; `VecIter` cursor borrow, no handle drop).
- Preflight: ready-to-push.

## Out of scope

- The residual mailbox record STRING-field leak belongs to the `alloc_cstring_data` allocation class and is tracked separately in #2738.

Closes #2721
Closes #2722
Closes #2725