### PR TITLE
fix(release): dispatch playground publish mode with exact commit identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
               - 'scripts/**'
               - '.github/workflows/freebsd.yml'
               - '.github/workflows/release-gate.yml'
+              - '.github/workflows/release.yml'
 
   # ─────────────────────────────────────────────────────────────────────────
   # Lightweight docs/scripts coverage — required signal for narrow PRs.
@@ -157,6 +158,10 @@ jobs:
       - name: Exercise doc-ratchet membership gate
         if: needs.changes.outputs.scripts == 'true'
         run: make doc-ratchet-selftest
+
+      - name: Verify release workflow contract
+        if: needs.changes.outputs.scripts == 'true'
+        run: make test-release-workflow-contract
 
       # <<< CI-PARITY-STEPS
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1303,16 +1303,33 @@ jobs:
     needs: release
     runs-on: ubuntu-24.04
     if: ${{ !cancelled() && needs.release.result == 'success' }}
-    # The downstream workflow is bounded at 5 + 45 + 30 minutes across its
-    # sequential verifier, smoke, and publish jobs. Leave another 40 minutes
-    # for dispatch visibility and runner scheduling while still failing closed.
+    # The downstream publish path is bounded at 5 + 5 + 45 + 30 + 5 minutes
+    # across its authority, contract-verify, smoke, publish, and result jobs
+    # (90 minutes sequential worst case). Leave another 30 minutes for dispatch
+    # visibility and runner scheduling while still failing closed.
     timeout-minutes: 120
 
     steps:
+      - name: Resolve release commit identity
+        id: release-commit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          HEW_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}" --jq '.sha')
+          if ! [[ "${HEW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::${RELEASE_TAG} did not resolve to an exact lowercase 40-character commit SHA"
+            exit 1
+          fi
+          echo "hew_sha=${HEW_SHA}" >> "${GITHUB_OUTPUT}"
+
       - name: Trigger playground image rebuild
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.PLAYGROUND_DISPATCH_TOKEN }}
+          HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}
         run: |
           set -euo pipefail
 
@@ -1320,9 +1337,13 @@ jobs:
             echo "::error::PLAYGROUND_DISPATCH_TOKEN secret is required for the playground dispatch"
             exit 1
           fi
+          if ! [[ "${HEW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::release commit identity is not an exact lowercase 40-character commit SHA"
+            exit 1
+          fi
           VERSION="${RELEASE_TAG#v}"
           CORRELATION_ID="hew-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          EXPECTED_DISPLAY_TITLE="Build Playground ${VERSION} [${CORRELATION_ID}]"
+          EXPECTED_DISPLAY_TITLE="Build Playground mode=publish sha=${HEW_SHA} version=${VERSION} correlation=${CORRELATION_ID}"
           if ! gh repo view hew-lang/playground --json name >/dev/null 2>&1; then
             echo "::error::hew-lang/playground is unavailable"
             exit 1
@@ -1347,6 +1368,8 @@ jobs:
           gh workflow run build.yml \
             -R hew-lang/playground \
             --ref "${PLAYGROUND_REF}" \
+            -f publish=true \
+            -f hew_sha="${HEW_SHA}" \
             -f version="${VERSION}" \
             -f correlation_id="${CORRELATION_ID}"
           RUN_ID=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,12 @@
 #   APPLE_API_KEY_ID            — App Store Connect API key ID
 #   APPLE_API_ISSUER_ID         — App Store Connect API issuer ID
 #
-# Required secrets for Homebrew tap updates (optional — skipped if absent):
+# Required secret for the required playground dispatch:
+#   PLAYGROUND_DISPATCH_TOKEN — purpose-scoped token with the minimum permission
+#     needed to dispatch hew-lang/playground's build.yml workflow
+#
+# Homebrew tap updates use a separate optional credential and are skipped for
+# prereleases:
 #   HOMEBREW_TAP_TOKEN           — GitHub PAT with actions:write scope for hew-lang/homebrew-hew
 #
 # Required secrets for VS Code extension publishing (optional — skipped if absent):
@@ -92,9 +97,11 @@ jobs:
       - name: Configure LLVM toolchain (macOS)
         if: startsWith(matrix.target, 'darwin')
         run: |
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
-          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
+          {
+            echo "CC=${LLVM_PREFIX}/bin/clang"
+            echo "CXX=${LLVM_PREFIX}/bin/clang++"
+            echo "MACOSX_DEPLOYMENT_TARGET=13.0"
+          } >> "$GITHUB_ENV"
           # The brew llvm bottle links libz3.dylib into its static libraries'
           # dependency set; hew never calls z3 (clang static-analyzer only).
           # dead_strip_dylibs drops load commands with no referenced symbols,
@@ -282,7 +289,6 @@ jobs:
         run: |
           VERSION="${RELEASE_TAG#v}"
           ARCHIVE_NAME="hew-v${VERSION}-${{ matrix.target }}"
-          RELEASE_DIR="target/${{ matrix.rust_target }}/release"
           RELEASE_LIB_DIR="target/${{ matrix.rust_target }}/release-lib"
 
           mkdir -p "${ARCHIVE_NAME}/bin" "${ARCHIVE_NAME}/lib" \
@@ -482,17 +488,18 @@ jobs:
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         run: |
           # Write the API key (base64-encoded in secret) to disk
-          mkdir -p ~/private_keys
-          echo "${APPLE_API_KEY_P8}" | base64 --decode > ~/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
+          KEY_PATH="${HOME}/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          mkdir -p "${HOME}/private_keys"
+          echo "${APPLE_API_KEY_P8}" | base64 --decode > "${KEY_PATH}"
 
           ditto -c -k --keepParent "${ARCHIVE_NAME}" "${ARCHIVE_NAME}-notarize.zip"
           xcrun notarytool submit "${ARCHIVE_NAME}-notarize.zip" \
-            --key ~/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8 \
+            --key "${KEY_PATH}" \
             --key-id "${APPLE_API_KEY_ID}" \
             --issuer "${APPLE_API_ISSUER_ID}" \
             --wait
           rm -f "${ARCHIVE_NAME}-notarize.zip"
-          rm -rf ~/private_keys
+          rm -rf "${HOME}/private_keys"
 
       # ── Create final archive ────────────────────────────────────────────
 
@@ -1296,30 +1303,103 @@ jobs:
     needs: release
     runs-on: ubuntu-24.04
     if: ${{ !cancelled() && needs.release.result == 'success' }}
-    timeout-minutes: 5
+    # The downstream workflow is bounded at 5 + 45 + 30 minutes across its
+    # sequential verifier, smoke, and publish jobs. Leave another 40 minutes
+    # for dispatch visibility and runner scheduling while still failing closed.
+    timeout-minutes: 120
 
     steps:
       - name: Trigger playground image rebuild
+        shell: bash
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ secrets.PLAYGROUND_DISPATCH_TOKEN }}
         run: |
