### PR TITLE
fix(runtime): close the stale-wake resume race and honest select timeouts

### DIFF
--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -414,6 +414,108 @@ fn select_after_genuine_expiry_takes_after_arm() {
     );
 }
 
+/// The resume-edge gate's emitted shape, pinned in the `.ll` dump: a -1
+/// scan consults the deadline arbiter, and each status routes to its
+/// proven-safe continuation. Behavioural coverage exists for the
+/// `TimedOut` arm (`select_after_genuine_expiry_takes_after_arm`) and the
+/// no-stale-timeout direction (`cross_actor_record_transition_watch_runs_clean`);
+/// the Pending-respark and Completed-rescan edges fire only on wake/scan
+/// races that cannot be forced end to end, so their CFG is pinned here:
+/// - `suspending_select_respark` loops back to the suspend point
+///   (Pending: re-park, never fabricate a timeout);
+/// - `suspending_select_rescan` loops back to the scan (Completed: the
+///   racing winner's readiness is visible, the re-scan finds it);
+/// - the fail-closed trap is reachable ONLY from the Completed check
+///   (i.e. only for Cancelled, the no-live-source state).
+#[test]
+fn suspending_select_wake_gate_ir_shape_holds() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("gate_shape.hew");
+    std::fs::write(
+        &source,
+        "import std::channel::channel;\n\
+         \n\
+         actor Observer {\n\
+         \x20   receive fn watch(rx: channel.Receiver<i64>) {\n\
+         \x20       select {\n\
+         \x20           v from rx.recv() => {\n\
+         \x20               match v {\n\
+         \x20                   Some(_) => println(\"value\"),\n\
+         \x20                   None => println(\"closed\"),\n\
+         \x20               }\n\
+         \x20           },\n\
+         \x20           after 1s => println(\"timeout\"),\n\
+         \x20       };\n\
+         \x20       rx.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let (tx, rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(4);\n\
+         \x20   let obs = spawn Observer;\n\
+         \x20   obs.watch(rx);\n\
+         \x20   tx.close();\n\
+         \x20   sleep(20ms);\n\
+         }\n",
+    )
+    .unwrap();
+
+    let emit_dir = dir.path().join("ll-out");
+    let output = support::run_hew_in(
+        dir.path(),
+        &[
+            "compile",
+            "--emit-dir",
+            emit_dir.to_str().unwrap(),
+            source.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "gate-shape fixture must compile:\n{}",
+        support::describe_output(&output),
+    );
+
+    let ll = std::fs::read_to_string(emit_dir.join("gate_shape.ll"))
+        .expect("--emit-dir must produce gate_shape.ll");
+
+    assert!(
+        ll.contains("%suspending_select_wake_status = call i32 @hew_await_cancel_status"),
+        "the -1 edge must consult the arbiter status"
+    );
+    let suspend_label = ll
+        .lines()
+        .find(|l| l.starts_with("suspending_select_suspend:"))
+        .expect("suspend block label present");
+    assert!(
+        suspend_label.contains("%suspending_select_respark"),
+        "Pending must re-suspend: respark is a predecessor of the suspend \
+         point; got: {suspend_label}"
+    );
+    let scan_label = ll
+        .lines()
+        .find(|l| l.starts_with("suspending_select_scan:"))
+        .expect("scan block label present");
+    assert!(
+        scan_label.contains("%suspending_select_rescan"),
+        "Completed must re-scan: rescan is a predecessor of the scan; \
+         got: {scan_label}"
+    );
+    let trap_label = ll
+        .lines()
+        .find(|l| l.starts_with("suspending_select_stale_trap:"))
+        .expect("stale-trap block label present");
+    assert!(
+        trap_label.contains("%suspending_select_completed_check")
+            && !trap_label.contains("%suspending_select_no_ready")
+            && !trap_label.contains("%suspending_select_pending_check"),
+        "the fail-closed trap must be reachable only from the Completed \
+         check (Cancelled); got: {trap_label}"
+    );
+}
+
 /// A heap-payload machine held in actor state: step into the
 /// string-payload `Failed` state and back out. The store-back rides the
 /// state-field overwrite-release path, so the old state's payload is

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -287,6 +287,14 @@ fn channel_handle_use_after_transfer_refused() {
 /// record transitions into a channel whose receiver was handed to a
 /// separate observer actor through a message; the observer selects on
 /// transitions with an `after` safety net and reacts to the Faulted edge.
+///
+/// Main blocks on a COMPLETION channel the observer closes out after its
+/// watch loop ends — a deterministic seam, not a `sleep` that races the
+/// observer under load. The `after 2s` arm must never fire here: every
+/// wake the select observes carries a real transition (or the close), so
+/// a `timeout` line in the output is the stale-wake fabricated-timeout
+/// regression (a wake with no readiness routed to the `after` arm while
+/// the deadline is unexpired), not a slow machine.
 #[test]
 fn cross_actor_record_transition_watch_runs_clean() {
     run_inline_scribbled(
@@ -319,7 +327,7 @@ fn cross_actor_record_transition_watch_runs_clean() {
          }\n\
          \n\
          actor Observer {\n\
-         \x20   receive fn watch(rx: channel.Receiver<Transition>) {\n\
+         \x20   receive fn watch(rx: channel.Receiver<Transition>, done: channel.Sender<i64>) {\n\
          \x20       var waiting = true;\n\
          \x20       while waiting {\n\
          \x20           select {\n\
@@ -344,18 +352,65 @@ fn cross_actor_record_transition_watch_runs_clean() {
          \x20           };\n\
          \x20       }\n\
          \x20       rx.close();\n\
+         \x20       done.send(1);\n\
+         \x20       done.close();\n\
          \x20   }\n\
          }\n\
          \n\
          fn main() {\n\
          \x20   let (tx, rx): (channel.Sender<Transition>, channel.Receiver<Transition>) = channel.new(8);\n\
+         \x20   let (done_tx, done_rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(1);\n\
          \x20   let obs = spawn Observer;\n\
-         \x20   obs.watch(rx);\n\
+         \x20   obs.watch(rx, done_tx);\n\
          \x20   let svc = spawn Service;\n\
          \x20   svc.drive(tx);\n\
-         \x20   sleep(300ms);\n\
+         \x20   let _ = done_rx.recv();\n\
+         \x20   done_rx.close();\n\
          }\n",
         "Created -> Initialising\nInitialising -> Faulted\nobserver: child faulted\nwatch closed\n",
+    );
+}
+
+/// The other direction of the timeout-honesty contract: a GENUINE deadline
+/// expiry (no sender ever publishes, the channel stays open) must still
+/// take the `after` arm. The resume-edge gate that refuses to fabricate a
+/// timeout on a stale wake consults the deadline arbiter — this pins that
+/// a real `TimedOut` still routes to the `after` body and is not
+/// re-suspended into a hang (main would block on the completion channel
+/// forever and the bounded runner would kill it).
+#[test]
+fn select_after_genuine_expiry_takes_after_arm() {
+    run_inline_scribbled(
+        "select_after_genuine_expiry",
+        "import std::channel::channel;\n\
+         \n\
+         actor Observer {\n\
+         \x20   receive fn watch(rx: channel.Receiver<i64>, done: channel.Sender<i64>) {\n\
+         \x20       select {\n\
+         \x20           v from rx.recv() => {\n\
+         \x20               match v {\n\
+         \x20                   Some(_) => println(\"value\"),\n\
+         \x20                   None => println(\"closed\"),\n\
+         \x20               }\n\
+         \x20           },\n\
+         \x20           after 400ms => println(\"timeout\"),\n\
+         \x20       };\n\
+         \x20       rx.close();\n\
+         \x20       done.send(1);\n\
+         \x20       done.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let (tx, rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(4);\n\
+         \x20   let (done_tx, done_rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(1);\n\
+         \x20   let obs = spawn Observer;\n\
+         \x20   obs.watch(rx, done_tx);\n\
+         \x20   let _ = done_rx.recv();\n\
+         \x20   done_rx.close();\n\
+         \x20   tx.close();\n\
+         }\n",
+        "timeout\n",
     );
 }
 

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -10987,10 +10987,19 @@ pub(crate) fn emit_suspending_select_terminator<'ctx>(
         },
         || {
             // Resume: a readiness arm fired (or the deadline). Scan the readiness
-            // flags once (non-blocking) to find the winner; -1 means the deadline
-            // won (no channel ready). Then dispatch through the shared winner
-            // blocks, which bind the winner, cancel the losers, and tear down the
-            // arbiter (cancel-no-wake + free) on every resume edge exactly once.
+            // flags once (non-blocking) to find the winner. A -1 scan is
+            // AMBIGUOUS — the deadline may have won, OR the wake was stale (a
+            // folded/leaked `pending_wake` with no readiness behind it) — so -1
+            // consults the arbiter's one-shot state before dispatch: ONLY
+            // TimedOut may enter the `after` arm. Pending re-suspends (the arms
+            // and the deadline are all still armed; nothing was torn down), so a
+            // stale wake never fabricates a timeout — the observable-honesty
+            // axiom at the runtime level. Completed/Cancelled with no ready arm
+            // violates the publish-ready-before-complete contract
+            // (`publish_reply_from_sender_ref`) and traps fail-closed. A real
+            // winner (>= 0) dispatches through the shared winner blocks, which
+            // bind the winner, cancel the losers, and tear down the arbiter
+            // (cancel-no-wake + free) on every resume edge exactly once.
             let idx0 = i32_ty.const_zero();
             let arr_first = unsafe {
                 fn_ctx
@@ -11024,6 +11033,95 @@ pub(crate) fn emit_suspending_select_terminator<'ctx>(
                     CodegenError::FailClosed("hew_select_ready_index returned void".into())
                 })?
                 .into_int_value();
+
+            // -1 gate: route through the arbiter status before any dispatch.
+            let dispatch_bb = ctx.append_basic_block(parent, "suspending_select_dispatch");
+            let no_ready_bb = ctx.append_basic_block(parent, "suspending_select_no_ready");
+            let pending_check_bb =
+                ctx.append_basic_block(parent, "suspending_select_pending_check");
+            let respark_bb = ctx.append_basic_block(parent, "suspending_select_respark");
+            let stale_trap_bb = ctx.append_basic_block(parent, "suspending_select_stale_trap");
+            let neg_one = i32_ty.const_all_ones();
+            let no_ready = fn_ctx
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::EQ,
+                    winner,
+                    neg_one,
+                    "suspending_select_scan_no_ready",
+                )
+                .llvm_ctx("suspending select no-ready compare")?;
+            fn_ctx
+                .builder
+                .build_conditional_branch(no_ready, no_ready_bb, dispatch_bb)
+                .llvm_ctx("suspending select no-ready branch")?;
+
+            fn_ctx.builder.position_at_end(no_ready_bb);
+            let status_fn = intern_runtime_decl(
+                ctx,
+                fn_ctx.llvm_mod,
+                &mut fn_ctx.runtime_decls.borrow_mut(),
+                "hew_await_cancel_status",
+            )?;
+            let status = fn_ctx
+                .builder
+                .build_call(status_fn, &[reg.into()], "suspending_select_wake_status")
+                .llvm_ctx("hew_await_cancel_status (select wake) call")?
+                .try_as_basic_value()
+                .basic()
+                .ok_or_else(|| {
+                    CodegenError::FailClosed("hew_await_cancel_status returned void".into())
+                })?
+                .into_int_value();
+            let timed_out = fn_ctx
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::EQ,
+                    status,
+                    i32_ty.const_int(3, false), // AwaitCancelStatus::TimedOut
+                    "suspending_select_deadline_won",
+                )
+                .llvm_ctx("suspending select timed-out compare")?;
+            fn_ctx
+                .builder
+                .build_conditional_branch(timed_out, dispatch_bb, pending_check_bb)
+                .llvm_ctx("suspending select timed-out branch")?;
+
+            fn_ctx.builder.position_at_end(pending_check_bb);
+            let still_pending = fn_ctx
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::EQ,
+                    status,
+                    i32_ty.const_zero(), // AwaitCancelStatus::Pending
+                    "suspending_select_stale_wake",
+                )
+                .llvm_ctx("suspending select pending compare")?;
+            fn_ctx
+                .builder
+                .build_conditional_branch(still_pending, respark_bb, stale_trap_bb)
+                .llvm_ctx("suspending select pending branch")?;
+
+            // Stale wake with the wait still Pending: re-suspend. Every arm
+            // registration and the deadline timer are still armed (this edge
+            // tore nothing down), so looping back to the suspend point re-parks
+            // the continuation against the SAME readiness sources — the
+            // executor's `ResumePoll::Pending` re-park path. The next genuine
+            // wake re-enters the scan above.
+            fn_ctx.builder.position_at_end(respark_bb);
+            fn_ctx
+                .builder
+                .build_unconditional_branch(do_suspend_bb)
+                .llvm_ctx("suspending select respark br")?;
+
+            // Completed or Cancelled with NO ready arm: the fire path publishes
+            // channel readiness BEFORE completing the arbiter, so this state is
+            // unreachable under the contract — fail closed, never fabricate a
+            // winner.
+            fn_ctx.builder.position_at_end(stale_trap_bb);
+            emit_select_no_winner_trap(fn_ctx)?;
+
+            fn_ctx.builder.position_at_end(dispatch_bb);
 
             // Tear down the shared arbiter once per resume edge (cancel-no-wake
             // settles the one-shot if the deadline won; the timer is already

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -10989,17 +10989,19 @@ pub(crate) fn emit_suspending_select_terminator<'ctx>(
             // Resume: a readiness arm fired (or the deadline). Scan the readiness
             // flags once (non-blocking) to find the winner. A -1 scan is
             // AMBIGUOUS — the deadline may have won, OR the wake was stale (a
