### PR TITLE
docs(guide): describe snapshot-send semantics for actor sends

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -49,7 +49,7 @@ for the documented resolver precedence.
 - Access actor state by bare field name inside handlers — no `self.` or `this.`.
 - Fire-and-forget actor sends have no return type and no `await`: `ref.method(arg);`.
 - Ask (request-reply) is `await ref.method(arg)` and returns `Result<R, AskError>` — match `Ok`/`Err`.
-- Passing a value into an actor consumes it; duplicate it first with `clone x` (canonical) if you keep using it afterward.
+- Sending a value into an actor delivers a logical snapshot; the sender's binding stays valid afterward — no `clone` needed to keep using it. Types that cannot be sent are rejected at compile time.
 - Within a fn or actor there is no borrow checker: pass values freely, mutations to Vec/HashMap persist in the caller.
 - Last expression of a block (no trailing semicolon) is its value; a trailing `;` makes it unit.
 - Lean on the safe stdlib trio: `std::string`, `std::math`, `std::iter`. Do not import `std::option`/`std::result`.
@@ -870,7 +870,7 @@ fn main() {
 }
 ```
 
-Use `.clone()` only when you need a second independent copy — e.g. before sending one to an actor and keeping one.
+Use `.clone()` only when you need a second independent copy — e.g. keeping the original after an ownership-sink like `HashSet.insert(x)`. Actor sends do not need it: the sender's binding stays valid after a send.
 
 ### clone x — the canonical duplication prefix
 
@@ -963,20 +963,20 @@ fn main() {
 
 For transformations, construct and return a fresh struct literal. Struct fields are immutable by default — produce a new struct rather than mutating.
 
-### Move-on-send: passing into an actor consumes it
+### Snapshot-on-send: the sender keeps its value
 
 ```hew
 actor Sink { let id: i64; receive fn take(data: string) -> i64 { data.len() } }
 fn main() {
     let s = spawn Sink(id: 0);
     let msg: string = "hello";
-    let n = await s.take(clone msg);   // send a copy to keep msg
+    let n = await s.take(msg);         // receiver gets a snapshot of msg
     match n { Ok(len) => println(len), Err(_) => println("ask failed") }
-    println(msg.len());   // 5, msg still valid
+    println(msg.len());   // 5 — msg still valid after the send
 }
 ```
 
-Passing a value into an actor's `receive fn` consumes it; reusing it after is a hard `use of moved value` error. Duplicate it first with `clone x` (or the equivalent `x.clone()`) to keep the original. `await actor.method(...)` on a request-reply fn returns `Result<R, AskError>` — match it.
+Passing a value into an actor's `receive fn` sends the receiver a logical snapshot: the receiver observes an independent value, and the sender's binding stays valid. Reuse after send — including sending the same value to many actors in a loop — is ordinary code with no `clone` ceremony. Types that cannot cross an actor boundary (such as `Rc<T>` and `Weak<T>`) are still rejected with a compile-time diagnostic. `await actor.method(...)` on a request-reply fn returns `Result<R, AskError>` — match it.
 
 ### Strings and scalars are freely reusable
 

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -583,9 +583,9 @@ A `let` (or bare) actor field is immutable after construction: it may be assigne
 
 This distinction exists because actor fields are stateful (they change over the actor's lifetime) and use initialization syntax similar to variable declarations, while type fields are data layout declarations.
 
-#### 3.4.4 The Boundary Rule: Move on Send
+#### 3.4.4 The Boundary Rule: Snapshot on Send
 
-The **only** ownership constraint is at actor boundaries. When a value crosses an actor boundary (via method call or `.send()`), it must be **moved** or **cloned**:
+The **only** ownership constraint is at actor boundaries. When a value crosses an actor boundary (via method call or `.send()`), the receiver observes a **logical snapshot** — an independent value — and the sender's binding stays valid:
 
 ```hew
 type Message { body: string }
