### PR TITLE
test(runtime): make remaining connmgr handshake guards wait on events

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -9049,7 +9049,7 @@ mod tests {
 
             assert_eq!(
                 remove_result_rx
-                    .recv_timeout(std::time::Duration::from_secs(1))
+                    .recv()
                     .expect("reentrant remove should finish without deadlocking"),
                 0
             );


### PR DESCRIPTION
## Summary

One connection-manager test still gated a cross-thread handshake on a 1-second wall-clock timeout (`remove_result_rx.recv_timeout`), which could spuriously fail on a heavily loaded CI runner where the thread is starved past the deadline even though no deadlock occurred. It now blocks on the event (`recv()`), matching the other handshake guards in this test; a genuine hang is still bounded by the test group's slow-timeout. The one deliberate negative-timing assertion is unchanged.

## Verification

- `cargo test connmgr_publish_skips`: pass
- Full `connection::tests` module: 63 passed
- Lint and format: clean

## Out of scope

- Broader load-sensitive-test recomposition across the runtime test suite.