+          set -euo pipefail
+
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::warning::HOMEBREW_TAP_TOKEN secret not set — skipping playground trigger"
-            exit 0
+            echo "::error::PLAYGROUND_DISPATCH_TOKEN secret is required for the playground dispatch"
+            exit 1
           fi
           VERSION="${RELEASE_TAG#v}"
-          # Check if the playground repo exists before dispatching
+          CORRELATION_ID="hew-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          EXPECTED_DISPLAY_TITLE="Build Playground ${VERSION} [${CORRELATION_ID}]"
           if ! gh repo view hew-lang/playground --json name >/dev/null 2>&1; then
-            echo "::warning::hew-lang/playground repo not found — skipping playground trigger"
-            exit 0
+            echo "::error::hew-lang/playground is unavailable"
+            exit 1
           fi
-          # Resolve the default branch via REST (avoids a GraphQL defaultBranchRef
-          # lookup that PATs without full repo scope cannot satisfy).
-          PLAYGROUND_REF=$(gh api repos/hew-lang/playground --jq '.default_branch' 2>/dev/null || echo "main")
+          PLAYGROUND_REF=$(gh api repos/hew-lang/playground --jq '.default_branch')
+          PLAYGROUND_SHA=$(gh api \
+            "repos/hew-lang/playground/commits/${PLAYGROUND_REF}" \
+            --jq '.sha')
+          DISPATCH_ACTOR=$(gh api user --jq '.login')
+          WORKFLOW_STATE=$(gh workflow view build.yml \
+            -R hew-lang/playground --json state --jq '.state')
+          if [ "${WORKFLOW_STATE}" != "active" ]; then
+            echo "::error::hew-lang/playground build.yml is not active"
+            exit 1
+          fi
+          PRE_DISPATCH_MAX_ID=$(gh api -X GET \
+            repos/hew-lang/playground/actions/workflows/build.yml/runs \
+            -f event=workflow_dispatch \
+            -f branch="${PLAYGROUND_REF}" \
+            -f per_page=100 \
+            --jq '[.workflow_runs[].id] | max // 0')
           gh workflow run build.yml \
             -R hew-lang/playground \
             --ref "${PLAYGROUND_REF}" \
