### PR TITLE
test(dist): derive monitor observations from registration events

### DIFF
--- a/hew-cli/tests/distributed_two_process_e2e.rs
+++ b/hew-cli/tests/distributed_two_process_e2e.rs
@@ -1153,9 +1153,11 @@ fn link_remote_non_crashlinked_policy_no_crash() {
 
 /// Cross-node demonitor reclamation: when a client closes a cross-node
 /// `MonitorRef`, the close routes to the cross-node teardown (not the local-table
-/// no-op), sending `CTRL_DEMONITOR` to the peer. The server observes its
-/// target-side watcher count rise then fall and prints the verdict with an exact
-/// reclaimed count.
+/// no-op), sending `CTRL_DEMONITOR` to the peer. The server derives the
+/// registration from the monotonic `hew_dist_monitor_remote_watcher_registered_total()`
+/// event counter (a sampled live count can miss the window under a coarse host
+/// timer tick), waits for the live count to fall to zero, and prints the verdict
+/// with an exact reclaimed count.
 #[test]
 fn cross_node_monitor_close_reclaims_watcher_entry() {
     let server_out = run_server_verdict_scenario("cross_node_monitor_close_reclaim");
@@ -1183,7 +1185,11 @@ fn cross_node_monitor_close_reclaims_watcher_entry() {
 
 /// Repeated cross-node monitor setup/close keeps both authorities exact: every
 /// handle id is distinct, close delivers no DOWN, and both watcher- and
-/// target-side tables finish at zero.
+/// target-side tables finish at zero. The server proves each cycle registered
+/// via the monotonic `hew_dist_monitor_remote_watcher_registered_total()` event
+/// counter (exactly one registration per cycle) — sampling the transient live
+/// count phase-locks with the client's short holds under a coarse host timer
+/// tick and can miss every window.
 #[test]
 fn repeated_cross_node_monitor_close_keeps_tables_empty() {
     let server_out = run_server_verdict_scenario("monitor_leak_low");

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -1468,6 +1468,7 @@ fn scenario_repoint_preserves_ref(kv: RemotePid<KeyValue>) -> i64 {
 
 extern "C" {
     fn hew_dist_monitor_remote_watcher_count() -> i64;
+    fn hew_dist_monitor_remote_watcher_registered_total() -> i64;
     fn hew_dist_monitor_current_actor_ref_id() -> u64;
     fn hew_dist_monitor_pending_observation_count() -> u64;
 }
@@ -1666,24 +1667,37 @@ fn scenario_link_remote_non_crashlinked(kv: RemotePid<KeyValue>) -> i64 {
 }
 
 fn scenario_server_monitor_close_reclaim() {
+    // Registration is derived from the monotonic event counter, not a sampled
+    // live count: a sleep-poll can miss a short-lived count==1 window under a
+    // coarse host timer tick, while the cumulative total cannot be missed.
+    let base = unsafe {
+        hew_dist_monitor_remote_watcher_registered_total()
+    };
     var registered: i64 = 0;
     var wait_attempts: i64 = 0;
     loop {
         let c = unsafe {
             hew_dist_monitor_remote_watcher_count()
         };
-        if c == 1 {
-            registered = c;
-            println(f"READY_SERVER_WATCHER_REGISTERED cross_node_monitor_close_reclaim count={registered}");
-            break;
-        }
         if c > 1 {
             println(f"FAIL cross_node_monitor_close_reclaim unexpected-watcher-count={c}");
             return;
         }
+        let total = unsafe {
+            hew_dist_monitor_remote_watcher_registered_total()
+        };
+        registered = total - base;
+        if registered > 1 {
+            println(f"FAIL cross_node_monitor_close_reclaim unexpected-registered-total={registered}");
+            return;
+        }
+        if registered == 1 {
+            println(f"READY_SERVER_WATCHER_REGISTERED cross_node_monitor_close_reclaim count={registered}");
+            break;
+        }
         wait_attempts = wait_attempts + 1;
         if wait_attempts >= 200 {
-            println(f"FAIL cross_node_monitor_close_reclaim server-no-watcher last-count={c}");
+            println(f"FAIL cross_node_monitor_close_reclaim server-no-watcher registered-total={registered}");
             return;
         }
         sleep(100ms);
@@ -1724,19 +1738,23 @@ fn scenario_client_monitor_close_reclaim(kv: RemotePid<KeyValue>) -> i64 {
 }
 
 fn scenario_server_monitor_leak(kx: string, scenario: string, expected: i64) {
-    var observed_one: bool = false;
+    // Registration is derived from the monotonic event counter, not a sampled
+    // live count: each client cycle holds its registration open only briefly,
+    // and a sleep-poll under a coarse host timer tick (default Windows ~15.6ms)
+    // can phase-lock with the cycles and miss every count==1 window. The
+    // cumulative total cannot be missed. The sampled count keeps only its
+    // over-registration tooth (count > 1), which can never false-fail.
+    let base = unsafe {
+        hew_dist_monitor_remote_watcher_registered_total()
+    };
     var attempts: i64 = 0;
     loop {
         let count = unsafe {
             hew_dist_monitor_remote_watcher_count()
         };
-        if count == 1 {
-            observed_one = true;
-        } else {
-            if count > 1 {
-                println(f"FAIL {scenario} target-count={count}");
-                return;
-            }
+        if count > 1 {
+            println(f"FAIL {scenario} target-count={count}");
+            return;
         }
         if fs.exists(f"{kx}/leak.done") {
             break;
@@ -1748,16 +1766,22 @@ fn scenario_server_monitor_leak(kx: string, scenario: string, expected: i64) {
         }
         sleep(2ms);
     }
+    // leak.done is published only after every register/close cycle has been
+    // acked, so the counter is final here: exactly one registration per cycle.
+    let total = unsafe {
+        hew_dist_monitor_remote_watcher_registered_total()
+    };
+    let registered = total - base;
+    if registered != expected {
+        println(f"FAIL {scenario} registered-total={registered} expected={expected}");
+        return;
+    }
     var cleanup_attempts: i64 = 0;
     loop {
         let count = unsafe {
             hew_dist_monitor_remote_watcher_count()
         };
         if count == 0 {
-            if !observed_one {
-                println(f"FAIL {scenario} target-never-observed-registration");
-                return;
-            }
             publish_atomic(kx, "leak.verdict", "target=0");
             println(f"PASS {scenario} iterations={expected} target=0 max=1");
             return;

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -4517,6 +4517,32 @@ pub extern "C" fn hew_dist_monitor_remote_watcher_count() -> i64 {
     }
 }
 
+/// Return the cumulative number of `RemoteWatcher` registrations ever accepted
+/// into the target-side monitor table — monotonic, process-local, never reset.
+///
+/// Test-introspection probe used by the two-process monitor fixtures to derive
+/// "a registration happened" from the event counter instead of sampling the
+/// transient live count. On hosts with a coarse timer tick (default Windows
+/// ~15.6 ms) a sleep-poll sampler can miss every short-lived `count == 1`
+/// window; the monotonic total cannot be missed. Not user-callable; the
+/// compiler does not emit calls to this symbol. Callable from `.hew` via
+/// `extern "C" { fn hew_dist_monitor_remote_watcher_registered_total() -> i64; }`.
+#[no_mangle]
+pub extern "C" fn hew_dist_monitor_remote_watcher_registered_total() -> i64 {
+    let Some(rt) = crate::runtime::rt_current_opt() else {
+        return -1;
+    };
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "the cumulative registration count grows by one per accepted remote \
+                  monitor/link registration and stays far below i64::MAX in any realistic \
+                  process lifetime; the sentinel -1 covers the no-runtime case"
+    )]
+    {
+        rt.monitors.remote_watchers_registered_total() as i64
+    }
+}
+
 /// Return the sole remote monitor id owned by the current actor, or zero when
 /// the actor has none or more than one.
 ///

--- a/hew-runtime/src/monitor.rs
+++ b/hew-runtime/src/monitor.rs
@@ -66,6 +66,11 @@ pub(crate) struct MonitorState {
     observations: Mutex<HashMap<u64, ObservationEntry>>,
     /// Target-side remote registrations used only to fan terminal frames to peers.
     remote_targets: Mutex<HashMap<u64, Vec<RemoteWatcher>>>,
+    /// Cumulative count of target-side remote-watcher registrations ever
+    /// accepted — monotonic, never reset. Test-introspection authority: an
+    /// event counter cannot be missed by a sampler the way the transient live
+    /// count can.
+    remote_watchers_registered_total: AtomicU64,
     ref_counter: AtomicU64,
     ref_exhausted: AtomicBool,
 }
@@ -143,6 +148,7 @@ impl MonitorState {
             }),
             observations: Mutex::new(HashMap::new()),
             remote_targets: Mutex::new(HashMap::new()),
+            remote_watchers_registered_total: AtomicU64::new(0),
             ref_counter: AtomicU64::new(1),
             ref_exhausted: AtomicBool::new(false),
         }
@@ -475,6 +481,8 @@ impl MonitorState {
                         ref_id: monitor_id,
                         is_link,
                     });
+                    self.remote_watchers_registered_total
+                        .fetch_add(1, Ordering::Relaxed);
                 }
                 RemoteWatcherSetup::Registered
             })
@@ -576,6 +584,11 @@ impl MonitorState {
             !watchers.is_empty()
         });
         pruned
+    }
+
+    pub(crate) fn remote_watchers_registered_total(&self) -> u64 {
+        self.remote_watchers_registered_total
+            .load(Ordering::Relaxed)
     }
 
     pub(crate) fn remote_watcher_count(&self) -> usize {

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -1306,6 +1306,12 @@ internal = [
   # target-side monitor table. Used by two-process fixtures to assert bounded
   # table growth after a watcher node dies. Not user-callable; not JIT-reachable.
   "hew_dist_monitor_remote_watcher_count",
+  # Test-introspection probe: returns the monotonic cumulative count of
+  # target-side RemoteWatcher registrations ever accepted. Used by two-process
+  # monitor fixtures to derive registration from an event counter instead of
+  # sampling the transient live count. Not user-callable; not
+  # JIT-reachable.
+  "hew_dist_monitor_remote_watcher_registered_total",
   "hew_dist_monitor_current_actor_ref_id",
   "hew_dist_monitor_pending_observation_count",
   # Test-introspection probe: returns the current actor's id (-1 outside a
@@ -1420,6 +1426,14 @@ internal = [
 ]
 
 [ownership]
+
+# Scalar i64 counter getter; no parameters, nothing owned crosses the boundary.
+[[ownership.contracts]]
+symbol = "hew_dist_monitor_remote_watcher_registered_total"
+result = "none"
+params = []
+release-symbol = ""
+discharge-depth = "none"
 
 [[ownership.contracts]]
 symbol = "hew_node_api_id"


### PR DESCRIPTION
## Summary

The distributed monitor scenarios asserted registration by sampling a transient watcher count with a 2ms poll against 10ms client windows. On Windows both intervals quantize to the 15.6ms timer tick and phase-lock, so a loaded runner misses every window and the tests fail with target-never-observed-registration despite correct product behaviour. The tests now read a monotonic registration counter — a new test-introspection FFI accessor mirroring the existing count getter, with its ownership contract classified — and assert exact registered totals after the client completes. The over-registration and exact-cleanup assertions are unchanged.

## Verification

- Mutation proof: suppressing the counter increment fails both scenarios with the new diagnostics
- Flake gate: distributed monitor scenarios 20/20, twice, under 32 CPU hogs
- distributed_two_process_e2e suite: 20/20
- `make lint`: pass, including FFI symbol verification
- hew-runtime tests: 2644/2644
- Preflight: ready-to-push

## Out of scope

- The fungible restart-join race — separate branch.