### PR TITLE
fix(mir): release copy-in Vec element temps that embed a string parameter

### DIFF
--- a/hew-cli/tests/vec_param_embed_copy_in_temp_leak_oracle.rs
+++ b/hew-cli/tests/vec_param_embed_copy_in_temp_leak_oracle.rs
@@ -1,0 +1,283 @@
+//! Retain-backed string parameter embeds in anonymous Vec COPY-IN source temps.
+//!
+//! A whole by-value parameter remains caller-owned. Aggregate lowering retains
+//! an embedded `string`, however, so the anonymous source temp owns one separate
+//! share that must be dropped after `hew_vec_{push,set}_owned` clones it into the
+//! Vec. These oracles pin flat leak slopes and prove that the caller's parameter
+//! remains readable and naturally droppable under the poisoned allocator.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::process::Command;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+const PUSH_TEMPLATE: &str = r#"
+type Wrap { f: Option<string> }
+
+fn pushParam(p: string) -> i64 {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: Some(p) });
+    v.len()
+}
+
+fn main() -> i64 {
+    for i in 0..$FRAMES {
+        let p = f"item-{i}";
+        if pushParam(p) != 1 { return 11; }
+        if p.len() < 6 { return 12; }
+    }
+    0
+}
+"#;
+
+const SET_TEMPLATE: &str = r#"
+type Wrap { f: Option<string> }
+
+fn setParam(p: string) -> i64 {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: None });
+    v.set(0, Wrap { f: Some(p) });
+    v.len()
+}
+
+fn main() -> i64 {
+    for i in 0..$FRAMES {
+        let p = f"item-{i}";
+        if setParam(p) != 1 { return 21; }
+        if p.len() < 6 { return 22; }
+    }
+    0
+}
+"#;
+
+const BOUND_FIRST_TEMPLATE: &str = r#"
+type Wrap { f: Option<string> }
+
+fn pushParam(p: string) -> i64 {
+    let v: Vec<Wrap> = [];
+    let w = Wrap { f: Some(p) };
+    v.push(w);
+    v.len()
+}
+
+fn main() -> i64 {
+    for i in 0..$FRAMES {
+        let p = f"item-{i}";
+        if pushParam(p) != 1 { return 31; }
+        if p.len() < 6 { return 32; }
+    }
+    0
+}
+"#;
+
+const MOVE_TEMPLATE: &str = r#"
+type Wrap { f: Option<string> }
+
+fn main() -> i64 {
+    for i in 0..$FRAMES {
+        let v: Vec<Wrap> = [];
+        v.push(Wrap { f: Some(f"item-{i}") });
+        if v.len() != 1 { return 41; }
+    }
+    0
+}
+"#;
+
+const ARENA_TEMPLATE: &str = r#"
+type Key<T> { index: i64 }
+type Slot<T> { value: Option<T> }
+type Arena<T> { slots: Vec<Slot<T>> }
+
+fn newArena<T>() -> Arena<T> {
+    Arena { slots: Vec::new() }
+}
+
+impl<T> Arena<T> {
+    fn insert(self, value: T) -> Key<T> {
+        let index = self.slots.len();
+        self.slots.push(Slot { value: Some(value) });
+        Key { index: index }
+    }
+
+    fn remove(self, key: Key<T>) -> T {
+        let slot = self.slots.remove(key.index);
+        slot.value.unwrap()
+    }
+
+    fn len(self) -> i64 {
+        self.slots.len()
+    }
+}
+
+fn main() -> i64 {
+    let arena = newArena<string>();
+    for i in 0..$FRAMES {
+        let key = arena.insert(f"item-{i}");
+        let got = arena.remove(key);
+        let expected = f"item-{i}";
+        if got != expected { return 52; }
+        if got.len() != expected.len() { return 53; }
+        if arena.len() != 0 { return 55; }
+    }
+    0
+}
+"#;
+
+const PARAM_NOT_DOUBLE_FREED_SOURCE: &str = r#"
+type Wrap { f: Option<string> }
+
+fn pushParam(p: string) -> i64 {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: Some(p) });
+    v.len()
+}
+
+fn setParam(p: string) -> i64 {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: None });
+    v.set(0, Wrap { f: Some(p) });
+    v.len()
+}
+
+fn main() -> i64 {
+    let p = "param-pin".to_upper();
+    print(p.len());
+    print("|");
+    print(pushParam(p));
+    print("|");
+    print(p.len());
+    print("|");
+    print(setParam(p));
+    print("|");
+    print(p.len());
+    print("|");
+    print(p);
+    print("|OK");
+    0
+}
+"#;
+
+const NON_STRING_PARAM_SOURCE: &str = r"
+type Holder { items: Vec<string> }
+type Wrap { f: Option<Holder> }
+
+fn pushParam(p: Holder) {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: Some(p) });
+}
+";
+
+fn with_frames(template: &str, frames: usize) -> String {
+    template.replace("$FRAMES", &frames.to_string())
+}
+
+fn push_source(frames: usize) -> String {
+    with_frames(PUSH_TEMPLATE, frames)
+}
+
+fn set_source(frames: usize) -> String {
+    with_frames(SET_TEMPLATE, frames)
+}
+
+fn bound_first_source(frames: usize) -> String {
+    with_frames(BOUND_FIRST_TEMPLATE, frames)
+}
+
+fn move_source(frames: usize) -> String {
+    with_frames(MOVE_TEMPLATE, frames)
+}
+
+fn arena_source(frames: usize) -> String {
+    with_frames(ARENA_TEMPLATE, frames)
+}
+
+fn dump_checked_mir(source: &str, name: &str) -> String {
+    let dir = tempfile::Builder::new()
+        .prefix("vec-param-embed-mir-")
+        .tempdir()
+        .expect("tempdir");
+    let source_path = dir.path().join(format!("{name}.hew"));
+    std::fs::write(&source_path, source).expect("write Hew source");
+    let output = Command::new(hew_binary())
+        .args(["compile", "--dump-mir", "checked"])
+        .arg(&source_path)
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile --dump-mir checked");
+    assert!(
+        output.status.success(),
+        "checked MIR dump failed:\n{}",
+        describe_output(&output)
+    );
+    String::from_utf8(output.stdout).expect("checked MIR is UTF-8")
+}
+
+#[test]
+fn direct_push_param_embed_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("vec_param_embed_push", push_source);
+}
+
+#[test]
+fn direct_set_param_embed_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("vec_param_embed_set", set_source);
+}
+
+#[test]
+fn bound_first_copy_in_control_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("vec_param_embed_bound_first", bound_first_source);
+}
+
+#[test]
+fn no_param_embed_move_control_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("vec_param_embed_move", move_source);
+}
+
+#[test]
+fn arena_insert_remove_param_embed_has_flat_leak_slope() {
+    // `arena_source(100)` is the explicit diagnostic form that reproduces the
+    // historical 100-node/3200-byte signature with the mint removed.
+    assert_frame_slope_below_tolerance("vec_param_embed_arena", arena_source);
+}
+
+#[test]
+fn caller_parameter_survives_push_set_and_natural_drop() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("vec-param-embed-caller-pin-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        PARAM_NOT_DOUBLE_FREED_SOURCE,
+        dir.path(),
+        "param_not_double_freed",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "the mint must drop only the temp's retained share; the caller still owns p:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "9|1|9|1|9|PARAM-PIN|OK",
+        "every post-store read must observe the live caller-owned parameter:\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn non_string_param_embed_never_mints_a_temp_owner() {
+    let mir = dump_checked_mir(NON_STRING_PARAM_SOURCE, "non_string_param_embed");
+    assert!(mir.contains("call hew_vec_push_owned("));
+    assert!(!mir.contains("hew_vec_push_owned_move"));
+    assert!(
+        !mir.contains("__hew_copy_in_param_temp"),
+        "an unretained Holder parameter is a borrowed alias and must never gain a temp owner:\n{mir}"
+    );
+}

