### PR TITLE
docs(design): state the ratified totality, release-order, and observability axioms

### DIFF
--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -47,6 +47,44 @@ source.hew
   work now widens the Rust HIR/MIR/codegen-rs path instead of adding dialect
   conversion passes.
 
+### Design axioms
+
+Three cross-cutting invariants the ladder, the gates, and the runtime are
+built to preserve.
+
+- **Totality at decision points.** Internal semantic decision enums, and the
+  dispatch tables over them, are total: no semantic branch carries a silent
+  wildcard or default arm. Adding a variant fails compilation at every
+  consumer site until that site decides what the new case means.
+  `SendAliasMode` (`hew-mir/src/model.rs`) is the exemplar: MIR authors a
+  complete per-argument send decision, and checked MIR may not contain an
+  undecided value. Genuinely undecidable cases take the sanctioned form of
+  an explicit fail-closed variant — `Strategy::UnknownBlocked`, routed to
+  `MirCheck::DropPlanUndetermined` — because "undecidable" is itself a
+  decision, and it must reject, never fall through. A wildcard arm on a
+  semantic branch converts a future variant into silent misbehaviour;
+  totality converts it into a build break that names every site owing a
+  decision.
+
+- **Leak-never-double-free total order.** Release bugs have a strict
+  severity order, and the gates enforce it as a total one: over-release is
+  unconditionally rejected (a refcount that would go below zero aborts, in
+  every build mode), under-release is tracked and ratcheted shrink-only, and
+  abort/trap paths may leak-at-abort but must never double-free. The full
+  statement lives in the ownership model doc
+  ([`docs/v05/ownership.md`](../v05/ownership.md)).
+
+- **Observable honesty.** Any silent adaptive behaviour in the runtime or
+  toolchain — execution-lane fallback, COW share-vs-materialize selection,
+  retained-version selection, supervision restart/rehoming — is observable
+  in the artifact's output, response, or telemetry. A fallback that cannot
+  be observed is a fail-open: the system substitutes behaviour without
+  leaving evidence, and neither users nor gates can tell the substituted
+  path from the intended one. The Ownership Plan Report (§4) is this axiom
+  applied to the value model — every share/materialize decision surfaces as
+  a `DecisionFact` — and the `std::observe` counters
+  ([`docs/observe.md`](../observe.md)) carry the runtime side.
+
 ---
 
 ## 2. Layer contracts

--- a/docs/observe.md
+++ b/docs/observe.md
@@ -4,6 +4,11 @@ Hew's observability surface is runtime-owned and read-only from Hew code. Use it
 when you want to inspect memory, scheduler, actor, coroutine, reactor, and
 runtime-hook counters that the native runtime already records.
 
+This surface also carries a design obligation: any silent adaptive behaviour in
+the runtime or toolchain must be observable in the artifact's output, response,
+or telemetry — see the observable-honesty axiom in the
+[IR ladder reference](internal/v05-ir-ladder.md#design-axioms).
+
 There are three primary metric APIs in `std::observe`:
 
 ```hew

--- a/docs/v05/ownership.md
+++ b/docs/v05/ownership.md
@@ -44,6 +44,29 @@ Ordinary Hew syntax has no references; the separate extern-signature-only FFI
 view spelling is documented in the language guide's
 [FFI boundary appendix](../hew-language-guide.md#appendix-a---ffi-boundary-types).
 
+### The leak-never-double-free order
+
+Release bugs are not all equal: a double-free corrupts memory another owner
+still holds, while a leak wastes memory the program has already paid for. The
+model, its runtime, and its gates enforce that severity difference as a total
+order:
+
+- **Over-release is unconditionally rejected.** Discharging an obligation that
+  was never minted — a refcount that would go below zero — aborts the program
+  rather than wrapping (the shared-refcount release assert in
+  `hew-runtime/src/arc.rs` is the canonical site). There is no build mode in
+  which a double-free proceeds.
+- **Under-release is tracked and ratcheted shrink-only.** A known leak is
+  recorded in the sanitizer and leak-oracle expectations (the ASan/LSan
+  fixture gate on Linux, the `leaks --atExit` oracle on macOS), and the
+  tracked set may only shrink: a new leak is a gate failure, and a fixed leak
+  deletes its entry so it cannot silently return.
+- **Abort and trap paths may leak-at-abort, never double-free.** A runtime
+  trap abandons outstanding obligations rather than force-discharging them:
+  an abandoned obligation is a bounded leak in a dying process, while a
+  speculative release on a trap path risks freeing a value another owner
+  still holds.
+
 ## `clone x` — the eager-copy cost operation
 
 `clone` is not an ownership keyword. It is a stdlib **cost operation** that means


### PR DESCRIPTION
## Summary

Three cross-cutting design axioms I've ratified are now written down in the authoritative internal docs, each grounded in the code that already exhibits it:

- **Totality at decision points** (`docs/internal/v05-ir-ladder.md`, new Design-axioms section): semantic branches carry no silent wildcard arms; an explicit fail-closed sentinel such as `Strategy::UnknownBlocked` is the sanctioned form for the undecidable case.
- **Leak-never-double-free severity order** (`docs/v05/ownership.md`, new release-order section): the order the gates already enforce — unconditional abort on over-release, shrink-only tracking for under-release, and a trap posture of leak-at-abort, never double-free.
- **Observable honesty** (`docs/observe.md` pointer): silently adaptive behaviour must be observable in output, response, or telemetry.

## Verification

- `make test-doc-examples`: green — doc-test ratchet passed, 87/87 tracked failures matched
- Leak-scan: clean

## Out of scope

- Construction hooks that mechanically enforce these axioms — those land with the ownership and authority workstreams.