-            // folded/leaked `pending_wake` with no readiness behind it) — so -1
-            // consults the arbiter's one-shot state before dispatch: ONLY
-            // TimedOut may enter the `after` arm. Pending re-suspends (the arms
-            // and the deadline are all still armed; nothing was torn down), so a
-            // stale wake never fabricates a timeout — the observable-honesty
-            // axiom at the runtime level. Completed/Cancelled with no ready arm
-            // violates the publish-ready-before-complete contract
-            // (`publish_reply_from_sender_ref`) and traps fail-closed. A real
-            // winner (>= 0) dispatches through the shared winner blocks, which
-            // bind the winner, cancel the losers, and tear down the arbiter
-            // (cancel-no-wake + free) on every resume edge exactly once.
+            // folded/leaked `pending_wake` with no readiness behind it), OR an
+            // arm's fire raced the scan — so -1 consults the arbiter's one-shot
+            // state before dispatch: ONLY TimedOut may enter the `after` arm.
+            // Pending re-suspends (the arms and the deadline are all still
+            // armed; nothing was torn down), so a stale wake never fabricates a
+            // timeout — the observable-honesty axiom at the runtime level.
+            // Completed re-scans: publish-ready-before-complete guarantees the
+            // racing winner's readiness is visible once the status reads
+            // Completed. Cancelled with no ready arm has no live source and
+            // traps fail-closed. A real winner (>= 0) dispatches through the
+            // shared winner blocks, which bind the winner, cancel the losers,
+            // and tear down the arbiter (cancel-no-wake + free) on every resume
+            // edge exactly once.
             let idx0 = i32_ty.const_zero();
             let arr_first = unsafe {
                 fn_ctx
@@ -11040,6 +11042,9 @@ pub(crate) fn emit_suspending_select_terminator<'ctx>(
             let pending_check_bb =
                 ctx.append_basic_block(parent, "suspending_select_pending_check");
             let respark_bb = ctx.append_basic_block(parent, "suspending_select_respark");
+            let completed_check_bb =
+                ctx.append_basic_block(parent, "suspending_select_completed_check");
+            let rescan_bb = ctx.append_basic_block(parent, "suspending_select_rescan");
             let stale_trap_bb = ctx.append_basic_block(parent, "suspending_select_stale_trap");
             let neg_one = i32_ty.const_all_ones();
             let no_ready = fn_ctx
@@ -11099,7 +11104,7 @@ pub(crate) fn emit_suspending_select_terminator<'ctx>(
                 .llvm_ctx("suspending select pending compare")?;
             fn_ctx
                 .builder
-                .build_conditional_branch(still_pending, respark_bb, stale_trap_bb)
+                .build_conditional_branch(still_pending, respark_bb, completed_check_bb)
                 .llvm_ctx("suspending select pending branch")?;
 
             // Stale wake with the wait still Pending: re-suspend. Every arm
@@ -11114,10 +11119,44 @@ pub(crate) fn emit_suspending_select_terminator<'ctx>(
                 .build_unconditional_branch(do_suspend_bb)
                 .llvm_ctx("suspending select respark br")?;
 
-            // Completed or Cancelled with NO ready arm: the fire path publishes
-            // channel readiness BEFORE completing the arbiter, so this state is
-            // unreachable under the contract — fail closed, never fabricate a
-            // winner.
+            // Completed with NO ready arm: an arm's fire RACED the scan — it
+            // published readiness and completed the arbiter after the scan read
+            // its channel but before the status load. Publish-ready-before-
+            // complete (`publish_reply_from_sender_ref`) plus the Acquire status
+            // load reading the completer's AcqRel one-shot CAS order the
+            // winner's readiness store before everything after the status load,
+            // so a RE-SCAN is guaranteed to find the winner (the loop terminates
+            // in one extra iteration). Never trap on a valid interleaving.
+            fn_ctx.builder.position_at_end(completed_check_bb);
+            let completed = fn_ctx
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::EQ,
+                    status,
+                    i32_ty.const_int(1, false), // AwaitCancelStatus::Completed
+                    "suspending_select_completed_race",
+                )
+                .llvm_ctx("suspending select completed compare")?;
+            fn_ctx
+                .builder
+                .build_conditional_branch(completed, rescan_bb, stale_trap_bb)
+                .llvm_ctx("suspending select completed branch")?;
+
+            fn_ctx.builder.position_at_end(rescan_bb);
+            fn_ctx
+                .builder
+                .build_unconditional_branch(scan_bb)
+                .llvm_ctx("suspending select rescan br")?;
+
+            // Cancelled with no ready arm: unreachable today, trap fail-closed.
+            // Cancelled requires `hew_await_cancel_cancel`/`observe_token` on
+            // this arbiter: the abandon edge cancels no-wake and DESTROYS the
+            // parked continuation (mutually exclusive with this resume edge),
+            // the resume teardown cancels no-wake only AFTER this gate passed
+            // (and the select is then complete — this gate never re-runs), and
+            // `hew_await_cancel_observe_token` has no callers. A Cancelled
+            // status observed here would mean an unknown cancel-with-wake
+            // source; never fabricate a timeout or a winner for it.
             fn_ctx.builder.position_at_end(stale_trap_bb);
             emit_select_no_winner_trap(fn_ctx)?;
 

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -1501,6 +1501,73 @@ mod tests {
         }
     }
 
