### PR TITLE
fix(hir): admit resolvable imported method calls

### DIFF
--- a/examples/benchmark_demo.hew
+++ b/examples/benchmark_demo.hew
@@ -1,4 +1,4 @@
-//! Status: aspirational (Hew roadmap: v0.5 codegen-rs parity for non-spine statements and stdlib calls)
+//! Status: runnable
 //! Description: Benchmark harness demo
 
 // Benchmark harness demo

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -925,8 +925,8 @@ struct ImplCloseSignature {
 /// Per-impl-block context threaded into `lower_impl_block` for imported
 /// modules. Carries the same-module fn-name rewrite map (bare helper name →
 /// mangled qualified symbol, identical to the free-function imported path) and
-/// the set of method names to skip because their bodies call a private helper
-/// the importer cannot reach.
+/// the set of method names to skip because their bodies or signatures cannot
+/// be resolved safely across the module boundary.
 struct ImportedImplLowering<'a> {
     rewrites: &'a HashMap<String, String>,
     skip_methods: &'a HashSet<String>,
@@ -3894,13 +3894,15 @@ pub fn lower_program_with_mono_cap(
                                 //
                                 // A method is skipped when EITHER:
                                 //  - its body calls a bare name that resolves in
-                                //    neither the same-module rewrite map nor
+                                //    neither the same-module rewrite map,
                                 //    `fn_registry` (which by now holds every
                                 //    seeded stdlib/runtime symbol and every
-                                //    same-module extern fn) — catches
-                                //    codegen-intercepted builtins that are not
-                                //    extern-declared, e.g. `std::channel`'s
-                                //    `recv` → `hew_channel_recv_layout`; OR
+                                //    same-module extern fn), a lexically-bound
+                                //    fn-typed parameter, nor the source builtin
+                                //    overload set — catches codegen-intercepted
+                                //    builtins that are not extern-declared, e.g.
+                                //    `std::channel`'s `recv` →
+                                //    `hew_channel_recv_layout`; OR
                                 //  - its signature names a user type that would
                                 //    not resolve at the MIR boundary — a
                                 //    cross-module dotted type (`fs.IoError`) or a
@@ -3930,6 +3932,14 @@ pub fn lower_program_with_mono_cap(
                                     .unwrap_or_default();
                                 let mut skip_methods: HashSet<String> = HashSet::new();
                                 for method in &impl_decl.methods {
+                                    let callable_params: HashSet<&str> = method
+                                        .params
+                                        .iter()
+                                        .filter(|param| {
+                                            matches!(&param.ty.0, TypeExpr::Function { .. })
+                                        })
+                                        .map(|param| param.name.as_str())
+                                        .collect();
                                     let body_unresolvable = collect_all_bare_call_names(
                                         &method.body,
                                     )
@@ -3949,6 +3959,8 @@ pub fn lower_program_with_mono_cap(
                                         !is_builtin_enum_variant_bare_name(&callee)
                                             && !same_module_fn_rewrites.contains_key(&callee)
                                             && !ctx.fn_registry.contains_key(&callee)
+                                            && !callable_params.contains(callee.as_str())
+                                            && !stdlib_catalog::is_overloaded_builtin(&callee)
                                     });
                                     // The generic params in scope for this method:
                                     // the impl-block params plus the method's own.
@@ -6821,12 +6833,12 @@ fn collect_bare_fn_call_refs(body: &Block, candidate_fns: &HashSet<String>) -> V
 ///
 /// Used to decide whether an imported impl-method body is safe to lower: a body
 /// that calls a bare name resolvable in neither `fn_registry`, the same-module
-/// rewrite map, nor the runtime/stdlib catalog cannot be lowered cross-module
+/// rewrite map, a lexically-bound fn-typed parameter, the source builtin
+/// overload set, nor the runtime/stdlib catalog cannot be lowered cross-module
 /// (e.g. `std::channel`'s `recv` calls the codegen-intercepted
 /// `hew_channel_recv_layout`, which is not extern-declared in the module and
-/// never reaches the imported
-/// `fn_registry`). Such methods are skipped, matching the prior behaviour where
-/// every imported impl method was dropped.
+/// never reaches the imported `fn_registry`). Such methods are skipped,
+/// matching the prior behaviour where every imported impl method was dropped.
 fn collect_all_bare_call_names(body: &Block) -> Vec<String> {
     let mut found = CallNames::default();
     scan_block_for_private_refs(body, None, &mut found);

--- a/hew-hir/tests/lowering_calls/imported_impl_lower.rs
+++ b/hew-hir/tests/lowering_calls/imported_impl_lower.rs
@@ -13,11 +13,16 @@
 //!    bodies), so the method *is* emitted and resolves the helper — e.g.
 //!    `net.set_read_timeout` calling `net_result_from_status`.
 //!
-//! 3. **Skip on genuinely-unresolvable call**: when a method body calls a bare
+//! 3. **Lexical/overload calls**: fn-typed parameters and source builtin names
+//!    resolved by overload lowering are admitted without weakening the general
+//!    bare-call gate.
+//!
+//! 4. **Skip on genuinely-unresolvable call**: when a method body calls a bare
 //!    name that resolves in neither `fn_registry`, the same-module rewrite map,
-//!    nor the builtin variant-ctor set, the method is *skipped* — not emitted —
-//!    and the module still imports cleanly (no module-level hard error). An
-//!    actual call to the skipped method fails closed downstream.
+//!    the builtin variant-ctor set, a fn-typed parameter, nor the overload
+//!    builtin set, the method is *skipped* — not emitted — and the module still
+//!    imports cleanly (no module-level hard error). An actual call to the
+//!    skipped method fails closed downstream.
 
 use hew_hir::{HirDiagnosticKind, HirItem};
 use hew_parser::ast::{Item, Program};
@@ -350,6 +355,74 @@ impl Foo {
 }
 
 #[test]
+fn imported_impl_body_calling_fn_typed_parameter_is_emitted() {
+    let imported_src = r"
+pub type Foo {
+    n: i64;
+}
+impl Foo {
+    pub fn apply(f: Foo, callback: fn()) {
+        callback();
+    }
+}
+";
+    let program = build_imported_impl_program_src(imported_src);
+    let output = support::checker_pipeline::lower_through_checker_from_program(&program);
+
+    let apply_emitted = output
+        .module
+        .items
+        .iter()
+        .any(|item| matches!(item, HirItem::Function(f) if f.name == "Foo::apply"));
+    assert!(
+        apply_emitted,
+        "expected `Foo::apply` to be emitted: `callback` is a lexically-bound \
+         fn-typed parameter, not an unresolved global call"
+    );
+
+    let result = output.into_result();
+    assert!(
+        result.is_ok(),
+        "imported impl method calling a fn-typed parameter must lower cleanly. Got: {:#?}",
+        result.err()
+    );
+}
+
+#[test]
+fn imported_impl_body_calling_overloaded_source_builtin_is_emitted() {
+    let imported_src = r"
+pub type Foo {
+    n: i64;
+}
+impl Foo {
+    pub fn report(f: Foo) {
+        println(f.n);
+    }
+}
+";
+    let program = build_imported_impl_program_src(imported_src);
+    let output = support::checker_pipeline::lower_through_checker_from_program(&program);
+
+    let report_emitted = output
+        .module
+        .items
+        .iter()
+        .any(|item| matches!(item, HirItem::Function(f) if f.name == "Foo::report"));
+    assert!(
+        report_emitted,
+        "expected `Foo::report` to be emitted: `println` is a source builtin \
+         resolved to a concrete catalog entry during overload lowering"
+    );
+
+    let result = output.into_result();
+    assert!(
+        result.is_ok(),
+        "imported impl method calling an overloaded source builtin must lower cleanly. Got: {:#?}",
+        result.err()
+    );
+}
+
+#[test]
 fn imported_impl_signature_returning_same_module_record_is_emitted() {
     // Regression for the imported-impl signature gate used by
     // std::text::regex: methods such as `Pattern::captures` return a public
@@ -522,5 +595,48 @@ impl Foo {
         blocked.is_empty(),
         "skipping an unresolvable-call imported impl method must not emit a \
          module-level diagnostic; got: {blocked:?}"
+    );
+}
+
+#[test]
+fn called_imported_impl_body_with_unresolvable_call_fails_closed() {
+    let imported_src = r"
+pub type Foo {
+    n: i64;
+}
+impl Foo {
+    pub fn bar(f: Foo) -> i64 { nonexistent_fn(f.n) }
+}
+";
+    let root_src = r"
+fn main() -> i64 {
+    let f = Foo { n: 42 };
+    f.bar()
+}
+";
+    let program = build_imported_module_program_src(imported_src, root_src);
+    let output = support::checker_pipeline::lower_through_checker_from_program(&program);
+
+    let diagnostic = output
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                &diagnostic.kind,
+                HirDiagnosticKind::CallableUnsupportedInMir { name } if name == "Foo::bar"
+            )
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "calling a skipped imported impl method must fail closed with \
+                 CallableUnsupportedInMir for `Foo::bar`; got: {:#?}",
+                output.diagnostics
+            )
+        });
+    assert!(
+        diagnostic
+            .note
+            .contains("has no MIR body or runtime-ABI lowering"),
+        "fail-closed diagnostic must explain the missing callable body: {diagnostic:?}"
     );
 }

