### PR TITLE
fix(mir): drop fresh Vec projection clones

### DIFF
--- a/examples/v05/checked-mir/golden/vec_owned_elems.elab.mir
+++ b/examples/v05/checked-mir/golden/vec_owned_elems.elab.mir
@@ -55,7 +55,9 @@ fn main -> ()
     use BindingId(10) tags site=SiteId(105) ty=Vec<Tag> intent=Read
     bind BindingId(12) tail_tags site=SiteId(104) ty=Vec<Tag>
     use BindingId(12) tail_tags site=SiteId(111) ty=Vec<Tag> intent=Read
+    bind BindingId(4294967231) __hew_vec_get_clone_projection_base site=SiteId(110) ty=Tag
     eval site=SiteId(108) ty=()
+    drop BindingId(4294967231) __hew_vec_get_clone_projection_base ty=Tag
     drop BindingId(12) tail_tags ty=Vec<Tag>
     drop BindingId(11) t ty=Tag
     drop BindingId(10) tags ty=Vec<Tag>
@@ -219,6 +221,7 @@ fn main -> ()
     call[bb51 println_i64 -> bb52] ->
       (none)
     return[bb52] ->
+      drop _92 ty=Tag kind=record_in_place
       drop _88 ty=Vec<Tag> kind=cow_heap(hew_vec_free_owned)
       drop _80 ty=Tag kind=record_in_place
       drop _69 ty=Vec<Tag> kind=cow_heap(hew_vec_free_owned)

--- a/examples/v05/checked-mir/golden/vec_owned_elems.raw.mir
+++ b/examples/v05/checked-mir/golden/vec_owned_elems.raw.mir
@@ -342,6 +342,7 @@ fn main() -> () [conv=default]
   bb50:
     _92 = call hew_vec_get_clone(_88, _89) -> bb51
   bb51:
+    stmt: bind BindingId(4294967231) __hew_vec_get_clone_projection_base site=SiteId(110) ty=Tag
     _93 = _92.field[1]
     call println_i64(_93) -> bb52
   bb52:

--- a/hew-cli/tests/fresh_vec_index_projection_drop_leak_oracle.rs
+++ b/hew-cli/tests/fresh_vec_index_projection_drop_leak_oracle.rs
@@ -1,0 +1,88 @@
+//! Direct projection from a fresh `Vec` composite-index result must release the
+//! cloned root once, without changing the bound-index control's ownership.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+fn direct_projection_source(frames: usize) -> String {
+    format!(
+        "record Holder {{\n\
+         \x20   items: [string],\n\
+         }}\n\
+         \n\
+         fn frame() -> i64 {{\n\
+         \x20   let v: [Holder] = [];\n\
+         \x20   v.push(Holder {{ items: [\"left\", \"right\"] }});\n\
+         \x20   v[0].items.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total == {} {{ 0 }} else {{ 71 }}\n\
+         }}\n",
+        frames * 2
+    )
+}
+
+fn bound_projection_source(frames: usize) -> String {
+    format!(
+        "record Holder {{\n\
+         \x20   items: [string],\n\
+         }}\n\
+         \n\
+         fn frame() -> i64 {{\n\
+         \x20   let v: [Holder] = [];\n\
+         \x20   v.push(Holder {{ items: [\"left\", \"right\"] }});\n\
+         \x20   let h = v[0];\n\
+         \x20   h.items.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total == {} {{ 0 }} else {{ 72 }}\n\
+         }}\n",
+        frames * 2
+    )
+}
+
+#[test]
+fn direct_fresh_vec_projection_has_no_per_frame_leak() {
+    assert_frame_slope_below_tolerance("fresh_vec_index_projection", direct_projection_source);
+}
+
+#[test]
+fn bound_fresh_vec_index_control_has_no_per_frame_leak() {
+    assert_frame_slope_below_tolerance("bound_vec_index_projection", bound_projection_source);
+}
+
+#[test]
+fn direct_fresh_vec_projection_returns_exact_result_under_malloc_scribble() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("fresh-vec-index-projection-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(&direct_projection_source(3), dir.path(), "projection");
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "direct projection must return its exact accumulated value under the poisoned allocator;\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-cli/tests/fresh_vec_index_projection_drop_leak_oracle.rs
+++ b/hew-cli/tests/fresh_vec_index_projection_drop_leak_oracle.rs
@@ -61,6 +61,88 @@ fn bound_projection_source(frames: usize) -> String {
     )
 }
 