-            -f version="${VERSION}"
+            -f version="${VERSION}" \
+            -f correlation_id="${CORRELATION_ID}"
+          RUN_ID=""
+          LAST_CANDIDATE_ID=""
+          for _ in $(seq 1 30); do
+            if ! RUNS_JSON=$(gh api -X GET \
+              repos/hew-lang/playground/actions/workflows/build.yml/runs \
+              -f event=workflow_dispatch \
+              -f branch="${PLAYGROUND_REF}" \
+              -f per_page=100); then
+              echo "::error::failed to list playground workflow runs"
+              exit 1
+            fi
+            if ! RUN_IDS_OUTPUT=$(jq -r \
+                --argjson floor "${PRE_DISPATCH_MAX_ID}" \
+                --arg sha "${PLAYGROUND_SHA}" \
+                --arg actor "${DISPATCH_ACTOR}" \
+                --arg display_title "${EXPECTED_DISPLAY_TITLE}" \
+                '.workflow_runs[]
+                  | select(.id > $floor)
+                  | select(.head_sha == $sha)
+                  | select(.actor.login == $actor)
+                  | select(.display_title == $display_title)
+                  | .id' <<< "${RUNS_JSON}"); then
+              echo "::error::failed to parse playground workflow runs"
+              exit 1
+            fi
+            RUN_IDS=()
+            while IFS= read -r CANDIDATE_ID; do
+              if [ -n "${CANDIDATE_ID}" ]; then
+                RUN_IDS[${#RUN_IDS[@]}]="${CANDIDATE_ID}"
+              fi
+            done <<< "${RUN_IDS_OUTPUT}"
+            if [ "${#RUN_IDS[@]}" -gt 1 ]; then
+              echo "::error::ambiguous playground workflow dispatch correlation"
+              exit 1
+            fi
+            if [ "${#RUN_IDS[@]}" -eq 1 ]; then
+              if [ "${RUN_IDS[0]}" = "${LAST_CANDIDATE_ID}" ]; then
+                RUN_ID="${RUN_IDS[0]}"
+                break
+              fi
+              LAST_CANDIDATE_ID="${RUN_IDS[0]}"
+            else
+              LAST_CANDIDATE_ID=""
+            fi
+            sleep 2
+          done
+          if [ -z "${RUN_ID}" ]; then
+            echo "::error::could not correlate the playground workflow dispatch with a run"
+            exit 1
+          fi
+          gh run watch "${RUN_ID}" -R hew-lang/playground --exit-status
 
   # ─────────────────────────────────────────────────────────────────────────
   # VS Code Extension — package + publish with bundled hew-lsp per platform

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test libhew-link-race-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest preflight-parity-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar sandbox-parity-coverage-check test-sandbox-parity-coverage-check doc-ratchet-selftest freebsd-workflow-contract-check
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest preflight-parity-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary test-release-workflow-contract check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar sandbox-parity-coverage-check test-sandbox-parity-coverage-check doc-ratchet-selftest freebsd-workflow-contract-check
 .PHONY: clean install install-check uninstall verify-ffi test-verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -1111,6 +1111,12 @@ sandbox-parity-coverage-check: test-sandbox-parity-coverage-check
 # evade classification. See scripts/tests/test_check_sandbox_parity_coverage.py.
 test-sandbox-parity-coverage-check:
 	python3 scripts/tests/test_check_sandbox_parity_coverage.py
+
+# Keep the required release handoff fail-closed and correlated to its exact
+# downstream workflow run. This target is called by CI for release workflow
+# and static-oracle changes and by the scripts/config preflight profile.
+test-release-workflow-contract:
+	python3 scripts/tests/test_release_workflow_contract.py
 
 # Scan tracked source for orchestration-token leaks (lane IDs, Q-tags, .tmp/ paths)
 # and scan commit-message bodies of commits not yet on origin/main for the same tokens.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -168,7 +168,34 @@ Expected `otool -L` output is limited to system paths under `/usr/lib/` and
 `/System/Library/`. Any `/opt/homebrew/` or `/usr/local/opt/` entry is a
 release blocker.
 
-## Phase 5 — Tag and release
+## Phase 5 — Candidate tag and publication order
+
+The publication sequence is a fail-closed dependency graph. Do not advance
+past a failed or missing result; items grouped in braces may run independently,
+but every arm must succeed before the graph rejoins:
+
+1. Confirm every release bar and the final-candidate checklist are green on
+   the exact candidate commit, including sanitizer evidence, required secrets,
+   and branch protection.
+2. Create the signed tag only after the preceding evidence is recorded.
+3. Let the release workflow build and publish the signed platform assets and
+   checksums. Its curated body must be the exact
+   `docs/releases/<tag>.md` file for that tag.
+4. After the assets exist, complete both independent publication arms:
+   - Manually dispatch `.github/workflows/publish-npm-packages.yml` for
+     `@hew-lang/{wasm,sandbox-wasm,sandbox-vm}@0.6.0-rc1` through its actual
+     workflow, and wait for each result. A tag does not publish these packages.
+   - Wait for the release workflow's automated playground dispatch, then
+     verify the published image, API, and `hew run` smoke path against the
+     candidate version.
+5. Only after both arms are green, pin the candidate and cut over the banner in
+   `hew.sh` and `hew.run`.
+6. Rebuild Android from the tagged candidate and verify its artifact.
+
+Homebrew intentionally skips prerelease tags; its optional tap update is
+separate from the required playground dispatch. Do not run obsolete downstream
+vendoring commands for npm consumers until their vendoring assumptions are
+repaired or the commands are removed.
 
 Do not tag until `.github/workflows/release-gate.yml` is green on the release
 branch. In particular, `gate-sanitizers` must have validated ASan on the exact

--- a/docs/releases/v0.6.0-rc1.md
+++ b/docs/releases/v0.6.0-rc1.md
@@ -1,0 +1,62 @@
+# Hew v0.6.0-rc1
+
+This is the first release candidate for v0.6.0. It is a candidate artifact,
+not a final release: the tag and final changelog date remain intentionally
+unset until the release gates are green on the exact candidate commit.
+
+## Ownership and runtime safety
+
+- **Owned values follow one type-directed drop path.** MIR elaboration now
+  releases owned fields exactly once across composite values, match bindings,
+  tuple chains, and temporary arguments. The ownership/drop regression corpus,
+  runtime cleanup tests, and checked-MIR verification gate cover the changed
+  paths.
+- **Resources close through fields.** `#[resource]` fields embedded in records
+  now close on scope exit. The resource cleanup tests cover the field-wise
+  path, including nested aggregates.
+- **Distributed identity is authenticated.** Stable credentials derive node
+  identity, route slots pin peer credentials, and durable actor locations fence
+  stale sessions. The runtime handshake, routing, monitor, and connection
+  teardown tests cover rejection and cleanup paths.
+
+## Language and diagnostics
+
+- **Fallible numeric conversion is explicit.** `try_to_*` conversions reject
+  lossy and out-of-range values instead of truncating them. Conversion tests
+  cover exact, boundary, and rejected values.
+- **Actor sends use one `.send()` surface.** Local and remote fire-and-forget
+  sends share the same spelling and error contract. The actor send tests cover
+  successful delivery and failure reporting.
+- **Wire declarations use `#[wire]`.** The declaration surface is aligned with
+  the wire codec, with parser, checker, and codec tests covering accepted and
+  rejected forms.
+- **Iterator coverage is complete across standard collections.** Non-consuming
+  `Vec<T>::iter()`, `HashMap::into_iter()`, and the related pipeline and
+  `for-in` paths are covered by the collection and end-to-end test suites.
+- **Machine and actor failures are observable.** Machine guards and emits,
+  bounded mailbox policies, supervisor escalation, collection bounds failures,
+  and broken-pipe sends now take their specified paths. The vertical-slice,
+  runtime, and sandbox parity gates exercise these behaviours.
+
+## Compatibility notes
+
+`impl Drop for T` is rejected. Handle-like types should use `#[resource]` and
+an explicit `close(self)` method; ordinary data types continue to receive
+automatic field-wise drop. The `.send()` spelling replaces the older
+fire-and-forget actor call form. `#[wire]` replaces the removed `struct` wire
+declaration form.
+
+## Candidate limits and publication order
+
+This candidate does not claim that platform bars, npm publication, playground
+deployment, `hew.sh`/`hew.run` cutover, Android rebuilds, or final release
+publication have completed. npm consumers are published manually through
+`.github/workflows/publish-npm-packages.yml`; they are not inferred from a tag.
+Homebrew intentionally skips `-rc` tags. The release workflow dispatches the
+playground build only with its purpose-scoped credential and fails closed if
+the dispatch or the resulting run fails.
+
+The named proof is the release-gate workflow plus the repository gates:
+`actionlint .github/workflows/release.yml`, the release workflow contract
+test, the CI preflight dispatcher contract test, and `cargo deny check
+licenses`. Candidate-specific publication remains ordered after those gates.

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -35,6 +35,7 @@ command_timeout_floor() {
         "make test-o2-differential") echo 1200 ;;
         "make o2-differential-selftest") echo 30 ;;
         "make doc-ratchet-selftest") echo 45 ;;
+        "make test-release-workflow-contract") echo 30 ;;
         "make test-stdlib-ratchet") echo 45 ;;
         "make test-doc-examples") echo 45 ;;
         "make sandbox-parity") echo 150 ;;
