### PR TITLE
fix(check): clear diagnostic for cross-module same-name generic collision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ ci-preflight-smoke:
 # Assert that target/debug/libhew.a is not stale relative to hew-lib and hew-runtime sources.
 # Run after `make stdlib` as a fast gate; exits non-zero if the .a predates any source input.
 check-libhew-fresh:
-	scripts/check-libhew-fresh.sh
+	scripts/check-libhew-fresh.sh --debug-dir $(DEBUG_DIR)
 
 # Opt-in merge-queue parity preflight.
 ci-preflight-strict:

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -2100,6 +2100,7 @@ impl Checker {
                     }
                     return Ty::Error;
                 }
+                self.check_cross_module_generic_layout_use(&resolved_name, &args, &te.1);
                 if builtin.is_some() && !local_source_type_def {
                     Ty::normalize_named(resolved_name, args)
                 } else {
@@ -2195,6 +2196,191 @@ impl Checker {
             }
         }
     }
+
+    /// Record an owner-qualified concrete generic use and reject a second owner
+    /// when both definitions collapse to the same rc1 monomorphisation symbol
+    /// but require incompatible record layouts.
+    pub(super) fn check_cross_module_generic_layout_use(
+        &mut self,
+        qualified_name: &str,
+        args: &[Ty],
+        span: &Span,
+    ) {
+        let Some((_, bare_name)) = qualified_name.rsplit_once('.') else {
+            return;
+        };
+        if args.is_empty()
+            || !self.cross_module_colliding_record_names.contains(bare_name)
+            || !args
+                .iter()
+                .all(|arg| self.generic_layout_arg_is_concrete(arg))
+        {
+            return;
+        }
+        let Some(current_def) = self.type_defs.get(qualified_name) else {
+            return;
+        };
+        if current_def.type_params.is_empty()
+            || current_def.type_params.len() != args.len()
+            || !matches!(current_def.kind, TypeDefKind::Struct | TypeDefKind::Record)
+        {
+            return;
+        }
+
+        let key = (bare_name.to_string(), args.to_vec());
+        let Some(first_owner) = self.generic_layout_instantiations.get(&key).cloned() else {
+            self.generic_layout_instantiations
+                .insert(key, qualified_name.to_string());
+            return;
+        };
+        if first_owner == qualified_name || self.reported_generic_layout_collisions.contains(&key) {
+            return;
+        }
+        let Some(first_def) = self.type_defs.get(&first_owner) else {
+            return;
+        };
+        if instantiated_record_layout(first_def, args)
+            == instantiated_record_layout(current_def, args)
+        {
+            return;
+        }
+
+        self.reported_generic_layout_collisions.insert(key);
+        let mut modules = [
+            first_owner
+                .rsplit_once('.')
+                .map_or(first_owner.as_str(), |(module, _)| module),
+            qualified_name
+                .rsplit_once('.')
+                .map_or(qualified_name, |(module, _)| module),
+        ];
+        modules.sort_unstable();
+        let instantiated = generic_instantiation_display(bare_name, args);
+        self.report_error(
+            TypeErrorKind::GenericLayoutCollision,
+            span,
+            format!(
+                "generic type layout collision for `{instantiated}`: modules `{}` and `{}` \
+                 export incompatible layouts for `{bare_name}`; rename one type, or use a \
+                 qualified/aliased import to select one definition",
+                modules[0], modules[1]
+            ),
+        );
+    }
+
+    fn generic_layout_arg_is_concrete(&self, ty: &Ty) -> bool {
+        match ty {
+            Ty::Var(_) | Ty::IntLiteral | Ty::FloatLiteral | Ty::Error => false,
+            Ty::Tuple(elements) => elements
+                .iter()
+                .all(|element| self.generic_layout_arg_is_concrete(element)),
+            Ty::Array(element, _) | Ty::Slice(element) | Ty::Task(element) => {
+                self.generic_layout_arg_is_concrete(element)
+            }
+            Ty::Named {
+                name,
+                args,
+                builtin,
+            } => {
+                let is_abstract_param = builtin.is_none()
+                    && args.is_empty()
+                    && !name.contains('.')
+                    && self.declared_type_param_names.contains(name)
+                    && !self.type_defs.contains_key(name);
+                !is_abstract_param
+                    && args
+                        .iter()
+                        .all(|arg| self.generic_layout_arg_is_concrete(arg))
+            }
+            Ty::Function { params, ret } => {
+                params
+                    .iter()
+                    .all(|param| self.generic_layout_arg_is_concrete(param))
+                    && self.generic_layout_arg_is_concrete(ret)
+            }
+            Ty::Closure {
+                params,
+                ret,
+                captures,
+            } => {
+                params
+                    .iter()
+                    .all(|param| self.generic_layout_arg_is_concrete(param))
+                    && self.generic_layout_arg_is_concrete(ret)
+                    && captures
+                        .iter()
+                        .all(|capture| self.generic_layout_arg_is_concrete(capture))
+            }
+            Ty::Pointer { pointee, .. } | Ty::Borrow { pointee } => {
+                self.generic_layout_arg_is_concrete(pointee)
+            }
+            Ty::TraitObject { traits } => traits.iter().all(|bound| {
+                bound
+                    .args
+                    .iter()
+                    .all(|arg| self.generic_layout_arg_is_concrete(arg))
+                    && bound
+                        .assoc_bindings
+                        .iter()
+                        .all(|(_, ty)| self.generic_layout_arg_is_concrete(ty))
+            }),
+            Ty::AssocType { base, .. } => self.generic_layout_arg_is_concrete(base),
+            Ty::I8
+            | Ty::I16
+            | Ty::I32
+            | Ty::I64
+            | Ty::U8
+            | Ty::U16
+            | Ty::U32
+            | Ty::U64
+            | Ty::Isize
+            | Ty::Usize
+            | Ty::F32
+            | Ty::F64
+            | Ty::Bool
+            | Ty::Char
+            | Ty::String
+            | Ty::Bytes
+            | Ty::CancellationToken
+            | Ty::Duration
+            | Ty::Unit
+            | Ty::Never => true,
+        }
+    }
+}
+
+fn instantiated_record_layout(
+    type_def: &TypeDef,
+    args: &[Ty],
+) -> Option<(TypeDefKind, bool, Vec<Ty>)> {
+    if type_def.type_params.len() != args.len()
+        || !matches!(type_def.kind, TypeDefKind::Struct | TypeDefKind::Record)
+    {
+        return None;
+    }
+    let substitutions: HashMap<String, Ty> = type_def
+        .type_params
+        .iter()
+        .cloned()
+        .zip(args.iter().cloned())
+        .collect();
+    let mut field_names = type_def.field_order.clone();
+    if field_names.is_empty() {
+        field_names.extend(type_def.fields.keys().cloned());
+        field_names.sort();
+    }
+    let fields = field_names
+        .iter()
+        .filter_map(|name| type_def.fields.get(name))
+        .map(|field| field.substitute_named_params_parallel(&substitutions))
+        .collect();
+    Some((type_def.kind, type_def.is_indirect, fields))
+}
+
+fn generic_instantiation_display(name: &str, args: &[Ty]) -> String {
+    Ty::named(name.to_string(), args.to_vec())
+        .user_facing()
+        .to_string()
 }
 
 fn builtin_generic_type_params(name: &str) -> Option<&'static [&'static str]> {

--- a/hew-types/src/check/tests/records.rs
+++ b/hew-types/src/check/tests/records.rs
@@ -41,6 +41,70 @@ mod cross_module_same_name {
         }
     }
 
