### PR TITLE
fix(runtime): report background-thread panics instead of swallowing them

### DIFF
--- a/hew-runtime/src/blocking_pool.rs
+++ b/hew-runtime/src/blocking_pool.rs
@@ -122,11 +122,20 @@ pub enum BlockingPoolError {
     /// runtime test guard (tests). The task was never enqueued; the entrypoint
     /// returns a clean error to the C caller instead of aborting.
     NoRuntime,
+    /// The worker caught a panic from the submitted closure and reported it to
+    /// the waiting caller.
+    WorkerPanicked,
+}
+
+enum SlotOutcome<T> {
+    Pending,
+    Ready(T),
+    Panicked(String),
 }
 
 /// Result slot shared between the caller (waits) and the worker (writes).
 struct Slot<T> {
-    value: Mutex<Option<T>>,
+    outcome: Mutex<SlotOutcome<T>>,
     ready: Condvar,
 }
 
@@ -158,11 +167,17 @@ where
     let TaskCtx { slot, mut f } = *ctx;
     // Take the FnOnce out of the Option so we can call it by value.
     let f = f.take().expect("FnOnce only invoked once");
-    let value = f();
-    // Publish the result. If the caller has already given up (timed out),
-    // the value is simply stored and dropped when the last Arc drops.
-    let mut guard = slot.value.lock_or_recover();
-    *guard = Some(value);
+    let outcome = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(value) => SlotOutcome::Ready(value),
+        Err(payload) => {
+            let message = crate::util::panic_payload_message(payload.as_ref());
+            SlotOutcome::Panicked(message)
+        }
+    };
+    // Publish the outcome. If the caller has already given up (timed out), it
+    // is stored and dropped when the last Arc drops.
+    let mut guard = slot.outcome.lock_or_recover();
+    *guard = outcome;
     slot.ready.notify_one();
 }
 
@@ -199,7 +214,8 @@ where
 /// Returns `Err(BlockingPoolError::PoolStopped)` if `pool` is null or the
 /// pool has been stopped (so the task could not be enqueued). Returns
 /// `Err(BlockingPoolError::TimedOut)` if `deadline` is `Some(d)` and `d`
-/// elapses before the worker publishes a result.
+/// elapses before the worker publishes a result. Returns
+/// `Err(BlockingPoolError::WorkerPanicked)` if the submitted closure panics.
 ///
 /// # Panics
 ///
@@ -227,7 +243,7 @@ where
     }
 
     let slot: Arc<Slot<T>> = Arc::new(Slot {
-        value: Mutex::new(None),
+        outcome: Mutex::new(SlotOutcome::Pending),
         ready: Condvar::new(),
     });
 
@@ -260,17 +276,16 @@ where
     // expires. cleanup-all-exits invariant: on the timeout path we explicitly
     // drop the guard and the Arc — the worker still holds a reference and
     // will drop the slot's storage after publishing.