@@ -88,6 +89,7 @@ CI_REQUIRED_CHECKS=(
     "O2 differential-exec parity gate (ci.yml: make test-o2-differential)	make test-o2-differential"
     "O2-differential gate self-test (ci.yml: make o2-differential-selftest)	make o2-differential-selftest"
     "Doc-ratchet membership self-test (ci.yml: make doc-ratchet-selftest)	make doc-ratchet-selftest"
+    "Release workflow contract (ci.yml: make test-release-workflow-contract)	make test-release-workflow-contract"
     "Stdlib type-check ratchet (ci.yml: make test-stdlib-ratchet)	make test-stdlib-ratchet"
     "Vertical slice oracle (ci.yml: make test-vertical-slice)	make test-vertical-slice"
     "Package-import oracle (ci.yml: make test-pkg-import)	make test-pkg-import"
@@ -671,6 +673,7 @@ case "$LANE" in
         ;;
     scripts-config)
         add_command "make leak-scan"
+        add_command "make test-release-workflow-contract"
         add_command "cargo fmt --all -- --check"
         add_command "make freebsd-workflow-contract-check"
         add_command "make test-rust"
@@ -801,6 +804,7 @@ case "$LANE" in
         add_command "make test-hew-ratchet"
         add_command "make test-o2-differential"
         add_command "make o2-differential-selftest"
+        add_command "make test-release-workflow-contract"
         add_command "make test-stdlib-ratchet"
         add_command "make test-doc-examples"
         add_command "make doc-ratchet-selftest"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -62,6 +62,7 @@ def assert_scripts_config_profile(result: subprocess.CompletedProcess[str]) -> N
     assert "make playground-check" not in result.stdout
     assert "  - cargo fmt --all -- --check" in result.stdout
     assert "  - make freebsd-workflow-contract-check" in result.stdout