--- a/hew-cli/tests/vec_param_embed_copy_in_temp_leak_oracle.rs
+++ b/hew-cli/tests/vec_param_embed_copy_in_temp_leak_oracle.rs
@@ -89,6 +89,23 @@ fn main() -> i64 {
 }
 "#;
 
+const TUPLE_TEMPLATE: &str = r#"
+fn pushParam(p: string) -> i64 {
+    let v: Vec<(string, i64)> = [];
+    v.push((p, 1));
+    v.len()
+}
+
+fn main() -> i64 {
+    for i in 0..$FRAMES {
+        let p = f"item-{i}";
+        if pushParam(p) != 1 { return 45; }
+        if p.len() < 6 { return 46; }
+    }
+    0
+}
+"#;
+
 const ARENA_TEMPLATE: &str = r#"
 type Key<T> { index: i64 }
 type Slot<T> { value: Option<T> }
@@ -163,13 +180,44 @@ fn main() -> i64 {
 }
 "#;
 
+const MIXED_PARAM_NOT_DOUBLE_FREED_SOURCE: &str = r#"
+type Holder { items: Vec<string> }
+type MixedWrap { s: string, items: Vec<string> }
+
+fn pushMixed(p: string, h: Holder) -> i64 {
+    let v: Vec<MixedWrap> = [];
+    v.push(MixedWrap { s: p, items: h.items });
+    v.len()
+}
+
+fn main() -> i64 {
+    let p = "param-pin".to_upper();
+    let h = Holder { items: ["deep-pin".to_upper()] };
+    print(p.len());
+    print("|");
+    print(pushMixed(p, h));
+    print("|");
+    print(p);
+    print("|");
+    print(h.items.len());
+    print("|OK");
+    0
+}
+"#;
+
 const NON_STRING_PARAM_SOURCE: &str = r"
 type Holder { items: Vec<string> }
 type Wrap { f: Option<Holder> }
+type MixedWrap { s: string, items: Vec<string> }
 
 fn pushParam(p: Holder) {
     let v: Vec<Wrap> = [];
     v.push(Wrap { f: Some(p) });
+}
+
+fn pushMixed(p: string, h: Holder) {
+    let v: Vec<MixedWrap> = [];
+    v.push(MixedWrap { s: p, items: h.items });
 }
 ";
 
@@ -193,8 +241,32 @@ fn move_source(frames: usize) -> String {
     with_frames(MOVE_TEMPLATE, frames)
 }
 
