### PR TITLE
fix: register nested Option/Result/generic-enum field layouts from record structure

### DIFF
--- a/hew-hir/src/layout_mono.rs
+++ b/hew-hir/src/layout_mono.rs
@@ -742,6 +742,13 @@ impl Discovery<'_> {
     ) {
         let substituted = substitute_ty(ty, subst);
         let mut worklist = vec![substituted];
+        // Guards the type-structure descent (below) against unbounded recursion
+        // on a recursive type shape (`type Node { next: Option<Node> }`). Keyed
+        // by the mangled instantiation name (bare name for a monomorphic type),
+        // so each distinct shape's fields/variants are enqueued at most once per
+        // `visit_ty` call. Registration itself is separately deduped by
+        // `seen_records`/`seen_enums`, so this guard never suppresses a layout.
+        let mut expanded: HashSet<String> = HashSet::new();
         while let Some(t) = worklist.pop() {
             // Enqueue nested args first so `Box<Pair<i64,bool>>` reaches
             // through both `Box<...>` and `Pair<i64,bool>`.
@@ -750,10 +757,18 @@ impl Discovery<'_> {
                 continue;
             };
             if args.is_empty() {
-                // A bare name is either a monomorphic type (no per-instantiation
-                // layout needed) or a residual abstract symbol. A residual is
-                // caught when it appears *as an arg* of a generic instantiation
-                // below; a top-level bare name is never a generic-layout site.
+                // A bare name is either a monomorphic type or a residual abstract
+                // symbol. A residual is caught when it appears *as an arg* of a
+                // generic instantiation below. A monomorphic named type needs no
+                // per-instantiation layout of its own, but it may carry a generic
+                // FIELD (`type CSlot { value: Option<string> }`) whose layout is
+                // registered ONLY from the constructed type's structure — never
+                // from a live value if that field is never exercised. Descend
+                // into its declared field/variant types so the nested
+                // `Option<string>` instantiation is discovered. A name that is
+                // not a user record/enum decl (a type-param, `Vec`, …) is a
+                // no-op descent.
+                self.enqueue_decl_fields(name, &[], &mut worklist, &mut expanded);
                 continue;
             }
             // Classify the args once. An instantiation is registrable only
@@ -790,7 +805,85 @@ impl Discovery<'_> {
                 }
                 self.register_enum(name, decl, args, span);
             }
+            // Descend into this instantiation's SUBSTITUTED field/variant types
+            // so a nested generic field reached only through structure — e.g.
+            // `Slot<string>`'s `value: Option<string>` → `Option$$string` — is
+            // discovered even when no live value of the inner type is lowered.
+            self.enqueue_decl_fields(name, args, &mut worklist, &mut expanded);
         }