+    /// The re-scan contract the suspending-select resume gate relies on: a
+    /// scan that reads -1 while an arm's fire races it can observe the
+    /// arbiter as `Completed` — and once it does, a RE-SCAN is GUARANTEED to
+    /// find the winner. `publish_reply_from_sender_ref` stores the readiness
+    /// flag (Release) BEFORE completing the arbiter (`AcqRel` one-shot CAS), so
+    /// an Acquire status load reading `Completed` orders the winner's
+    /// readiness store before every subsequent operation: the re-scan cannot
+    /// read -1 again. This is why the codegen gate loops back to the scan on
+    /// `Completed` instead of trapping — the interleaving is valid, and the
+    /// loop terminates in one extra iteration.
+    #[test]
+    fn completed_status_after_empty_scan_guarantees_rescan_finds_winner() {
+        let _guard = crate::runtime_test_guard();
+        let ch = hew_reply_channel_new();
+
+        // SAFETY: the test owns the channel and registration; the producer
+        // thread consumes only the retained observer reference.
+        unsafe {
+            let reg =
+                crate::await_cancel::hew_await_cancel_new(ptr::null_mut(), None, ptr::null_mut());
+            hew_reply_channel_set_await_cancel(ch, reg);
+
+            // The first scan: nothing fired yet — -1, the ambiguous edge.
+            let mut channels = [ch];
+            assert_eq!(
+                hew_select_ready_index(channels.as_mut_ptr(), 1),
+                -1,
+                "pre-fire scan must read no winner"
+            );
+
+            // The racing arm fire: publish readiness, then complete the
+            // arbiter (the signal_ready path — publish-before-complete).
+            hew_reply_channel_retain(ch);
+            let ch_addr = ch as usize;
+            let producer = std::thread::spawn(move || {
+                hew_reply_channel_signal_ready((ch_addr as *mut HewReplyChannel).cast());
+            });
+
+            // Spin until the arbiter reads Completed (the status load the
+            // resume gate performs), bounded so a broken contract fails the
+            // test instead of hanging it.
+            let mut spins: u64 = 0;
+            while crate::await_cancel::hew_await_cancel_status(reg)
+                != crate::await_cancel::AwaitCancelStatus::Completed as i32
+            {
+                spins += 1;
+                assert!(
+                    spins < 500_000_000,
+                    "arbiter never read Completed after the fire"
+                );
+                std::hint::spin_loop();
+            }
+
+            // The re-scan MUST find the winner: no -1, no trap, no timeout.
+            assert_eq!(
+                hew_select_ready_index(channels.as_mut_ptr(), 1),
+                0,
+                "a Completed status guarantees the re-scan finds the \
+                 published winner (publish-ready-before-complete)"
+            );
+
+            producer.join().expect("producer thread must not panic");
+            hew_reply_channel_free(ch);
+            crate::await_cancel::hew_await_cancel_free(reg);
+        }
+    }
+
     #[test]
     fn is_orphaned_reports_mailbox_teardown_flag() {
         let _guard = crate::runtime_test_guard();

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -870,35 +870,52 @@ pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
 
         // CAS Suspended → Runnable; only enqueue on success (fail-closed against
         // a terminal or not-yet-parked actor).
-        if a.actor_state
-            .compare_exchange(
-                HewActorState::Suspended as i32,
-                HewActorState::Runnable as i32,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
-            .is_ok()
-        {
-            // Direct delivery won: consume the pending marker so recorded and
-            // direct delivery collapse into ONE wake. Without this, the mark at
-            // the top of this call (mid-park window, park published `Suspended`
-            // between the slot load and the re-check) leaks past the park's own
-            // FG3 drain and fires a stale wake on the actor's NEXT park — the
-            // fabricated-timeout race (see the fn doc). Consuming a CONCURRENT
-            // racer's marker here is equally correct: its readiness deposit
-            // happens-before its mark (deposit-then-wake contract), so the
-            // single direct wake's resume scan observes that readiness too.
-            let _ = crate::coro_exec::take_pending_wake(a);
-            (true, actor_runtime_id)
-        } else {
-            // The actor was not `Suspended` yet (park still completing) — record
-            // the wake so the suspend edge observes it. Terminal actors also land
-            // here; marking is harmless (the actor will never park again). A
-            // `Runnable` actor (another wake's delivery in flight) also lands
-            // here; the marker folds this wake into that delivery, and the
-            // winning deliverer consumes it above.
-            crate::coro_exec::mark_pending_wake(a);
-            (false, actor_runtime_id)
+        match a.actor_state.compare_exchange(
+            HewActorState::Suspended as i32,
+            HewActorState::Runnable as i32,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                // Direct delivery won: consume the pending marker so recorded and
+                // direct delivery collapse into ONE wake. Without this, the mark at
+                // the top of this call (mid-park window, park published `Suspended`
+                // between the slot load and the re-check) leaks past the park's own
+                // FG3 drain and fires a stale wake on the actor's NEXT park — the
+                // fabricated-timeout race (see the fn doc). Consuming a CONCURRENT
+                // racer's marker here is equally correct: its readiness deposit
+                // happens-before its mark (deposit-then-wake contract), so the
+                // single direct wake's resume scan observes that readiness too.
+                let _ = crate::coro_exec::take_pending_wake(a);
+                (true, actor_runtime_id)
+            }
+            Err(observed) if observed == HewActorState::Runnable as i32 => {
+                // `Runnable`: a delivery is ALREADY enqueued — either the park's
+                // FG3 drain (it consumed a marker and re-enqueued) or another
+                // source's direct CAS win. Marking here would be the stale-wake
+                // duplicate: if this call's own mark above was already drained,
+                // a second mark survives into a later park and fires with no
+                // readiness behind it. No wake is lost by not marking:
+                // - if the drain consumed OUR mark, its AcqRel swap reading our
+                //   Release mark orders our readiness deposit before the drain's
+                //   enqueue and hence before the resume's scan;
+                // - if another source won directly, every enqueue_resume source
+                //   settles a one-shot arbiter BEFORE waking — our source either
+                //   won it (its readiness is published before the completion the
+                //   resume edge observes, so the resume's status-gated re-scan
+                //   finds it) or lost it (the winner carries the resume; our
+                //   effect is resolved by the arbiter).
+                (false, actor_runtime_id)
+            }
+            Err(_) => {
+                // `Running` (dispatch park not yet published — the FG3 window) or
+                // `Idle` (lifecycle park's Idle → Suspended window): the wake
+                // could genuinely be missed — record it so the park's drain
+                // delivers. Terminal actors (`Stopped`/`Crashed`) also land
+                // here; the mark is inert (a terminal actor never parks again).
+                crate::coro_exec::mark_pending_wake(a);
+                (false, actor_runtime_id)
+            }
         }
     });
 