+fn early_return_projection_source(frames: usize) -> String {
+    format!(
+        "record Holder {{\n\
+         \x20   items: [string],\n\
+         }}\n\
+         \n\
+         fn frame(flag: bool) -> i64 {{\n\
+         \x20   let v: [Holder] = [];\n\
+         \x20   v.push(Holder {{ items: [\"left\", \"right\"] }});\n\
+         \x20   if flag {{\n\
+         \x20       return v[0].items.len();\n\
+         \x20   }}\n\
+         \x20   99\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame(true);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total == {} {{ 0 }} else {{ 73 }}\n\
+         }}\n",
+        frames * 2
+    )
+}
+
+fn break_projection_source(frames: usize) -> String {
+    format!(
+        "record Holder {{\n\
+         \x20   items: [string],\n\
+         }}\n\
+         \n\
+         fn frame() -> i64 {{\n\
+         \x20   let v: [Holder] = [];\n\
+         \x20   v.push(Holder {{ items: [\"left\", \"right\"] }});\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   while total == 0 {{\n\
+         \x20       total = v[0].items.len();\n\
+         \x20       break;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total == {} {{ 0 }} else {{ 74 }}\n\
+         }}\n",
+        frames * 2
+    )
+}
+
+/// Moving the projected field out is deliberately a correctness-only pin.
+/// The generic owned-record field-escape path has a separately proven,
+/// pre-existing leak and is outside this narrow fix; this fixture prevents the
+/// new synthetic root owner from turning that known leak into a double-free or
+/// use-after-free without falsely claiming leak closure.
+fn escaped_projection_source() -> String {
+    "record Holder {\n\
+     \x20   items: [string],\n\
+     }\n\
+     \n\
+     fn take_items() -> [string] {\n\
+     \x20   let v: [Holder] = [];\n\
+     \x20   v.push(Holder { items: [\"left\", \"right\"] });\n\
+     \x20   let items = v[0].items;\n\
+     \x20   items\n\
+     }\n\
+     \n\
+     fn main() -> i64 {\n\
+     \x20   let items = take_items();\n\
+     \x20   if items.len() == 2 { 0 } else { 75 }\n\
+     }\n"
+    .to_string()
+}
+
 #[test]
 fn direct_fresh_vec_projection_has_no_per_frame_leak() {
     assert_frame_slope_below_tolerance("fresh_vec_index_projection", direct_projection_source);
@@ -69,6 +151,19 @@ fn direct_fresh_vec_projection_has_no_per_frame_leak() {
 #[test]
 fn bound_fresh_vec_index_control_has_no_per_frame_leak() {
     assert_frame_slope_below_tolerance("bound_vec_index_projection", bound_projection_source);
+}
+
+#[test]
+fn early_return_fresh_vec_projection_has_no_per_frame_leak() {
+    assert_frame_slope_below_tolerance(
+        "early_return_fresh_vec_index_projection",
+        early_return_projection_source,
+    );
+}
+
+#[test]
+fn break_fresh_vec_projection_has_no_per_frame_leak() {
+    assert_frame_slope_below_tolerance("break_fresh_vec_index_projection", break_projection_source);
 }
 
 #[test]
@@ -83,6 +178,26 @@ fn direct_fresh_vec_projection_returns_exact_result_under_malloc_scribble() {
     assert!(
         output.status.success(),
         "direct projection must return its exact accumulated value under the poisoned allocator;\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn escaped_projection_field_remains_live_under_malloc_scribble() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("fresh-vec-index-projection-escape-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        &escaped_projection_source(),
+        dir.path(),
+        "projection_escape",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "a transferred projected field must remain live under the poisoned allocator;\n{}",
         describe_output(&output)
     );
 }

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -1935,6 +1935,19 @@ pub(super) fn derive_owned_record_drop_allowed(
                     }
                 }
             }