+    assert "  - make test-release-workflow-contract" in result.stdout
     assert "  - make test-rust" in result.stdout
     assert "  - make doc-ratchet-selftest" in result.stdout
     assert "make test-codegen" not in result.stdout

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -1,0 +1,443 @@
+"""Static contract tests for the release workflow's prerelease handoff."""
+
+import os
+import re
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+RELEASE_NOTES = ROOT / "docs" / "releases" / "v0.6.0-rc1.md"
+RUNBOOK = ROOT / "docs" / "release-runbook.md"
+
+
+def workflow() -> str:
+    return WORKFLOW.read_text()
+
+
+def playground_job(text: str | None = None) -> str:
+    text = workflow() if text is None else text
+    start = text.index("  playground:\n")
+    end = text.index(
+        "  # ─────────────────────────────────────────────────────────────────────────\n  # VS Code",
+        start,
+    )
+    return text[start:end]
+
+
+def playground_script(text: str | None = None) -> str:
+    """Extract the exact Bash program executed by the playground job."""
+    job = playground_job() if text is None else text
+    step = job.index("      - name: Trigger playground image rebuild\n")
+    run = job.index("        run: |\n", step) + len("        run: |\n")
+    return textwrap.dedent(job[run:]).rstrip() + "\n"
+
+
+def assert_exact_dispatch_correlation(job: str) -> None:
+    """Require the unique caller identity in both dispatch and run selection."""
+    assert 'CORRELATION_ID="hew-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' in job
+    assert (
+        'EXPECTED_DISPLAY_TITLE="Build Playground ${VERSION} [${CORRELATION_ID}]"'
+        in job
+    )
+
+    dispatch_start = job.index("          gh workflow run build.yml")
+    dispatch_end = job.index('          RUN_ID=""', dispatch_start)
+    dispatch = job[dispatch_start:dispatch_end]
+    assert '-f version="${VERSION}" \\\n' in dispatch
+    assert '-f correlation_id="${CORRELATION_ID}"' in dispatch
+
+    query_start = job.index("            if ! RUN_IDS_OUTPUT=$(jq -r")
+    query_end = job.index("            RUN_IDS=()", query_start)
+    query = job[query_start:query_end]
+    expected = """            if ! RUN_IDS_OUTPUT=$(jq -r \\
+                --argjson floor "${PRE_DISPATCH_MAX_ID}" \\
+                --arg sha "${PLAYGROUND_SHA}" \\
+                --arg actor "${DISPATCH_ACTOR}" \\
+                --arg display_title "${EXPECTED_DISPLAY_TITLE}" \\
+                '.workflow_runs[]
+                  | select(.id > $floor)
+                  | select(.head_sha == $sha)
+                  | select(.actor.login == $actor)
+                  | select(.display_title == $display_title)
+                  | .id' <<< "${RUNS_JSON}"); then
+              echo "::error::failed to parse playground workflow runs"
+              exit 1
+            fi
+"""
+    assert query == expected
+
+
+def assert_fail_closed_run_retrieval(job: str) -> None:
+    """Require API retrieval and jq parsing to have independent status checks."""
+    assert "        shell: bash\n" in job
+    script = playground_script(job)
+    assert script.startswith("set -euo pipefail\n")
+    start = job.index("            if ! RUNS_JSON=$(gh api -X GET")
+    end = job.index("            if ! RUN_IDS_OUTPUT=$(jq -r", start)
+    retrieval = job[start:end]
+    assert "| jq" not in retrieval
+    assert 'echo "::error::failed to list playground workflow runs"' in retrieval
+    assert "              exit 1\n" in retrieval
+
+
+_MOCK_GH = r"""#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+state = Path(os.environ["MOCK_STATE"])
+log = Path(os.environ["MOCK_LOG"])
+with log.open("a") as stream:
+    stream.write("gh " + " ".join(args) + "\n")
+
+if args[:2] == ["repo", "view"]:
+    raise SystemExit(0)
+if args[:2] == ["workflow", "view"]:
+    print("active")
+    raise SystemExit(0)
+if args[:2] == ["workflow", "run"]:
+    raise SystemExit(0)
+if args[:2] == ["run", "watch"]:
+    raise SystemExit(0 if args[2] == "101" else 91)
+if not args or args[0] != "api":
+    raise SystemExit(92)
+
+joined = " ".join(args)
+if "repos/hew-lang/playground/commits/main" in joined:
+    print("sha-good")
+    raise SystemExit(0)
+if "repos/hew-lang/playground/actions/workflows/build.yml/runs" in joined:
+    if "--jq" in args:
+        print("100")
+        raise SystemExit(0)
+    scenario = os.environ["MOCK_SCENARIO"]
+    if scenario == "api-failure":
+        print("mock API failure", file=sys.stderr)
+        raise SystemExit(42)
+    poll = int(state.read_text() or "0") + 1 if state.exists() else 1
+    state.write_text(str(poll))
+    matching = {
+        "id": 101,
+        "head_sha": "sha-good",
+        "actor": {"login": "actor-good"},
+        "display_title": (
+            "Build Playground 0.6.0-rc1 [hew-777-2]"
+        ),
+    }
+    if scenario == "empty":
+        runs = []
+    elif scenario == "ambiguous":
+        runs = [matching, {**matching, "id": 102}]
+    elif scenario in {"title", "head", "actor", "floor"}:
+        candidate = dict(matching)
+        if scenario == "title":
+            candidate["display_title"] = "Build Playground wrong"
+        elif scenario == "head":
+            candidate["head_sha"] = "sha-wrong"
+        elif scenario == "actor":
+            candidate["actor"] = {"login": "actor-wrong"}
+        else:
+            candidate["id"] = 100
+        runs = [candidate]
+    else:
+        runs = [
+            {**matching, "id": 100},
+            {**matching, "head_sha": "sha-wrong", "id": 103},
+            {**matching, "actor": {"login": "actor-wrong"}, "id": 104},
+            {**matching, "display_title": "Build Playground wrong", "id": 105},
+            matching,
+        ]
+    print(json.dumps({"workflow_runs": runs}))
+    raise SystemExit(0)
+if "repos/hew-lang/playground" in joined:
+    print("main")
+    raise SystemExit(0)
+if args[1:] == ["user", "--jq", ".login"]:
+    print("actor-good")
+    raise SystemExit(0)
+raise SystemExit(93)
+"""
+
+
+def run_playground(scenario: str, *, jq_failure: bool = False) -> tuple:
+    """Execute the workflow's exact Bash with deterministic command doubles."""
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text(_MOCK_GH)
+        gh.chmod(0o755)
+        sleep = bin_dir / "sleep"
+        sleep.write_text("#!/usr/bin/env bash\nexit 0\n")
+        sleep.chmod(0o755)
+        if jq_failure:
+            jq = bin_dir / "jq"
+            jq.write_text("#!/usr/bin/env bash\nexit 23\n")
+            jq.chmod(0o755)
+        state = root / "state"
+        log = root / "calls.log"
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "GH_TOKEN": "test-token",
+                "RELEASE_TAG": "v0.6.0-rc1",
+                "GITHUB_RUN_ID": "777",
+                "GITHUB_RUN_ATTEMPT": "2",
+                "MOCK_SCENARIO": scenario,
+                "MOCK_STATE": str(state),
+                "MOCK_LOG": str(log),
+            }
+        )
+        result = subprocess.run(
+            ["bash", "-c", playground_script()],
+            cwd=ROOT,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        calls = log.read_text().splitlines() if log.exists() else []
+        polls = int(state.read_text()) if state.exists() else 0
+        return result, calls, polls
+
+
+def assert_wait_budget(job: str) -> None:
+    """Keep caller time above the downstream 5 + 45 + 30 minute maximum."""
+    match = re.search(r"^    timeout-minutes: (\d+)$", job, re.MULTILINE)
+    assert match is not None
+    assert int(match.group(1)) >= 100
+
+
+def test_rc_tag_normalization_and_exact_release_body() -> None:
+    text = workflow()
+    assert "RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}" in text
+    assert 'VERSION="${RELEASE_TAG#v}"' in playground_job()
+    assert "body_path: docs/releases/${{ env.RELEASE_TAG }}.md" in text
+    assert RELEASE_NOTES.exists()
+
+
+def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
+    job = playground_job()
+    assert "PLAYGROUND_DISPATCH_TOKEN" in job
+    assert "HOMEBREW_TAP_TOKEN" not in job
+    assert 'if [ -z "${GH_TOKEN}" ]; then' in job
+    assert "PLAYGROUND_DISPATCH_TOKEN secret is required" in job
+    assert "exit 1" in job
+    assert "gh repo view hew-lang/playground" in job
+    assert "gh api repos/hew-lang/playground --jq '.default_branch'" in job
+    assert "gh workflow view build.yml" in job
+    assert '!= "active"' in job
+    assert "could not correlate" in job
+
+
+def test_dispatch_uses_exact_playground_workflow_input_and_ref() -> None:
+    job = playground_job()
+    assert "gh workflow run build.yml" in job
+    assert '--ref "${PLAYGROUND_REF}"' in job
+    assert '-f version="${VERSION}"' in job
+    assert "-f event=workflow_dispatch" in job
+    assert '-f branch="${PLAYGROUND_REF}"' in job
+    assert 'gh run watch "${RUN_ID}" -R hew-lang/playground --exit-status' in job
+
+
+def test_dispatch_correlation_is_unique_and_bounded() -> None:
+    job = playground_job()
+    assert_wait_budget(job)
+    assert_exact_dispatch_correlation(job)
+    assert "PLAYGROUND_SHA=" in job
+    assert "PRE_DISPATCH_MAX_ID=" in job
+    assert '--argjson floor "${PRE_DISPATCH_MAX_ID}"' in job
+    assert '--arg sha "${PLAYGROUND_SHA}"' in job
+    assert "DISPATCH_ACTOR=" in job
+    assert '--arg actor "${DISPATCH_ACTOR}"' in job
+    assert "select(.id > $floor)" in job
+    assert "select(.head_sha == $sha)" in job
+    assert "select(.actor.login == $actor)" in job
+    assert_fail_closed_run_retrieval(job)
+    assert "if ! RUN_IDS_OUTPUT=$(jq -r" in job
+    assert 'if [ -n "${CANDIDATE_ID}" ]; then' in job
+    assert "mapfile -t RUN_IDS < <(" not in job
+    assert "LAST_CANDIDATE_ID" in job
+    assert "ambiguous playground workflow dispatch correlation" in job
+
+
+def test_exact_workflow_shell_accepts_one_stable_matching_run() -> None:
+    result, calls, polls = run_playground("success")
+    assert result.returncode == 0, result.stderr
+    assert polls == 2
+    watches = [call for call in calls if call.startswith("gh run watch")]
+    assert watches == ["gh run watch 101 -R hew-lang/playground --exit-status"]
+
+
+def test_run_listing_api_failure_is_terminal() -> None:
+    result, calls, polls = run_playground("api-failure")
+    assert result.returncode != 0
+    assert "failed to list playground workflow runs" in result.stdout
+    assert polls == 0
+    assert not any(call.startswith("gh run watch") for call in calls)
+
+
+def test_run_listing_jq_failure_is_terminal() -> None:
+    result, calls, polls = run_playground("success", jq_failure=True)
+    assert result.returncode != 0
+    assert "failed to parse playground workflow runs" in result.stdout
+    assert polls == 1
+    assert not any(call.startswith("gh run watch") for call in calls)
+
+
+def test_successful_empty_polls_exhaust_the_bound() -> None:
+    result, calls, polls = run_playground("empty")
+    assert result.returncode != 0
+    assert "could not correlate" in result.stdout
+    assert polls == 30
+    assert not any(call.startswith("gh run watch") for call in calls)
+
+
+def test_ambiguous_correlation_fails_on_the_first_poll() -> None:
+    result, calls, polls = run_playground("ambiguous")
+    assert result.returncode != 0
+    assert "ambiguous playground workflow dispatch correlation" in result.stdout
+    assert polls == 1
+    assert not any(call.startswith("gh run watch") for call in calls)
+
+
+def test_each_exact_run_identity_dimension_is_mandatory() -> None:
+    for scenario in ("title", "head", "actor", "floor"):
+        result, calls, polls = run_playground(scenario)
+        assert result.returncode != 0, scenario
+        assert "could not correlate" in result.stdout, scenario
+        assert polls == 30, scenario
+        assert not any(call.startswith("gh run watch") for call in calls), scenario
+
+
+def test_timeout_undercut_mutation_is_rejected() -> None:
+    mutated = playground_job().replace(
+        "    timeout-minutes: 120", "    timeout-minutes: 80"
+    )
+    try:
+        assert_wait_budget(mutated)
+    except AssertionError:
+        return
+    raise AssertionError(
+        "the upstream wait accepted the downstream maximum without margin"
+    )
+
+
+def test_correlation_swap_with_padding_is_rejected() -> None:
+    mutated = playground_job().replace(
+        "select(.display_title == $display_title)",
+        "select(.display_title == $actor)",
+    )
+    mutated += "\n# select(.display_title == $display_title)\n"
+    try:
+        assert_exact_dispatch_correlation(mutated)
+    except (AssertionError, ValueError):
+        return
+    raise AssertionError("a swapped selector was hidden by padding outside its query")
+
+
+def test_correlation_argument_swap_with_padding_is_rejected() -> None:
+    mutated = playground_job().replace(
+        '--arg sha "${PLAYGROUND_SHA}"',
+        '--arg sha "${DISPATCH_ACTOR}"',
+    )
+    mutated += '\n# --arg sha "${PLAYGROUND_SHA}"\n'
+    try:
+        assert_exact_dispatch_correlation(mutated)
+    except (AssertionError, ValueError):
+        return
+    raise AssertionError("a swapped argument was hidden by padding outside its query")
+
+
+def test_pipeline_status_masking_mutation_is_rejected() -> None:
+    mutated = playground_job().replace(
+        "            if ! RUNS_JSON=$(gh api -X GET \\",
+        "            RUNS_JSON=$(gh api -X GET \\",
+    )
+    mutated += "\n# if ! RUNS_JSON=$(gh api -X GET\n"
+    try:
+        assert_fail_closed_run_retrieval(mutated)
+    except (AssertionError, ValueError):
+        return
+    raise AssertionError("an unchecked API retrieval was hidden by padding")
+
+
+def test_required_downstream_failure_is_not_masked() -> None:
+    job = playground_job()
+    assert "gh run watch" in job
+    assert "continue-on-error" not in job
+    assert "skipping playground trigger" not in job
+
+
+def test_prerelease_homebrew_skip_is_separate() -> None:
+    text = workflow()
+    homebrew_start = text.index("  homebrew:\n")
+    playground_start = text.index("  playground:\n")
+    homebrew = text[homebrew_start:playground_start]
+    assert "HOMEBREW_TAP_TOKEN" in homebrew
+    assert "contains(github.ref_name, '-rc')" in homebrew
+    assert "PLAYGROUND_DISPATCH_TOKEN" not in homebrew
+
+
+def test_release_notes_and_runbook_keep_candidate_truthful() -> None:
+    notes = RELEASE_NOTES.read_text()
+    runbook = RUNBOOK.read_text()
+    assert "v0.6.0-rc1" in notes
+    assert "not a final release" in notes
+    assert "every release bar and the final-candidate checklist are green" in runbook
+    assert "Manually dispatch" in runbook
+    assert "both independent publication arms" in runbook
+    assert "Only after both arms are green" in runbook
+    assert "Homebrew" in runbook and "prerelease" in runbook
+    assert "publish-npm-packages.yml" in runbook
+
+
+def test_contract_oracle_runs_in_required_ci() -> None:
+    ci = CI_WORKFLOW.read_text()
+    assert "'.github/workflows/release.yml'" in ci
+    assert "make test-release-workflow-contract" in ci
+
+
+_TESTS = [
+    test_rc_tag_normalization_and_exact_release_body,
+    test_playground_dispatch_is_purpose_scoped_and_fail_closed,
+    test_dispatch_uses_exact_playground_workflow_input_and_ref,
+    test_dispatch_correlation_is_unique_and_bounded,
+    test_exact_workflow_shell_accepts_one_stable_matching_run,
+    test_run_listing_api_failure_is_terminal,
+    test_run_listing_jq_failure_is_terminal,
+    test_successful_empty_polls_exhaust_the_bound,
+    test_ambiguous_correlation_fails_on_the_first_poll,
+    test_each_exact_run_identity_dimension_is_mandatory,
+    test_timeout_undercut_mutation_is_rejected,
+    test_correlation_swap_with_padding_is_rejected,
+    test_correlation_argument_swap_with_padding_is_rejected,
+    test_pipeline_status_masking_mutation_is_rejected,
+    test_required_downstream_failure_is_not_masked,
+    test_prerelease_homebrew_skip_is_separate,
+    test_release_notes_and_runbook_keep_candidate_truthful,
+    test_contract_oracle_runs_in_required_ci,
+]
+
+
+if __name__ == "__main__":
+    failures = 0
+    for test in _TESTS:
+        try:
+            test()
+            print(f"PASS {test.__name__}")
+        except AssertionError as exc:
+            print(f"FAIL {test.__name__}: {exc}")
+            failures += 1
+    if failures:
+        raise SystemExit(f"{failures}/{len(_TESTS)} tests failed")
+    print(f"All {len(_TESTS)} tests passed.")

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
+HEW_SHA = "0123456789abcdef0123456789abcdef01234567"
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_NOTES = ROOT / "docs" / "releases" / "v0.6.0-rc1.md"
@@ -41,13 +42,15 @@ def assert_exact_dispatch_correlation(job: str) -> None:
     """Require the unique caller identity in both dispatch and run selection."""
     assert 'CORRELATION_ID="hew-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' in job
     assert (
-        'EXPECTED_DISPLAY_TITLE="Build Playground ${VERSION} [${CORRELATION_ID}]"'
-        in job
+        'EXPECTED_DISPLAY_TITLE="Build Playground mode=publish'
+        ' sha=${HEW_SHA} version=${VERSION} correlation=${CORRELATION_ID}"' in job
     )
 
     dispatch_start = job.index("          gh workflow run build.yml")
     dispatch_end = job.index('          RUN_ID=""', dispatch_start)
     dispatch = job[dispatch_start:dispatch_end]
+    assert "-f publish=true \\\n" in dispatch
+    assert '-f hew_sha="${HEW_SHA}" \\\n' in dispatch
     assert '-f version="${VERSION}" \\\n' in dispatch
     assert '-f correlation_id="${CORRELATION_ID}"' in dispatch
 
@@ -128,7 +131,9 @@ if "repos/hew-lang/playground/actions/workflows/build.yml/runs" in joined:
         "head_sha": "sha-good",
         "actor": {"login": "actor-good"},
         "display_title": (
-            "Build Playground 0.6.0-rc1 [hew-777-2]"
+            "Build Playground mode=publish"
+            " sha=0123456789abcdef0123456789abcdef01234567"
+            " version=0.6.0-rc1 correlation=hew-777-2"
         ),
     }
     if scenario == "empty":