@@ -3653,6 +3670,57 @@ mod tests {
             "a direct delivery must consume the pending marker — a surviving \
              marker is a STALE wake for the actor's next park (the \
              fabricated-timeout race)"
+        );
+    }
+
+    /// Stale-wake guard, CAS-lose direction: a wake that loses the
+    /// `Suspended → Runnable` CAS to an ALREADY-`Runnable` actor must NOT
+    /// record a pending marker.
+    ///
+    /// This pins the duplicate-marker interleaving: the waker marks
+    /// `pending_wake` mid-park; the park publishes `Suspended` and its FG3
+    /// drain consumes the marker and re-enqueues (state now `Runnable`); the
+    /// waker's CAS then loses. The old unconditional re-mark created a second
+    /// marker with no readiness behind it — the same stale wake the
+    /// direct-delivery consume closes. The wake is already delivered: the
+    /// drain's `AcqRel` swap reading the waker's Release mark orders the
+    /// readiness deposit before the drain's enqueue, so nothing is lost by
+    /// not marking. The test enters `enqueue_resume` with the drain's exact
+    /// post-state (parked handle, `Runnable`, marker already consumed) and
+    /// asserts no marker is recorded and no second enqueue occurs.
+    #[test]
+    fn enqueue_resume_cas_lose_to_runnable_does_not_mark() {
+        let sched = NoWorkerSchedulerForTest::install();
+        let actor = TrackedTestActor::install(stub_actor());
+        // The drain's post-state: handle parked, marker consumed, and the
+        // actor already `Runnable` (the drain won and enqueued).
+        actor
+            .actor_state
+            .store(HewActorState::Runnable as i32, Ordering::Release);
+        actor.suspended_cont.store(
+            ptr::null_mut::<u8>().wrapping_add(1).cast(),
+            Ordering::Release,
+        );
+        actor.cont_tag.store(
+            crate::internal::types::ContTag::Parked as i32,
+            Ordering::Release,
+        );
+        let actor_ptr = actor.ptr();
+
+        // SAFETY: actor is live (tracked); the sentinel handle is never
+        // resumed (no worker thread exists under NoWorkerSchedulerForTest).
+        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+
+        assert_eq!(
+            sched.pop_global(),
+            None,
+            "a lost CAS must not enqueue a second delivery"
+        );
+        assert!(
+            !crate::coro_exec::take_pending_wake(&actor),
+            "losing the CAS to Runnable must not record a marker — the \
+             delivery already in flight covers this wake, and a recorded \
+             marker is a stale wake for the actor's next park"
         );
     }
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -802,6 +802,18 @@ fn assert_wake_routes_to_owning_runtime(actor_runtime_id: crate::runtime_id::Run
 /// mirroring the `Idle → Runnable` waker discipline in `activate_actor`, which
 /// closes the use-after-free window against a freed actor.
 ///
+/// RECORDED-vs-DIRECT delivery is exclusive (stale-wake guard): a call that
+/// wins the CAS delivers DIRECTLY and must CONSUME any `pending_wake` marker —
+/// including one this same call recorded moments earlier in the mid-park
+/// window. A marker left set after a direct delivery is a STALE wake: it
+/// survives into the actor's NEXT park cycle, whose FG3 drain re-enqueues a
+/// wake with no readiness behind it, and a suspending `select` resumed by that
+/// stale wake scans `hew_select_ready_index() == -1` and fabricates a timeout
+/// (the `after` arm fires with the deadline unexpired — the event sits queued,
+/// unconsumed, until teardown). Consuming under the registry lock BEFORE the
+/// enqueue is race-free: the actor is `Runnable` but not yet on the queue, so
+/// nothing can run it and re-park between the CAS and the consume.
+///
 /// # Safety
 ///
 /// `actor`, if non-null, may reference a freed `HewActor` — this function does
@@ -867,11 +879,24 @@ pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
             )
             .is_ok()
         {
+            // Direct delivery won: consume the pending marker so recorded and
+            // direct delivery collapse into ONE wake. Without this, the mark at
+            // the top of this call (mid-park window, park published `Suspended`
+            // between the slot load and the re-check) leaks past the park's own
+            // FG3 drain and fires a stale wake on the actor's NEXT park — the
+            // fabricated-timeout race (see the fn doc). Consuming a CONCURRENT
+            // racer's marker here is equally correct: its readiness deposit
+            // happens-before its mark (deposit-then-wake contract), so the
+            // single direct wake's resume scan observes that readiness too.
+            let _ = crate::coro_exec::take_pending_wake(a);
             (true, actor_runtime_id)
         } else {
             // The actor was not `Suspended` yet (park still completing) — record
             // the wake so the suspend edge observes it. Terminal actors also land
-            // here; marking is harmless (the actor will never park again).
+            // here; marking is harmless (the actor will never park again). A
+            // `Runnable` actor (another wake's delivery in flight) also lands
+            // here; the marker folds this wake into that delivery, and the
+            // winning deliverer consumes it above.
             crate::coro_exec::mark_pending_wake(a);
             (false, actor_runtime_id)
         }