+fn tuple_source(frames: usize) -> String {
+    with_frames(TUPLE_TEMPLATE, frames)
+}
+
 fn arena_source(frames: usize) -> String {
     with_frames(ARENA_TEMPLATE, frames)
+}
+
+fn assert_source_succeeds_under_scribble(shape_name: &str, source_fn: fn(usize) -> String) {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("vec-param-embed-run-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(&source_fn(3), dir.path(), shape_name);
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "{shape_name} must complete its semantic checks before its leak slope is trusted:\n{}",
+        describe_output(&output)
+    );
+}
+
+fn assert_clean_slope(shape_name: &str, source_fn: fn(usize) -> String) {
+    assert_source_succeeds_under_scribble(shape_name, source_fn);
+    assert_frame_slope_below_tolerance(shape_name, source_fn);
 }
 
 fn dump_checked_mir(source: &str, name: &str) -> String {
@@ -220,29 +292,34 @@ fn dump_checked_mir(source: &str, name: &str) -> String {
 
 #[test]
 fn direct_push_param_embed_has_flat_leak_slope() {
-    assert_frame_slope_below_tolerance("vec_param_embed_push", push_source);
+    assert_clean_slope("vec_param_embed_push", push_source);
 }
 
 #[test]
 fn direct_set_param_embed_has_flat_leak_slope() {
-    assert_frame_slope_below_tolerance("vec_param_embed_set", set_source);
+    assert_clean_slope("vec_param_embed_set", set_source);
 }
 
 #[test]
 fn bound_first_copy_in_control_has_flat_leak_slope() {
-    assert_frame_slope_below_tolerance("vec_param_embed_bound_first", bound_first_source);
+    assert_clean_slope("vec_param_embed_bound_first", bound_first_source);
 }
 
 #[test]
 fn no_param_embed_move_control_has_flat_leak_slope() {
-    assert_frame_slope_below_tolerance("vec_param_embed_move", move_source);
+    assert_clean_slope("vec_param_embed_move", move_source);
+}
+
+#[test]
+fn tuple_param_embed_has_flat_leak_slope() {
+    assert_clean_slope("vec_param_embed_tuple", tuple_source);
 }
 
 #[test]
 fn arena_insert_remove_param_embed_has_flat_leak_slope() {
     // `arena_source(100)` is the explicit diagnostic form that reproduces the
     // historical 100-node/3200-byte signature with the mint removed.
-    assert_frame_slope_below_tolerance("vec_param_embed_arena", arena_source);
+    assert_clean_slope("vec_param_embed_arena", arena_source);
 }
 
 #[test]
@@ -272,12 +349,38 @@ fn caller_parameter_survives_push_set_and_natural_drop() {
 }
 
 #[test]
+fn mixed_parameter_projection_survives_store_and_natural_drop() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("vec-param-embed-mixed-caller-pin-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        MIXED_PARAM_NOT_DOUBLE_FREED_SOURCE,
+        dir.path(),
+        "mixed_param_not_double_freed",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "a mixed temp must not drop the caller-owned projected Vec:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "9|1|PARAM-PIN|1|OK",
+        "both caller-owned parameters must remain live after the store:\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
 fn non_string_param_embed_never_mints_a_temp_owner() {
     let mir = dump_checked_mir(NON_STRING_PARAM_SOURCE, "non_string_param_embed");
     assert!(mir.contains("call hew_vec_push_owned("));
     assert!(!mir.contains("hew_vec_push_owned_move"));
     assert!(
         !mir.contains("__hew_copy_in_param_temp"),
-        "an unretained Holder parameter is a borrowed alias and must never gain a temp owner:\n{mir}"
+        "an unretained Holder parameter or projection is a borrowed alias and must never gain a temp owner:\n{mir}"
     );
 }

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -3191,6 +3191,16 @@ pub(super) fn derive_tuple_composite_drop_allowed(
                 }
             }
         }
+        // COPY-IN Vec element stores clone the whole tuple source rather than
+        // consuming it. Preserve the tuple's scope-exit owner exactly as the
+        // record/enum provers do; the receiver and any element binder remain
+        // borrowed for this call.
+        let copy_in_elem_store = matches!(
+            &block.terminator,
+            Terminator::Call { callee, .. }
+                if crate::runtime_symbols::callee_ownership_contract(callee)
+                    .is_vec_copy_in_element_store()
+        );
         // Caller-side owned-param completion: a whole tuple passed by value at a
         // proven-borrow call position is a transient borrow, so the caller keeps
         // its `TupleInPlace` scope-exit drop. Element binders (`f(t.0)`) are a
@@ -3205,7 +3215,8 @@ pub(super) fn derive_tuple_composite_drop_allowed(
         // not an escape (`binder_read_is_borrow_safe_terminator`).
         for p in terminator_source_places(&block.terminator, suspend_kinds.get(&block.id)) {
             if let Some(l) = base_local(p) {
-                if alias_of.contains_key(&l)
+                if !copy_in_elem_store
+                    && alias_of.contains_key(&l)
                     && matches!(p, Place::Local(_) | Place::ReturnSlot)
                     && !proven_borrow_arg_locals.contains(&l)
                     && !binder_read_is_borrow_safe_terminator(
@@ -3216,7 +3227,8 @@ pub(super) fn derive_tuple_composite_drop_allowed(
                 {
                     note_alias_escape(l, &mut excluded_roots);
                 }
-                if is_escape_binder(l)
+                if !copy_in_elem_store
+                    && is_escape_binder(l)
                     && !binder_read_is_borrow_safe_terminator(
                         &block.terminator,
                         suspend_kinds.get(&block.id),

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -4610,6 +4610,9 @@ impl Builder {
                         self.enforce_closure_pair_ingress(arg);
                     }
                 }
+                // COPY-IN param embeds stay caller-borrowed; only the source
+                // temp's independently retained string share gains an owner.
+                self.register_copy_in_param_embed_temp_owner(&callee, args, &arg_places);
                 let dest = if matches!(ret_ty, ResolvedTy::Unit) {
                     None
                 } else {

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -275,6 +275,11 @@ const SYNTHETIC_DISCARDED_CALL_RESULT_NAME: &str = "__hew_discarded_call_result"
 /// once at caller scope exit. Gated on the target param being BORROW (a CONSUME
 /// target's temporary is the callee's obligation — no caller drop).
 const SYNTHETIC_TEMP_ARG_NAME: &str = "__hew_temp_arg";
+/// Name for the owner minted over a fresh Vec COPY-IN element temporary when
+/// every whole by-value parameter embedded in it is a retained string share.
+/// The binding owns the temporary's retained share only; the parameter remains
+/// caller-owned and keeps its natural drop.
+const SYNTHETIC_COPY_IN_PARAM_TEMP_NAME: &str = "__hew_copy_in_param_temp";
 
 /// Prefix of the synthetic for-iteration cursor binding minted by the HIR
 /// for-loop desugar (`hew-hir/src/lower.rs`, `lower_for_iter_desugar`:

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -9,9 +9,30 @@ use super::{
     MirStatement, OwnedLocalEntry, OwnershipCtx, OwnershipDecision, Place, PlaceProvenance,
     Projection, ResolvedRef, ResolvedTy, ResourceMarker, SiteId, Strategy, Terminator, ValueClass,
     ValueOwnership, ValueProvenance, SYNTHETIC_CALL_SCRUTINEE_NAME,
-    SYNTHETIC_DISCARDED_CALL_RESULT_NAME, SYNTHETIC_OWNED_TEMP_BINDING_BASE,
-    SYNTHETIC_WHILE_LET_ITERATION_NAME,
+    SYNTHETIC_COPY_IN_PARAM_TEMP_NAME, SYNTHETIC_DISCARDED_CALL_RESULT_NAME,
+    SYNTHETIC_OWNED_TEMP_BINDING_BASE, SYNTHETIC_WHILE_LET_ITERATION_NAME,
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WholeParamEmbedClass {
+    None,
+    RetainBackedStringOnly,
+    UnsupportedBorrowAlias,
+}
+
+impl WholeParamEmbedClass {
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::UnsupportedBorrowAlias, _) | (_, Self::UnsupportedBorrowAlias) => {
+                Self::UnsupportedBorrowAlias
+            }
+            (Self::RetainBackedStringOnly, _) | (_, Self::RetainBackedStringOnly) => {
+                Self::RetainBackedStringOnly
+            }
+            (Self::None, Self::None) => Self::None,
+        }
+    }
+}
 
 impl Builder {
     /// The ownership classify context over this builder's live registries — the
@@ -269,6 +290,70 @@ impl Builder {
             _ => false,
         };
         is_fresh_producer.then_some(ty)
+    }
+    /// Return the owned type of a fresh Vec COPY-IN element temporary whose
+    /// only whole-parameter embeds are independently retained strings.
+    ///
+    /// A by-value parameter remains caller-owned. Aggregate lowering explicitly
+    /// retains a whole `string` parameter before storing it, so the anonymous
+    /// source temp owns exactly that retained share and may receive one ordinary
+    /// scope-exit drop. Other heap-owning parameter types are stored as borrowed
+    /// aliases; minting an aggregate owner for them would free the caller's
+    /// value.
+    pub(crate) fn copy_in_param_embed_temp_owned_ty(
+        &self,
+        callee: &str,
+        arg: &HirExpr,
+    ) -> Option<ResolvedTy> {
+        if !matches!(callee, "hew_vec_push_owned" | "hew_vec_set_owned") {
+            return None;
+        }
+        if !matches!(
+            arg.kind,
+            HirExprKind::StructInit { .. }
+                | HirExprKind::TupleLiteral { .. }
+                | HirExprKind::MachineVariantCtor { .. }
+        ) {
+            return None;
+        }
+        let class = Self::classify_whole_param_embeds(arg, &self.funcupdate_param_ids, &|ty| {
+            self.subst_ty(ty)
+        });
+        if class != WholeParamEmbedClass::RetainBackedStringOnly {
+            return None;
+        }
+        let ty = self.subst_ty(&arg.ty);
+        crate::model::ty_owns_heap_mir(&ty, &self.record_field_orders, &self.enum_layouts)
+            .then_some(ty)
+    }
+    /// Register the proven retain-backed Vec element source after all call
+    /// arguments have materialised. Push uses args[0]/places[1], while set uses
+    /// args[1]/places[2]; the receiver and set index can never become owners.
+    pub(crate) fn register_copy_in_param_embed_temp_owner(
+        &mut self,
+        callee: &str,
+        args: &[HirExpr],
+        arg_places: &[Place],
+    ) {
+        let candidate = match callee {
+            "hew_vec_push_owned" if args.len() == 1 => Some((&args[0], 1)),
+            "hew_vec_set_owned" if args.len() == 2 => Some((&args[1], 2)),
+            _ => None,
+        }
+        .and_then(|(arg, place_index)| {
+            let ty = self.copy_in_param_embed_temp_owned_ty(callee, arg)?;
+            let place = arg_places.get(place_index).copied()?;
+            Some((arg.site, place, ty))
+        });
+        let Some((site, Place::Local(local), ty)) = candidate else {
+            return;
+        };
+        // Fresh constructors must never lower into a parameter slot. Keep the
+        // mint fail-closed if that invariant ever changes.
+        if self.parameter_locals.contains(&local) {
+            return;
+        }
+        self.register_synthetic_owned_local(SYNTHETIC_COPY_IN_PARAM_TEMP_NAME, site, local, ty);
     }
     /// Whether a direct-`Call` callee resolves to a runtime symbol carrying the
     /// `produces_fresh_owned_string` ownership contract. The symbol is resolved
@@ -2349,29 +2434,18 @@ impl Builder {
             // result, or a `.clone()` is refcount-bumped / COW-copied / consumed
             // into the new slot — empirically owner-preserving (a destructive
             // funcupdate over such a record does not dangle the source). The ONE
-            // exception is a WHOLE by-value PARAMETER operand: a parameter is a
-            // borrow stored WITHOUT a refcount bump, so `{ ..Wrap { s: p, .. },
-            // s: new }` frees the caller's `p` at the override-drop. Reject a
-            // construction that embeds (directly or through nested constructions)
-            // a whole parameter; admit every other construction. A nested `..base`
-            // is checked too — its own embedded parameters dangle identically.
-            HirExprKind::StructInit { fields, base, .. } => {
-                !fields
-                    .iter()
-                    .any(|(_, v)| Self::expr_embeds_whole_param(v, params))
-                    && base
-                        .as_deref()
-                        .is_none_or(|b| !Self::expr_embeds_whole_param(b, params))
+            // exception is a WHOLE by-value PARAMETER operand. Non-string heap
+            // parameters are borrowed aliases stored without a clone; string
+            // parameters carry a retained share but remain intentionally outside
+            // the destructive/MOVE-owner route. Reject both embed classes here.
+            // A nested `..base` is checked too.
+            HirExprKind::StructInit { .. } => {
+                Self::classify_whole_param_embeds(expr, params, &ResolvedTy::clone)
+                    == WholeParamEmbedClass::None
             }
-            HirExprKind::TupleLiteral { elements } => !elements
-                .iter()
-                .any(|value| Self::expr_embeds_whole_param(value, params)),
-            HirExprKind::MachineVariantCtor { payload, .. } => {
-                payload.as_ref().is_none_or(|fields| {
-                    !fields
-                        .iter()
-                        .any(|(_, value)| Self::expr_embeds_whole_param(value, params))
-                })
+            HirExprKind::TupleLiteral { .. } | HirExprKind::MachineVariantCtor { .. } => {
+                Self::classify_whole_param_embeds(expr, params, &ResolvedTy::clone)
+                    == WholeParamEmbedClass::None
             }
             // A projection is materialised iff its object chain is.
             HirExprKind::FieldAccess { object, .. } => {
@@ -2386,8 +2460,7 @@ impl Builder {
             _ => false,
         }
     }
-    /// True when `expr` is, or embeds through a construction, a WHOLE by-value
-    /// parameter — the borrow that a constructor stores without a refcount bump.
+    /// Classify WHOLE by-value parameter embeds through constructors.
     ///
     /// Recurses only through constructions (struct / tuple / machine-variant
     /// literals), which embed operands by value. A PROJECTION (`p.inner`), a
@@ -2395,33 +2468,43 @@ impl Builder {
     /// whole parameter — a field read bumps, a call/clone materialises a fresh
     /// value — so they stop the recursion (return `false`). A bare parameter
     /// binding is the borrow this catches; a bare LOCAL is move-consumed into the
-    /// construction and stays an owner, so only `params` membership returns
-    /// `true`.
-    pub(crate) fn expr_embeds_whole_param(expr: &HirExpr, params: &HashSet<BindingId>) -> bool {
+    /// construction and stays an owner. String parameters are distinguished from
+    /// every unsupported parameter type so only the proven retained-share class
+    /// can feed the Vec COPY-IN temp mint.
+    fn classify_whole_param_embeds(
+        expr: &HirExpr,
+        params: &HashSet<BindingId>,
+        resolve_ty: &impl Fn(&ResolvedTy) -> ResolvedTy,
+    ) -> WholeParamEmbedClass {
         match &expr.kind {
             HirExprKind::BindingRef {
                 resolved: ResolvedRef::Binding(id),
                 ..
-            } => params.contains(id),
-            HirExprKind::StructInit { fields, base, .. } => {
-                fields
-                    .iter()
-                    .any(|(_, v)| Self::expr_embeds_whole_param(v, params))
-                    || base
-                        .as_deref()
-                        .is_some_and(|b| Self::expr_embeds_whole_param(b, params))
+            } if params.contains(id) => {
+                if matches!(resolve_ty(&expr.ty), ResolvedTy::String) {
+                    WholeParamEmbedClass::RetainBackedStringOnly
+                } else {
+                    WholeParamEmbedClass::UnsupportedBorrowAlias
+                }
             }
+            HirExprKind::StructInit { fields, base, .. } => fields
+                .iter()
+                .map(|(_, value)| Self::classify_whole_param_embeds(value, params, resolve_ty))
+                .chain(
+                    base.iter()
+                        .map(|value| Self::classify_whole_param_embeds(value, params, resolve_ty)),
+                )
+                .fold(WholeParamEmbedClass::None, WholeParamEmbedClass::merge),
             HirExprKind::TupleLiteral { elements } => elements
                 .iter()
-                .any(|e| Self::expr_embeds_whole_param(e, params)),
-            HirExprKind::MachineVariantCtor { payload, .. } => {
-                payload.as_ref().is_some_and(|fields| {
-                    fields
-                        .iter()
-                        .any(|(_, v)| Self::expr_embeds_whole_param(v, params))
-                })
-            }
-            _ => false,
+                .map(|value| Self::classify_whole_param_embeds(value, params, resolve_ty))
+                .fold(WholeParamEmbedClass::None, WholeParamEmbedClass::merge),
+            HirExprKind::MachineVariantCtor { payload, .. } => payload
+                .iter()
+                .flatten()
+                .map(|(_, value)| Self::classify_whole_param_embeds(value, params, resolve_ty))
+                .fold(WholeParamEmbedClass::None, WholeParamEmbedClass::merge),
+            _ => WholeParamEmbedClass::None,
         }
     }
     /// Emit a `MirStatement::Use(Consume)` for a managed-type binding that is

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -316,9 +316,13 @@ impl Builder {
         ) {
             return None;
         }
-        let class = Self::classify_whole_param_embeds(arg, &self.funcupdate_param_ids, &|ty| {
-            self.subst_ty(ty)
-        });
+        let class = Self::classify_whole_param_embeds(
+            arg,
+            &self.funcupdate_param_ids,
+            &|ty| self.subst_ty(ty),
+            true,
+            &|ty| crate::model::ty_owns_heap_mir(ty, &self.record_field_orders, &self.enum_layouts),
+        );
         if class != WholeParamEmbedClass::RetainBackedStringOnly {
             return None;
         }
@@ -2440,12 +2444,14 @@ impl Builder {
             // the destructive/MOVE-owner route. Reject both embed classes here.
             // A nested `..base` is checked too.
             HirExprKind::StructInit { .. } => {
-                Self::classify_whole_param_embeds(expr, params, &ResolvedTy::clone)
-                    == WholeParamEmbedClass::None
+                Self::classify_whole_param_embeds(expr, params, &ResolvedTy::clone, false, &|_| {
+                    false
+                }) == WholeParamEmbedClass::None
             }
             HirExprKind::TupleLiteral { .. } | HirExprKind::MachineVariantCtor { .. } => {
-                Self::classify_whole_param_embeds(expr, params, &ResolvedTy::clone)
-                    == WholeParamEmbedClass::None
+                Self::classify_whole_param_embeds(expr, params, &ResolvedTy::clone, false, &|_| {
+                    false
+                }) == WholeParamEmbedClass::None
             }
             // A projection is materialised iff its object chain is.
             HirExprKind::FieldAccess { object, .. } => {
@@ -2463,18 +2469,18 @@ impl Builder {
     /// Classify WHOLE by-value parameter embeds through constructors.
     ///
     /// Recurses only through constructions (struct / tuple / machine-variant
-    /// literals), which embed operands by value. A PROJECTION (`p.inner`), a
-    /// CALL, a `.clone()`, a `Vec` element, and a literal are NOT embeds of a
-    /// whole parameter — a field read bumps, a call/clone materialises a fresh
-    /// value — so they stop the recursion (return `false`). A bare parameter
-    /// binding is the borrow this catches; a bare LOCAL is move-consumed into the
-    /// construction and stays an owner. String parameters are distinguished from
-    /// every unsupported parameter type so only the proven retained-share class
-    /// can feed the Vec COPY-IN temp mint.
+    /// literals), which embed operands by value. For the existing materialised-
+    /// owner route, other leaves stop the recursion. The Vec COPY-IN mint uses
+    /// the stricter mode: every non-constructor heap-owning leaf fails closed,
+    /// because a projection or unproven call result can carry an unretained alias
+    /// derived from another parameter. This admits only construction trees whose
+    /// owned leaves are the whole retained string parameters being discharged.
     fn classify_whole_param_embeds(
         expr: &HirExpr,
         params: &HashSet<BindingId>,
         resolve_ty: &impl Fn(&ResolvedTy) -> ResolvedTy,
+        reject_unproven_owned_leaves: bool,
+        owns_heap: &impl Fn(&ResolvedTy) -> bool,
     ) -> WholeParamEmbedClass {
         match &expr.kind {
             HirExprKind::BindingRef {
@@ -2489,21 +2495,53 @@ impl Builder {
             }
             HirExprKind::StructInit { fields, base, .. } => fields
                 .iter()
-                .map(|(_, value)| Self::classify_whole_param_embeds(value, params, resolve_ty))
-                .chain(
-                    base.iter()
-                        .map(|value| Self::classify_whole_param_embeds(value, params, resolve_ty)),
-                )
+                .map(|(_, value)| {
+                    Self::classify_whole_param_embeds(
+                        value,
+                        params,
+                        resolve_ty,
+                        reject_unproven_owned_leaves,
+                        owns_heap,
+                    )
+                })
+                .chain(base.iter().map(|value| {
+                    Self::classify_whole_param_embeds(
+                        value,
+                        params,
+                        resolve_ty,
+                        reject_unproven_owned_leaves,
+                        owns_heap,
+                    )
+                }))
                 .fold(WholeParamEmbedClass::None, WholeParamEmbedClass::merge),
             HirExprKind::TupleLiteral { elements } => elements
                 .iter()
-                .map(|value| Self::classify_whole_param_embeds(value, params, resolve_ty))
+                .map(|value| {
+                    Self::classify_whole_param_embeds(
+                        value,
+                        params,
+                        resolve_ty,
+                        reject_unproven_owned_leaves,
+                        owns_heap,
+                    )
+                })
                 .fold(WholeParamEmbedClass::None, WholeParamEmbedClass::merge),
             HirExprKind::MachineVariantCtor { payload, .. } => payload
                 .iter()
                 .flatten()
-                .map(|(_, value)| Self::classify_whole_param_embeds(value, params, resolve_ty))
+                .map(|(_, value)| {
+                    Self::classify_whole_param_embeds(
+                        value,
+                        params,
+                        resolve_ty,
+                        reject_unproven_owned_leaves,
+                        owns_heap,
+                    )
+                })
                 .fold(WholeParamEmbedClass::None, WholeParamEmbedClass::merge),
+            _ if reject_unproven_owned_leaves && owns_heap(&resolve_ty(&expr.ty)) => {
+                WholeParamEmbedClass::UnsupportedBorrowAlias
+            }
             _ => WholeParamEmbedClass::None,
         }
     }

--- a/hew-mir/tests/lowering_expr/anonymous_owned_temp_drop.rs
+++ b/hew-mir/tests/lowering_expr/anonymous_owned_temp_drop.rs
@@ -1,6 +1,6 @@
 //! Anonymous caller-owned result and while-let scrutinee drop regressions.
 
-use hew_mir::{DropKind, ElabDrop, ExitPath, IrPipeline, MirStatement};
+use hew_mir::{DropKind, ElabDrop, ExitPath, Instr, IrPipeline, MirStatement, Terminator};
 use hew_types::module_registry::ModuleRegistry;
 use hew_types::Checker;
 
@@ -46,6 +46,131 @@ fn enum_drops(p: &IrPipeline, fn_name: &str, pred: impl Fn(&ExitPath) -> bool) -
         .filter(|drop| matches!(drop.kind, DropKind::EnumInPlace))
         .cloned()
         .collect()
+}
+
+fn record_drops(p: &IrPipeline, fn_name: &str, pred: impl Fn(&ExitPath) -> bool) -> Vec<ElabDrop> {
+    p.elaborated_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .drop_plans
+        .iter()
+        .filter(|(exit, _)| pred(exit))
+        .flat_map(|(_, plan)| plan.drops.iter())
+        .filter(|drop| matches!(drop.kind, DropKind::RecordInPlace))
+        .cloned()
+        .collect()
+}
+
+fn call_count(p: &IrPipeline, fn_name: &str, symbol: &str) -> usize {
+    p.raw_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .blocks
+        .iter()
+        .filter(|block| {
+            matches!(&block.terminator, Terminator::Call { callee, .. } if callee == symbol)
+        })
+        .count()
+}
+
+fn string_retain_count(p: &IrPipeline, fn_name: &str) -> usize {
+    p.raw_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter(|instr| matches!(instr, Instr::StringRetain { .. }))
+        .count()
+}
+
+#[test]
+fn vec_copy_in_string_param_temps_own_only_their_retained_share() {
+    let p = pipeline_with_tc(
+        r#"
+type Holder { items: Vec<string> }
+type Wrap { f: Option<string> }
+type HolderWrap { f: Option<Holder> }
+
+fn pushParam(p: string) {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: Some(p) });
+}
+
+fn setParam(p: string) {
+    let v: Vec<Wrap> = [];
+    v.set(0, Wrap { f: Some(p) });
+}
+
+fn boundFirst(p: string) {
+    let v: Vec<Wrap> = [];
+    let w = Wrap { f: Some(p) };
+    v.push(w);
+}
+
+fn freshMove() {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: Some("item".to_upper()) });
+}
+
+fn unsupported(p: Holder) {
+    let v: Vec<HolderWrap> = [];
+    v.push(HolderWrap { f: Some(p) });
+}
+"#,
+    );
+
+    for (fn_name, copy_symbol, move_symbol) in [
+        ("pushParam", "hew_vec_push_owned", "hew_vec_push_owned_move"),
+        ("setParam", "hew_vec_set_owned", "hew_vec_set_owned_move"),
+    ] {
+        assert_eq!(
+            string_retain_count(&p, fn_name),
+            1,
+            "{fn_name} must retain exactly the string share owned by the source temp"
+        );
+        assert_eq!(call_count(&p, fn_name, copy_symbol), 1);
+        assert_eq!(
+            call_count(&p, fn_name, move_symbol),
+            0,
+            "a parameter embed must remain COPY-IN"
+        );
+        assert_eq!(
+            synthetic_binds(&p, fn_name, "__hew_copy_in_param_temp"),
+            1,
+            "{fn_name} must mint exactly one source-temp owner"
+        );
+        assert_eq!(
+            record_drops(&p, fn_name, |exit| matches!(exit, ExitPath::Return { .. })).len(),
+            1,
+            "{fn_name} must drop the retained source-temp share exactly once on return"
+        );
+    }
+
+    assert_eq!(
+        synthetic_binds(&p, "boundFirst", "__hew_copy_in_param_temp"),
+        0,
+        "a named source already has its ordinary owner"
+    );
+    assert_eq!(call_count(&p, "freshMove", "hew_vec_push_owned_move"), 1);
+    assert_eq!(
+        synthetic_binds(&p, "freshMove", "__hew_copy_in_param_temp"),
+        0,
+        "a no-parameter fresh owner must stay on MOVE-IN"
+    );
+    assert_eq!(call_count(&p, "unsupported", "hew_vec_push_owned"), 1);
+    assert_eq!(
+        synthetic_binds(&p, "unsupported", "__hew_copy_in_param_temp"),
+        0,
+        "an unretained non-string parameter alias must never gain an owner"
+    );
+    assert!(
+        record_drops(&p, "unsupported", |_| true).is_empty(),
+        "the borrowed Holder alias must never be dropped through the source temp"
+    );
 }
 
 #[test]

--- a/hew-mir/tests/lowering_expr/anonymous_owned_temp_drop.rs
+++ b/hew-mir/tests/lowering_expr/anonymous_owned_temp_drop.rs
@@ -62,6 +62,20 @@ fn record_drops(p: &IrPipeline, fn_name: &str, pred: impl Fn(&ExitPath) -> bool)
         .collect()
 }
 
+fn tuple_drops(p: &IrPipeline, fn_name: &str, pred: impl Fn(&ExitPath) -> bool) -> Vec<ElabDrop> {
+    p.elaborated_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .drop_plans
+        .iter()
+        .filter(|(exit, _)| pred(exit))
+        .flat_map(|(_, plan)| plan.drops.iter())
+        .filter(|drop| matches!(drop.kind, DropKind::TupleInPlace))
+        .cloned()
+        .collect()
+}
+
 fn call_count(p: &IrPipeline, fn_name: &str, symbol: &str) -> usize {
     p.raw_mir
         .iter()
@@ -87,6 +101,63 @@ fn string_retain_count(p: &IrPipeline, fn_name: &str) -> usize {
         .count()
 }
 
+fn assert_record_param_embed_mints(p: &IrPipeline) {
+    for (fn_name, copy_symbol, move_symbol) in [
+        ("pushParam", "hew_vec_push_owned", "hew_vec_push_owned_move"),
+        ("setParam", "hew_vec_set_owned", "hew_vec_set_owned_move"),
+    ] {
+        assert_eq!(string_retain_count(p, fn_name), 1);
+        assert_eq!(call_count(p, fn_name, copy_symbol), 1);
+        assert_eq!(call_count(p, fn_name, move_symbol), 0);
+        assert_eq!(synthetic_binds(p, fn_name, "__hew_copy_in_param_temp"), 1);
+        assert_eq!(
+            record_drops(p, fn_name, |exit| matches!(exit, ExitPath::Return { .. })).len(),
+            1,
+            "{fn_name} must drop the retained source-temp share exactly once"
+        );
+    }
+}
+
+fn assert_tuple_param_embed_mints(p: &IrPipeline) {
+    for (fn_name, copy_symbol, move_symbol) in [
+        (
+            "tuplePushParam",
+            "hew_vec_push_owned",
+            "hew_vec_push_owned_move",
+        ),
+        (
+            "tupleSetParam",
+            "hew_vec_set_owned",
+            "hew_vec_set_owned_move",
+        ),
+    ] {
+        assert_eq!(string_retain_count(p, fn_name), 1);
+        assert_eq!(call_count(p, fn_name, copy_symbol), 1);
+        assert_eq!(call_count(p, fn_name, move_symbol), 0);
+        assert_eq!(synthetic_binds(p, fn_name, "__hew_copy_in_param_temp"), 1);
+        assert_eq!(
+            tuple_drops(p, fn_name, |exit| matches!(exit, ExitPath::Return { .. })).len(),
+            1,
+            "{fn_name} must drop the retained tuple source-temp share exactly once"
+        );
+    }
+}
+
+fn assert_unsupported_param_embeds_fail_closed(p: &IrPipeline) {
+    assert_eq!(call_count(p, "unsupported", "hew_vec_push_owned"), 1);
+    for fn_name in ["unsupported", "unsupportedProjection"] {
+        assert_eq!(
+            synthetic_binds(p, fn_name, "__hew_copy_in_param_temp"),
+            0,
+            "{fn_name} must not mint an owner for an unretained parameter alias"
+        );
+        assert!(
+            record_drops(p, fn_name, |_| true).is_empty(),
+            "{fn_name} must not drop a caller-owned parameter alias"
+        );
+    }
+}
+
 #[test]
 fn vec_copy_in_string_param_temps_own_only_their_retained_share() {
     let p = pipeline_with_tc(
@@ -94,6 +165,7 @@ fn vec_copy_in_string_param_temps_own_only_their_retained_share() {
 type Holder { items: Vec<string> }
 type Wrap { f: Option<string> }
 type HolderWrap { f: Option<Holder> }
+type MixedWrap { s: string, items: Vec<string> }
 
 fn pushParam(p: string) {
     let v: Vec<Wrap> = [];
@@ -103,6 +175,16 @@ fn pushParam(p: string) {
 fn setParam(p: string) {
     let v: Vec<Wrap> = [];
     v.set(0, Wrap { f: Some(p) });
+}
+
+fn tuplePushParam(p: string) {
+    let v: Vec<(string, i64)> = [];
+    v.push((p, 1));
+}
+
+fn tupleSetParam(p: string) {
+    let v: Vec<(string, i64)> = [];
+    v.set(0, (p, 1));
 }
 
 fn boundFirst(p: string) {
@@ -120,35 +202,16 @@ fn unsupported(p: Holder) {
     let v: Vec<HolderWrap> = [];
     v.push(HolderWrap { f: Some(p) });
 }
+
+fn unsupportedProjection(p: string, h: Holder) {
+    let v: Vec<MixedWrap> = [];
+    v.push(MixedWrap { s: p, items: h.items });
+}
 "#,
     );
 
-    for (fn_name, copy_symbol, move_symbol) in [
-        ("pushParam", "hew_vec_push_owned", "hew_vec_push_owned_move"),
-        ("setParam", "hew_vec_set_owned", "hew_vec_set_owned_move"),
-    ] {
-        assert_eq!(
-            string_retain_count(&p, fn_name),
-            1,
-            "{fn_name} must retain exactly the string share owned by the source temp"
-        );
-        assert_eq!(call_count(&p, fn_name, copy_symbol), 1);
-        assert_eq!(
-            call_count(&p, fn_name, move_symbol),
-            0,
-            "a parameter embed must remain COPY-IN"
-        );
-        assert_eq!(
-            synthetic_binds(&p, fn_name, "__hew_copy_in_param_temp"),
-            1,
-            "{fn_name} must mint exactly one source-temp owner"
-        );
-        assert_eq!(
-            record_drops(&p, fn_name, |exit| matches!(exit, ExitPath::Return { .. })).len(),
-            1,
-            "{fn_name} must drop the retained source-temp share exactly once on return"
-        );
-    }
+    assert_record_param_embed_mints(&p);
+    assert_tuple_param_embed_mints(&p);
 
     assert_eq!(
         synthetic_binds(&p, "boundFirst", "__hew_copy_in_param_temp"),
@@ -161,16 +224,7 @@ fn unsupported(p: Holder) {
         0,
         "a no-parameter fresh owner must stay on MOVE-IN"
     );
-    assert_eq!(call_count(&p, "unsupported", "hew_vec_push_owned"), 1);
-    assert_eq!(
-        synthetic_binds(&p, "unsupported", "__hew_copy_in_param_temp"),
-        0,
-        "an unretained non-string parameter alias must never gain an owner"
-    );
-    assert!(
-        record_drops(&p, "unsupported", |_| true).is_empty(),
-        "the borrowed Holder alias must never be dropped through the source temp"
-    );
+    assert_unsupported_param_embeds_fail_closed(&p);
 }
 
 #[test]

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -379,6 +379,12 @@ ENUM_RESOURCE_STATE_SRC="${ROOT}/tests/vertical-slice/accept/enum_resource_state
 # COPY-IN the per-iteration `set` temp leaked its inner Vec; macOS `leaks` slope
 # proves it there, LSan proves it here. Exits 0, clean.
 VEC_ELEM_STORE_TEMP_SRC="${ROOT}/tests/vertical-slice/accept/vec_elem_store_owned_temp_no_leak.hew"
+# Retain-backed string parameter embeds stay on the owned-Vec COPY-IN ABI, but
+# the anonymous source temp's explicit retained share must receive one ordinary
+# drop. Includes direct push/set caller-after-store reads and a generic Arena
+# insert/remove cycle. An over-eager mint drops the caller's parameter; a missed
+# temp drop leaks once per store. ASan/LSan catches both directions.
+VEC_PARAM_EMBED_TEMP_SRC="${ROOT}/tests/vertical-slice/accept/vec_param_embed_copy_in_temp_no_leak.hew"
 
 # ── Step 3: compile the Hew fixtures ─────────────────────────────────────
 echo ""
@@ -433,6 +439,9 @@ compile_asan_fixture "resource enum actor-state overwrite (#2641)" "${ENUM_RESOU
 
 VEC_ELEM_STORE_TEMP_BIN="${WORK_DIR}/vec_elem_store_owned_temp_no_leak"
 compile_asan_fixture "owned-Vec element-store temp (push/set move-in)" "${VEC_ELEM_STORE_TEMP_SRC}" "${VEC_ELEM_STORE_TEMP_BIN}"
+
+VEC_PARAM_EMBED_TEMP_BIN="${WORK_DIR}/vec_param_embed_copy_in_temp_no_leak"
+compile_asan_fixture "owned-Vec retained param-embed temp (push/set/Arena)" "${VEC_PARAM_EMBED_TEMP_SRC}" "${VEC_PARAM_EMBED_TEMP_BIN}"
 
 # ── Step 3c: compile and link the clean probe via the CLI flag path ───────
 # Uses HEW_SANITIZE_ADDRESS=1 hew build (full link, not --emit-obj) to exercise
@@ -570,6 +579,12 @@ else
 fi
 
 if run_asan_fixture "owned-Vec element-store temp (push/set move-in)" "${VEC_ELEM_STORE_TEMP_BIN}" 0; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+if run_asan_fixture "owned-Vec retained param-embed temp (push/set/Arena)" "${VEC_PARAM_EMBED_TEMP_BIN}" 0; then
   pass=$((pass + 1))
 else
   fail=$((fail + 1))

--- a/tests/vertical-slice/accept/vec_param_embed_copy_in_temp_no_leak.hew
+++ b/tests/vertical-slice/accept/vec_param_embed_copy_in_temp_no_leak.hew
@@ -4,6 +4,8 @@
 // generic insert/remove form of the same seam. ASan/LSan catches leaks,
 // refcount underflow, double-free, and caller-after-store use-after-free.
 type Wrap { f: Option<string> }
+type Holder { items: Vec<string> }
+type MixedWrap { s: string, items: Vec<string> }
 type Key<T> { index: i64 }
 type Slot<T> { value: Option<T> }
 type Arena<T> { slots: Vec<Slot<T>> }
@@ -18,6 +20,12 @@ fn setParam(p: string) -> i64 {
     let v: Vec<Wrap> = [];
     v.push(Wrap { f: None });
     v.set(0, Wrap { f: Some(p) });
+    v.len()
+}
+
+fn pushMixed(p: string, h: Holder) -> i64 {
+    let v: Vec<MixedWrap> = [];
+    v.push(MixedWrap { s: p, items: h.items });
     v.len()
 }
 
@@ -50,6 +58,11 @@ fn main() -> i64 {
         if p.len() < 6 { return 62; }
         if setParam(p) != 1 { return 63; }
         if p.len() < 6 { return 64; }
+
+        let h = Holder { items: [f"deep-{i}"] };
+        if pushMixed(p, h) != 1 { return 65; }
+        if p.len() < 6 { return 70; }
+        if h.items.len() != 1 { return 71; }
 
         let key = arena.insert(f"arena-{i}");
         let got = arena.remove(key);

--- a/tests/vertical-slice/accept/vec_param_embed_copy_in_temp_no_leak.hew
+++ b/tests/vertical-slice/accept/vec_param_embed_copy_in_temp_no_leak.hew
@@ -1,0 +1,62 @@
+// Retain-backed string parameter embeds in anonymous owned-Vec COPY-IN source
+// temps. The caller retains ownership of each parameter while the temporary's
+// independent retained share is released exactly once. The Arena cycle is the
+// generic insert/remove form of the same seam. ASan/LSan catches leaks,
+// refcount underflow, double-free, and caller-after-store use-after-free.
+type Wrap { f: Option<string> }
+type Key<T> { index: i64 }
+type Slot<T> { value: Option<T> }
+type Arena<T> { slots: Vec<Slot<T>> }
+
+fn pushParam(p: string) -> i64 {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: Some(p) });
+    v.len()
+}
+
+fn setParam(p: string) -> i64 {
+    let v: Vec<Wrap> = [];
+    v.push(Wrap { f: None });
+    v.set(0, Wrap { f: Some(p) });
+    v.len()
+}
+
+fn newArena<T>() -> Arena<T> {
+    Arena { slots: Vec::new() }
+}
+
+impl<T> Arena<T> {
+    fn insert(self, value: T) -> Key<T> {
+        let index = self.slots.len();
+        self.slots.push(Slot { value: Some(value) });
+        Key { index: index }
+    }
+
+    fn remove(self, key: Key<T>) -> T {
+        let slot = self.slots.remove(key.index);
+        slot.value.unwrap()
+    }
+
+    fn len(self) -> i64 {
+        self.slots.len()
+    }
+}
+
+fn main() -> i64 {
+    let arena = newArena<string>();
+    for i in 0..32 {
+        let p = f"item-{i}";
+        if pushParam(p) != 1 { return 61; }
+        if p.len() < 6 { return 62; }
+        if setParam(p) != 1 { return 63; }
+        if p.len() < 6 { return 64; }
+
+        let key = arena.insert(f"arena-{i}");
+        let got = arena.remove(key);
+        let expected = f"arena-{i}";
+        if got != expected { return 66; }
+        if got.len() != expected.len() { return 67; }
+        if arena.len() != 0 { return 69; }
+    }
+    0
+}


### PR DESCRIPTION
A fresh aggregate constructor that embeds a whole by-value `string` parameter and is stored copy-in into a Vec (e.g. `v.push(Slot{ value: Some(param) })`) made an owned clone whose release nobody scheduled, leaking one heap allocation per store. This is the last-known residual of the copy-in element-store leak class (the move-in routing lanes correctly could not cover it, since the constructor embeds a borrowed parameter and moving it would double-free the caller's value).

This mints a scope-exit release for that copy-in temp's own clone. The borrowed parameter's caller ownership is preserved (never released here); non-string and mixed/projection-owned parameter embeds are handled fail-closed, since minting there would release storage the caller still owns.

## Verification
- Leak closed: the standalone Arena insert/remove cycle drops from a linear per-cycle leak to a flat 0 slope; a permanent parameter-embed ownership oracle (9 cases) pins release-count-one, caller-parameter-not-double-freed, mixed-projection-not-double-freed, and non-string rejection under the poisoned allocator.
- ll-diff, checked-mir-verify, funcupdate baselines, corpus coverage, and the compiled-.hew ratchet all green; no golden movement.

## Out of scope
- Arbitrary deep-owned (non-string) parameter embeds — minting there is not statically sound and stays fail-closed.