@@ -166,7 +171,9 @@ raise SystemExit(93)
 """
 
 
-def run_playground(scenario: str, *, jq_failure: bool = False) -> tuple:
+def run_playground(
+    scenario: str, *, jq_failure: bool = False, hew_sha: str = HEW_SHA
+) -> tuple:
     """Execute the workflow's exact Bash with deterministic command doubles."""
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
@@ -189,6 +196,7 @@ def run_playground(scenario: str, *, jq_failure: bool = False) -> tuple:
             {
                 "PATH": f"{bin_dir}:{env['PATH']}",
                 "GH_TOKEN": "test-token",
+                "HEW_SHA": hew_sha,
                 "RELEASE_TAG": "v0.6.0-rc1",
                 "GITHUB_RUN_ID": "777",
                 "GITHUB_RUN_ATTEMPT": "2",
@@ -211,7 +219,7 @@ def run_playground(scenario: str, *, jq_failure: bool = False) -> tuple:
 
 
 def assert_wait_budget(job: str) -> None:
-    """Keep caller time above the downstream 5 + 45 + 30 minute maximum."""
+    """Keep caller time above the downstream 5+5+45+30+5 minute maximum."""
     match = re.search(r"^    timeout-minutes: (\d+)$", job, re.MULTILINE)
     assert match is not None
     assert int(match.group(1)) >= 100
@@ -227,6 +235,12 @@ def test_rc_tag_normalization_and_exact_release_body() -> None:
 
 def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
     job = playground_job()
+    assert "      - name: Resolve release commit identity\n" in job
+    assert (
+        "gh api \"repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}\" --jq '.sha'"
+    ) in job
+    assert "did not resolve to an exact lowercase" in job
+    assert "HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}" in job
     assert "PLAYGROUND_DISPATCH_TOKEN" in job
     assert "HOMEBREW_TAP_TOKEN" not in job
     assert 'if [ -z "${GH_TOKEN}" ]; then' in job
@@ -243,6 +257,8 @@ def test_dispatch_uses_exact_playground_workflow_input_and_ref() -> None:
     job = playground_job()
     assert "gh workflow run build.yml" in job
     assert '--ref "${PLAYGROUND_REF}"' in job
+    assert "-f publish=true" in job
+    assert '-f hew_sha="${HEW_SHA}"' in job
     assert '-f version="${VERSION}"' in job
     assert "-f event=workflow_dispatch" in job
     assert '-f branch="${PLAYGROUND_REF}"' in job
@@ -274,8 +290,27 @@ def test_exact_workflow_shell_accepts_one_stable_matching_run() -> None:
     result, calls, polls = run_playground("success")
     assert result.returncode == 0, result.stderr
     assert polls == 2
+    dispatches = [call for call in calls if call.startswith("gh workflow run")]
+    assert dispatches == [
+        "gh workflow run build.yml -R hew-lang/playground --ref main"
+        f" -f publish=true -f hew_sha={HEW_SHA}"
+        " -f version=0.6.0-rc1 -f correlation_id=hew-777-2"
+    ]
     watches = [call for call in calls if call.startswith("gh run watch")]
     assert watches == ["gh run watch 101 -R hew-lang/playground --exit-status"]
+
+
+def test_malformed_release_commit_identity_is_terminal() -> None:
+    for bad_sha in ("", "not-a-sha", HEW_SHA[:39], HEW_SHA.upper()):
+        result, calls, polls = run_playground("success", hew_sha=bad_sha)
+        assert result.returncode != 0, repr(bad_sha)
+        assert "release commit identity is not an exact lowercase" in result.stdout, (
+            repr(bad_sha)
+        )
+        assert polls == 0, repr(bad_sha)
+        assert not any(call.startswith("gh workflow run") for call in calls), repr(
+            bad_sha
+        )
 
 
 def test_run_listing_api_failure_is_terminal() -> None:
@@ -330,6 +365,16 @@ def test_timeout_undercut_mutation_is_rejected() -> None:
     raise AssertionError(
         "the upstream wait accepted the downstream maximum without margin"
     )
+
+
+def test_publish_mode_downgrade_mutation_is_rejected() -> None:
+    mutated = playground_job().replace("-f publish=true", "-f publish=false")
+    mutated += "\n# -f publish=true\n"
+    try:
+        assert_exact_dispatch_correlation(mutated)
+    except (AssertionError, ValueError):
+        return
+    raise AssertionError("a publish-mode downgrade was hidden by padding")
 
 
 def test_correlation_swap_with_padding_is_rejected() -> None:
@@ -413,12 +458,14 @@ _TESTS = [
     test_dispatch_uses_exact_playground_workflow_input_and_ref,
     test_dispatch_correlation_is_unique_and_bounded,
     test_exact_workflow_shell_accepts_one_stable_matching_run,
+    test_malformed_release_commit_identity_is_terminal,
     test_run_listing_api_failure_is_terminal,
     test_run_listing_jq_failure_is_terminal,
     test_successful_empty_polls_exhaust_the_bound,
     test_ambiguous_correlation_fails_on_the_first_poll,
     test_each_exact_run_identity_dimension_is_mandatory,
     test_timeout_undercut_mutation_is_rejected,
+    test_publish_mode_downgrade_mutation_is_rejected,
     test_correlation_swap_with_padding_is_rejected,
     test_correlation_argument_swap_with_padding_is_rejected,
     test_pipeline_status_masking_mutation_is_rejected,


### PR DESCRIPTION
## Summary

The release workflow's playground handoff was fail-open: v0.5.0-rc1 reported green while logging repository-not-found and building nothing, and the step predates the playground's typed dispatch contract. The workflow now dispatches publish mode with a resolved-and-validated exact commit identity (tag resolved to a SHA via the commits API, annotated tags peeled, terminal on malformed identity), correlates the downstream run by the exact publish-mode run-name with a new-run floor and consecutive-observation confirmation, and bounds the wait at 120 minutes over the 90-minute downstream worst case. The rc1 publication-order doc defines the ordering the workflow enforces, and a 20-test mocked-gh oracle (including mutation teeth) pins the whole contract.

## Verification

- `make test-release-workflow-contract`: contract oracle 20/20
- CI preflight dispatcher suite: 41/41
- `actionlint` + `shellcheck`: clean
- Preflight dispatcher parity: 4/4
- Preflight: ready-to-push

## Out of scope

- `PLAYGROUND_DISPATCH_TOKEN` provisioning — repository secret, tracked separately.
- The live dispatch proof runs at the first rc1 tag.