--- a/scripts/hew-corpus-expected-failures.txt
+++ b/scripts/hew-corpus-expected-failures.txt
@@ -35,9 +35,6 @@
 
 # ── examples/ ────────────────────────────────────────────────────────────────
 
-# deferred-nyi: channel/select syntax not yet lowered
-examples/benchmark_demo.hew
-
 # deferred-nyi: distributed / net NYI features
 
 # deferred-nyi: lambda actor syntax not yet supported

--- a/tests/hew/bench_test.hew
+++ b/tests/hew/bench_test.hew
@@ -1,0 +1,16 @@
+//! Compiled/executed proof for imported std::bench impl methods.
+
+import std::bench;
+import std::testing;
+
+#[test]
+fn test_imported_bench_suite_add_and_report() {
+    let s = bench.suite("Imported Bench");
+    s.add("noop", 1, || {});
+
+    testing.assert_eq(s.results.len(), 1);
+    testing.assert_eq_str(s.results[0].name, "noop");
+    testing.assert_eq(s.results[0].iterations, 1);
+
+    s.report();
+}

--- a/tests/vertical-slice/accept/std_bench_import_run.hew
+++ b/tests/vertical-slice/accept/std_bench_import_run.hew
@@ -1,0 +1,7 @@
+import std::bench;
+
+fn main() {
+    let s = bench.suite("Imported Bench");
+    s.add("noop", 1, || {});
+    s.report();
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -117,6 +117,19 @@ run_accept_expect_stdout() {
   diff -u "${ROOT}/tests/vertical-slice/accept/${fixture}.expected" "${stdout_output}"
 }
 
+run_accept_expect_stdout_contains() {
+  local fixture="$1"
+  shift
+  run_accept_expect_status "${fixture}" 0
+  for expected in "$@"; do
+    if ! grep -qF -- "${expected}" "${stdout_output}"; then
+      echo "expected ${fixture} stdout to contain: ${expected}" >&2
+      cat "${stdout_output}" >&2
+      exit 1
+    fi
+  done
+}
+
 # Run a fixture that is expected to terminate via a hardware trap. Accepts exit
 # code 132 (SIGILL+128 on x86_64 Linux: `ud2`) or 133 (SIGTRAP+128 on
 # aarch64/macOS: `brk #1`) — both are valid trap-signal encodings of
@@ -419,6 +432,13 @@ run_accept_expect_stdout "nested_string_concat_temp"
 # bindings + a helper chain) must keep compiling and produce deterministic
 # output — the D108 non-regression the return-provenance preflight protects.
 run_accept_expect_stdout "call_scrutinee_fresh_forwarder_release"
+
+# Imported std::bench impl methods must carry MIR bodies across the module
+# boundary. The output timings vary, so assert the stable report fragments.
+run_accept_expect_stdout_contains \
+    "std_bench_import_run" \
+    "=== Imported Bench ===" \
+    "  noop  1 iters  avg "
 
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types


### PR DESCRIPTION
## Summary

`std::bench` now compiles and runs. Previously, importing `std::bench` and calling `Suite::add`/`report`/`report_json` failed at build time with an internal "no MIR body" error, because imported trait-impl methods that call a function-typed parameter (like the benchmark closure) or an overloaded builtin (like `println`) weren't admitted for lowering. Now those method bodies are lowered when their otherwise-unresolved calls provably resolve — to an in-scope function-typed parameter or a known overloaded builtin — while genuinely unresolved calls still fail closed with a clear diagnostic.

## Verification

- New accept fixture imports `std::bench`, builds and runs a real suite (adds a benchmark, reports), and asserts the actual printed report output.
- Unit tests cover both the function-typed-parameter and overloaded-builtin admission paths, and confirm a genuinely-unresolved imported method call still fails closed with the exact diagnostic.
- The benchmark example is re-classified runnable.
- Full check-all, ratchet, coverage, lint, and fmt pass.

## Out of scope

Broader stdlib execution-proof coverage for other modules is a separate follow-up.