@@ -3572,6 +3597,62 @@ mod tests {
         assert!(
             crate::coro_exec::take_pending_wake(&actor),
             "a wake in the park window must be recorded, not lost (FG3)"
+        );
+    }
+
+    /// Stale-wake guard: a direct delivery (successful `Suspended → Runnable`
+    /// CAS) must CONSUME the `pending_wake` marker, not leave it set.
+    ///
+    /// This pins the exact interleaving of the fabricated-timeout race: a
+    /// readiness source's `enqueue_resume` loads a null `suspended_cont`
+    /// mid-park and marks `pending_wake`; the park publishes `Suspended` and
+    /// its FG3 drain runs FIRST (finds no marker yet); the source then marks,
+    /// re-checks, sees `Suspended`, and wins the CAS — delivering directly with
+    /// the marker unconsumed. The test enters `enqueue_resume` with that exact
+    /// pre-state (parked + marker set) and asserts the delivery consumes the
+    /// marker. Before the fix the marker survived into the actor's next park,
+    /// whose drain re-enqueued a wake with no readiness behind it — a resumed
+    /// `select` scanned -1 and fabricated a timeout while its event sat queued.
+    #[test]
+    fn enqueue_resume_direct_delivery_consumes_pending_marker() {
+        let sched = NoWorkerSchedulerForTest::install();
+        let actor = TrackedTestActor::install(stub_actor());
+        // Fully parked: Suspended, published (sentinel) handle, Parked tag.
+        actor
+            .actor_state
+            .store(HewActorState::Suspended as i32, Ordering::Release);
+        actor.suspended_cont.store(
+            ptr::null_mut::<u8>().wrapping_add(1).cast(),
+            Ordering::Release,
+        );
+        actor.cont_tag.store(
+            crate::internal::types::ContTag::Parked as i32,
+            Ordering::Release,
+        );
+        // The unconsumed marker: recorded by this wake's own mid-park mark
+        // (the park's FG3 drain already ran and missed it).
+        crate::coro_exec::mark_pending_wake(&actor);
+        let actor_ptr = actor.ptr();
+
+        // SAFETY: actor is live (tracked); the sentinel handle is never resumed
+        // (no worker thread exists under NoWorkerSchedulerForTest).
+        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+
+        assert_eq!(
+            actor.actor_state.load(Ordering::Acquire),
+            HewActorState::Runnable as i32,
+            "the direct delivery must win the Suspended -> Runnable CAS"
+        );
+        assert_eq!(
+            sched.pop_global(),
+            Some(actor_ptr),
+            "the woken actor must be enqueued exactly once"
+        );
+        assert!(
+            !crate::coro_exec::take_pending_wake(&actor),
+            "a direct delivery must consume the pending marker — a surviving \
+             marker is a STALE wake for the actor's next park (the \
+             fabricated-timeout race)"
         );
     }
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -86,6 +86,17 @@ static ACTIVATE_PRE_REENQUEUE_HOOK: PoisonSafe<Option<fn(*mut HewActor)>> = Pois
 #[cfg(test)]
 static ACTIVATE_POST_CAS_HOOK: PoisonSafe<Option<fn(*mut HewActor)>> = PoisonSafe::new(None);
 