-    let mut guard = slot.value.lock_or_recover();
+    let mut guard = slot.outcome.lock_or_recover();
     match deadline {
         None => {
-            while guard.is_none() {
+            while matches!(*guard, SlotOutcome::Pending) {
                 guard = slot.ready.wait_or_recover(guard);
             }
-            Ok(guard.take().expect("value was just observed Some"))
         }
         Some(d) => {
             let start = std::time::Instant::now();
-            while guard.is_none() {
+            while matches!(*guard, SlotOutcome::Pending) {
                 let elapsed = start.elapsed();
                 let Some(remaining) = d.checked_sub(elapsed) else {
                     return Err(BlockingPoolError::TimedOut);
@@ -278,15 +293,23 @@ where
                 let (next_guard, wait_result) =
                     slot.ready.wait_timeout_or_recover(guard, remaining);
                 guard = next_guard;
-                if wait_result.timed_out() && guard.is_none() {
+                if wait_result.timed_out() && matches!(*guard, SlotOutcome::Pending) {
                     // cleanup-all-exits: dropping `guard` releases the lock
                     // before we return; `slot` (Arc) stays alive on the worker
                     // side and is freed when the worker publishes and drops.
                     return Err(BlockingPoolError::TimedOut);
                 }
             }
-            Ok(guard.take().expect("value was just observed Some"))
         }
+    }
+
+    match std::mem::replace(&mut *guard, SlotOutcome::Pending) {
+        SlotOutcome::Ready(value) => Ok(value),
+        SlotOutcome::Panicked(message) => {
+            crate::set_last_error(format!("blocking pool worker panicked: {message}"));
+            Err(BlockingPoolError::WorkerPanicked)
+        }
+        SlotOutcome::Pending => unreachable!("worker outcome was observed ready"),
     }
 }
 
@@ -401,7 +424,14 @@ pub unsafe extern "C" fn hew_blocking_pool_stop(pool: *mut HewBlockingPool) {
 
     // Join all worker threads.
     for handle in p.workers.drain(..) {
-        let _ = handle.join();
+        if let Err(panic_payload) = handle.join() {
+            let message = format!(
+                "blocking pool worker panicked during teardown: {}",
+                crate::util::panic_payload_message(panic_payload.as_ref())
+            );
+            crate::set_last_error(message.clone());
+            eprintln!("hew: {message}");
+        }
     }
 }
 
@@ -438,6 +468,7 @@ fn worker_loop(inner: &PoolInner) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CStr;
     use std::sync::atomic::{AtomicU32, Ordering};
 
     /// A count paired with a Mutex+Condvar "done" latch so the submitting
@@ -622,6 +653,46 @@ mod tests {
             // shared state was wedged.
             let result2 = spawn_blocking_result(pool, || "hello".to_string(), None);
             assert_eq!(result2.as_deref(), Ok("hello"));
+
+            hew_blocking_pool_stop(pool);
+        }
+    }
+
+    #[test]
+    fn worker_panic_reports_and_pool_survives() {
+        crate::hew_clear_error();
+
+        // SAFETY: test owns pool lifetime.
+        unsafe {
+            let pool = hew_blocking_pool_new();
+
+            let result = spawn_blocking_result::<(), _>(
+                pool,
+                || panic!("blocking worker intentional panic"),
+                None,
+            );
+            assert_eq!(result, Err(BlockingPoolError::WorkerPanicked));
+
+            let error_ptr = crate::hew_last_error();
+            assert!(
+                !error_ptr.is_null(),
+                "a panicking blocking worker must record a diagnostic"
+            );
+            // SAFETY: spawn_blocking_result populated this thread's last-error slot.
+            let error = CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8");
+            assert!(
+                error.contains("blocking pool worker panicked"),
+                "unexpected last error: {error}"
+            );
+            assert!(
+                error.contains("blocking worker intentional panic"),
+                "panic payload must be included in the diagnostic: {error}"
+            );
+
+            let following = spawn_blocking_result(pool, || 41_i32 + 1, None);
+            assert_eq!(following, Ok(42), "the pool queue must remain serviceable");
 
             hew_blocking_pool_stop(pool);
         }

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -480,16 +480,6 @@ impl std::fmt::Debug for HewTask {
 // the enclosing task scope. No cross-thread sharing occurs.
 unsafe impl Send for HewTask {}
 
-fn panic_payload_message(panic_payload: &(dyn std::any::Any + Send)) -> String {
-    if let Some(s) = panic_payload.downcast_ref::<&str>() {
-        (*s).to_string()
-    } else if let Some(s) = panic_payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "non-string panic payload".to_string()
-    }
-}
-
 impl HewTask {
     /// Atomically load the current state with `Acquire` ordering.
     ///
@@ -558,7 +548,7 @@ impl HewTask {
                     unsafe { f(env_ptr) };
                 }));
                 if let Err(panic_payload) = result {
-                    let msg = panic_payload_message(panic_payload.as_ref());
+                    let msg = crate::util::panic_payload_message(panic_payload.as_ref());
                     let error_msg = format!("task_scope cancel_cleanup_fn panicked: {msg}");
                     crate::set_last_error(error_msg.clone());
                     #[cfg(test)]
@@ -597,7 +587,7 @@ fn reap_detached_scope_tasks(
         if let Err(panic_payload) = handle.join() {
             let error_msg = format!(
                 "task_scope detached worker panicked during teardown: {}",
-                panic_payload_message(panic_payload.as_ref())
+                crate::util::panic_payload_message(panic_payload.as_ref())
             );
             crate::set_last_error(error_msg.clone());
             // Background reapers have a separate thread-local error slot, so

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -581,6 +581,17 @@ fn should_fail_ticker_spawn() -> bool {
     FAIL_TICKER_SPAWN.with(std::cell::Cell::get)
 }
 
+fn report_ticker_join_result(join_result: std::thread::Result<()>) {
+    if let Err(panic_payload) = join_result {
+        let message = format!(
+            "hew timer ticker panicked during shutdown: {}",
+            crate::util::panic_payload_message(panic_payload.as_ref())
+        );
+        crate::set_last_error(message.clone());
+        eprintln!("hew: {message}");
+    }
+}
+
 /// Gracefully stop the ticker thread.
 ///
 /// Sets the stop flag, waits for the thread to join, then resets the flag
@@ -593,14 +604,16 @@ pub(crate) fn shutdown_ticker() {
     // sleeping until its next deadline (or indefinitely on an empty wheel).
     ticker_park_notify();
 
-    // Get the handle and join the thread if it exists
-    if let Some(handle_mutex) = TICKER_HANDLE.get() {
-        if let Ok(mut guard) = handle_mutex.lock() {
-            if let Some(handle) = guard.take() {
-                // Wait for the thread to finish
-                let _ = handle.join();
-            }
-        }
+    // Take the handle without holding its mutex while joining or reporting.
+    let handle = TICKER_HANDLE.get().and_then(|handle_mutex| {
+        handle_mutex
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    });
+    if let Some(handle) = handle {
+        let join_result = handle.join();
+        report_ticker_join_result(join_result);
     }
 
     // Reset flags for potential re-initialisation
@@ -768,6 +781,43 @@ mod tests {
         // This should not panic or hang
         shutdown_ticker(); // Should be safe to call multiple times
         shutdown_ticker(); // Should be safe to call again
+    }
+
+    #[test]
+    fn ticker_shutdown_reports_worker_panic() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        crate::hew_clear_error();
+
+        let handle_mutex = TICKER_HANDLE.get_or_init(|| Mutex::new(None));
+        *handle_mutex
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(std::thread::spawn(|| panic!("ticker intentional panic")));
+        TICKER_RUNNING.store(true, Ordering::SeqCst);
+
+        shutdown_ticker();
+
+        let error_ptr = crate::hew_last_error();
+        assert!(
+            !error_ptr.is_null(),
+            "joining a panicked ticker must record a diagnostic"
+        );
+        // SAFETY: shutdown_ticker populated this thread's last-error slot.
+        let error = unsafe {
+            CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8")
+        };
+        assert!(
+            error.contains("hew timer ticker panicked during shutdown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("ticker intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
     }
 
     #[test]

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -1567,6 +1567,13 @@ pub unsafe extern "C" fn hew_tcp_connect_timed(addr: *const c_char, deadline_ms:
             );
             return -1;
         }
+        Err(BlockingPoolError::WorkerPanicked) => {
+            hew_cabi::sink::set_last_error_with_errno(
+                String::from("hew_tcp_connect: DNS resolution worker panicked"),
+                0,
+            );
+            return -1;
+        }
         Err(BlockingPoolError::NoRuntime) => {
             // Fail closed: no runtime installed, so no blocking pool to offload
             // DNS onto. Clean -1 with EINVAL rather than a SIGABRT across the ABI.
@@ -1762,6 +1769,13 @@ pub unsafe extern "C" fn hew_tcp_connect_timeout(
             return -1;
         }
         Err(BlockingPoolError::PoolStopped) => {
+            return -1;
+        }
+        Err(BlockingPoolError::WorkerPanicked) => {
+            hew_cabi::sink::set_last_error_with_errno(
+                String::from("hew_tcp_connect: DNS resolution worker panicked"),
+                0,
+            );
             return -1;
         }
         Err(BlockingPoolError::NoRuntime) => {

--- a/hew-runtime/src/util.rs
+++ b/hew-runtime/src/util.rs
@@ -58,6 +58,17 @@ pub(crate) fn push_json_string(out: &mut String, s: &str) {
     out.push('"');
 }
 
+/// Extract a readable message from a panic payload.
+pub(crate) fn panic_payload_message(panic_payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = panic_payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
 /// Extension trait for [`Mutex`] that recovers from poisoned locks.
 pub(crate) trait MutexExt<T> {
     fn lock_or_recover(&self) -> MutexGuard<'_, T>;

--- a/hew-std/src/dns.rs
+++ b/hew-std/src/dns.rs
@@ -25,9 +25,9 @@ use std::time::Duration;
 ///   The pool thread keeps running `getaddrinfo` until it returns; its
 ///   result is discarded when the worker publishes it (no leak; see
 ///   `spawn_blocking_result` saturation note).
-/// - `Err(false)` — `getaddrinfo` itself errored, the pool was stopped, or no
-///   runtime is installed (fail closed: the entrypoint returns its empty/null
-///   sentinel rather than aborting across the ABI).
+/// - `Err(false)` — `getaddrinfo` itself errored, the pool was stopped, its
+///   worker panicked, or no runtime is installed (fail closed: the entrypoint
+///   returns its empty/null sentinel rather than aborting across the ABI).
 fn resolve_via_pool(host: &str, deadline_ms: i64) -> Result<Vec<IpAddr>, bool> {
     let host = format!("{host}:0");
     let deadline = if deadline_ms <= 0 {
@@ -63,9 +63,12 @@ fn resolve_via_pool(host: &str, deadline_ms: i64) -> Result<Vec<IpAddr>, bool> {
     match result {
         Ok(Ok(addrs)) => Ok(addrs),
         Err(BlockingPoolError::TimedOut) => Err(true),
-        Ok(Err(())) | Err(BlockingPoolError::PoolStopped | BlockingPoolError::NoRuntime) => {
-            Err(false)
-        }
+        Ok(Err(()))
+        | Err(
+            BlockingPoolError::PoolStopped
+            | BlockingPoolError::NoRuntime
+            | BlockingPoolError::WorkerPanicked,
+        ) => Err(false),
     }
 }
 


### PR DESCRIPTION
## Summary

Background threads no longer swallow panics. The blocking-thread pool and the periodic-timer ticker previously discarded their worker/ticker join results, so a panicking job or a ticker crash vanished with no diagnostic. Now a panic on any of these threads is caught on the Rust side of the FFI trampoline, reported as a typed failure to the waiter (with the panic message), and a faulting job no longer strands the work queue; the ticker's shutdown join reports its panic (and no longer skips the join on a poisoned lock). The panic-message formatter is promoted to a shared runtime helper.

## Verification

- New tests spawn a panicking job/ticker and assert the panic message is reported and the queue survives (a following job returns `Ok(42)`).
- The containment path is exercised under the test/unwind profile (production stays `panic=abort`).
- Full `hew-runtime` suite: green.
- Panic-containment and the FFI boundary verified memory-safe under a poisoned allocator (MallocScribble/GuardEdges).

## Out of scope

The same join-inspection pattern applies to other runtime teardown sites — that's a separate follow-up (tracked as issue #45).