@@ -598,7 +598,7 @@ actor Handler {
 
 actor Forwarder {
     receive fn forward(message: Message, target: LocalPid<Handler>) {
-        target.process(message);  // message is MOVED to target's mailbox
+        target.process(message);  // target receives a snapshot of message
     }
 }
 
@@ -613,21 +613,22 @@ fn main() {
 
 > **Send semantics (language vs runtime):**
 >
-> - **Language level** (unchanged): A method call or `.send()` moves the value — the sender can no longer use it.
-> - **Runtime level** (gated): the send mechanism is selected based on the value's admissibility class:
+> - **Language level**: A method call or `.send()` delivers a logical snapshot to the receiver. The sender's binding remains valid after the send; reuse after send — including fan-out sends in a loop — is ordinary code with no `clone` ceremony.
+> - **Runtime level** (gated): the snapshot mechanism is selected based on the value's admissibility class:
+>   - **Provably-unique values** (refcount 1 at the send, with no later use): transferred by pointer — zero copy.
 >   - **Immutable-shareable** types (`string`, `bytes`): alias-shared by **refcount retain** — the receiver gets a retained reference to the same backing buffer; no byte copy occurs; a COW write-barrier (`ensure_unique`) forks the buffer before any subsequent mutation, preserving actor isolation.
 >   - **Mutable collections** (`Vec<T>`, `HashMap<K,V>`, `HashSet<T>`): **deep-copied** into the receiver's per-actor heap.
 >   - **Consumed-linear (`iso`/Linear) values**: zero-copy **ownership move** (P6 — not yet surfaced in edition 2026).
 > - The send-admissibility gate is `is_immutable_shareable || consumed-Linear || deep-copy`. Note: bare `copy` does **not** imply sendability — a type may derive `Copy` yet hold non-send internals (`copy ⊥ sendable`, B-INV-3). Foreign-view syntax is not legal in ordinary message declarations, so it cannot cross an actor boundary.
-> - From the programmer's perspective the gated model is indistinguishable from move-then-independent-value: the receiver observes an independent value; the sender cannot use the value after send. Alias-sharing is a runtime optimization valid precisely because immutable-shareable values are never mutated in place through shared aliases.
+> - Each mechanism is indistinguishable from the others at the source level: the receiver observes an independent value and the sender keeps a valid, independent value. A surface move survives only as the pointer-transfer fast path for provably-unique values — a runtime optimization, never a rule the programmer must reason about.
 
-**Why move semantics?**
+**Why snapshot semantics?**
 
 - The receiving actor may be on a different thread (in the runtime)
 - Two actors cannot share mutable state (this is the core safety guarantee)
-- Move ensures the sender relinquishes the value
+- The snapshot gives the receiver an independent value while the sender keeps its own — actor isolation without a use-after-send rule to reason about
 
-**Cloning for continued use:**
+**Duplication syntax:**
 
 Hew provides two syntactic forms for duplication:
 
@@ -637,6 +638,9 @@ Hew provides two syntactic forms for duplication:
   Only acts as a prefix when followed by an operand token (identifier or
   literal); otherwise `clone` is a plain identifier, so `clone(args)` and
   `x.clone()` are unaffected.
+
+Cloning is never required to keep using a value after a send — the sender's
+binding stays valid. Fan-out to multiple receivers is ordinary code:
 
 ```hew
 type Message { body: string }
@@ -649,8 +653,8 @@ actor Handler {
 
 actor Broadcaster {
     receive fn broadcast(message: Message, first: LocalPid<Handler>, second: LocalPid<Handler>) {
-        first.process(message.clone());
-        second.process(message.clone());
+        first.process(message);
+        second.process(message);   // message still valid — each send snapshots
     }
 }
 
@@ -661,7 +665,7 @@ fn main() {
     broadcaster.broadcast(Message { body: "hello" }, first, second);
 }
 
-// Lambda actor .send() uses the same move-on-send rule.
+// Lambda actor .send() uses the same snapshot-on-send rule.
 ```
 
 #### 3.4.5 Capturing Values in Lambda Actors
@@ -738,20 +742,12 @@ actor Example {
 
 ```hew
 actor Example {
-    var data: Vec<i64> = Vec::new();
-
     receive fn bad_examples(other: LocalPid<Other>) {
-        // Sending without move - ERROR (implicit move makes source invalid)
-        other.process(data);
-        data.push(1);     // compile error: data was moved
-
-        // Using value after send - ERROR
-        let msg = Message::new();
-        other.process(msg);
-        println(msg.content);  // compile error: msg was moved
+        // Sending a non-Send value - ERROR
+        let local_handle: RawPointer = get_handle();
+        other.process(local_handle);  // compile error: RawPointer is not Send
 
         // Capturing non-Send value - ERROR
-        let local_handle: RawPointer = get_handle();
         let worker = actor |x: i64| {
             use(local_handle);  // compile error: RawPointer is not Send
         };
@@ -759,14 +755,17 @@ actor Example {
 }
 ```
 
+Sending a non-`Send` value — `Rc<T>`, `Weak<T>`, raw handles, or any type
+containing one — is a fail-closed compile error, never a silent copy.
+
 #### 3.4.8 Summary
 
-| Context       | Aliasing     | Mutation     | Borrow checking |
-| ------------- | ------------ | ------------ | --------------- |
-| Within actor  | Unrestricted | Unrestricted | None            |
-| Across actors | Not allowed  | N/A          | Move required   |
+| Context       | Aliasing     | Mutation     | Boundary rule    |
+| ------------- | ------------ | ------------ | ---------------- |
+| Within actor  | Unrestricted | Unrestricted | None             |
+| Across actors | Not allowed  | N/A          | Snapshot on send |
 
-**Hew's guarantee:** No data races between actors, enforced at compile time through `Send` and move semantics. No runtime overhead, no borrow checker complexity for local code.
+**Hew's guarantee:** No data races between actors, enforced at compile time through `Send` and snapshot-on-send semantics. No borrow checker complexity for local code.
 
 ---
 
@@ -1227,7 +1226,7 @@ Hew guarantees no GC pauses. Memory reclamation is entirely deterministic:
 
 #### 3.7.2 Message Passing Semantics
 
-At the **language level**, `send()` **moves** the value — the sender loses access and cannot use it after sending (see §3.4.4). At the **runtime level**, the send mechanism is **gated** on the value's admissibility class (D355):
+At the **language level**, `send()` delivers a **logical snapshot** — the receiver observes an independent value and the sender's binding remains valid after the send (see §3.4.4). At the **runtime level**, the snapshot mechanism is **gated** on the value's admissibility class (D355):
 
 | Admissibility class | Runtime mechanism | Examples |
 | ------------------- | ----------------- | -------- |
@@ -1237,15 +1236,15 @@ At the **language level**, `send()` **moves** the value — the sender loses acc
 
 The gate is `is_immutable_shareable || consumed-Linear || deep-copy`. Bare `copy` does **not** imply sendability (`copy ⊥ sendable`, B-INV-3). Foreign-view syntax is not legal in ordinary message declarations, so it cannot cross an actor boundary.
 
-This hybrid gives the safety of Rust's move semantics (no use-after-send bugs) with actor isolation (no shared mutable state between actors).
+This hybrid gives actor isolation (no shared mutable state between actors) with none of the ceremony of surface move semantics: there is no use-after-send error to avoid.
 
-> **Immutable-shareable alias sharing:** `string` and `bytes` are immutable-shareable owned heap types. When sent, the runtime retains a reference to the same backing buffer for the receiver rather than copying it. The sender's move and the receiver's retained alias both resolve to the same buffer with a shared refcount; the buffer is freed once the last reference drops. The backing buffer is never mutated in place through a shared alias — if a mutation targets a shared (`rc>1`) buffer, the COW write-barrier (`ensure_unique`) forks a private copy before the write, preserving actor isolation. An immutable `let`-bound sendable value is alias-shared with no barrier (never mutated in place).
+> **Immutable-shareable alias sharing:** `string` and `bytes` are immutable-shareable owned heap types. When sent, the runtime retains a reference to the same backing buffer for the receiver rather than copying it. The sender's retained binding and the receiver's retained alias both resolve to the same buffer with a shared refcount; the buffer is freed once the last reference drops. The backing buffer is never mutated in place through a shared alias — if a mutation targets a shared (`rc>1`) buffer, the COW write-barrier (`ensure_unique`) forks a private copy before the write, preserving actor isolation. An immutable `let`-bound sendable value is alias-shared with no barrier (never mutated in place).
 
-> **Programmer indistinguishability preserved:** From the programmer's perspective the gated model is indistinguishable from move-then-independent-value. The receiver observes an independent value; the sender cannot use the value after send. Alias-sharing is a runtime optimization valid precisely because immutable-shareable values are never mutated in place through shared aliases.
+> **Programmer indistinguishability preserved:** From the programmer's perspective the gated model is indistinguishable from deep-copy-then-independent-value. The receiver observes an independent value; the sender keeps its own valid, independent value. Alias-sharing is a runtime optimization valid precisely because immutable-shareable values are never mutated in place through shared aliases.
 
-**Move-on-send:**
+**Snapshot-on-send:**
 
-- When a message is sent to an actor (via method call or `.send()`), the value is moved at the language level — the sender can no longer use it. At runtime, the mechanism is gated: immutable-shareable values (`string`, `bytes`) are alias-shared by retain; mutable collections are deep-copied; `iso`/Linear values are moved (P6).
+- When a message is sent to an actor (via method call or `.send()`), the receiver gets a logical snapshot and the sender's binding stays valid. At runtime, the mechanism is gated: provably-unique values are transferred by pointer; immutable-shareable values (`string`, `bytes`) are alias-shared by retain; mutable collections are deep-copied; `iso`/Linear values are moved (P6).
 - The receiver observes an independent value (alias-sharing is an optimization invisible to program semantics)
 - No user-visible references or borrows cross actor boundaries: ordinary message declarations cannot contain foreign-view syntax. The runtime retain optimization applies only to admissible immutable-shareable **owned** values, and the receiver always observes an independent owned value at the language level, never a view into the sender's heap.
 
@@ -1260,7 +1259,7 @@ actor Handler {
 
 actor Forwarder {
     receive fn forward(message: Message, target: LocalPid<Handler>) {
-        target.process(message);  // message is MOVED by the gated send mechanism
+        target.process(message);  // target receives a snapshot; message stays valid
     }
 }
 

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -70,7 +70,7 @@ spec-0015   1507524389   # SNIPPET: bare `type Point { ... }` + bare `var` — s
 spec-0020   3005964102   # SNIPPET: bare `let config = load_config()` — actor capture illustration
 spec-0021   667087144   # SNIPPET: bare `let local_ref = ...` — non-Send capture illustration
 spec-0022   1016251393   # FRAGMENT: actor calls undefined `process()` — allowed-ops illustration
-spec-0023   2765383023   # ERROR-DEMO: intentionally shows use-after-send and non-Send capture errors
+spec-0023   3898239403   # ERROR-DEMO: intentionally shows non-Send send and non-Send capture errors
 spec-0024   2818127750   # SPEC-BUG: type mismatch in aspirational TCP module example
 spec-0025   1856890936   # FRAGMENT: imports `network::tcp` — hypothetical module, not in stdlib
 spec-0026   1579215179   # SNIPPET: bare code after import statement — illustration of import effect


### PR DESCRIPTION
## Summary

The language guide and spec still documented pre-snapshot-send move-on-send semantics — mandatory clone before send, use-of-moved-value after — which has been false since #2772. The guide quick-reference and §966 section, plus spec §3.4.4/§3.4.7/§3.4.8/§3.7.2, now describe snapshot-on-send: the sender keeps its value after a send, and non-Send rejection is unchanged. The dead clones are dropped from the examples.

## Verification

- All three documented behaviours proven against a fresh build: reuse-after-send 5/5; fan-out 6/6/6; `Rc<Node>` send rejected with "type is not Send"
- `make test-doc-examples`: green — 188 passed, 87 tracked expected failures, 22 skipped; ratchet PASSED
- spec-0023 cksum re-labelled for the changed fence
- Preflight: ready-to-push

## Out of scope

- Genuinely move-related passages (lambda move-capture, `@resource`/`@linear`, generator moves) — verified still accurate and untouched.