### PR TITLE
fix(mir): route fresh-temp Vec index-assign to the move-in store

### DIFF
--- a/hew-cli/tests/vec_index_assign_temp_leak_oracle.rs
+++ b/hew-cli/tests/vec_index_assign_temp_leak_oracle.rs
@@ -1,0 +1,352 @@
+//! Owned-Vec INDEX-ASSIGNMENT (`v[i] = ..`) TEMP leak oracle: a fresh, unbound
+//! aggregate rvalue used as an index-assignment RHS must not leak its heap.
+//!
+//! ## The bug this pins
+//!
+//! `v[i] = Holder { .. }` lowers through `assign()`'s Vec-set target arm, which
+//! emitted `hew_vec_set_owned` (COPY-IN — deep-clone the element into the slot)
+//! UNCONDITIONALLY. The `.set(i, ..)` METHOD path already routed a fresh
+//! materialised owner to the MOVE-in sibling `hew_vec_set_owned_move`, but the
+//! index-assignment SUGAR did not: it never applied the
+//! `expr_is_materialized_owner` gate, so an unbound `Holder { .. }` RHS was
+//! deep-cloned COPY-IN with no binding and no scope-exit drop to balance the
+//! clone — the source temp's owned heap leaked once per store. Measured on the
+//! fix base: the 50-frame positive shape leaks 200 nodes (~4 per store); the fix
+//! routes the fresh materialised RHS to `hew_vec_set_owned_move` and it leaks 0.
+//!
+//! ## Why a DEEP-OWNED element (not a string field)
+//!
+//! Same rationale as the sibling `vec_push_temp_leak_oracle`: a record with only
+//! a `string` field does NOT leak under copy-in (strings are refcount-shared and
+//! reclaimed via the vec free). Only a DEEP-OWNED element (`Holder { items:
+//! Vec<string> }`, whose `clone_fn` deep-copies into a DISTINCT buffer) exposes
+//! the leak. A `Vec<record{string}>` fixture would pass even with the bug.
+//!
+//! ## The copy-shape pin
+//!
+//! A bare-binding RHS (`v[i] = h`) must STAY `hew_vec_set_owned` (COPY-IN):
+//! `expr_is_materialized_owner` returns false for a `BindingRef`, so the router
+//! must not widen it to the move sibling. Unlike the `.set()` method path, the
+//! index-assignment lowering CONSUMES the binding in checked MIR (`v[i] = h; use
+//! h` is a use-after-consume error), so a wrongful move would not double-free a
+//! live reader at runtime — a run-clean check alone is toothless here. The pin
+//! therefore asserts the EMITTED SYMBOL directly: the bound-local shape's object
+//! must reference `hew_vec_set_owned` and must NOT reference
+//! `hew_vec_set_owned_move`. That is the routing decision the fix must leave
+//! intact for non-materialised sources.
+//!
+//! ## Skip behaviour
+//!
+//! The slope oracle is macOS-only (`leaks(1)` is Darwin's allocator inspector);
+//! elsewhere it logs `skip:` and returns. The symbol pin runs on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// Low frame count: exercises the loop back-edge at least twice while staying
+/// near the constant-overhead floor.
+const LOW_FRAMES: usize = 3;
+
+/// High frame count for the slope check. A pre-fix slope of ~4 leaks/frame for
+/// the deep-owned element leak class produces `HIGH_FRAMES - LOW_FRAMES = 47`
+/// frames × 4 ≈ 188 excess nodes against the tolerance of 5.
+const HIGH_FRAMES: usize = 50;
+
+/// Maximum permitted leak-node delta between the HIGH and LOW probes. Same
+/// headroom rationale as the sibling oracles: absorbs one-off runtime/scheduler
+/// allocations that appear only in the HIGH run while still catching a slope of
+/// ~0.1 leaks/frame.
+const SLOPE_TOLERANCE: usize = 5;
+
+/// Shared prelude: a deep-owned element type and a fresh-Vec producer. `mkItems`
+/// returns a FRESH `Vec<string>` (rc=1, its own buffer) so each element the
+/// store ingests owns distinct heap the leak oracle can count.
+const PRELUDE: &str = "\
+record Holder { items: Vec<string> }\n\
+fn mkItems(i: i64) -> Vec<string> {\n\
+\x20   var xs: Vec<string> = Vec::new();\n\
+\x20   xs.push(\"deep-elem-a\");\n\
+\x20   xs.push(\"deep-elem-b\");\n\
+\x20   return xs;\n\
+}\n";
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+
+/// An unbound `Holder { .. }` INDEX-ASSIGN per iteration over a one-element seed.
+/// The RHS is a fresh materialised owner routed to `hew_vec_set_owned_move`;
+/// index-assignment's overwrite-drop frees the replaced element and the move
+/// transfers the new element's heap, so the source temp leaks nothing. Pre-fix
+/// (`hew_vec_set_owned`, COPY-IN) this leaks ~4 nodes/frame.
+fn index_assign_temp_source(frames: usize) -> String {
+    format!(
+        "{PRELUDE}\
+         fn main() -> i64 {{\n\
+         \x20   var v: Vec<Holder> = Vec::new();\n\
+         \x20   v.push(Holder {{ items: mkItems(0) }});\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       v[0] = Holder {{ items: mkItems(i) }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   v.len()\n\
+         }}\n"
+    )
+}
+
+/// Copy-shape pin source: a bare-binding index-assign (`v[0] = h`). The RHS is a
+/// `BindingRef`, not a materialised rvalue, so the router must keep COPY-IN. The
+/// binding is consumed by the assignment, so the stored element is read back
+/// through the vec (`v[0].items.len()` == 2) to prove the store landed. Expected
+/// stdout: `2OK`.
+const COPY_SHAPE_SOURCE: &str = "\
+record Holder { items: Vec<string> }\n\
+fn mkItems(i: i64) -> Vec<string> {\n\
+\x20   var xs: Vec<string> = Vec::new();\n\
+\x20   xs.push(\"deep-elem-a\");\n\
+\x20   xs.push(\"deep-elem-b\");\n\
+\x20   return xs;\n\
+}\n\
+fn indexAssignBound() -> i64 {\n\
+\x20   var v: Vec<Holder> = Vec::new();\n\
+\x20   v.push(Holder { items: mkItems(0) });\n\
+\x20   let h = Holder { items: mkItems(1) };\n\
+\x20   v[0] = h;\n\
+\x20   return v[0].items.len();\n\
+}\n\
+fn main() {\n\
+\x20   print(indexAssignBound());\n\
+\x20   print(\"OK\");\n\
+}\n";
+
+// ── leak measurement plumbing (same shape as vec_push_temp_leak_oracle) ────
+
+/// Compile `source` to a native binary via `hew compile --emit-dir` and return
+/// the emit directory plus the binary path. The relocatable `<name>.o` sits
+/// alongside the binary in the emit dir for symbol inspection.
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and return
+/// `Some(leak_count)` when `leaks` produced a usable report.
+fn measure_leaks(bin: &std::path::Path) -> Option<usize> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    let mut parsed: Option<usize> = None;
+    for line in report.lines() {
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Process ") {
+            if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            if let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) {
+                if let Some(n) = after_colon.split_whitespace().next() {
+                    if let Ok(n) = n.parse::<usize>() {
+                        eprintln!("  parsed leak count from line: {line}");
+                        parsed = Some(n);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if parsed.is_none() {
+        eprintln!(
+            "skip: leaks did not emit a `Process <pid>: N leak(s) for B total leaked bytes.` \
+             summary for {}: stderr=\n{}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    parsed
+}
+
+/// Build the shape at `low_frames` and `high_frames`, measure leak NODE counts,
+/// and assert the delta stays within `SLOPE_TOLERANCE`.
+fn assert_frame_slope_below_tolerance(
+    shape_name: &str,
+    source_fn: fn(usize) -> String,
+    low_frames: usize,
+    high_frames: usize,
+) {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {shape_name}: leaks(1) is macOS-only");
+        return;
+    }
+    let leaks_avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !leaks_avail {
+        eprintln!("skip: {shape_name}: `leaks` binary not on PATH");
+        return;
+    }
+
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("vec-index-assign-leak-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+
+    let bin_low = compile_to_native(
+        &source_fn(low_frames),
+        dir.path(),
+        &format!("{shape_name}_low"),
+    );
+    let bin_high = compile_to_native(
+        &source_fn(high_frames),
+        dir.path(),
+        &format!("{shape_name}_high"),
+    );
+
+    let Some(low_leaks) = measure_leaks(&bin_low) else {
+        return;
+    };
+    let Some(high_leaks) = measure_leaks(&bin_high) else {
+        return;
+    };
+
+    eprintln!(
+        "{shape_name}: low_frames={low_frames} low_leaks={low_leaks} \
+         high_frames={high_frames} high_leaks={high_leaks} tolerance={SLOPE_TOLERANCE}"
+    );
+    assert!(
+        high_leaks <= low_leaks + SLOPE_TOLERANCE,
+        "{shape_name}: per-frame leak SLOPE — low_frames={low_frames} low_leaks={low_leaks}, \
+         high_frames={high_frames} high_leaks={high_leaks}. Excess of {} NODES over the \
+         tolerance of {SLOPE_TOLERANCE} indicates a per-iteration owned-element temp is not \
+         being released — the unbound aggregate index-assign RHS is deep-cloned COPY-IN and its \
+         heap leaks. Route the fresh materialised RHS to the MOVE-in sibling \
+         (`hew_vec_set_owned_move`) in `assign()`'s Vec-set target arm. Re-run with \
+         `MallocStackLogging=1 leaks --atExit -- {}` to see the leaked block's stack.",
+        high_leaks.saturating_sub(low_leaks + SLOPE_TOLERANCE),
+        bin_high.display()
+    );
+}
+
+// ── oracles ───────────────────────────────────────────────────────────────
+
+/// An unbound `Holder { .. }` INDEX-ASSIGN per iteration must not leak — the
+/// fresh materialised RHS is routed to `hew_vec_set_owned_move`, not deep-cloned.
+/// Reverting the `expr_is_materialized_owner` gate in `assign()`'s Vec-set arm
+/// fails this by ~188 nodes: this is the hole the fix closes.
+#[test]
+fn vec_index_assign_owned_temp_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "index_assign_temp",
+        index_assign_temp_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Copy-shape pin: a bare-binding index-assign (`v[0] = h`) must STAY COPY-IN.
+/// The router must not widen a `BindingRef` RHS to `hew_vec_set_owned_move`, so
+/// the emitted object must reference `hew_vec_set_owned` and NOT the move
+/// sibling. The binary also runs clean under the poisoned-allocator triple and
+/// prints `2OK` (the stored element read back through the vec).
+#[test]
+fn vec_index_assign_bound_local_stays_copy_in() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("vec-index-assign-copy-shape-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(COPY_SHAPE_SOURCE, dir.path(), "copy_shape");
+
+    // The relocatable object sits alongside the binary in the emit dir.
+    let obj = dir.path().join("copy_shape.o");
+    let nm = Command::new("nm")
+        .arg(&obj)
+        .output()
+        .expect("invoke nm on emitted object");
+    assert!(
+        nm.status.success(),
+        "nm failed on {}:\n{}",
+        obj.display(),
+        describe_output(&nm)
+    );
+    let symbols = String::from_utf8_lossy(&nm.stdout);
+    // Symbol names are `_`-prefixed on Mach-O and bare on ELF; match the stem.
+    assert!(
+        symbols.contains("hew_vec_set_owned")
+            && !symbols
+                .lines()
+                .any(|l| l.contains("hew_vec_set_owned_move")),
+        "bound-local index-assign (`v[i] = h`) must emit the COPY-IN symbol \
+         `hew_vec_set_owned`, never the MOVE sibling `hew_vec_set_owned_move` — a \
+         `BindingRef` RHS is not a materialised owner and `expr_is_materialized_owner` \
+         must return false for it. Emitted symbols were:\n{symbols}"
+    );
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run copy-shape binary");
+    assert!(
+        output.status.success(),
+        "copy-shape index-assign must run clean under the poisoned allocator;\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "2OK",
+        "copy-shape index-assign must print the stored element's len (2) then OK;\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -1880,11 +1880,36 @@ impl Builder {
                 self.enforce_closure_pair_ingress(value);
                 let arg_places = vec![receiver_place, index_place, src];
                 let next = self.alloc_block();
+                // A Vec index-assignment of a fresh materialised rvalue
+                // (`v[i] = Name { .. }`, `v[i] = make()`) has the SAME
+                // unbound-temp hole the `.set(i, ..)` method path does:
+                // `hew_vec_set_owned` is COPY-IN (deep-clones the element into
+                // the slot), but the throwaway constructor temp has no binding
+                // and no scope-exit drop to balance that clone, so its owned
+                // heap leaks. Route it to the MOVE-in sibling
+                // `hew_vec_set_owned_move` (byte-transfers the element's heap
+                // into the slot without a clone; the source temp is then dead).
+                // `expr_is_materialized_owner` is the identical fresh-rvalue
+                // predicate the `.set()`/push paths use: a bare `BindingRef`
+                // (a shared/after-read local) returns false and stays COPY-IN
+                // (moving it would double-free the live binding's heap), and a
+                // construction embedding a whole by-value parameter returns
+                // false too. This mirrors the method path's Vec::Set routing.
+                let effective_symbol = if target_symbol.as_str() == "hew_vec_set_owned"
+                    && Self::expr_is_materialized_owner(
+                        value,
+                        &self.funcupdate_fn_returns_fresh,
+                        &self.funcupdate_param_ids,
+                    ) {
+                    "hew_vec_set_owned_move"
+                } else {
+                    target_symbol.as_str()
+                };
                 let builtin = hew_types::runtime_call::RuntimeCallFamily::from_mir_builtin_symbol(
-                    target_symbol,
+                    effective_symbol,
                 );
                 self.finish_current_block(Terminator::Call {
-                    callee: target_symbol.clone(),
+                    callee: effective_symbol.to_string(),
                     builtin,
                     args: arg_places,
                     dest: None,


### PR DESCRIPTION
A Vec index-assignment `v[i] = X` with a fresh materialized-owner right-hand side emitted the copy-in store (`hew_vec_set_owned`) unconditionally, leaking the source temp. It now routes to the move-in store on the same materialized-owner gate the `.set()` method already uses; bound locals stay copy-in.

## Verification
- Leak-oracle test: 0 per-cycle slope for index-assign of a materialized deep-owned element; a copy-shape symbol pin confirms bound locals stay copy-in.
- Goldens byte-identical; corpus coverage and the compiled-.hew ratchet green.

## Out of scope
- A consumed bound-local index-assign copies-in (a separate, pre-existing minor leak).