### PR TITLE
fix(ci): make shell ratchet membership pipe-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,12 @@ jobs:
       - name: Exercise O2 differential gate
         if: needs.changes.outputs.scripts == 'true'
         run: make o2-differential-selftest
+
       # <<< CI-PARITY-STEPS
+
+      - name: Exercise doc-ratchet membership gate
+        if: needs.changes.outputs.scripts == 'true'
+        run: make doc-ratchet-selftest
 
   # ─────────────────────────────────────────────────────────────────────────
   # Lint — fast feedback on code quality (always runs, ~1.5 min)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,11 +152,11 @@ jobs:
         if: needs.changes.outputs.scripts == 'true'
         run: make o2-differential-selftest
 
-      # <<< CI-PARITY-STEPS
-
       - name: Exercise doc-ratchet membership gate
         if: needs.changes.outputs.scripts == 'true'
         run: make doc-ratchet-selftest
+
+      # <<< CI-PARITY-STEPS
 
   # ─────────────────────────────────────────────────────────────────────────
   # Lint — fast feedback on code quality (always runs, ~1.5 min)

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test libhew-link-race-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest preflight-parity-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar sandbox-parity-coverage-check test-sandbox-parity-coverage-check
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest preflight-parity-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar sandbox-parity-coverage-check test-sandbox-parity-coverage-check doc-ratchet-selftest
 .PHONY: clean install install-check uninstall verify-ffi test-verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -934,6 +934,11 @@ test-surface-examples: hew runtime stdlib
 # regressions were introduced.
 test-doc-examples: hew
 	@scripts/extract-doc-fences.sh
+
+# Exercise the doc-ratchet harness without building Hew. The fake compiler
+# drives matching and mutated failure sets through the same production script.
+doc-ratchet-selftest:
+	@scripts/tests/test_doc_ratchet_membership.sh
 
 # Release sanitizer gate validator self-test.
 check-sanitizer-gate:

--- a/Makefile
+++ b/Makefile
@@ -935,9 +935,10 @@ test-surface-examples: hew runtime stdlib
 test-doc-examples: hew
 	@scripts/extract-doc-fences.sh
 
-# Exercise the doc-ratchet harness without building Hew. The fake compiler
-# drives matching and mutated failure sets through the same production script.
+# Exercise pipe-safe membership wiring across every shell ratchet, then drive
+# matching and mutated doc-failure sets through the production harness.
 doc-ratchet-selftest:
+	@scripts/tests/test_ratchet_membership_wiring.sh
 	@scripts/tests/test_doc_ratchet_membership.sh
 
 # Release sanitizer gate validator self-test.

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -34,6 +34,7 @@ command_timeout_floor() {
         "make test-hew-ratchet") echo 600 ;;
         "make test-o2-differential") echo 1200 ;;
         "make o2-differential-selftest") echo 30 ;;
+        "make doc-ratchet-selftest") echo 45 ;;
         "make test-stdlib-ratchet") echo 45 ;;
         "make test-doc-examples") echo 45 ;;
         "make sandbox-parity") echo 150 ;;
@@ -85,6 +86,7 @@ CI_REQUIRED_CHECKS=(
     "Hew test suite ratchet (ci.yml: make test-hew-ratchet)	make test-hew-ratchet"
     "O2 differential-exec parity gate (ci.yml: make test-o2-differential)	make test-o2-differential"
     "O2-differential gate self-test (ci.yml: make o2-differential-selftest)	make o2-differential-selftest"
+    "Doc-ratchet membership self-test (ci.yml: make doc-ratchet-selftest)	make doc-ratchet-selftest"
     "Stdlib type-check ratchet (ci.yml: make test-stdlib-ratchet)	make test-stdlib-ratchet"
     "Vertical slice oracle (ci.yml: make test-vertical-slice)	make test-vertical-slice"
     "Package-import oracle (ci.yml: make test-pkg-import)	make test-pkg-import"
@@ -671,6 +673,7 @@ case "$LANE" in
         add_command "cargo fmt --all -- --check"
         add_command "make test-rust"
         add_command "make o2-differential-selftest"
+        add_command "make doc-ratchet-selftest"
         ;;
     grammar)
         add_command "cargo fmt --all -- --check"
@@ -797,6 +800,7 @@ case "$LANE" in
         add_command "make o2-differential-selftest"
         add_command "make test-stdlib-ratchet"
         add_command "make test-doc-examples"
+        add_command "make doc-ratchet-selftest"
         add_command "make sandbox-parity"
         add_command "make checked-mir-verify"
         add_command "make ll-diff"

--- a/scripts/extract-doc-fences.sh
+++ b/scripts/extract-doc-fences.sh
@@ -46,6 +46,10 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/line-set.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/line-set.sh"
+
 EXPECTED_FAILURES_FILE="$REPO_ROOT/scripts/doc-test-expected-failures.txt"
 OUTDIR="$REPO_ROOT/.tmp/doc-fences"
 HEW_BIN="${HEW_BIN:-$REPO_ROOT/target/debug/hew}"