+/// Fires inside `enqueue_resume`'s CAS-lose arm, AFTER the failed
+/// `Suspended -> Runnable` CAS and BEFORE the pending-wake mark — the exact
+/// window the lifecycle-park lost-wake interleaving spans: a park can publish
+/// `Suspended` AND run its one-shot drain inside this gap, so the mark lands
+/// after the only drain that would have consumed it. A regression test installs
+/// a park-completion hook here to force that ordering deterministically and
+/// asserts the post-mark re-check + CAS retry delivers the wake instead of
+/// stranding the actor `Suspended` with a set marker.
+#[cfg(test)]
+static ENQUEUE_RESUME_CAS_FAIL_HOOK: PoisonSafe<Option<fn(*mut HewActor)>> = PoisonSafe::new(None);
+
 #[cfg(any(test, debug_assertions))]
 static INJECT_NULL_LOCK_SEAT_ONCE: AtomicBool = AtomicBool::new(false);
 
@@ -123,6 +134,14 @@ fn run_activate_pre_reenqueue_hook(actor: *mut HewActor) {
 #[cfg(test)]
 fn run_activate_post_cas_hook(actor: *mut HewActor) {
     let hook = ACTIVATE_POST_CAS_HOOK.access(|h| *h);
+    if let Some(hook) = hook {
+        hook(actor);
+    }
+}
+
+#[cfg(test)]
+fn run_enqueue_resume_cas_fail_hook(actor: *mut HewActor) {
+    let hook = ENQUEUE_RESUME_CAS_FAIL_HOOK.access(|h| *h);
     if let Some(hook) = hook {
         hook(actor);
     }
@@ -869,52 +888,89 @@ pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
         }
 
         // CAS Suspended → Runnable; only enqueue on success (fail-closed against
-        // a terminal or not-yet-parked actor).
-        match a.actor_state.compare_exchange(
-            HewActorState::Suspended as i32,
-            HewActorState::Runnable as i32,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => {
-                // Direct delivery won: consume the pending marker so recorded and
-                // direct delivery collapse into ONE wake. Without this, the mark at
-                // the top of this call (mid-park window, park published `Suspended`
-                // between the slot load and the re-check) leaks past the park's own
-                // FG3 drain and fires a stale wake on the actor's NEXT park — the
-                // fabricated-timeout race (see the fn doc). Consuming a CONCURRENT
-                // racer's marker here is equally correct: its readiness deposit
-                // happens-before its mark (deposit-then-wake contract), so the
-                // single direct wake's resume scan observes that readiness too.
-                let _ = crate::coro_exec::take_pending_wake(a);
-                (true, actor_runtime_id)
-            }
-            Err(observed) if observed == HewActorState::Runnable as i32 => {
-                // `Runnable`: a delivery is ALREADY enqueued — either the park's
-                // FG3 drain (it consumed a marker and re-enqueued) or another
-                // source's direct CAS win. Marking here would be the stale-wake
-                // duplicate: if this call's own mark above was already drained,
-                // a second mark survives into a later park and fires with no
-                // readiness behind it. No wake is lost by not marking:
-                // - if the drain consumed OUR mark, its AcqRel swap reading our
-                //   Release mark orders our readiness deposit before the drain's
-                //   enqueue and hence before the resume's scan;
-                // - if another source won directly, every enqueue_resume source
-                //   settles a one-shot arbiter BEFORE waking — our source either
-                //   won it (its readiness is published before the completion the
-                //   resume edge observes, so the resume's status-gated re-scan
-                //   finds it) or lost it (the winner carries the resume; our
-                //   effect is resolved by the arbiter).
-                (false, actor_runtime_id)
-            }
-            Err(_) => {
-                // `Running` (dispatch park not yet published — the FG3 window) or
-                // `Idle` (lifecycle park's Idle → Suspended window): the wake
-                // could genuinely be missed — record it so the park's drain
-                // delivers. Terminal actors (`Stopped`/`Crashed`) also land
-                // here; the mark is inert (a terminal actor never parks again).
-                crate::coro_exec::mark_pending_wake(a);
-                (false, actor_runtime_id)
+        // a terminal or not-yet-parked actor). The loop runs AT MOST twice: the
+        // second iteration exists only for the mark-after-drain window (see the
+        // `Err(_)` arm) and every second-iteration outcome is terminal.
+        let mut retried = false;
+        loop {
+            match a.actor_state.compare_exchange(
+                HewActorState::Suspended as i32,
+                HewActorState::Runnable as i32,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    // Direct delivery won: consume the pending marker so recorded
+                    // and direct delivery collapse into ONE wake. Without this,
+                    // the mark at the top of this call (mid-park window, park
+                    // published `Suspended` between the slot load and the
+                    // re-check) leaks past the park's own FG3 drain and fires a
+                    // stale wake on the actor's NEXT park — the
+                    // fabricated-timeout race (see the fn doc). Consuming a
+                    // CONCURRENT racer's marker here is equally correct: its
+                    // readiness deposit happens-before its mark (deposit-then-
+                    // wake contract), so the single direct wake's resume scan
+                    // observes that readiness too.
+                    let _ = crate::coro_exec::take_pending_wake(a);
+                    break (true, actor_runtime_id);
+                }
+                Err(observed) if observed == HewActorState::Runnable as i32 => {
+                    // `Runnable`: a delivery is ALREADY enqueued — either the
+                    // park's FG3 drain (it consumed a marker and re-enqueued) or
+                    // another source's direct CAS win. Marking here would be the
+                    // stale-wake duplicate: if this call's own mark above was
+                    // already drained, a second mark survives into a later park
+                    // and fires with no readiness behind it. No wake is lost by
+                    // not marking:
+                    // - if the drain consumed OUR mark, its AcqRel swap reading
+                    //   our Release mark orders our readiness deposit before the
+                    //   drain's enqueue and hence before the resume's scan;
+                    // - if another source won directly, every enqueue_resume
+                    //   source settles a one-shot arbiter BEFORE waking — our
+                    //   source either won it (its readiness is published before
+                    //   the completion the resume edge observes, so the resume's
+                    //   status-gated re-scan finds it) or lost it (the winner
+                    //   carries the resume; our effect is resolved by the
+                    //   arbiter).
+                    break (false, actor_runtime_id);
+                }
+                Err(_) => {
+                    // `Running` (dispatch park not yet published — the FG3
+                    // window) or `Idle` (lifecycle park's Idle → Suspended
+                    // window): the wake could genuinely be missed — record it so
+                    // the park's drain delivers. Terminal actors
+                    // (`Stopped`/`Crashed`) also land here; the mark is inert (a
+                    // terminal actor never parks again).
+                    #[cfg(test)]
+                    run_enqueue_resume_cas_fail_hook(actor);
+                    crate::coro_exec::mark_pending_wake(a);
+                    // Mark-after-drain guard: the park can publish `Suspended`
+                    // AND run its ONE-SHOT drain inside the gap between our
+                    // failed CAS and the mark above. The mark then lands after
+                    // the only drain that would have consumed it, stranding the
+                    // actor `Suspended` with a set marker (the lifecycle park
+                    // has no second drain; the dispatch park's is equally
+                    // one-shot). Re-check: if the state now reads `Suspended`,
+                    // retry the CAS ourselves — the `Ok` arm consumes the
+                    // marker, so the retry self-cleans. ONE retry suffices;
+                    // every retry outcome is terminal:
+                    // - `Ok`: delivered, marker consumed;
+                    // - `Err(Runnable)`: another delivery is in flight (the
+                    //   no-mark arm's safety argument applies; the residual
+                    //   marker is at worst one honest respark);
+                    // - `Err(Running|Idle)`: a NEW park cycle began after our
+                    //   mark, so its future drain (which runs after it publishes
+                    //   `Suspended`) is ordered after our mark and consumes it —
+                    //   the strand needs mark-after-drain, and our mark is now
+                    //   provably before that park's drain.
+                    if !retried
+                        && a.actor_state.load(Ordering::Acquire) == HewActorState::Suspended as i32
+                    {
+                        retried = true;
+                        continue;
+                    }
+                    break (false, actor_runtime_id);
+                }
             }
         }
     });
