### PR TITLE
fix(mir): drop owned composite fields at a project-match parameter tail

### DIFF
--- a/examples/v05/checked-mir/golden/pattern_param_tail_owned_project.elab.mir
+++ b/examples/v05/checked-mir/golden/pattern_param_tail_owned_project.elab.mir
@@ -1,0 +1,507 @@
+fn record_tail -> i64
+  statements:
+    use BindingId(0) p site=SiteId(1) ty=Packet intent=Read
+    return site=Some(SiteId(0)) ty=i64
+    bind BindingId(1) tag site=SiteId(2) ty=string
+    bind BindingId(2) body site=SiteId(2) ty=string
+    use BindingId(0) p site=SiteId(1) ty=Packet intent=Consume
+    use BindingId(1) tag site=SiteId(4) ty=string intent=Read
+    use BindingId(2) body site=SiteId(7) ty=string intent=Read
+    drop BindingId(2) body ty=string
+    drop BindingId(1) tag ty=string
+  drop_plans:
+    goto[bb0->bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+    call[bb2 hew_string_length -> bb3] ->
+      (none)
+    call[bb3 hew_string_length -> bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    panic[bb5] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb6->bb1] ->
+      (none)
+    cancel[bb6] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+
+fn record_nontail -> i64
+  statements:
+    use BindingId(3) p site=SiteId(10) ty=Packet intent=Read
+    bind BindingId(6) total site=SiteId(9) ty=i64
+    use BindingId(6) total site=SiteId(18) ty=i64 intent=Read
+    return site=Some(SiteId(18)) ty=i64
+    bind BindingId(4) tag site=SiteId(11) ty=string
+    bind BindingId(5) body site=SiteId(11) ty=string
+    use BindingId(3) p site=SiteId(10) ty=Packet intent=Consume
+    use BindingId(4) tag site=SiteId(13) ty=string intent=Read
+    use BindingId(5) body site=SiteId(16) ty=string intent=Read
+    drop BindingId(5) body ty=string
+    drop BindingId(4) tag ty=string
+  drop_plans:
+    goto[bb0->bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+    call[bb2 hew_string_length -> bb3] ->
+      (none)
+    call[bb3 hew_string_length -> bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    panic[bb5] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb6->bb1] ->
+      (none)
+    cancel[bb6] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+
+fn tuple_tail -> i64
+  statements:
+    use BindingId(7) p site=SiteId(20) ty=(string, string) intent=Read
+    return site=Some(SiteId(19)) ty=i64
+    bind BindingId(8) left site=SiteId(21) ty=string
+    bind BindingId(9) right site=SiteId(21) ty=string
+    use BindingId(7) p site=SiteId(20) ty=(string, string) intent=Consume
+    use BindingId(8) left site=SiteId(23) ty=string intent=Read
+    use BindingId(9) right site=SiteId(26) ty=string intent=Read
+    drop BindingId(9) right ty=string
+    drop BindingId(8) left ty=string
+  drop_plans:
+    goto[bb0->bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+    call[bb2 hew_string_length -> bb3] ->
+      (none)
+    call[bb3 hew_string_length -> bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    panic[bb5] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb6->bb1] ->
+      (none)
+    cancel[bb6] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+
+fn tuple_nontail -> i64
+  statements:
+    use BindingId(10) p site=SiteId(29) ty=(string, string) intent=Read
+    bind BindingId(13) total site=SiteId(28) ty=i64
+    use BindingId(13) total site=SiteId(37) ty=i64 intent=Read
+    return site=Some(SiteId(37)) ty=i64
+    bind BindingId(11) left site=SiteId(30) ty=string
+    bind BindingId(12) right site=SiteId(30) ty=string
+    use BindingId(10) p site=SiteId(29) ty=(string, string) intent=Consume
+    use BindingId(11) left site=SiteId(32) ty=string intent=Read
+    use BindingId(12) right site=SiteId(35) ty=string intent=Read
+    drop BindingId(12) right ty=string
+    drop BindingId(11) left ty=string
+  drop_plans:
+    goto[bb0->bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+    call[bb2 hew_string_length -> bb3] ->
+      (none)
+    call[bb3 hew_string_length -> bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    panic[bb5] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb6->bb1] ->
+      (none)
+    cancel[bb6] ->
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
+
+fn borrow_record -> i64
+  statements:
+    use BindingId(14) p site=SiteId(39) ty=Packet intent=Read
+    return site=Some(SiteId(38)) ty=i64
+  drop_plans:
+    goto[bb0->bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+    goto[bb2->bb1] ->
+      (none)
+    cancel[bb2] ->
+      (none)
+    panic[bb3] ->
+      (none)
+
+fn borrow_tuple -> i64
+  statements:
+    use BindingId(15) p site=SiteId(42) ty=(string, string) intent=Read
+    return site=Some(SiteId(41)) ty=i64
+  drop_plans:
+    goto[bb0->bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+    goto[bb2->bb1] ->
+      (none)
+    cancel[bb2] ->
+      (none)
+    panic[bb3] ->
+      (none)
+
+fn main -> i64
+  statements:
+    bind BindingId(16) a site=SiteId(44) ty=i64
+    bind BindingId(17) b site=SiteId(53) ty=i64
+    bind BindingId(18) c site=SiteId(62) ty=i64
+    bind BindingId(19) d site=SiteId(71) ty=i64
+    bind BindingId(20) packet site=SiteId(80) ty=Packet
+    use BindingId(20) packet site=SiteId(88) ty=Packet intent=Read
+    bind BindingId(21) record_borrow site=SiteId(87) ty=i64
+    use BindingId(20) packet site=SiteId(92) ty=Packet intent=Read
+    bind BindingId(22) record_reuse site=SiteId(90) ty=i64
+    bind BindingId(23) tuple site=SiteId(94) ty=(string, string)
+    use BindingId(23) tuple site=SiteId(102) ty=(string, string) intent=Read
+    bind BindingId(24) tuple_borrow site=SiteId(101) ty=i64
+    use BindingId(23) tuple site=SiteId(106) ty=(string, string) intent=Read
+    bind BindingId(25) tuple_reuse site=SiteId(104) ty=i64
+    use BindingId(16) a site=SiteId(115) ty=i64 intent=Read
+    use BindingId(17) b site=SiteId(116) ty=i64 intent=Read
+    use BindingId(18) c site=SiteId(117) ty=i64 intent=Read
+    use BindingId(19) d site=SiteId(118) ty=i64 intent=Read
+    use BindingId(21) record_borrow site=SiteId(122) ty=i64 intent=Read
+    use BindingId(22) record_reuse site=SiteId(123) ty=i64 intent=Read
+    use BindingId(24) tuple_borrow site=SiteId(127) ty=i64 intent=Read
+    use BindingId(25) tuple_reuse site=SiteId(128) ty=i64 intent=Read
+    return site=Some(SiteId(108)) ty=i64
+    drop BindingId(23) tuple ty=(string, string)
+    drop BindingId(20) packet ty=Packet
+  drop_plans:
+    call[bb0 record_tail -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 record_nontail -> bb2] ->
+      (none)
+    call[bb2 tuple_tail -> bb3] ->
+      (none)
+    call[bb3 tuple_nontail -> bb4] ->
+      (none)
+    call[bb4 borrow_record -> bb5] ->
+      (none)
+    call[bb5 hew_string_length -> bb6] ->
+      (none)
+    call[bb6 borrow_tuple -> bb7] ->
+      (none)
+    call[bb7 hew_string_length -> bb8] ->
+      (none)
+    branch[bb8: bb9/bb10] ->
+      (none)
+    panic[bb9] ->
+      drop _56 ty=(string, string) kind=tuple_in_place
+      drop _43 ty=Packet kind=record_in_place
+    branch[bb10: bb11/bb12] ->
+      (none)
+    panic[bb11] ->
+      drop _56 ty=(string, string) kind=tuple_in_place
+      drop _43 ty=Packet kind=record_in_place
+    branch[bb12: bb13/bb14] ->
+      (none)
+    panic[bb13] ->
+      drop _56 ty=(string, string) kind=tuple_in_place
+      drop _43 ty=Packet kind=record_in_place
+    branch[bb14: bb15/bb16] ->
+      (none)
+    branch[bb15: bb17/bb18] ->
+      (none)
+    branch[bb16: bb19/bb20] ->
+      (none)
+    panic[bb17] ->
+      drop _56 ty=(string, string) kind=tuple_in_place
+      drop _43 ty=Packet kind=record_in_place
+    goto[bb18->bb16] ->
+      (none)
+    cancel[bb18] ->
+      drop _56 ty=(string, string) kind=tuple_in_place
+      drop _43 ty=Packet kind=record_in_place
+    branch[bb19: bb21/bb22] ->
+      (none)
+    branch[bb20: bb23/bb24] ->
+      (none)
+    panic[bb21] ->
+      drop _56 ty=(string, string) kind=tuple_in_place
+      drop _43 ty=Packet kind=record_in_place
+    goto[bb22->bb20] ->
+      (none)
+    cancel[bb22] ->
+      drop _56 ty=(string, string) kind=tuple_in_place
+      drop _43 ty=Packet kind=record_in_place
+    goto[bb23->bb25] ->
+      (none)
+    goto[bb24->bb25] ->
+      (none)
+    return[bb25] ->
+      drop _56 ty=(string, string) kind=tuple_in_place
+      drop _43 ty=Packet kind=record_in_place
+
+fn i8::fmt -> string
+  statements:
+    use BindingId(34) val site=SiteId(204) ty=i8 intent=Read
+    return site=Some(SiteId(202)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i16::fmt -> string
+  statements:
+    use BindingId(35) val site=SiteId(208) ty=i16 intent=Read
+    return site=Some(SiteId(206)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i32::fmt -> string
+  statements:
+    use BindingId(36) val site=SiteId(211) ty=i32 intent=Read
+    return site=Some(SiteId(210)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i64::fmt -> string
+  statements:
+    use BindingId(37) val site=SiteId(214) ty=i64 intent=Read
+    return site=Some(SiteId(213)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u8::fmt -> string
+  statements:
+    use BindingId(38) val site=SiteId(217) ty=u8 intent=Read
+    return site=Some(SiteId(216)) ty=string
+  drop_plans:
+    call[bb0 to_string_u8 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u16::fmt -> string
+  statements:
+    use BindingId(39) val site=SiteId(220) ty=u16 intent=Read
+    return site=Some(SiteId(219)) ty=string
+  drop_plans:
+    call[bb0 to_string_u16 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u32::fmt -> string
+  statements:
+    use BindingId(40) val site=SiteId(223) ty=u32 intent=Read
+    return site=Some(SiteId(222)) ty=string
+  drop_plans:
+    call[bb0 to_string_u32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u64::fmt -> string
+  statements:
+    use BindingId(41) val site=SiteId(226) ty=u64 intent=Read
+    return site=Some(SiteId(225)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn isize::fmt -> string
+  statements:
+    use BindingId(42) val site=SiteId(230) ty=isize intent=Read
+    return site=Some(SiteId(228)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn usize::fmt -> string
+  statements:
+    use BindingId(43) val site=SiteId(234) ty=usize intent=Read
+    return site=Some(SiteId(232)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn bool::fmt -> string
+  statements:
+    use BindingId(44) val site=SiteId(237) ty=bool intent=Read
+    return site=Some(SiteId(236)) ty=string
+  drop_plans:
+    call[bb0 to_string_bool -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn char::fmt -> string
+  statements:
+    use BindingId(45) val site=SiteId(240) ty=char intent=Read
+    return site=Some(SiteId(239)) ty=string
+  drop_plans:
+    call[bb0 to_string_char -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f64::fmt -> string
+  statements:
+    use BindingId(46) val site=SiteId(243) ty=f64 intent=Read
+    return site=Some(SiteId(242)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f32::fmt -> string
+  statements:
+    use BindingId(47) val site=SiteId(247) ty=f32 intent=Read
+    return site=Some(SiteId(245)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::fmt -> string
+  statements:
+    use BindingId(48) val site=SiteId(249) ty=string intent=Read
+    return site=Some(SiteId(249)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn duration::from_nanos -> duration
+  statements:
+    use BindingId(49) n site=SiteId(251) ty=i64 intent=Read
+    return site=Some(SiteId(250)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_micros -> duration
+  statements:
+    use BindingId(50) n site=SiteId(254) ty=i64 intent=Read
+    return site=Some(SiteId(253)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_millis -> duration
+  statements:
+    use BindingId(51) n site=SiteId(257) ty=i64 intent=Read
+    return site=Some(SiteId(256)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_secs -> duration
+  statements:
+    use BindingId(52) n site=SiteId(260) ty=i64 intent=Read
+    return site=Some(SiteId(259)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::fmt -> string
+  statements:
+    use BindingId(53) val site=SiteId(265) ty=duration intent=Read
+    return site=Some(SiteId(262)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+

--- a/examples/v05/checked-mir/golden/pattern_param_tail_owned_project.raw.mir
+++ b/examples/v05/checked-mir/golden/pattern_param_tail_owned_project.raw.mir
@@ -1,0 +1,722 @@
+fn record_tail(Packet) -> i64 [conv=default]
+  locals:
+    _0: Packet
+    _1: i64
+    _2: string
+    _3: string
+    _4: i64
+    _5: i64
+    _6: i64
+    _7: bool
+  bb0:
+    stmt: use BindingId(0) p site=SiteId(1) ty=Packet intent=Read
+    goto bb2
+  bb1:
+    stmt: return site=Some(SiteId(0)) ty=i64
+    ret = move _1
+    return
+  bb2:
+    stmt: bind BindingId(1) tag site=SiteId(2) ty=string
+    stmt: bind BindingId(2) body site=SiteId(2) ty=string
+    stmt: use BindingId(0) p site=SiteId(1) ty=Packet intent=Consume
+    stmt: use BindingId(1) tag site=SiteId(4) ty=string intent=Read
+    _2 = _0.field[0]
+    drop_field_in_place _0.field[0] ty=string
+    _3 = _0.field[1]
+    drop_field_in_place _0.field[1] ty=string
+    _4 = call hew_string_length(_2) -> bb3
+  bb3:
+    stmt: use BindingId(2) body site=SiteId(7) ty=string intent=Read
+    _5 = call hew_string_length(_3) -> bb4
+  bb4:
+    _6 ovf=_7 = add.checked.s _4 _5
+    branch _7 ? bb5 : bb6
+  bb5:
+    trap(IntegerOverflow)
+  bb6:
+    _1 = move _6
+    goto bb1
+
+fn record_nontail(Packet) -> i64 [conv=default]
+  locals:
+    _0: Packet
+    _1: i64
+    _2: string
+    _3: string
+    _4: i64
+    _5: i64
+    _6: i64
+    _7: bool
+    _8: i64
+  bb0:
+    stmt: use BindingId(3) p site=SiteId(10) ty=Packet intent=Read
+    goto bb2
+  bb1:
+    stmt: bind BindingId(6) total site=SiteId(9) ty=i64
+    stmt: use BindingId(6) total site=SiteId(18) ty=i64 intent=Read
+    stmt: return site=Some(SiteId(18)) ty=i64
+    _8 = move _1
+    ret = move _8
+    return
+  bb2:
+    stmt: bind BindingId(4) tag site=SiteId(11) ty=string
+    stmt: bind BindingId(5) body site=SiteId(11) ty=string
+    stmt: use BindingId(3) p site=SiteId(10) ty=Packet intent=Consume
+    stmt: use BindingId(4) tag site=SiteId(13) ty=string intent=Read
+    _2 = _0.field[0]
+    drop_field_in_place _0.field[0] ty=string
+    _3 = _0.field[1]
+    drop_field_in_place _0.field[1] ty=string
+    _4 = call hew_string_length(_2) -> bb3
+  bb3:
+    stmt: use BindingId(5) body site=SiteId(16) ty=string intent=Read
+    _5 = call hew_string_length(_3) -> bb4
+  bb4:
+    _6 ovf=_7 = add.checked.s _4 _5
+    branch _7 ? bb5 : bb6
+  bb5:
+    trap(IntegerOverflow)
+  bb6:
+    _1 = move _6
+    goto bb1
+
+fn tuple_tail((string, string)) -> i64 [conv=default]
+  locals:
+    _0: (string, string)
+    _1: i64
+    _2: string
+    _3: string
+    _4: i64
+    _5: i64
+    _6: i64
+    _7: bool
+  bb0:
+    stmt: use BindingId(7) p site=SiteId(20) ty=(string, string) intent=Read
+    goto bb2
+  bb1:
+    stmt: return site=Some(SiteId(19)) ty=i64
+    ret = move _1
+    return
+  bb2:
+    stmt: bind BindingId(8) left site=SiteId(21) ty=string
+    stmt: bind BindingId(9) right site=SiteId(21) ty=string
+    stmt: use BindingId(7) p site=SiteId(20) ty=(string, string) intent=Consume
+    stmt: use BindingId(8) left site=SiteId(23) ty=string intent=Read
+    _2 = _0.0
+    drop_field_in_place _0.0 ty=string
+    _3 = _0.1
+    drop_field_in_place _0.1 ty=string
+    _4 = call hew_string_length(_2) -> bb3
+  bb3:
+    stmt: use BindingId(9) right site=SiteId(26) ty=string intent=Read
+    _5 = call hew_string_length(_3) -> bb4
+  bb4:
+    _6 ovf=_7 = add.checked.s _4 _5
+    branch _7 ? bb5 : bb6
+  bb5:
+    trap(IntegerOverflow)
+  bb6:
+    _1 = move _6
+    goto bb1
+
+fn tuple_nontail((string, string)) -> i64 [conv=default]
+  locals:
+    _0: (string, string)
+    _1: i64
+    _2: string
+    _3: string
+    _4: i64
+    _5: i64
+    _6: i64
+    _7: bool
+    _8: i64
+  bb0:
+    stmt: use BindingId(10) p site=SiteId(29) ty=(string, string) intent=Read
+    goto bb2
+  bb1:
+    stmt: bind BindingId(13) total site=SiteId(28) ty=i64
+    stmt: use BindingId(13) total site=SiteId(37) ty=i64 intent=Read
+    stmt: return site=Some(SiteId(37)) ty=i64
+    _8 = move _1
+    ret = move _8
+    return
+  bb2:
+    stmt: bind BindingId(11) left site=SiteId(30) ty=string
+    stmt: bind BindingId(12) right site=SiteId(30) ty=string
+    stmt: use BindingId(10) p site=SiteId(29) ty=(string, string) intent=Consume
+    stmt: use BindingId(11) left site=SiteId(32) ty=string intent=Read
+    _2 = _0.0
+    drop_field_in_place _0.0 ty=string
+    _3 = _0.1
+    drop_field_in_place _0.1 ty=string
+    _4 = call hew_string_length(_2) -> bb3
+  bb3:
+    stmt: use BindingId(12) right site=SiteId(35) ty=string intent=Read
+    _5 = call hew_string_length(_3) -> bb4
+  bb4:
+    _6 ovf=_7 = add.checked.s _4 _5
+    branch _7 ? bb5 : bb6
+  bb5:
+    trap(IntegerOverflow)
+  bb6:
+    _1 = move _6
+    goto bb1
+
+fn borrow_record(Packet) -> i64 [conv=default]
+  locals:
+    _0: Packet
+    _1: i64
+    _2: i64
+  bb0:
+    stmt: use BindingId(14) p site=SiteId(39) ty=Packet intent=Read
+    goto bb2
+  bb1:
+    stmt: return site=Some(SiteId(38)) ty=i64
+    ret = move _1
+    return
+  bb2:
+    _2 = const.i64 1
+    _1 = move _2
+    goto bb1
+  bb3:
+    trap(ExhaustivenessFallthrough)
+
+fn borrow_tuple((string, string)) -> i64 [conv=default]
+  locals:
+    _0: (string, string)
+    _1: i64
+    _2: i64
+  bb0:
+    stmt: use BindingId(15) p site=SiteId(42) ty=(string, string) intent=Read
+    goto bb2
+  bb1:
+    stmt: return site=Some(SiteId(41)) ty=i64
+    ret = move _1
+    return
+  bb2:
+    _2 = const.i64 1
+    _1 = move _2
+    goto bb1
+  bb3:
+    trap(ExhaustivenessFallthrough)
+
+fn main() -> i64 [conv=default]
+  locals:
+    _0: string
+    _1: string
+    _2: string
+    _3: string
+    _4: string
+    _5: string
+    _6: Packet
+    _7: i64
+    _8: i64
+    _9: string
+    _10: string
+    _11: string
+    _12: string
+    _13: string
+    _14: string
+    _15: Packet
+    _16: i64
+    _17: i64
+    _18: string
+    _19: string
+    _20: string
+    _21: string
+    _22: string
+    _23: string
+    _24: (string, string)
+    _25: i64
+    _26: i64
+    _27: string
+    _28: string
+    _29: string
+    _30: string
+    _31: string
+    _32: string
+    _33: (string, string)
+    _34: i64
+    _35: i64
+    _36: string
+    _37: string
+    _38: string
+    _39: string
+    _40: string
+    _41: string
+    _42: Packet
+    _43: Packet
+    _44: i64
+    _45: i64
+    _46: string
+    _47: i64
+    _48: i64
+    _49: string
+    _50: string
+    _51: string
+    _52: string
+    _53: string
+    _54: string
+    _55: (string, string)
+    _56: (string, string)
+    _57: i64
+    _58: i64
+    _59: string
+    _60: i64
+    _61: i64
+    _62: i64
+    _63: bool
+    _64: bool
+    _65: i64
+    _66: bool
+    _67: i64
+    _68: bool
+    _69: i64
+    _70: bool
+    _71: i64
+    _72: bool
+    _73: i64
+    _74: bool
+    _75: i64
+    _76: bool
+    _77: i64
+    _78: bool
+    _79: i64
+    _80: bool
+    _81: i64
+    _82: i64
+    _83: i64
+    _84: i64
+  bb0:
+    _0 = string_lit "r"
+    _1 = string_lit "t"
+    _2 = call_rt hew_string_concat(_0, _1)
+    _3 = string_lit "a"
+    _4 = string_lit "b"
+    _5 = call_rt hew_string_concat(_3, _4)
+    _6 = record_init Packet { .0=_2, .1=_5 }
+    _7 = call record_tail(_6) -> bb1
+  bb1:
+    stmt: bind BindingId(16) a site=SiteId(44) ty=i64
+    _8 = move _7
+    _9 = string_lit "r"
+    _10 = string_lit "n"
+    _11 = call_rt hew_string_concat(_9, _10)
+    _12 = string_lit "c"
+    _13 = string_lit "d"
+    _14 = call_rt hew_string_concat(_12, _13)
+    _15 = record_init Packet { .0=_11, .1=_14 }
+    _16 = call record_nontail(_15) -> bb2
+  bb2:
+    stmt: bind BindingId(17) b site=SiteId(53) ty=i64
+    _17 = move _16
+    _18 = string_lit "t"
+    _19 = string_lit "t"
+    _20 = call_rt hew_string_concat(_18, _19)
+    _21 = string_lit "e"
+    _22 = string_lit "f"
+    _23 = call_rt hew_string_concat(_21, _22)
+    _24 = tuple (_20, _23)
+    _25 = call tuple_tail(_24) -> bb3
+  bb3:
+    stmt: bind BindingId(18) c site=SiteId(62) ty=i64
+    _26 = move _25
+    _27 = string_lit "t"
+    _28 = string_lit "n"
+    _29 = call_rt hew_string_concat(_27, _28)
+    _30 = string_lit "g"
+    _31 = string_lit "h"
+    _32 = call_rt hew_string_concat(_30, _31)
+    _33 = tuple (_29, _32)
+    _34 = call tuple_nontail(_33) -> bb4
+  bb4:
+    stmt: bind BindingId(19) d site=SiteId(71) ty=i64
+    stmt: bind BindingId(20) packet site=SiteId(80) ty=Packet
+    stmt: use BindingId(20) packet site=SiteId(88) ty=Packet intent=Read
+    _35 = move _34
+    _36 = string_lit "o"
+    _37 = string_lit "k"
+    _38 = call_rt hew_string_concat(_36, _37)
+    _39 = string_lit "i"
+    _40 = string_lit "j"
+    _41 = call_rt hew_string_concat(_39, _40)
+    _42 = record_init Packet { .0=_38, .1=_41 }
+    _43 = move _42
+    _44 = call borrow_record(_43) -> bb5
+  bb5:
+    stmt: bind BindingId(21) record_borrow site=SiteId(87) ty=i64
+    stmt: use BindingId(20) packet site=SiteId(92) ty=Packet intent=Read
+    _45 = move _44
+    _46 = _43.field[0]
+    _47 = call hew_string_length(_46) -> bb6
+  bb6:
+    stmt: bind BindingId(22) record_reuse site=SiteId(90) ty=i64
+    stmt: bind BindingId(23) tuple site=SiteId(94) ty=(string, string)
+    stmt: use BindingId(23) tuple site=SiteId(102) ty=(string, string) intent=Read
+    drop _46 ty=string fn=release(hew_string_drop)
+    _48 = move _47
+    _49 = string_lit "k"
+    _50 = string_lit "l"
+    _51 = call_rt hew_string_concat(_49, _50)
+    _52 = string_lit "m"
+    _53 = string_lit "n"
+    _54 = call_rt hew_string_concat(_52, _53)
+    _55 = tuple (_51, _54)
+    _56 = move _55
+    _57 = call borrow_tuple(_56) -> bb7
+  bb7:
+    stmt: bind BindingId(24) tuple_borrow site=SiteId(101) ty=i64
+    stmt: use BindingId(23) tuple site=SiteId(106) ty=(string, string) intent=Read
+    _58 = move _57
+    _59 = _56.0
+    _60 = call hew_string_length(_59) -> bb8
+  bb8:
+    stmt: bind BindingId(25) tuple_reuse site=SiteId(104) ty=i64
+    stmt: use BindingId(16) a site=SiteId(115) ty=i64 intent=Read
+    stmt: use BindingId(17) b site=SiteId(116) ty=i64 intent=Read
+    drop _59 ty=string fn=release(hew_string_drop)
+    _61 = move _60
+    _63 = const.i64 0
+    _64 = const.i64 0
+    _65 ovf=_66 = add.checked.s _8 _17
+    branch _66 ? bb9 : bb10
+  bb9:
+    trap(IntegerOverflow)
+  bb10:
+    stmt: use BindingId(18) c site=SiteId(117) ty=i64 intent=Read
+    _67 ovf=_68 = add.checked.s _65 _26
+    branch _68 ? bb11 : bb12
+  bb11:
+    trap(IntegerOverflow)
+  bb12:
+    stmt: use BindingId(19) d site=SiteId(118) ty=i64 intent=Read
+    _69 ovf=_70 = add.checked.s _67 _35
+    branch _70 ? bb13 : bb14
+  bb13:
+    trap(IntegerOverflow)
+  bb14:
+    _71 = const.i64 16
+    _72 = icmp.eq _69 _71
+    branch _72 ? bb15 : bb16
+  bb15:
+    stmt: use BindingId(21) record_borrow site=SiteId(122) ty=i64 intent=Read
+    stmt: use BindingId(22) record_reuse site=SiteId(123) ty=i64 intent=Read
+    _73 ovf=_74 = add.checked.s _45 _48
+    branch _74 ? bb17 : bb18
+  bb16:
+    branch _64 ? bb19 : bb20
+  bb17:
+    trap(IntegerOverflow)
+  bb18:
+    _75 = const.i64 3
+    _76 = icmp.eq _73 _75
+    _64 = move _76
+    goto bb16
+  bb19:
+    stmt: use BindingId(24) tuple_borrow site=SiteId(127) ty=i64 intent=Read
+    stmt: use BindingId(25) tuple_reuse site=SiteId(128) ty=i64 intent=Read
+    _77 ovf=_78 = add.checked.s _58 _61
+    branch _78 ? bb21 : bb22
+  bb20:
+    branch _63 ? bb23 : bb24
+  bb21:
+    trap(IntegerOverflow)
+  bb22:
+    _79 = const.i64 3
+    _80 = icmp.eq _77 _79
+    _63 = move _80
+    goto bb20
+  bb23:
+    _81 = const.i64 0
+    _82 = move _81
+    _62 = move _82
+    goto bb25
+  bb24:
+    _83 = const.i64 1
+    _84 = move _83
+    _62 = move _84
+    goto bb25
+  bb25:
+    stmt: return site=Some(SiteId(108)) ty=i64
+    ret = move _62
+    return
+
+fn i8::fmt(i8) -> string [conv=default]
+  locals:
+    _0: i8
+    _1: i32
+    _2: string
+  bb0:
+    stmt: use BindingId(34) val site=SiteId(204) ty=i8 intent=Read
+    _1 = cast _0 i8 -> i32
+    _2 = call to_string_i32(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(202)) ty=string
+    ret = move _2
+    return
+
+fn i16::fmt(i16) -> string [conv=default]
+  locals:
+    _0: i16
+    _1: i32
+    _2: string
+  bb0:
+    stmt: use BindingId(35) val site=SiteId(208) ty=i16 intent=Read
+    _1 = cast _0 i16 -> i32
+    _2 = call to_string_i32(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(206)) ty=string
+    ret = move _2
+    return
+
+fn i32::fmt(i32) -> string [conv=default]
+  locals:
+    _0: i32
+    _1: string
+  bb0:
+    stmt: use BindingId(36) val site=SiteId(211) ty=i32 intent=Read
+    _1 = call to_string_i32(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(210)) ty=string
+    ret = move _1
+    return
+
+fn i64::fmt(i64) -> string [conv=default]
+  locals:
+    _0: i64
+    _1: string
+  bb0:
+    stmt: use BindingId(37) val site=SiteId(214) ty=i64 intent=Read
+    _1 = call to_string_i64(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(213)) ty=string
+    ret = move _1
+    return
+
+fn u8::fmt(u8) -> string [conv=default]
+  locals:
+    _0: u8
+    _1: string
+  bb0:
+    stmt: use BindingId(38) val site=SiteId(217) ty=u8 intent=Read
+    _1 = call to_string_u8(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(216)) ty=string
+    ret = move _1
+    return
+
+fn u16::fmt(u16) -> string [conv=default]
+  locals:
+    _0: u16
+    _1: string
+  bb0:
+    stmt: use BindingId(39) val site=SiteId(220) ty=u16 intent=Read
+    _1 = call to_string_u16(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(219)) ty=string
+    ret = move _1
+    return
+
+fn u32::fmt(u32) -> string [conv=default]
+  locals:
+    _0: u32
+    _1: string
+  bb0:
+    stmt: use BindingId(40) val site=SiteId(223) ty=u32 intent=Read
+    _1 = call to_string_u32(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(222)) ty=string
+    ret = move _1
+    return
+
+fn u64::fmt(u64) -> string [conv=default]
+  locals:
+    _0: u64
+    _1: string
+  bb0:
+    stmt: use BindingId(41) val site=SiteId(226) ty=u64 intent=Read
+    _1 = call to_string_u64(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(225)) ty=string
+    ret = move _1
+    return
+
+fn isize::fmt(isize) -> string [conv=default]
+  locals:
+    _0: isize
+    _1: i64
+    _2: string
+  bb0:
+    stmt: use BindingId(42) val site=SiteId(230) ty=isize intent=Read
+    _1 = cast _0 isize -> i64
+    _2 = call to_string_i64(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(228)) ty=string
+    ret = move _2
+    return
+
+fn usize::fmt(usize) -> string [conv=default]
+  locals:
+    _0: usize
+    _1: u64
+    _2: string
+  bb0:
+    stmt: use BindingId(43) val site=SiteId(234) ty=usize intent=Read
+    _1 = cast _0 usize -> u64
+    _2 = call to_string_u64(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(232)) ty=string
+    ret = move _2
+    return
+
+fn bool::fmt(bool) -> string [conv=default]
+  locals:
+    _0: bool
+    _1: string
+  bb0:
+    stmt: use BindingId(44) val site=SiteId(237) ty=bool intent=Read
+    _1 = call to_string_bool(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(236)) ty=string
+    ret = move _1
+    return
+
+fn char::fmt(char) -> string [conv=default]
+  locals:
+    _0: char
+    _1: string
+  bb0:
+    stmt: use BindingId(45) val site=SiteId(240) ty=char intent=Read
+    _1 = call to_string_char(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(239)) ty=string
+    ret = move _1
+    return
+
+fn f64::fmt(f64) -> string [conv=default]
+  locals:
+    _0: f64
+    _1: string
+  bb0:
+    stmt: use BindingId(46) val site=SiteId(243) ty=f64 intent=Read
+    _1 = call to_string_f64(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(242)) ty=string
+    ret = move _1
+    return
+
+fn f32::fmt(f32) -> string [conv=default]
+  locals:
+    _0: f32
+    _1: f64
+    _2: string
+  bb0:
+    stmt: use BindingId(47) val site=SiteId(247) ty=f32 intent=Read
+    _1 = cast _0 f32 -> f64
+    _2 = call to_string_f64(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(245)) ty=string
+    ret = move _2
+    return
+
+fn string::fmt(string) -> string [conv=default]
+  locals:
+    _0: string
+  bb0:
+    stmt: use BindingId(48) val site=SiteId(249) ty=string intent=Read
+    stmt: return site=Some(SiteId(249)) ty=string
+    string.retain _0
+    ret = move _0
+    return
+
+fn duration::from_nanos(i64) -> duration [conv=default]
+  locals:
+    _0: i64
+    _1: duration
+    _2: duration
+    _3: bool
+  bb0:
+    stmt: use BindingId(49) n site=SiteId(251) ty=i64 intent=Read
+    _1 = const.duration 1ns
+    _2 ovf=_3 = mul.checked.s _0 _1
+    branch _3 ? bb1 : bb2
+  bb1:
+    trap(IntegerOverflow)
+  bb2:
+    stmt: return site=Some(SiteId(250)) ty=duration
+    ret = move _2
+    return
+
+fn duration::from_micros(i64) -> duration [conv=default]
+  locals:
+    _0: i64
+    _1: duration
+    _2: duration
+    _3: bool
+  bb0:
+    stmt: use BindingId(50) n site=SiteId(254) ty=i64 intent=Read
+    _1 = const.duration 1000ns
+    _2 ovf=_3 = mul.checked.s _0 _1
+    branch _3 ? bb1 : bb2
+  bb1:
+    trap(IntegerOverflow)
+  bb2:
+    stmt: return site=Some(SiteId(253)) ty=duration
+    ret = move _2
+    return
+
+fn duration::from_millis(i64) -> duration [conv=default]
+  locals:
+    _0: i64
+    _1: duration
+    _2: duration
+    _3: bool
+  bb0:
+    stmt: use BindingId(51) n site=SiteId(257) ty=i64 intent=Read
+    _1 = const.duration 1000000ns
+    _2 ovf=_3 = mul.checked.s _0 _1
+    branch _3 ? bb1 : bb2
+  bb1:
+    trap(IntegerOverflow)
+  bb2:
+    stmt: return site=Some(SiteId(256)) ty=duration
+    ret = move _2
+    return
+
+fn duration::from_secs(i64) -> duration [conv=default]
+  locals:
+    _0: i64
+    _1: duration
+    _2: duration
+    _3: bool
+  bb0:
+    stmt: use BindingId(52) n site=SiteId(260) ty=i64 intent=Read
+    _1 = const.duration 1000000000ns
+    _2 ovf=_3 = mul.checked.s _0 _1
+    branch _3 ? bb1 : bb2
+  bb1:
+    trap(IntegerOverflow)
+  bb2:
+    stmt: return site=Some(SiteId(259)) ty=duration
+    ret = move _2
+    return
+
+fn duration::fmt(duration) -> string [conv=default]
+  locals:
+    _0: duration
+    _1: i64
+    _2: string
+    _3: string
+    _4: string
+  bb0:
+    stmt: use BindingId(53) val site=SiteId(265) ty=duration intent=Read
+    _1 = call_rt hew_duration_nanos(_0)
+    _2 = call to_string_i64(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(262)) ty=string
+    _3 = string_lit "ns"
+    _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
+    ret = move _4
+    return
+

--- a/examples/v05/checked-mir/pattern_param_tail_owned_project.hew
+++ b/examples/v05/checked-mir/pattern_param_tail_owned_project.hew
@@ -1,0 +1,64 @@
+// Owned record/tuple parameters use one chain-wide ownership decision. Full
+// projection transfers both string fields to binders in tail and non-tail
+// position; wildcard-only helpers borrow so their caller can reuse and drop the
+// original composite once.
+type Packet {
+    tag: string;
+    body: string;
+}
+
+fn record_tail(p: Packet) -> i64 {
+    match p {
+        Packet { tag, body } => tag.len() + body.len(),
+    }
+}
+
+fn record_nontail(p: Packet) -> i64 {
+    let total = match p {
+        Packet { tag, body } => tag.len() + body.len(),
+    };
+    total
+}
+
+fn tuple_tail(p: (string, string)) -> i64 {
+    match p {
+        (left, right) => left.len() + right.len(),
+    }
+}
+
+fn tuple_nontail(p: (string, string)) -> i64 {
+    let total = match p {
+        (left, right) => left.len() + right.len(),
+    };
+    total
+}
+
+fn borrow_record(p: Packet) -> i64 {
+    match p {
+        _ => 1,
+    }
+}
+
+fn borrow_tuple(p: (string, string)) -> i64 {
+    match p {
+        _ => 1,
+    }
+}
+
+fn main() -> i64 {
+    let a = record_tail(Packet { tag: "r" + "t", body: "a" + "b" });
+    let b = record_nontail(Packet { tag: "r" + "n", body: "c" + "d" });
+    let c = tuple_tail(("t" + "t", "e" + "f"));
+    let d = tuple_nontail(("t" + "n", "g" + "h"));
+    let packet = Packet { tag: "o" + "k", body: "i" + "j" };
+    let record_borrow = borrow_record(packet);
+    let record_reuse = packet.tag.len();
+    let tuple = ("k" + "l", "m" + "n");
+    let tuple_borrow = borrow_tuple(tuple);
+    let tuple_reuse = tuple.0.len();
+    if a + b + c + d == 16 && record_borrow + record_reuse == 3 && tuple_borrow + tuple_reuse == 3 {
+        0
+    } else {
+        1
+    }
+}

--- a/hew-cli/tests/owned_project_param_tail_drop_leak_oracle.rs
+++ b/hew-cli/tests/owned_project_param_tail_drop_leak_oracle.rs
@@ -1,0 +1,86 @@
+//! Leak and poisoned-allocator oracle for owned record/tuple project matches
+//! over by-value parameters.
+//!
+//! Tail and non-tail full projections transfer both string fields to arm
+//! binders, while wildcard-only helpers borrow their parameter so the caller
+//! can reuse and release the original composite. The LOW/HIGH run pins a flat
+//! leak slope; the exact-output scribble run pins valid reads and exactly-once
+//! releases.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+fn param_tail_project_source(frames: usize) -> String {
+    format!(
+        "type Packet {{ tag: string, body: string }}\n\
+         fn record_tail(p: Packet) -> i64 {{\n\
+         \x20   match p {{ Packet {{ tag, body }} => tag.len() + body.len() }}\n\
+         }}\n\
+         fn record_nontail(p: Packet) -> i64 {{\n\
+         \x20   let total = match p {{ Packet {{ tag, body }} => tag.len() + body.len() }};\n\
+         \x20   total\n\
+         }}\n\
+         fn tuple_tail(p: (string, string)) -> i64 {{\n\
+         \x20   match p {{ (left, right) => left.len() + right.len() }}\n\
+         }}\n\
+         fn tuple_nontail(p: (string, string)) -> i64 {{\n\
+         \x20   let total = match p {{ (left, right) => left.len() + right.len() }};\n\
+         \x20   total\n\
+         }}\n\
+         fn borrow_record(p: Packet) -> i64 {{ match p {{ _ => 1 }} }}\n\
+         fn borrow_tuple(p: (string, string)) -> i64 {{ match p {{ _ => 1 }} }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       total = total + record_tail(Packet {{ tag: \"r\" + \"t\", body: \"a\" + \"b\" }});\n\
+         \x20       total = total + record_nontail(Packet {{ tag: \"r\" + \"n\", body: \"c\" + \"d\" }});\n\
+         \x20       total = total + tuple_tail((\"t\" + \"t\", \"e\" + \"f\"));\n\
+         \x20       total = total + tuple_nontail((\"t\" + \"n\", \"g\" + \"h\"));\n\
+         \x20       let packet = Packet {{ tag: \"o\" + \"k\", body: \"i\" + \"j\" }};\n\
+         \x20       total = total + borrow_record(packet) + packet.tag.len();\n\
+         \x20       let tuple = (\"k\" + \"l\", \"m\" + \"n\");\n\
+         \x20       total = total + borrow_tuple(tuple) + tuple.0.len();\n\
+         \x20   }}\n\
+         \x20   if total != {frames} * 22 {{ return 71; }}\n\
+         \x20   println(\"param-tail-ok\");\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+#[test]
+fn owned_project_param_tail_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("owned_project_param_tail", param_tail_project_source);
+}
+
+#[test]
+fn owned_project_param_tail_is_clean_under_malloc_scribble() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("owned-project-param-tail-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        &param_tail_project_source(50),
+        dir.path(),
+        "owned_project_param_tail_scribble",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "owned project parameter paths must run clean under the poisoned allocator;\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "param-tail-ok\n",
+        "owned project parameter paths must preserve exact output;\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-mir/src/lower/facts.rs
+++ b/hew-mir/src/lower/facts.rs
@@ -2,10 +2,11 @@
 use super::*;
 #[cfg(not(test))]
 use super::{
-    named_type_names, short_name, BindingId, Builder, BuiltinType, HashMap, HashSet, HirBlock,
-    HirExpr, HirExprKind, HirFn, HirItem, HirStmtKind, Instr, IntentKind, LayoutReadiness,
-    MirDiagnostic, MirDiagnosticKind, MirStatement, ParamOwnershipFacts, Place, ResolvedRef,
-    ResolvedTy, ResourceMarker, ScanCtx, Strategy, ValueClass,
+    named_type_names, project_match_ownership_mode, short_name, BindingId, Builder, BuiltinType,
+    HashMap, HashSet, HirBlock, HirExpr, HirExprKind, HirFn, HirItem, HirStmtKind, Instr,
+    IntentKind, LayoutReadiness, MirDiagnostic, MirDiagnosticKind, MirStatement,
+    ParamOwnershipFacts, Place, ProjectMatchOwnershipMode, ResolvedRef, ResolvedTy, ResourceMarker,
+    ScanCtx, Strategy, ValueClass,
 };
 
 /// Flow-insensitive prescan deciding, for every binding in `func`, whether a
@@ -1272,7 +1273,15 @@ fn scan_expr_for_consume(expr: &HirExpr, b_p: BindingId, pc: &ScanCtx<'_>) -> bo
                 || scan_block_for_consume(body, b_p, pc)
         }
         HirExprKind::Match { scrutinee, arms } => {
-            scan_expr_for_consume(scrutinee, b_p, pc)
+            let scrutinee_consumes = if is_binding_ref(scrutinee, b_p) {
+                !matches!(
+                    project_match_ownership_mode(arms),
+                    ProjectMatchOwnershipMode::Borrow
+                )
+            } else {
+                scan_expr_for_consume(scrutinee, b_p, pc)
+            };
+            scrutinee_consumes
                 || arms.iter().any(|arm| {
                     arm.guard
                         .as_ref()

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -69,6 +69,8 @@ mod suspend_places;
 mod task;
 mod temp_drop;
 
+use self::pattern::{project_match_ownership_mode, ProjectMatchOwnershipMode};
+
 #[cfg(not(test))]
 use self::cfg_util::{
     block_by_id, blocks_reachable_from, call_terminator_next, local_is_used_after,

--- a/hew-mir/src/lower/pattern.rs
+++ b/hew-mir/src/lower/pattern.rs
@@ -12,6 +12,48 @@ use super::{
     VecElementRelease,
 };
 
+/// Chain-wide ownership mode for record/tuple project matches.
+///
+/// Project arms that introduce no field bindings, together with wildcard
+/// fallbacks, only inspect the scrutinee. Any projected field binding or
+/// whole-value binding transfers ownership on selection. Other predicate
+/// families are not project chains and retain their existing classification.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ProjectMatchOwnershipMode {
+    Borrow,
+    Consume,
+    NotApplicable,
+}
+
+/// Classify a complete match chain before either parameter-consumption facts
+/// or project lowering make an ownership decision.
+pub(super) fn project_match_ownership_mode(
+    arms: &[hew_hir::HirMatchArm],
+) -> ProjectMatchOwnershipMode {
+    if arms.is_empty()
+        || arms.iter().any(|arm| {
+            !matches!(
+                arm.predicate,
+                hew_hir::HirMatchArmPredicate::RecordProject { .. }
+                    | hew_hir::HirMatchArmPredicate::TupleProject { .. }
+                    | hew_hir::HirMatchArmPredicate::Wildcard
+                    | hew_hir::HirMatchArmPredicate::Binding { .. }
+            )
+        })
+    {
+        return ProjectMatchOwnershipMode::NotApplicable;
+    }
+
+    if arms.iter().any(|arm| {
+        !arm.bindings.is_empty()
+            || matches!(arm.predicate, hew_hir::HirMatchArmPredicate::Binding { .. })
+    }) {
+        ProjectMatchOwnershipMode::Consume
+    } else {
+        ProjectMatchOwnershipMode::Borrow
+    }
+}
+
 impl Builder {
     /// Lower an `HirExprKind::Match` expression to a tag-dispatch CFG.
     ///

--- a/hew-mir/tests/lowering_expr/match_project.rs
+++ b/hew-mir/tests/lowering_expr/match_project.rs
@@ -1,5 +1,8 @@
-use hew_hir::{lower_program, ResolutionCtx};
-use hew_mir::{lower_hir_module, FieldOffset, Instr, IrPipeline, MirDiagnosticKind};
+use hew_hir::{lower_program, IntentKind, ResolutionCtx};
+use hew_mir::{
+    lower_hir_module, DropKind, ElabDrop, ExitPath, FieldOffset, Instr, IrPipeline,
+    MirDiagnosticKind, MirStatement,
+};
 use hew_types::{module_registry::ModuleRegistry, Checker};
 
 fn pipeline_with_tc(source: &str) -> IrPipeline {
@@ -72,6 +75,72 @@ fn find_fn<'a>(p: &'a IrPipeline, name: &str) -> &'a hew_mir::RawMirFunction {
         .iter()
         .find(|f| f.name == name)
         .unwrap_or_else(|| panic!("function `{name}` not found in raw_mir"))
+}
+
+fn all_drops(pipeline: &IrPipeline, name: &str) -> Vec<ElabDrop> {
+    pipeline
+        .elaborated_mir
+        .iter()
+        .find(|function| function.name == name)
+        .unwrap_or_else(|| panic!("function `{name}` not found in elaborated MIR"))
+        .drop_plans
+        .iter()
+        .flat_map(|(_, plan)| plan.drops.iter().cloned())
+        .collect()
+}
+
+fn return_drops(pipeline: &IrPipeline, name: &str) -> Vec<ElabDrop> {
+    pipeline
+        .elaborated_mir
+        .iter()
+        .find(|function| function.name == name)
+        .unwrap_or_else(|| panic!("function `{name}` not found in elaborated MIR"))
+        .drop_plans
+        .iter()
+        .filter(|(exit, _)| matches!(exit, ExitPath::Return { .. }))
+        .flat_map(|(_, plan)| plan.drops.iter().cloned())
+        .collect()
+}
+
+fn drop_kind_counts(drops: &[ElabDrop]) -> (usize, usize, usize) {
+    drops.iter().fold(
+        (0, 0, 0),
+        |(cow_heap, record_in_place, tuple_in_place), drop| match drop.kind {
+            DropKind::CowHeap { .. } => (cow_heap + 1, record_in_place, tuple_in_place),
+            DropKind::RecordInPlace => (cow_heap, record_in_place + 1, tuple_in_place),
+            DropKind::TupleInPlace => (cow_heap, record_in_place, tuple_in_place + 1),
+            _ => (cow_heap, record_in_place, tuple_in_place),
+        },
+    )
+}
+
+fn cow_drop_places(drops: &[ElabDrop]) -> std::collections::HashSet<hew_mir::Place> {
+    drops
+        .iter()
+        .filter(|drop| matches!(drop.kind, DropKind::CowHeap { .. }))
+        .map(|drop| drop.place)
+        .collect()
+}
+
+fn source_consume_count(pipeline: &IrPipeline, name: &str, source_name: &str) -> usize {
+    pipeline
+        .thir
+        .iter()
+        .find(|function| function.name == name)
+        .unwrap_or_else(|| panic!("function `{name}` not found in THIR"))
+        .statements
+        .iter()
+        .filter(|statement| {
+            matches!(
+                statement,
+                MirStatement::Use {
+                    name,
+                    intent: IntentKind::Consume,
+                    ..
+                } if name == source_name
+            )
+        })
+        .count()
 }
 
 #[test]
@@ -220,4 +289,144 @@ fn diff(r: R) -> i64 {
         FieldOffset(0),
         "binding `b` must load from FieldOffset(0) — declaration position of `b` in `R {{ b, a }}`; got loads: {loads:?}"
     );
+}
+
+#[test]
+fn owned_project_param_tail_and_nontail_have_identical_release_authority() {
+    let pipeline = pipeline_with_tc(
+        r"
+type Packet {
+    tag: string,
+    body: string,
+}
+
+fn record_tail(p: Packet) -> i64 {
+    match p {
+        Packet { tag, body } => tag.len() + body.len(),
+    }
+}
+
+fn record_nontail(p: Packet) -> i64 {
+    let total = match p {
+        Packet { tag, body } => tag.len() + body.len(),
+    };
+    total
+}
+
+fn tuple_tail(p: (string, string)) -> i64 {
+    match p {
+        (left, right) => left.len() + right.len(),
+    }
+}
+
+fn tuple_nontail(p: (string, string)) -> i64 {
+    let total = match p {
+        (left, right) => left.len() + right.len(),
+    };
+    total
+}
+",
+    );
+
+    let record_tail = all_drops(&pipeline, "record_tail");
+    let record_nontail = all_drops(&pipeline, "record_nontail");
+    let tuple_tail = all_drops(&pipeline, "tuple_tail");
+    let tuple_nontail = all_drops(&pipeline, "tuple_nontail");
+
+    assert_eq!(drop_kind_counts(&record_tail), (6, 0, 0));
+    assert_eq!(drop_kind_counts(&record_nontail), (6, 0, 0));
+    assert_eq!(drop_kind_counts(&tuple_tail), (6, 0, 0));
+    assert_eq!(drop_kind_counts(&tuple_nontail), (6, 0, 0));
+    assert_eq!(cow_drop_places(&record_tail).len(), 2);
+    assert_eq!(cow_drop_places(&record_nontail).len(), 2);
+    assert_eq!(cow_drop_places(&tuple_tail).len(), 2);
+    assert_eq!(cow_drop_places(&tuple_nontail).len(), 2);
+    assert_eq!(
+        drop_kind_counts(&return_drops(&pipeline, "record_tail")),
+        (2, 0, 0)
+    );
+    assert_eq!(
+        drop_kind_counts(&return_drops(&pipeline, "record_nontail")),
+        (2, 0, 0)
+    );
+    assert_eq!(
+        drop_kind_counts(&return_drops(&pipeline, "tuple_tail")),
+        (2, 0, 0)
+    );
+    assert_eq!(
+        drop_kind_counts(&return_drops(&pipeline, "tuple_nontail")),
+        (2, 0, 0)
+    );
+    assert_eq!(
+        drop_kind_counts(&record_tail),
+        drop_kind_counts(&record_nontail)
+    );
+    assert_eq!(
+        drop_kind_counts(&tuple_tail),
+        drop_kind_counts(&tuple_nontail)
+    );
+
+    assert_eq!(source_consume_count(&pipeline, "record_tail", "p"), 1);
+    assert_eq!(source_consume_count(&pipeline, "record_nontail", "p"), 1);
+    assert_eq!(source_consume_count(&pipeline, "tuple_tail", "p"), 1);
+    assert_eq!(source_consume_count(&pipeline, "tuple_nontail", "p"), 1);
+}
+
+#[test]
+fn wildcard_project_param_borrows_and_keeps_one_caller_composite_drop() {
+    let pipeline = pipeline_with_tc(
+        r#"
+type Packet {
+    tag: string,
+    body: string,
+}
+
+fn borrow_record(p: Packet) -> i64 {
+    match p { _ => 1 }
+}
+
+fn borrow_tuple(p: (string, string)) -> i64 {
+    match p { _ => 1 }
+}
+
+fn caller() -> i64 {
+    let packet = Packet { tag: "o" + "k", body: "a" + "b" };
+    let record_result = borrow_record(packet);
+    let record_reuse = packet.tag.len();
+    let tuple = ("c" + "d", "e" + "f");
+    let tuple_result = borrow_tuple(tuple);
+    let tuple_reuse = tuple.0.len();
+    record_result + record_reuse + tuple_result + tuple_reuse
+}
+"#,
+    );
+
+    assert_eq!(source_consume_count(&pipeline, "borrow_record", "p"), 0);
+    assert_eq!(source_consume_count(&pipeline, "borrow_tuple", "p"), 0);
+    assert_eq!(
+        drop_kind_counts(&all_drops(&pipeline, "borrow_record")),
+        (0, 0, 0)
+    );
+    assert_eq!(
+        drop_kind_counts(&all_drops(&pipeline, "borrow_tuple")),
+        (0, 0, 0)
+    );
+    let caller_drops = all_drops(&pipeline, "caller");
+    assert_eq!(drop_kind_counts(&caller_drops), (0, 4, 4));
+    assert_eq!(
+        drop_kind_counts(&return_drops(&pipeline, "caller")),
+        (0, 1, 1)
+    );
+    let record_places = caller_drops
+        .iter()
+        .filter(|drop| matches!(drop.kind, DropKind::RecordInPlace))
+        .map(|drop| drop.place)
+        .collect::<std::collections::HashSet<_>>();
+    let tuple_places = caller_drops
+        .iter()
+        .filter(|drop| matches!(drop.kind, DropKind::TupleInPlace))
+        .map(|drop| drop.place)
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(record_places.len(), 1);
+    assert_eq!(tuple_places.len(), 1);
 }


### PR DESCRIPTION
A parameter matched by a projection/destructuring pattern that binds its owned composite fields did not have those fields dropped at the parameter tail, leaking the owned heap. This classifies project-match parameter ownership so a binding-bearing projection consumes (and drops) the composite exactly once, while a wildcard-only projection stays a borrow (the source retains its composite-drop authority) — caller-keeps-drop and callee-owns-drop remain mutually exclusive, so no value is dropped twice.

## Verification
- New leak-slope oracle (`owned_project_param_tail_leak_slope`) asserts a flat 0 per-frame slope for both tail and non-tail project bindings; full-binding tests confirm exactly one source consume and equal release authority across forms.
- ll-diff and checked-mir-verify byte-identical (drop-planning change, no emitted-IR change for existing fixtures); corpus, ratchet, doc-test all pass.

## Out of scope
- Owned record/tuple literal predicates themselves (this is the ownership precursor for that lane).