@@ -205,15 +209,15 @@ while IFS= read -r line; do
     fields="${fields#"${fields%%[! ]*}"}" # ltrim
     fields="${fields%"${fields##*[! ]}"}" # rtrim
     [[ -z "$fields" ]] && continue
-    set -- $fields
-    if [[ $# -ne 2 ]]; then
+    name=""
+    recorded_cksum=""
+    extra_field=""
+    read -r name recorded_cksum extra_field <<< "$fields"
+    if [[ -z "$name" || -z "$recorded_cksum" || -n "$extra_field" ]]; then
         echo "error: expected-failures entry must be: <fence-id> <cksum>" >&2
         echo "       bad entry: $line" >&2
         exit 1
     fi
-    name="$1"
-    recorded_cksum="$2"
-    [[ -z "$name" ]] && continue
     if [[ ! "$recorded_cksum" =~ ^[0-9]+$ ]]; then
         echo "error: expected-failures checksum must be decimal cksum output" >&2
         echo "       bad entry: $line" >&2
@@ -257,11 +261,8 @@ echo "    Total fences: $total_fences"
 
 # ── Ratchet ────────────────────────────────────────────────────────────────────
 
-count_expected=0
-[[ -n "$EXPECTED_STR" ]] && count_expected="$(printf '%s' "$EXPECTED_STR" | grep -c .)"
-
-count_actual=0
-[[ -n "$ACTUAL_STR" ]] && count_actual="$(printf '%s' "$ACTUAL_STR" | grep -c .)"
+count_expected="$(line_set_count "$EXPECTED_STR")"
+count_actual="$(line_set_count "$ACTUAL_STR")"
 
 echo ""
 echo "==> Doc-test ratchet"
@@ -272,7 +273,7 @@ echo "    Actual failures:   $count_actual"
 unexpected_failures=""
 while IFS= read -r name; do
     [[ -z "$name" ]] && continue
-    if ! printf '%s\n' "$EXPECTED_STR" | grep -qxF "$name"; then
+    if ! line_set_contains "$EXPECTED_STR" "$name"; then
         unexpected_failures="${unexpected_failures}${name}"$'\n'
     fi
 done <<< "$ACTUAL_STR"
@@ -281,7 +282,7 @@ done <<< "$ACTUAL_STR"
 unexpected_passes=""
 while IFS= read -r name; do
     [[ -z "$name" ]] && continue
-    if ! printf '%s\n' "$ACTUAL_STR" | grep -qxF "$name"; then
+    if ! line_set_contains "$ACTUAL_STR" "$name"; then
         unexpected_passes="${unexpected_passes}${name}"$'\n'
     fi
 done <<< "$EXPECTED_STR"
@@ -291,9 +292,7 @@ done <<< "$EXPECTED_STR"
 stale_metadata=""
 while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
-    set -- $entry
-    name="$1"
-    recorded_cksum="$2"
+    read -r name recorded_cksum <<< "$entry"
     outfile="$OUTDIR/${name}.hew"
     [[ -f "$outfile" ]] || continue
     actual_cksum="$(cksum "$outfile" | awk '{print $1}')"
@@ -302,14 +301,9 @@ while IFS= read -r entry; do
     fi
 done <<< "$EXPECTED_CKSUM_STR"
 
-count_unexpected_fail=0
-[[ -n "$unexpected_failures" ]] && count_unexpected_fail="$(printf '%s' "$unexpected_failures" | grep -c .)"
-
-count_unexpected_pass=0
-[[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(printf '%s' "$unexpected_passes" | grep -c .)"
-
-count_stale_metadata=0
-[[ -n "$stale_metadata" ]] && count_stale_metadata="$(printf '%s' "$stale_metadata" | grep -c .)"
+count_unexpected_fail="$(line_set_count "$unexpected_failures")"
+count_unexpected_pass="$(line_set_count "$unexpected_passes")"
+count_stale_metadata="$(line_set_count "$stale_metadata")"
 
 if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 && $count_stale_metadata -eq 0 ]]; then
     if [[ $count_actual -eq 0 ]]; then
@@ -361,10 +355,7 @@ if [[ $count_stale_metadata -gt 0 ]]; then
     echo "RATCHET FAIL: $count_stale_metadata stale expected-failure metadata entr$( [[ $count_stale_metadata -eq 1 ]] && echo "y" || echo "ies" ):"
     while IFS= read -r entry; do
         [[ -z "$entry" ]] && continue
-        set -- $entry
-        name="$1"
-        recorded_cksum="$2"
-        actual_cksum="$3"
+        read -r name recorded_cksum actual_cksum <<< "$entry"
         echo "  STALE METADATA: $name content changed since label was written (recorded=$recorded_cksum actual=$actual_cksum) — re-verify and update the label"
     done <<< "$stale_metadata"
     echo ""

--- a/scripts/hew-corpus-check.sh
+++ b/scripts/hew-corpus-check.sh
@@ -38,6 +38,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/line-set.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/line-set.sh"
 EXPECTED_FAILURES_FILE="$REPO_ROOT/scripts/hew-corpus-expected-failures.txt"
 HEW_BIN="${HEW_BIN:-$REPO_ROOT/target/debug/hew}"
 
@@ -164,19 +167,19 @@ fi
 # Count entries.
 count_expected=0
 if [[ -n "$EXPECTED_STR" ]]; then
-    count_expected="$(printf '%s' "$EXPECTED_STR" | grep -c .)"
+    count_expected="$(line_set_count "$EXPECTED_STR")"
 fi
 
 count_actual=0
 if [[ -n "$ACTUAL_STR" ]]; then
-    count_actual="$(printf '%s' "$ACTUAL_STR" | grep -c .)"
+    count_actual="$(line_set_count "$ACTUAL_STR")"
 fi
 
 # Find unexpected failures (in actual but not in expected list).
 unexpected_failures=""
 while IFS= read -r path; do
     [[ -z "$path" ]] && continue
-    if ! printf '%s\n' "$EXPECTED_STR" | grep -qxF "$path"; then
+    if ! line_set_contains "$EXPECTED_STR" "$path"; then
         unexpected_failures="${unexpected_failures}${path}"$'\n'
     fi
 done <<< "$ACTUAL_STR"
@@ -185,7 +188,7 @@ done <<< "$ACTUAL_STR"
 unexpected_passes=""
 while IFS= read -r path; do
     [[ -z "$path" ]] && continue
-    if ! printf '%s\n' "$ACTUAL_STR" | grep -qxF "$path"; then
+    if ! line_set_contains "$ACTUAL_STR" "$path"; then
         unexpected_passes="${unexpected_passes}${path}"$'\n'
     fi
 done <<< "$EXPECTED_STR"
@@ -198,10 +201,10 @@ echo "Actual failures:        $count_actual"
 echo ""
 
 count_unexpected_fail=0
-[[ -n "$unexpected_failures" ]] && count_unexpected_fail="$(printf '%s' "$unexpected_failures" | grep -c .)"
+[[ -n "$unexpected_failures" ]] && count_unexpected_fail="$(line_set_count "$unexpected_failures")"
 
 count_unexpected_pass=0
-[[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(printf '%s' "$unexpected_passes" | grep -c .)"
+[[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(line_set_count "$unexpected_passes")"
 
 if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 ]]; then
     if [[ $count_actual -eq 0 ]]; then

--- a/scripts/hew-suite-ratchet.sh
+++ b/scripts/hew-suite-ratchet.sh
@@ -37,6 +37,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/line-set.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/line-set.sh"
 EXPECTED_FAILURES_FILE="$REPO_ROOT/scripts/hew-suite-expected-failures.txt"
 # HEW_BIN is overridable for parser tests (point it at a stub that replays
 # captured runner output); production callers use the default.
@@ -128,8 +131,16 @@ RAW_OUTPUT=$("$HEW_BIN" test "$TESTS_DIR" 2>&1) || true
 CLEAN_OUTPUT="$(printf '%s\n' "$RAW_OUTPUT" | sed $'s/\x1b\\[[0-9;]*m//g')"
 
 # Fail closed if the runner produced no summary line: a runner crash or an
-# output-format change must never read as success.
-if ! printf '%s\n' "$CLEAN_OUTPUT" | grep -q "^test result:"; then
+# output-format change must never read as success. Keep this loop local so an
+# early match cannot SIGPIPE an upstream producer under pipefail.
+has_test_summary=0
+while IFS= read -r line; do
+    if [[ "$line" == "test result:"* ]]; then
+        has_test_summary=1
+        break
+    fi
+done <<< "$CLEAN_OUTPUT"
+if (( has_test_summary == 0 )); then
     echo "error: no 'test result:' summary in hew test output; refusing to ratchet" >&2
     printf '%s\n' "$RAW_OUTPUT"
     exit 1
@@ -167,7 +178,7 @@ summary_failed="$(printf '%s\n' "$CLEAN_OUTPUT" | sed -n 's/^test result:.*[^0-9
 [[ -z "$summary_failed" ]] && summary_failed=0
 parsed_failed=0
 if [[ -n "$ACTUAL_STR" ]]; then
-    parsed_failed="$(printf '%s' "$ACTUAL_STR" | grep -c .)"
+    parsed_failed="$(line_set_count "$ACTUAL_STR")"
 fi
 if [[ "$parsed_failed" -ne "$summary_failed" ]]; then
     echo "error: parsed $parsed_failed FAILED line(s) but runner summary reports $summary_failed failed; refusing to ratchet" >&2
@@ -184,19 +195,19 @@ fi
 # Count entries.
 count_expected=0
 if [[ -n "$EXPECTED_STR" ]]; then
-    count_expected="$(printf '%s' "$EXPECTED_STR" | grep -c .)"
+    count_expected="$(line_set_count "$EXPECTED_STR")"
 fi
 
 count_actual=0
 if [[ -n "$ACTUAL_STR" ]]; then
-    count_actual="$(printf '%s' "$ACTUAL_STR" | grep -c .)"
+    count_actual="$(line_set_count "$ACTUAL_STR")"
 fi
 
 # Find unexpected failures (in actual but not in expected).
 unexpected_failures=""
 while IFS= read -r name; do
     [[ -z "$name" ]] && continue
-    if ! printf '%s\n' "$EXPECTED_STR" | grep -qxF "$name"; then
+    if ! line_set_contains "$EXPECTED_STR" "$name"; then
         unexpected_failures="${unexpected_failures}${name}"$'\n'
     fi
 done <<< "$ACTUAL_STR"
@@ -205,7 +216,7 @@ done <<< "$ACTUAL_STR"
 unexpected_passes=""
 while IFS= read -r name; do
     [[ -z "$name" ]] && continue
-    if ! printf '%s\n' "$ACTUAL_STR" | grep -qxF "$name"; then
+    if ! line_set_contains "$ACTUAL_STR" "$name"; then
         unexpected_passes="${unexpected_passes}${name}"$'\n'
     fi
 done <<< "$EXPECTED_STR"
@@ -216,10 +227,10 @@ echo "Actual failures:   $count_actual"
 echo ""
 
 count_unexpected_fail=0
-[[ -n "$unexpected_failures" ]] && count_unexpected_fail="$(printf '%s' "$unexpected_failures" | grep -c .)"
+[[ -n "$unexpected_failures" ]] && count_unexpected_fail="$(line_set_count "$unexpected_failures")"
 
 count_unexpected_pass=0
-[[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(printf '%s' "$unexpected_passes" | grep -c .)"
+[[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(line_set_count "$unexpected_passes")"
 
 if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 ]]; then
     if [[ $count_actual -eq 0 ]]; then

--- a/scripts/lib/line-set.sh
+++ b/scripts/lib/line-set.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# scripts/lib/line-set.sh — Exact newline-delimited set helpers for shell ratchets.
+#
+# Source this file; do NOT execute it directly.
+#
+# These helpers intentionally avoid producer | grep -q membership pipelines.
+# Under `set -o pipefail`, grep may exit after an early match, deliver SIGPIPE
+# to the producer, and turn a present entry into a false absence.
+
+line_set_contains() {
+    local line_set="$1"
+    local needle="$2"
+    local line
+
+    while IFS= read -r line; do
+        if [[ "$line" == "$needle" ]]; then
+            return 0
+        fi
+    done <<< "$line_set"
+
+    return 1
+}
+
+line_set_count() {
+    local line_set="$1"
+    local line
+    local count=0
+
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        count=$(( count + 1 ))
+    done <<< "$line_set"
+
+    printf '%d\n' "$count"
+}

--- a/scripts/stdlib-ratchet.sh
+++ b/scripts/stdlib-ratchet.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/line-set.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/line-set.sh"
 EXPECTED_FAILURES_FILE="$REPO_ROOT/scripts/stdlib-expected-failures.txt"
 HEW_BIN="${HEW_BIN:-$REPO_ROOT/target/debug/hew}"
 STDLIB_DIR="$REPO_ROOT/std"
@@ -115,19 +118,19 @@ fi
 # Count entries.
 count_expected=0
 if [[ -n "$EXPECTED_STR" ]]; then
-    count_expected="$(printf '%s' "$EXPECTED_STR" | grep -c .)"
+    count_expected="$(line_set_count "$EXPECTED_STR")"
 fi
 
 count_actual=0
 if [[ -n "$ACTUAL_STR" ]]; then
-    count_actual="$(printf '%s' "$ACTUAL_STR" | grep -c .)"
+    count_actual="$(line_set_count "$ACTUAL_STR")"
 fi
 
 # Find unexpected failures (in actual but not in expected).
 unexpected_failures=""
 while IFS= read -r path; do
     [[ -z "$path" ]] && continue
-    if ! printf '%s\n' "$EXPECTED_STR" | grep -qxF "$path"; then
+    if ! line_set_contains "$EXPECTED_STR" "$path"; then
         unexpected_failures="${unexpected_failures}${path}"$'\n'
     fi
 done <<< "$ACTUAL_STR"
@@ -136,7 +139,7 @@ done <<< "$ACTUAL_STR"
 unexpected_passes=""
 while IFS= read -r path; do
     [[ -z "$path" ]] && continue
-    if ! printf '%s\n' "$ACTUAL_STR" | grep -qxF "$path"; then
+    if ! line_set_contains "$ACTUAL_STR" "$path"; then
         unexpected_passes="${unexpected_passes}${path}"$'\n'
     fi
 done <<< "$EXPECTED_STR"
@@ -148,10 +151,10 @@ echo "Actual failures:   $count_actual"
 echo ""
 
 count_unexpected_fail=0
-[[ -n "$unexpected_failures" ]] && count_unexpected_fail="$(printf '%s' "$unexpected_failures" | grep -c .)"
+[[ -n "$unexpected_failures" ]] && count_unexpected_fail="$(line_set_count "$unexpected_failures")"
 
 count_unexpected_pass=0
-[[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(printf '%s' "$unexpected_passes" | grep -c .)"
+[[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(line_set_count "$unexpected_passes")"
 
 if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 ]]; then
     if [[ $count_actual -eq 0 ]]; then

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -52,6 +52,7 @@ def assert_scripts_config_profile(result: subprocess.CompletedProcess[str]) -> N
     assert "make playground-check" not in result.stdout
     assert "  - cargo fmt --all -- --check" in result.stdout
     assert "  - make test-rust" in result.stdout
+    assert "  - make doc-ratchet-selftest" in result.stdout
     assert "make test-codegen" not in result.stdout
 
 

--- a/scripts/tests/test_doc_ratchet_membership.sh
+++ b/scripts/tests/test_doc_ratchet_membership.sh
@@ -35,6 +35,22 @@ assert_contains() {
     fi
 }
 
+assert_production_membership_wiring() {
+    # These are literal source contracts; variable expansion would weaken the
+    # assertion by substituting the self-test's current values.
+    # shellcheck disable=SC2016
+    local expected_lookup='    if ! line_set_contains "$EXPECTED_STR" "$name"; then'
+    # shellcheck disable=SC2016
+    local actual_lookup='    if ! line_set_contains "$ACTUAL_STR" "$name"; then'
+
+    if grep -Fqx "$expected_lookup" "$HARNESS" \
+        && grep -Fqx "$actual_lookup" "$HARNESS"; then
+        pass "production ratchet uses exact membership for both set comparisons"
+    else
+        fail "production ratchet bypasses exact membership wiring"
+    fi
+}
+
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hew-doc-ratchet-test.XXXXXX")"
 cleanup() {
     rm -rf "$TMP_ROOT"
@@ -98,12 +114,38 @@ else
     fail "discovery harness failed with status $HARNESS_STATUS"
 fi
 
-# Reproduce the old false-absence mechanism deterministically. The producer is
-# much larger than a pipe buffer and the present needle is first, so grep -q
-# exits early and the producer receives SIGPIPE under pipefail.
+# Keep the regression tooth attached to the production ratchet. A large helper
+# test alone would remain green if either production lookup were restored to a
+# producer-to-grep pipeline, so require both call sites explicitly.
+assert_production_membership_wiring
+
+# Reproduce the old false-absence mechanism deterministically. The set is much
+# larger than a pipe buffer and the present needle is first. The consumer closes
+# its pipe after grep's early match, records that closure, and only then lets the
+# producer write the remaining set and receive SIGPIPE under pipefail.
 LARGE_SET="$(awk 'BEGIN { print "present"; for (i = 0; i < 200000; i++) printf "filler-%06d\\n", i }')"
+LARGE_SET_MIN_BYTES=$(( 2 * 1024 * 1024 ))
+if (( ${#LARGE_SET} > LARGE_SET_MIN_BYTES )); then
+    pass "membership regression set exceeds a 2 MiB pipe-capacity bound"
+else
+    fail "membership regression set does not exceed the pipe-capacity bound"
+fi
+LEGACY_PIPE_CLOSED="$TMP_ROOT/legacy-pipe-closed"
+legacy_large_set_producer() {
+    printf '%s\n' "present"
+    while [[ ! -e "$LEGACY_PIPE_CLOSED" ]]; do
+        :
+    done
+    printf '%s\n' "${LARGE_SET#*$'\n'}"
+}
+legacy_early_exit_consumer() {
+    grep -qxF "present"
+    exec 0<&-
+    : > "$LEGACY_PIPE_CLOSED"
+}
+
 legacy_status=0
-printf '%s\n' "$LARGE_SET" 2>/dev/null | grep -qxF "present" || legacy_status=$?
+legacy_large_set_producer 2>/dev/null | legacy_early_exit_consumer || legacy_status=$?
 if [[ "$legacy_status" -ne 0 ]]; then
     pass "legacy producer-to-grep membership fails on a present large-set entry"
 else

--- a/scripts/tests/test_doc_ratchet_membership.sh
+++ b/scripts/tests/test_doc_ratchet_membership.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Deterministic regression and mutation tests for the doc-fence ratchet.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HARNESS="$REPO_ROOT/scripts/extract-doc-fences.sh"
+
+# shellcheck source=scripts/lib/line-set.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/line-set.sh"
+
+PASSES=0
+FAILURES=0
+
+pass() {
+    echo "PASS: $*"
+    PASSES=$(( PASSES + 1 ))
+}
+
+fail() {
+    echo "FAIL: $*" >&2
+    FAILURES=$(( FAILURES + 1 ))
+}
+
+assert_contains() {
+    local output="$1"
+    local expected="$2"
+    local label="$3"
+
+    if [[ "$output" == *"$expected"* ]]; then
+        pass "$label"
+    else
+        fail "$label (missing: $expected)"
+    fi
+}
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hew-doc-ratchet-test.XXXXXX")"
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FAKE_HEW="$TMP_ROOT/hew"
+FAIL_IDS="$TMP_ROOT/fail-ids.txt"
+CALL_LOG="$TMP_ROOT/calls.txt"
+OUTDIR="$TMP_ROOT/fences"
+EMPTY_EXPECTED="$TMP_ROOT/expected-empty.txt"
+BASELINE_EXPECTED="$TMP_ROOT/expected-baseline.txt"
+BASELINE_FAIL_IDS="$TMP_ROOT/fail-baseline.txt"
+NOW_PASS_IDS="$TMP_ROOT/fail-now-pass.txt"
+NEW_FAILURE_IDS="$TMP_ROOT/fail-new-failure.txt"
+STALE_EXPECTED="$TMP_ROOT/expected-stale.txt"
+
+touch "$FAIL_IDS" "$CALL_LOG" "$EMPTY_EXPECTED"
+
+cat > "$FAKE_HEW" <<'FAKE_HEW_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ $# -eq 2 && "$1" == "check" ]] || exit 64
+
+fence_id="${2##*/}"
+fence_id="${fence_id%.hew}"
+printf '%s\n' "$fence_id" >> "${HEW_CALL_LOG:?}"
+
+while IFS= read -r failing_id; do
+    [[ "$failing_id" == "$fence_id" ]] && exit 1
+done < "${HEW_FAIL_IDS:?}"
+
+exit 0
+FAKE_HEW_EOF
+chmod +x "$FAKE_HEW"
+
+HARNESS_OUTPUT=""
+HARNESS_STATUS=0
+run_harness() {
+    local expected_file="$1"
+    local fail_file="$2"
+    local call_log="$3"
+
+    HARNESS_STATUS=0
+    HARNESS_OUTPUT="$({
+        HEW_FAIL_IDS="$fail_file" \
+        HEW_CALL_LOG="$call_log" \
+        "$HARNESS" \
+            --expected-failures "$expected_file" \
+            --outdir "$OUTDIR" \
+            --hew-bin "$FAKE_HEW"
+    } 2>&1)" || HARNESS_STATUS=$?
+}
+
+# First extract the real documentation corpus and discover every non-skipped ID.
+run_harness "$EMPTY_EXPECTED" "$FAIL_IDS" "$CALL_LOG"
+if [[ "$HARNESS_STATUS" -eq 0 ]]; then
+    pass "discovery harness accepts an all-pass fake compiler"
+else
+    fail "discovery harness failed with status $HARNESS_STATUS"
+fi
+
+# Reproduce the old false-absence mechanism deterministically. The producer is
+# much larger than a pipe buffer and the present needle is first, so grep -q
+# exits early and the producer receives SIGPIPE under pipefail.
+LARGE_SET="$(awk 'BEGIN { print "present"; for (i = 0; i < 200000; i++) printf "filler-%06d\\n", i }')"
+legacy_status=0
+printf '%s\n' "$LARGE_SET" 2>/dev/null | grep -qxF "present" || legacy_status=$?
+if [[ "$legacy_status" -ne 0 ]]; then
+    pass "legacy producer-to-grep membership fails on a present large-set entry"
+else
+    fail "legacy producer-to-grep membership did not reproduce SIGPIPE"
+fi
+
+if line_set_contains "$LARGE_SET" "present"; then
+    pass "exact membership keeps a present large-set entry present"
+else
+    fail "exact membership lost a present large-set entry"
+fi
+
+if line_set_contains "$LARGE_SET" "absent"; then
+    fail "exact membership accepted an absent large-set entry"
+else
+    pass "exact membership rejects an absent large-set entry"
+fi
+
+# Build a sizeable tracked-failure subset while retaining at least one passing
+# fence for the new-failure mutation.
+baseline_count=0
+passing_id=""
+while IFS= read -r fence_id; do
+    [[ -z "$fence_id" ]] && continue
+    if (( baseline_count < 200 )); then
+        printf '%s\n' "$fence_id" >> "$BASELINE_FAIL_IDS"
+        checksum_output="$(cksum "$OUTDIR/${fence_id}.hew")"
+        read -r checksum _ <<< "$checksum_output"
+        printf '%s %s\n' "$fence_id" "$checksum" >> "$BASELINE_EXPECTED"
+        baseline_count=$(( baseline_count + 1 ))
+    elif [[ -z "$passing_id" ]]; then
+        passing_id="$fence_id"
+    fi
+done < "$CALL_LOG"
+
+if (( baseline_count == 200 )) && [[ -n "$passing_id" ]]; then
+    pass "fixture retains 200 tracked failures and an untracked passing fence"
+else
+    fail "fixture corpus is too small for mutation coverage"
+fi
+
+run_harness "$BASELINE_EXPECTED" "$BASELINE_FAIL_IDS" /dev/null
+if [[ "$HARNESS_STATUS" -eq 0 ]]; then
+    pass "matching large expected and actual failure sets pass"
+else
+    fail "matching failure sets rejected with status $HARNESS_STATUS"
+fi
+
+# Mutation 1: a listed failure now passes and must be rejected.
+first_failure=""
+while IFS= read -r fence_id; do
+    [[ -z "$fence_id" ]] && continue
+    if [[ -z "$first_failure" ]]; then
+        first_failure="$fence_id"
+        continue
+    fi
+    printf '%s\n' "$fence_id" >> "$NOW_PASS_IDS"
+done < "$BASELINE_FAIL_IDS"
+
+run_harness "$BASELINE_EXPECTED" "$NOW_PASS_IDS" /dev/null
+if [[ "$HARNESS_STATUS" -ne 0 ]]; then
+    pass "now-pass mutation is rejected"
+else
+    fail "now-pass mutation was accepted"
+fi
+assert_contains "$HARNESS_OUTPUT" "NOW-PASSES: $first_failure" \
+    "now-pass mutation names the exact fence"
+
+# Mutation 2: a previously passing fence fails and must be rejected.
+cp "$BASELINE_FAIL_IDS" "$NEW_FAILURE_IDS"
+printf '%s\n' "$passing_id" >> "$NEW_FAILURE_IDS"
+run_harness "$BASELINE_EXPECTED" "$NEW_FAILURE_IDS" /dev/null
+if [[ "$HARNESS_STATUS" -ne 0 ]]; then
+    pass "new-failure mutation is rejected"
+else
+    fail "new-failure mutation was accepted"
+fi
+assert_contains "$HARNESS_OUTPUT" "UNEXPECTED: $passing_id" \
+    "new-failure mutation names the exact fence"
+
+# Mutation 3: a tracked fence checksum drifts and must be rejected.
+first_entry=1
+while read -r fence_id checksum; do
+    [[ -z "$fence_id" ]] && continue
+    if (( first_entry == 1 )); then
+        checksum=$(( checksum + 1 ))
+        first_entry=0
+    fi
+    printf '%s %s\n' "$fence_id" "$checksum" >> "$STALE_EXPECTED"
+done < "$BASELINE_EXPECTED"
+
+run_harness "$STALE_EXPECTED" "$BASELINE_FAIL_IDS" /dev/null
+if [[ "$HARNESS_STATUS" -ne 0 ]]; then
+    pass "stale-metadata mutation is rejected"
+else
+    fail "stale-metadata mutation was accepted"
+fi
+assert_contains "$HARNESS_OUTPUT" "STALE METADATA: $first_failure" \
+    "stale-metadata mutation names the exact fence"
+
+echo ""
+echo "Doc-ratchet membership self-test: $PASSES passed, $FAILURES failed"
+(( FAILURES == 0 ))

--- a/scripts/tests/test_doc_ratchet_membership.sh
+++ b/scripts/tests/test_doc_ratchet_membership.sh
@@ -3,12 +3,50 @@
 
 set -euo pipefail
 
+LEGACY_HANDSHAKE_TIMEOUT_SECONDS=2
+LEGACY_HANDSHAKE_TIMEOUT_STATUS=125
+LEGACY_HANDSHAKE_POLL_SECONDS=0.01
+
+legacy_large_set_producer() {
+    local pipe_closed_marker="$1"
+    local deadline=$(( SECONDS + LEGACY_HANDSHAKE_TIMEOUT_SECONDS ))
+
+    printf '%s\n' "present"
+    while [[ ! -e "$pipe_closed_marker" ]]; do
+        if (( SECONDS >= deadline )); then
+            return "$LEGACY_HANDSHAKE_TIMEOUT_STATUS"
+        fi
+        sleep "$LEGACY_HANDSHAKE_POLL_SECONDS"
+    done
+    printf '%s\n' "${LARGE_SET#*$'\n'}"
+}
+
+# Internal child mode for the watchdog-backed missing-marker tooth below.
+if [[ "${1:-}" == "--probe-legacy-handshake-timeout" ]]; then
+    probe_root="$(mktemp -d "${TMPDIR:-/tmp}/hew-doc-ratchet-timeout.XXXXXX")"
+    probe_status=0
+    unset LARGE_SET 2>/dev/null || true
+    legacy_large_set_producer "$probe_root/never-created" >/dev/null \
+        || probe_status=$?
+    rmdir "$probe_root"
+    exit "$probe_status"
+fi
+
+if [[ $# -ne 0 ]]; then
+    echo "error: unexpected argument: $1" >&2
+    exit 64
+fi
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HARNESS="$REPO_ROOT/scripts/extract-doc-fences.sh"
 
 # shellcheck source=scripts/lib/line-set.sh
 # shellcheck disable=SC1091
 source "$REPO_ROOT/scripts/lib/line-set.sh"
+
+# shellcheck source=scripts/lib/timeout.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/timeout.sh"
 
 PASSES=0
 FAILURES=0
@@ -131,13 +169,6 @@ else
     fail "membership regression set does not exceed the pipe-capacity bound"
 fi
 LEGACY_PIPE_CLOSED="$TMP_ROOT/legacy-pipe-closed"
-legacy_large_set_producer() {
-    printf '%s\n' "present"
-    while [[ ! -e "$LEGACY_PIPE_CLOSED" ]]; do
-        :
-    done
-    printf '%s\n' "${LARGE_SET#*$'\n'}"
-}
 legacy_early_exit_consumer() {
     grep -qxF "present"
     exec 0<&-
@@ -145,12 +176,39 @@ legacy_early_exit_consumer() {
 }
 
 legacy_status=0
-legacy_large_set_producer 2>/dev/null | legacy_early_exit_consumer || legacy_status=$?
-if [[ "$legacy_status" -ne 0 ]]; then
-    pass "legacy producer-to-grep membership fails on a present large-set entry"
-else
-    fail "legacy producer-to-grep membership did not reproduce SIGPIPE"
-fi
+legacy_large_set_producer "$LEGACY_PIPE_CLOSED" 2>/dev/null \
+    | legacy_early_exit_consumer || legacy_status=$?
+case "$legacy_status" in
+    0)
+        fail "legacy producer-to-grep membership did not reproduce SIGPIPE"
+        ;;
+    "$LEGACY_HANDSHAKE_TIMEOUT_STATUS")
+        fail "legacy producer handshake timed out before consumer pipe closure"
+        ;;
+    *)
+        pass "legacy producer-to-grep membership fails on a present large-set entry"
+        ;;
+esac
+
+# Exercise the absent-marker path in a separate process group. The producer's
+# dedicated status must win before the outer watchdog; removing or bypassing
+# the internal deadline therefore fails quickly instead of hanging this gate.
+timeout_probe_status=0
+timeout_probe_budget=$(( LEGACY_HANDSHAKE_TIMEOUT_SECONDS + 3 ))
+run_with_timeout "$timeout_probe_budget" "$BASH" "${BASH_SOURCE[0]}" \
+    --probe-legacy-handshake-timeout >/dev/null 2>&1 \
+    || timeout_probe_status=$?
+case "$timeout_probe_status" in
+    "$LEGACY_HANDSHAKE_TIMEOUT_STATUS")
+        pass "missing-marker handshake reports its dedicated timeout status"
+        ;;
+    124|137)
+        fail "missing-marker handshake exceeded its external watchdog"
+        ;;
+    *)
+        fail "missing-marker handshake returned unexpected status $timeout_probe_status"
+        ;;
+esac
 
 if line_set_contains "$LARGE_SET" "present"; then
     pass "exact membership keeps a present large-set entry present"

--- a/scripts/tests/test_ratchet_membership_wiring.sh
+++ b/scripts/tests/test_ratchet_membership_wiring.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Fail-closed source contracts for every newline-set ratchet consumer.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PASSES=0
+FAILURES=0
+
+pass() {
+    echo "PASS: $*"
+    PASSES=$(( PASSES + 1 ))
+}
+
+fail() {
+    echo "FAIL: $*" >&2
+    FAILURES=$(( FAILURES + 1 ))
+}
+
+assert_exact_source_line() {
+    local script="$1"
+    local expected="$2"
+    local label="$3"
+    local line
+    local matches=0
+
+    while IFS= read -r line; do
+        [[ "$line" == "$expected" ]] && matches=$(( matches + 1 ))
+    done < "$REPO_ROOT/$script"
+
+    if (( matches == 1 )); then
+        pass "$label"
+    else
+        fail "$label (expected one exact call site, found $matches)"
+    fi
+}
+
+# shellcheck disable=SC2016
+assert_exact_source_line scripts/extract-doc-fences.sh \
+    '    if ! line_set_contains "$EXPECTED_STR" "$name"; then' \
+    "doc ratchet expected-set lookup stays pipe-safe"
+# shellcheck disable=SC2016
+assert_exact_source_line scripts/extract-doc-fences.sh \
+    '    if ! line_set_contains "$ACTUAL_STR" "$name"; then' \
+    "doc ratchet actual-set lookup stays pipe-safe"
+
+# shellcheck disable=SC2016
+assert_exact_source_line scripts/hew-suite-ratchet.sh \
+    '    if ! line_set_contains "$EXPECTED_STR" "$name"; then' \
+    "Hew-suite ratchet expected-set lookup stays pipe-safe"
+# shellcheck disable=SC2016
+assert_exact_source_line scripts/hew-suite-ratchet.sh \
+    '    if ! line_set_contains "$ACTUAL_STR" "$name"; then' \
+    "Hew-suite ratchet actual-set lookup stays pipe-safe"
+
+# shellcheck disable=SC2016
+assert_exact_source_line scripts/stdlib-ratchet.sh \
+    '    if ! line_set_contains "$EXPECTED_STR" "$path"; then' \
+    "stdlib ratchet expected-set lookup stays pipe-safe"
+# shellcheck disable=SC2016
+assert_exact_source_line scripts/stdlib-ratchet.sh \
+    '    if ! line_set_contains "$ACTUAL_STR" "$path"; then' \
+    "stdlib ratchet actual-set lookup stays pipe-safe"
+
+# shellcheck disable=SC2016
+assert_exact_source_line scripts/hew-corpus-check.sh \
+    '    if ! line_set_contains "$EXPECTED_STR" "$path"; then' \
+    "corpus ratchet expected-set lookup stays pipe-safe"
+# shellcheck disable=SC2016
+assert_exact_source_line scripts/hew-corpus-check.sh \
+    '    if ! line_set_contains "$ACTUAL_STR" "$path"; then' \
+    "corpus ratchet actual-set lookup stays pipe-safe"
+
+echo ""
+echo "Ratchet membership wiring self-test: $PASSES passed, $FAILURES failed"
+(( FAILURES == 0 ))


### PR DESCRIPTION
## Summary

- Replaces pipefail-sensitive newline-set membership in the doc, Hew-suite, stdlib, and corpus ratchets with exact loop-based helpers.
- Adds fail-closed production-wiring checks and a deterministic oversized SIGPIPE regression.
- Bounds the SIGPIPE test handshake and distinguishes internal timeout from the expected producer failure.
- Requires the membership self-test through authoritative CI parity, scripts-config, and fallback dispatcher lanes.

## Root cause

Under `set -o pipefail`, `grep -q` exits after an early match while the upstream producer can receive `SIGPIPE`. The resulting nonzero pipeline status misclassifies a present ratchet entry as absent and can report a false `NOW-PASSES` failure. The same membership pattern existed in four shell ratchets.

## Impact

Ratchet comparisons now remain exact and deterministic for sets larger than a pipe buffer. CI also rejects restoring the unsafe production wiring.

## Verification

- Ratchet membership wiring: 8/8
- Doc-ratchet self-test: 15/15, repeated 5/5 on Bash 3.2
- Suppressed-marker and deadline-bypass mutations: rejected without hanging
- Native and Perl process-group watchdog backends
- Unsafe doc restoration: rejected, 14/15
- Unsafe sibling restorations: rejected, 2/8
- CI parity: 19/19 required checks; 16/16 workflow steps
- Dispatcher tests: 40/40
- Parity self-test: 4/4
- Documentation fences: 87/87 expected failures
- Hew suite: 0/0
- Stdlib: 0/0 across 73 files
- Corpus sweep: 134/134 across 1,677 files
- ShellCheck, Bash syntax, actionlint, diff, signatures, executable mode, and project voice