+            // A destructive functional update over an owned nested-record
+            // binder uses `RecordFieldDrop` for an overridden COW leaf. The
+            // binder aliases its parent root's storage, so the leaf release
+            // discharges part of that root just like the `FieldDropInPlace`
+            // case above. Exclude the attributed root or its later recursive
+            // drop would release the overridden leaf a second time. Keep a
+            // whole-root `RecordFieldDrop` on the existing interior-operation
+            // path below; only an attributed field binder transfers ownership.
+            if let Instr::RecordFieldDrop { record, .. } = instr {
+                if let Some(l) = base_local(*record).filter(|local| is_escape_binder(*local)) {
+                    note_field_escape(l, &mut excluded_roots);
+                }
+            }
             // A `Move` discriminates a benign whole-value hand-off (dest is
             // another alias member) from a real whole-record escape.
             if let Instr::Move { dest, src } = instr {

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -12,12 +12,13 @@ use super::{
     unresolved_fn_sig_reason, user_record_layout_key, vec_iter_let_cursor_owns_handle,
     vec_iter_ty_drop_safe, ActorStateLoadMode, BinaryOp, BindingId, Builder, BuiltinType,
     ChildKind, ClosurePairRhs, CmpPred, Disposition, FailClosedReason, FieldOffset, FloatWidth,
-    HashMap, HashSet, HirExpr, HirExprKind, HirLiteral, HirStmtKind, HirVarSelfMethodTarget, Instr,
-    IntArithOp, IntSignedness, IntentKind, MirDiagnostic, MirDiagnosticKind, MirStatement,
-    NumericMethodFamily, Place, ProjectedPayloadOrigin, ProjectedPayloadRejectReason,
-    ReleaseSymbolVerdict, ResolvedRef, ResolvedTy, RuntimeCallContext, SiteId, SuspendKind,
-    Terminator, TrapKind, UnaryOp, ValueClass, VecElementRelease, FOR_ITER_CURSOR_NAME_PREFIX,
-    SENTINEL_RECV_GEN_COMPANION_BINDING, SYNTHETIC_TEMP_ARG_NAME,
+    FreshVecGetCloneProjectionBase, HashMap, HashSet, HirExpr, HirExprKind, HirLiteral,
+    HirStmtKind, HirVarSelfMethodTarget, Instr, IntArithOp, IntSignedness, IntentKind,
+    MirDiagnostic, MirDiagnosticKind, MirStatement, NumericMethodFamily, Place,
+    ProjectedPayloadOrigin, ProjectedPayloadRejectReason, ReleaseSymbolVerdict, ResolvedRef,
+    ResolvedTy, RuntimeCallContext, SiteId, SuspendKind, Terminator, TrapKind, UnaryOp, ValueClass,
+    VecElementRelease, FOR_ITER_CURSOR_NAME_PREFIX, SENTINEL_RECV_GEN_COMPANION_BINDING,
+    SYNTHETIC_TEMP_ARG_NAME,
 };
 #[cfg(test)]
 use super::{FieldLoadClass, PlaceProvenance, Projection, ValueProvenance};
@@ -4037,6 +4038,7 @@ impl Builder {
                 };
                 self.mark_owned_string_record_field_site(object);
                 let record_place = self.lower_value(object)?;
+                self.register_fresh_vec_get_clone_projection_base_owner(object, record_place);
                 let dest = self.alloc_local(self.subst_ty(&expr.ty));
                 self.push_instr(Instr::RecordFieldLoad {
                     record: record_place,
@@ -6915,6 +6917,9 @@ impl Builder {
         };
 
         let result_place = self.alloc_local(elem_ty.clone());
+        let Place::Local(result_local) = result_place else {
+            unreachable!("alloc_local always returns a local place");
+        };
         if clone_owned_value {
             let next = self.alloc_block();
             self.finish_current_block(Terminator::Call {
@@ -6925,6 +6930,12 @@ impl Builder {
                 next,
             });
             self.start_block(next);
+            self.fresh_vec_get_clone_projection_bases
+                .push(FreshVecGetCloneProjectionBase {
+                    local: result_local,
+                    ty: elem_ty.clone(),
+                    site,
+                });
         } else {
             self.push_instr(Instr::CallRuntimeAbi(
                 crate::model::RuntimeCall::new(

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -12,13 +12,12 @@ use super::{
     unresolved_fn_sig_reason, user_record_layout_key, vec_iter_let_cursor_owns_handle,
     vec_iter_ty_drop_safe, ActorStateLoadMode, BinaryOp, BindingId, Builder, BuiltinType,
     ChildKind, ClosurePairRhs, CmpPred, Disposition, FailClosedReason, FieldOffset, FloatWidth,
-    FreshVecGetCloneProjectionBase, HashMap, HashSet, HirExpr, HirExprKind, HirLiteral,
-    HirStmtKind, HirVarSelfMethodTarget, Instr, IntArithOp, IntSignedness, IntentKind,
-    MirDiagnostic, MirDiagnosticKind, MirStatement, NumericMethodFamily, Place,
-    ProjectedPayloadOrigin, ProjectedPayloadRejectReason, ReleaseSymbolVerdict, ResolvedRef,
-    ResolvedTy, RuntimeCallContext, SiteId, SuspendKind, Terminator, TrapKind, UnaryOp, ValueClass,
-    VecElementRelease, FOR_ITER_CURSOR_NAME_PREFIX, SENTINEL_RECV_GEN_COMPANION_BINDING,
-    SYNTHETIC_TEMP_ARG_NAME,
+    HashMap, HashSet, HirExpr, HirExprKind, HirLiteral, HirStmtKind, HirVarSelfMethodTarget, Instr,
+    IntArithOp, IntSignedness, IntentKind, MirDiagnostic, MirDiagnosticKind, MirStatement,
+    NumericMethodFamily, Place, ProjectedPayloadOrigin, ProjectedPayloadRejectReason,
+    ReleaseSymbolVerdict, ResolvedRef, ResolvedTy, RuntimeCallContext, SiteId, SuspendKind,
+    Terminator, TrapKind, UnaryOp, ValueClass, VecElementRelease, FOR_ITER_CURSOR_NAME_PREFIX,
+    SENTINEL_RECV_GEN_COMPANION_BINDING, SYNTHETIC_TEMP_ARG_NAME,
 };
 #[cfg(test)]
 use super::{FieldLoadClass, PlaceProvenance, Projection, ValueProvenance};
@@ -6917,9 +6916,6 @@ impl Builder {
         };
 
         let result_place = self.alloc_local(elem_ty.clone());
-        let Place::Local(result_local) = result_place else {
-            unreachable!("alloc_local always returns a local place");
-        };
         if clone_owned_value {
             let next = self.alloc_block();
             self.finish_current_block(Terminator::Call {
@@ -6930,12 +6926,7 @@ impl Builder {
                 next,
             });
             self.start_block(next);
-            self.fresh_vec_get_clone_projection_bases
-                .push(FreshVecGetCloneProjectionBase {
-                    local: result_local,
-                    ty: elem_ty.clone(),
-                    site,
-                });
+            self.note_fresh_vec_clone_projection_base(result_place, elem_ty.clone(), site);
         } else {
             self.push_instr(Instr::CallRuntimeAbi(
                 crate::model::RuntimeCall::new(

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -289,6 +289,10 @@ const SYNTHETIC_DISCARDED_CALL_RESULT_NAME: &str = "__hew_discarded_call_result"
 /// once at caller scope exit. Gated on the target param being BORROW (a CONSUME
 /// target's temporary is the callee's obligation — no caller drop).
 const SYNTHETIC_TEMP_ARG_NAME: &str = "__hew_temp_arg";
+/// Name for the owner of a fresh composite cloned from a `Vec` solely to read
+/// one of its fields. The clone result has no source binding, so this owner
+/// carries it through the ordinary scope-exit drop machinery.
+const SYNTHETIC_VEC_GET_CLONE_PROJECTION_BASE_NAME: &str = "__hew_vec_get_clone_projection_base";
 /// Name for the owner minted over a fresh Vec COPY-IN element temporary when
 /// every whole by-value parameter embedded in it is a retained string share.
 /// The binding owns the temporary's retained share only; the parameter remains
@@ -445,6 +449,9 @@ struct Builder {
     /// descending per-function range that stays clear of both the fixed
     /// `u32::MAX ..= u32::MAX - 4` sentinels and real HIR binding ids.
     pub(crate) synthetic_owned_temp_bindings: u32,
+    /// Fresh composite clone results emitted by `lower_vec_index`. A direct
+    /// record projection consumes its matching local once and mints the owner.
+    pub(crate) fresh_vec_get_clone_projection_bases: Vec<FreshVecGetCloneProjectionBase>,
     /// Per-function destructive-funcupdate base provenance. Maps a `BindingId`
     /// to whether `{ ..<binding>, f: new }` over it is a PROVEN unique owner of
     /// its heap fields — i.e. consuming it leaves no live alias, so the
@@ -1350,6 +1357,13 @@ struct Builder {
     /// host-width guards — a fail-open hole). Defaults to `Bits64` (every native
     /// target); the host-defaulting `lower_hir_module` wrapper keeps the default.
     pub(crate) pointer_width: PointerWidth,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FreshVecGetCloneProjectionBase {
+    pub(crate) local: u32,
+    pub(crate) ty: ResolvedTy,
+    pub(crate) site: SiteId,
 }
 
 #[must_use]

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -4,14 +4,15 @@ use super::{
     monomorphic_user_record_key, named_type_marker, ty_is_closure_pair,
     ty_is_heap_owning_enum_composite, ty_is_local_collection_handle, user_record_layout_key,
     vec_iter_record_layout_key, ActiveIterationOwner, BindingId, Builder, BuiltinType,
-    ClosurePairIngress, CmpPred, DecisionFact, Disposition, FieldLoadClass, HashMap, HashSet,
-    HirBinding, HirBlock, HirExpr, HirExprKind, HirStmtKind, Instr, IntentKind, LayoutClass,
-    MirDiagnostic, MirDiagnosticKind, MirStatement, OwnedLocalEntry, OwnershipCtx,
-    OwnershipDecision, Place, PlaceProvenance, Projection, ResolvedRef, ResolvedTy, ResourceMarker,
-    SiteId, Strategy, Terminator, ValueClass, ValueOwnership, ValueProvenance,
-    SYNTHETIC_CALL_SCRUTINEE_NAME, SYNTHETIC_COPY_IN_PARAM_TEMP_NAME,
-    SYNTHETIC_DISCARDED_CALL_RESULT_NAME, SYNTHETIC_OWNED_TEMP_BINDING_BASE,
-    SYNTHETIC_VEC_GET_CLONE_PROJECTION_BASE_NAME, SYNTHETIC_WHILE_LET_ITERATION_NAME,
+    ClosurePairIngress, CmpPred, DecisionFact, Disposition, FieldLoadClass,
+    FreshVecGetCloneProjectionBase, HashMap, HashSet, HirBinding, HirBlock, HirExpr, HirExprKind,
+    HirStmtKind, Instr, IntentKind, LayoutClass, MirDiagnostic, MirDiagnosticKind, MirStatement,
+    OwnedLocalEntry, OwnershipCtx, OwnershipDecision, Place, PlaceProvenance, Projection,
+    ResolvedRef, ResolvedTy, ResourceMarker, SiteId, Strategy, Terminator, ValueClass,
+    ValueOwnership, ValueProvenance, SYNTHETIC_CALL_SCRUTINEE_NAME,
+    SYNTHETIC_COPY_IN_PARAM_TEMP_NAME, SYNTHETIC_DISCARDED_CALL_RESULT_NAME,
+    SYNTHETIC_OWNED_TEMP_BINDING_BASE, SYNTHETIC_VEC_GET_CLONE_PROJECTION_BASE_NAME,
+    SYNTHETIC_WHILE_LET_ITERATION_NAME,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,6 +106,19 @@ impl Builder {
         self.record_binding_scope(binding);
         self.register_owned_local(binding, name.to_string(), ty);
         binding
+    }
+
+    pub(crate) fn note_fresh_vec_clone_projection_base(
+        &mut self,
+        place: Place,
+        ty: ResolvedTy,
+        site: SiteId,
+    ) {
+        let Place::Local(local) = place else {
+            unreachable!("the Vec clone destination is always a local");
+        };
+        self.fresh_vec_get_clone_projection_bases
+            .push(FreshVecGetCloneProjectionBase { local, ty, site });
     }
 
     /// Registers the ordinary scope-exit owner for a fresh composite cloned by

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -11,7 +11,7 @@ use super::{
     SiteId, Strategy, Terminator, ValueClass, ValueOwnership, ValueProvenance,
     SYNTHETIC_CALL_SCRUTINEE_NAME, SYNTHETIC_COPY_IN_PARAM_TEMP_NAME,
     SYNTHETIC_DISCARDED_CALL_RESULT_NAME, SYNTHETIC_OWNED_TEMP_BINDING_BASE,
-    SYNTHETIC_WHILE_LET_ITERATION_NAME,
+    SYNTHETIC_VEC_GET_CLONE_PROJECTION_BASE_NAME, SYNTHETIC_WHILE_LET_ITERATION_NAME,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,6 +105,49 @@ impl Builder {
         self.record_binding_scope(binding);
         self.register_owned_local(binding, name.to_string(), ty);
         binding
+    }
+
+    /// Registers the ordinary scope-exit owner for a fresh composite cloned by
+    /// `Vec` indexing and immediately used as a record-projection base.
+    pub(crate) fn register_fresh_vec_get_clone_projection_base_owner(
+        &mut self,
+        object: &HirExpr,
+        record_place: Place,
+    ) {
+        if !matches!(object.kind, HirExprKind::Index { .. }) {
+            return;
+        }
+        let Place::Local(local) = record_place else {
+            return;
+        };
+        let object_ty = self.subst_ty(&object.ty);
+        let Some(fact_index) = self
+            .fresh_vec_get_clone_projection_bases
+            .iter()
+            .position(|fact| fact.local == local && fact.ty == object_ty)
+        else {
+            return;
+        };
+        if self.parameter_locals.contains(&local)
+            || self
+                .binding_locals
+                .values()
+                .any(|place| *place == record_place)
+            || !crate::model::ty_owns_heap_mir(
+                &object_ty,
+                &self.record_field_orders,
+                &self.enum_layouts,
+            )
+        {
+            return;
+        }
+        let fact = self.fresh_vec_get_clone_projection_bases.remove(fact_index);
+        self.register_synthetic_owned_local(
+            SYNTHETIC_VEC_GET_CLONE_PROJECTION_BASE_NAME,
+            fact.site,
+            fact.local,
+            fact.ty,
+        );
     }
     /// Register a `let`-bound field projection whose result is a byte-copy
     /// interior ALIAS of the still-live owner named by `provenance` — the

--- a/hew-mir/tests/lowering_expr.rs
+++ b/hew-mir/tests/lowering_expr.rs
@@ -18,6 +18,8 @@ mod cstring_container_domain_canary;
 mod elaborate;
 #[path = "lowering_expr/forawait_loopvar_release.rs"]
 mod forawait_loopvar_release;
+#[path = "lowering_expr/fresh_vec_projection_owner.rs"]
+mod fresh_vec_projection_owner;
 #[path = "lowering_expr/gen_block_mir_lowering.rs"]
 mod gen_block_mir_lowering;
 #[path = "lowering_expr/generic_record_layout_test.rs"]

--- a/hew-mir/tests/lowering_expr/fresh_vec_projection_owner.rs
+++ b/hew-mir/tests/lowering_expr/fresh_vec_projection_owner.rs
@@ -1,0 +1,268 @@
+//! Structural ownership pins for fresh owned records cloned by `Vec` indexing
+//! and used immediately as record-projection bases.
+
+use hew_mir::{DropKind, ExitPath, Instr, IrPipeline, MirStatement, Place, Terminator};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+const OWNER_NAME: &str = "__hew_vec_get_clone_projection_base";
+
+fn pipeline(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = hew_hir::lower_program(
+        &parsed.program,
+        &tc_output,
+        &hew_hir::ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    let pipeline = hew_mir::lower_hir_module(&output.module);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "MIR diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    pipeline
+}
+
+fn synthetic_binds(pipeline: &IrPipeline, fn_name: &str) -> usize {
+    pipeline
+        .raw_mir
+        .iter()
+        .find(|function| function.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .blocks
+        .iter()
+        .flat_map(|block| block.statements.iter())
+        .filter(
+            |statement| matches!(statement, MirStatement::Bind { name, .. } if name == OWNER_NAME),
+        )
+        .count()
+}
+
+fn synthetic_locals(pipeline: &IrPipeline, fn_name: &str) -> Vec<u32> {
+    pipeline
+        .raw_mir
+        .iter()
+        .find(|function| function.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .local_names
+        .iter()
+        .enumerate()
+        .filter(|(_, name)| name.as_deref() == Some(OWNER_NAME))
+        .map(|(local, _)| {
+            u32::try_from(local).expect("MIR local index must fit its u32 identity domain")
+        })
+        .collect()
+}
+
+fn call_count(pipeline: &IrPipeline, fn_name: &str, symbol: &str) -> usize {
+    pipeline
+        .raw_mir
+        .iter()
+        .find(|function| function.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .blocks
+        .iter()
+        .filter(|block| {
+            matches!(
+                &block.terminator,
+                Terminator::Call { callee, .. } if callee == symbol
+            )
+        })
+        .count()
+}
+
+fn runtime_call_count(pipeline: &IrPipeline, fn_name: &str, symbol: &str) -> usize {
+    pipeline
+        .raw_mir
+        .iter()
+        .find(|function| function.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter(|instruction| {
+            matches!(instruction, Instr::CallRuntimeAbi(call) if call.symbol() == symbol)
+        })
+        .count()
+}
+
+fn synthetic_drop_exits<'a>(
+    pipeline: &'a IrPipeline,
+    fn_name: &str,
+    local: u32,
+) -> Vec<(&'a ExitPath, usize)> {
+    pipeline
+        .elaborated_mir
+        .iter()
+        .find(|function| function.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .drop_plans
+        .iter()
+        .filter_map(|(exit, plan)| {
+            let count = plan
+                .drops
+                .iter()
+                .filter(|drop| {
+                    drop.place == Place::Local(local)
+                        && matches!(drop.kind, DropKind::RecordInPlace)
+                })
+                .count();
+            (count != 0).then_some((exit, count))
+        })
+        .collect()
+}
+
+#[test]
+fn direct_projection_gets_exactly_one_synthetic_root_but_bound_control_does_not() {
+    let p = pipeline(
+        r#"
+record Holder { items: Vec<string> }
+
+fn direct() -> i64 {
+    let v: Vec<Holder> = [];
+    v.push(Holder { items: ["left", "right"] });
+    v[0].items.len()
+}
+
+fn bound() -> i64 {
+    let v: Vec<Holder> = [];
+    v.push(Holder { items: ["left", "right"] });
+    let h = v[0];
+    h.items.len()
+}
+
+record Scalar { value: i64 }
+
+fn bitcopy_control() -> i64 {
+    let v: Vec<Scalar> = [];
+    v.push(Scalar { value: 7 });
+    v[0].value
+}
+
+fn borrowed_control() -> i64 {
+    let v: Vec<HashMap<i64, string>> = [];
+    let m: HashMap<i64, string> = HashMap::new();
+    m.insert(1, "value");
+    v.push(m);
+    let got = v[0];
+    got.len()
+}
+"#,
+    );
+
+    assert_eq!(call_count(&p, "direct", "hew_vec_get_clone"), 1);
+    assert_eq!(synthetic_binds(&p, "direct"), 1);
+    let direct_locals = synthetic_locals(&p, "direct");
+    assert_eq!(direct_locals.len(), 1);
+    let direct_exits = synthetic_drop_exits(&p, "direct", direct_locals[0]);
+    assert_eq!(direct_exits.len(), 1);
+    assert!(matches!(direct_exits[0], (ExitPath::Return { .. }, 1)));
+
+    assert_eq!(call_count(&p, "bound", "hew_vec_get_clone"), 1);
+    assert_eq!(synthetic_binds(&p, "bound"), 0);
+    assert!(synthetic_locals(&p, "bound").is_empty());
+
+    assert_eq!(call_count(&p, "bitcopy_control", "hew_vec_get_clone"), 0);
+    assert_eq!(synthetic_binds(&p, "bitcopy_control"), 0);
+    assert!(synthetic_locals(&p, "bitcopy_control").is_empty());
+
+    assert_eq!(
+        runtime_call_count(&p, "borrowed_control", "hew_vec_get_owned"),
+        1,
+        "the nested collection must use the borrow getter, not the fresh composite clone route"
+    );
+    assert_eq!(call_count(&p, "borrowed_control", "hew_vec_get_clone"), 0);
+    assert_eq!(synthetic_binds(&p, "borrowed_control"), 0);
+    assert!(synthetic_locals(&p, "borrowed_control").is_empty());
+}
+
+#[test]
+fn panic_edge_never_drops_an_uninitialised_projection_owner() {
+    let p = pipeline(
+        r#"
+record Holder { items: Vec<string> }
+
+fn indexed(i: i64) -> i64 {
+    let v: Vec<Holder> = [];
+    v.push(Holder { items: ["left", "right"] });
+    v[i].items.len()
+}
+"#,
+    );
+
+    let locals = synthetic_locals(&p, "indexed");
+    assert_eq!(locals.len(), 1);
+    let exits = synthetic_drop_exits(&p, "indexed", locals[0]);
+    assert_eq!(exits.len(), 1);
+    assert!(matches!(exits[0], (ExitPath::Return { .. }, 1)));
+    assert!(
+        !exits
+            .iter()
+            .any(|(exit, _)| matches!(exit, ExitPath::Panic { .. })),
+        "the bounds-failure edge precedes the clone and must not drop its uninitialised result"
+    );
+}
+
+#[test]
+fn early_return_back_edge_and_break_each_release_the_live_root_once() {
+    let p = pipeline(
+        r#"
+record Holder { items: Vec<string> }
+
+fn early(flag: bool) -> i64 {
+    let v: Vec<Holder> = [];
+    v.push(Holder { items: ["left", "right"] });
+    if flag {
+        return v[0].items.len();
+    }
+    v[0].items.len()
+}
+
+fn loop_edges(stop: bool) -> i64 {
+    let v: Vec<Holder> = [];
+    v.push(Holder { items: ["left", "right"] });
+    var i = 0;
+    while i < 2 {
+        let n = v[0].items.len();
+        if stop {
+            break;
+        }
+        i = i + n;
+    }
+    i
+}
+"#,
+    );
+
+    assert_eq!(synthetic_binds(&p, "early"), 2);
+    for local in synthetic_locals(&p, "early") {
+        let exits = synthetic_drop_exits(&p, "early", local);
+        assert_eq!(exits.len(), 1, "each return-site root must drop once");
+        assert!(matches!(exits[0], (ExitPath::Return { .. }, 1)));
+    }
+
+    assert_eq!(synthetic_binds(&p, "loop_edges"), 1);
+    let loop_locals = synthetic_locals(&p, "loop_edges");
+    assert_eq!(loop_locals.len(), 1);
+    let exits = synthetic_drop_exits(&p, "loop_edges", loop_locals[0]);
+    assert_eq!(
+        exits
+            .iter()
+            .filter(|(exit, _)| matches!(exit, ExitPath::Goto { .. }))
+            .count(),
+        2,
+        "the live root must drop once on the loop back-edge and once on break"
+    );
+    assert!(
+        exits.iter().all(|(_, count)| *count == 1),
+        "every exit from the live projection region must carry exactly one root drop: {exits:?}"
+    );
+}

--- a/hew-mir/tests/lowering_expr/fresh_vec_projection_owner.rs
+++ b/hew-mir/tests/lowering_expr/fresh_vec_projection_owner.rs
@@ -212,6 +212,32 @@ fn indexed(i: i64) -> i64 {
 }
 
 #[test]
+fn destructive_update_of_projected_member_transfers_out_of_the_synthetic_root() {
+    let p = pipeline(
+        r#"
+record Inner { label: string, n: i64 }
+record Mid { inner: Inner, k: i64 }
+
+fn transfer() -> i64 {
+    let v: Vec<Mid> = [];
+    v.push(Mid { inner: Inner { label: "a".to_upper(), n: 7 }, k: 3 });
+    let u = Inner { label: "b".to_upper(), ..v[0].inner };
+    u.label.len()
+}
+"#,
+    );
+
+    assert_eq!(call_count(&p, "transfer", "hew_vec_get_clone"), 1);
+    assert_eq!(synthetic_binds(&p, "transfer"), 1);
+    let locals = synthetic_locals(&p, "transfer");
+    assert_eq!(locals.len(), 1);
+    assert!(
+        synthetic_drop_exits(&p, "transfer", locals[0]).is_empty(),
+        "the destructive update transfers the projected member and must exclude the parent root"
+    );
+}
+
+#[test]
 fn early_return_back_edge_and_break_each_release_the_live_root_once() {
     let p = pipeline(
         r#"

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -385,6 +385,9 @@ VEC_ELEM_STORE_TEMP_SRC="${ROOT}/tests/vertical-slice/accept/vec_elem_store_owne
 # insert/remove cycle. An over-eager mint drops the caller's parameter; a missed
 # temp drop leaks once per store. ASan/LSan catches both directions.
 VEC_PARAM_EMBED_TEMP_SRC="${ROOT}/tests/vertical-slice/accept/vec_param_embed_copy_in_temp_no_leak.hew"
+# Direct field projection from a fresh Vec-owned record index. The anonymous
+# clone base must receive exactly one scope-exit release before the next loop.
+FRESH_VEC_INDEX_PROJECTION_SRC="${ROOT}/tests/vertical-slice/accept/fresh_vec_index_projection_drop.hew"
 # Rc/Weak graph lifecycle: two record replacements, an embedded Weak back-edge,
 # exact upgrade teardown, and final strong/weak releases must stay LSan-clean.
 RC_WEAK_SRC="${ROOT}/tests/vertical-slice/accept/rc_weak_lifecycle.hew"
@@ -445,6 +448,9 @@ compile_asan_fixture "owned-Vec element-store temp (push/set move-in)" "${VEC_EL
 
 VEC_PARAM_EMBED_TEMP_BIN="${WORK_DIR}/vec_param_embed_copy_in_temp_no_leak"
 compile_asan_fixture "owned-Vec retained param-embed temp (push/set/Arena)" "${VEC_PARAM_EMBED_TEMP_SRC}" "${VEC_PARAM_EMBED_TEMP_BIN}"
+
+FRESH_VEC_INDEX_PROJECTION_BIN="${WORK_DIR}/fresh_vec_index_projection_drop"
+compile_asan_fixture "fresh Vec index projection" "${FRESH_VEC_INDEX_PROJECTION_SRC}" "${FRESH_VEC_INDEX_PROJECTION_BIN}"
 
 RC_WEAK_BIN="${WORK_DIR}/rc_weak_lifecycle"
 compile_asan_fixture "Rc/Weak graph replacement lifecycle" "${RC_WEAK_SRC}" "${RC_WEAK_BIN}"
@@ -591,6 +597,12 @@ else
 fi
 
 if run_asan_fixture "owned-Vec retained param-embed temp (push/set/Arena)" "${VEC_PARAM_EMBED_TEMP_BIN}" 0; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+if run_asan_fixture "fresh Vec index projection" "${FRESH_VEC_INDEX_PROJECTION_BIN}" 0; then
   pass=$((pass + 1))
 else
   fail=$((fail + 1))

--- a/tests/vertical-slice/accept/fresh_vec_index_projection_drop.hew
+++ b/tests/vertical-slice/accept/fresh_vec_index_projection_drop.hew
@@ -1,0 +1,24 @@
+// A direct field projection from a Vec-owned record index clones the record,
+// reads its field, and releases the anonymous clone on each loop iteration.
+record Holder {
+    items: Vec<string>
+}
+
+fn frame() -> i64 {
+    let values: Vec<Holder> = Vec::new();
+    values.push(Holder { items: ["left", "right"] });
+    values[0].items.len()
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 32 {
+        total = total + frame();
+        i = i + 1;
+    }
+    if total != 64 {
+        return 73;
+    }
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3232,6 +3232,10 @@ run_accept_expect_status "vec_string_index_discard_loop" 9
 # and index_nested_in_loop_balances.
 run_accept_expect_status "vec_string_index_use_loop" 14
 
+# A direct field projection from a fresh owned record index has no source binding
+# to carry its clone through scope-exit cleanup. Exit 0 requires 32 exact reads.
+run_accept_expect_status "fresh_vec_index_projection_drop" 0
+
 # Accept (S0): scalar index control on Vec<i64> (BitCopy scalar element). Same
 # bounds-checked lower_vec_index path, dispatching to hew_vec_get_i64. Exit 22
 # = xs[1] + xs[2] - xs[0] (20 + 12 - 10).


### PR DESCRIPTION
## Summary

I give fresh `Vec::get_clone` projection bases one synthetic MIR owner so their composite values are released on every live exit. I also route destructive record updates through the existing ownership authority so transferring a projected field does not release the overridden leaf twice.

## Design

The owner is minted only after the clone call succeeds, never on the bounds-failure edge. Return, early-return, loop, break, panic, and cancellation paths share the same drop-plan authority. Borrowed, bit-copy, bound, and scalar controls do not mint a synthetic owner.

The update path recognizes an attributed nested-record field binder and discharges its synthetic parent through the existing record sole-owner flow. Whole-root field drops and backend ABI/codegen behavior remain unchanged.

## Verification

- Full `hew-mir` and `hew-cli` lane: 1,544 tests
- Checked-MIR corpus: 57 fixtures × 2 stages
- Functional-update suite: 47/47
- Projection leak/escape oracle: 6/6
- Nested clone canary: 2/2
- Native/wasm LLVM parity: 15 fixtures
- Clippy, formatting, vertical slice, leak hygiene, and line-ceiling checks

Independent local, memory-safety, and cross-codegen reviews accepted the exact signed head. The separately proven generic owned-record field-escape sibling leak remains an explicit pre-existing nonclaim; this change closes the fresh-projection double-free without widening that residual.
