### PR TITLE
fix(runtime): report remaining background-thread teardown panics

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -532,7 +532,7 @@ impl Drop for ConnectionActor {
         // Wait for reader thread (best-effort).
         if let Some(handle) = self.reader_handle.take() {
             if handle.thread().id() != thread::current().id() {
-                let _ = handle.join();
+                crate::util::report_join_panic("connection reader thread", handle.join());
             }
         }
     }
@@ -606,7 +606,7 @@ fn collect_finished_reconnect_workers(mgr: &HewConnMgr) {
         while idx < workers.len() {
             if workers[idx].is_finished() {
                 let handle = workers.swap_remove(idx);
-                let _ = handle.join();
+                crate::util::report_join_panic("connection reconnect worker", handle.join());
             } else {
                 idx += 1;
             }
@@ -3495,11 +3495,11 @@ pub unsafe extern "C" fn hew_connmgr_free(mgr: *mut HewConnMgr) {
         mgr.reader_lifecycle.wait_for_idle();
         let workers: Vec<JoinHandle<()>> = mgr.reverse_link_workers.access(std::mem::take);
         for worker in workers {
-            let _ = worker.join();
+            crate::util::report_join_panic("connection reverse-link worker", worker.join());
         }
         let workers: Vec<JoinHandle<()>> = mgr.reconnect_workers.access(std::mem::take);
         for worker in workers {
-            let _ = worker.join();
+            crate::util::report_join_panic("connection reconnect worker", worker.join());
         }
         // mgr is dropped here, freeing the HewConnMgr.
     }
@@ -3622,7 +3622,7 @@ pub(crate) unsafe fn hew_connmgr_track_reverse_link_worker(
     worker: JoinHandle<()>,
 ) {
     if mgr.is_null() {
-        let _ = worker.join();
+        crate::util::report_join_panic("connection reverse-link worker", worker.join());
         return;
     }
     // SAFETY: caller guarantees `mgr` is valid for this call.
@@ -3641,7 +3641,7 @@ pub(crate) unsafe fn hew_connmgr_track_reverse_link_worker(
         finished
     });
     for worker in finished {
-        let _ = worker.join();
+        crate::util::report_join_panic("connection reverse-link worker", worker.join());
     }
 }
 
@@ -5090,6 +5090,205 @@ pub fn snapshot_connections_json(mgr: &HewConnMgr) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn last_error_string() -> String {
+        let error_ptr = crate::hew_last_error();
+        assert!(!error_ptr.is_null(), "expected a last-error diagnostic");
+        // SAFETY: the caller established that the current thread's last-error is set.
+        unsafe {
+            CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8")
+                .to_owned()
+        }
+    }
+
+    fn test_manager_with_transport() -> (*mut HewConnMgr, *mut HewTransport) {
+        let transport = Box::into_raw(Box::new(HewTransport {
+            ops: std::ptr::null(),
+            r#impl: std::ptr::null_mut(),
+        }));
+        // SAFETY: transport is a live test-owned allocation and the remaining pointers are null.
+        let mgr = unsafe {
+            hew_connmgr_new(
+                transport,
+                None,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                1,
+            )
+        };
+        assert!(!mgr.is_null());
+        (mgr, transport)
+    }
+
+    unsafe fn free_test_manager_and_transport(mgr: *mut HewConnMgr, transport: *mut HewTransport) {
+        // SAFETY: the caller owns both allocations and the manager still borrows transport.
+        unsafe { hew_connmgr_free(mgr) };
+        // SAFETY: the manager has been freed and no connection actor references transport.
+        let _ = unsafe { Box::from_raw(transport) };
+    }
+
+    #[test]
+    fn connection_actor_drop_reports_reader_panic() {
+        crate::hew_clear_error();
+        let mut actor = ConnectionActor::new(17);
+        actor.reader_handle = Some(std::thread::spawn(|| panic!("reader intentional panic")));
+
+        drop(actor);
+
+        let error = last_error_string();
+        assert!(
+            error.contains("connection reader thread panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("reader intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+    }
+
+    #[test]
+    fn collect_finished_reconnect_worker_reports_panic_and_removes_handle() {
+        crate::hew_clear_error();
+        let (mgr, transport) = test_manager_with_transport();
+        let worker = std::thread::spawn(|| panic!("reconnect collector intentional panic"));
+        while !worker.is_finished() {
+            std::thread::yield_now();
+        }
+        // SAFETY: mgr is live and exclusively owned by this test.
+        unsafe { &*mgr }
+            .reconnect_workers
+            .access(|workers| workers.push(worker));
+
+        // SAFETY: mgr is live for this call.
+        collect_finished_reconnect_workers(unsafe { &*mgr });
+
+        let error = last_error_string();
+        assert!(
+            error.contains("connection reconnect worker panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("reconnect collector intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        // SAFETY: mgr is live for this assertion.
+        assert!(unsafe { &*mgr }
+            .reconnect_workers
+            .access(|workers| workers.is_empty()));
+
+        // SAFETY: this test owns mgr and transport.
+        unsafe { free_test_manager_and_transport(mgr, transport) };
+    }
+
+    #[test]
+    fn manager_free_reports_reverse_link_worker_panic() {
+        crate::hew_clear_error();
+        let (mgr, transport) = test_manager_with_transport();
+        let exited = Arc::new(AtomicBool::new(false));
+        let worker_exited = Arc::clone(&exited);
+        let worker = std::thread::spawn(move || {
+            worker_exited.store(true, Ordering::Release);
+            panic!("reverse-link free intentional panic");
+        });
+        // SAFETY: mgr is live and exclusively owned by this test.
+        unsafe { &*mgr }
+            .reverse_link_workers
+            .access(|workers| workers.push(worker));
+
+        // SAFETY: this test owns mgr and transport.
+        unsafe { free_test_manager_and_transport(mgr, transport) };
+
+        let error = last_error_string();
+        assert!(
+            error.contains("connection reverse-link worker panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("reverse-link free intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        assert!(
+            exited.load(Ordering::Acquire),
+            "manager free must join the reverse-link worker before returning"
+        );
+    }
+
+    #[test]
+    fn manager_free_reports_reconnect_worker_panic() {
+        crate::hew_clear_error();
+        let (mgr, transport) = test_manager_with_transport();
+        let exited = Arc::new(AtomicBool::new(false));
+        let worker_exited = Arc::clone(&exited);
+        let worker = std::thread::spawn(move || {
+            worker_exited.store(true, Ordering::Release);
+            panic!("reconnect free intentional panic");
+        });
+        // SAFETY: mgr is live and exclusively owned by this test.
+        unsafe { &*mgr }
+            .reconnect_workers
+            .access(|workers| workers.push(worker));
+
+        // SAFETY: this test owns mgr and transport.
+        unsafe { free_test_manager_and_transport(mgr, transport) };
+
+        let error = last_error_string();
+        assert!(
+            error.contains("connection reconnect worker panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("reconnect free intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        assert!(
+            exited.load(Ordering::Acquire),
+            "manager free must join the reconnect worker before returning"
+        );
+    }
+
+    #[test]
+    fn reverse_link_tracking_reports_panics_on_immediate_and_reaped_joins() {
+        crate::hew_clear_error();
+        let immediate = std::thread::spawn(|| panic!("reverse-link null manager panic"));
+        // SAFETY: null manager explicitly requests an immediate join.
+        unsafe { hew_connmgr_track_reverse_link_worker(std::ptr::null_mut(), immediate) };
+        let error = last_error_string();
+        assert!(error.contains("reverse-link null manager panic"));
+
+        crate::hew_clear_error();
+        let (mgr, transport) = test_manager_with_transport();
+        let finished = std::thread::spawn(|| panic!("reverse-link reaped panic"));
+        while !finished.is_finished() {
+            std::thread::yield_now();
+        }
+        // SAFETY: mgr is live and exclusively owned by this test.
+        unsafe { &*mgr }
+            .reverse_link_workers
+            .access(|workers| workers.push(finished));
+        let following = std::thread::spawn(|| {});
+        // SAFETY: mgr remains live through manager teardown below.
+        unsafe { hew_connmgr_track_reverse_link_worker(mgr, following) };
+
+        let error = last_error_string();
+        assert!(
+            error.contains("connection reverse-link worker panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("reverse-link reaped panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        // SAFETY: mgr remains live and only the non-panicking following worker is tracked.
+        let tracked_workers = unsafe { &*mgr }
+            .reverse_link_workers
+            .access(|workers| workers.len());
+        assert_eq!(tracked_workers, 1);
+
+        // SAFETY: this test owns mgr and transport.
+        unsafe { free_test_manager_and_transport(mgr, transport) };
+    }
 
     fn test_node_id(route_slot: u16) -> NodeId {
         test_node_identity(route_slot)

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -2462,6 +2462,14 @@ fn drain_inbound_ask_workers(inbound_active: Option<&Arc<AtomicUsize>>) {
     }
 }
 
+fn stop_node_accept_thread(node: &mut HewNode) {
+    node.accept_stop.store(true, Ordering::Release);
+    let handle = node.accept_thread.lock_or_recover().take();
+    if let Some(handle) = handle {
+        crate::util::report_join_panic("hew node accept thread", handle.join());
+    }
+}
+
 /// Stop the node runtime.
 ///
 /// # Safety
@@ -2550,13 +2558,7 @@ pub unsafe extern "C" fn hew_node_stop(node: *mut HewNode) -> c_int {
                 }
             });
         }
-        node.accept_stop.store(true, Ordering::Release);
-        {
-            let mut guard = node.accept_thread.lock_or_recover();
-            if let Some(handle) = guard.take() {
-                let _ = handle.join();
-            }
-        }
+        stop_node_accept_thread(node);
 
         // Stop and JOIN the SWIM ticker before freeing the cluster / conn_mgr
         // it dereferences each period. The join is the lifetime barrier: once
@@ -6266,6 +6268,47 @@ mod tests {
     use std::time::{Duration, Instant};
 
     const TEST_REMOTE_ASK_TIMEOUT_MS: u64 = 250;
+
+    #[test]
+    fn accept_thread_stop_reports_panic_and_consumes_handle() {
+        let _runtime_guard = crate::runtime_test_guard();
+        crate::hew_clear_error();
+        let bind = CString::new("127.0.0.1:0").expect("valid bind address");
+        // SAFETY: bind is a valid C string for the duration of the call.
+        let node_ptr = unsafe { hew_node_new(991, bind.as_ptr()) };
+        assert!(!node_ptr.is_null());
+        // SAFETY: this test exclusively owns the live node allocation.
+        let node = unsafe { &mut *node_ptr };
+        *node.accept_thread.lock_or_recover() =
+            Some(std::thread::spawn(|| panic!("accept intentional panic")));
+
+        stop_node_accept_thread(node);
+
+        let error_ptr = crate::hew_last_error();
+        assert!(
+            !error_ptr.is_null(),
+            "joining a panicked accept thread must record a diagnostic"
+        );
+        // SAFETY: stop_node_accept_thread populated this thread's last-error slot.
+        let error = unsafe {
+            CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8")
+        };
+        assert!(
+            error.contains("hew node accept thread panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("accept intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        assert!(node.accept_stop.load(Ordering::Acquire));
+        assert!(node.accept_thread.lock_or_recover().is_none());
+
+        // SAFETY: the test owns node_ptr and its accept thread has been joined.
+        unsafe { hew_node_free(node_ptr) };
+    }
 
     #[test]
     fn monitor_and_link_setup_statuses_match_hew_error_discriminants() {

--- a/hew-runtime/src/profiler/mod.rs
+++ b/hew-runtime/src/profiler/mod.rs
@@ -158,7 +158,10 @@ pub fn maybe_start_with_context(
             let Some(disc_dir) = discovery::discovery_dir() else {
                 eprintln!("[hew-pprof] could not resolve a safe discovery directory");
                 PROFILER_SHUTDOWN.store(true, Ordering::Release);
-                let _ = sampler_handle.join();
+                crate::util::report_join_panic(
+                    "hew profiler sampler thread",
+                    sampler_handle.join(),
+                );
                 return;
             };
 
@@ -183,7 +186,7 @@ pub fn maybe_start_with_context(
     let Ok(server_handle) = server_handle else {
         eprintln!("[hew-pprof] failed to spawn server thread");
         PROFILER_SHUTDOWN.store(true, Ordering::Release);
-        let _ = sampler_handle.join();
+        crate::util::report_join_panic("hew profiler sampler thread", sampler_handle.join());
         return;
     };
 
@@ -312,8 +315,11 @@ pub(crate) fn shutdown() {
     // joining so no other path is blocked while we wait for the threads.
     let threads = PROFILER_STATE.access(Option::take);
     if let Some(threads) = threads {
-        let _ = threads.server_handle.join();
-        let _ = threads.sampler_handle.join();
+        crate::util::report_join_panic("hew profiler server thread", threads.server_handle.join());
+        crate::util::report_join_panic(
+            "hew profiler sampler thread",
+            threads.sampler_handle.join(),
+        );
     }
 
     // Clean up unix socket and discovery file if we were in unix mode.
@@ -323,5 +329,85 @@ pub(crate) fn shutdown() {
         if let Some(disc_dir) = disc_dir {
             discovery::cleanup(&disc_dir);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+
+    static PROFILER_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn last_error_string() -> String {
+        let error_ptr = crate::hew_last_error();
+        assert!(!error_ptr.is_null(), "expected a last-error diagnostic");
+        // SAFETY: the caller established that the current thread's last-error is set.
+        unsafe {
+            CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8")
+                .to_owned()
+        }
+    }
+
+    #[test]
+    fn shutdown_reports_server_panic_and_consumes_profiler_state() {
+        let _guard = PROFILER_TEST_MUTEX.lock_or_recover();
+        shutdown();
+        crate::hew_clear_error();
+        PROFILER_SHUTDOWN.store(false, Ordering::Release);
+        PROFILER_STATE.access(|state| {
+            *state = Some(ProfilerThreads {
+                server_handle: std::thread::spawn(|| {
+                    panic!("profiler server intentional panic");
+                }),
+                sampler_handle: std::thread::spawn(|| {}),
+            });
+        });
+
+        shutdown();
+
+        let error = last_error_string();
+        assert!(
+            error.contains("hew profiler server thread panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("profiler server intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        assert!(PROFILER_STATE.access(|state| state.is_none()));
+        assert!(PROFILER_SHUTDOWN.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn shutdown_reports_sampler_panic_and_consumes_profiler_state() {
+        let _guard = PROFILER_TEST_MUTEX.lock_or_recover();
+        shutdown();
+        crate::hew_clear_error();
+        PROFILER_SHUTDOWN.store(false, Ordering::Release);
+        PROFILER_STATE.access(|state| {
+            *state = Some(ProfilerThreads {
+                server_handle: std::thread::spawn(|| {}),
+                sampler_handle: std::thread::spawn(|| {
+                    panic!("profiler sampler intentional panic");
+                }),
+            });
+        });
+
+        shutdown();
+
+        let error = last_error_string();
+        assert!(
+            error.contains("hew profiler sampler thread panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("profiler sampler intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        assert!(PROFILER_STATE.access(|state| state.is_none()));
+        assert!(PROFILER_SHUTDOWN.load(Ordering::Acquire));
     }
 }

--- a/hew-runtime/src/reactor.rs
+++ b/hew-runtime/src/reactor.rs
@@ -1783,12 +1783,13 @@ fn queue_unregister_fds(fds: &[c_int]) {
 /// idempotent.
 pub(crate) fn reactor_shutdown() {
     REACTOR_STOP.store(true, Ordering::Release);
-    if let Some(slot) = REACTOR_HANDLE.get() {
-        if let Ok(mut guard) = slot.lock() {
-            if let Some(handle) = guard.take() {
-                let _ = handle.join();
-            }
-        }
+    let handle = REACTOR_HANDLE.get().and_then(|slot| {
+        slot.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    });
+    if let Some(handle) = handle {
+        crate::util::report_join_panic("hew I/O reactor thread", handle.join());
     }
     REACTOR_RUNNING.store(false, Ordering::SeqCst);
     REACTOR_STOP.store(false, Ordering::SeqCst);
@@ -2039,6 +2040,7 @@ fn fire_resume_pre_deposit_hook() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CStr;
     use std::sync::Mutex as StdMutex;
     use std::time::{Duration, Instant};
 
@@ -2083,6 +2085,53 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(500),
             "reactor join took too long ({elapsed:?}) — possible hung thread"
+        );
+    }
+
+    #[test]
+    fn reactor_shutdown_reports_worker_panic_and_clears_state() {
+        let _guard = REACTOR_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset_reactor();
+        crate::hew_clear_error();
+
+        REACTOR_STATE.access(|state| state.pending.push(Pending::Remove { conn: 17 }));
+        let slot = REACTOR_HANDLE.get_or_init(|| Mutex::new(None));
+        *slot
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(std::thread::spawn(|| panic!("reactor intentional panic")));
+        REACTOR_RUNNING.store(true, Ordering::SeqCst);
+
+        reactor_shutdown();
+
+        let error_ptr = crate::hew_last_error();
+        assert!(
+            !error_ptr.is_null(),
+            "joining a panicked reactor must record a diagnostic"
+        );
+        // SAFETY: reactor_shutdown populated this thread's last-error slot.
+        let error = unsafe {
+            CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8")
+        };
+        assert!(
+            error.contains("hew I/O reactor thread panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("reactor intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        assert!(!REACTOR_RUNNING.load(Ordering::SeqCst));
+        assert!(REACTOR_STATE.access(|state| state.pending.is_empty()));
+        assert!(
+            slot.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_none(),
+            "shutdown must consume the reactor join handle"
         );
     }
 

--- a/hew-runtime/src/swim_driver.rs
+++ b/hew-runtime/src/swim_driver.rs
@@ -275,7 +275,7 @@ pub(crate) unsafe fn stop_swim_driver(node: *mut HewNode) {
     };
     handle.stop.store(true, Ordering::Release);
     if let Some(join) = handle.join.take() {
-        let _ = join.join();
+        crate::util::report_join_panic("hew SWIM driver thread", join.join());
     }
 }
 
@@ -417,6 +417,7 @@ unsafe fn run_one_period(node: *mut HewNode) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CStr;
 
     /// Stopping a node with no running driver is a safe no-op.
     #[test]
@@ -470,5 +471,50 @@ mod tests {
 
         // SAFETY: node was allocated by hew_node_new and the driver is stopped.
         unsafe { crate::hew_node::hew_node_free(node) };
+    }
+
+    #[test]
+    fn stop_reports_driver_panic_and_removes_registry_entry() {
+        crate::hew_clear_error();
+        let node = 0xdead_1000 as *mut HewNode;
+        let stop = Arc::new(AtomicBool::new(false));
+        let join = std::thread::spawn(|| panic!("SWIM driver intentional panic"));
+        SWIM_DRIVERS.access(|slot| {
+            slot.get_or_insert_with(HashMap::new).insert(
+                node as usize,
+                DriverHandle {
+                    stop: Arc::clone(&stop),
+                    join: Some(join),
+                },
+            );
+        });
+
+        // SAFETY: the fabricated pointer is used only as a registry key.
+        unsafe { stop_swim_driver(node) };
+
+        let error_ptr = crate::hew_last_error();
+        assert!(
+            !error_ptr.is_null(),
+            "joining a panicked SWIM driver must record a diagnostic"
+        );
+        // SAFETY: stop_swim_driver populated this thread's last-error slot.
+        let error = unsafe {
+            CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8")
+        };
+        assert!(
+            error.contains("hew SWIM driver thread panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("SWIM driver intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
+        );
+        assert!(stop.load(Ordering::Acquire));
+        assert!(SWIM_DRIVERS.access(|slot| {
+            slot.as_ref()
+                .is_none_or(|table| !table.contains_key(&(node as usize)))
+        }));
     }
 }

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -1604,7 +1604,7 @@ pub unsafe extern "C" fn hew_task_scope_join_all(scope: *mut HewTaskScope) {
         if detach_cancelled_worker {
             t.detached_on_cancel = true;
         } else if let Some(handle) = t.thread_handle.take() {
-            let _ = handle.join();
+            crate::util::report_join_panic("task scope worker thread", handle.join());
             t.detached_on_cancel = false;
         } else {
             t.detached_on_cancel = false;
@@ -1688,7 +1688,7 @@ unsafe fn cancel_scope_deadlines(scope: &mut HewTaskScope) {
         deadline.cancelled.store(true, Ordering::Release);
         if let Some(handle) = deadline.thread_handle.take() {
             handle.thread().unpark();
-            let _ = handle.join();
+            crate::util::report_join_panic("task scope deadline thread", handle.join());
         }
     }
 }
@@ -3605,6 +3605,95 @@ mod tests {
             error.contains("detached worker intentional panic"),
             "panic payload must be included in the diagnostic: {error}"
         );
+    }
+
+    #[test]
+    fn scope_join_reports_worker_panic_and_consumes_handle() {
+        crate::hew_clear_error();
+        // SAFETY: this test exclusively owns the scope and task allocations.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_scope_spawn(scope, task);
+            (*task).store_state(HewTaskState::Running, Ordering::Release);
+            (*task).thread_handle = Some(std::thread::spawn(|| {
+                panic!("scope worker intentional panic")
+            }));
+
+            hew_task_scope_join_all(scope);
+
+            let error_ptr = crate::hew_last_error();
+            assert!(
+                !error_ptr.is_null(),
+                "joining a panicked scope worker must record a diagnostic"
+            );
+            // SAFETY: hew_task_scope_join_all populated this thread's last-error slot.
+            let error = CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8");
+            assert!(
+                error.contains("task scope worker thread panicked during teardown"),
+                "unexpected last error: {error}"
+            );
+            assert!(
+                error.contains("scope worker intentional panic"),
+                "panic payload must be included in the diagnostic: {error}"
+            );
+            assert!(
+                (*task).thread_handle.is_none(),
+                "join_all must consume the worker handle"
+            );
+            assert!(!(*task).detached_on_cancel);
+
+            hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn scope_destroy_reports_deadline_panic_and_reclaims_deadline() {
+        crate::hew_clear_error();
+        // SAFETY: this test exclusively owns the scope and deadline allocation.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let cancelled = Arc::new(AtomicBool::new(false));
+            (*scope).deadlines = Box::into_raw(Box::new(HewTaskScopeDeadline {
+                cancelled: Arc::clone(&cancelled),
+                thread_handle: Some(std::thread::spawn(|| {
+                    panic!("scope deadline intentional panic");
+                })),
+                next: ptr::null_mut(),
+            }));
+
+            cancel_scope_deadlines(&mut *scope);
+
+            let error_ptr = crate::hew_last_error();
+            assert!(
+                !error_ptr.is_null(),
+                "joining a panicked deadline thread must record a diagnostic"
+            );
+            // SAFETY: cancel_scope_deadlines populated this thread's last-error slot.
+            let error = CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8");
+            assert!(
+                error.contains("task scope deadline thread panicked during teardown"),
+                "unexpected last error: {error}"
+            );
+            assert!(
+                error.contains("scope deadline intentional panic"),
+                "panic payload must be included in the diagnostic: {error}"
+            );
+            assert!(
+                (*scope).deadlines.is_null(),
+                "deadline cleanup must unlink the reclaimed node"
+            );
+            assert!(
+                cancelled.load(Ordering::Acquire),
+                "deadline cleanup must publish cancellation before joining"
+            );
+
+            hew_task_scope_destroy(scope);
+        }
     }
 
     #[test]

--- a/hew-runtime/src/util.rs
+++ b/hew-runtime/src/util.rs
@@ -69,6 +69,19 @@ pub(crate) fn panic_payload_message(panic_payload: &(dyn std::any::Any + Send)) 
     }
 }
 
+/// Report a background-thread panic observed while joining during teardown.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn report_join_panic(context: &str, join_result: std::thread::Result<()>) {
+    if let Err(panic_payload) = join_result {
+        let message = format!(
+            "{context} panicked during teardown: {}",
+            panic_payload_message(panic_payload.as_ref())
+        );
+        crate::set_last_error(message.clone());
+        eprintln!("hew: {message}");
+    }
+}
+
 /// Extension trait for [`Mutex`] that recovers from poisoned locks.
 pub(crate) trait MutexExt<T> {
     fn lock_or_recover(&self) -> MutexGuard<'_, T>;


### PR DESCRIPTION
## Summary

Background and worker threads across the runtime no longer swallow panics at teardown. Following the earlier fix for the blocking pool and periodic timer, this extends the same join-inspection to the remaining teardown paths — the reactor, SWIM driver, node accept thread, connection reader/reconnect/manager-free/reverse-link workers, profiler sampler and server, and task-scope worker/deadline threads. Each now inspects its join result and reports a panicked thread (context plus payload) instead of discarding it; join ordering and normal-path behaviour are unchanged, and deliberate test-only joins are left as-is.

## Verification

- New tests spawn a panicking thread at each converted teardown path and assert the panic is reported (context and message) with the handle consumed and state cleared.
- Full `hew-runtime` test suite: passing.
- `cargo fmt --check` and lint: clean.

## Out of scope

Nothing.