### PR TITLE
test(stdlib): prove seven module execution paths compile and run

### DIFF
--- a/tests/vertical-slice/accept/std_concurrency_import_run.hew
+++ b/tests/vertical-slice/accept/std_concurrency_import_run.hew
@@ -1,0 +1,11 @@
+import std::concurrency::{ScopeError};
+
+fn main() {
+    let failures: Vec<i64> = [8, 9];
+    let error: ScopeError<i64> = ScopeError {
+        primary: 7,
+        also_failed: failures,
+        cancelled_count: 2,
+    };
+    println(f"scope:{error.primary}:{error.also_failed[0]}:{error.also_failed[1]}:{error.cancelled_count}");
+}

--- a/tests/vertical-slice/accept/std_concurrency_lifecycle_import_run.hew
+++ b/tests/vertical-slice/accept/std_concurrency_lifecycle_import_run.hew
@@ -1,0 +1,15 @@
+import std::concurrency::lifecycle;
+
+fn main() {
+    var service: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle::Created;
+    let created = service.state_name();
+    service.step(Initialise);
+    let initialising = service.state_name();
+    service.step(lifecycle.LifecycleEvent::Started { handle: 42 });
+    let running = service.state_name();
+    service.step(Stop);
+    let stopping = service.state_name();
+    service.step(Stop);
+    let stopped = service.state_name();
+    println(f"lifecycle:{created}:{initialising}:{running}:{stopping}:{stopped}");
+}

--- a/tests/vertical-slice/accept/std_encoding_markdown_import_run.hew
+++ b/tests/vertical-slice/accept/std_encoding_markdown_import_run.hew
@@ -1,0 +1,9 @@
+import std::encoding::markdown;
+
+fn main() {
+    let html = markdown.to_html("**bold**");
+    if html != "<p><strong>bold</strong></p>\n" {
+        panic(f"unexpected markdown HTML: {html}");
+    }
+    println("markdown:<p><strong>bold</strong></p>");
+}

--- a/tests/vertical-slice/accept/std_encoding_wire_value_trait_import_run.hew
+++ b/tests/vertical-slice/accept/std_encoding_wire_value_trait_import_run.hew
@@ -1,0 +1,14 @@
+import std::encoding::wire::value_trait::{CanonicalValueMethods};
+import std::encoding::json;
+
+fn canonical_int<T: CanonicalValueMethods>(value: T) -> i64 {
+    let result = value.get_int();
+    value.free();
+    result
+}
+
+fn main() {
+    let value = json.parse("42");
+    let result = canonical_int(value);
+    println(f"canonical-value:{result}");
+}

