### PR TITLE
fix(mir): move consumed index-assign locals

### DIFF
--- a/examples/v05/checked-mir/golden/vec_index_assign_consumed_move.elab.mir
+++ b/examples/v05/checked-mir/golden/vec_index_assign_consumed_move.elab.mir
@@ -1,0 +1,293 @@
+fn mkItems -> Vec<string>
+  statements:
+    bind BindingId(0) xs site=SiteId(0) ty=Vec<string>
+    use BindingId(0) xs site=SiteId(3) ty=Vec<string> intent=Read
+    eval site=SiteId(2) ty=()
+    use BindingId(0) xs site=SiteId(6) ty=Vec<string> intent=Read
+    eval site=SiteId(5) ty=()
+    use BindingId(0) xs site=SiteId(8) ty=Vec<string> intent=Consume
+    return site=Some(SiteId(8)) ty=Vec<string>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_vec_push_str -> bb2] ->
+      (none)
+    call[bb2 hew_vec_push_str -> bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+
+fn main -> ()
+  statements:
+    bind BindingId(1) v site=SiteId(9) ty=Vec<Holder>
+    use BindingId(1) v site=SiteId(12) ty=Vec<Holder> intent=Read
+    eval site=SiteId(11) ty=()
+    bind BindingId(2) h site=SiteId(16) ty=Holder
+    use BindingId(2) h site=SiteId(22) ty=Holder intent=Consume
+    use BindingId(1) v site=SiteId(20) ty=Vec<Holder> intent=Read
+    eval site=SiteId(22) ty=()
+    use BindingId(1) v site=SiteId(25) ty=Vec<Holder> intent=Read
+    eval site=SiteId(23) ty=()
+    drop BindingId(1) v ty=Vec<Holder>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 mkItems -> bb2] ->
+      (none)
+    call[bb2 hew_vec_push_owned_move -> bb3] ->
+      (none)
+    call[bb3 mkItems -> bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    panic[bb5] ->
+      drop _1 ty=Vec<Holder> kind=cow_heap(hew_vec_free_owned)
+    call[bb6 hew_vec_set_owned_move -> bb7] ->
+      (none)
+    call[bb7 hew_vec_len -> bb8] ->
+      (none)
+    call[bb8 println_i64 -> bb9] ->
+      (none)
+    return[bb9] ->
+      drop _1 ty=Vec<Holder> kind=cow_heap(hew_vec_free_owned)
+
+fn i8::fmt -> string
+  statements:
+    use BindingId(11) val site=SiteId(97) ty=i8 intent=Read
+    return site=Some(SiteId(95)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i16::fmt -> string
+  statements:
+    use BindingId(12) val site=SiteId(101) ty=i16 intent=Read
+    return site=Some(SiteId(99)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i32::fmt -> string
+  statements:
+    use BindingId(13) val site=SiteId(104) ty=i32 intent=Read
+    return site=Some(SiteId(103)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i64::fmt -> string
+  statements:
+    use BindingId(14) val site=SiteId(107) ty=i64 intent=Read
+    return site=Some(SiteId(106)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u8::fmt -> string
+  statements:
+    use BindingId(15) val site=SiteId(110) ty=u8 intent=Read
+    return site=Some(SiteId(109)) ty=string
+  drop_plans:
+    call[bb0 to_string_u8 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u16::fmt -> string
+  statements:
+    use BindingId(16) val site=SiteId(113) ty=u16 intent=Read
+    return site=Some(SiteId(112)) ty=string
+  drop_plans:
+    call[bb0 to_string_u16 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u32::fmt -> string
+  statements:
+    use BindingId(17) val site=SiteId(116) ty=u32 intent=Read
+    return site=Some(SiteId(115)) ty=string
+  drop_plans:
+    call[bb0 to_string_u32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u64::fmt -> string
+  statements:
+    use BindingId(18) val site=SiteId(119) ty=u64 intent=Read
+    return site=Some(SiteId(118)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn isize::fmt -> string
+  statements:
+    use BindingId(19) val site=SiteId(123) ty=isize intent=Read
+    return site=Some(SiteId(121)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn usize::fmt -> string
+  statements:
+    use BindingId(20) val site=SiteId(127) ty=usize intent=Read
+    return site=Some(SiteId(125)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn bool::fmt -> string
+  statements:
+    use BindingId(21) val site=SiteId(130) ty=bool intent=Read
+    return site=Some(SiteId(129)) ty=string
+  drop_plans:
+    call[bb0 to_string_bool -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn char::fmt -> string
+  statements:
+    use BindingId(22) val site=SiteId(133) ty=char intent=Read
+    return site=Some(SiteId(132)) ty=string
+  drop_plans:
+    call[bb0 to_string_char -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f64::fmt -> string
+  statements:
+    use BindingId(23) val site=SiteId(136) ty=f64 intent=Read
+    return site=Some(SiteId(135)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f32::fmt -> string
+  statements:
+    use BindingId(24) val site=SiteId(140) ty=f32 intent=Read
+    return site=Some(SiteId(138)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::fmt -> string
+  statements:
+    use BindingId(25) val site=SiteId(142) ty=string intent=Read
+    return site=Some(SiteId(142)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn duration::from_nanos -> duration
+  statements:
+    use BindingId(26) n site=SiteId(144) ty=i64 intent=Read
+    return site=Some(SiteId(143)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_micros -> duration
+  statements:
+    use BindingId(27) n site=SiteId(147) ty=i64 intent=Read
+    return site=Some(SiteId(146)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_millis -> duration
+  statements:
+    use BindingId(28) n site=SiteId(150) ty=i64 intent=Read
+    return site=Some(SiteId(149)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_secs -> duration
+  statements:
+    use BindingId(29) n site=SiteId(153) ty=i64 intent=Read
+    return site=Some(SiteId(152)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::fmt -> string
+  statements:
+    use BindingId(30) val site=SiteId(158) ty=duration intent=Read
+    return site=Some(SiteId(155)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+

--- a/examples/v05/checked-mir/golden/vec_index_assign_consumed_move.raw.mir
+++ b/examples/v05/checked-mir/golden/vec_index_assign_consumed_move.raw.mir
@@ -1,0 +1,355 @@
+fn mkItems() -> Vec<string> [conv=default]
+  locals:
+    _0: Vec<string>
+    _1: Vec<string>
+    _2: string
+    _3: string
+  bb0:
+    _0 = call Vec::new() -> bb1
+  bb1:
+    stmt: bind BindingId(0) xs site=SiteId(0) ty=Vec<string>
+    stmt: use BindingId(0) xs site=SiteId(3) ty=Vec<string> intent=Read
+    _1 = move _0
+    _2 = string_lit "deep-elem-a"
+    call hew_vec_push_str(_1, _2) -> bb2
+  bb2:
+    stmt: eval site=SiteId(2) ty=()
+    stmt: use BindingId(0) xs site=SiteId(6) ty=Vec<string> intent=Read
+    _3 = string_lit "deep-elem-b"
+    call hew_vec_push_str(_1, _3) -> bb3
+  bb3:
+    stmt: eval site=SiteId(5) ty=()
+    stmt: use BindingId(0) xs site=SiteId(8) ty=Vec<string> intent=Consume
+    stmt: return site=Some(SiteId(8)) ty=Vec<string>
+    ret = move _1
+    return
+
+fn main() -> () [conv=default]
+  locals:
+    _0: Vec<Holder>
+    _1: Vec<Holder>
+    _2: Vec<string>
+    _3: Holder
+    _4: Vec<string>
+    _5: Holder
+    _6: Holder
+    _7: i64
+    _8: i64
+    _9: bool
+    _10: i64
+  bb0:
+    _0 = call Vec::new() -> bb1
+  bb1:
+    stmt: bind BindingId(1) v site=SiteId(9) ty=Vec<Holder>
+    stmt: use BindingId(1) v site=SiteId(12) ty=Vec<Holder> intent=Read
+    _1 = move _0
+    _2 = call mkItems() -> bb2
+  bb2:
+    _3 = record_init Holder { .0=_2 }
+    call hew_vec_push_owned_move(_1, _3) -> bb3
+  bb3:
+    stmt: eval site=SiteId(11) ty=()
+    _4 = call mkItems() -> bb4
+  bb4:
+    stmt: bind BindingId(2) h site=SiteId(16) ty=Holder
+    stmt: use BindingId(2) h site=SiteId(22) ty=Holder intent=Consume
+    stmt: use BindingId(1) v site=SiteId(20) ty=Vec<Holder> intent=Read
+    _5 = record_init Holder { .0=_4 }
+    _6 = move _5
+    _7 = const.i64 0
+    _8 = call_rt hew_vec_len(_1)
+    _9 = icmp.uge _7 _8
+    branch _9 ? bb5 : bb6
+  bb5:
+    trap(IndexOutOfBounds)
+  bb6:
+    call hew_vec_set_owned_move(_1, _7, _6) -> bb7
+  bb7:
+    stmt: eval site=SiteId(22) ty=()
+    stmt: use BindingId(1) v site=SiteId(25) ty=Vec<Holder> intent=Read
+    _10 = call hew_vec_len(_1) [builtin=VecLen] -> bb8
+  bb8:
+    call println_i64(_10) -> bb9
+  bb9:
+    stmt: eval site=SiteId(23) ty=()
+    return
+
+fn i8::fmt(i8) -> string [conv=default]
+  locals:
+    _0: i8
+    _1: i32
+    _2: string
+  bb0:
+    stmt: use BindingId(11) val site=SiteId(97) ty=i8 intent=Read
+    _1 = cast _0 i8 -> i32
+    _2 = call to_string_i32(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(95)) ty=string
+    ret = move _2
+    return
+
+fn i16::fmt(i16) -> string [conv=default]
+  locals:
+    _0: i16
+    _1: i32
+    _2: string
+  bb0:
+    stmt: use BindingId(12) val site=SiteId(101) ty=i16 intent=Read
+    _1 = cast _0 i16 -> i32
+    _2 = call to_string_i32(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(99)) ty=string
+    ret = move _2
+    return
+
+fn i32::fmt(i32) -> string [conv=default]
+  locals:
+    _0: i32
+    _1: string
+  bb0:
+    stmt: use BindingId(13) val site=SiteId(104) ty=i32 intent=Read
+    _1 = call to_string_i32(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(103)) ty=string
+    ret = move _1
+    return
+
+fn i64::fmt(i64) -> string [conv=default]
+  locals:
+    _0: i64
+    _1: string
+  bb0:
+    stmt: use BindingId(14) val site=SiteId(107) ty=i64 intent=Read
+    _1 = call to_string_i64(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(106)) ty=string
+    ret = move _1
+    return
+
+fn u8::fmt(u8) -> string [conv=default]
+  locals:
+    _0: u8
+    _1: string
+  bb0:
+    stmt: use BindingId(15) val site=SiteId(110) ty=u8 intent=Read
+    _1 = call to_string_u8(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(109)) ty=string
+    ret = move _1
+    return
+
+fn u16::fmt(u16) -> string [conv=default]
+  locals:
+    _0: u16
+    _1: string
+  bb0:
+    stmt: use BindingId(16) val site=SiteId(113) ty=u16 intent=Read
+    _1 = call to_string_u16(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(112)) ty=string
+    ret = move _1
+    return
+
+fn u32::fmt(u32) -> string [conv=default]
+  locals:
+    _0: u32
+    _1: string
+  bb0:
+    stmt: use BindingId(17) val site=SiteId(116) ty=u32 intent=Read
+    _1 = call to_string_u32(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(115)) ty=string
+    ret = move _1
+    return
+
+fn u64::fmt(u64) -> string [conv=default]
+  locals:
+    _0: u64
+    _1: string
+  bb0:
+    stmt: use BindingId(18) val site=SiteId(119) ty=u64 intent=Read
+    _1 = call to_string_u64(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(118)) ty=string
+    ret = move _1
+    return
+
+fn isize::fmt(isize) -> string [conv=default]
+  locals:
+    _0: isize
+    _1: i64
+    _2: string
+  bb0:
+    stmt: use BindingId(19) val site=SiteId(123) ty=isize intent=Read
+    _1 = cast _0 isize -> i64
+    _2 = call to_string_i64(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(121)) ty=string
+    ret = move _2
+    return
+
+fn usize::fmt(usize) -> string [conv=default]
+  locals:
+    _0: usize
+    _1: u64
+    _2: string
+  bb0:
+    stmt: use BindingId(20) val site=SiteId(127) ty=usize intent=Read
+    _1 = cast _0 usize -> u64
+    _2 = call to_string_u64(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(125)) ty=string
+    ret = move _2
+    return
+
+fn bool::fmt(bool) -> string [conv=default]
+  locals:
+    _0: bool
+    _1: string
+  bb0:
+    stmt: use BindingId(21) val site=SiteId(130) ty=bool intent=Read
+    _1 = call to_string_bool(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(129)) ty=string
+    ret = move _1
+    return
+
+fn char::fmt(char) -> string [conv=default]
+  locals:
+    _0: char
+    _1: string
+  bb0:
+    stmt: use BindingId(22) val site=SiteId(133) ty=char intent=Read
+    _1 = call to_string_char(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(132)) ty=string
+    ret = move _1
+    return
+
+fn f64::fmt(f64) -> string [conv=default]
+  locals:
+    _0: f64
+    _1: string
+  bb0:
+    stmt: use BindingId(23) val site=SiteId(136) ty=f64 intent=Read
+    _1 = call to_string_f64(_0) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(135)) ty=string
+    ret = move _1
+    return
+
+fn f32::fmt(f32) -> string [conv=default]
+  locals:
+    _0: f32
+    _1: f64
+    _2: string
+  bb0:
+    stmt: use BindingId(24) val site=SiteId(140) ty=f32 intent=Read
+    _1 = cast _0 f32 -> f64
+    _2 = call to_string_f64(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(138)) ty=string
+    ret = move _2
+    return
+
+fn string::fmt(string) -> string [conv=default]
+  locals:
+    _0: string
+  bb0:
+    stmt: use BindingId(25) val site=SiteId(142) ty=string intent=Read
+    stmt: return site=Some(SiteId(142)) ty=string
+    string.retain _0
+    ret = move _0
+    return
+
+fn duration::from_nanos(i64) -> duration [conv=default]
+  locals:
+    _0: i64
+    _1: duration
+    _2: duration
+    _3: bool
+  bb0:
+    stmt: use BindingId(26) n site=SiteId(144) ty=i64 intent=Read
+    _1 = const.duration 1ns
+    _2 ovf=_3 = mul.checked.s _0 _1
+    branch _3 ? bb1 : bb2
+  bb1:
+    trap(IntegerOverflow)
+  bb2:
+    stmt: return site=Some(SiteId(143)) ty=duration
+    ret = move _2
+    return
+
+fn duration::from_micros(i64) -> duration [conv=default]
+  locals:
+    _0: i64
+    _1: duration
+    _2: duration
+    _3: bool
+  bb0:
+    stmt: use BindingId(27) n site=SiteId(147) ty=i64 intent=Read
+    _1 = const.duration 1000ns
+    _2 ovf=_3 = mul.checked.s _0 _1
+    branch _3 ? bb1 : bb2
+  bb1:
+    trap(IntegerOverflow)
+  bb2:
+    stmt: return site=Some(SiteId(146)) ty=duration
+    ret = move _2
+    return
+
+fn duration::from_millis(i64) -> duration [conv=default]
+  locals:
+    _0: i64
+    _1: duration
+    _2: duration
+    _3: bool
+  bb0:
+    stmt: use BindingId(28) n site=SiteId(150) ty=i64 intent=Read
+    _1 = const.duration 1000000ns
+    _2 ovf=_3 = mul.checked.s _0 _1
+    branch _3 ? bb1 : bb2
+  bb1:
+    trap(IntegerOverflow)
+  bb2:
+    stmt: return site=Some(SiteId(149)) ty=duration
+    ret = move _2
+    return
+
+fn duration::from_secs(i64) -> duration [conv=default]
+  locals:
+    _0: i64
+    _1: duration
+    _2: duration
+    _3: bool
+  bb0:
+    stmt: use BindingId(29) n site=SiteId(153) ty=i64 intent=Read
+    _1 = const.duration 1000000000ns
+    _2 ovf=_3 = mul.checked.s _0 _1
+    branch _3 ? bb1 : bb2
+  bb1:
+    trap(IntegerOverflow)
+  bb2:
+    stmt: return site=Some(SiteId(152)) ty=duration
+    ret = move _2
+    return
+
+fn duration::fmt(duration) -> string [conv=default]
+  locals:
+    _0: duration
+    _1: i64
+    _2: string
+    _3: string
+    _4: string
+  bb0:
+    stmt: use BindingId(30) val site=SiteId(158) ty=duration intent=Read
+    _1 = call_rt hew_duration_nanos(_0)
+    _2 = call to_string_i64(_1) -> bb1
+  bb1:
+    stmt: return site=Some(SiteId(155)) ty=string
+    _3 = string_lit "ns"
+    _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
+    ret = move _4
+    return
+

--- a/examples/v05/checked-mir/vec_index_assign_consumed_move.hew
+++ b/examples/v05/checked-mir/vec_index_assign_consumed_move.hew
@@ -1,0 +1,23 @@
+// MIR-corpus fixture: consumed bound-local owned-element index assignment.
+//
+// The assignment consumes `h` in checked MIR, so its scope-exit drop is
+// suppressed. The store must therefore use `hew_vec_set_owned_move`: COPY-IN
+// would clone into the slot and orphan `h`'s original nested Vec heap.
+record Holder {
+    items: Vec<string>
+}
+
+fn mkItems() -> Vec<string> {
+    let xs: Vec<string> = Vec::new();
+    xs.push("deep-elem-a");
+    xs.push("deep-elem-b");
+    return xs;
+}
+
+fn main() {
+    var v: Vec<Holder> = Vec::new();
+    v.push(Holder { items: mkItems() });
+    let h = Holder { items: mkItems() };
+    v[0] = h;
+    println(v.len());
+}

--- a/hew-cli/tests/vec_index_assign_temp_leak_oracle.rs
+++ b/hew-cli/tests/vec_index_assign_temp_leak_oracle.rs
@@ -1,5 +1,5 @@
-//! Owned-Vec INDEX-ASSIGNMENT (`v[i] = ..`) TEMP leak oracle: a fresh, unbound
-//! aggregate rvalue used as an index-assignment RHS must not leak its heap.
+//! Owned-Vec INDEX-ASSIGNMENT (`v[i] = ..`) leak oracles: neither a fresh
+//! aggregate RHS nor a consumed bound-local RHS may leak its heap.
 //!
 //! ## The bug this pins
 //!
@@ -22,18 +22,15 @@
 //! Vec<string> }`, whose `clone_fn` deep-copies into a DISTINCT buffer) exposes
 //! the leak. A `Vec<record{string}>` fixture would pass even with the bug.
 //!
-//! ## The copy-shape pin
+//! ## The consumed bound-local hole
 //!
-//! A bare-binding RHS (`v[i] = h`) must STAY `hew_vec_set_owned` (COPY-IN):
-//! `expr_is_materialized_owner` returns false for a `BindingRef`, so the router
-//! must not widen it to the move sibling. Unlike the `.set()` method path, the
-//! index-assignment lowering CONSUMES the binding in checked MIR (`v[i] = h; use
-//! h` is a use-after-consume error), so a wrongful move would not double-free a
-//! live reader at runtime — a run-clean check alone is toothless here. The pin
-//! therefore asserts the EMITTED SYMBOL directly: the bound-local shape's object
-//! must reference `hew_vec_set_owned` and must NOT reference
-//! `hew_vec_set_owned_move`. That is the routing decision the fix must leave
-//! intact for non-materialised sources.
+//! A bare-binding RHS (`v[i] = h`) is `Use { intent=Consume }` in checked MIR:
+//! `v[i] = h; use h` is rejected. COPY-IN cloned `h` into the slot while the
+//! consume suppressed `h`'s scope-exit drop, orphaning the original deep-owned
+//! heap (~4 nodes/store). The fix routes exactly a consumed non-parameter,
+//! non-capture `BindingRef` to `hew_vec_set_owned_move`. A borrowed/read binding,
+//! such as a local borrowed through a closure capture, remains COPY-IN because
+//! the capture environment still owns it.
 //!
 //! ## Skip behaviour
 //!
@@ -99,12 +96,30 @@ fn index_assign_temp_source(frames: usize) -> String {
     )
 }
 
-/// Copy-shape pin source: a bare-binding index-assign (`v[0] = h`). The RHS is a
-/// `BindingRef`, not a materialised rvalue, so the router must keep COPY-IN. The
-/// binding is consumed by the assignment, so the stored element is read back
-/// through the vec (`v[0].items.len()` == 2) to prove the store landed. Expected
-/// stdout: `2OK`.
-const COPY_SHAPE_SOURCE: &str = "\
+/// A consumed bound local per iteration. Checked MIR suppresses the local's
+/// scope-exit drop, so MOVE-IN must transfer its heap into the Vec slot. Pre-fix,
+/// COPY-IN leaks the local's original nested Vec and strings (~4 nodes/frame).
+fn index_assign_consumed_bound_source(frames: usize) -> String {
+    format!(
+        "{PRELUDE}\
+         fn main() -> i64 {{\n\
+         \x20   var v: Vec<Holder> = Vec::new();\n\
+         \x20   v.push(Holder {{ items: mkItems(0) }});\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let h = Holder {{ items: mkItems(i) }};\n\
+         \x20       v[0] = h;\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   v.len()\n\
+         }}\n"
+    )
+}
+
+/// Symbol/run pin source for the consumed bound-local route. The stored element
+/// is read back through the Vec (`v[0].items.len()` == 2). Expected stdout:
+/// `2OK`.
+const CONSUMED_BOUND_SOURCE: &str = "\
 record Holder { items: Vec<string> }\n\
 fn mkItems(i: i64) -> Vec<string> {\n\
 \x20   var xs: Vec<string> = Vec::new();\n\
@@ -121,6 +136,30 @@ fn indexAssignBound() -> i64 {\n\
 }\n\
 fn main() {\n\
 \x20   print(indexAssignBound());\n\
+\x20   print(\"OK\");\n\
+}\n";
+
+/// Borrowed negative control: `h` is a bound local owned by the closure capture
+/// environment. Each invocation may read it into the Vec, so index-assignment
+/// must remain COPY-IN. Expected stdout: `22OK`.
+const BORROWED_CAPTURE_SOURCE: &str = "\
+record Holder { items: Vec<string> }\n\
+fn mkItems() -> Vec<string> {\n\
+\x20   let xs: Vec<string> = Vec::new();\n\
+\x20   xs.push(\"deep-elem-a\");\n\
+\x20   xs.push(\"deep-elem-b\");\n\
+\x20   return xs;\n\
+}\n\
+fn main() {\n\
+\x20   let h = Holder { items: mkItems() };\n\
+\x20   let assign = || {\n\
+\x20       var v: Vec<Holder> = Vec::new();\n\
+\x20       v.push(Holder { items: mkItems() });\n\
+\x20       v[0] = h;\n\
+\x20       v[0].items.len()\n\
+\x20   };\n\
+\x20   print(assign());\n\
+\x20   print(assign());\n\
 \x20   print(\"OK\");\n\
 }\n";
 
@@ -291,23 +330,32 @@ fn vec_index_assign_owned_temp_no_per_frame_leak_slope() {
     );
 }
 
-/// Copy-shape pin: a bare-binding index-assign (`v[0] = h`) must STAY COPY-IN.
-/// The router must not widen a `BindingRef` RHS to `hew_vec_set_owned_move`, so
-/// the emitted object must reference `hew_vec_set_owned` and NOT the move
-/// sibling. The binary also runs clean under the poisoned-allocator triple and
-/// prints `2OK` (the stored element read back through the vec).
+/// A consumed bound-local index-assignment must have zero per-frame leak slope.
+/// Reverting the consumed-`BindingRef` route leaks ~4 nodes/frame.
 #[test]
-fn vec_index_assign_bound_local_stays_copy_in() {
+fn vec_index_assign_consumed_bound_local_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "index_assign_consumed_bound",
+        index_assign_consumed_bound_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// The consumed bound-local route must emit MOVE-IN rather than COPY-IN. The
+/// binary also runs clean under the poisoned allocator and prints `2OK`.
+#[test]
+fn vec_index_assign_consumed_bound_local_moves_in() {
     require_codegen();
 
     let dir = tempfile::Builder::new()
-        .prefix("vec-index-assign-copy-shape-")
+        .prefix("vec-index-assign-consumed-bound-")
         .tempdir()
         .expect("tempdir");
-    let bin = compile_to_native(COPY_SHAPE_SOURCE, dir.path(), "copy_shape");
+    let bin = compile_to_native(CONSUMED_BOUND_SOURCE, dir.path(), "consumed_bound");
 
     // The relocatable object sits alongside the binary in the emit dir.
-    let obj = dir.path().join("copy_shape.o");
+    let obj = dir.path().join("consumed_bound.o");
     let nm = Command::new("nm")
         .arg(&obj)
         .output()
@@ -321,14 +369,12 @@ fn vec_index_assign_bound_local_stays_copy_in() {
     let symbols = String::from_utf8_lossy(&nm.stdout);
     // Symbol names are `_`-prefixed on Mach-O and bare on ELF; match the stem.
     assert!(
-        symbols.contains("hew_vec_set_owned")
-            && !symbols
-                .lines()
-                .any(|l| l.contains("hew_vec_set_owned_move")),
-        "bound-local index-assign (`v[i] = h`) must emit the COPY-IN symbol \
-         `hew_vec_set_owned`, never the MOVE sibling `hew_vec_set_owned_move` — a \
-         `BindingRef` RHS is not a materialised owner and `expr_is_materialized_owner` \
-         must return false for it. Emitted symbols were:\n{symbols}"
+        symbols
+            .lines()
+            .any(|line| line.contains("hew_vec_set_owned_move")),
+        "consumed bound-local index-assign (`v[i] = h`) must emit the MOVE-IN symbol \
+         `hew_vec_set_owned_move`; checked MIR consumes `h`, so COPY-IN would orphan \
+         `h`'s original heap. Emitted symbols were:\n{symbols}"
     );
 
     let output = Command::new(&bin)
@@ -336,17 +382,69 @@ fn vec_index_assign_bound_local_stays_copy_in() {
         .env("MallocPreScribble", "1")
         .env("MallocGuardEdges", "1")
         .output()
-        .expect("run copy-shape binary");
+        .expect("run consumed-bound binary");
     assert!(
         output.status.success(),
-        "copy-shape index-assign must run clean under the poisoned allocator;\n{}",
+        "consumed bound-local index-assign must run clean under the poisoned allocator;\n{}",
         describe_output(&output)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert_eq!(
         stdout,
         "2OK",
-        "copy-shape index-assign must print the stored element's len (2) then OK;\n{}",
+        "consumed bound-local index-assign must print the stored element's len (2) then OK;\n{}",
+        describe_output(&output)
+    );
+}
+
+/// Borrowed bound-local negative control: a closure capture remains COPY-IN and
+/// can be used by two invocations without transferring the capture's heap.
+#[test]
+fn vec_index_assign_borrowed_capture_stays_copy_in() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("vec-index-assign-borrowed-capture-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(BORROWED_CAPTURE_SOURCE, dir.path(), "borrowed_capture");
+
+    let obj = dir.path().join("borrowed_capture.o");
+    let nm = Command::new("nm")
+        .arg(&obj)
+        .output()
+        .expect("invoke nm on emitted object");
+    assert!(
+        nm.status.success(),
+        "nm failed on {}:\n{}",
+        obj.display(),
+        describe_output(&nm)
+    );
+    let symbols = String::from_utf8_lossy(&nm.stdout);
+    assert!(
+        symbols.contains("hew_vec_set_owned")
+            && !symbols
+                .lines()
+                .any(|line| line.contains("hew_vec_set_owned_move")),
+        "borrowed closure-captured bound local must emit COPY-IN \
+         `hew_vec_set_owned`, never `hew_vec_set_owned_move`. Emitted symbols were:\n{symbols}"
+    );
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run borrowed-capture binary");
+    assert!(
+        output.status.success(),
+        "borrowed-capture index-assign must run clean under the poisoned allocator;\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "22OK",
+        "borrowed capture must survive both index assignments;\n{}",
         describe_output(&output)
     );
 }

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -1765,6 +1765,31 @@ impl Builder {
         }
     }
 
+    fn binding_ref_use_intent(&self, expr: &HirExpr) -> IntentKind {
+        if self.param_ownership.borrow_arg_sites.contains(&expr.site)
+            || self.bytes_local_share_sites.contains(&expr.site)
+            || self.string_local_share_sites.contains_key(&expr.site)
+        {
+            IntentKind::Read
+        } else {
+            expr.intent
+        }
+    }
+
+    fn is_consumed_bound_local(&self, expr: &HirExpr) -> bool {
+        let HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(binding),
+            ..
+        } = &expr.kind
+        else {
+            return false;
+        };
+        self.binding_locals.contains_key(binding)
+            && !self.capture_env_sources.contains_key(binding)
+            && !self.funcupdate_param_ids.contains(binding)
+            && self.binding_ref_use_intent(expr) == IntentKind::Consume
+    }
+
     #[allow(
         clippy::too_many_lines,
         reason = "single match over assignable HIR target shapes (binding, record field, \
@@ -1881,26 +1906,28 @@ impl Builder {
                 let arg_places = vec![receiver_place, index_place, src];
                 let next = self.alloc_block();
                 // A Vec index-assignment of a fresh materialised rvalue
-                // (`v[i] = Name { .. }`, `v[i] = make()`) has the SAME
-                // unbound-temp hole the `.set(i, ..)` method path does:
+                // (`v[i] = Name { .. }`, `v[i] = make()`) or a consumed bound
+                // local (`v[i] = h`) has the SAME source-owner hole:
                 // `hew_vec_set_owned` is COPY-IN (deep-clones the element into
-                // the slot), but the throwaway constructor temp has no binding
-                // and no scope-exit drop to balance that clone, so its owned
-                // heap leaks. Route it to the MOVE-in sibling
+                // the slot), but neither source has a later drop to balance that
+                // clone. The constructor temp is unbound, while checked MIR
+                // marks the local `Use { Consume }` and suppresses its scope-exit
+                // drop. Route either sole-owner source to the MOVE-in sibling
                 // `hew_vec_set_owned_move` (byte-transfers the element's heap
-                // into the slot without a clone; the source temp is then dead).
+                // into the slot without a clone; the source is then dead).
                 // `expr_is_materialized_owner` is the identical fresh-rvalue
-                // predicate the `.set()`/push paths use: a bare `BindingRef`
-                // (a shared/after-read local) returns false and stays COPY-IN
-                // (moving it would double-free the live binding's heap), and a
-                // construction embedding a whole by-value parameter returns
-                // false too. This mirrors the method path's Vec::Set routing.
+                // predicate the `.set()`/push paths use. The second predicate is
+                // deliberately narrower: only a non-parameter, non-capture
+                // `BindingRef` whose effective MIR use intent is `Consume`
+                // moves. A borrowed/read binding stays COPY-IN, as do
+                // constructions embedding a whole by-value parameter.
                 let effective_symbol = if target_symbol.as_str() == "hew_vec_set_owned"
-                    && Self::expr_is_materialized_owner(
+                    && (Self::expr_is_materialized_owner(
                         value,
                         &self.funcupdate_fn_returns_fresh,
                         &self.funcupdate_param_ids,
-                    ) {
+                    ) || self.is_consumed_bound_local(value))
+                {
                     "hew_vec_set_owned_move"
                 } else {
                     target_symbol.as_str()
@@ -2288,14 +2315,7 @@ impl Builder {
                     // exit. Consulted at the single resource-arg `Use` emission
                     // point; non-borrow sites (consumed params, unresolved
                     // callees) keep the over-stamped intent unchanged.
-                    let use_intent = if self.param_ownership.borrow_arg_sites.contains(&expr.site)
-                        || self.bytes_local_share_sites.contains(&expr.site)
-                        || self.string_local_share_sites.contains_key(&expr.site)
-                    {
-                        IntentKind::Read
-                    } else {
-                        expr.intent
-                    };
+                    let use_intent = self.binding_ref_use_intent(expr);
                     self.statements.push(MirStatement::Use {
                         binding: *id,
                         name: name.clone(),


### PR DESCRIPTION
## Summary

`v[i] = h`, where `h` is a bound local the checker marks consumed at the store, now moves `h` into the vector (`hew_vec_set_owned_move`) instead of copying it in (`hew_vec_set_owned`). Previously `h` was consumed — no scope-exit drop ran for it — yet its value was cloned into the vector anyway, orphaning the original heap allocation: roughly a 4-node leak per occurrence. The move is gated on the checker's `Consume` intent, the same fact that already suppresses the drop, so move and drop-suppression stay in lockstep by construction. Borrowed bound-locals are untouched and keep the copy-in path.

## Verification

- Leak oracle: asserts a flat (zero) allocation slope for the consumed case, and the old copy-in pin is inverted to assert the move symbol instead.
- Negative control: a borrowed-capture case stays on copy-in and runs clean under a poisoned allocator.
- `ll-diff`, `checked-mir-verify`, `hew-types` coverage, `hew-check-all`, `test-hew-ratchet`, lint, and fmt all pass.

## Out of scope

- The materialized-owner RHS path is already handled and untouched here.
- The borrow case is untouched.