+    }
+
+    /// Enqueue the (substituted) declared field / variant types of the user
+    /// record or enum `name` instantiated with `args` onto `worklist`, so the
+    /// discovery walk descends through the constructed type's structure. This is
+    /// what lets a present-but-unexercised generic field type (`Option<string>`
+    /// inside a constructed record whose Option is never a live value) register
+    /// its layout from TYPE STRUCTURE rather than from a value-lowering side
+    /// effect. `args` is empty for a monomorphic type (substitution is then the
+    /// identity). `expanded` dedups by mangled/bare name to bound recursion on a
+    /// recursive type shape. A `name` that resolves to no user record/enum decl
+    /// (a builtin like `Vec`, or a type-parameter symbol) is a no-op.
+    fn enqueue_decl_fields(
+        &self,
+        name: &str,
+        args: &[ResolvedTy],
+        worklist: &mut Vec<ResolvedTy>,
+        expanded: &mut HashSet<String>,
+    ) {
+        let dedup_key = if args.is_empty() {
+            name.to_string()
+        } else {
+            mangle(name, args)
+        };
+        if !expanded.insert(dedup_key) {
+            return;
+        }
+        let substituted_fields: Vec<ResolvedTy> = if let Some(decl) = self.record_decls.get(name) {
+            if args.len() != decl.type_params.len() {
+                return;
+            }
+            decl.fields
+                .iter()
+                .map(|(_, fty)| {
+                    crate::monomorph::substitute_type_params(fty, &decl.type_params, args)
+                })
+                .collect()
+        } else if let Some(decl) = self.enum_decls.get(name) {
+            if args.len() != decl.type_params.len() {
+                return;
+            }
+            decl.variants
+                .iter()
+                .flat_map(|variant| {
+                    variant
+                        .field_tys()
+                        .into_iter()
+                        .map(|fty| {
+                            crate::monomorph::substitute_type_params(&fty, &decl.type_params, args)
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        } else {
+            // Not a user record/enum decl (builtin container, type-param
+            // symbol, …): nothing to descend into.
+            return;
+        };
+        // Do NOT descend through a recursive-polymorphic-diverging instantiation.
+        // `register_record` / `register_enum` reject such an instantiation with
+        // `RecursiveGenericTypeUnsupported` and register no layout; its
+        // substituted fields reference the same origin with strictly-larger args
+        // (`Grow<i64>` → field `Grow<Grow<i64>>`), so seeding them would drive
+        // unbounded layout expansion the origin path never performs. Match that
+        // guard here so structural descent registers exactly the layouts the
+        // (bounded) type graph admits — no more.
+        if substituted_fields
+            .iter()
+            .any(|fty| contains_recursive_polymorphic_self(fty, name, args))
+        {
+            return;
+        }
+        worklist.extend(substituted_fields);
     }
 
     /// Classify a generic instantiation's type arguments for registration.

--- a/tests/hew/nested_option_layout_registration_test.hew
+++ b/tests/hew/nested_option_layout_registration_test.hew
@@ -1,0 +1,122 @@
+//! Nested field-type layout registration must derive from a constructed
+//! record's TYPE STRUCTURE, not from a live value of the inner type being
+//! lowered (#2746).
+//!
+//! A record with a transitively-nested `Option<…>` / `Result<…>` / generic
+//! user-enum field, constructed while NO live path ever constructs or matches
+//! that inner enum, must still compile: the nested `Option$$string` /
+//! `Result$$i64$string` / `Box$$Color` `EnumLayout` is registered from the
+//! constructed record's field structure, upstream of the actor-state /
+//! value-class classifier.
+//!
+//! Before the fix this failed closed with:
+//!   `could not resolve RecordLayout for nested user record Option
+//!    (record layouts must precede actor layouts in lower_hir_module)`
+//! because the inner enum layout was only ever registered as a side effect of
+//! a live `Some`/`None`/match on that Option — which these programs never hit.
+//!
+//! Teeth: the `*_unexercised_*` tests preserve the exact defect trigger (the
+//! inner enum is NEVER exercised) and assert exact structural values; the
+//! `exercised_*` test pins the already-working matched-Option path so the fix
+//! does not perturb it.
+
+import std::testing;
+
+// ── SF2-shape: transitively-nested `Option<string>`, never exercised. ──
+type CSlot {
+    generation: i64;
+    value: Option<string>;
+}
+
+type CArena {
+    slots: Vec<CSlot>;
+    free: Vec<i64>;
+}
+
+fn cnew() -> CArena {
+    CArena { slots: Vec::new(), free: Vec::new() }
+}
+
+#[test]
+fn constructs_record_with_unexercised_nested_option_field() {
+    // Construct the outer record but NEVER build or match the nested Option.
+    let a: CArena = cnew();
+    // Assert exact structural values without touching the Option field, so the
+    // present-but-unexercised trigger is preserved.
+    testing.assert_eq(a.slots.len(), 0);
+    testing.assert_eq(a.free.len(), 0);
+}
+
+// ── Nested-enum coverage: `Result<i64, string>`, never exercised. ──
+type RSlot {
+    code: i64;
+    outcome: Result<i64, string>;
+}
+
+type RBox {
+    slots: Vec<RSlot>;
+}
+
+fn rnew() -> RBox {
+    RBox { slots: Vec::new() }
+}
+
+#[test]
+fn constructs_record_with_unexercised_nested_result_field() {
+    let b: RBox = rnew();
+    testing.assert_eq(b.slots.len(), 0);
+}
+
+// ── Nested generic-enum-of-user-enum: `Option<Colour>`, never exercised. ──
+enum Colour {
+    Red;
+    Green;
+    Blue;
+}
+
+type Pixel {
+    id: i64;
+    tint: Option<Colour>;
+}
+
+type Canvas {
+    pixels: Vec<Pixel>;
+}
+
+fn canvas_new() -> Canvas {
+    Canvas { pixels: Vec::new() }
+}
+
+#[test]
+fn constructs_record_with_unexercised_nested_generic_enum_field() {
+    let c: Canvas = canvas_new();
+    testing.assert_eq(c.pixels.len(), 0);
+}
+
+// ── Regression pin: the matched-Option path still round-trips its value. ──
+type XSlot {
+    generation: i64;
+    value: Option<string>;
+}
+
+type XArena {
+    slots: Vec<XSlot>;
+}
+
+fn xnew() -> XArena {
+    XArena { slots: Vec::new() }
+}
+
+#[test]
+fn exercised_nested_option_field_roundtrips_value() {
+    let a: XArena = xnew();
+    a.slots.push(XSlot { generation: 0, value: Some("hello") });
+    let got = match a.slots.get(0) {
+        Some(slot) => match slot.value {
+            Some(v) => v,
+            None => "MISS",
+        },
+        None => "NONE",
+    };
+    testing.assert_eq_str(got, "hello");
+}


### PR DESCRIPTION
## Summary

A record with a nested `Option`/`Result`/generic-enum field that the program constructs but never exercises previously failed to compile with `MissingRecordLayout`. The nested type's layout was only registered as a side effect of a live value flowing through it, so a field that was built but never read, matched, or unwrapped never got its layout registered.

The fix descends the record/enum field/variant structure in the layout-mono walker, registering each nested type's layout from the type structure itself rather than relying on a live value. The descent is bounded by the existing recursive-polymorphism guard, so recursive generic types still terminate.

## Verification

- New fixture `tests/hew/nested_option_layout_registration_test.hew` (4 tests): unexercised nested `Option`, `Result`, and generic-enum fields now compile; regression pins for the exercised path continue to hold.
- Neutering the fix reproduces the original `MissingRecordLayout` failure.
- `test-hew-ratchet` green.

## Out of scope

No behavioural change beyond layout registration; codegen for exercised paths is unaffected.

Closes #2746