### PR TITLE
test(codegen): observe restart before stable joins

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -5751,7 +5751,12 @@ fn tree_sum(tree: Tree) -> i64 {
 
 actor Worker {
     receive fn score(tag: i64, tree: Tree) -> i64 { tag + tree_sum(tree) }
-    receive fn boom() { panic("restart"); }
+    receive fn boom() {
+        // Keep the crash beyond the 250 ms contextless-await grace while
+        // remaining well inside the restart barrier's bounded timeout.
+        sleep(500ms);
+        panic("restart");
+    }
 }
 
 supervisor App {
@@ -5760,11 +5765,20 @@ supervisor App {
     child worker: Worker;
 }
 
+extern "C" {
+    fn hew_supervisor_wait_restart(sup: LocalPid<App>, target: i64, timeout_ms: i64) -> i64;
+}
+
 fn main() -> i64 {
     let sup = spawn App;
     let worker = sup.worker;
     worker.boom();
-    let _ = await_restart sup.worker;
+    let restarted = unsafe {
+        hew_supervisor_wait_restart(sup, 1, 5000)
+    };
+    if restarted == 0 {
+        return 1;
+    }
     let (a, b) = join {
         worker.score(11, Node(Leaf(1), Leaf(2))),
         worker.score(22, Node(Leaf(3), Leaf(4))),


### PR DESCRIPTION
## Summary

Makes the stable-role join oracle wait for completed supervisor restart publication before submitting through its held pre-crash binding. The test no longer depends on the contextless `await_restart` healthy-child grace window.

## Root cause

Post-main Windows CI run `29948909427` failed `run_fungible_child_binding_joins_after_observed_restart` with empty stdout after the expected worker panic. The fixture queued `worker.boom()` and immediately entered contextless `await_restart`; that primitive may return after a 250 ms grace while the child is still live. Under scheduler contention, both joins could then submit to the retiring incarnation and lose their reply channels during teardown.

The stable-role lookup ABI is unchanged. The defect was the test claiming deterministic restart observation without a causal barrier.

## Design

The fixture now uses the existing `hew_supervisor_wait_restart` counter barrier with exact target `1` on its fresh supervisor and a bounded 5-second timeout. Restart counter publication follows replacement-slot publication. Timeout exits nonzero.

`Worker::boom` delays its panic by 500 ms, twice the historical grace. This makes restoration of the prior `await_restart` path deterministically reproduce the old empty-output failure while the counter barrier remains green. The pre-crash `worker` binding and exact two-join `14,29,44,59` oracle are unchanged.

## Verification

- Focused oracle with exact output: pass
- Windows accepted candidate: 10/10 serial passes plus restored post-mutation pass
- Historical-await mutant with delayed crash: rejected with the hosted empty-output restart signature
- Windows `run_e2e` contention lane before repair: 160/160, confirming nondeterministic exposure rather than an ABI break
- Clippy with warnings denied
- Canonical workspace formatting
- Diff checks and independent causal review

Fresh protected CI, CodeQL, Copilot review, and exact-head Windows coverage remain mandatory before merge.