@@ -3192,6 +3248,23 @@ mod tests {
         }
     }
 
+    struct EnqueueResumeCasFailHookGuard;
+
+    impl EnqueueResumeCasFailHookGuard {
+        fn install(hook: fn(*mut HewActor)) -> Self {
+            ENQUEUE_RESUME_CAS_FAIL_HOOK.access(|h| {
+                assert!(h.replace(hook).is_none(), "test hook already installed");
+            });
+            Self
+        }
+    }
+
+    impl Drop for EnqueueResumeCasFailHookGuard {
+        fn drop(&mut self) {
+            ENQUEUE_RESUME_CAS_FAIL_HOOK.access(|h| *h = None);
+        }
+    }
+
     impl Drop for ActivatePostCasHookGuard {
         fn drop(&mut self) {
             ACTIVATE_POST_CAS_HOOK.access(|h| *h = None);
@@ -3721,6 +3794,85 @@ mod tests {
             "losing the CAS to Runnable must not record a marker — the \
              delivery already in flight covers this wake, and a recorded \
              marker is a stale wake for the actor's next park"
+        );
+    }
+
+    /// The park completing inside the waker's CAS-fail → mark gap: publish
+    /// `Suspended` (the lifecycle park's `Idle → Suspended` win), then run the
+    /// one-shot drain, which finds NO marker — the waker's mark has not landed
+    /// yet. This is steps 3-4 of the lost-wake interleaving, forced into the
+    /// exact window via `ENQUEUE_RESUME_CAS_FAIL_HOOK`.
+    fn park_completes_inside_cas_fail_gap(actor: *mut HewActor) {
+        // SAFETY: the test owns the tracked actor for the whole call.
+        let a = unsafe { &*actor };
+        a.actor_state
+            .compare_exchange(
+                HewActorState::Idle as i32,
+                HewActorState::Suspended as i32,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .expect("the park must win Idle -> Suspended inside the gap");
+        assert!(
+            !crate::coro_exec::take_pending_wake(a),
+            "the park's one-shot drain runs BEFORE the waker's mark and \
+             must find no marker (that ordering IS the lost-wake window)"
+        );
+    }
+
+    /// Lifecycle-park lost-wake guard: the exact 5-step strand interleaving,
+    /// forced deterministically.
+    ///
+    /// (1) the lifecycle park stores the handle, state still `Idle`; (2) the
+    /// waker loads the non-null handle and its `Suspended → Runnable` CAS
+    /// FAILS observing `Idle`; (3-4) the park wins `Idle → Suspended` and
+    /// runs its ONE-SHOT drain, finding no marker (both forced into the
+    /// CAS-fail → mark gap by the hook); (5) the waker's mark lands AFTER
+    /// the only drain that could have consumed it. Without the post-mark
+    /// re-check + CAS retry the actor strands `Suspended` with a set marker
+    /// and the one-shot wake hangs until an unrelated wake happens by. The
+    /// retry must deliver: `Runnable`, enqueued exactly once, marker
+    /// consumed.
+    #[test]
+    fn enqueue_resume_mark_after_drain_retries_and_delivers() {
+        let sched = NoWorkerSchedulerForTest::install();
+        let actor = TrackedTestActor::install(stub_actor());
+        // Step 1: the lifecycle park's window — handle stored, state Idle.
+        actor
+            .actor_state
+            .store(HewActorState::Idle as i32, Ordering::Release);
+        actor.suspended_cont.store(
+            ptr::null_mut::<u8>().wrapping_add(1).cast(),
+            Ordering::Release,
+        );
+        actor.cont_tag.store(
+            crate::internal::types::ContTag::Parked as i32,
+            Ordering::Release,
+        );
+        let actor_ptr = actor.ptr();
+
+        // Steps 2-5 with the park completion (3-4) forced into the gap.
+        let _hook = EnqueueResumeCasFailHookGuard::install(park_completes_inside_cas_fail_gap);
+        // SAFETY: actor is live (tracked); the sentinel handle is never
+        // resumed (no worker thread exists under NoWorkerSchedulerForTest).
+        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+
+        assert_eq!(
+            actor.actor_state.load(Ordering::Acquire),
+            HewActorState::Runnable as i32,
+            "the retry must win Suspended -> Runnable — a Suspended actor \
+             here is the stranded lost wake"
+        );
+        assert_eq!(
+            sched.pop_global(),
+            Some(actor_ptr),
+            "the retry must enqueue the delivery exactly once"
+        );
+        assert_eq!(sched.pop_global(), None, "no duplicate enqueue");
+        assert!(
+            !crate::coro_exec::take_pending_wake(&actor),
+            "the retry's delivery must consume the marker it recorded — a \
+             surviving marker is the stale wake for the actor's next park"
         );
     }
 


### PR DESCRIPTION
A parked actor could observe a fabricated select timeout: enqueue_resume could leave a pending-wake marker unconsumed (direct-delivery CAS win, and a mark landing after the park drain), and the suspending select treated an empty readiness scan unconditionally as the after arm — so a stale wake produced a timeout that never expired, while the real event stayed queued. Reproduced on Windows CI as the machine-transition-watch failure finishing at 1.1s against a 2s deadline.

The fix makes recorded-vs-direct delivery exclusive (the CAS winner consumes the marker under the registry lock), replaces the unconditional mark on CAS failure with a per-state analysis (Running and Idle windows still mark; a Runnable loser does not re-mark — that was the stale-marker source; a mark landing inside the CAS-fail gap retries delivery, closing a pre-existing lifecycle lost-wake on trunk), and gates the select scan on the deadline arbiter: only a TimedOut arbiter may take the after arm, Pending re-suspends with all registrations intact, and a Completed arbiter re-scans — publish-before-complete guarantees the winner is visible, bounding the loop to one extra iteration.

Verification: forced-interleaving regressions for each window (direct-delivery consume, Runnable no-mark, mark-after-drain retry — each with a negative proof), a cross-thread publish/complete ordering test, an IR-shape pin for the select gate CFG, both transition-watch e2e teeth (completion-channel seam and genuine-expiry), all 20x stable; full hew-runtime suite 2664/2664; compiled ratchet 0/0; fmt/clippy clean.

Out of scope: the stable-role join race (separate branch in review).