+    fn generic_record_def(field_ty: Ty) -> TypeDef {
+        TypeDef {
+            kind: TypeDefKind::Struct,
+            name: "Key".to_string(),
+            type_params: vec!["T".to_string()],
+            bounds: HashMap::new(),
+            fields: HashMap::from([("v".to_string(), field_ty)]),
+            field_order: vec!["v".to_string()],
+            variants: HashMap::new(),
+            methods: HashMap::new(),
+            doc_comment: None,
+            is_indirect: false,
+        }
+    }
+
+    #[test]
+    fn incompatible_same_name_generic_layouts_fail_at_resolution() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        checker
+            .cross_module_colliding_record_names
+            .insert("Key".to_string());
+        checker
+            .type_defs
+            .insert("keyleft.Key".to_string(), generic_record_def(Ty::I64));
+        checker
+            .type_defs
+            .insert("keyright.Key".to_string(), generic_record_def(Ty::String));
+
+        checker.check_cross_module_generic_layout_use("keyleft.Key", &[Ty::I32], &(10..20));
+        checker.check_cross_module_generic_layout_use("keyright.Key", &[Ty::I32], &(30..40));
+
+        assert_eq!(checker.errors.len(), 1);
+        assert_eq!(
+            checker.errors[0].kind,
+            TypeErrorKind::GenericLayoutCollision
+        );
+        assert_eq!(
+            checker.errors[0].message,
+            "generic type layout collision for `Key<i32>`: modules `keyleft` and \
+             `keyright` export incompatible layouts for `Key`; rename one type, or use a \
+             qualified/aliased import to select one definition"
+        );
+        assert_eq!(checker.errors[0].span, 30..40);
+    }
+
+    #[test]
+    fn compatible_same_name_generic_layouts_remain_accepted() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        checker
+            .cross_module_colliding_record_names
+            .insert("Key".to_string());
+        checker
+            .type_defs
+            .insert("keyleft.Key".to_string(), generic_record_def(Ty::I64));
+        checker
+            .type_defs
+            .insert("keyright.Key".to_string(), generic_record_def(Ty::I64));
+
+        checker.check_cross_module_generic_layout_use("keyleft.Key", &[Ty::I32], &(10..20));
+        checker.check_cross_module_generic_layout_use("keyright.Key", &[Ty::I32], &(30..40));
+
+        assert!(checker.errors.is_empty());
+    }
+
     fn make_constructor_body(record_name: &str, field_name: &str) -> FnDecl {
         FnDecl {
             attributes: vec![],

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2974,6 +2974,14 @@ pub struct Checker {
     /// record (a name unique to one module keeps its bare identity, so no
     /// stdlib `http.Response`/`xml.Node` over-qualification) (#2208).
     pub(super) cross_module_colliding_record_names: HashSet<String>,
+    /// First owner-qualified use of each concrete bare generic
+    /// monomorphisation key. Rc1 layout symbols omit the owner module, so a
+    /// later use from a different owner must prove layout compatibility before
+    /// the checker permits the program to reach HIR/MIR.
+    pub(super) generic_layout_instantiations: HashMap<(String, Vec<Ty>), String>,
+    /// Concrete generic layout keys for which the checker already emitted the
+    /// cross-module collision diagnostic.
+    pub(super) reported_generic_layout_collisions: HashSet<(String, Vec<Ty>)>,
     /// 1-based index of the non-root module currently being type-checked.
     /// 0 = root; N = N-th non-root module in topo order. Combined with
     /// `SpanKey.module_idx` to prevent byte-offset collisions across files.
@@ -3398,6 +3406,8 @@ impl Checker {
             task_scope_depth: 0,
             current_module: None,
             cross_module_colliding_record_names: HashSet::new(),
+            generic_layout_instantiations: HashMap::new(),
+            reported_generic_layout_collisions: HashSet::new(),
             current_module_idx: 0,
             local_type_defs: HashSet::new(),
             source_type_defs: HashSet::new(),

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -619,6 +619,9 @@ pub enum TypeErrorKind {
     /// `DuplicateDefinition` (two defs in one module): the name resolves to
     /// several valid defs across modules.
     AmbiguousType,
+    /// Two owner-qualified generic types collapse to the same bare
+    /// monomorphisation key but require incompatible concrete layouts.
+    GenericLayoutCollision,
     /// Value cannot be sent to another actor
     InvalidSend,
     /// Operation not supported for this type
@@ -1307,6 +1310,7 @@ impl TypeErrorKind {
             Self::UndefinedMethod => "UndefinedMethod",
             Self::AmbiguousTraitMethod => "AmbiguousTraitMethod",
             Self::AmbiguousType => "AmbiguousType",
+            Self::GenericLayoutCollision => "GenericLayoutCollision",
             Self::InvalidSend => "InvalidSend",
             Self::InvalidOperation => "InvalidOperation",
             Self::SupervisorError { subkind } => subkind.as_kind_str(),

--- a/tests/pkg-import/run.sh
+++ b/tests/pkg-import/run.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-HEW="${ROOT}/target/debug/hew"
+HEW="${HEW_BIN:-${ROOT}/target/debug/hew}"
 DIR="${ROOT}/tests/pkg-import"
 PKGS="${DIR}/pkgs"
 
@@ -902,20 +902,25 @@ echo "PASS ${imported_trait_ok}"
 # module-qualified definition identity), a cross-layer reshape out of scope for
 # #2744.
 #
-# This pin asserts the collision fails CLOSED: `hew check` REJECTS the program
-# at the codegen-front slot-type gate (`E_CODEGEN_FRONT_FAIL_CLOSED`), proving
-# the collision is memory-safe (no silent miscompile / type confusion), never
-# that the rejection is desirable. When #2653 lands, this program becomes VALID
-# (each `Key<T>` resolves to its own module's instantiation) and this pin flips
-# to a compile+run oracle — update it then, do not delete it.
+# This pin asserts the collision fails CLOSED with a checker-level diagnostic
+# that names both modules, the concrete type, and the available resolution.
+# When #2653 lands, this program becomes VALID (each `Key<T>` resolves to its
+# own module's instantiation) and this pin flips to a compile+run oracle —
+# update it then, do not delete it.
 two_module_generic_reject="two_module_same_generic_valueclass_reject"
 two_module_generic_reject_out="$("${HEW}" check --pkg-path "${PKGS}" "${DIR}/${two_module_generic_reject}.hew" 2>&1)" && {
   echo "FAIL ${two_module_generic_reject}: hew check unexpectedly succeeded — the #2653 two-module same-name generic collision must fail closed until #2653 lands" >&2
   echo "${two_module_generic_reject_out}" >&2
   exit 1
 }
-if ! grep -q "E_CODEGEN_FRONT_FAIL_CLOSED" <<<"${two_module_generic_reject_out}"; then
-  echo "FAIL ${two_module_generic_reject}: expected the codegen-front slot-type fail-closed diagnostic (#2653 known gap)" >&2
+two_module_generic_diagnostic="generic type layout collision for \`Key<i32>\`: modules \`keyleft\` and \`keyright\` export incompatible layouts for \`Key\`; rename one type, or use a qualified/aliased import to select one definition"
+if ! grep -Fq "${two_module_generic_diagnostic}" <<<"${two_module_generic_reject_out}"; then
+  echo "FAIL ${two_module_generic_reject}: expected the clear checker-level same-name generic collision diagnostic (#2653 known gap)" >&2
+  echo "${two_module_generic_reject_out}" >&2
+  exit 1
+fi
+if grep -q "E_CODEGEN_FRONT_FAIL_CLOSED" <<<"${two_module_generic_reject_out}"; then
+  echo "FAIL ${two_module_generic_reject}: collision leaked past the checker into codegen-front" >&2
   echo "${two_module_generic_reject_out}" >&2
   exit 1
 fi

--- a/tests/pkg-import/two_module_same_generic_valueclass_reject.hew
+++ b/tests/pkg-import/two_module_same_generic_valueclass_reject.hew
@@ -11,10 +11,11 @@
 // #2744 and is FIXED: an imported generic value record with no same-named twin
 // resolves its BitCopy value class correctly and runs.
 //
-// This pin asserts the two-module collision fails CLOSED — the compiler REJECTS
-// the program at the codegen-front slot-type gate (`E_CODEGEN_FRONT_FAIL_CLOSED`,
-// the RecordInit/RecordFieldLoad slot-type mismatch), never a silent miscompile.
-// It proves the collision is memory-safe, not that the rejection is desirable.
+// This pin asserts the two-module collision fails CLOSED — the checker REJECTS
+// the program with a diagnostic naming both modules, `Key<i32>`, and the
+// available resolution, never a codegen-front verifier dump or silent
+// miscompile. It proves the collision is memory-safe, not that the rejection is
+// desirable.
 // When #2653 lands the qualified-identity reshape (layout mangling + MIR keying
 // + codegen symbols), this program becomes VALID and both `Key<T>`s resolve to
 // their own module's instantiation — at which point this reject pin flips to a


### PR DESCRIPTION
Importing two different generics that share a name from different modules (e.g. `keyleft.Key<T>` and `keyright.Key<T>` with different payloads) previously failed with a cryptic codegen-internal error. This detects the collision early, at the checker, and reports a clear message naming both modules and the type with a resolution (rename one type or use a qualified/aliased import).

The program is still rejected — permissive disambiguation is a separate, later change — but the failure is now comprehensible rather than a bare internal fail-closed code.

## Verification
- `make test-pkg-import`: the two-module reject fixture rejects with the new clear message; the single-module generic case still compiles. All 12 pkg-import tests pass.
- Ratchet, lint, fmt green.