--- a/tests/vertical-slice/accept/std_io_closable_import_run.hew
+++ b/tests/vertical-slice/accept/std_io_closable_import_run.hew
@@ -1,0 +1,25 @@
+import std::io::closable::{Closable, CloseError};
+import std::io::closable;
+
+type TestHandle {
+    id: i64;
+}
+
+impl Closable for TestHandle {
+    fn close(handle: TestHandle) -> Result<(), closable.CloseError> {
+        if handle.id == 7 {
+            Err(closable.CloseError::AlreadyClosed)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn main() {
+    let handle = TestHandle { id: 7 };
+    match handle.close() {
+        Err(CloseError::AlreadyClosed) => println("closable:AlreadyClosed"),
+        Err(CloseError::Io(_)) => println("closable:Io"),
+        Ok(_) => println("closable:Ok"),
+    }
+}

--- a/tests/vertical-slice/accept/std_io_import_run.hew
+++ b/tests/vertical-slice/accept/std_io_import_run.hew
@@ -1,0 +1,5 @@
+import std::io;
+
+fn main() {
+    io.write("stdlib-io:write\n");
+}

--- a/tests/vertical-slice/accept/std_machines_toggle_import_run.hew
+++ b/tests/vertical-slice/accept/std_machines_toggle_import_run.hew
@@ -1,0 +1,11 @@
+import std::machines::toggle::{Toggle};
+
+fn main() {
+    var toggle: Toggle = Toggle::Off;
+    let off = toggle.state_name();
+    toggle.step(Flip);
+    let on = toggle.state_name();
+    toggle.step(Flip);
+    let off_again = toggle.state_name();
+    println(f"toggle:{off}:{on}:{off_again}");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -476,6 +476,12 @@ run_accept_expect_stdout_contains \
     "std_encoding_wire_value_trait_import_run" \
     "canonical-value:42"
 
+# std::io's imported write wrapper must reach the runtime and emit the exact
+# requested bytes.
+run_accept_expect_stdout_contains \
+    "std_io_import_run" \
+    "stdlib-io:write"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -452,6 +452,12 @@ run_accept_expect_stdout_contains \
     "std_concurrency_lifecycle_import_run" \
     "lifecycle:Created:Initialising:Running:Stopping:Stopped"
 
+# std::encoding::markdown must call the native renderer through its imported
+# wrapper and return the exact CommonMark HTML for a stable input.
+run_accept_expect_stdout_contains \
+    "std_encoding_markdown_import_run" \
+    "markdown:<p><strong>bold</strong></p>"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -470,6 +470,12 @@ run_accept_expect_stdout_contains \
     "std_machines_toggle_import_run" \
     "toggle:Off:On:Off"
 
+# std::encoding::wire::value_trait must dispatch an imported canonical method
+# through a generic bound to JSON's concrete implementation.
+run_accept_expect_stdout_contains \
+    "std_encoding_wire_value_trait_import_run" \
+    "canonical-value:42"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -440,6 +440,12 @@ run_accept_expect_stdout_contains \
     "=== Imported Bench ===" \
     "  noop  1 iters  avg "
 
+# std::concurrency's generic failure record must construct across the module
+# boundary and preserve every exact field value at runtime.
+run_accept_expect_stdout_contains \
+    "std_concurrency_import_run" \
+    "scope:7:8:9:2"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -446,6 +446,12 @@ run_accept_expect_stdout_contains \
     "std_concurrency_import_run" \
     "scope:7:8:9:2"
 
+# std::concurrency::lifecycle's imported generic machine must execute the full
+# happy-path transition sequence with exact state names.
+run_accept_expect_stdout_contains \
+    "std_concurrency_lifecycle_import_run" \
+    "lifecycle:Created:Initialising:Running:Stopping:Stopped"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -464,6 +464,12 @@ run_accept_expect_stdout_contains \
     "std_io_closable_import_run" \
     "closable:AlreadyClosed"
 
+# std::machines::toggle must construct its imported state and execute both
+# cross-module event transitions with exact state names.
+run_accept_expect_stdout_contains \
+    "std_machines_toggle_import_run" \
+    "toggle:Off:On:Off"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -458,6 +458,12 @@ run_accept_expect_stdout_contains \
     "std_encoding_markdown_import_run" \
     "markdown:<p><strong>bold</strong></p>"
 
+# std::io::closable's imported trait and error enum must support a concrete
+# implementation, receiver dispatch, and exact variant matching.
+run_accept_expect_stdout_contains \
+    "std_io_closable_import_run" \
+    "closable:AlreadyClosed"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.


### PR DESCRIPTION
## Summary

Adds compiled, executed proofs that seven standard-library modules actually build and run, not merely type-check: `std::concurrency` and its lifecycle helper, `encoding::markdown`, `io::closable`, `machines::toggle`, `encoding::wire::value_trait`, and `io`. Each fixture imports the module, exercises its public API, runs, and asserts exact output — closing the gap where a type-check-only ratchet could green-light an API that fails at build (as `std::bench` did before its recent fix).

## Verification

- All seven fixtures run under the compiled `.hew` acceptance suite with exact stdout assertions.
- Full ratchet: 0 expected/actual failures.
- No production or compiler code changed — test fixtures only.

## Out of scope

- `std::concurrency::lambda_actor`'s direct-construction path (`LambdaActorHandle::new`) fails closed against its runtime ABI and needs a separate diagnostic/fix — tracked separately, not in this PR.