### PR TITLE
fix(deps): bump fast-uri past host-confusion advisories

### DIFF
--- a/hew-sandbox-vm/package-lock.json
+++ b/hew-sandbox-vm/package-lock.json
@@ -49,9 +49,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Bumps the npm fast-uri dependency past two high-severity advisories: host confusion via a literal backslash authority delimiter, and host confusion via failed IDN canonicalization (the two open Dependabot alerts on the default branch).

Verification: lockfile regenerated with the workspace toolchain; affected workspace builds; standard lint gates green on the diff.

Out of scope: other Dependabot ecosystems; no runtime/compiler code touched.