### PR TITLE
feat(ffi): carry ownership contracts into the compiler and classify the std-used extern surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,6 +1911,7 @@ dependencies = [
  "proptest",
  "serde",
  "siphasher",
+ "toml",
 ]
 
 [[package]]

--- a/hew-mir/Cargo.toml
+++ b/hew-mir/Cargo.toml
@@ -33,6 +33,10 @@ hew-types = { path = "../hew-types" }
 # Runtime layout authorities are used only by native parity tests.
 hew-runtime = { path = "../hew-runtime", default-features = false }
 proptest = "1"
+# Independent TOML parser for the FFI ownership-contract drift test
+# (tests/ffi_contract_drift.rs) — deliberately NOT the build script's
+# hand parser, so parser bugs cannot self-validate.
+toml.workspace = true
 
 [lints]
 workspace = true

--- a/hew-mir/build.rs
+++ b/hew-mir/build.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use hew_types::runtime_call::{all_runtime_call_families, RuntimeCallFamily};
 
@@ -103,6 +104,185 @@ fn toml_symbol_tier(source: &str, tier: &str) -> BTreeSet<String> {
     panic!("unterminated `{tier}` TOML symbol list");
 }
 
+/// One `[[ownership.contracts]]` row from the FFI classification TOML.
+struct ContractRow {
+    result: String,
+    params: Vec<String>,
+    release_symbol: String,
+    discharge_depth: String,
+}
+
+fn quoted_list(line: &str) -> Vec<String> {
+    let (_, value) = line.split_once('=').expect("params line must carry `=`");
+    let value = value.trim();
+    let inner = value
+        .strip_prefix('[')
+        .and_then(|v| v.strip_suffix(']'))
+        .expect("params must be a single-line array");
+    inner
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.strip_prefix('"')
+                .and_then(|p| p.strip_suffix('"'))
+                .expect("params entries must be quoted")
+                .to_owned()
+        })
+        .collect()
+}
+
+/// Parse the full `[[ownership.contracts]]` table. Every axis is validated
+/// against the closed schema vocabularies here (fail-closed: an unknown
+/// spelling aborts the build rather than degrading to a default), and the
+/// owned-result/release-symbol coupling from `verify-ffi-symbols.py` is
+/// re-checked so the generated compiler table can never carry a row the
+/// out-of-band validator would reject.
+fn toml_ownership_contracts(path: &Path) -> BTreeMap<String, ContractRow> {
+    let source = fs::read_to_string(path).expect("read FFI classification TOML");
+    let mut contracts = BTreeMap::new();
+    let mut current: Option<(Option<String>, ContractRow)> = None;
+
+    let finish = |entry: Option<(Option<String>, ContractRow)>,
+                  contracts: &mut BTreeMap<String, ContractRow>| {
+        if let Some((symbol, row)) = entry {
+            let symbol = symbol.expect("ownership contract missing `symbol`");
+            assert!(
+                ["fresh", "retained", "borrowed", "none"].contains(&row.result.as_str()),
+                "unknown ownership result for {symbol}: {}",
+                row.result
+            );
+            for param in &row.params {
+                assert!(
+                    ["borrow", "consume", "retain"].contains(&param.as_str()),
+                    "unknown param ownership for {symbol}: {param}"
+                );
+            }
+            assert!(
+                ["shallow", "deep", "none"].contains(&row.discharge_depth.as_str()),
+                "unknown discharge depth for {symbol}: {}",
+                row.discharge_depth
+            );
+            if matches!(row.result.as_str(), "fresh" | "retained") {
+                assert!(
+                    !row.release_symbol.is_empty() && row.discharge_depth != "none",
+                    "owned result for {symbol} requires release-symbol and discharge depth"
+                );
+            } else {
+                assert!(
+                    row.release_symbol.is_empty() && row.discharge_depth == "none",
+                    "borrowed/none result for {symbol} must carry no release axis"
+                );
+            }
+            assert!(
+                contracts.insert(symbol.clone(), row).is_none(),
+                "duplicate TOML ownership contract for {symbol}"
+            );
+        }
+    };
+
+    for line in source.lines() {
+        let line = line.trim();
+        if line == "[[ownership.contracts]]" {
+            finish(current.take(), &mut contracts);
+            current = Some((
+                None,
+                ContractRow {
+                    result: String::new(),
+                    params: Vec::new(),
+                    release_symbol: String::new(),
+                    discharge_depth: String::new(),
+                },
+            ));
+            continue;
+        }
+        let Some((symbol, row)) = current.as_mut() else {
+            continue;
+        };
+        if line.starts_with("symbol =") {
+            *symbol = Some(
+                quoted_value(line)
+                    .expect("contract symbol must be quoted")
+                    .to_owned(),
+            );
+        } else if line.starts_with("result =") {
+            quoted_value(line)
+                .expect("contract result must be quoted")
+                .clone_into(&mut row.result);
+        } else if line.starts_with("params =") {
+            row.params = quoted_list(line);
+        } else if line.starts_with("release-symbol =") {
+            quoted_value(line)
+                .expect("contract release-symbol must be quoted")
+                .clone_into(&mut row.release_symbol);
+        } else if line.starts_with("discharge-depth =") {
+            quoted_value(line)
+                .expect("contract discharge-depth must be quoted")
+                .clone_into(&mut row.discharge_depth);
+        }
+    }
+    finish(current.take(), &mut contracts);
+    assert!(
+        !contracts.is_empty(),
+        "classification TOML must declare ownership contracts"
+    );
+    contracts
+}
+
+/// Generate the static, sorted extern-ownership table consumed by
+/// `hew_mir::ffi_contracts` via `include!`. The TOML is the single source of
+/// truth; this table is a build-time projection of it, so the two carriers
+/// cannot drift without a rebuild (a 1:1 drift test re-checks with an
+/// independent TOML parser).
+fn generate_ffi_ownership_table(contracts: &BTreeMap<String, ContractRow>) {
+    let mut generated = String::from(
+        "// Generated by hew-mir/build.rs from scripts/jit-symbol-classification.toml.\n\
+         // Do not edit; edit the TOML `[[ownership.contracts]]` rows instead.\n\
+         /// Sorted (by symbol) extern-ownership contract rows projected from the\n\
+         /// machine-checked TOML classification. Sorted order is the binary-search\n\
+         /// invariant of [`extern_ownership_contract`].\n\
+         pub static FFI_OWNERSHIP_CONTRACTS: &[(&str, ExternOwnershipContract)] = &[\n",
+    );
+    for (symbol, row) in contracts {
+        let params = row
+            .params
+            .iter()
+            .map(|param| match param.as_str() {
+                "borrow" => "ExternParamOwnership::Borrow",
+                "consume" => "ExternParamOwnership::Consume",
+                "retain" => "ExternParamOwnership::Retain",
+                other => panic!("unmapped param ownership: {other}"),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let result = match row.result.as_str() {
+            "fresh" => "ExternResultOwnership::Fresh",
+            "retained" => "ExternResultOwnership::Retained",
+            "borrowed" => "ExternResultOwnership::Borrowed",
+            "none" => "ExternResultOwnership::None",
+            other => panic!("unmapped result ownership: {other}"),
+        };
+        let depth = match row.discharge_depth.as_str() {
+            "shallow" => "ReleaseDischargeDepth::Shallow",
+            "deep" => "ReleaseDischargeDepth::Deep",
+            "none" => "ReleaseDischargeDepth::None",
+            other => panic!("unmapped discharge depth: {other}"),
+        };
+        writeln!(
+            generated,
+            "    (\"{symbol}\", ExternOwnershipContract {{ params: &[{params}], \
+             result: {result}, release_symbol: \"{}\", discharge_depth: {depth} }}),",
+            row.release_symbol
+        )
+        .expect("write generated contract row");
+    }
+    generated.push_str("];\n");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR set by cargo"));
+    fs::write(out_dir.join("ffi_ownership_contracts.rs"), generated)
+        .expect("write generated FFI ownership table");
+}
+
 fn runtime_backed_mir_symbols() -> BTreeSet<String> {
     all_runtime_call_families()
         .into_iter()
@@ -134,6 +314,8 @@ fn main() {
          `codegen-stable` classification: {}",
         missing.join(", ")
     );
+
+    generate_ffi_ownership_table(&toml_ownership_contracts(&classification));
 
     let toml = toml_results(&classification);
     for (symbol, expected) in checked_runtime_results(&runtime_symbols) {

--- a/hew-mir/build.rs
+++ b/hew-mir/build.rs
@@ -112,13 +112,16 @@ struct ContractRow {
     discharge_depth: String,
 }
 
-fn quoted_list(line: &str) -> Vec<String> {
-    let (_, value) = line.split_once('=').expect("params line must carry `=`");
+/// Parse a `params = [...]` array body. The TOML formatter wraps long arrays
+/// across lines, so the caller accumulates lines until the closing `]` and
+/// hands the joined body here.
+fn quoted_list(body: &str) -> Vec<String> {
+    let (_, value) = body.split_once('=').expect("params line must carry `=`");
     let value = value.trim();
     let inner = value
         .strip_prefix('[')
         .and_then(|v| v.strip_suffix(']'))
-        .expect("params must be a single-line array");
+        .expect("params must be a bracketed array");
     inner
         .split(',')
         .map(str::trim)
@@ -181,7 +184,8 @@ fn toml_ownership_contracts(path: &Path) -> BTreeMap<String, ContractRow> {
         }
     };
 
-    for line in source.lines() {
+    let mut lines = source.lines();
+    while let Some(line) = lines.next() {
         let line = line.trim();
         if line == "[[ownership.contracts]]" {
             finish(current.take(), &mut contracts);
@@ -210,7 +214,16 @@ fn toml_ownership_contracts(path: &Path) -> BTreeMap<String, ContractRow> {
                 .expect("contract result must be quoted")
                 .clone_into(&mut row.result);
         } else if line.starts_with("params =") {
-            row.params = quoted_list(line);
+            // Accumulate a formatter-wrapped multi-line array until its `]`.
+            let mut body = line.to_owned();
+            while !body.trim_end().ends_with(']') {
+                let continuation = lines
+                    .next()
+                    .expect("unterminated params array in ownership contract");
+                body.push(' ');
+                body.push_str(continuation.trim());
+            }
+            row.params = quoted_list(&body);
         } else if line.starts_with("release-symbol =") {
             quoted_value(line)
                 .expect("contract release-symbol must be quoted")

--- a/hew-mir/build.rs
+++ b/hew-mir/build.rs
@@ -5,12 +5,6 @@ use std::path::{Path, PathBuf};
 
 use hew_types::runtime_call::{all_runtime_call_families, RuntimeCallFamily};
 
-fn quoted_value(line: &str) -> Option<&str> {
-    let (_, value) = line.split_once('=')?;
-    let value = value.trim();
-    value.strip_prefix('"')?.strip_suffix('"')
-}
-
 fn toml_results(path: &Path) -> BTreeMap<String, String> {
     let source = fs::read_to_string(path).expect("read FFI classification TOML");
     let mut results = BTreeMap::new();
@@ -104,142 +98,16 @@ fn toml_symbol_tier(source: &str, tier: &str) -> BTreeSet<String> {
     panic!("unterminated `{tier}` TOML symbol list");
 }
 
-/// One `[[ownership.contracts]]` row from the FFI classification TOML.
-struct ContractRow {
-    result: String,
-    params: Vec<String>,
-    release_symbol: String,
-    discharge_depth: String,
-}
+// The `[[ownership.contracts]]` parser (ContractRow, quoted_value,
+// quoted_list, parse_ownership_contracts) is shared with the hardening test
+// in tests/ffi_contract_parse_hardening.rs so the exact build-time parser is
+// what the test exercises.
+include!("build_support/ownership_contract_parse.rs");
 
-/// Parse a `params = [...]` array body. The TOML formatter wraps long arrays
-/// across lines, so the caller accumulates lines until the closing `]` and
-/// hands the joined body here.
-fn quoted_list(body: &str) -> Vec<String> {
-    let (_, value) = body.split_once('=').expect("params line must carry `=`");
-    let value = value.trim();
-    let inner = value
-        .strip_prefix('[')
-        .and_then(|v| v.strip_suffix(']'))
-        .expect("params must be a bracketed array");
-    inner
-        .split(',')
-        .map(str::trim)
-        .filter(|part| !part.is_empty())
-        .map(|part| {
-            part.strip_prefix('"')
-                .and_then(|p| p.strip_suffix('"'))
-                .expect("params entries must be quoted")
-                .to_owned()
-        })
-        .collect()
-}
-
-/// Parse the full `[[ownership.contracts]]` table. Every axis is validated
-/// against the closed schema vocabularies here (fail-closed: an unknown
-/// spelling aborts the build rather than degrading to a default), and the
-/// owned-result/release-symbol coupling from `verify-ffi-symbols.py` is
-/// re-checked so the generated compiler table can never carry a row the
-/// out-of-band validator would reject.
+/// Read and parse the classification TOML's ownership-contract table.
 fn toml_ownership_contracts(path: &Path) -> BTreeMap<String, ContractRow> {
     let source = fs::read_to_string(path).expect("read FFI classification TOML");
-    let mut contracts = BTreeMap::new();
-    let mut current: Option<(Option<String>, ContractRow)> = None;
-
-    let finish = |entry: Option<(Option<String>, ContractRow)>,
-                  contracts: &mut BTreeMap<String, ContractRow>| {
-        if let Some((symbol, row)) = entry {
-            let symbol = symbol.expect("ownership contract missing `symbol`");
-            assert!(
-                ["fresh", "retained", "borrowed", "none"].contains(&row.result.as_str()),
-                "unknown ownership result for {symbol}: {}",
-                row.result
-            );
-            for param in &row.params {
-                assert!(
-                    ["borrow", "consume", "retain"].contains(&param.as_str()),
-                    "unknown param ownership for {symbol}: {param}"
-                );
-            }
-            assert!(
-                ["shallow", "deep", "none"].contains(&row.discharge_depth.as_str()),
-                "unknown discharge depth for {symbol}: {}",
-                row.discharge_depth
-            );
-            if matches!(row.result.as_str(), "fresh" | "retained") {
-                assert!(
-                    !row.release_symbol.is_empty() && row.discharge_depth != "none",
-                    "owned result for {symbol} requires release-symbol and discharge depth"
-                );
-            } else {
-                assert!(
-                    row.release_symbol.is_empty() && row.discharge_depth == "none",
-                    "borrowed/none result for {symbol} must carry no release axis"
-                );
-            }
-            assert!(
-                contracts.insert(symbol.clone(), row).is_none(),
-                "duplicate TOML ownership contract for {symbol}"
-            );
-        }
-    };
-
-    let mut lines = source.lines();
-    while let Some(line) = lines.next() {
-        let line = line.trim();
-        if line == "[[ownership.contracts]]" {
-            finish(current.take(), &mut contracts);
-            current = Some((
-                None,
-                ContractRow {
-                    result: String::new(),
-                    params: Vec::new(),
-                    release_symbol: String::new(),
-                    discharge_depth: String::new(),
-                },
-            ));
-            continue;
-        }
-        let Some((symbol, row)) = current.as_mut() else {
-            continue;
-        };
-        if line.starts_with("symbol =") {
-            *symbol = Some(
-                quoted_value(line)
-                    .expect("contract symbol must be quoted")
-                    .to_owned(),
-            );
-        } else if line.starts_with("result =") {
-            quoted_value(line)
-                .expect("contract result must be quoted")
-                .clone_into(&mut row.result);
-        } else if line.starts_with("params =") {
-            // Accumulate a formatter-wrapped multi-line array until its `]`.
-            let mut body = line.to_owned();
-            while !body.trim_end().ends_with(']') {
-                let continuation = lines
-                    .next()
-                    .expect("unterminated params array in ownership contract");
-                body.push(' ');
-                body.push_str(continuation.trim());
-            }
-            row.params = quoted_list(&body);
-        } else if line.starts_with("release-symbol =") {
-            quoted_value(line)
-                .expect("contract release-symbol must be quoted")
-                .clone_into(&mut row.release_symbol);
-        } else if line.starts_with("discharge-depth =") {
-            quoted_value(line)
-                .expect("contract discharge-depth must be quoted")
-                .clone_into(&mut row.discharge_depth);
-        }
-    }
-    finish(current.take(), &mut contracts);
-    assert!(
-        !contracts.is_empty(),
-        "classification TOML must declare ownership contracts"
-    );
-    contracts
+    parse_ownership_contracts(&source)
 }
 
 /// Generate the static, sorted extern-ownership table consumed by

--- a/hew-mir/build_support/ownership_contract_parse.rs
+++ b/hew-mir/build_support/ownership_contract_parse.rs
@@ -1,0 +1,164 @@
+// `[[ownership.contracts]]` hand parser, shared between `hew-mir/build.rs`
+// (via `include!`) and the parser-hardening test in
+// `tests/ffi_contract_parse_hardening.rs` so the exact build-time code is
+// what the test exercises. Types are referred to fully-qualified (no `use`
+// items) because this file is textually included into hosts that carry their
+// own imports.
+
+/// One `[[ownership.contracts]]` row from the FFI classification TOML.
+struct ContractRow {
+    result: String,
+    params: Vec<String>,
+    release_symbol: String,
+    discharge_depth: String,
+}
+
+fn quoted_value(line: &str) -> Option<&str> {
+    let (_, value) = line.split_once('=')?;
+    let value = value.trim();
+    value.strip_prefix('"')?.strip_suffix('"')
+}
+
+/// Parse a `params = [...]` array body. The TOML formatter wraps long arrays
+/// across lines, so the caller accumulates lines until the closing `]` and
+/// hands the joined body here.
+fn quoted_list(body: &str) -> Vec<String> {
+    let (_, value) = body.split_once('=').expect("params line must carry `=`");
+    let value = value.trim();
+    let inner = value
+        .strip_prefix('[')
+        .and_then(|v| v.strip_suffix(']'))
+        .expect("params must be a bracketed array");
+    inner
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.strip_prefix('"')
+                .and_then(|p| p.strip_suffix('"'))
+                .expect("params entries must be quoted")
+                .to_owned()
+        })
+        .collect()
+}
+
+/// Parse the full `[[ownership.contracts]]` table from TOML source. Every
+/// axis is validated against the closed schema vocabularies here
+/// (fail-closed: an unknown spelling aborts rather than degrading to a
+/// default), and the owned-result/release-symbol coupling from
+/// `verify-ffi-symbols.py` is re-checked so the generated compiler table can
+/// never carry a row the out-of-band validator would reject.
+///
+/// Any table header other than `[[ownership.contracts]]` closes out the
+/// contract being accumulated and enters a skip state: keys inside a foreign
+/// trailing table — even ones spelled `symbol =` / `result =` — must never
+/// pollute the final contract.
+fn parse_ownership_contracts(
+    source: &str,
+) -> std::collections::BTreeMap<String, ContractRow> {
+    let mut contracts = std::collections::BTreeMap::new();
+    let mut current: Option<(Option<String>, ContractRow)> = None;
+
+    let finish = |entry: Option<(Option<String>, ContractRow)>,
+                  contracts: &mut std::collections::BTreeMap<String, ContractRow>| {
+        if let Some((symbol, row)) = entry {
+            let symbol = symbol.expect("ownership contract missing `symbol`");
+            assert!(
+                ["fresh", "retained", "borrowed", "none"].contains(&row.result.as_str()),
+                "unknown ownership result for {symbol}: {}",
+                row.result
+            );
+            for param in &row.params {
+                assert!(
+                    ["borrow", "consume", "retain"].contains(&param.as_str()),
+                    "unknown param ownership for {symbol}: {param}"
+                );
+            }
+            assert!(
+                ["shallow", "deep", "none"].contains(&row.discharge_depth.as_str()),
+                "unknown discharge depth for {symbol}: {}",
+                row.discharge_depth
+            );
+            if matches!(row.result.as_str(), "fresh" | "retained") {
+                assert!(
+                    !row.release_symbol.is_empty() && row.discharge_depth != "none",
+                    "owned result for {symbol} requires release-symbol and discharge depth"
+                );
+            } else {
+                assert!(
+                    row.release_symbol.is_empty() && row.discharge_depth == "none",
+                    "borrowed/none result for {symbol} must carry no release axis"
+                );
+            }
+            assert!(
+                contracts.insert(symbol.clone(), row).is_none(),
+                "duplicate TOML ownership contract for {symbol}"
+            );
+        }
+    };
+
+    let mut lines = source.lines();
+    while let Some(line) = lines.next() {
+        let line = line.trim();
+        if line == "[[ownership.contracts]]" {
+            finish(current.take(), &mut contracts);
+            current = Some((
+                None,
+                ContractRow {
+                    result: String::new(),
+                    params: Vec::new(),
+                    release_symbol: String::new(),
+                    discharge_depth: String::new(),
+                },
+            ));
+            continue;
+        }
+        if line.starts_with('[') {
+            // A DIFFERENT table header ([header] or [[header]]): the contract
+            // section is over for the current entry. Close it out and skip
+            // until the next [[ownership.contracts]] header, so a foreign
+            // table's keys cannot be absorbed into the last contract.
+            finish(current.take(), &mut contracts);
+            continue;
+        }
+        let Some((symbol, row)) = current.as_mut() else {
+            continue;
+        };
+        if line.starts_with("symbol =") {
+            *symbol = Some(
+                quoted_value(line)
+                    .expect("contract symbol must be quoted")
+                    .to_owned(),
+            );
+        } else if line.starts_with("result =") {
+            quoted_value(line)
+                .expect("contract result must be quoted")
+                .clone_into(&mut row.result);
+        } else if line.starts_with("params =") {
+            // Accumulate a formatter-wrapped multi-line array until its `]`.
+            let mut body = line.to_owned();
+            while !body.trim_end().ends_with(']') {
+                let continuation = lines
+                    .next()
+                    .expect("unterminated params array in ownership contract");
+                body.push(' ');
+                body.push_str(continuation.trim());
+            }
+            row.params = quoted_list(&body);
+        } else if line.starts_with("release-symbol =") {
+            quoted_value(line)
+                .expect("contract release-symbol must be quoted")
+                .clone_into(&mut row.release_symbol);
+        } else if line.starts_with("discharge-depth =") {
+            quoted_value(line)
+                .expect("contract discharge-depth must be quoted")
+                .clone_into(&mut row.discharge_depth);
+        }
+    }
+    finish(current.take(), &mut contracts);
+    assert!(
+        !contracts.is_empty(),
+        "classification TOML must declare ownership contracts"
+    );
+    contracts
+}

--- a/hew-mir/src/ffi_contracts.rs
+++ b/hew-mir/src/ffi_contracts.rs
@@ -182,5 +182,24 @@ mod tests {
             .contract()
             .expect("hew_vec_get_owned is classified");
         assert_eq!(get_owned.result, ExternResultOwnership::Borrowed);
+
+        // `hew_string_drop` is THE universal String release: it consumes its
+        // single parameter (hew-runtime/src/string.rs `free_cstring`).
+        let string_drop = extern_ownership_contract("hew_string_drop")
+            .contract()
+            .expect("hew_string_drop is classified");
+        assert_eq!(string_drop.params, [ExternParamOwnership::Consume]);
+        assert_eq!(string_drop.result, ExternResultOwnership::None);
+
+        // `hew_tcp_write` reads its by-pointer BytesTriple without taking
+        // ownership (hew-runtime/src/transport.rs ABI doc).
+        let tcp_write = extern_ownership_contract("hew_tcp_write")
+            .contract()
+            .expect("hew_tcp_write is classified");
+        assert_eq!(
+            tcp_write.params,
+            [ExternParamOwnership::Borrow, ExternParamOwnership::Borrow]
+        );
+        assert_eq!(tcp_write.result, ExternResultOwnership::None);
     }
 }

--- a/hew-mir/src/ffi_contracts.rs
+++ b/hew-mir/src/ffi_contracts.rs
@@ -1,0 +1,186 @@
+//! In-compiler carriage of the machine-checked FFI ownership contracts.
+//!
+//! `scripts/jit-symbol-classification.toml` `[[ownership.contracts]]` rows are
+//! the single authority for per-parameter consume/borrow facts, result
+//! freshness, and the release axis of `hew_*` extern symbols (schema from
+//! PR #2561, validated out-of-band by `scripts/verify-ffi-symbols.py`).
+//! `hew-mir/build.rs` projects that table into a static, sorted slice at build
+//! time (`FFI_OWNERSHIP_CONTRACTS`, included below), so the facts are readable
+//! at the MIR lowering positions that consult callee contracts — the same seam
+//! where `callee_ownership_contract` serves the emitter-symbol subset.
+//!
+//! CARRIAGE ONLY: nothing here is enforcement. The S1 obligation validator and
+//! OWN-V1 consume these facts; until then extern calls keep today's
+//! conservative behaviour (caller retains the drop obligation). An extern
+//! symbol with no contract yields the explicit [`ExternOwnershipFact::Absent`]
+//! verdict — never a fabricated default contract.
+
+/// Ownership fact for one C-ABI parameter position.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExternParamOwnership {
+    /// The callee reads (or copies from) the parameter; the caller keeps the
+    /// drop obligation.
+    Borrow,
+    /// The callee takes ownership; the caller's drop obligation is discharged
+    /// by the call.
+    Consume,
+    /// The callee retains an additional reference; the caller keeps its own
+    /// obligation and the callee owes an independent release.
+    Retain,
+}
+
+/// Ownership fact for a callee result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExternResultOwnership {
+    /// A newly owned allocation transfers to the caller.
+    Fresh,
+    /// An additional reference to an existing ref-counted allocation
+    /// transfers to the caller.
+    Retained,
+    /// The result remains owned elsewhere and may be invalidated by mutation.
+    Borrowed,
+    /// The call hands back no owned result.
+    None,
+}
+
+/// Whether the contract's release symbol recursively discharges children.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReleaseDischargeDepth {
+    /// The release discharges only the top-level allocation.
+    Shallow,
+    /// The release recursively discharges owned children.
+    Deep,
+    /// No owned result, so no release axis.
+    None,
+}
+
+/// One extern symbol's machine-checked ownership contract.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExternOwnershipContract {
+    /// Per-parameter ownership, positionally matching the C signature.
+    pub params: &'static [ExternParamOwnership],
+    /// Result ownership.
+    pub result: ExternResultOwnership,
+    /// The `hew_*` release entry (or type-directed drop-thunk spelling) that
+    /// balances an owned result; empty for borrowed/none results.
+    pub release_symbol: &'static str,
+    /// Recursion depth of the release symbol's discharge.
+    pub discharge_depth: ReleaseDischargeDepth,
+}
+
+/// The fact available at a lowering position for an extern callee symbol.
+///
+/// `Absent` is an explicit verdict, not a default: the consumer must keep the
+/// conservative behaviour (caller retains the drop obligation) and must never
+/// synthesize a contract for an unclassified symbol.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExternOwnershipFact {
+    /// The symbol carries a machine-checked contract.
+    Contract(&'static ExternOwnershipContract),
+    /// The symbol has no contract; fail closed (caller retains drop).
+    Absent,
+}
+
+impl ExternOwnershipFact {
+    /// True iff a contract is present.
+    #[must_use]
+    pub const fn is_contract(self) -> bool {
+        matches!(self, Self::Contract(_))
+    }
+
+    /// The contract, when present.
+    #[must_use]
+    pub const fn contract(self) -> Option<&'static ExternOwnershipContract> {
+        match self {
+            Self::Contract(contract) => Some(contract),
+            Self::Absent => None,
+        }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/ffi_ownership_contracts.rs"));
+
+/// Look up the ownership fact for an extern callee symbol.
+#[must_use]
+pub fn extern_ownership_contract(symbol: &str) -> ExternOwnershipFact {
+    match FFI_OWNERSHIP_CONTRACTS.binary_search_by(|(row, _)| (*row).cmp(symbol)) {
+        Ok(index) => ExternOwnershipFact::Contract(&FFI_OWNERSHIP_CONTRACTS[index].1),
+        Err(_) => ExternOwnershipFact::Absent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_is_sorted_and_unique() {
+        // The binary-search invariant: strictly ascending symbol order.
+        assert!(
+            FFI_OWNERSHIP_CONTRACTS.windows(2).all(|w| w[0].0 < w[1].0),
+            "generated contract table must be sorted and duplicate-free"
+        );
+    }
+
+    #[test]
+    fn unclassified_symbol_is_explicit_absent() {
+        assert_eq!(
+            extern_ownership_contract("hew_nope"),
+            ExternOwnershipFact::Absent
+        );
+        assert_eq!(extern_ownership_contract(""), ExternOwnershipFact::Absent);
+    }
+
+    #[test]
+    fn owned_results_carry_release_axis() {
+        // Mirror of the verify-ffi-symbols.py coupling rule: an owned result
+        // names its release; a borrowed/none result carries no release axis.
+        for (symbol, contract) in FFI_OWNERSHIP_CONTRACTS {
+            match contract.result {
+                ExternResultOwnership::Fresh | ExternResultOwnership::Retained => {
+                    assert!(
+                        !contract.release_symbol.is_empty()
+                            && contract.discharge_depth != ReleaseDischargeDepth::None,
+                        "{symbol}: owned result requires a release axis"
+                    );
+                }
+                ExternResultOwnership::Borrowed | ExternResultOwnership::None => {
+                    assert!(
+                        contract.release_symbol.is_empty()
+                            && contract.discharge_depth == ReleaseDischargeDepth::None,
+                        "{symbol}: unowned result must carry no release axis"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn known_contracts_readable() {
+        // `hew_json_free` consumes its single value parameter
+        // (hew-std/src/json.rs reconstructs and drops `val`).
+        let json_free = extern_ownership_contract("hew_json_free")
+            .contract()
+            .expect("hew_json_free is classified");
+        assert_eq!(json_free.params, [ExternParamOwnership::Consume]);
+        assert_eq!(json_free.result, ExternResultOwnership::None);
+
+        // `hew_bytes_to_string` borrows its source and returns a fresh owned
+        // string balanced by exactly one `hew_string_drop`.
+        let bytes_to_string = extern_ownership_contract("hew_bytes_to_string")
+            .contract()
+            .expect("hew_bytes_to_string is classified");
+        assert_eq!(bytes_to_string.result, ExternResultOwnership::Fresh);
+        assert_eq!(bytes_to_string.release_symbol, "hew_string_drop");
+        assert_eq!(
+            bytes_to_string.discharge_depth,
+            ReleaseDischargeDepth::Shallow
+        );
+
+        // `hew_vec_get_owned` returns an alias invalidated by vec mutation.
+        let get_owned = extern_ownership_contract("hew_vec_get_owned")
+            .contract()
+            .expect("hew_vec_get_owned is classified");
+        assert_eq!(get_owned.result, ExternResultOwnership::Borrowed);
+    }
+}

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -9,6 +9,7 @@ pub mod closure_env;
 pub mod dataflow;
 pub mod dump;
 pub mod dyn_vtable_registry;
+pub mod ffi_contracts;
 pub mod liveness;
 pub mod lower;
 pub mod model;

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -538,7 +538,7 @@ impl Builder {
                 // unclassified symbol is an explicit `Absent`, never a
                 // fabricated contract.
                 debug_assert!(
-                    crate::ffi_contracts::extern_ownership_contract("hew_json_free")
+                    crate::ffi_contracts::extern_ownership_contract("hew_string_drop")
                         .contract()
                         .is_some_and(|contract| contract.params
                             == [crate::ffi_contracts::ExternParamOwnership::Consume]),

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -531,6 +531,20 @@ impl Builder {
             // trusted-Fresh in the interim (the marker-backed jwt/encrypt rows
             // land at S4b).
             if prov.extern_names.contains(name) {
+                // OWN-0b carriage: the machine-checked per-symbol ownership
+                // fact is consultable at exactly this extern-callee position.
+                // Nothing is enforced from it yet (S1/V1 consume it); the
+                // conservative reject below stays authoritative, and an
+                // unclassified symbol is an explicit `Absent`, never a
+                // fabricated contract.
+                debug_assert!(
+                    crate::ffi_contracts::extern_ownership_contract("hew_json_free")
+                        .contract()
+                        .is_some_and(|contract| contract.params
+                            == [crate::ffi_contracts::ExternParamOwnership::Consume]),
+                    "FFI ownership carriage table unreadable at the extern-call \
+                     lowering position"
+                );
                 return Err(Box::new(Self::call_scrutinee_reject(
                     scrutinee,
                     "an un-audited heap-returning `extern` may hand back an interior pointer \

--- a/hew-mir/tests/ffi_contract_drift.rs
+++ b/hew-mir/tests/ffi_contract_drift.rs
@@ -1,0 +1,116 @@
+//! 1:1 drift proof between the two ownership-contract carriers.
+//!
+//! `scripts/jit-symbol-classification.toml` `[[ownership.contracts]]` is the
+//! authority; `hew-mir/build.rs` projects it into the static
+//! `FFI_OWNERSHIP_CONTRACTS` table with a hand-rolled line parser. This test
+//! re-parses the TOML with the independent `toml` crate and asserts exact
+//! row-for-row equality, so neither a build-script parser bug nor a stale
+//! generated table can put the compiler's facts out of sync with the
+//! machine-checked contracts.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use hew_mir::ffi_contracts::{
+    ExternParamOwnership, ExternResultOwnership, ReleaseDischargeDepth, FFI_OWNERSHIP_CONTRACTS,
+};
+
+#[derive(Debug, serde::Deserialize)]
+struct Document {
+    ownership: Ownership,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Ownership {
+    contracts: Vec<Contract>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Contract {
+    symbol: String,
+    result: String,
+    params: Vec<String>,
+    #[serde(rename = "release-symbol")]
+    release_symbol: String,
+    #[serde(rename = "discharge-depth")]
+    discharge_depth: String,
+}
+
+fn classification_toml() -> Document {
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../scripts/jit-symbol-classification.toml");
+    let source = std::fs::read_to_string(&path).expect("read FFI classification TOML");
+    toml::from_str(&source).expect("parse FFI classification TOML")
+}
+
+fn param_spelling(param: ExternParamOwnership) -> &'static str {
+    match param {
+        ExternParamOwnership::Borrow => "borrow",
+        ExternParamOwnership::Consume => "consume",
+        ExternParamOwnership::Retain => "retain",
+    }
+}
+
+fn result_spelling(result: ExternResultOwnership) -> &'static str {
+    match result {
+        ExternResultOwnership::Fresh => "fresh",
+        ExternResultOwnership::Retained => "retained",
+        ExternResultOwnership::Borrowed => "borrowed",
+        ExternResultOwnership::None => "none",
+    }
+}
+
+fn depth_spelling(depth: ReleaseDischargeDepth) -> &'static str {
+    match depth {
+        ReleaseDischargeDepth::Shallow => "shallow",
+        ReleaseDischargeDepth::Deep => "deep",
+        ReleaseDischargeDepth::None => "none",
+    }
+}
+
+#[test]
+fn compiler_table_matches_toml_one_to_one() {
+    let document = classification_toml();
+    let mut toml_rows = BTreeMap::new();
+    for contract in document.ownership.contracts {
+        let symbol = contract.symbol.clone();
+        assert!(
+            toml_rows.insert(symbol.clone(), contract).is_none(),
+            "duplicate TOML contract for {symbol}"
+        );
+    }
+
+    assert_eq!(
+        FFI_OWNERSHIP_CONTRACTS.len(),
+        toml_rows.len(),
+        "compiler table and TOML carry different contract counts"
+    );
+
+    for (symbol, compiled) in FFI_OWNERSHIP_CONTRACTS {
+        let expected = toml_rows
+            .get(*symbol)
+            .unwrap_or_else(|| panic!("{symbol} is compiled but absent from the TOML"));
+        let compiled_params: Vec<&str> = compiled
+            .params
+            .iter()
+            .map(|param| param_spelling(*param))
+            .collect();
+        assert_eq!(compiled_params, expected.params, "{symbol}: params drift");
+        assert_eq!(
+            result_spelling(compiled.result),
+            expected.result,
+            "{symbol}: result drift"
+        );
+        assert_eq!(
+            compiled.release_symbol, expected.release_symbol,
+            "{symbol}: release-symbol drift"
+        );
+        assert_eq!(
+            depth_spelling(compiled.discharge_depth),
+            expected.discharge_depth,
+            "{symbol}: discharge-depth drift"
+        );
+    }
+}

--- a/hew-mir/tests/ffi_contract_parse_hardening.rs
+++ b/hew-mir/tests/ffi_contract_parse_hardening.rs
@@ -1,0 +1,82 @@
+//! Hardening proof for the build-script `[[ownership.contracts]]` parser.
+//!
+//! Includes the EXACT parser `hew-mir/build.rs` compiles
+//! (`build_support/ownership_contract_parse.rs`) and proves that a trailing
+//! foreign table cannot pollute the final contract: any `[header]` /
+//! `[[header]]` line other than `[[ownership.contracts]]` closes out the
+//! contract being accumulated and enters a skip state.
+
+#![allow(dead_code, reason = "the included parser carries build-only helpers")]
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/build_support/ownership_contract_parse.rs"
+));
+
+const CONTRACT_THEN_FOREIGN_TABLE: &str = r#"
+[[ownership.contracts]]
+symbol = "hew_alpha"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# A trailing foreign table reusing the contract key spellings. Nothing below
+# may reach hew_alpha or mint a new contract.
+[foreign.table]
+symbol = "hew_polluter"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+"#;
+
+#[test]
+fn trailing_foreign_table_cannot_alter_the_last_contract() {
+    let contracts = parse_ownership_contracts(CONTRACT_THEN_FOREIGN_TABLE);
+    assert_eq!(contracts.len(), 1, "foreign table must not mint a contract");
+    let row = contracts
+        .get("hew_alpha")
+        .expect("hew_alpha contract parsed");
+    // The open hew_alpha entry was closed out AT the foreign header with its
+    // own values intact — none of the foreign keys were absorbed.
+    assert_eq!(row.result, "none");
+    assert_eq!(row.params, ["consume"]);
+    assert_eq!(row.release_symbol, "");
+    assert_eq!(row.discharge_depth, "none");
+    assert!(!contracts.contains_key("hew_polluter"));
+}
+
+const FOREIGN_TABLE_BETWEEN_CONTRACTS: &str = r#"
+[[ownership.contracts]]
+symbol = "hew_alpha"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[interloper]
+result = "fresh"
+
+[[ownership.contracts]]
+symbol = "hew_beta"
+result = "fresh"
+params = [
+  "borrow",
+  "borrow",
+]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+"#;
+
+#[test]
+fn foreign_table_between_contracts_is_skipped_and_wrapped_params_parse() {
+    let contracts = parse_ownership_contracts(FOREIGN_TABLE_BETWEEN_CONTRACTS);
+    assert_eq!(contracts.len(), 2);
+    assert_eq!(contracts["hew_alpha"].result, "none");
+    // The interloper's `result = "fresh"` did not leak into hew_alpha, and
+    // parsing resumed cleanly at the next contract header — including the
+    // formatter-wrapped multi-line params array.
+    assert_eq!(contracts["hew_beta"].result, "fresh");
+    assert_eq!(contracts["hew_beta"].params, ["borrow", "borrow"]);
+}

--- a/hew-mir/tests/lowering_calls/extern_string_ownership.rs
+++ b/hew-mir/tests/lowering_calls/extern_string_ownership.rs
@@ -139,12 +139,27 @@ fn user_package_provenance_foreign_string_is_adopted() {
 
 #[test]
 fn user_package_symbol_collision_with_absent_std_producer_still_adopts() {
-    // A user-package extern whose NAME collides with a std string producer
-    // (`hew_uuid_v4`, which is absent from the JIT catalog) must classify from
-    // its user/package provenance — adopt — not from the colliding name. This is
-    // the exact failure the old "absence from diagnostic_source_modules" heuristic
-    // could not distinguish; provenance can.
+    // A user-package extern whose NAME wears the `hew_` prefix but is absent
+    // from the JIT catalog must classify from its user/package provenance —
+    // adopt — not from the name spelling. This is the exact failure the old
+    // "absence from diagnostic_source_modules" heuristic could not
+    // distinguish; provenance can. (`hew_uuid_v4` served as the fixture until
+    // the std-used extern surface was classified into the catalog, which
+    // correctly flipped it to the suppressed case below.)
     assert!(!hew_types::jit_symbols::is_classified_hew_ffi_symbol(
+        "hew_uuid_v99"
+    ));
+    assert_eq!(
+        classify_extern_string_ownership(
+            &ExternProvenance::Module("mypkg.strings".to_string()),
+            "hew_uuid_v99",
+        ),
+        ExternStringOwnership::ForeignAdopt,
+    );
+    // The classified std producer itself is monotonically suppressed to
+    // header-aware even from user provenance: adopting a header-aware
+    // `str_to_malloc` string as foreign malloc is the memory-unsafe direction.
+    assert!(hew_types::jit_symbols::is_classified_hew_ffi_symbol(
         "hew_uuid_v4"
     ));
     assert_eq!(
@@ -152,7 +167,7 @@ fn user_package_symbol_collision_with_absent_std_producer_still_adopts() {
             &ExternProvenance::Module("mypkg.strings".to_string()),
             "hew_uuid_v4",
         ),
-        ExternStringOwnership::ForeignAdopt,
+        ExternStringOwnership::HeaderAware,
     );
 }
 
@@ -207,9 +222,16 @@ fn lowering_root_foreign_string_extern_adopts() {
 
 #[test]
 fn lowering_user_package_collision_string_extern_adopts() {
-    // Package provenance beats a name that happens to match an absent std
-    // producer — the decl adopts.
+    // Package provenance beats a `hew_`-prefixed name absent from the catalog
+    // — the decl adopts. A CLASSIFIED std producer (`hew_uuid_v4`) is instead
+    // monotonically suppressed even from package provenance.
     assert!(malloc_string_return_for(
+        "hew_uuid_v99",
+        ResolvedTy::String,
+        "C",
+        ExternProvenance::Module("mypkg.strings".to_string()),
+    ));
+    assert!(!malloc_string_return_for(
         "hew_uuid_v4",
         ResolvedTy::String,
         "C",

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -2,4 +2,4 @@
 #
 # This value must exactly match the verifier's computed count. Any classification
 # or contract change that changes the count must deliberately update this ratchet.
-unclassified = 972
+unclassified = 831

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -160,6 +160,7 @@ stable = [
   "hew_channel_detach_recv",
   "hew_channel_new",
   "hew_channel_pair_free",
+  "hew_channel_pair_is_valid",
   "hew_channel_pair_receiver",
   "hew_channel_pair_sender",
   "hew_channel_poll",
@@ -537,6 +538,7 @@ stable = [
   "hew_stream_next_sized",
   "hew_stream_next_view",
   "hew_stream_pair_free",
+  "hew_stream_pair_is_valid",
   "hew_stream_pair_sink",
   "hew_stream_pair_sink_bytes",
   "hew_stream_pair_stream",
@@ -854,6 +856,17 @@ stable = [
 # linker knows which stdlib archives to pull in. User `extern "rt"` blocks
 # may name these directly; the checker treats them identically to `stable`.
 stable-stdlib = [
+  "hew_cidr_broadcast",
+  "hew_cidr_contains",
+  "hew_cidr_hosts",
+  "hew_cidr_network",
+  "hew_constant_time_eq_hew",
+  "hew_cron_free",
+  "hew_cron_is_valid",
+  "hew_cron_last_error",
+  "hew_cron_next_hew",
+  "hew_cron_parse",
+  "hew_cron_to_string",
   "hew_datetime_day",
   "hew_datetime_format",
   "hew_datetime_hour",
@@ -866,21 +879,278 @@ stable-stdlib = [
   "hew_datetime_second",
   "hew_datetime_weekday",
   "hew_datetime_year",
+  "hew_deflate_compress_hew",
+  "hew_deflate_decompress_hew",
+  "hew_dns_lookup_host",
+  "hew_dns_lookup_host_timed",
+  "hew_dns_resolve",
+  "hew_dns_resolve_timed",
+  "hew_ed25519_generate_pkcs8_hew",
+  "hew_ed25519_public_key_from_pkcs8_hew",
+  "hew_ed25519_sign_hew",
+  "hew_ed25519_verify_hew",
+  "hew_encrypt_last_open_error_code",
+  "hew_encrypt_must_open_hew",
+  "hew_encrypt_seal_base64_hew",
+  "hew_encrypt_try_open_hew",
+  "hew_gzip_compress_hew",
+  "hew_gzip_decompress_hew",
+  "hew_hmac_sha256_hew",
+  "hew_http_last_error",
+  "hew_http_request_body_string",
+  "hew_http_request_free",
+  "hew_http_request_header",
+  "hew_http_request_headers",
+  "hew_http_request_hew",
+  "hew_http_request_method",
+  "hew_http_request_path",
+  "hew_http_respond_bridge",
+  "hew_http_respond_json",
+  "hew_http_respond_stream",
+  "hew_http_respond_text",
+  "hew_http_response_body",
+  "hew_http_response_content_type",
+  "hew_http_response_free",
+  "hew_http_response_header",
+  "hew_http_response_headers",
+  "hew_http_response_status",
+  "hew_http_server_close",
+  "hew_http_server_new",
+  "hew_http_server_recv",
+  "hew_http_server_set_request_timeout_ms",
+  "hew_http_set_timeout",
+  "hew_ip_is_loopback",
+  "hew_ip_is_private",
+  "hew_ip_is_v4",
+  "hew_ip_is_v6",
+  "hew_ip_parse",
+  "hew_json_array_get",
+  "hew_json_array_len",
+  "hew_json_array_new",
   "hew_json_array_push",
+  "hew_json_array_push_bool",
+  "hew_json_array_push_float",
+  "hew_json_array_push_int",
+  "hew_json_array_push_null",
+  "hew_json_array_push_string",
   "hew_json_free",
+  "hew_json_from_bool",
+  "hew_json_from_float",
+  "hew_json_from_int",
+  "hew_json_from_null",
+  "hew_json_from_string",
+  "hew_json_get_bool",
+  "hew_json_get_field",
+  "hew_json_get_float",
+  "hew_json_get_int",
+  "hew_json_get_string",
+  "hew_json_last_error",
+  "hew_json_object_keys",
+  "hew_json_object_new",
   "hew_json_object_set",
+  "hew_json_object_set_bool",
+  "hew_json_object_set_float",
+  "hew_json_object_set_int",
+  "hew_json_object_set_null",
+  "hew_json_object_set_string",
+  "hew_json_parse",
+  "hew_json_stringify",
+  "hew_json_type",
+  "hew_jwt_decode_hew",
+  "hew_jwt_decode_insecure",
+  "hew_jwt_encode_hew",
+  "hew_jwt_last_error_code",
+  "hew_jwt_validate",
   "hew_markdown_to_html",
   "hew_markdown_to_html_safe",
+  "hew_msgpack_encode_bytes_hew",
+  "hew_msgpack_encode_int_hew",
+  "hew_msgpack_encode_string_hew",
+  "hew_msgpack_from_json_hew",
+  "hew_msgpack_last_error",
+  "hew_msgpack_to_json_hew",
+  "hew_password_hash",
+  "hew_password_hash_custom",
+  "hew_password_verify",
+  "hew_proto_msg_free",
   "hew_proto_msg_get_string",
+  "hew_proto_msg_get_varint",
+  "hew_proto_msg_has_field",
+  "hew_proto_msg_new",
+  "hew_proto_msg_set_string",
+  "hew_proto_msg_set_varint",
+  "hew_quic_conn_accept_stream",
+  "hew_quic_conn_accepted_streams",
+  "hew_quic_conn_bytes_received",
+  "hew_quic_conn_bytes_sent",
+  "hew_quic_conn_disconnect",
+  "hew_quic_conn_is_closed",
+  "hew_quic_conn_last_error",
+  "hew_quic_conn_local_addr",
+  "hew_quic_conn_on_event",
+  "hew_quic_conn_open_stream",
+  "hew_quic_conn_opened_streams",
+  "hew_quic_conn_peer_addr",
+  "hew_quic_conn_rtt_ms",
+  "hew_quic_endpoint_accept",
+  "hew_quic_endpoint_accepted_connections",
+  "hew_quic_endpoint_close",
+  "hew_quic_endpoint_connect",
+  "hew_quic_endpoint_last_error",
+  "hew_quic_endpoint_local_addr",
+  "hew_quic_endpoint_on_event",
+  "hew_quic_event_free",
+  "hew_quic_event_kind",
+  "hew_quic_last_error",
+  "hew_quic_new_client",
+  "hew_quic_new_client_with_ca",
+  "hew_quic_new_server",
+  "hew_quic_new_server_with_tls",
+  "hew_quic_stream_bytes_received",
+  "hew_quic_stream_bytes_sent",
+  "hew_quic_stream_close",
+  "hew_quic_stream_finish",
+  "hew_quic_stream_last_error",
+  "hew_quic_stream_last_recv_status",
+  "hew_quic_stream_recv",
+  "hew_quic_stream_recv_closed",
+  "hew_quic_stream_recv_timeout_hew",
+  "hew_quic_stream_send",
+  "hew_quic_stream_send_closed",
+  "hew_quic_stream_send_timeout_hew",
+  "hew_quic_stream_stop",
+  "hew_random_bytes_hew",
+  "hew_regex_capture_index_one",
+  "hew_regex_capture_name_one",
+  "hew_regex_capture_width",
+  "hew_regex_captures_flat",
+  "hew_regex_clone",
+  "hew_regex_find",
+  "hew_regex_find_all",
+  "hew_regex_find_all_submatch_flat",
+  "hew_regex_free",
+  "hew_regex_is_match",
+  "hew_regex_is_valid",
+  "hew_regex_new",
+  "hew_regex_replace",
+  "hew_sha256_hew",
+  "hew_sha384_hew",
+  "hew_sha512_hew",
+  "hew_smtp_close",
+  "hew_smtp_connect",
+  "hew_smtp_connect_tls",
+  "hew_smtp_last_error",
+  "hew_smtp_send",
+  "hew_smtp_send_html",
+  "hew_smtp_send_html_once",
+  "hew_smtp_send_once",
+  "hew_sort_floats",
+  "hew_tls_attach",
+  "hew_tls_close",
+  "hew_tls_connect",
+  "hew_tls_last_error",
+  "hew_tls_read_result",
+  "hew_tls_write_result",
+  "hew_toml_array_get",
+  "hew_toml_array_len",
+  "hew_toml_array_new",
   "hew_toml_array_push",
+  "hew_toml_array_push_bool",
+  "hew_toml_array_push_float",
+  "hew_toml_array_push_int",
+  "hew_toml_array_push_string",
   "hew_toml_free",
+  "hew_toml_from_bool",
+  "hew_toml_from_float",
+  "hew_toml_from_int",
+  "hew_toml_from_string",
+  "hew_toml_get_bool",
+  "hew_toml_get_field",
+  "hew_toml_get_float",
+  "hew_toml_get_int",
   "hew_toml_get_string",
   "hew_toml_last_error",
-  "hew_toml_table_set",
+  "hew_toml_parse",
   "hew_toml_stringify",
+  "hew_toml_table_new",
+  "hew_toml_table_set",
+  "hew_toml_table_set_bool",
+  "hew_toml_table_set_float",
+  "hew_toml_table_set_int",
+  "hew_toml_table_set_string",
+  "hew_toml_type",
+  "hew_url_fragment",
+  "hew_url_free",
+  "hew_url_host",
+  "hew_url_is_valid",
+  "hew_url_join",
+  "hew_url_parse",
+  "hew_url_path",
+  "hew_url_port",
+  "hew_url_query",
+  "hew_url_scheme",
+  "hew_url_to_string",
+  "hew_uuid_parse",
+  "hew_uuid_v4",
+  "hew_uuid_v7",
+  "hew_ws_attach",
+  "hew_ws_close",
+  "hew_ws_connect",
+  "hew_ws_message_free",
+  "hew_ws_message_is_valid",
+  "hew_ws_message_text",
+  "hew_ws_message_type",
+  "hew_ws_recv",
+  "hew_ws_recv_last_timed_out",
+  "hew_ws_recv_timeout",
+  "hew_ws_send_text",
+  "hew_ws_server_accept",
+  "hew_ws_server_close",
+  "hew_ws_server_new",
+  "hew_ws_server_port",
+  "hew_xml_children_count",
+  "hew_xml_free",
+  "hew_xml_get_attribute",
+  "hew_xml_get_child",
+  "hew_xml_get_tag",
+  "hew_xml_get_text",
+  "hew_xml_is_element",
+  "hew_xml_last_error",
+  "hew_xml_parse",
+  "hew_xml_to_string",
+  "hew_yaml_array_get",
+  "hew_yaml_array_len",
+  "hew_yaml_array_new",
   "hew_yaml_array_push",
+  "hew_yaml_array_push_bool",
+  "hew_yaml_array_push_float",
+  "hew_yaml_array_push_int",
+  "hew_yaml_array_push_null",
+  "hew_yaml_array_push_string",
   "hew_yaml_free",
+  "hew_yaml_from_bool",
+  "hew_yaml_from_float",
+  "hew_yaml_from_int",
+  "hew_yaml_from_null",
+  "hew_yaml_from_string",
+  "hew_yaml_get_bool",
+  "hew_yaml_get_field",
+  "hew_yaml_get_float",
+  "hew_yaml_get_int",
+  "hew_yaml_get_string",
+  "hew_yaml_last_error",
+  "hew_yaml_object_new",
   "hew_yaml_object_set",
+  "hew_yaml_object_set_bool",
+  "hew_yaml_object_set_float",
+  "hew_yaml_object_set_int",
+  "hew_yaml_object_set_null",
+  "hew_yaml_object_set_string",
+  "hew_yaml_parse",
+  "hew_yaml_stringify",
+  "hew_yaml_type",
+  "hew_zlib_compress_hew",
+  "hew_zlib_decompress_hew",
 ]
 
 # jit: codegen-stable — symbols the Hew compiler emits into generated IR for
@@ -1579,4 +1849,3038 @@ symbol = "hew_weak_clone_rc"
 result = "retained"
 params = ["borrow"]
 release-symbol = "hew_weak_drop_rc"
+discharge-depth = "shallow"
+
+# ── std-used extern surface (derived by reading each runtime implementation;
+# per-family provenance in the comments below) ──
+
+# process environment / identity — hew-runtime/src/env.rs. String results are
+# string_to_malloc/str_to_malloc header-aware allocations (fresh); key/value
+# params are read via CStr::from_ptr (borrow).
+[[ownership.contracts]]
+symbol = "hew_args_count"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_args_get"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_cwd"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_env_get"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_env_has"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_env_remove"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_env_set"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_home_dir"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_hostname"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_pid"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_temp_dir"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# runtime error/control singles — hew-runtime/src/lib.rs (hew_clear_error),
+# hew-runtime/src/execution_context.rs (hew_set_partition_policy: scalar tag in,
+# bool out).
+[[ownership.contracts]]
+symbol = "hew_clear_error"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_set_partition_policy"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# stdio — hew-runtime/src/stdio.rs. read_line/read_all return str_to_malloc
+# strings; write/write_err read their C-string operand only.
+[[ownership.contracts]]
+symbol = "hew_io_read_all"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_io_read_line"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_io_write"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_io_write_err"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# logging — hew-runtime/src/log_core.rs. hew_log_emit/_ex read msg via
+# cstr_to_str (borrow); hew_log_encode_field_value returns a malloc_cstring
+# copy (fresh).
+[[ownership.contracts]]
+symbol = "hew_log_emit"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_log_emit_ex"
+result = "none"
+params = ["borrow", "borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_log_encode_field_value"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_log_get_format"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_log_get_level"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_log_set_format"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_log_set_level"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# string singles — hew-runtime/src/string.rs. hew_string_drop is THE universal
+# String release (free_cstring; consume). hew_char_to_string allocates a fresh
+# string; hew_string_to_bytes forwards to bytes.rs hew_bytes_from_str (fresh
+# rc=1 buffer, released via hew_bytes_drop); hew_string_compare and the
+# hew_unicode_* codepoint predicates/mappers are read-only.
+[[ownership.contracts]]
+symbol = "hew_char_to_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_string_compare"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_string_drop"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_string_to_bytes"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_unicode_is_alnum"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_unicode_is_digit"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_unicode_is_letter"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_unicode_is_lower"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_unicode_is_space"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_unicode_is_upper"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_unicode_to_lower"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_unicode_to_upper"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# bytes construction — hew-runtime/src/bytes.rs hew_bytes_from_str copies the
+# borrowed C string into a fresh rc=1 bytes buffer.
+[[ownership.contracts]]
+symbol = "hew_bytes_from_str"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+# stream error channel — hew-runtime/src/stream_error.rs. hew_stream_last_error
+# returns an alloc_cstring_from_str header-aware string (fresh); the errno/kind
+# probes are scalar.
+[[ownership.contracts]]
+symbol = "hew_stream_last_errno"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_stream_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_stream_last_error_kind"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+# streams and sinks — hew-runtime/src/stream.rs. hew_stream_channel and
+# hew_tcp_stream_from_conn hand back a Box'd HewStreamPair whose free also
+# drops unextracted handles (deep). hew_stream_pair_sink/_stream (and _bytes
+# aliases) null-out the pair slot and MOVE the handle to the caller (fresh;
+# released via hew_sink_close / hew_stream_close). hew_stream_pipe takes
+# Box::from_raw ownership of BOTH handles; hew_stream_collect_string consumes
+# its stream and returns a fresh alloc_cstring string.
+[[ownership.contracts]]
+symbol = "hew_sink_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_stream_channel"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_stream_pair_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_stream_collect_string"
+result = "fresh"
+params = ["consume"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_stream_from_file_read"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_stream_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_stream_from_file_write"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_sink_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_stream_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_stream_pair_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_stream_pair_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_stream_pair_sink"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_sink_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_stream_pair_sink_bytes"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_sink_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_stream_pair_stream"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_stream_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_stream_pair_stream_bytes"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_stream_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_stream_pipe"
+result = "none"
+params = ["consume", "consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_stream_from_conn"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_stream_pair_free"
+discharge-depth = "deep"
+
+# channels — hew-runtime/src/channel.rs (native) / channel_wasm.rs (wasm; same
+# ownership shape). hew_channel_new returns a Box'd pair whose free drops
+# unextracted halves (deep); pair_sender/pair_receiver MOVE the half out
+# (null-out; fresh). hew_channel_sender_clone allocates a NEW Box'd handle over
+# an Arc clone (fresh). The *_close entries Box::from_raw their handle.
+[[ownership.contracts]]
+symbol = "hew_channel_new"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_channel_pair_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_channel_pair_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_channel_pair_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_channel_pair_receiver"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_channel_receiver_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_channel_pair_sender"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_channel_sender_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_channel_receiver_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_channel_sender_clone"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_channel_sender_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_channel_sender_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# semaphore — hew-runtime/src/semaphore.rs. new is Box::into_raw (fresh);
+# free is Box::from_raw (consume); the rest borrow the handle.
+[[ownership.contracts]]
+symbol = "hew_semaphore_acquire"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_semaphore_acquire_timeout"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_semaphore_count"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_semaphore_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_semaphore_new"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_semaphore_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_semaphore_release"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_semaphore_try_acquire"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# deque — hew-runtime/src/vecdeque.rs. i64-element deque: new is fresh, free
+# consumes, push/pop/len/is_empty borrow the handle.
+[[ownership.contracts]]
+symbol = "hew_deque_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_deque_is_empty"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_deque_len"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_deque_new"
+result = "fresh"
+params = []
+release-symbol = "hew_deque_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_deque_pop_back"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_deque_pop_front"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_deque_push_back"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_deque_push_front"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# random — hew-runtime/src/random.rs. Scalar RNG surface; the vec-taking
+# entries (choices_vec, shuffle_i64) mutate the borrowed HewVec in place.
+[[ownership.contracts]]
+symbol = "hew_random_choices_vec"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_random_gauss"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_random_randint"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_random_random"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_random_seed"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_random_shuffle_i64"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# process — hew-runtime/src/process.rs. run/run_argv return a Box'd
+# HewProcessResult whose free also releases the malloc'd stdout/stderr fields
+# (deep). spawn returns a Box'd HewProcess reaped by hew_process_drop.
+# result_stdout/result_stderr clone the stored strings (fresh). wait/kill
+# borrow; hew_process_run_argv borrows its Vec<String> argv.
+[[ownership.contracts]]
+symbol = "hew_process_drop"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_process_kill"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_process_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_process_result_exit_code"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_process_result_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_process_result_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_process_result_stderr"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_process_result_stdout"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_process_run"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_process_result_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_process_run_argv"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_process_result_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_process_spawn"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_process_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_process_wait"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# file I/O — hew-runtime/src/file_io.rs. Path/content params are borrowed C
+# strings; hew_file_read returns a fresh string, hew_file_read_bytes a fresh
+# bytes buffer, hew_fs_list_dir a fresh Vec<string> (hew_vec_free discharges
+# the element strings: deep).
+[[ownership.contracts]]
+symbol = "hew_file_append"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_file_delete"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_file_exists"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_file_read"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_file_read_bytes"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_file_size"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_file_write"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_file_write_bytes"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_fs_copy"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_fs_is_dir"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_fs_list_dir"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_fs_mkdir"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_fs_mkdir_all"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_fs_rename"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_path_exists"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# path / glob — hew-runtime/src/path.rs. hew_glob returns a Box'd
+# HewGlobResult (freed by hew_glob_free); hew_glob_get and hew_path_absolute
+# return str_to_malloc strings (fresh).
+[[ownership.contracts]]
+symbol = "hew_glob"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_glob_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_glob_count"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_glob_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_glob_get"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_path_absolute"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_path_is_dir"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_path_is_file"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# TCP transport — hew-runtime/src/transport.rs. Connections/listeners are
+# scalar c_int table handles (no pointer ownership axis). hew_tcp_read returns
+# a fresh BytesTriple; hew_tcp_write / hew_tcp_broadcast_except take the bytes
+# triple by-pointer WITHOUT transferring ownership (borrow).
+[[ownership.contracts]]
+symbol = "hew_connection_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_listener_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_accept"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_broadcast_except"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_close"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_connect"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_connect_timeout"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_listen"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_listener_close"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_listener_local_port"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_read"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_set_read_timeout"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_set_write_timeout"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tcp_write"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# IP / CIDR — hew-std/src/ipnet.rs. Read-only string predicates; network and
+# broadcast return str_to_malloc strings.
+[[ownership.contracts]]
+symbol = "hew_cidr_broadcast"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_cidr_contains"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_cidr_hosts"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_cidr_network"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ip_is_loopback"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ip_is_private"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ip_is_v4"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ip_is_v6"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ip_parse"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# DNS — hew-std/src/dns.rs. lookup_host(_timed) return str_to_malloc strings;
+# resolve(_timed) return a fresh Vec<string> built with hew_vec_new_str /
+# hew_vec_push_str (hew_vec_free discharges element strings: deep).
+[[ownership.contracts]]
+symbol = "hew_dns_lookup_host"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_dns_lookup_host_timed"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_dns_resolve"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_dns_resolve_timed"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+# crypto digests — hew-std/src/crypto.rs. BytesTriple params are read via
+# bytes_slice_from_triple (borrow); results are fresh bytes via
+# hew_bytes_from_static copies.
+[[ownership.contracts]]
+symbol = "hew_constant_time_eq_hew"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_hmac_sha256_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_random_bytes_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_sha256_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_sha384_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_sha512_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+# compression — hew-std/src/compress.rs. Borrowed BytesTriple in, fresh
+# BytesTriple out (bytes_triple_from_slice → hew_bytes_from_static).
+[[ownership.contracts]]
+symbol = "hew_deflate_compress_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_deflate_decompress_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_gzip_compress_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_gzip_decompress_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_zlib_compress_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_zlib_decompress_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+# msgpack — hew-std/src/msgpack.rs. Encoders borrow their scalar/string/bytes
+# input and return fresh bytes; to_json returns a fresh string.
+[[ownership.contracts]]
+symbol = "hew_msgpack_encode_bytes_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_msgpack_encode_int_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_msgpack_encode_string_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_msgpack_from_json_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_msgpack_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_msgpack_to_json_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# ed25519 signing — hew-std/src/sign.rs. Borrowed BytesTriple params; fresh
+# bytes results (key material / signatures).
+[[ownership.contracts]]
+symbol = "hew_ed25519_generate_pkcs8_hew"
+result = "fresh"
+params = []
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ed25519_public_key_from_pkcs8_hew"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ed25519_sign_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ed25519_verify_hew"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# authenticated encryption — hew-std/src/encrypt.rs. Key/ciphertext are
+# borrowed; seal/open results are fresh strings.
+[[ownership.contracts]]
+symbol = "hew_encrypt_last_open_error_code"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_encrypt_must_open_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_encrypt_seal_base64_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_encrypt_try_open_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# JWT — hew-std/src/jwt.rs. Token/secret/payload strings are borrowed;
+# encode/decode return fresh JSON/token strings.
+[[ownership.contracts]]
+symbol = "hew_jwt_decode_hew"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_jwt_decode_insecure"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_jwt_encode_hew"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_jwt_last_error_code"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_jwt_validate"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# password hashing — hew-std/src/password.rs. Borrowed inputs; bcrypt hash
+# results are fresh strings.
+[[ownership.contracts]]
+symbol = "hew_password_hash"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_password_hash_custom"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_password_verify"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# UUID — hew-std/src/uuid.rs. v4/v7 return fresh formatted strings; parse is
+# a read-only validity probe.
+[[ownership.contracts]]
+symbol = "hew_uuid_parse"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_uuid_v4"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_uuid_v7"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# datetime — hew-std/src/time/datetime.rs. Scalar epoch math; format and
+# last_error return fresh strings; parse borrows both strings.
+[[ownership.contracts]]
+symbol = "hew_datetime_day"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_format"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_hour"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_minute"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_month"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_now_ms"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_now_nanos"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_parse"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_second"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_weekday"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_datetime_year"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# cron — hew-std/src/time/cron.rs. parse returns a Box'd HewCronExpr (freed
+# by hew_cron_free); next_hew returns a scalar-only HewCronNextResult struct;
+# last_error/to_string return fresh strings.
+[[ownership.contracts]]
+symbol = "hew_cron_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_cron_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_cron_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_cron_next_hew"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_cron_parse"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_cron_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_cron_to_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# URL — hew-std/src/url.rs. parse/join return Box'd HewUrl handles (freed by
+# hew_url_free); component getters return str_to_malloc strings.
+[[ownership.contracts]]
+symbol = "hew_url_fragment"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_url_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_url_host"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_url_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_url_join"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_url_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_url_parse"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_url_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_url_path"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_url_port"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_url_query"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_url_scheme"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_url_to_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# HTTP server — hew-std/src/http/server.rs. server_new/server_recv return
+# Box'd handles; respond_* take the responder out of the borrowed request but
+# the handle itself stays caller-owned (freed by hew_http_request_free).
+# respond_stream hands back an owned HewSink; request_headers builds a fresh
+# owned-element Vec<(String,String)> discharged by hew_vec_free_owned (deep).
+[[ownership.contracts]]
+symbol = "hew_http_request_body_string"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_request_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_http_request_header"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_request_headers"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free_owned"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_http_request_method"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_request_path"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_respond_bridge"
+result = "none"
+params = ["borrow", "borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_http_respond_json"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_http_respond_stream"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_sink_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_respond_text"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_http_server_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_http_server_new"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_http_server_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_server_recv"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_http_request_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_server_set_request_timeout_ms"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# HTTP client — hew-std/src/http/client.rs. request_hew borrows its
+# Vec<(String,String)> headers and returns a Box'd HewHttpResponse whose free
+# releases the owned body (deep). Body/header getters strdup fresh strings;
+# response_headers builds a fresh owned-element Vec (hew_vec_free_owned deep).
+[[ownership.contracts]]
+symbol = "hew_http_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_request_hew"
+result = "fresh"
+params = ["borrow", "borrow", "borrow", "borrow"]
+release-symbol = "hew_http_response_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_http_response_body"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_response_content_type"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_response_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_http_response_header"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_http_response_headers"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free_owned"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_http_response_status"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_http_set_timeout"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# WebSocket — hew-std/src/websocket.rs. connect/server_accept return Box'd
+# HewWsConn handles (Box::from_raw in hew_ws_close); recv(_timeout) return
+# Box'd HewWsMessage handles; message_text returns a fresh alloc_cstring
+# string. hew_ws_attach snapshots the actor ref by value (borrow).
+[[ownership.contracts]]
+symbol = "hew_ws_attach"
+result = "none"
+params = ["borrow", "borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ws_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ws_connect"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_ws_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ws_message_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ws_message_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ws_message_text"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ws_message_type"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ws_recv"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_ws_message_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ws_recv_last_timed_out"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ws_recv_timeout"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_ws_message_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ws_send_text"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ws_server_accept"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_ws_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ws_server_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_ws_server_new"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_ws_server_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_ws_server_port"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# TLS — hew-std/src/tls.rs. connect returns a Box'd HewTlsStream consumed by
+# hew_tls_close. hew_tls_read_result returns a repr(C) struct whose .data
+# field is a fresh owned BytesTriple (released via hew_bytes_drop); the write
+# bridge only reads its borrowed BytesTriple. hew_tls_attach snapshots the
+# actor ref by value (borrow).
+[[ownership.contracts]]
+symbol = "hew_tls_attach"
+result = "none"
+params = ["borrow", "borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tls_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_tls_connect"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_tls_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_tls_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_tls_read_result"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_tls_write_result"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# SMTP — hew-std/src/smtp.rs. connect(_tls) return Box'd HewSmtpConn handles
+# consumed by hew_smtp_close; all send entries borrow their string params.
+[[ownership.contracts]]
+symbol = "hew_smtp_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_smtp_connect"
+result = "fresh"
+params = ["borrow", "borrow", "borrow", "borrow"]
+release-symbol = "hew_smtp_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_smtp_connect_tls"
+result = "fresh"
+params = ["borrow", "borrow", "borrow", "borrow"]
+release-symbol = "hew_smtp_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_smtp_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_smtp_send"
+result = "none"
+params = ["borrow", "borrow", "borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_smtp_send_html"
+result = "none"
+params = ["borrow", "borrow", "borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_smtp_send_html_once"
+result = "none"
+params = [
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_smtp_send_once"
+result = "none"
+params = [
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+  "borrow",
+]
+release-symbol = ""
+discharge-depth = "none"
+
+# QUIC — hew-std/src/quic.rs. Endpoint/conn/stream/event handles are Box'd;
+# the close entries (endpoint_close, conn_disconnect, stream_close,
+# event_free) Box::from_raw (consume). Producers hand back the matching owned
+# handle; *_last_error / *_addr return str_to_malloc strings; stream_recv(_
+# timeout_hew) return fresh BytesTriples; stream_send borrows its triple
+# (ownership not transferred, per the ABI doc).
+[[ownership.contracts]]
+symbol = "hew_quic_conn_accept_stream"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_quic_stream_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_accepted_streams"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_bytes_received"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_bytes_sent"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_disconnect"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_is_closed"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_last_error"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_local_addr"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_on_event"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_quic_event_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_open_stream"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_quic_stream_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_opened_streams"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_peer_addr"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_conn_rtt_ms"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_endpoint_accept"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_quic_conn_disconnect"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_endpoint_accepted_connections"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_endpoint_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_endpoint_connect"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_quic_conn_disconnect"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_endpoint_last_error"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_endpoint_local_addr"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_endpoint_on_event"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_quic_event_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_event_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_event_kind"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_new_client"
+result = "fresh"
+params = []
+release-symbol = "hew_quic_endpoint_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_new_client_with_ca"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_quic_endpoint_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_new_server"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_quic_endpoint_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_new_server_with_tls"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_quic_endpoint_close"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_bytes_received"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_bytes_sent"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_close"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_finish"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_last_error"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_last_recv_status"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_recv"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_recv_closed"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_recv_timeout_hew"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_bytes_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_send"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_send_closed"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_send_timeout_hew"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_quic_stream_stop"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# JSON values — hew-std/src/json.rs. Every value producer (parse, from_*,
+# object_new/array_new, get_field/array_get/object_keys — the getters clone
+# the sub-value) returns a Box'd HewJsonValue released by hew_json_free,
+# which drops the whole serde tree (deep). Setters/pushes borrow the target
+# and copy scalar/string operands; get_string/stringify return fresh strings.
+[[ownership.contracts]]
+symbol = "hew_json_array_get"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_array_len"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_array_new"
+result = "fresh"
+params = []
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_array_push_bool"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_array_push_float"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_array_push_int"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_array_push_null"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_array_push_string"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_from_bool"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_from_float"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_from_int"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_from_null"
+result = "fresh"
+params = []
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_from_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_get_bool"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_get_field"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_get_float"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_get_int"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_get_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_json_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_json_object_keys"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_object_new"
+result = "fresh"
+params = []
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_object_set_bool"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_object_set_float"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_object_set_int"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_object_set_null"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_object_set_string"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_json_parse"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_json_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_json_stringify"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_json_type"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# TOML values — hew-std/src/toml.rs. Same shape as the JSON family: value
+# producers (parse, from_*, table_new/array_new, get_field/array_get clone-
+# out) return Box'd HewTomlValue handles released by hew_toml_free (deep);
+# setters/pushes borrow and copy.
+[[ownership.contracts]]
+symbol = "hew_toml_array_get"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_array_len"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_array_new"
+result = "fresh"
+params = []
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_array_push_bool"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_array_push_float"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_array_push_int"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_array_push_string"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_from_bool"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_from_float"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_from_int"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_from_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_get_bool"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_get_field"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_get_float"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_get_int"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_parse"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_table_new"
+result = "fresh"
+params = []
+release-symbol = "hew_toml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_toml_table_set_bool"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_table_set_float"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_table_set_int"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_table_set_string"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_toml_type"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# YAML values — hew-std/src/yaml.rs. Same shape as the JSON family: value
+# producers return Box'd HewYamlValue handles released by hew_yaml_free
+# (deep); setters/pushes borrow and copy; get_string/stringify return fresh
+# strings.
+[[ownership.contracts]]
+symbol = "hew_yaml_array_get"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_array_len"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_array_new"
+result = "fresh"
+params = []
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_array_push_bool"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_array_push_float"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_array_push_int"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_array_push_null"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_array_push_string"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_from_bool"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_from_float"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_from_int"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_from_null"
+result = "fresh"
+params = []
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_from_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_get_bool"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_get_field"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_get_float"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_get_int"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_get_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_object_new"
+result = "fresh"
+params = []
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_object_set_bool"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_object_set_float"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_object_set_int"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_object_set_null"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_object_set_string"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_parse"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_yaml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_stringify"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_yaml_type"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# XML — hew-std/src/xml.rs. parse and get_child (clone-out) return Box'd
+# HewXmlNode trees released by hew_xml_free (deep); tag/text/attribute/error/
+# to_string return str_to_malloc strings (hew_xml_string_free is the same
+# free_cstring path as hew_string_drop).
+[[ownership.contracts]]
+symbol = "hew_xml_children_count"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_xml_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_xml_get_attribute"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_xml_get_child"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_xml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_xml_get_tag"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_xml_get_text"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_xml_is_element"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_xml_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_xml_parse"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_xml_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_xml_to_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# regex — hew-std/src/regex.rs. new/clone return Box'd HewRegex handles
+# (hew_regex_free). Match/capture entries borrow the regex and text; the
+# Vec<string> producers build fresh vecs via hew_vec_new_str/hew_vec_push_str
+# (hew_vec_free deep); find/replace return str_to_malloc strings.
+[[ownership.contracts]]
+symbol = "hew_regex_capture_index_one"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_regex_capture_name_one"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_regex_capture_width"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_regex_captures_flat"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_regex_clone"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_regex_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_regex_find"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_regex_find_all"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_regex_find_all_submatch_flat"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_regex_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_regex_is_match"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_regex_is_valid"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_regex_new"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_regex_free"
+discharge-depth = "shallow"
+
+[[ownership.contracts]]
+symbol = "hew_regex_replace"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# protobuf — hew-std/src/protobuf.rs. msg_new returns a Box'd HewProtoMsg
+# (hew_proto_msg_free drops owned field storage: deep); setters borrow the
+# message and copy their operands; getters are scalar reads.
+[[ownership.contracts]]
+symbol = "hew_proto_msg_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_proto_msg_get_varint"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_proto_msg_has_field"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_proto_msg_new"
+result = "fresh"
+params = []
+release-symbol = "hew_proto_msg_free"
+discharge-depth = "deep"
+
+[[ownership.contracts]]
+symbol = "hew_proto_msg_set_string"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+[[ownership.contracts]]
+symbol = "hew_proto_msg_set_varint"
+result = "none"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# sorting — hew-std/src/sort.rs. hew_sort_floats clones the borrowed input
+# vec (hew_vec_clone) and sorts the copy: fresh f64 vec, hew_vec_free.
+[[ownership.contracts]]
+symbol = "hew_sort_floats"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free"
 discharge-depth = "shallow"

--- a/scripts/verify-ffi-symbols.py
+++ b/scripts/verify-ffi-symbols.py
@@ -207,6 +207,58 @@ def _extract_native_exports(source_dir: Path) -> set[str]:
     return exports
 
 
+# Release symbols that are not literal exports: type-directed drop thunks
+# resolved through the element layout descriptor at codegen time.
+DROP_THUNK_RELEASES = {"HewTypeLayout.drop_fn"}
+
+
+def _extract_fn_param_counts(source_dirs: list[Path]) -> dict[str, set[int]]:
+    """Map every literally-declared `fn name(...)` to its parameter count(s).
+
+    Multiple counts per name are possible (cfg-gated native/wasm variants).
+    Macro-generated exports have no literal signature and are absent from the
+    map; the params-arity check skips them rather than guessing.
+    """
+    counts: dict[str, set[int]] = {}
+    decl_re = re.compile(r"\bfn\s+(\w+)\s*\(")
+    for source_dir in source_dirs:
+        for rs_file in source_dir.rglob("*.rs"):
+            source = rs_file.read_text(encoding=SOURCE_ENCODING)
+            for match in decl_re.finditer(source):
+                name = match.group(1)
+                depth = 0
+                end = match.end() - 1
+                for index in range(end, len(source)):
+                    if source[index] == "(":
+                        depth += 1
+                    elif source[index] == ")":
+                        depth -= 1
+                        if depth == 0:
+                            end = index
+                            break
+                params_text = source[match.end() : end]
+                parts: list[str] = []
+                nest = 0
+                current = ""
+                for ch in params_text:
+                    if ch in "<([":
+                        nest += 1
+                    elif ch in ">)]":
+                        nest -= 1
+                    if ch == "," and nest == 0:
+                        parts.append(current.strip())
+                        current = ""
+                    else:
+                        current += ch
+                if current.strip():
+                    parts.append(current.strip())
+                arity = len(
+                    [part for part in parts if part and not part.startswith("#")]
+                )
+                counts.setdefault(name, set()).add(arity)
+    return counts
+
+
 def extract_runtime_exports() -> set[str]:
     """Return native exports defined by hew-runtime."""
     return _extract_native_exports(RUNTIME_SRC)
@@ -247,7 +299,11 @@ def load_jit_symbol_classification() -> dict[str, set[str]]:
     return classification
 
 
-def validate_ownership_contracts(classification: dict[str, set[str]]) -> list[str]:
+def validate_ownership_contracts(
+    classification: dict[str, set[str]],
+    all_exports: set[str],
+    fn_param_counts: dict[str, set[int]],
+) -> list[str]:
     errors: list[str] = []
     document = tomllib.loads(
         JIT_SYMBOL_CLASSIFICATION.read_text(encoding=SOURCE_ENCODING)
@@ -292,11 +348,34 @@ def validate_ownership_contracts(classification: dict[str, set[str]]) -> list[st
             errors.append(
                 f"{location} params must contain only {sorted(PARAM_OWNERSHIP)}"
             )
+        elif symbol in fn_param_counts and len(params) not in fn_param_counts[symbol]:
+            # Arity teeth: a contract whose params row no longer matches the C
+            # signature of the implementation is stale and must fail here, not
+            # silently mis-describe ownership positionally. Macro-generated
+            # exports have no literal signature and are skipped.
+            found = sorted(fn_param_counts[symbol])
+            errors.append(
+                f"{location} declares {len(params)} params but the FFI "
+                f"declaration has {found} parameters"
+            )
 
         release_symbol = contract.get("release-symbol")
         discharge_depth = contract.get("discharge-depth")
         if not isinstance(release_symbol, str):
             errors.append(f"{location} requires string release-symbol")
+        elif (
+            release_symbol
+            and release_symbol not in all_exports
+            and release_symbol not in DROP_THUNK_RELEASES
+        ):
+            # Release-symbol teeth: an owned result must name a REAL release
+            # entry (or the documented drop-thunk spelling); a renamed or
+            # deleted release function fails validation instead of leaving the
+            # contract pointing at a phantom discharge path.
+            errors.append(
+                f"{location} release-symbol {release_symbol!r} is not an "
+                "exported hew-runtime/hew-std symbol or known drop thunk"
+            )
         if discharge_depth not in DISCHARGE_DEPTHS:
             errors.append(
                 f"{location} discharge-depth must be one of {sorted(DISCHARGE_DEPTHS)}"
@@ -380,7 +459,13 @@ def validate_jit_symbol_classification(
             + ", ".join(missing_stdlib_exports)
             + f" (remove from {JIT_SYMBOL_CLASSIFICATION})"
         )
-    errors.extend(validate_ownership_contracts(classification))
+    errors.extend(
+        validate_ownership_contracts(
+            classification,
+            runtime_exports | stdlib_exports,
+            _extract_fn_param_counts([RUNTIME_SRC, STDLIB_SRC]),
+        )
+    )
     return errors
 
 

--- a/scripts/verify-ffi-symbols.py
+++ b/scripts/verify-ffi-symbols.py
@@ -183,8 +183,13 @@ def _extract_native_exports(source_dir: Path) -> set[str]:
     """
     fn_pattern = re.compile(
         r"#\[no_mangle\]"
-        r"(?:\s*#\[[^\]]*(?:\([^)]*\))?[^\]]*\])*"  # skip interleaved attrs
-        r'\s*(?:pub\s+)?(?:unsafe\s+)?extern\s+"C(?:-unwind)?"\s+fn\s+'
+        # Skip interleaved attributes AND doc/line comments: several modules
+        # (quic.rs among others) place `#[no_mangle]` BEFORE the doc comment,
+        # and a scanner that stops at `///` silently drops those exports from
+        # the candidate ABI (they can then never be classified or contracted).
+        # `const` qualifiers (e.g. hew_stream_pair_is_valid) are accepted too.
+        r"(?:\s*(?:#\[[^\]]*(?:\([^)]*\))?[^\]]*\]|//[^\n]*))*"
+        r'\s*(?:pub\s+)?(?:const\s+)?(?:unsafe\s+)?extern\s+"C(?:-unwind)?"\s+fn\s+'
         r"(\w+)",
         re.DOTALL,
     )


### PR DESCRIPTION
## Summary

FFI ownership contracts existed as a machine-checked TOML table but were never loaded into the compiler, leaving 93.7% of std→runtime extern call edges without per-param ownership facts at MIR lowering. The contract table is now carried into the compiler at build time as a generated static slice, with an explicit Absent verdict for uncontracted symbols — unknown externs keep caller-retained drops rather than silently gaining facts.

The full std-used extern surface is now classified: 411 symbols across 42 families, each contract derived from its runtime implementation. Consistency is enforced by a 1:1 TOML↔compiler drift test using an independent parser, plus arity and release-symbol validation in the verifier. The build-time contract parser is hardened against foreign trailing tables (unit-tested against the exact build-time code), and the symbol-export scanner no longer silently drops 44 real exports. The unclassified ratchet shrinks 972 → 831.

## Verification

- `cargo nextest run -p hew-mir`: 1172 passed, 0 failed (re-run after rebase onto main)
- Drift, parser-hardening, and contract tests green
- `scripts/verify-ffi-symbols.py --classify stable --validate`: clean
- `make lint`: clean
- `make test-hew-ratchet`: 0 regressions
- Preflight: ready-to-push

## Out of scope

- Enforcement/consumption of the carried ownership facts — the balance validator and verifier consume them in follow-on work.