### PR TITLE
fix(runtime): refresh identity before connection teardown

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -4340,10 +4340,24 @@ pub unsafe extern "C" fn hew_connmgr_remove(mgr: *mut HewConnMgr, conn_id: c_int
     {
         let _publication = publication_sync.lock_or_recover();
         publication_removed.store(true, Ordering::Release);
-        if !mgr.routing_table.is_null() {
-            let Some(peer_identity) = peer_identity else {
-                return -1;
-            };
+    }
+    // Publication may have filled in the identity after the initial lookup
+    // snapshot. Refresh it only after cancellation is serialized: an earlier
+    // publisher has now exposed its identity and route, while a later one must
+    // observe `publication_removed` and cannot add a route.
+    let peer_identity = peer_identity.or_else(|| {
+        mgr.connections.access(|connections| {
+            connections
+                .iter()
+                .find(|connection| {
+                    connection.conn_id == conn_id
+                        && connection.publication_token == publication_token
+                })
+                .and_then(|connection| connection.peer_identity)
+        })
+    });
+    if !mgr.routing_table.is_null() {
+        if let Some(peer_identity) = peer_identity {
             // SAFETY: routing_table is valid per manager contract.
             let _ = unsafe {
                 hew_routing_remove_route_if_conn(mgr.routing_table, peer_identity, conn_id)


### PR DESCRIPTION
## Why

Main CI currently times out
`connection::tests::connmgr_publish_skips_removed_connection_while_establish_blocks`
on both Linux and Windows
([run 29842052171](https://github.com/hew-lang/hew/actions/runs/29842052171)).

During an establish/remove race, removal can snapshot a connection before
publication has filled in its peer identity. After serializing publication
cancellation, the previous path returned before route cleanup and transport
close. The regression waits for that close and therefore wedges. The
publication/removal race coverage was introduced in #660; this is a follow-up
to that invariant, not a closure for a separate issue.

## What

- Cancel establishment publication while holding the publication
  synchronization lock.
- Refresh peer identity only from the exact connection ID and publication token
  after cancellation is serialized.
- Remove only the route owned by that exact connection when an identity is
  available.
- Continue transport close, claim retirement, and teardown when the original
  identity snapshot was empty.

This changes no public API or runtime ABI.

## Test

- `cargo nextest run -p hew-runtime --profile ci --no-fail-fast` — 2619/2619
- Repeated `connmgr_publish_skips_removed_connection_while_establish_blocks`
  race regression — 100/100
- Repeated no-routing-table and reentrant-remove sibling regressions — 100/100
- Connection module — 68/68
- `cargo fmt --check`
- `cargo clippy -p hew-runtime --all-targets -- -D warnings`

Linux, Windows, macOS, and the ordinary PR checks remain the promotion gate.

## Quality Checklist

- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [x] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
- [x] No new allocations or cleanup obligations
- [x] No serialization-format changes
- [x] No new runtime feature or exported symbol
- [x] No duplicated logic — checked for existing helpers before adding new ones
