### PR TITLE
fix(mir): tighten and complete fresh-owner freshness recognition

### DIFF
--- a/hew-cli/tests/fresh_composite_push_move_leak_oracle.rs
+++ b/hew-cli/tests/fresh_composite_push_move_leak_oracle.rs
@@ -69,6 +69,31 @@ fn push_letbound_composite_source(frames: usize) -> String {
     )
 }
 
+/// A producer that moves a fresh, deep-owned Holder through two immutable
+/// bindings before returning it. The move from `a` to `b` is the only use of
+/// `a`; proving the chain fresh routes `v.push(mkHolder(i))` to move-in so the
+/// nested `Vec<string>` is released with the outer container.
+fn push_nested_single_move_composite_source(frames: usize) -> String {
+    format!(
+        "type Holder {{ items: Vec<string> }}\n\
+         fn mkHolder(i: i64) -> Holder {{\n\
+         \x20   let a = Holder {{ items: [f\"x{{i % 10}}\", f\"y{{i % 10}}\"] }};\n\
+         \x20   let b = a;\n\
+         \x20   b\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       var v: Vec<Holder> = [];\n\
+         \x20       v.push(mkHolder(i));\n\
+         \x20       total = total + v.len();\n\
+         \x20   }}\n\
+         \x20   if total != {frames} {{ return 75; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
 /// Poisoned-allocator exactly-once pin: a leak is caught by the slope test; a
 /// double-free aborts under the scribbled allocator; a mis-read fails the
 /// program's content assertion (non-zero exit). Clean success == read-correct
@@ -103,6 +128,14 @@ fn push_letbound_composite_call_leak_slope_below_tolerance() {
 }
 
 #[test]
+fn push_nested_single_move_composite_has_no_per_cycle_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "fresh_composite_push_nested_single_move",
+        push_nested_single_move_composite_source,
+    );
+}
+
+#[test]
 fn push_fresh_composite_call_does_not_double_free() {
     assert_no_double_free(
         "fresh_composite_push_array_df",
@@ -115,5 +148,13 @@ fn push_letbound_composite_call_does_not_double_free() {
     assert_no_double_free(
         "fresh_composite_push_letbound_df",
         &push_letbound_composite_source(50),
+    );
+}
+
+#[test]
+fn push_nested_single_move_composite_does_not_double_free() {
+    assert_no_double_free(
+        "fresh_composite_push_nested_single_move_df",
+        &push_nested_single_move_composite_source(50),
     );
 }

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -439,22 +439,30 @@ fn see_through_let_binding_bits<P: LeafPolicy>(
     init_bits.map(|base| base | content)
 }
 
-/// The receiver and argument expressions of a method-call form, or `None` for a
-/// non-method expression. Used by [`see_through_let_binding_bits`] to recognise
-/// an interior container append (`id.push(e)`) rooted at a tracked binding.
+/// The receiver and argument expressions of an audited append method, or `None`
+/// for every other expression. Used by [`see_through_let_binding_bits`] to
+/// recognise an interior container append (`id.push(e)`) rooted at a tracked
+/// binding.
+///
+/// The checker-authored [`hew_types::MethodTargetFamily`] is the identity
+/// authority here: every supported `Vec<T>` push ABI has the same
+/// `Vec(VecMethod::Push)` family even though its emitted symbol varies with
+/// `T`. Dynamic/static trait dispatch, user var-self methods, numeric methods,
+/// and every non-push collection method stay fail-closed. Merely having a
+/// receiver and arguments is not proof that a call only appends those arguments
+/// to the receiver.
 ///
 /// `pub(crate)` so the frozen-reference see-through reuses the IDENTICAL
 /// structural append-recognition (only the may-alias recursion is reimplemented
 /// there), keeping the `coarse_verdict_differential` pin byte-identical.
 pub(crate) fn method_receiver_and_args(expr: &HirExpr) -> Option<(&HirExpr, Vec<&HirExpr>)> {
     match &expr.kind {
-        HirExprKind::ResolvedImplCall { receiver, args, .. }
-        | HirExprKind::CallDynMethod { receiver, args, .. }
-        | HirExprKind::CallTraitMethodStatic { receiver, args, .. }
-        | HirExprKind::VarSelfMethodCall { receiver, args, .. } => {
-            Some((receiver, args.iter().collect()))
-        }
-        HirExprKind::NumericMethod { receiver, arg, .. } => Some((receiver, vec![arg])),
+        HirExprKind::ResolvedImplCall {
+            receiver,
+            target_family: hew_types::MethodTargetFamily::Vec(hew_types::VecMethod::Push),
+            args,
+            ..
+        } => Some((receiver, args.iter().collect())),
         _ => None,
     }
 }
@@ -3026,6 +3034,39 @@ mod tests {
         assert_eq!(
             coarse, frozen,
             "see-through drift between the shared walk and the frozen reference"
+        );
+    }
+
+    #[test]
+    fn see_through_accepts_only_audited_vec_push_methods() {
+        let module = lower_source(
+            r"
+            fn appendThenReturn() -> Vec<i64> {
+                let items: Vec<i64> = [];
+                items.push(1);
+                items
+            }
+            fn inspectThenReturn() -> Vec<i64> {
+                let items: Vec<i64> = [];
+                items.len();
+                items
+            }
+            ",
+        );
+        let origin_fns = origin_fns_of(&module);
+        let coarse = compute_fn_returns_fresh_owner(&origin_fns);
+        assert!(
+            coarse[&fn_id(&module, "appendThenReturn")],
+            "the checker-authoritative Vec::push identity preserves freshness"
+        );
+        assert!(
+            !coarse[&fn_id(&module, "inspectThenReturn")],
+            "a non-append receiver method must remain an other-use and fail closed"
+        );
+        assert_eq!(
+            coarse,
+            compute_fn_returns_fresh_owner_ref(&origin_fns),
+            "the shared walk and frozen reference must apply the same audited append identity"
         );
     }
 

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -345,7 +345,7 @@ fn return_alias_bits_scoped<P: LeafPolicy>(
             ..
         } => scope
             .and_then(|s| s.resolve(*id))
-            .and_then(|block| see_through_let_binding_bits(block, *id, policy, scope))
+            .and_then(|block| see_through_let_binding_bits(block, *id, policy, scope, None))
             .unwrap_or_else(|| policy.leaf_bits(expr)),
         // Every other form (a `Binary`, a method call, a deref, any unmodelled
         // shape) is not provably fresh → the policy's leaf.
@@ -361,7 +361,9 @@ fn return_alias_bits_scoped<P: LeafPolicy>(
 /// unless `id` is a single-assignment `let` local (never a `var`, never a param,
 /// never reassigned) whose value is provably the union of its `let` initializer
 /// and a set of interior container appends (`id.push(e)` — the array-literal
-/// desugar). The returned bits are that union.
+/// desugar). A direct consuming initializer may recursively see through one
+/// earlier immutable binding (`let next = id`) when that move is the earlier
+/// binding's only use. The returned bits are that union.
 ///
 /// # Soundness (the double-free crux)
 ///
@@ -379,6 +381,9 @@ fn return_alias_bits_scoped<P: LeafPolicy>(
 /// - refuses on ANY other use of `id` — a call argument, an aggregate operand, a
 ///   field object that escapes — because such a use is a channel through which a
 ///   param alias could enter the value unmeasured.
+/// - permits exactly one direct `Consume` move into the next immutable `let` in
+///   a return chain; the complete statement scan rejects a second use, mutation,
+///   reassignment, wrapper, projection, or escape of the moved source.
 ///
 /// A param root is structurally excluded: a parameter has no `Let` in the block,
 /// so `init_bits` stays `None` and the reference falls to the leaf. This is the
@@ -389,9 +394,12 @@ fn see_through_let_binding_bits<P: LeafPolicy>(
     id: BindingId,
     policy: &P,
     scope: Option<&SeeThroughScope>,
+    forwarded_to: Option<BindingId>,
 ) -> Option<AliasBits> {
     let mut init_bits: Option<AliasBits> = None;
+    let mut init_is_move = false;
     let mut content = AliasBits::EMPTY;
+    let mut saw_forward = false;
     for stmt in &block.statements {
         match &stmt.kind {
             // The defining `let`. A `var` (mutable) binding is never seen through
@@ -404,13 +412,47 @@ fn see_through_let_binding_bits<P: LeafPolicy>(
                     return None;
                 }
                 let init = init.as_ref()?;
-                init_bits = Some(return_alias_bits_scoped(init, policy, scope));
+                let move_source = moved_binding_ref(init);
+                init_is_move = move_source.is_some();
+                init_bits = Some(if let Some(source_id) = move_source {
+                    scope
+                        .and_then(|s| s.resolve(source_id))
+                        .and_then(|source_block| {
+                            see_through_let_binding_bits(
+                                source_block,
+                                source_id,
+                                policy,
+                                scope,
+                                Some(id),
+                            )
+                        })
+                        .unwrap_or_else(|| return_alias_bits_scoped(init, policy, scope))
+                } else {
+                    return_alias_bits_scoped(init, policy, scope)
+                });
             }
             // A whole-binding reassignment of `id` clobbers the proven-fresh init.
             HirStmtKind::Assign { target, .. } if place_root_binding(target) == Some(id) => {
                 return None;
             }
             _ => {
+                // A direct immutable move into the binding currently being
+                // resolved is the source's one permitted forwarding use:
+                // `let source = <fresh>; let destination = source; destination`.
+                // The Consume intent distinguishes the move from a borrow, and
+                // every other mention of `source` still fails closed below.
+                if let HirStmtKind::Let(binding, Some(init)) = &stmt.kind {
+                    if Some(binding.id) == forwarded_to
+                        && !binding.mutable
+                        && moved_binding_ref(init) == Some(id)
+                    {
+                        if init_bits.is_none() || saw_forward {
+                            return None;
+                        }
+                        saw_forward = true;
+                        continue;
+                    }
+                }
                 // An interior container append rooted at `id` (`id.push(e)` — the
                 // array-literal desugar's push statements): its arguments become
                 // the container's content, so union their bits. A self-referential
@@ -418,6 +460,9 @@ fn see_through_let_binding_bits<P: LeafPolicy>(
                 if let HirStmtKind::Expr(e) = &stmt.kind {
                     if let Some((receiver, args)) = method_receiver_and_args(e) {
                         if place_root_binding(receiver) == Some(id) {
+                            if forwarded_to.is_some() || init_is_move {
+                                return None;
+                            }
                             for arg in &args {
                                 if expr_mentions_binding(arg, id) {
                                     return None;
@@ -436,7 +481,26 @@ fn see_through_let_binding_bits<P: LeafPolicy>(
             }
         }
     }
+    if forwarded_to.is_some() && !saw_forward {
+        return None;
+    }
     init_bits.map(|base| base | content)
+}
+
+/// The source binding of a direct consuming move (`let destination = source`).
+/// Wrappers, projections, aggregate embedding, and non-consuming references are
+/// deliberately excluded: only the exact immutable single-move chain is audited.
+pub(crate) fn moved_binding_ref(expr: &HirExpr) -> Option<BindingId> {
+    if expr.intent != hew_hir::IntentKind::Consume {
+        return None;
+    }
+    match &expr.kind {
+        HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(id),
+            ..
+        } => Some(*id),
+        _ => None,
+    }
 }
 
 /// The receiver and argument expressions of an audited append method, or `None`
@@ -3067,6 +3131,66 @@ mod tests {
             coarse,
             compute_fn_returns_fresh_owner_ref(&origin_fns),
             "the shared walk and frozen reference must apply the same audited append identity"
+        );
+    }
+
+    #[test]
+    fn see_through_chained_immutable_single_moves_only() {
+        let module = lower_source(
+            r#"
+            type Holder { items: Vec<string> }
+            fn observe(h: Holder) -> i64 { h.items.len() }
+            fn nestedFresh() -> Holder {
+                let a = Holder { items: ["fresh"] };
+                let b = a;
+                b
+            }
+            fn nestedParam(h: Holder) -> Holder {
+                let a = h;
+                let b = a;
+                b
+            }
+            fn nestedReassigned(h: Holder) -> Holder {
+                var a = Holder { items: ["fresh"] };
+                a = h;
+                let b = a;
+                b
+            }
+            fn nestedOtherUse() -> Holder {
+                let a = Holder { items: ["fresh"] };
+                observe(a);
+                let b = a;
+                b
+            }
+            fn nestedMutated() -> Holder {
+                let a = Holder { items: ["fresh"] };
+                a.items.push("other");
+                let b = a;
+                b
+            }
+            "#,
+        );
+        let origin_fns = origin_fns_of(&module);
+        let coarse = compute_fn_returns_fresh_owner(&origin_fns);
+        assert!(
+            coarse[&fn_id(&module, "nestedFresh")],
+            "a direct immutable single-move chain preserves the fresh source"
+        );
+        for name in [
+            "nestedParam",
+            "nestedReassigned",
+            "nestedOtherUse",
+            "nestedMutated",
+        ] {
+            assert!(
+                !coarse[&fn_id(&module, name)],
+                "`{name}` is not an immutable single-use move chain and must fail closed"
+            );
+        }
+        assert_eq!(
+            coarse,
+            compute_fn_returns_fresh_owner_ref(&origin_fns),
+            "the shared walk and frozen reference must agree on chained moves and every guard"
         );
     }
 

--- a/hew-mir/src/return_provenance_ref.rs
+++ b/hew-mir/src/return_provenance_ref.rs
@@ -27,8 +27,8 @@ use hew_types::ResolvedTy;
 
 use crate::lower::collect_return_values_in_block;
 use crate::return_provenance::{
-    expr_mentions_binding, method_receiver_and_args, place_root_binding, stmt_mentions_binding,
-    SeeThroughScope,
+    expr_mentions_binding, method_receiver_and_args, moved_binding_ref, place_root_binding,
+    stmt_mentions_binding, SeeThroughScope,
 };
 
 /// Verbatim copy of the pre-refactor `compute_fn_returns_fresh_owner`.
@@ -155,7 +155,7 @@ fn return_value_may_alias_borrow_ref(
             ..
         } => scope
             .and_then(|s| s.resolve(*id))
-            .and_then(|block| block_let_may_alias_ref(block, *id, scope, fresh))
+            .and_then(|block| block_let_may_alias_ref(block, *id, scope, fresh, None))
             .unwrap_or(true),
         _ => true,
     }
@@ -163,16 +163,20 @@ fn return_value_may_alias_borrow_ref(
 
 /// Independent bool twin of `see_through_let_binding_bits`: `Some(may_alias)`
 /// for a single-assignment `let`-bound local seen through to its init plus
-/// interior appends; `None` (keep the fail-closed leaf) for a `var`, a
-/// reassignment, or any other use of `id`. `may_alias` mirrors `!bits.is_fresh()`.
+/// interior appends and direct immutable single-move chains; `None` (keep the
+/// fail-closed leaf) for a `var`, a reassignment, or any other use of `id`.
+/// `may_alias` mirrors `!bits.is_fresh()`.
 fn block_let_may_alias_ref(
     block: &HirBlock,
     id: BindingId,
     scope: Option<&SeeThroughScope>,
     fresh: &HashMap<hew_hir::ItemId, bool>,
+    forwarded_to: Option<BindingId>,
 ) -> Option<bool> {
     let mut init_may_alias: Option<bool> = None;
+    let mut init_is_move = false;
     let mut content_may_alias = false;
+    let mut saw_forward = false;
     for stmt in &block.statements {
         match &stmt.kind {
             HirStmtKind::Let(binding, init) if binding.id == id => {
@@ -180,15 +184,41 @@ fn block_let_may_alias_ref(
                     return None;
                 }
                 let init = init.as_ref()?;
-                init_may_alias = Some(return_value_may_alias_borrow_ref(init, scope, fresh));
+                let move_source = moved_binding_ref(init);
+                init_is_move = move_source.is_some();
+                init_may_alias = Some(if let Some(source_id) = move_source {
+                    scope
+                        .and_then(|s| s.resolve(source_id))
+                        .and_then(|source_block| {
+                            block_let_may_alias_ref(source_block, source_id, scope, fresh, Some(id))
+                        })
+                        .unwrap_or_else(|| return_value_may_alias_borrow_ref(init, scope, fresh))
+                } else {
+                    return_value_may_alias_borrow_ref(init, scope, fresh)
+                });
             }
             HirStmtKind::Assign { target, .. } if place_root_binding(target) == Some(id) => {
                 return None;
             }
             _ => {
+                if let HirStmtKind::Let(binding, Some(init)) = &stmt.kind {
+                    if Some(binding.id) == forwarded_to
+                        && !binding.mutable
+                        && moved_binding_ref(init) == Some(id)
+                    {
+                        if init_may_alias.is_none() || saw_forward {
+                            return None;
+                        }
+                        saw_forward = true;
+                        continue;
+                    }
+                }
                 if let HirStmtKind::Expr(e) = &stmt.kind {
                     if let Some((receiver, args)) = method_receiver_and_args(e) {
                         if place_root_binding(receiver) == Some(id) {
+                            if forwarded_to.is_some() || init_is_move {
+                                return None;
+                            }
                             for arg in &args {
                                 if expr_mentions_binding(arg, id) {
                                     return None;
@@ -205,6 +235,9 @@ fn block_let_may_alias_ref(
                 }
             }
         }
+    }
+    if forwarded_to.is_some() && !saw_forward {
+        return None;
     }
     init_may_alias.map(|base| base || content_may_alias)
 }


### PR DESCRIPTION
Two follow-ups to the fresh-composite sole-owner recognizer, surfaced by an adversarial memory-safety review of the base change.

- **Tighten the append recognizer:** the fresh-preserving `id.push(e)` recognition accepted any receiver method; it now admits only audited append/push identities, so a future method cannot silently launder a non-fresh value into 'fresh'. No behavioural change for real appends.
- **Recognize immutable single-move chains:** `fn f() -> T { let a = T{..}; let b = a; b }` was conservatively classified non-fresh, so `push(f())` copied-in and leaked the inner heap. Chained immutable single-moves (each binding used once, moved forward, no mutation or other use) are now recognized as fresh. `var`/reassignment/parameter roots and any real other-use still bottom out non-fresh.

## Verification
- The permanent adversarial no-double-free oracle stays green: all six borrowed-alias-return shapes (passthrough, get-field, conditional, array-of-param, let-param, reassign) still classify non-fresh, no double-free under the poisoned allocator.
- New nested-single-move leak oracle (0 per-cycle slope, deep-owned element) + a double-free pin + a unit test for the chained-move recognizer.
- ll-diff, checked-mir-verify, funcupdate baselines, corpus coverage, and the compiled-.hew ratchet all green; no golden movement.