### PR TITLE
fix(runtime): make the stable-role ask owner-scoped to close a fungible restart-join race

### DIFF
--- a/examples/v05/checked-mir/golden/supervisor_await_restart.raw.mir
+++ b/examples/v05/checked-mir/golden/supervisor_await_restart.raw.mir
@@ -28,20 +28,17 @@ fn main() -> i64 [conv=default]
     _6: __HewChildLookupResult
     _7: i64
     _8: i64
-    _9: i64
-    _10: __HewChildLookupResult
+    _9: ()
+    _10: Result<i64, AskError>
     _11: i64
-    _12: ()
-    _13: Result<i64, AskError>
+    _12: AskError
+    _13: i64
     _14: i64
-    _15: AskError
+    _15: bool
     _16: i64
-    _17: i64
-    _18: bool
+    _17: bool
+    _18: i64
     _19: i64
-    _20: bool
-    _21: i64
-    _22: i64
   bb0:
     _0 = call App__bootstrap() -> bb1
   bb1:
@@ -57,16 +54,12 @@ fn main() -> i64 [conv=default]
     _6 = call_rt hew_supervisor_child_get(_1, _5)
     _7 = _6.field[1]
     actor3 = move _7
-    _9 = const.i64 0
-    _10 = call_rt hew_supervisor_child_get(_1, _9)
-    _11 = _10.field[1]
-    actor3 = move _11
-    _13 = ask actor3[msg=-346962505] _12 reply=_14 err=_15 -> bb2
+    _10 = ask actor3[msg=-346962505] _9 reply=_11 err=_12 -> bb2
   bb2:
-    _16 = move etag13
-    _17 = const.i64 0
-    _18 = icmp.eq _16 _17
-    branch _18 ? bb4 : bb7
+    _13 = move etag10
+    _14 = const.i64 0
+    _15 = icmp.eq _13 _14
+    branch _15 ? bb4 : bb7
   bb3:
     stmt: return site=Some(SiteId(6)) ty=i64
     ret = move _8
@@ -74,19 +67,19 @@ fn main() -> i64 [conv=default]
   bb4:
     stmt: bind BindingId(2) v site=SiteId(10) ty=i64
     stmt: use BindingId(2) v site=SiteId(10) ty=i64 intent=Read
-    _21 = move mvar13.0.0
-    _8 = move _21
+    _18 = move mvar10.0.0
+    _8 = move _18
     goto bb3
   bb5:
-    _22 = const.i64 0
-    _8 = move _22
+    _19 = const.i64 0
+    _8 = move _19
     goto bb3
   bb6:
     trap(ExhaustivenessFallthrough)
   bb7:
-    _19 = const.i64 1
-    _20 = icmp.eq _16 _19
-    branch _20 ? bb5 : bb6
+    _16 = const.i64 1
+    _17 = icmp.eq _13 _16
+    branch _17 ? bb5 : bb6
 
 fn i8::fmt(i8) -> string [conv=default]
   locals:

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -5849,6 +5849,62 @@ fn main() -> i64 {
     );
 }
 
+/// A join branch whose handler traps mid-dispatch fails CLOSED with a
+/// status-bearing diagnostic: the classified cause ("handler trapped") and the
+/// branch index reach stderr, and the process exits by the canonical
+/// `JoinBranchFailed` trap — never the pre-fix empty-output abort that carried
+/// no evidence of which branch died or why.
+#[test]
+fn run_join_branch_handler_trap_names_cause() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let main = dir.path().join("main.hew");
+    std::fs::write(
+        &main,
+        r#"
+actor Worker {
+    receive fn ok(x: i64) -> i64 { x }
+    receive fn boom() -> i64 {
+        panic("kaboom");
+        0
+    }
+}
+
+fn main() -> i64 {
+    let w = spawn Worker;
+    let (a, b) = join {
+        w.ok(5),
+        w.boom(),
+    };
+    print(f"{a},{b}");
+    0
+}
+"#,
+    )
+    .unwrap();
+
+    let output = run_bounded_hew_run(&main, dir.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a trapped join branch must fail the program; stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("5,"),
+        "the join must not bind a tuple from a trapped branch; stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("join branch 1 failed") && stderr.contains("handler trapped"),
+        "the failure must name the branch and the classified cause; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("JoinBranchFailed"),
+        "the trap must carry the canonical JoinBranchFailed kind; stderr: {stderr}"
+    );
+}
+
 /// Security regression (private-actor routing): a root/pub actor `Account` and
 /// a *private* (non-pub) imported actor `secret.Account` must NOT let
 /// `spawn secret.Account()` silently route to the root actor. Module-qualified

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -25201,6 +25201,7 @@ fn dispatch_collapsed_suspend<'ctx>(
     match kind {
         SuspendKind::Ask {
             actor,
+            stable_role,
             msg_type,
             value,
             arg_modes,
@@ -25214,6 +25215,7 @@ fn dispatch_collapsed_suspend<'ctx>(
                 fn_ctx,
                 crate::suspend::SuspendingAskEmit {
                     actor: *actor,
+                    stable_role: *stable_role,
                     msg_type: *msg_type,
                     value: *value,
                     cleanup_plan: cleanup_plan.clone(),
@@ -27276,6 +27278,7 @@ fn lower_terminator<'ctx>(
         }
         Terminator::Ask {
             actor,
+            stable_role,
             msg_type,
             value,
             arg_modes,
@@ -27286,15 +27289,8 @@ fn lower_terminator<'ctx>(
             next,
         } => {
             validate_prepared_outbound_modes(fn_ctx, *value, arg_modes)?;
-            let actor_ptr = load_duplex_handle(fn_ctx, *actor, "actor_ask receiver")?;
             let (payload_ptr, payload_size) =
                 actor_payload_ptr_size(fn_ctx, *value, "actor_ask_payload")?;
-            let ask = intern_runtime_decl(
-                fn_ctx.ctx,
-                fn_ctx.llvm_mod,
-                &mut fn_ctx.runtime_decls.borrow_mut(),
-                "hew_actor_ask",
-            )?;
             let msg_type_val = fn_ctx.ctx.i32_type().const_int(*msg_type as u64, false);
             // `payload_size` is built as i64; the `size` param is `usize`/
             // `size_t` (i32 on wasm32). Reconcile to the target-correct width.
@@ -27305,23 +27301,75 @@ fn lower_terminator<'ctx>(
                 ask_size_ty.into(),
                 "actor ask payload size",
             )?;
-            let reply_ptr = fn_ctx
-                .builder
-                .build_call(
-                    ask,
-                    &[
-                        actor_ptr.into(),
-                        msg_type_val.into(),
-                        payload_ptr.into(),
-                        payload_size.into(),
-                    ],
-                    "hew_actor_ask_call",
-                )
-                .llvm_ctx("hew_actor_ask call")?
-                .try_as_basic_value()
-                .basic()
-                .ok_or_else(|| CodegenError::FailClosed("hew_actor_ask returned void".into()))?
-                .into_pointer_value();
+            // A fungible stable-role receiver submits through the blocking
+            // OWNER-SCOPED role ask (resolve + ID-pinned submission inside the
+            // runtime; same null-or-reply return contract as hew_actor_ask).
+            // The former shape dereferenced a re-resolved, UNPINNED child
+            // pointer that a restart could free before the deref.
+            let reply_ptr = if let Some(role) = stable_role {
+                let i64_ty = fn_ctx.ctx.i64_type();
+                let sup_token = load_int_arg(
+                    fn_ctx,
+                    role.supervisor_token,
+                    i64_ty,
+                    "actor_ask_role_supervisor_token",
+                )?;
+                let slot_idx = fn_ctx
+                    .ctx
+                    .i32_type()
+                    .const_int(u64::from(role.slot_index), false);
+                let role_ask = intern_runtime_decl(
+                    fn_ctx.ctx,
+                    fn_ctx.llvm_mod,
+                    &mut fn_ctx.runtime_decls.borrow_mut(),
+                    "hew_supervisor_role_ask",
+                )?;
+                fn_ctx
+                    .builder
+                    .build_call(
+                        role_ask,
+                        &[
+                            sup_token.into(),
+                            slot_idx.into(),
+                            msg_type_val.into(),
+                            payload_ptr.into(),
+                            payload_size.into(),
+                        ],
+                        "hew_supervisor_role_ask_call",
+                    )
+                    .llvm_ctx("hew_supervisor_role_ask call")?
+                    .try_as_basic_value()
+                    .basic()
+                    .ok_or_else(|| {
+                        CodegenError::FailClosed("hew_supervisor_role_ask returned void".into())
+                    })?
+                    .into_pointer_value()
+            } else {
+                let actor_ptr = load_duplex_handle(fn_ctx, *actor, "actor_ask receiver")?;
+                let ask = intern_runtime_decl(
+                    fn_ctx.ctx,
+                    fn_ctx.llvm_mod,
+                    &mut fn_ctx.runtime_decls.borrow_mut(),
+                    "hew_actor_ask",
+                )?;
+                fn_ctx
+                    .builder
+                    .build_call(
+                        ask,
+                        &[
+                            actor_ptr.into(),
+                            msg_type_val.into(),
+                            payload_ptr.into(),
+                            payload_size.into(),
+                        ],
+                        "hew_actor_ask_call",
+                    )
+                    .llvm_ctx("hew_actor_ask call")?
+                    .try_as_basic_value()
+                    .basic()
+                    .ok_or_else(|| CodegenError::FailClosed("hew_actor_ask returned void".into()))?
+                    .into_pointer_value()
+            };
             let parent = fn_ctx
                 .builder
                 .get_insert_block()

--- a/hew-codegen-rs/src/llvm_tests.rs
+++ b/hew-codegen-rs/src/llvm_tests.rs
@@ -2370,6 +2370,135 @@ fn emit_select_ir(name: &str, pipeline: &IrPipeline) -> String {
     llvm_mod.print_to_string().to_string()
 }
 
+/// Build a pipeline whose entry block is sealed by `Terminator::Join`
+/// (single result local; per-branch reply slots), the join analogue of
+/// [`pipeline_with_select_arms`].
+fn pipeline_with_join_branches(
+    branches: Vec<hew_mir::JoinBranch>,
+    locals: Vec<ResolvedTy>,
+    result: Place,
+    next_id: u32,
+) -> IrPipeline {
+    let blocks = vec![
+        BasicBlock {
+            id: 0,
+            statements: Vec::new(),
+            instructions: Vec::new(),
+            terminator: Terminator::Join {
+                branches,
+                result,
+                next: next_id,
+            },
+        },
+        BasicBlock {
+            id: next_id,
+            statements: Vec::new(),
+            instructions: Vec::new(),
+            terminator: Terminator::Return,
+        },
+    ];
+    // Reuse the select fixture's pipeline scaffolding (which carries every
+    // IrPipeline field), then seal the entry with the join CFG built above.
+    let mut pipeline = pipeline_with_select_arms(Vec::new(), locals, &[], next_id);
+    pipeline.raw_mir[0].blocks = blocks;
+    pipeline
+}
+
+/// A fungible stable-role join branch submits through the OWNER-SCOPED
+/// runtime op — supervisor token + slot index + payload in ONE call — and
+/// emits NO trace of the racy lookup-token-then-send pair
+/// (`hew_local_pid_supervisor_child_get` → `hew_local_pid_ask_with_channel`),
+/// whose unlocked gap let the restart machinery retire the resolved
+/// incarnation between the two calls.
+#[test]
+fn join_stable_role_branch_submits_owner_scoped() {
+    let branches = vec![hew_mir::JoinBranch {
+        actor: Place::DuplexHandle(0),
+        stable_role: Some(hew_mir::StableActorRole {
+            supervisor_token: Place::Local(2),
+            slot_index: 0,
+        }),
+        method: "score".to_string(),
+        args: Vec::new(),
+        msg_type: 7,
+        value: Place::Local(3),
+        cleanup_plan: None,
+        reply_dest: Place::Local(1),
+        reply_ty: ResolvedTy::I64,
+    }];
+    let locals = vec![
+        duplex_ty(),      // 0: actor handle (unused by the stable-role path)
+        ResolvedTy::I64,  // 1: reply slot / join result (single branch)
+        ResolvedTy::I64,  // 2: stable supervisor token
+        ResolvedTy::Unit, // 3: payload
+    ];
+    let pipeline = pipeline_with_join_branches(branches, locals, Place::Local(1), 99);
+    let ir = emit_select_ir("join_stable_role", &pipeline);
+
+    assert_eq!(
+        ir.matches("call i32 @hew_supervisor_role_ask_with_channel(")
+            .count(),
+        1,
+        "the stable-role branch must submit through the owner-scoped ask; ir:\n{ir}"
+    );
+    assert!(
+        !ir.contains("hew_local_pid_supervisor_child_get")
+            && !ir.contains("hew_local_pid_ask_with_channel"),
+        "no lookup-token-then-send pair may survive on the stable-role join \
+             path; ir:\n{ir}"
+    );
+    assert!(
+        !ir.contains("call i32 @hew_actor_ask_with_channel("),
+        "a stable-role branch must not fall back to the raw-handle ask; ir:\n{ir}"
+    );
+}
+
+/// The join null-reply edge is STATUS-BEARING: it classifies the failure via
+/// `hew_join_branch_failed` while the caller-side channel ref is live, then
+/// traps with the canonical join-branch code (211) — never the bare
+/// `llvm.trap` that produced an empty-output abort with no diagnostic.
+#[test]
+fn join_null_reply_edge_diagnoses_then_traps_with_code() {
+    let branches = vec![hew_mir::JoinBranch {
+        actor: Place::DuplexHandle(0),
+        stable_role: None,
+        method: "score".to_string(),
+        args: Vec::new(),
+        msg_type: 7,
+        value: Place::Local(2),
+        cleanup_plan: None,
+        reply_dest: Place::Local(1),
+        reply_ty: ResolvedTy::I64,
+    }];
+    let locals = vec![
+        duplex_ty(),      // 0: actor handle
+        ResolvedTy::I64,  // 1: reply slot / join result
+        ResolvedTy::Unit, // 2: payload
+    ];
+    let pipeline = pipeline_with_join_branches(branches, locals, Place::Local(1), 99);
+    let ir = emit_select_ir("join_null_reply_diagnosis", &pipeline);
+
+    let null_idx = ir
+        .find("join_reply_null_0:")
+        .expect("join null-reply block must exist");
+    let null_region = &ir[null_idx..];
+    let diagnose_at = null_region
+        .find("call i32 @hew_join_branch_failed(")
+        .expect("null edge must classify the failure via hew_join_branch_failed");
+    let free_at = null_region
+        .find("call void @hew_reply_channel_free(")
+        .expect("null edge frees the failing channel");
+    assert!(
+        diagnose_at < free_at,
+        "the classifier must read the channel BEFORE its caller-side ref is \
+             freed; ir:\n{ir}"
+    );
+    assert!(
+        null_region.contains("call void @hew_trap_with_code(i32 211)"),
+        "the null edge must trap with HEW_TRAP_JOIN_BRANCH_FAILED (211); ir:\n{ir}"
+    );
+}
+
 /// Two ActorAsk arms (no AfterTimer): emit shows exactly 2 channel
 /// allocations, 2 ask-issues, 1 `hew_select_first` call with
 /// timeout=-1, a switch on the winner index, per-winner reply
@@ -2529,6 +2658,64 @@ fn select_actor_ask_plus_after_timer_emits_deadline() {
     assert!(
         ir.contains("select_win_ask_0:") && ir.contains("select_win_after:"),
         "expected both winner branch labels; ir:\n{ir}"
+    );
+}
+
+/// A fungible stable-role select arm submits through the OWNER-SCOPED
+/// runtime op, mirroring the join cutover: no lookup-token-then-send pair
+/// survives on the select ask path either.
+#[test]
+fn select_stable_role_arm_submits_owner_scoped() {
+    let arms = vec![
+        hew_mir::SelectArm {
+            kind: hew_mir::SelectArmKind::ActorAsk {
+                actor: Place::DuplexHandle(0),
+                stable_role: Some(hew_mir::StableActorRole {
+                    supervisor_token: Place::Local(2),
+                    slot_index: 1,
+                }),
+                method: "ping".to_string(),
+                args: Vec::new(),
+                msg_type: 7,
+                value: Place::Local(3),
+                cleanup_plan: None,
+            },
+            body_block: 10,
+            binding: Some(Place::Local(1)),
+        },
+        hew_mir::SelectArm {
+            kind: hew_mir::SelectArmKind::AfterTimer {
+                duration: Place::Local(4),
+            },
+            body_block: 11,
+            binding: None,
+        },
+    ];
+    let locals = vec![
+        duplex_ty(),          // 0: actor handle (unused by the stable-role path)
+        ResolvedTy::I64,      // 1: reply slot
+        ResolvedTy::I64,      // 2: stable supervisor token
+        ResolvedTy::Unit,     // 3: payload
+        ResolvedTy::Duration, // 4: after-arm duration
+    ];
+    let pipeline = pipeline_with_select_arms(arms, locals, &[10, 11], 99);
+    let ir = emit_select_ir("select_stable_role", &pipeline);
+
+    assert_eq!(
+        ir.matches("call i32 @hew_supervisor_role_ask_with_channel(")
+            .count(),
+        1,
+        "the stable-role arm must submit through the owner-scoped ask; ir:\n{ir}"
+    );
+    assert!(
+        !ir.contains("hew_local_pid_supervisor_child_get")
+            && !ir.contains("hew_local_pid_ask_with_channel"),
+        "no lookup-token-then-send pair may survive on the stable-role select \
+             path; ir:\n{ir}"
+    );
+    assert!(
+        !ir.contains("call i32 @hew_actor_ask_with_channel("),
+        "a stable-role arm must not fall back to the raw-handle ask; ir:\n{ir}"
     );
 }
 

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -3948,10 +3948,20 @@ pub(crate) fn intern_runtime_decl<'ctx>(
             ],
             false,
         ),
-        // Stable actor-token twin used by fungible supervisor-child roles.
-        "hew_local_pid_ask_with_channel" => i32_ty.fn_type(
+        // hew_supervisor_role_ask_with_channel(token: i64, key: u32,
+        //     msg_type: i32, data: *mut c_void, size: usize,
+        //     ch: *mut HewReplyChannel) -> i32
+        // (`hew-runtime/src/supervisor.rs`). Owner-scoped stable-role ask:
+        // resolves the supervisor child slot and enqueues into the CURRENT
+        // incarnation under one children_lock section, replacing the racy
+        // lookup-token-then-send pair. 0 = submitted; non-zero fails closed
+        // with the classified slot state in the error slot. Channel-ref
+        // discipline matches hew_actor_ask_with_channel (creator ref
+        // survives failure).
+        "hew_supervisor_role_ask_with_channel" => i32_ty.fn_type(
             &[
                 i64_ty.into(),
+                i32_ty.into(),
                 i32_ty.into(),
                 ptr_ty.into(),
                 size_ty.into(),
@@ -3959,6 +3969,14 @@ pub(crate) fn intern_runtime_decl<'ctx>(
             ],
             false,
         ),
+        // hew_join_branch_failed(ch: *mut HewReplyChannel, branch: i32) -> i32
+        // (`hew-runtime/src/reply_channel.rs`). Classifies a join branch's
+        // null reply (actor stopped / cancelled / handler trapped / payload
+        // allocation failure), records + prints the diagnostic, and returns
+        // the HEW_REPLY_FAIL_* kind. Called on the join null-reply edge
+        // BEFORE the caller-side channel ref is freed and the branch traps
+        // with HEW_TRAP_JOIN_BRANCH_FAILED.
+        "hew_join_branch_failed" => i32_ty.fn_type(&[ptr_ty.into(), i32_ty.into()], false),
         // hew_reply_channel_new() -> *mut HewReplyChannel
         // (`hew-runtime/src/reply_channel.rs:78`). Box-allocates a fresh
         // single-shot reply channel with one caller-side reference.

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -3958,6 +3958,22 @@ pub(crate) fn intern_runtime_decl<'ctx>(
         // with the classified slot state in the error slot. Channel-ref
         // discipline matches hew_actor_ask_with_channel (creator ref
         // survives failure).
+        // hew_supervisor_role_ask(token: i64, key: u32, msg_type: i32,
+        //     data: *mut c_void, size: usize) -> *mut c_void
+        // (`hew-runtime/src/supervisor.rs`). Blocking owner-scoped stable-role
+        // ask: classified resolve under children_lock, then the ID-pinned
+        // blocking ask. Same null-or-reply return contract as hew_actor_ask
+        // (null binds Err via hew_actor_ask_take_last_error).
+        "hew_supervisor_role_ask" => ptr_ty.fn_type(
+            &[
+                i64_ty.into(),
+                i32_ty.into(),
+                i32_ty.into(),
+                ptr_ty.into(),
+                size_ty.into(),
+            ],
+            false,
+        ),
         "hew_supervisor_role_ask_with_channel" => i32_ty.fn_type(
             &[
                 i64_ty.into(),

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -65,6 +65,9 @@ pub(crate) struct SuspendingRemoteAskEmit<'a> {
 
 pub(crate) struct SuspendingAskEmit {
     pub(crate) actor: Place,
+    /// Present only for a fungible supervisor-child receiver: submit through
+    /// the owner-scoped role ask instead of a resolved child pointer.
+    pub(crate) stable_role: Option<hew_mir::StableActorRole>,
     pub(crate) msg_type: i32,
     pub(crate) value: Place,
     pub(crate) cleanup_plan: Option<hew_mir::state_clone::ValueSnapshotPlan>,
@@ -4818,7 +4821,6 @@ pub(crate) fn emit_suspending_ask_terminator<'ctx>(
         .basic()
         .ok_or_else(|| CodegenError::FailClosed("hew_actor_self returned void".into()))?
         .into_pointer_value();
-    let actor_ptr = load_duplex_handle(fn_ctx, term.actor, "suspending_ask receiver")?;
     let (payload_ptr, payload_size) =
         actor_payload_ptr_size(fn_ctx, term.value, "suspending_ask_payload")?;
 
@@ -4896,12 +4898,6 @@ pub(crate) fn emit_suspending_ask_terminator<'ctx>(
         None
     };
 
-    let ask_fn = intern_runtime_decl(
-        fn_ctx.ctx,
-        fn_ctx.llvm_mod,
-        &mut fn_ctx.runtime_decls.borrow_mut(),
-        "hew_actor_ask_with_channel",
-    )?;
     let msg_type_val = fn_ctx.ctx.i32_type().const_int(term.msg_type as u64, false);
     // `payload_size` is built as i64; the `size` param is `usize`/`size_t`
     // (i32 on wasm32). Reconcile to the target-correct width.
@@ -4912,24 +4908,77 @@ pub(crate) fn emit_suspending_ask_terminator<'ctx>(
         suspending_ask_size_ty.into(),
         "suspending ask payload size",
     )?;
-    let rc = fn_ctx
-        .builder
-        .build_call(
-            ask_fn,
-            &[
-                actor_ptr.into(),
-                msg_type_val.into(),
-                payload_ptr.into(),
-                payload_size.into(),
-                ch.into(),
-            ],
-            "suspending_ask_submit",
-        )
-        .llvm_ctx("hew_actor_ask_with_channel call")?
-        .try_as_basic_value()
-        .basic()
-        .ok_or_else(|| CodegenError::FailClosed("hew_actor_ask_with_channel returned void".into()))?
-        .into_int_value();
+    // A fungible stable-role receiver submits through the OWNER-SCOPED role
+    // ask (resolve + ID-pinned submission inside the runtime; same status
+    // return contract as hew_actor_ask_with_channel). The former shape
+    // dereferenced a re-resolved, UNPINNED child pointer that a restart could
+    // free before the deref.
+    let rc = if let Some(role) = term.stable_role {
+        let sup_token = load_int_arg(
+            fn_ctx,
+            role.supervisor_token,
+            i64_ty,
+            "suspending_ask_role_supervisor_token",
+        )?;
+        let slot_idx = i32_ty.const_int(u64::from(role.slot_index), false);
+        let role_ask_fn = intern_runtime_decl(
+            fn_ctx.ctx,
+            fn_ctx.llvm_mod,
+            &mut fn_ctx.runtime_decls.borrow_mut(),
+            "hew_supervisor_role_ask_with_channel",
+        )?;
+        fn_ctx
+            .builder
+            .build_call(
+                role_ask_fn,
+                &[
+                    sup_token.into(),
+                    slot_idx.into(),
+                    msg_type_val.into(),
+                    payload_ptr.into(),
+                    payload_size.into(),
+                    ch.into(),
+                ],
+                "suspending_ask_submit",
+            )
+            .llvm_ctx("hew_supervisor_role_ask_with_channel call")?
+            .try_as_basic_value()
+            .basic()
+            .ok_or_else(|| {
+                CodegenError::FailClosed(
+                    "hew_supervisor_role_ask_with_channel returned void".into(),
+                )
+            })?
+            .into_int_value()
+    } else {
+        let actor_ptr = load_duplex_handle(fn_ctx, term.actor, "suspending_ask receiver")?;
+        let ask_fn = intern_runtime_decl(
+            fn_ctx.ctx,
+            fn_ctx.llvm_mod,
+            &mut fn_ctx.runtime_decls.borrow_mut(),
+            "hew_actor_ask_with_channel",
+        )?;
+        fn_ctx
+            .builder
+            .build_call(
+                ask_fn,
+                &[
+                    actor_ptr.into(),
+                    msg_type_val.into(),
+                    payload_ptr.into(),
+                    payload_size.into(),
+                    ch.into(),
+                ],
+                "suspending_ask_submit",
+            )
+            .llvm_ctx("hew_actor_ask_with_channel call")?
+            .try_as_basic_value()
+            .basic()
+            .ok_or_else(|| {
+                CodegenError::FailClosed("hew_actor_ask_with_channel returned void".into())
+            })?
+            .into_int_value()
+    };
 
     let parent = fn_ctx
         .builder

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -27,7 +27,7 @@ use hew_mir::{
     ActorLayout, ChildInitArg, Place, PoolCount, RecordLayout, StateFieldCloneKind,
     SupervisorChildLayout, SupervisorLayout,
 };
-use hew_runtime::internal::types::HEW_TRAP_ACTOR_SEND_FAILED;
+use hew_runtime::internal::types::{HEW_TRAP_ACTOR_SEND_FAILED, HEW_TRAP_JOIN_BRANCH_FAILED};
 use hew_types::ResolvedTy;
 
 use crate::llvm::CoroState;
@@ -9675,103 +9675,6 @@ fn emit_select_winner_dispatch<'ctx>(
     Ok(())
 }
 
-/// Resolve one fungible `(stable supervisor token, static slot)` role to the
-/// current child `LocalPid` token immediately before request submission.
-///
-/// The runtime pins the supervisor control and copies the child token under
-/// `children_lock`. The returned token can become retired after this call, but
-/// `hew_local_pid_ask_with_channel` then fails closed by identity; no allocation
-/// pointer crosses this boundary. The aggregate return follows the same
-/// register-pair/MSVC-sret classifier as the legacy child lookup.
-fn resolve_stable_role_token<'ctx>(
-    fn_ctx: &FnCtx<'_, 'ctx>,
-    role: hew_mir::StableActorRole,
-    label: &str,
-) -> CodegenResult<IntValue<'ctx>> {
-    let i32_ty = fn_ctx.ctx.i32_type();
-    let i64_ty = fn_ctx.ctx.i64_type();
-    let ptr_ty = fn_ctx.ctx.ptr_type(AddressSpace::default());
-    let supervisor_token = load_int_arg(
-        fn_ctx,
-        role.supervisor_token,
-        i64_ty,
-        &format!("{label}_supervisor_token"),
-    )?;
-    let slot = i32_ty.const_int(u64::from(role.slot_index), false);
-    let result_ty = fn_ctx.ctx.struct_type(
-        &[
-            fn_ctx.ctx.i8_type().into(),
-            fn_ctx.ctx.i8_type().into(),
-            fn_ctx.ctx.i8_type().array_type(6).into(),
-            ptr_ty.into(),
-        ],
-        false,
-    );
-    let triple = fn_ctx.llvm_mod.get_triple();
-    let triple_str = triple.as_str().to_string_lossy();
-    let (lookup, return_abi) = crate::abi_class::declare_aggregate_return(
-        fn_ctx.ctx,
-        fn_ctx.llvm_mod,
-        fn_ctx.target_data,
-        &triple_str,
-        "hew_local_pid_supervisor_child_get",
-        result_ty,
-        &[i64_ty.into(), i32_ty.into()],
-    )?;
-    match return_abi {
-        crate::abi_class::AggregateReturnAbi::RegisterPair { .. } => {
-            let pair = fn_ctx
-                .builder
-                .build_call(
-                    lookup,
-                    &[supervisor_token.into(), slot.into()],
-                    &format!("{label}_lookup"),
-                )
-                .llvm_ctx("stable supervisor role lookup")?
-                .try_as_basic_value()
-                .basic()
-                .ok_or_else(|| {
-                    CodegenError::FailClosed(
-                        "hew_local_pid_supervisor_child_get returned void".into(),
-                    )
-                })?
-                .into_array_value();
-            Ok(fn_ctx
-                .builder
-                .build_extract_value(pair, 1, &format!("{label}_child_token"))
-                .llvm_ctx("stable role child token extract")?
-                .into_int_value())
-        }
-        crate::abi_class::AggregateReturnAbi::Sret => {
-            let result_slot = fn_ctx
-                .builder
-                .build_alloca(result_ty, &format!("{label}_lookup_result"))
-                .llvm_ctx("stable role sret alloca")?;
-            fn_ctx
-                .builder
-                .build_call(
-                    lookup,
-                    &[result_slot.into(), supervisor_token.into(), slot.into()],
-                    &format!("{label}_lookup"),
-                )
-                .llvm_ctx("stable supervisor role sret lookup")?;
-            let handle_field = fn_ctx
-                .builder
-                .build_struct_gep(result_ty, result_slot, 3, &format!("{label}_handle_gep"))
-                .llvm_ctx("stable role handle gep")?;
-            let handle = fn_ctx
-                .builder
-                .build_load(ptr_ty, handle_field, &format!("{label}_handle"))
-                .llvm_ctx("stable role handle load")?
-                .into_pointer_value();
-            fn_ctx
-                .builder
-                .build_ptr_to_int(handle, i64_ty, &format!("{label}_child_token"))
-                .llvm_ctx("stable role token ptrtoint")
-        }
-    }
-}
-
 /// Emit the per-arm readiness setup shared by [`emit_select_terminator`]
 /// (blocking) and [`emit_suspending_select_terminator`] (coro-suspend): for each
 /// wait arm allocate its reply channel, store it into `channel_array[slot]`,
@@ -9823,11 +9726,11 @@ fn emit_select_arm_setup<'ctx>(
         &mut fn_ctx.runtime_decls.borrow_mut(),
         "hew_actor_ask_with_channel",
     )?;
-    let local_pid_ask_with_channel = intern_runtime_decl(
+    let role_ask_with_channel = intern_runtime_decl(
         ctx,
         fn_ctx.llvm_mod,
         &mut fn_ctx.runtime_decls.borrow_mut(),
-        "hew_local_pid_ask_with_channel",
+        "hew_supervisor_role_ask_with_channel",
     )?;
     let channel_cancel = intern_runtime_decl(
         ctx,
@@ -10052,42 +9955,66 @@ fn emit_select_arm_setup<'ctx>(
                     select_ask_size_ty.into(),
                     "select ask payload size",
                 )?;
-                let (ask_fn, actor_arg) = if let Some(role) = stable_role {
-                    (
-                        local_pid_ask_with_channel,
-                        resolve_stable_role_token(
-                            fn_ctx,
-                            *role,
-                            &format!("select_role_{slot_idx}"),
-                        )?
-                        .into(),
-                    )
+                // A fungible stable-role arm submits through the OWNER-SCOPED
+                // ask (resolve + enqueue under one children_lock section) —
+                // the same cutover as the join emitter; the former
+                // lookup-token-then-send pair raced the restart machinery.
+                let status = if let Some(role) = stable_role {
+                    let sup_token = load_int_arg(
+                        fn_ctx,
+                        role.supervisor_token,
+                        i64_ty,
+                        &format!("select_role_{slot_idx}_supervisor_token"),
+                    )?;
+                    let slot_const = i32_ty.const_int(u64::from(role.slot_index), false);
+                    fn_ctx
+                        .builder
+                        .build_call(
+                            role_ask_with_channel,
+                            &[
+                                sup_token.into(),
+                                slot_const.into(),
+                                msg_type_val.into(),
+                                payload_ptr.into(),
+                                payload_size.into(),
+                                ch_val.into(),
+                            ],
+                            &format!("select_ask_issue_{slot_idx}"),
+                        )
+                        .llvm_ctx("hew_supervisor_role_ask_with_channel call")?
+                        .try_as_basic_value()
+                        .basic()
+                        .ok_or_else(|| {
+                            CodegenError::FailClosed(
+                                "hew_supervisor_role_ask_with_channel returned void".into(),
+                            )
+                        })?
+                        .into_int_value()
                 } else {
-                    (
-                        ask_with_channel,
-                        load_duplex_handle(fn_ctx, *actor, "select_actor_handle")?.into(),
-                    )
+                    let actor_arg = load_duplex_handle(fn_ctx, *actor, "select_actor_handle")?;
+                    fn_ctx
+                        .builder
+                        .build_call(
+                            ask_with_channel,
+                            &[
+                                actor_arg.into(),
+                                msg_type_val.into(),
+                                payload_ptr.into(),
+                                payload_size.into(),
+                                ch_val.into(),
+                            ],
+                            &format!("select_ask_issue_{slot_idx}"),
+                        )
+                        .llvm_ctx("hew_actor_ask_with_channel call")?
+                        .try_as_basic_value()
+                        .basic()
+                        .ok_or_else(|| {
+                            CodegenError::FailClosed(
+                                "hew_actor_ask_with_channel returned void".into(),
+                            )
+                        })?
+                        .into_int_value()
                 };
-                let status = fn_ctx
-                    .builder
-                    .build_call(
-                        ask_fn,
-                        &[
-                            actor_arg,
-                            msg_type_val.into(),
-                            payload_ptr.into(),
-                            payload_size.into(),
-                            ch_val.into(),
-                        ],
-                        &format!("select_ask_issue_{slot_idx}"),
-                    )
-                    .llvm_ctx("hew_actor_ask_with_channel call")?
-                    .try_as_basic_value()
-                    .basic()
-                    .ok_or_else(|| {
-                        CodegenError::FailClosed("hew_actor_ask_with_channel returned void".into())
-                    })?
-                    .into_int_value();
                 (status, false, true)
             }
             SelectArmKind::StreamNext { stream } => {
@@ -11286,11 +11213,11 @@ pub(crate) fn emit_join_terminator<'ctx>(
         &mut fn_ctx.runtime_decls.borrow_mut(),
         "hew_actor_ask_with_channel",
     )?;
-    let local_pid_ask_with_channel = intern_runtime_decl(
+    let role_ask_with_channel = intern_runtime_decl(
         ctx,
         fn_ctx.llvm_mod,
         &mut fn_ctx.runtime_decls.borrow_mut(),
-        "hew_local_pid_ask_with_channel",
+        "hew_supervisor_role_ask_with_channel",
     )?;
     let channel_cancel = intern_runtime_decl(
         ctx,
@@ -11309,6 +11236,12 @@ pub(crate) fn emit_join_terminator<'ctx>(
         fn_ctx.llvm_mod,
         &mut fn_ctx.runtime_decls.borrow_mut(),
         "hew_reply_wait",
+    )?;
+    let join_branch_failed = intern_runtime_decl(
+        ctx,
+        fn_ctx.llvm_mod,
+        &mut fn_ctx.runtime_decls.borrow_mut(),
+        "hew_join_branch_failed",
     )?;
     let libc_free = get_or_declare_free(fn_ctx);
 
@@ -11369,37 +11302,68 @@ pub(crate) fn emit_join_terminator<'ctx>(
             join_ask_size_ty.into(),
             "join ask payload size",
         )?;
-        let (ask_fn, actor_arg) = if let Some(role) = branch.stable_role {
-            (
-                local_pid_ask_with_channel,
-                resolve_stable_role_token(fn_ctx, role, &format!("join_role_{i}"))?.into(),
-            )
+        // A fungible stable-role branch submits through the OWNER-SCOPED ask:
+        // the runtime pins the supervisor, resolves the slot, and enqueues
+        // into the CURRENT incarnation under ONE children_lock section. The
+        // former lookup-token-then-send pair
+        // (hew_local_pid_supervisor_child_get → hew_local_pid_ask_with_channel)
+        // let the restart machinery advance the slot between the two calls,
+        // losing the ask into a retiring incarnation with no diagnostic.
+        let status = if let Some(role) = branch.stable_role {
+            let i64_ty = ctx.i64_type();
+            let sup_token = load_int_arg(
+                fn_ctx,
+                role.supervisor_token,
+                i64_ty,
+                &format!("join_role_{i}_supervisor_token"),
+            )?;
+            let slot_idx = i32_ty.const_int(u64::from(role.slot_index), false);
+            fn_ctx
+                .builder
+                .build_call(
+                    role_ask_with_channel,
+                    &[
+                        sup_token.into(),
+                        slot_idx.into(),
+                        msg_type_val.into(),
+                        payload_ptr.into(),
+                        payload_size.into(),
+                        ch_val.into(),
+                    ],
+                    &format!("join_ask_issue_{i}"),
+                )
+                .llvm_ctx("hew_supervisor_role_ask_with_channel call")?
+                .try_as_basic_value()
+                .basic()
+                .ok_or_else(|| {
+                    CodegenError::FailClosed(
+                        "hew_supervisor_role_ask_with_channel returned void".into(),
+                    )
+                })?
+                .into_int_value()
         } else {
-            (
-                ask_with_channel,
-                load_duplex_handle(fn_ctx, branch.actor, "join_actor_handle")?.into(),
-            )
+            let actor_arg = load_duplex_handle(fn_ctx, branch.actor, "join_actor_handle")?;
+            fn_ctx
+                .builder
+                .build_call(
+                    ask_with_channel,
+                    &[
+                        actor_arg.into(),
+                        msg_type_val.into(),
+                        payload_ptr.into(),
+                        payload_size.into(),
+                        ch_val.into(),
+                    ],
+                    &format!("join_ask_issue_{i}"),
+                )
+                .llvm_ctx("hew_actor_ask_with_channel call")?
+                .try_as_basic_value()
+                .basic()
+                .ok_or_else(|| {
+                    CodegenError::FailClosed("hew_actor_ask_with_channel returned void".into())
+                })?
+                .into_int_value()
         };
-        let status = fn_ctx
-            .builder
-            .build_call(
-                ask_fn,
-                &[
-                    actor_arg,
-                    msg_type_val.into(),
-                    payload_ptr.into(),
-                    payload_size.into(),
-                    ch_val.into(),
-                ],
-                &format!("join_ask_issue_{i}"),
-            )
-            .llvm_ctx("hew_actor_ask_with_channel call")?
-            .try_as_basic_value()
-            .basic()
-            .ok_or_else(|| {
-                CodegenError::FailClosed("hew_actor_ask_with_channel returned void".into())
-            })?
-            .into_int_value();
 
         // Branch on status: 0 → next ask; non-zero → mid-setup recovery
         // (free every channel allocated through `i` inclusive, then trap).
@@ -11523,6 +11487,19 @@ pub(crate) fn emit_join_terminator<'ctx>(
 
         // Cancel-rest + trap branch.
         fn_ctx.builder.position_at_end(null_bb);
+        // Status-bearing failure: classify the null reply (actor stopped /
+        // cancelled / handler trapped / reply allocation failure) and emit the
+        // diagnostic WHILE the caller-side channel ref is still live — the
+        // runtime reads the channel's failure classification.
+        let branch_idx_const = i32_ty.const_int(i as u64, false);
+        fn_ctx
+            .builder
+            .build_call(
+                join_branch_failed,
+                &[win_ch.into(), branch_idx_const.into()],
+                &format!("join_branch_failed_{i}"),
+            )
+            .llvm_ctx("hew_join_branch_failed call")?;
         // Free the failing channel's caller-side ref (its reply was null).
         fn_ctx
             .builder
@@ -11557,20 +11534,16 @@ pub(crate) fn emit_join_terminator<'ctx>(
                 )
                 .llvm_ctx("join error rest free")?;
         }
-        let trap_intrinsic = Intrinsic::find("llvm.trap").ok_or_else(|| {
-            CodegenError::Llvm("llvm.trap intrinsic not found in LLVM build".into())
-        })?;
-        let trap_fn = trap_intrinsic
-            .get_declaration(fn_ctx.llvm_mod, &[])
-            .ok_or_else(|| CodegenError::Llvm("llvm.trap declaration failed".into()))?;
-        fn_ctx
-            .builder
-            .build_call(trap_fn, &[], &format!("join_reply_null_trap_{i}"))
-            .llvm_ctx("join reply null trap")?;
-        fn_ctx
-            .builder
-            .build_unreachable()
-            .llvm_ctx("join reply null unreachable")?;
+        // Fail-closed with the canonical join-branch trap code — the bare
+        // llvm.trap this replaces produced an empty-output abort with no
+        // diagnostic; the classified cause above plus this code make the
+        // failure observable in actor context (error_code 211) and in main
+        // context (the trap-kind diagnostic on stderr).
+        emit_trap_with_code(
+            fn_ctx,
+            HEW_TRAP_JOIN_BRANCH_FAILED as u64,
+            &format!("join_reply_null_trap_{i}"),
+        )?;
 
         // Ok branch: materialise the reply into result tuple element `i`.
         fn_ctx.builder.position_at_end(ok_bb);

--- a/hew-codegen-rs/tests/structural/snapshot_send.rs
+++ b/hew-codegen-rs/tests/structural/snapshot_send.rs
@@ -260,10 +260,11 @@ fn failed_select_and_join_requests_drop_the_unsubmitted_indirect_payload() {
         );
     }
     assert_eq!(
-        ll.matches("call i32 @hew_local_pid_ask_with_channel(")
+        ll.matches("call i32 @hew_supervisor_role_ask_with_channel(")
             .count(),
         3,
-        "the fungible select arm and both join branches must submit through stable child tokens"
+        "the fungible select arm and both join branches must submit through \
+         the owner-scoped stable-role ask"
     );
 }
 
@@ -309,20 +310,21 @@ fn fungible_join_uses_stable_supervisor_role_and_local_pid_submission() {
         ll.contains("call i64 @hew_supervisor_direct_id("),
         "fungible role binding must capture the stable supervisor token:\n{ll}"
     );
-    assert_eq!(
-        ll.lines()
-            .filter(|line| {
-                line.contains("call ") && line.contains("@hew_local_pid_supervisor_child_get(")
-            })
-            .count(),
-        4,
-        "each join branch must re-resolve the role immediately before submission:\n{ll}"
+    assert!(
+        !ll.contains("@hew_local_pid_supervisor_child_get("),
+        "no join branch may emit the lookup-token half of the retired \
+         lookup-token-then-send pair:\n{ll}"
     );
     assert_eq!(
-        ll.matches("call i32 @hew_local_pid_ask_with_channel(")
+        ll.matches("call i32 @hew_supervisor_role_ask_with_channel(")
             .count(),
         4,
-        "each fungible join branch must submit through a stable child token:\n{ll}"
+        "each fungible join branch must submit through the owner-scoped \
+         stable-role ask (resolve + submission in ONE runtime call):\n{ll}"
+    );
+    assert!(
+        !ll.contains("@hew_local_pid_ask_with_channel("),
+        "the token-submission half of the retired pair must not survive:\n{ll}"
     );
 }
 
@@ -351,9 +353,57 @@ fn direct_join_keeps_raw_actor_submission() {
         "direct actor join branches must preserve raw-pointer submission"
     );
     assert_eq!(
-        ll.matches("call i32 @hew_local_pid_ask_with_channel(")
+        ll.matches("call i32 @hew_supervisor_role_ask_with_channel(")
             .count(),
         0,
         "direct actor joins must not be reclassified as fungible roles"
+    );
+}
+
+/// A fungible single ask — blocking (`main`) and suspending (an actor
+/// handler's `await`) — submits through the OWNER-SCOPED role ask. The
+/// retired shape resolved a raw child pointer (`hew_supervisor_child_get`)
+/// and dereferenced it at the ask site: an UNPINNED pointer a restart could
+/// free between the lookup and the deref.
+#[test]
+fn fungible_single_ask_submits_owner_scoped_never_raw_pointer() {
+    let ll = emit_ll(
+        r#"
+        actor Worker {
+            receive fn score(tag: i64) -> i64 { tag }
+        }
+
+        supervisor App {
+            strategy: one_for_one;
+            intensity: 3 within 60s;
+            child worker: Worker;
+        }
+
+        fn main() -> i64 {
+            let sup = spawn App;
+            let worker = sup.worker;
+            let blocking = match await worker.score(11) {
+                Ok(v) => v,
+                Err(_) => 0,
+            };
+            supervisor_stop(sup);
+            blocking
+        }
+        "#,
+    );
+
+    assert_eq!(
+        ll.matches("call ptr @hew_supervisor_role_ask(").count(),
+        1,
+        "a blocking fungible ask must submit through the owner-scoped role \
+         ask:\n{ll}"
+    );
+    // The retired raw-pointer shape must not survive on the ask path: no
+    // child-pointer re-resolve feeding a raw hew_actor_ask deref.
+    assert_eq!(
+        ll.matches("call ptr @hew_actor_ask(").count(),
+        0,
+        "a fungible ask must never dereference a re-resolved child \
+         pointer:\n{ll}"
     );
 }

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -402,6 +402,7 @@ fn render_terminator(term: &Terminator) -> String {
         ),
         Terminator::Ask {
             actor,
+            stable_role: _,
             msg_type,
             value,
             arg_modes: _,

--- a/hew-mir/src/lower/actor.rs
+++ b/hew-mir/src/lower/actor.rs
@@ -4,7 +4,7 @@ use super::{
     recv_result_payload_ty, ty_contains_channel_handle, ActorLayout, ActorMethodInfo, Builder,
     BuiltinType, CmpPred, FieldOffset, FloatWidth, FungibleChildRef, HashMap, HirExpr, HirExprKind,
     Instr, MirDiagnostic, MirDiagnosticKind, PendingOutboundArg, PendingOutboundSite, Place,
-    ReleaseSymbolVerdict, ResolvedTy, RuntimeCallContext, SuspendKind, Terminator,
+    ReleaseSymbolVerdict, ResolvedTy, RuntimeCallContext, StableActorRole, SuspendKind, Terminator,
     CHILD_LOOKUP_RESULT_TY_NAME, RECEIVE_GEN_STREAM_CAPACITY,
 };
 
@@ -2461,19 +2461,23 @@ impl Builder {
             return None;
         }
         let actor = self.lower_value(receiver)?;
-        // F-04: an ask through a FUNGIBLE supervisor-child reference re-resolves
-        // the current child at the ask site. Unlike the tell path, the ask needs
-        // NO liveness branch: a not-live slot resolves to a null handle, and the
-        // existing ask err path fail-closes a null/stale actor to
-        // `Err(AskError::ActorStopped)` (`actor_send_result_internal_reply`
-        // null-guards at actor.rs:4078 → `ErrActorStopped` →
-        // `hew_actor_ask_take_last_error` → `Err`). So storing the freshly
-        // resolved pointer (null when not-live) into the handle alloca is
-        // sufficient: a live child is asked, a not-live one yields a recoverable
-        // `Err` rather than a UAF or trap.
-        if let Some(child_ref) = self.fungible_child_ref_of(actor) {
-            self.emit_child_get_into(child_ref.sup_place, child_ref.slot_index, actor);
-        }
+        // F-04: an ask through a FUNGIBLE supervisor-child reference carries
+        // the stable role (supervisor token + slot) into the ask terminator;
+        // codegen submits through the OWNER-SCOPED role ask
+        // (`hew_supervisor_role_ask` / `hew_supervisor_role_ask_with_channel`),
+        // which resolves the current incarnation and submits under the
+        // runtime's liveness protocol. The former shape re-resolved to a raw
+        // `*mut HewActor` here (`emit_child_get_into`) and dereferenced it at
+        // the ask site — an UNPINNED pointer a restart could free between the
+        // lookup and the deref (use-after-free, not a refusal). A not-live or
+        // retired slot now fails closed to `Err(AskError::ActorStopped)` with
+        // the slot state classified in the error slot.
+        let stable_role = self
+            .fungible_child_ref_of(actor)
+            .map(|child_ref| StableActorRole {
+                supervisor_token: child_ref.supervisor_token,
+                slot_index: child_ref.slot_index,
+            });
         let mut lowered: Vec<(Place, ResolvedTy)> = Vec::with_capacity(args.len());
         for arg in args {
             lowered.push((self.lower_value_for_move(arg)?, self.subst_ty(&arg.ty)));
@@ -2532,6 +2536,7 @@ impl Builder {
             }
             self.record_suspend_kind(SuspendKind::Ask {
                 actor,
+                stable_role,
                 msg_type: info.msg_type,
                 value,
                 arg_modes: Vec::new(),
@@ -2568,6 +2573,7 @@ impl Builder {
             }
             self.finish_current_block(Terminator::Ask {
                 actor,
+                stable_role,
                 msg_type: info.msg_type,
                 value,
                 arg_modes: Vec::new(),

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -5468,6 +5468,7 @@ pub(super) fn enumerate_exits(
             ),
             Terminator::Ask {
                 actor,
+                stable_role: _,
                 msg_type: _,
                 value: _,
                 arg_modes: _,

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -38,8 +38,8 @@ use crate::model::{
     IntArithOp, IntSignedness, IrPipeline, JoinBranch, LambdaCapture, MirCheck, MirConst,
     MirConstValue, MirDiagnostic, MirDiagnosticKind, MirStatement, Place, PointerWidth,
     ProjectedPayloadRejectReason, RawMirFunction, RecordLayout, SelectArm, SelectArmKind,
-    SendAliasMode, SourceOrigin, SpawnEnvFieldOwnership, Strategy, SuspendKind, Terminator,
-    ThirFunction, TraitObjectStorage, TrapKind,
+    SendAliasMode, SourceOrigin, SpawnEnvFieldOwnership, StableActorRole, Strategy, SuspendKind,
+    Terminator, ThirFunction, TraitObjectStorage, TrapKind,
 };
 use crate::ownership::FailClosedReason;
 use crate::ownership::LayoutClass;

--- a/hew-mir/src/lower/suspend_places.rs
+++ b/hew-mir/src/lower/suspend_places.rs
@@ -1087,6 +1087,7 @@ mod f1_suspending_escape_poison {
     fn suspending_ask_poisons_its_owned_payload() {
         let value = Place::Local(3);
         let kind = SuspendKind::Ask {
+            stable_role: None,
             actor: Place::Local(1),
             msg_type: 0,
             value,
@@ -1128,6 +1129,7 @@ mod f1_suspending_escape_poison {
         let value = Place::Local(3);
         let local_tys = vec![ResolvedTy::I64; 7];
         let blocking = Terminator::Ask {
+            stable_role: None,
             actor: Place::Local(1),
             msg_type: 0,
             value,
@@ -1139,6 +1141,7 @@ mod f1_suspending_escape_poison {
             next: 1,
         };
         let kind = SuspendKind::Ask {
+            stable_role: None,
             actor: Place::Local(1),
             msg_type: 0,
             value,

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -2494,6 +2494,10 @@ pub enum SuspendKind {
     /// Non-blocking `await actor.method(value)` (`SuspendingAsk`).
     Ask {
         actor: Place,
+        /// Present only for a fungible supervisor-child binding: the ask
+        /// submits through `hew_supervisor_role_ask_with_channel` (the
+        /// owner-scoped role ask) instead of a resolved child pointer.
+        stable_role: Option<StableActorRole>,
         msg_type: i32,
         value: Place,
         arg_modes: Vec<SendAliasMode>,
@@ -3561,6 +3565,12 @@ pub enum Terminator {
     /// lands.
     Ask {
         actor: Place,
+        /// Present only for a fungible supervisor-child binding. Codegen
+        /// submits through the owner-scoped role ask
+        /// (`hew_supervisor_role_ask`) instead of dereferencing a resolved
+        /// child pointer — the raw lookup-then-ask pair left an unpinned
+        /// `*mut HewActor` that a restart could free before the deref.
+        stable_role: Option<StableActorRole>,
         msg_type: i32,
         value: Place,
         /// One resolved mode per source argument, in handler parameter order.

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -296,6 +296,16 @@ fn actor_ask_null(err: AskError) -> *mut c_void {
     ptr::null_mut()
 }
 
+/// Refuse an ask closed with `AskError::ActorStopped` and return null —
+/// the blocking stable-role ask's classified-refusal surface
+/// (`hew_supervisor_role_ask` records the slot-state diagnostic separately
+/// via the error slot; this binds the user-visible `Err(AskError::*)`).
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+pub(crate) fn actor_ask_null_actor_stopped() -> *mut c_void {
+    actor_ask_null(AskError::ActorStopped)
+}
+
 /// Clear the local-ask error slot (called on successful ask return).
 #[inline]
 fn actor_ask_clear() {

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -890,12 +890,23 @@ fn should_fail_arena_alloc() -> bool {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 thread_local! {
-    static NEXT_SPAWN_ACTOR_ID_OVERRIDE: Cell<Option<u64>> = const { Cell::new(None) };
+    static NEXT_SPAWN_ACTOR_ID_OVERRIDE: Cell<Option<(u64, u64)>> = const { Cell::new(None) };
 }
 
+/// Force the next spawn to adopt `actor_id` as its packed `id` while keeping the
+/// full serial equal to it — the common case where aliasing is not under test.
 #[cfg(all(test, not(target_arch = "wasm32")))]
 fn override_next_spawn_actor_id(actor_id: u64) {
-    NEXT_SPAWN_ACTOR_ID_OVERRIDE.with(|slot| slot.set(Some(actor_id)));
+    NEXT_SPAWN_ACTOR_ID_OVERRIDE.with(|slot| slot.set(Some((actor_id, actor_id))));
+}
+
+/// Force the next spawn to adopt `actor_id` as its packed `id` but a DISTINCT
+/// full `serial`. Fabricates the masked-`id` alias shape: two incarnations that
+/// collide on `id` yet differ on the aliasing-proof discriminator. Used by the
+/// supervisor role-ask alias tooth (`supervisor.rs`).
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) fn override_next_spawn_actor_identity(actor_id: u64, serial: u64) {
+    NEXT_SPAWN_ACTOR_ID_OVERRIDE.with(|slot| slot.set(Some((actor_id, serial))));
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
@@ -1322,6 +1333,22 @@ pub struct HewActor {
     /// compiler cutover. Appended at the tail so the codegen-mirrored `id` and
     /// `state` offsets and every established prefix offset remain unchanged.
     pub local_pid_id: crate::lifetime::local_handles::HewLocalPidId,
+
+    /// Full, un-masked spawn serial — the aliasing-proof incarnation
+    /// discriminator.
+    ///
+    /// `id` packs only the low 48 bits of the serial (`pid::hew_pid_make`
+    /// masks with `SERIAL_MASK`), so after 2^48 allocations a fresh actor can
+    /// carry a retired incarnation's masked `id`. The two-phase owner-scoped
+    /// role ask copies this full serial out under `children_lock`
+    /// (`supervisor::role_resolve_current_child_id`) and re-checks it against
+    /// the pinned actor before enqueue
+    /// (`live_actors::with_actor_send_by_identity`): an aliased `id` pins a
+    /// DIFFERENT incarnation whose serial differs, so the submission refuses
+    /// closed instead of delivering to the wrong actor. Runtime-internal; not
+    /// mirrored by codegen. Appended at the struct tail so no codegen-mirrored
+    /// offset (`id` at 8, `state` at 16) moves.
+    pub spawn_serial: u64,
 }
 
 // SAFETY: `HewActor` is designed for concurrent access across worker threads.
@@ -2479,19 +2506,33 @@ unsafe fn cleanup_failed_spawn(config: &ActorSpawnConfig, init_state: *mut c_voi
     }
 }
 
-fn next_spawn_actor_identity() -> u64 {
+/// A freshly allocated actor identity: the packed, location-transparent `id`
+/// (masked serial) plus the full un-masked `serial` used as the aliasing-proof
+/// incarnation discriminator (see [`HewActor::spawn_serial`]).
+#[derive(Clone, Copy)]
+struct SpawnIdentity {
+    id: u64,
+    serial: u64,
+}
+
+fn next_spawn_actor_identity() -> SpawnIdentity {
     #[cfg(not(target_arch = "wasm32"))]
     {
         #[cfg(test)]
-        if let Some(actor_id) = NEXT_SPAWN_ACTOR_ID_OVERRIDE.with(Cell::take) {
-            return actor_id;
+        if let Some((id, serial)) = NEXT_SPAWN_ACTOR_ID_OVERRIDE.with(Cell::take) {
+            return SpawnIdentity { id, serial };
         }
-        crate::pid::next_actor_id(NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed))
+        let serial = NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed);
+        SpawnIdentity {
+            id: crate::pid::next_actor_id(serial),
+            serial,
+        }
     }
 
     #[cfg(target_arch = "wasm32")]
     {
-        NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed)
+        let serial = NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed);
+        SpawnIdentity { id: serial, serial }
     }
 }
 
@@ -2501,7 +2542,7 @@ fn next_spawn_actor_identity() -> u64 {
 )]
 fn build_spawned_actor(
     config: ActorSpawnConfig,
-    actor_id: u64,
+    identity: SpawnIdentity,
     init_state: *mut c_void,
     arena: *mut crate::arena::ActorArena,
 ) -> Box<HewActor> {
@@ -2510,7 +2551,7 @@ fn build_spawned_actor(
 
     Box::new(HewActor {
         sched_link_next: AtomicPtr::new(ptr::null_mut()),
-        id: actor_id,
+        id: identity.id,
         state: config.state,
         state_size: config.state_size,
         dispatch: config.dispatch,
@@ -2561,6 +2602,7 @@ fn build_spawned_actor(
         send_pin_count: AtomicU32::new(0),
         gen_sink: AtomicPtr::new(ptr::null_mut()),
         local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+        spawn_serial: identity.serial,
     })
 }
 
@@ -2710,12 +2752,12 @@ unsafe fn spawn_actor_internal(config: ActorSpawnConfig) -> *mut HewActor {
         unsafe { cleanup_failed_spawn(&config, init_state) };
         return ptr::null_mut();
     }
-    let actor_id = next_spawn_actor_identity();
-    let actor = build_spawned_actor(config, actor_id, init_state, arena);
+    let identity = next_spawn_actor_identity();
+    let actor = build_spawned_actor(config, identity, init_state, arena);
     let raw = Box::into_raw(actor);
     register_actor_state_lock(raw);
     // SAFETY: `raw` comes from `Box::into_raw` and has not yet been tracked.
-    if !unsafe { finalize_spawned_actor(raw, actor_id) } {
+    if !unsafe { finalize_spawned_actor(raw, identity.id) } {
         // SAFETY: registration failed after liveness was rolled back; no caller
         // or scheduler can observe `raw`.
         unsafe { free_actor_resources_with_options(raw, false) };
@@ -2764,12 +2806,12 @@ unsafe fn spawn_actor_internal(config: ActorSpawnConfig) -> *mut HewActor {
         return ptr::null_mut();
     }
 
-    let actor_id = next_spawn_actor_identity();
-    let actor = build_spawned_actor(config, actor_id, init_state, arena);
+    let identity = next_spawn_actor_identity();
+    let actor = build_spawned_actor(config, identity, init_state, arena);
     let raw = Box::into_raw(actor);
     register_actor_state_lock(raw);
     // SAFETY: `raw` comes from `Box::into_raw` and has not yet been tracked.
-    if !unsafe { finalize_spawned_actor(raw, actor_id) } {
+    if !unsafe { finalize_spawned_actor(raw, identity.id) } {
         // SAFETY: registration failed after liveness was rolled back; no caller
         // or scheduler can observe `raw`.
         unsafe { free_actor_resources_with_options(raw, false) };
@@ -5332,6 +5374,51 @@ pub(crate) unsafe fn hew_actor_ask_by_id(
     data: *mut c_void,
     size: usize,
 ) -> *mut c_void {
+    // SAFETY: same contract as this fn; `expected_serial: None` selects the
+    // plain by-ID pin.
+    unsafe { actor_ask_by_id_inner(actor_id, None, msg_type, data, size) }
+}
+
+/// Identity-verified variant of [`hew_actor_ask_by_id`]: pins the resolved
+/// incarnation by `actor_id` AND requires its full [`HewActor::spawn_serial`]
+/// to equal `expected_serial` before enqueuing, so a masked-`id` alias (a fresh
+/// actor reusing a retired incarnation's low-48-bit `id` after 2^48
+/// allocations) fails closed to `AskError::ActorStopped` instead of delivering
+/// to the wrong actor. Used by the blocking owner-scoped role ask, whose phase
+/// one resolves the serial under `children_lock`.
+///
+/// # Safety
+///
+/// Same as [`hew_actor_ask_by_id`].
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) unsafe fn hew_actor_ask_by_identity(
+    actor_id: u64,
+    expected_serial: u64,
+    msg_type: i32,
+    data: *mut c_void,
+    size: usize,
+) -> *mut c_void {
+    // SAFETY: same contract as this fn; the serial gate runs under the pin.
+    unsafe { actor_ask_by_id_inner(actor_id, Some(expected_serial), msg_type, data, size) }
+}
+
+/// Shared body for the by-ID blocking ask. When `expected_serial` is `Some`,
+/// the send phase pins through [`live_actors::with_actor_send_by_identity`] so
+/// an aliased `id` (serial mismatch) refuses closed without enqueuing;
+/// otherwise it uses the plain by-ID pin.
+///
+/// # Safety
+///
+/// `data` must point to at least `size` readable bytes, or be null when `size`
+/// is 0.
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn actor_ask_by_id_inner(
+    actor_id: u64,
+    expected_serial: Option<u64>,
+    msg_type: i32,
+    data: *mut c_void,
+    size: usize,
+) -> *mut c_void {
     let ch = reply_channel::hew_reply_channel_new();
 
     // SAFETY: `ch` is a live reply channel owned by this ask call and the
@@ -5341,14 +5428,21 @@ pub(crate) unsafe fn hew_actor_ask_by_id(
             // Use the liveness-pin protocol (same as hew_actor_send_by_id):
             // under LIVE_ACTORS, validate + pin; release lock; run the send;
             // SendPinGuard decrements on return.  The untrack-first free path
-            // cannot finalize while this pin is held.
-            live_actors::with_actor_send_by_id(actor_id, |actor| {
-                // SAFETY: `actor` is pinned live by `with_actor_send_by_id`;
-                // allocation valid for the closure.  `ch` is a live reply
-                // channel retained above.  Same data/size preconditions as
-                // hew_actor_ask.  Outer `unsafe` block covers this call.
+            // cannot finalize while this pin is held.  With `expected_serial`
+            // set, the pin additionally verifies the incarnation's full serial
+            // so an aliased `id` fails closed here instead of at a later deref.
+            let dispatch = |actor: *mut HewActor| {
+                // SAFETY: `actor` is pinned live by the by-ID pin; allocation
+                // valid for the closure.  `ch` is a live reply channel retained
+                // above.  Same data/size preconditions as hew_actor_ask.
                 actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast())
-            })
+            };
+            match expected_serial {
+                Some(serial) => {
+                    live_actors::with_actor_send_by_identity(actor_id, serial, dispatch)
+                }
+                None => live_actors::with_actor_send_by_id(actor_id, dispatch),
+            }
             .unwrap_or(HewError::ErrActorStopped as i32)
         })
     };
@@ -7663,13 +7757,15 @@ mod tests {
                 send_pin_count: AtomicU32::new(0),
                 gen_sink: AtomicPtr::new(ptr::null_mut()),
                 local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+                spawn_serial: id,
             }));
             (actor, mailbox)
         }
     }
 
     fn make_tracked_wasm_free_test_actor(initial_state: HewActorState) -> *mut HewActor {
-        let actor_id = crate::pid::next_actor_id(NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed));
+        let spawn_serial = NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed);
+        let actor_id = crate::pid::next_actor_id(spawn_serial);
         let actor = Box::into_raw(Box::new(HewActor {
             sched_link_next: AtomicPtr::new(ptr::null_mut()),
             id: actor_id,
@@ -7709,6 +7805,7 @@ mod tests {
             send_pin_count: AtomicU32::new(0),
             gen_sink: AtomicPtr::new(ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial,
         }));
         // SAFETY: actor is fully initialised above with a valid id field.
         assert!(unsafe { live_actors::track_actor(actor) });
@@ -11702,7 +11799,8 @@ mod tests {
         // Capture the address before transferring ownership to the actor struct.
         let arena_addr = arena as usize;
 
-        let actor_id = crate::pid::next_actor_id(NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed));
+        let spawn_serial = NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed);
+        let actor_id = crate::pid::next_actor_id(spawn_serial);
         let actor = Box::into_raw(Box::new(HewActor {
             sched_link_next: AtomicPtr::new(ptr::null_mut()),
             id: actor_id,
@@ -11743,6 +11841,7 @@ mod tests {
             send_pin_count: AtomicU32::new(0),
             gen_sink: AtomicPtr::new(ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial,
         }));
         // SAFETY: actor is fully initialised above with a valid id field.
         assert!(unsafe { live_actors::track_actor(actor) });

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -5080,6 +5080,39 @@ where
     send_result
 }
 
+/// Submit an ask with a caller-owned reply channel against an actor
+/// allocation whose liveness the CALLER pins (the owner-scoped stable-role
+/// path: `hew_supervisor_role_ask_with_channel` resolves the child slot and
+/// submits while holding the supervisor's `children_lock`, so the incarnation
+/// cannot be replaced or reclaimed across the submission).
+///
+/// Channel-reference discipline is identical to
+/// [`hew_actor_ask_with_channel`]: the queued sender-side ref is retained here
+/// and released on a failed submission; the caller-provided creator ref
+/// survives failure so the caller can still free the channel.
+///
+/// # Safety
+///
+/// - `actor` must be a live `HewActor` the caller keeps live for the call.
+/// - `data` and `ch` must satisfy [`hew_actor_ask_with_channel`]'s contract.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) unsafe fn ask_with_channel_pinned(
+    actor: *mut HewActor,
+    msg_type: i32,
+    data: *mut c_void,
+    size: usize,
+    ch: *mut c_void,
+) -> i32 {
+    // SAFETY: the caller pins `actor`; channel/data follow this fn's contract.
+    unsafe {
+        submit_ask_with_reply_channel(
+            ch.cast(),
+            AskReplyChannelFailureCleanup::KeepCreatorRef,
+            |ch| actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast()),
+        )
+    }
+}
+
 // ── Ask (request-response) ──────────────────────────────────────────────
 // Native asks block on threaded reply channels; WASM asks cooperate by
 // driving the single-threaded scheduler in bounded ticks.

--- a/hew-runtime/src/actor_group.rs
+++ b/hew-runtime/src/actor_group.rs
@@ -447,6 +447,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: id,
         }
     }
 
@@ -629,6 +630,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: actor_id,
         });
 
         // Fill the mailbox to capacity (capacity = 1).

--- a/hew-runtime/src/coro_exec.rs
+++ b/hew-runtime/src/coro_exec.rs
@@ -650,6 +650,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: 1,
         })
     }
 
@@ -1087,6 +1088,7 @@ mod forced_ordering_probe {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: 1,
         })
     }
 

--- a/hew-runtime/src/internal/types.rs
+++ b/hew-runtime/src/internal/types.rs
@@ -546,6 +546,56 @@ pub const HEW_TRAP_MODULE_INIT_REGEX_FAILED: i32 = 209;
 /// this constant so a renumber here fails the codegen build closed.
 pub const HEW_TRAP_WIRE_DECODE_FAILED: i32 = 210;
 
+/// Error code recorded when a `join{}` branch's reply resolves without a
+/// value. The join surface awaits every branch and binds a tuple — it has no
+/// per-branch `Result` binding — so a branch failure is fail-closed
+/// (§4.11.2: cancel the remaining branches and propagate). Pre-fix the null
+/// branch emitted a bare `llvm.trap` with no code and no diagnostic; the
+/// failure now traps with THIS code after `hew_join_branch_failed` names the
+/// classified cause (actor stopped, cancelled, handler trapped, or reply
+/// allocation failure — the observable-honesty axiom applied to the join
+/// site).
+///
+/// The single source of truth for the codegen literal: `hew-codegen-rs`
+/// imports this constant so a renumber here fails the codegen build closed.
+pub const HEW_TRAP_JOIN_BRANCH_FAILED: i32 = 211;
+
+// ── Reply-failure classification ─────────────────────────────────────────
+//
+// Discriminants recorded on a reply channel (`HewReplyChannel.fail_reason`,
+// first-write-wins) so a null reply is status-bearing: the waiter can name
+// WHY no value arrived instead of collapsing every failure into "null".
+// Consumed by `hew_reply_channel_failure_kind` / `hew_join_branch_failed`.
+
+/// No failure recorded: a null reply with this kind is a legitimate null.
+pub const HEW_REPLY_FAIL_NONE: i32 = 0;
+/// The target actor stopped (mailbox teardown retired the queued ask before
+/// dispatch — the orphaned-ask class).
+pub const HEW_REPLY_FAIL_ACTOR_STOPPED: i32 = 1;
+/// The waiting side cancelled the ask before a reply arrived.
+pub const HEW_REPLY_FAIL_CANCELLED: i32 = 2;
+/// The handler trapped mid-dispatch; the scheduler's crash fallback resolved
+/// the waiter with an empty reply.
+pub const HEW_REPLY_FAIL_HANDLER_TRAPPED: i32 = 3;
+/// The reply payload could not be materialized (allocation failure on the
+/// deposit or submission path).
+pub const HEW_REPLY_FAIL_PAYLOAD_ALLOC_FAILED: i32 = 4;
+
+/// Name a reply-failure discriminant for diagnostics. Fail-closed: an
+/// unrecognized discriminant names itself rather than borrowing a real
+/// kind's name.
+#[must_use]
+pub const fn reply_fail_kind_name(kind: i32) -> &'static str {
+    match kind {
+        HEW_REPLY_FAIL_NONE => "no failure recorded",
+        HEW_REPLY_FAIL_ACTOR_STOPPED => "actor stopped before replying",
+        HEW_REPLY_FAIL_CANCELLED => "ask cancelled before a reply arrived",
+        HEW_REPLY_FAIL_HANDLER_TRAPPED => "handler trapped during dispatch",
+        HEW_REPLY_FAIL_PAYLOAD_ALLOC_FAILED => "reply payload allocation failed",
+        _ => "(unrecognized reply-failure discriminant)",
+    }
+}
+
 /// Convert a canonical Hew trap discriminator into the WASI process exit code
 /// used when a trap escapes outside actor dispatch.
 ///
@@ -565,7 +615,8 @@ pub fn canonical_trap_wasi_exit_code(code: i32) -> Option<i32> {
         | HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE
         | HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH
         | HEW_TRAP_MODULE_INIT_REGEX_FAILED
-        | HEW_TRAP_WIRE_DECODE_FAILED => Some(code),
+        | HEW_TRAP_WIRE_DECODE_FAILED
+        | HEW_TRAP_JOIN_BRANCH_FAILED => Some(code),
         _ => None,
     }
 }
@@ -612,6 +663,13 @@ pub enum ExitReason {
     /// the decode call site traps on that null. Reachable on malformed or
     /// adversarial input — the fail-closed boundary, not a producer regression.
     WireDecodeFailed,
+    /// Actor crashed because a `join{}` branch's reply resolved without a
+    /// value (error code 211): the branch's target actor stopped, the ask was
+    /// cancelled, the handler trapped, or the reply payload failed to
+    /// materialize. `hew_join_branch_failed` names the classified cause in the
+    /// diagnostic before the trap fires. Reachable whenever a joined actor
+    /// dies mid-join — an environmental failure, not a producer regression.
+    JoinBranchFailed,
     /// Actor crashed with a hardware signal or via `hew_panic`. The raw
     /// signal number is preserved.
     Signal(i32),
@@ -641,6 +699,7 @@ impl ExitReason {
             ExitReason::ExhaustivenessFallthrough => "ExhaustivenessFallthrough",
             ExitReason::ModuleInitRegexFailed => "ModuleInitRegexFailed",
             ExitReason::WireDecodeFailed => "WireDecodeFailed",
+            ExitReason::JoinBranchFailed => "JoinBranchFailed",
             ExitReason::Signal(_) => "Signal",
             ExitReason::Normal => "Normal",
         }
@@ -663,6 +722,7 @@ impl ExitReason {
             HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH => ExitReason::ExhaustivenessFallthrough,
             HEW_TRAP_MODULE_INIT_REGEX_FAILED => ExitReason::ModuleInitRegexFailed,
             HEW_TRAP_WIRE_DECODE_FAILED => ExitReason::WireDecodeFailed,
+            HEW_TRAP_JOIN_BRANCH_FAILED => ExitReason::JoinBranchFailed,
             sig => ExitReason::Signal(sig),
         }
     }
@@ -708,6 +768,7 @@ impl ExitReason {
             | ExitReason::ExhaustivenessFallthrough
             | ExitReason::ModuleInitRegexFailed
             | ExitReason::WireDecodeFailed
+            | ExitReason::JoinBranchFailed
             | ExitReason::Signal(_)
             | ExitReason::Normal => CrashKind::Crashed,
         }
@@ -802,6 +863,7 @@ mod crash_kind_projection_tests {
             HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH,
             HEW_TRAP_MODULE_INIT_REGEX_FAILED,
             HEW_TRAP_WIRE_DECODE_FAILED,
+            HEW_TRAP_JOIN_BRANCH_FAILED,
         ] {
             assert_eq!(
                 CrashKind::tag_from_error_code(code),
@@ -839,6 +901,7 @@ mod crash_kind_projection_tests {
             ExitReason::ExhaustivenessFallthrough,
             ExitReason::ModuleInitRegexFailed,
             ExitReason::WireDecodeFailed,
+            ExitReason::JoinBranchFailed,
             ExitReason::Signal(-1),
             ExitReason::Normal,
         ];

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -432,6 +432,35 @@ pub(crate) fn with_actor_send_by_id<R>(
     Some(f(pin.as_ptr()))
 }
 
+/// Like [`with_actor_send_by_id`], but additionally verifies the pinned actor
+/// IS the resolved incarnation by matching its full [`HewActor::spawn_serial`]
+/// against `expected_serial` before running `f`.
+///
+/// The by-ID pin resolves through `LIVE_ACTORS`, keyed by the packed `id`,
+/// whose serial portion is masked to 48 bits (`pid::hew_pid_make`). After 2^48
+/// allocations a fresh actor can carry a retired incarnation's masked `id`, so
+/// a pin by `id` alone could hand `f` the WRONG actor. The two-phase
+/// owner-scoped role ask copies the resolved incarnation's full serial out
+/// under `children_lock` and passes it here; on serial mismatch this returns
+/// `None` WITHOUT calling `f` — fail closed, treated exactly like a retirement
+/// (the ID aliased a different incarnation). Only used where the caller holds
+/// the resolved incarnation's authoritative serial.
+// live on not(wasm32) — supervisor role ask + by-id ask; dead on wasm32.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub(crate) fn with_actor_send_by_identity<R>(
+    actor_id: u64,
+    expected_serial: u64,
+    f: impl FnOnce(*mut HewActor) -> R,
+) -> Option<R> {
+    let pin = pin_actor_by_id(actor_id)?;
+    // SAFETY: the pin keeps the actor allocation live for this field read; the
+    // free path cannot reclaim it until the pin drops.
+    if unsafe { (*pin.as_ptr()).spawn_serial } != expected_serial {
+        return None;
+    }
+    Some(f(pin.as_ptr()))
+}
+
 /// Resolve the per-actor-TYPE dispatch function pointer for a live actor id,
 /// returned as an opaque `*const c_void` codec-registry key.
 ///
@@ -482,8 +511,13 @@ pub(crate) fn is_actor_live(actor: *mut HewActor) -> bool {
 
 /// Check whether `actor_id` still maps to the expected live actor pointer.
 ///
-/// ABA-proof variant of [`is_actor_live`]: actor ids are never reused, so a
-/// recycled allocation address cannot resurrect liveness for a freed actor.
+/// ABA-proof variant of [`is_actor_live`]: it also matches `expected`, so a
+/// recycled allocation address cannot resurrect liveness for a freed actor
+/// (a different live actor reusing the address maps under a different `id` or
+/// pointer). Note the packed `id` masks the serial to 48 bits, so full
+/// incarnation identity across a 2^48 wrap needs the serial discriminator
+/// (`with_actor_send_by_identity`); this probe's pointer + id match is
+/// sufficient for its liveness-probe callers.
 #[cfg_attr(
     not(test),
     allow(

--- a/hew-runtime/src/link.rs
+++ b/hew-runtime/src/link.rs
@@ -655,6 +655,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(std::ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: id,
         }
     }
 

--- a/hew-runtime/src/monitor.rs
+++ b/hew-runtime/src/monitor.rs
@@ -1623,6 +1623,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(std::ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: id,
         }
     }
 

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -17,7 +17,7 @@ use crate::await_cancel::{hew_await_cancel_status, AwaitCancelStatus, HewAwaitCa
 use crate::util::{CondvarExt, MutexExt};
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
 
@@ -99,6 +99,12 @@ pub struct HewReplyChannel {
     reply_drop_fn: AtomicPtr<c_void>,
     /// Distinguishes allocator failure from a legitimate null reply.
     allocation_failed: AtomicBool,
+    /// Reply-failure classification (`HEW_REPLY_FAIL_*`), first-write-wins.
+    /// Stamped by the failure producers (mailbox orphan retire, the
+    /// scheduler's crash fallback, allocation-failure marks) so a null reply
+    /// is status-bearing: `hew_reply_channel_failure_kind` names WHY no value
+    /// arrived instead of collapsing every failure into "null".
+    fail_reason: AtomicI32,
     /// The waiter-kind discriminator (W6.010). When non-null, the waiter is a
     /// PARKED CONTINUATION belonging to this actor: a reply wakes it via
     /// `scheduler::enqueue_resume(caller_actor, ..)` (the suspend edge owns the
@@ -153,6 +159,7 @@ pub extern "C" fn hew_reply_channel_new() -> *mut HewReplyChannel {
         value_size: 0,
         reply_drop_fn: AtomicPtr::new(ptr::null_mut()),
         allocation_failed: AtomicBool::new(false),
+        fail_reason: AtomicI32::new(crate::internal::types::HEW_REPLY_FAIL_NONE),
         caller_actor: AtomicPtr::new(ptr::null_mut()),
         lock: Mutex::new(()),
         cond: Condvar::new(),
@@ -438,7 +445,112 @@ pub(crate) unsafe fn hew_reply_channel_mark_allocation_failed(ch: *mut HewReplyC
     // SAFETY: caller guarantees `ch` is a live reply channel reference.
     unsafe {
         (*ch).allocation_failed.store(true, Ordering::Release);
+        hew_reply_channel_mark_failed(
+            ch,
+            crate::internal::types::HEW_REPLY_FAIL_PAYLOAD_ALLOC_FAILED,
+        );
     }
+}
+
+/// Stamp a reply-failure classification (`HEW_REPLY_FAIL_*`) on the channel,
+/// first-write-wins: the FIRST failure producer to classify owns the reason,
+/// so a later teardown sweep (e.g. the mailbox orphan retire running after
+/// the scheduler's crash fallback already resolved the waiter) cannot repaint
+/// a specific cause with a generic one.
+pub(crate) unsafe fn hew_reply_channel_mark_failed(ch: *mut HewReplyChannel, reason: i32) {
+    if ch.is_null() || reason == crate::internal::types::HEW_REPLY_FAIL_NONE {
+        return;
+    }
+    // SAFETY: caller guarantees `ch` is a live reply channel reference.
+    unsafe {
+        let _ = (*ch).fail_reason.compare_exchange(
+            crate::internal::types::HEW_REPLY_FAIL_NONE,
+            reason,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+}
+
+/// Publish the scheduler's crash fallback: classify the null reply as a
+/// handler trap, then deposit the empty reply that unblocks the waiter. The
+/// classification is stamped BEFORE the deposit so the woken waiter's
+/// `hew_reply_channel_failure_kind` read observes it (release/acquire through
+/// the ready flag).
+pub(crate) unsafe fn hew_reply_channel_publish_crash_fallback(ch: *mut HewReplyChannel) {
+    if ch.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `ch` is a live reply channel reference.
+    unsafe {
+        hew_reply_channel_mark_failed(ch, crate::internal::types::HEW_REPLY_FAIL_HANDLER_TRAPPED);
+        let _ = hew_reply(ch, ptr::null_mut(), 0);
+    }
+}
+
+/// Classify a resolved-null reply: WHY did the wait produce no value?
+///
+/// Returns a `HEW_REPLY_FAIL_*` discriminant. Precedence: an explicitly
+/// stamped reason (handler trap, allocation failure) wins; otherwise the
+/// channel flags classify — cancelled, then orphaned (actor stopped before
+/// dispatch). `HEW_REPLY_FAIL_NONE` means the null was a legitimate reply
+/// value. Read on the caller-side reference BEFORE it is released.
+///
+/// # Safety
+///
+/// `ch` must be a valid pointer returned by [`hew_reply_channel_new`] that the
+/// caller still holds a reference to.
+#[no_mangle]
+pub unsafe extern "C" fn hew_reply_channel_failure_kind(ch: *mut HewReplyChannel) -> i32 {
+    use crate::internal::types::{
+        HEW_REPLY_FAIL_ACTOR_STOPPED, HEW_REPLY_FAIL_CANCELLED, HEW_REPLY_FAIL_NONE,
+    };
+    if ch.is_null() {
+        return HEW_REPLY_FAIL_NONE;
+    }
+    // SAFETY: caller guarantees `ch` is a live reply channel reference.
+    unsafe {
+        let stamped = (*ch).fail_reason.load(Ordering::Acquire);
+        if stamped != HEW_REPLY_FAIL_NONE {
+            return stamped;
+        }
+        if (*ch).cancelled.load(Ordering::Acquire) {
+            return HEW_REPLY_FAIL_CANCELLED;
+        }
+        if (*ch).orphaned.load(Ordering::Acquire) {
+            return HEW_REPLY_FAIL_ACTOR_STOPPED;
+        }
+        HEW_REPLY_FAIL_NONE
+    }
+}
+
+/// Diagnose a failed `join{}` branch before the caller traps.
+///
+/// Classifies the branch's null reply via [`hew_reply_channel_failure_kind`],
+/// records the diagnostic in the error slot, and prints it to stderr — the
+/// join surface binds a tuple (no per-branch `Result`), so the trap that
+/// follows is fail-closed, and this call is what makes it status-bearing:
+/// actor-stop, cancellation, handler trap, and payload failure are
+/// distinguishable at the join site (the observable-honesty axiom). Returns
+/// the classified kind. The caller (codegen's join null-reply edge) traps
+/// with `HEW_TRAP_JOIN_BRANCH_FAILED` immediately after.
+///
+/// # Safety
+///
+/// `ch` must be a valid pointer returned by [`hew_reply_channel_new`] that the
+/// caller still holds a reference to.
+#[no_mangle]
+pub unsafe extern "C" fn hew_join_branch_failed(
+    ch: *mut HewReplyChannel,
+    branch_index: i32,
+) -> i32 {
+    // SAFETY: caller guarantees `ch` is a live reply channel reference.
+    let kind = unsafe { hew_reply_channel_failure_kind(ch) };
+    let cause = crate::internal::types::reply_fail_kind_name(kind);
+    let diagnostic = format!("hew: join branch {branch_index} failed: {cause}");
+    crate::set_last_error(diagnostic.clone());
+    eprintln!("{diagnostic}");
+    kind
 }
 
 /// Retire an ask sender reference whose mailbox ownership ends before dispatch.
@@ -537,6 +649,10 @@ pub unsafe extern "C" fn hew_reply(
             let buf = alloc_reply_buffer(size);
             if buf.is_null() {
                 (*ch).allocation_failed.store(true, Ordering::Release);
+                hew_reply_channel_mark_failed(
+                    ch,
+                    crate::internal::types::HEW_REPLY_FAIL_PAYLOAD_ALLOC_FAILED,
+                );
                 // The reply buffer could not be allocated; the waiter will
                 // observe a null reply and the allocation-failed flag. The
                 // channel never took `value`, so reclaim its embedded heap via
@@ -2364,6 +2480,101 @@ mod tests {
 
         for h in handles {
             h.join().unwrap();
+        }
+    }
+
+    /// The scheduler's crash fallback stamps `HANDLER_TRAPPED` before the
+    /// null deposit, and the classification is first-write-wins: a later
+    /// generic teardown mark cannot repaint the specific cause.
+    #[test]
+    fn crash_fallback_classifies_handler_trap_first_write_wins() {
+        use crate::internal::types::{
+            HEW_REPLY_FAIL_ACTOR_STOPPED, HEW_REPLY_FAIL_HANDLER_TRAPPED,
+        };
+        // SAFETY: the channel is created, used, and freed within this test.
+        unsafe {
+            let ch = hew_reply_channel_new();
+            hew_reply_channel_retain(ch); // sender's reference
+            hew_reply_channel_publish_crash_fallback(ch);
+            assert!(
+                hew_reply_wait(ch).is_null(),
+                "the crash fallback resolves the waiter with an empty reply"
+            );
+            assert_eq!(
+                hew_reply_channel_failure_kind(ch),
+                HEW_REPLY_FAIL_HANDLER_TRAPPED,
+                "a crash-fallback null must classify as a handler trap"
+            );
+            // A later, more generic classification must not repaint it.
+            hew_reply_channel_mark_failed(ch, HEW_REPLY_FAIL_ACTOR_STOPPED);
+            assert_eq!(
+                hew_reply_channel_failure_kind(ch),
+                HEW_REPLY_FAIL_HANDLER_TRAPPED,
+                "the first failure producer owns the classification"
+            );
+            hew_reply_channel_free(ch);
+        }
+    }
+
+    /// A mailbox-teardown orphan retire (no explicit stamp) classifies as
+    /// actor-stopped; a cancelled channel classifies as cancelled; an
+    /// untouched channel classifies as no-failure (a legitimate null).
+    #[test]
+    fn failure_kind_classifies_orphaned_cancelled_and_clean_channels() {
+        use crate::internal::types::{
+            HEW_REPLY_FAIL_ACTOR_STOPPED, HEW_REPLY_FAIL_CANCELLED, HEW_REPLY_FAIL_NONE,
+        };
+        // SAFETY: each channel is created, used, and freed within this test.
+        unsafe {
+            let clean = hew_reply_channel_new();
+            assert_eq!(hew_reply_channel_failure_kind(clean), HEW_REPLY_FAIL_NONE);
+            hew_reply_channel_free(clean);
+
+            let orphaned = hew_reply_channel_new();
+            hew_reply_channel_retain(orphaned); // mailbox sender's reference
+            hew_reply_channel_retire_orphaned_ask_sender_ref(orphaned);
+            assert!(hew_reply_wait(orphaned).is_null());
+            assert_eq!(
+                hew_reply_channel_failure_kind(orphaned),
+                HEW_REPLY_FAIL_ACTOR_STOPPED,
+                "an orphan retire with no explicit stamp is an actor-stop"
+            );
+            hew_reply_channel_free(orphaned);
+
+            let cancelled = hew_reply_channel_new();
+            hew_reply_channel_cancel(cancelled);
+            assert_eq!(
+                hew_reply_channel_failure_kind(cancelled),
+                HEW_REPLY_FAIL_CANCELLED,
+                "a cancelled channel classifies as cancelled"
+            );
+            hew_reply_channel_free(cancelled);
+        }
+    }
+
+    /// The join-branch diagnostic names the classified cause, records it in
+    /// the error slot, and returns the kind for the trap edge.
+    #[test]
+    fn join_branch_failed_names_the_classified_cause() {
+        use crate::internal::types::HEW_REPLY_FAIL_HANDLER_TRAPPED;
+        // SAFETY: the channel is created, used, and freed within this test.
+        unsafe {
+            let ch = hew_reply_channel_new();
+            hew_reply_channel_retain(ch); // sender's reference
+            hew_reply_channel_publish_crash_fallback(ch);
+            assert!(hew_reply_wait(ch).is_null());
+
+            crate::hew_clear_error();
+            let kind = hew_join_branch_failed(ch, 1);
+            assert_eq!(kind, HEW_REPLY_FAIL_HANDLER_TRAPPED);
+            let err = crate::hew_last_error();
+            assert!(!err.is_null(), "the diagnostic must land in the error slot");
+            let msg = std::ffi::CStr::from_ptr(err).to_string_lossy();
+            assert!(
+                msg.contains("join branch 1") && msg.contains("handler trapped"),
+                "the diagnostic must name the branch and the classified cause; got: {msg}"
+            );
+            hew_reply_channel_free(ch);
         }
     }
 }

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -1430,6 +1430,7 @@ mod tests {
                 send_pin_count: std::sync::atomic::AtomicU32::new(0),
                 gen_sink: AtomicPtr::new(ptr::null_mut()),
                 local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+                spawn_serial: id,
             })
         }
 

--- a/hew-runtime/src/reply_channel_wasm.rs
+++ b/hew-runtime/src/reply_channel_wasm.rs
@@ -393,6 +393,62 @@ pub(crate) unsafe fn reply_is_orphaned(ch: *mut WasmReplyChannel) -> bool {
     unsafe { (*ch).orphaned }
 }
 
+/// Classify a resolved-null reply (wasm parity of the native
+/// `hew_reply_channel_failure_kind`): cancelled, orphaned (actor stopped /
+/// mailbox teardown), or allocation failure. The wasm channel carries no
+/// handler-trap stamp — a trapped wasm dispatch retires through the same
+/// mailbox-teardown orphan path, so it classifies as actor-stopped.
+///
+/// # Safety
+///
+/// `ch` must be a valid pointer returned by [`hew_reply_channel_new`] that the
+/// caller still holds a reference to.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_reply_channel_failure_kind(ch: *mut WasmReplyChannel) -> i32 {
+    use crate::internal::types::{
+        HEW_REPLY_FAIL_ACTOR_STOPPED, HEW_REPLY_FAIL_CANCELLED, HEW_REPLY_FAIL_NONE,
+        HEW_REPLY_FAIL_PAYLOAD_ALLOC_FAILED,
+    };
+    if ch.is_null() {
+        return HEW_REPLY_FAIL_NONE;
+    }
+    // SAFETY: caller guarantees `ch` is a live reply channel reference.
+    unsafe {
+        if (*ch).allocation_failed {
+            return HEW_REPLY_FAIL_PAYLOAD_ALLOC_FAILED;
+        }
+        if (*ch).cancelled {
+            return HEW_REPLY_FAIL_CANCELLED;
+        }
+        if (*ch).orphaned {
+            return HEW_REPLY_FAIL_ACTOR_STOPPED;
+        }
+        HEW_REPLY_FAIL_NONE
+    }
+}
+
+/// Diagnose a failed `join{}` branch before the caller traps (wasm parity of
+/// the native `hew_join_branch_failed`): classify, record the diagnostic, and
+/// print it, returning the classified kind.
+///
+/// # Safety
+///
+/// `ch` must be a valid pointer returned by [`hew_reply_channel_new`] that the
+/// caller still holds a reference to.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_join_branch_failed(
+    ch: *mut WasmReplyChannel,
+    branch_index: i32,
+) -> i32 {
+    // SAFETY: caller guarantees `ch` is a live reply channel reference.
+    let kind = unsafe { hew_reply_channel_failure_kind(ch) };
+    let cause = crate::internal::types::reply_fail_kind_name(kind);
+    let diagnostic = format!("hew: join branch {branch_index} failed: {cause}");
+    crate::set_last_error(diagnostic.clone());
+    eprintln!("{diagnostic}");
+    kind
+}
+
 /// Release a WASM reply channel reference and free it when the count reaches zero.
 ///
 /// # Safety

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -3351,6 +3351,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(std::ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: 1,
         }
     }
 
@@ -4385,6 +4386,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(std::ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: 0,
         };
         let actor_ptr: *mut HewActor = (&raw const actor).cast_mut();
 
@@ -5878,6 +5880,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(std::ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: 0,
         };
         let actor_ptr: *mut HewActor = (&raw const actor).cast_mut();
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -1673,8 +1673,10 @@ unsafe fn resume_crash_recovery(actor: *mut HewActor, resume_context: *mut HewEx
     // invariant is observable as soon as the actor is terminal.
     if !reply_consumed && !crash_reply.is_null() {
         // SAFETY: `crash_reply` is a valid `HewReplyChannel` pointer.
+        // Classified as a handler trap so the waiter's null reply is
+        // status-bearing, never a bare null.
         unsafe {
-            let _ = crate::reply_channel::hew_reply(crash_reply.cast(), std::ptr::null_mut(), 0);
+            crate::reply_channel::hew_reply_channel_publish_crash_fallback(crash_reply.cast());
         }
     }
 
@@ -2198,11 +2200,12 @@ fn activate_actor(actor: *mut HewActor) {
 
                         if !reply_consumed && !crash_reply.is_null() {
                             // SAFETY: crash_reply is a valid HewReplyChannel pointer.
+                            // Classified as a handler trap (the lock-refused
+                            // dispatch trapped the actor) so the waiter's null
+                            // reply is status-bearing.
                             unsafe {
-                                let _ = crate::reply_channel::hew_reply(
+                                crate::reply_channel::hew_reply_channel_publish_crash_fallback(
                                     crash_reply.cast(),
-                                    std::ptr::null_mut(),
-                                    0,
                                 );
                             }
                         }
@@ -2512,11 +2515,11 @@ fn activate_actor(actor: *mut HewActor) {
                     // as state becomes `Crashed`.
                     if !reply_consumed && !crash_reply.is_null() {
                         // SAFETY: crash_reply is a valid HewReplyChannel pointer.
+                        // Classified as a handler trap so the waiter's null
+                        // reply is status-bearing, never a bare null.
                         unsafe {
-                            let _ = crate::reply_channel::hew_reply(
+                            crate::reply_channel::hew_reply_channel_publish_crash_fallback(
                                 crash_reply.cast(),
-                                std::ptr::null_mut(),
-                                0,
                             );
                         }
                     }

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -143,6 +143,11 @@ pub struct HewActor {
     pub gen_sink: AtomicPtr<c_void>,
     // Stable target-word local-handle identity; mirrors the canonical tail.
     pub local_pid_id: crate::lifetime::local_handles::HewLocalPidId,
+    // Full un-masked spawn serial; mirrors the canonical tail so the layout
+    // parity this module asserts holds. Never read on WASM (the owner-scoped
+    // role ask that consumes it is native-only), but present for size/offset
+    // parity with the native `HewActor`.
+    pub spawn_serial: u64,
 }
 
 // SAFETY: Single-threaded on WASM; on native (tests), the struct is only
@@ -208,6 +213,7 @@ const _: () = {
     assert!(offset_of!(W, send_pin_count) == offset_of!(N, send_pin_count));
     assert!(offset_of!(W, gen_sink) == offset_of!(N, gen_sink));
     assert!(offset_of!(W, local_pid_id) == offset_of!(N, local_pid_id));
+    assert!(offset_of!(W, spawn_serial) == offset_of!(N, spawn_serial));
 };
 
 // ── HewMsgNode layout (strict prefix of native mailbox.rs) ──────────────
@@ -2264,6 +2270,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: 1,
         }
     }
 
@@ -5413,6 +5420,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: 99,
         }));
 
         // ── 3. Enqueue one message and run dispatch ───────────────────────────

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -4375,6 +4375,7 @@ mod tests {
 
             let before = crate::reply_channel::active_channel_count();
             let ch = crate::reply_channel::hew_reply_channel_new();
+            crate::hew_clear_error();
             let status = hew_supervisor_role_ask_with_channel(
                 supervisor_token,
                 0,
@@ -4387,6 +4388,13 @@ mod tests {
                 status,
                 crate::internal::types::HewError::ErrActorStopped as i32,
                 "a mid-restart slot must refuse, never guess a future incarnation"
+            );
+            let err = crate::hew_last_error();
+            assert!(!err.is_null(), "the refusal must record a diagnostic");
+            let msg = std::ffi::CStr::from_ptr(err).to_string_lossy();
+            assert!(
+                msg.contains("Restarting"),
+                "the refusal must carry the classified slot state (tag semantics); got: {msg}"
             );
             assert_eq!(
                 crate::reply_channel::active_channel_count(),
@@ -5889,8 +5897,16 @@ fn child_get_from_supervisor(
     }
 
     // Slot is null — classify why using the per-child spec.
-    // child_specs is parallel to children and has the same length after
-    // hew_supervisor_start, so the index is always valid here.
+    classify_null_child_slot(s, i)
+}
+
+/// Classify a null child slot from its per-child spec (the FSM in §2.2):
+/// circuit-breaker cooldown, backoff timer pending, or an active restart.
+/// Shared by the classified lookups and the owner-scoped role ask so both
+/// surfaces name the same slot state. Caller holds `children_lock`;
+/// `child_specs` is parallel to `children` after `hew_supervisor_start`, so
+/// the index is always valid here.
+fn classify_null_child_slot(s: &HewSupervisor, i: usize) -> ChildLookupResult {
     let spec = &s.child_specs[i];
 
     // CB OPEN = circuit breaker is suppressing restarts during cooldown.
@@ -5964,6 +5980,37 @@ fn fire_role_ask_submit_gap_hook() {
     }
 }
 
+/// Name a [`ChildSlotReason`] discriminant for the role-ask refusal
+/// diagnostic. Fail-closed: an out-of-range discriminant (ABI drift) names
+/// itself as such rather than borrowing a real reason's name.
+#[cfg(not(target_arch = "wasm32"))]
+const fn child_slot_reason_name(reason: u8) -> &'static str {
+    match reason {
+        r if r == ChildSlotReason::Ok as u8 => "Ok",
+        r if r == ChildSlotReason::Restarting as u8 => "Restarting",
+        r if r == ChildSlotReason::BackoffDelay as u8 => "BackoffDelay",
+        r if r == ChildSlotReason::CircuitOpen as u8 => "CircuitOpen",
+        r if r == ChildSlotReason::BudgetExhausted as u8 => "BudgetExhausted",
+        r if r == ChildSlotReason::SupervisorShutdown as u8 => "SupervisorShutdown",
+        r if r == ChildSlotReason::UnknownSlot as u8 => "UnknownSlot",
+        _ => "(unrecognized ChildSlotReason discriminant)",
+    }
+}
+
+/// Refuse an owner-scoped role ask closed, recording the classified slot
+/// state so a Dead slot is never conflated with a Transient one at the
+/// diagnostic surface (the tag semantics of the classified lookup ABIs —
+/// contrast the tag-unchecked handle extraction the retired token path
+/// performed, which collapsed every non-Live state into a token-0 send).
+#[cfg(not(target_arch = "wasm32"))]
+fn role_ask_refuse(reason: u8, key: u32) -> i32 {
+    set_last_error(format!(
+        "stable-role ask refused: child slot {key} is {}",
+        child_slot_reason_name(reason)
+    ));
+    crate::internal::types::HewError::ErrActorStopped as i32
+}
+
 /// Submit an ask through a fungible `(stable supervisor token, static slot)`
 /// role as ONE owner-scoped operation: pin the supervisor identity, resolve
 /// the slot, and enqueue into the CURRENT incarnation's mailbox — all inside
@@ -6008,10 +6055,8 @@ pub unsafe extern "C" fn hew_supervisor_role_ask_with_channel(
     size: usize,
     ch: *mut c_void,
 ) -> i32 {
-    use crate::internal::types::HewError;
-
     let Some(pin) = crate::lifetime::local_handles::pin_current_supervisor(token) else {
-        return HewError::ErrActorStopped as i32;
+        return role_ask_refuse(ChildSlotReason::SupervisorShutdown as u8, key);
     };
     let sup = pin.supervisor();
     // SAFETY: the stable-identity pin prevents supervisor reclamation for the
@@ -6020,11 +6065,11 @@ pub unsafe extern "C" fn hew_supervisor_role_ask_with_channel(
 
     // Fast-path shutdown check (atomics, no lock).
     if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
-        return HewError::ErrActorStopped as i32;
+        return role_ask_refuse(ChildSlotReason::SupervisorShutdown as u8, key);
     }
     let i = key as usize;
     if i >= s.child_count {
-        return HewError::ErrActorStopped as i32;
+        return role_ask_refuse(ChildSlotReason::UnknownSlot as u8, key);
     }
 
     let _guard = s.children_lock.lock_or_recover();
@@ -6032,15 +6077,17 @@ pub unsafe extern "C" fn hew_supervisor_role_ask_with_channel(
     // Re-check shutdown under the lock (the supervisor can be cancelled
     // between the atomic check above and acquiring the lock).
     if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
-        return HewError::ErrActorStopped as i32;
+        return role_ask_refuse(ChildSlotReason::SupervisorShutdown as u8, key);
     }
 
     let child = s.children.get(i).copied().unwrap_or(ptr::null_mut());
     if child.is_null() {
         // Mid-restart (Transient) or permanently dead: refuse rather than
-        // guess a future incarnation. Nothing was enqueued; the caller's
-        // fail-closed surface names the refusal.
-        return HewError::ErrActorStopped as i32;
+        // guess a future incarnation. Nothing was enqueued; the refusal
+        // carries the classified slot state (the tag semantics the lookup
+        // ABIs expose) so a Dead slot is never conflated with a Transient
+        // one at the diagnostic surface.
+        return role_ask_refuse(classify_null_child_slot(s, i).reason, key);
     }
 
     #[cfg(test)]

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -4413,6 +4413,235 @@ mod tests {
         }
     }
 
+    /// Fixture for the lock-order test: a supervised child with a BOUNDED
+    /// Block-policy mailbox (capacity 1), so a second enqueue WAITS for space.
+    unsafe fn make_supervisor_with_block_mailbox_child(
+    ) -> (*mut HewSupervisor, *mut HewActor, *mut HewActor) {
+        // SAFETY: this helper creates a fresh supervisor tree for the test and
+        // returns the owned raw pointers without publishing them elsewhere.
+        unsafe {
+            let sup = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 1, 1);
+            assert!(!sup.is_null());
+
+            let spec = HewChildSpec {
+                name: ptr::null(),
+                init_state: ptr::null_mut(),
+                init_state_size: 0,
+                dispatch: Some(noop_child_dispatch),
+                restart_policy: RESTART_TEMPORARY,
+                mailbox_capacity: 1,
+                overflow: 0, // HewOverflowPolicy::Block
+                coalesce_key_fn: None,
+                coalesce_fallback: 0,
+                message_drop_fn: None,
+                arena_cap_bytes: 0,
+                cycle_capable: 0,
+                on_crash: None,
+                lifecycle_fn: None,
+                init_fn: None,
+                config: ptr::null_mut(),
+                config_size: 0,
+            };
+            assert_eq!(hew_supervisor_add_child_spec(sup, &raw const spec), 0);
+            assert_eq!(hew_supervisor_start(sup), 0);
+
+            let child = (&(*sup).children)[0];
+            let self_actor = (*sup).self_actor;
+            (sup, child, self_actor)
+        }
+    }
+
+    /// LOCK-ORDER INVARIANT: the role-ask enqueue — including a Block-policy
+    /// capacity WAIT — never runs under `children_lock`. Holding the lock
+    /// across the wait closes a cycle: the submitter waits for the child to
+    /// drain its full mailbox, while the child's own handler can be blocked
+    /// acquiring `children_lock` for a stable-role ask of its own. The pinned
+    /// hook proves the lock is FREE at submission time, and a full Block
+    /// mailbox is then drained by the test to complete the waiting enqueue.
+    #[test]
+    fn role_ask_block_mailbox_wait_runs_outside_children_lock() {
+        let _rt = crate::runtime_test_guard();
+        // SAFETY: the test owns the supervisor tree; thread coordination uses
+        // barriers and joins only (no sleeps).
+        unsafe {
+            let (sup, child, _self_actor) = make_supervisor_with_block_mailbox_child();
+            let supervisor_token = (*sup).local_pid_id;
+            let sup_addr = sup as usize;
+
+            // Fill the capacity-1 mailbox so the role ask's enqueue must wait.
+            actor::hew_actor_send(child, 1, ptr::null_mut(), 0);
+            assert!(
+                mailbox::hew_mailbox_len((*child).mailbox.cast()) >= 1,
+                "the pre-fill send must occupy the capacity-1 mailbox"
+            );
+
+            let entered_submit = Arc::new(std::sync::Barrier::new(2));
+            let entered_hook = Arc::clone(&entered_submit);
+            let lock_free_at_submit = Arc::new(AtomicBool::new(false));
+            let lock_free_hook = Arc::clone(&lock_free_at_submit);
+            *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() = Some(Arc::new(move || {
+                // The resolve phase released children_lock before this point;
+                // probe from a joined helper thread (try_lock from the owning
+                // thread is not the invariant under test).
+                let probe = std::thread::spawn(move || {
+                    let sup = sup_addr as *mut HewSupervisor;
+                    // The supervisor outlives the ask that fires this hook;
+                    // the probe only touches the lock word.
+                    (*sup).children_lock.try_lock().is_ok()
+                });
+                lock_free_hook.store(probe.join().expect("lock probe"), Ordering::Release);
+                entered_hook.wait();
+            }));
+
+            let ch = crate::reply_channel::hew_reply_channel_new();
+            let ch_addr = ch as usize;
+            let submitter = std::thread::spawn(move || {
+                // The channel outlives the submission (the main thread joins
+                // before freeing); the token is a Copy scalar identity.
+                hew_supervisor_role_ask_with_channel(
+                    supervisor_token,
+                    0,
+                    42,
+                    ptr::null_mut(),
+                    0,
+                    ch_addr as *mut c_void,
+                )
+            });
+
+            // The submitter is at (or past) the pinned-submit seam; the slot
+            // lock must be free even though its enqueue may be waiting for
+            // mailbox capacity.
+            entered_submit.wait();
+            *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() = None;
+            assert!(
+                lock_free_at_submit.load(Ordering::Acquire),
+                "children_lock must be FREE during the role-ask submission \
+                 (the Block-policy capacity wait must not run under the slot lock)"
+            );
+            assert!(
+                (*sup).children_lock.try_lock().is_ok(),
+                "slot writers must not be excluded while the enqueue waits"
+            );
+
+            // Drain the pre-fill message: capacity frees and the waiting
+            // enqueue completes.
+            let mb = (*child).mailbox.cast::<mailbox::HewMailbox>();
+            let prefill = mailbox::hew_mailbox_try_recv(mb);
+            assert!(!prefill.is_null());
+            mailbox::hew_msg_node_free(prefill);
+
+            let status = submitter.join().expect("submitter thread");
+            assert_eq!(
+                status,
+                crate::internal::types::HewError::Ok as i32,
+                "the waiting enqueue must complete once capacity frees"
+            );
+
+            // Drain the ask node (retires its queued sender ref), resolve the
+            // creator-side wait, and tear down.
+            let ask_node = mailbox::hew_mailbox_try_recv(mb);
+            assert!(!ask_node.is_null());
+            assert_eq!((*ask_node).msg_type, 42);
+            mailbox::hew_msg_node_free(ask_node);
+            assert!(crate::reply_channel::hew_reply_wait(ch).is_null());
+            crate::reply_channel::hew_reply_channel_free(ch);
+
+            // Worker-less runtime: the enqueue left the child Runnable with no
+            // worker to drain it; restore Idle so the supervisor stop's
+            // quiescence wait can finalize it.
+            (*child)
+                .actor_state
+                .store(HewActorState::Idle as i32, Ordering::Release);
+            hew_supervisor_stop(sup);
+        }
+    }
+
+    /// A retirement landing between the classified resolve and the ID-pinned
+    /// submission fails CLOSED with a named refusal — the interleaving that
+    /// was a use-after-free in the raw lookup-then-ask shape (an unpinned
+    /// child pointer dereferenced after the incarnation was freed). Covers
+    /// both role-ask entry points; the channel twin also preserves the
+    /// caller's creator reference.
+    #[test]
+    fn role_ask_retirement_between_resolve_and_submit_fails_closed() {
+        let _rt = crate::runtime_test_guard();
+        // SAFETY: the test owns the tree; the hook retires + frees the
+        // resolved incarnation at the exact resolve→submit seam.
+        unsafe {
+            let (sup, _child, _self_actor) = make_supervisor_with_child();
+            let supervisor_token = (*sup).local_pid_id;
+            let sup_addr = sup as usize;
+
+            // The hook retires the CURRENT incarnation: pull it from the
+            // slot, force the terminal state the drain would have produced
+            // (worker-less runtime), and free it — the exact former-UAF
+            // interleaving, now required to fail closed.
+            let retire_hook: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+                let sup = sup_addr as *mut HewSupervisor;
+                // The supervisor outlives the ask firing this hook; the
+                // retired incarnation is exclusively owned once pulled from
+                // the slot.
+                let retired = take_child_slot(&mut *sup, 0);
+                assert!(!retired.is_null(), "hook must find the live incarnation");
+                (*retired)
+                    .actor_state
+                    .store(HewActorState::Stopped as i32, Ordering::Release);
+                assert_eq!(actor::hew_actor_free(retired), 0);
+            });
+
+            // Channel twin.
+            *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() = Some(Arc::clone(&retire_hook));
+            let before = crate::reply_channel::active_channel_count();
+            let ch = crate::reply_channel::hew_reply_channel_new();
+            crate::hew_clear_error();
+            let status = hew_supervisor_role_ask_with_channel(
+                supervisor_token,
+                0,
+                7,
+                ptr::null_mut(),
+                0,
+                ch.cast(),
+            );
+            *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() = None;
+            assert_eq!(
+                status,
+                crate::internal::types::HewError::ErrActorStopped as i32
+            );
+            let err = crate::hew_last_error();
+            assert!(!err.is_null());
+            let msg = std::ffi::CStr::from_ptr(err).to_string_lossy();
+            assert!(
+                msg.contains("retired during submission"),
+                "the refusal must name the retirement interleaving; got: {msg}"
+            );
+            assert_eq!(
+                crate::reply_channel::active_channel_count(),
+                before + 1,
+                "the refused ask must preserve the caller-owned channel reference"
+            );
+            crate::reply_channel::hew_reply_channel_free(ch);
+
+            // Blocking twin: re-arm the slot with a fresh incarnation, retire
+            // it at the same seam, and require the null + AskError refusal.
+            let respawned = restart_child_from_spec(&mut *sup, 0);
+            assert!(!respawned.is_null());
+            *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() = Some(retire_hook);
+            let reply = hew_supervisor_role_ask(supervisor_token, 0, 7, ptr::null_mut(), 0);
+            *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() = None;
+            assert!(
+                reply.is_null(),
+                "the blocking role ask must refuse, never dereference the retired incarnation"
+            );
+            assert_eq!(
+                actor::hew_actor_ask_take_last_error(),
+                crate::internal::types::AskError::ActorStopped as i32,
+                "the blocking refusal must bind AskError::ActorStopped"
+            );
+
+            hew_supervisor_stop(sup);
+        }
+    }
+
     /// An out-of-range key returns Dead(UnknownSlot).
     #[test]
     fn child_get_unknown_key_returns_dead_unknown_slot() {
@@ -5968,18 +6197,36 @@ pub extern "C" fn hew_local_pid_supervisor_child_get(
     ChildLookupResult::dead(ChildSlotReason::SupervisorShutdown)
 }
 
-/// Test-only hook fired inside [`hew_supervisor_role_ask_with_channel`] in the
-/// gap between resolving the current child slot and submitting the ask — with
+/// Test-only hook fired inside [`role_resolve_current_child_id`] in the gap
+/// between resolving the current child slot and returning its ID — with
 /// `children_lock` HELD. The forced-interleaving regression installs a closure
 /// that probes the lock from another thread at this exact point, proving the
 /// restart machinery's slot writers (`store_child_slot` / `take_child_slot`)
-/// cannot interpose between resolution and submission.
+/// cannot interpose inside the classified-resolution critical section.
 #[cfg(all(test, not(target_arch = "wasm32")))]
 static ROLE_ASK_SUBMIT_GAP_HOOK: Mutex<Option<Arc<dyn Fn() + Send + Sync>>> = Mutex::new(None);
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 fn fire_role_ask_submit_gap_hook() {
     let hook = ROLE_ASK_SUBMIT_GAP_HOOK.lock_or_recover().clone();
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+/// Test-only hook fired by the role-ask entry points AFTER `children_lock` is
+/// released and BEFORE the ID-pinned submission. Two regressions install it:
+/// the lock-order test probes `children_lock` from a helper thread and asserts
+/// it is FREE (the enqueue — including a Block-policy capacity wait — never
+/// runs under the slot lock), and the retirement-interleaving test frees the
+/// resolved incarnation here and asserts the submission fails closed instead
+/// of touching reclaimed storage.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+static ROLE_ASK_PINNED_SUBMIT_HOOK: Mutex<Option<Arc<dyn Fn() + Send + Sync>>> = Mutex::new(None);
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn fire_role_ask_pinned_submit_hook() {
+    let hook = ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover().clone();
     if let Some(hook) = hook {
         hook();
     }
@@ -6016,35 +6263,118 @@ fn role_ask_refuse(reason: u8, key: u32) -> i32 {
     crate::internal::types::HewError::ErrActorStopped as i32
 }
 
-/// Submit an ask through a fungible `(stable supervisor token, static slot)`
-/// role as ONE owner-scoped operation: pin the supervisor identity, resolve
-/// the slot, and enqueue into the CURRENT incarnation's mailbox — all inside
-/// one `children_lock` critical section.
+/// Resolve the CURRENT incarnation of a stable-role slot to its actor ID
+/// under ONE `children_lock` critical section, with every refusal classified
+/// by slot state (see [`role_ask_refuse`]).
 ///
-/// This replaces the lookup-token-then-send shape
-/// (`hew_local_pid_supervisor_child_get` followed by
-/// `hew_local_pid_ask_with_channel`), whose unlocked gap let the restart
-/// machinery advance the slot between resolution and submission: the resolved
-/// token either went stale (send refused after the caller observed a live
-/// slot) or — worse — the ask was accepted by an incarnation the supervisor
-/// was about to retire, orphaning the reply with no diagnostic at the join
-/// site. The doctrinal sibling is the connection-manager
-/// refresh-identity-under-owner-lock fix: identity resolution and use happen
-/// under the owner's lock, never across it.
+/// This is phase one of the owner-scoped role ask. The lock covers resolution
+/// and classification ONLY — never the mailbox submission. LOCK-ORDER
+/// INVARIANT: `children_lock` must not be held across a mailbox enqueue,
+/// because a Block-policy mailbox at capacity WAITS for space
+/// (`mailbox.rs` `HewOverflowPolicy::Block`), and the child draining that
+/// mailbox may itself issue a stable-role ask that acquires `children_lock` —
+/// holding the lock across the wait closes a cycle (submitter waits for the
+/// drainer, drainer waits for the lock). Phase two therefore submits against
+/// the returned ID via the `LIVE_ACTORS` send pin (`with_actor_send_by_id`),
+/// the same liveness protocol every by-ID send uses: the pin guarantees the
+/// allocation outlives the submission, and a retirement that lands between
+/// the phases fails CLOSED (the ID is never reused) instead of touching
+/// reclaimed storage.
+#[cfg(not(target_arch = "wasm32"))]
+fn role_resolve_current_child_id(
+    token: crate::lifetime::local_handles::HewLocalPidId,
+    key: u32,
+) -> Result<u64, i32> {
+    let Some(pin) = crate::lifetime::local_handles::pin_current_supervisor(token) else {
+        return Err(role_ask_refuse(
+            ChildSlotReason::SupervisorShutdown as u8,
+            key,
+        ));
+    };
+    let sup = pin.supervisor();
+    // SAFETY: the stable-identity pin prevents supervisor reclamation for the
+    // complete classified lookup, including the children-lock section.
+    let s = unsafe { &*sup };
+
+    // Fast-path shutdown check (atomics, no lock).
+    if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
+        return Err(role_ask_refuse(
+            ChildSlotReason::SupervisorShutdown as u8,
+            key,
+        ));
+    }
+    let i = key as usize;
+    if i >= s.child_count {
+        return Err(role_ask_refuse(ChildSlotReason::UnknownSlot as u8, key));
+    }
+
+    let _guard = s.children_lock.lock_or_recover();
+
+    // Re-check shutdown under the lock (the supervisor can be cancelled
+    // between the atomic check above and acquiring the lock).
+    if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
+        return Err(role_ask_refuse(
+            ChildSlotReason::SupervisorShutdown as u8,
+            key,
+        ));
+    }
+
+    let child = s.children.get(i).copied().unwrap_or(ptr::null_mut());
+    if child.is_null() {
+        // Mid-restart (Transient) or permanently dead: refuse rather than
+        // guess a future incarnation. Nothing was enqueued; the refusal
+        // carries the classified slot state (the tag semantics the lookup
+        // ABIs expose) so a Dead slot is never conflated with a Transient
+        // one at the diagnostic surface.
+        return Err(role_ask_refuse(classify_null_child_slot(s, i).reason, key));
+    }
+
+    #[cfg(test)]
+    fire_role_ask_submit_gap_hook();
+
+    // SAFETY: `child` is the slot's live incarnation and cannot be replaced or
+    // reclaimed while `children_lock` is held; only the scalar ID is copied
+    // out — no pointer crosses the lock boundary.
+    Ok(unsafe { (*child).id })
+}
+
+/// The classified refusal for a resolution that succeeded but whose
+/// incarnation was retired before the ID-pinned submission could begin
+/// (`with_actor_send_by_id` found the ID no longer live). Fail-closed and
+/// named: the ask enqueued nothing.
+#[cfg(not(target_arch = "wasm32"))]
+fn role_ask_refuse_retired(key: u32) -> i32 {
+    set_last_error(format!(
+        "stable-role ask refused: child slot {key} incarnation retired during submission"
+    ));
+    crate::internal::types::HewError::ErrActorStopped as i32
+}
+
+/// Submit an ask with a caller-owned reply channel through a fungible
+/// `(stable supervisor token, static slot)` role.
 ///
-/// Locking: `children_lock` is the slot writers' exclusion
-/// (`store_child_slot` / `take_child_slot`), and a non-null slot's allocation
-/// is owned by the supervisor and cannot be reclaimed while the lock is held —
-/// the same liveness contract `child_get_from_supervisor` documents for the
-/// token copy. The mailbox submission inside the critical section takes only
-/// the mailbox and scheduler queue locks, which are never held while a thread
-/// waits on `children_lock` (slot writers acquire it with no locks held).
+/// Two-phase owner-scoped submission, replacing the racy
+/// lookup-token-then-send shape (`hew_local_pid_supervisor_child_get` followed
+/// by `hew_local_pid_ask_with_channel`), whose unlocked gap let the restart
+/// machinery advance the slot between resolution and submission — the
+/// resolved identity went stale, or the ask was accepted by an incarnation
+/// the supervisor was about to retire, orphaning the reply with no diagnostic
+/// at the join site:
 ///
-/// Returns `HewError::Ok` on submission. A dead, unknown, or mid-restart slot
-/// fails closed with `HewError::ErrActorStopped` and enqueues nothing —
-/// matching the refusal the retired-token path produced. The channel-reference
-/// discipline matches [`crate::actor::hew_actor_ask_with_channel`]: the
-/// caller's creator ref survives failure.
+/// 1. [`role_resolve_current_child_id`]: resolve + classify under
+///    `children_lock`; only the incarnation's scalar ID leaves the lock.
+/// 2. ID-pinned submission via `with_actor_send_by_id`: the `LIVE_ACTORS` pin
+///    keeps the allocation live for the complete enqueue (including a
+///    Block-policy capacity wait, which deliberately runs OUTSIDE
+///    `children_lock` — see the lock-order invariant on phase one). A
+///    retirement interposing between the phases fails closed with a named
+///    refusal; an ask accepted and then retired before dispatch resolves
+///    through the classified-null machinery (`hew_reply_channel_failure_kind`).
+///
+/// Returns `HewError::Ok` on submission; every refusal is classified in the
+/// error slot. The channel-reference discipline matches
+/// [`crate::actor::hew_actor_ask_with_channel`]: the caller's creator ref
+/// survives failure.
 ///
 /// # Safety
 ///
@@ -6060,48 +6390,59 @@ pub unsafe extern "C" fn hew_supervisor_role_ask_with_channel(
     size: usize,
     ch: *mut c_void,
 ) -> i32 {
-    let Some(pin) = crate::lifetime::local_handles::pin_current_supervisor(token) else {
-        return role_ask_refuse(ChildSlotReason::SupervisorShutdown as u8, key);
+    let child_id = match role_resolve_current_child_id(token, key) {
+        Ok(id) => id,
+        Err(code) => return code,
     };
-    let sup = pin.supervisor();
-    // SAFETY: the stable-identity pin prevents supervisor reclamation for the
-    // complete lookup + submission, including the children-lock section.
-    let s = unsafe { &*sup };
-
-    // Fast-path shutdown check (atomics, no lock).
-    if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
-        return role_ask_refuse(ChildSlotReason::SupervisorShutdown as u8, key);
-    }
-    let i = key as usize;
-    if i >= s.child_count {
-        return role_ask_refuse(ChildSlotReason::UnknownSlot as u8, key);
-    }
-
-    let _guard = s.children_lock.lock_or_recover();
-
-    // Re-check shutdown under the lock (the supervisor can be cancelled
-    // between the atomic check above and acquiring the lock).
-    if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
-        return role_ask_refuse(ChildSlotReason::SupervisorShutdown as u8, key);
-    }
-
-    let child = s.children.get(i).copied().unwrap_or(ptr::null_mut());
-    if child.is_null() {
-        // Mid-restart (Transient) or permanently dead: refuse rather than
-        // guess a future incarnation. Nothing was enqueued; the refusal
-        // carries the classified slot state (the tag semantics the lookup
-        // ABIs expose) so a Dead slot is never conflated with a Transient
-        // one at the diagnostic surface.
-        return role_ask_refuse(classify_null_child_slot(s, i).reason, key);
-    }
-
     #[cfg(test)]
-    fire_role_ask_submit_gap_hook();
+    fire_role_ask_pinned_submit_hook();
+    crate::lifetime::live_actors::with_actor_send_by_id(child_id, |actor| {
+        // SAFETY: the send pin keeps `actor` live for the submission;
+        // `data`/`ch` follow this fn's contract.
+        unsafe { crate::actor::ask_with_channel_pinned(actor, msg_type, data, size, ch) }
+    })
+    .unwrap_or_else(|| role_ask_refuse_retired(key))
+}
 
-    // SAFETY: `child` is the slot's live incarnation and cannot be replaced or
-    // reclaimed while `children_lock` is held; `data`/`ch` follow this fn's
-    // contract.
-    unsafe { crate::actor::ask_with_channel_pinned(child, msg_type, data, size, ch) }
+/// Blocking twin of [`hew_supervisor_role_ask_with_channel`] for callers with
+/// no parkable continuation (`main` / free functions): resolve the role under
+/// `children_lock` (classified refusals), then run the ID-pinned blocking ask
+/// (`hew_actor_ask_by_id` — the same pin + reply-wait protocol every by-ID ask
+/// uses).
+///
+/// This replaces the raw lookup-then-ask pair the blocking fungible path
+/// emitted (`hew_supervisor_child_get` returning an UNPINNED `*mut HewActor`,
+/// then `hew_actor_ask` dereferencing it), whose gap let a restart free the
+/// incarnation between the lookup and the deref — a use-after-free, not a
+/// refusal. No pointer crosses the resolve/submit boundary here; a retirement
+/// interposing between the phases fails closed to a null reply with
+/// `AskError::ActorStopped`.
+///
+/// Return contract matches [`crate::actor::hew_actor_ask`]: the reply buffer
+/// (caller frees) or null with the ask error recorded for
+/// `hew_actor_ask_take_last_error`.
+///
+/// # Safety
+///
+/// `data` must point to at least `size` readable bytes, or be null when
+/// `size` is 0.
+#[cfg(not(target_arch = "wasm32"))]
+#[no_mangle]
+pub unsafe extern "C" fn hew_supervisor_role_ask(
+    token: crate::lifetime::local_handles::HewLocalPidId,
+    key: u32,
+    msg_type: i32,
+    data: *mut c_void,
+    size: usize,
+) -> *mut c_void {
+    let Ok(child_id) = role_resolve_current_child_id(token, key) else {
+        return crate::actor::actor_ask_null_actor_stopped();
+    };
+    #[cfg(test)]
+    fire_role_ask_pinned_submit_hook();
+    // SAFETY: the by-ID ask pins the resolved actor for the submission and
+    // blocks on the reply channel; `data`/`size` follow this fn's contract.
+    unsafe { crate::actor::hew_actor_ask_by_id(child_id, msg_type, data, size) }
 }
 
 /// Supervisors are unavailable on the wasm runtime; the owner-scoped role ask
@@ -6117,6 +6458,20 @@ pub extern "C" fn hew_supervisor_role_ask_with_channel(
     _ch: *mut c_void,
 ) -> i32 {
     crate::internal::types::HewError::ErrActorStopped as i32
+}
+
+/// Supervisors are unavailable on the wasm runtime; the blocking role ask
+/// keeps symbol parity and fails closed to a null reply.
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn hew_supervisor_role_ask(
+    _token: crate::lifetime::local_handles::HewLocalPidId,
+    _key: u32,
+    _msg_type: i32,
+    _data: *mut c_void,
+    _size: usize,
+) -> *mut c_void {
+    ptr::null_mut()
 }
 
 /// Look up a nested child supervisor by its compile-time-assigned slot index.

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -4642,6 +4642,162 @@ mod tests {
         }
     }
 
+    /// TOOTH for the masked-`id` reuse finding: after 2^48 allocations a fresh
+    /// actor can carry a retired incarnation's packed `id` (the serial is masked
+    /// to 48 bits). If phase two pinned by `id` alone it would submit to that
+    /// DIFFERENT actor — the exact wrong-actor delivery this lane exists to make
+    /// impossible.
+    ///
+    /// This fabricates the alias at the resolve→submit seam: the hook retires
+    /// the resolved incarnation A, then spawns a genuine actor B tracked under
+    /// A's identical packed `id` but a DISTINCT full serial (a 2^48 wrap). A
+    /// naive by-`id` pin would find B and enqueue to it; the identity-verified
+    /// pin must instead refuse CLOSED (the pinned actor's full serial differs
+    /// from the resolved one) and never enqueue. Covers both entry points; run
+    /// 20× to shake out any ordering dependence.
+    /// Build a resolve→submit-seam hook that fabricates the masked-`id` alias:
+    /// it retires + frees the resolved incarnation A, then spawns a genuine
+    /// actor B tracked under A's identical packed `id` but a DISTINCT full
+    /// serial (a 2^48 wrap), publishing B's pointer through `alias_out`.
+    ///
+    /// # Safety
+    ///
+    /// `sup_addr` must be a live `*mut HewSupervisor` the caller owns for the
+    /// hook's lifetime; the caller reclaims the actor stored in `alias_out`.
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe fn make_role_ask_alias_hook(
+        sup_addr: usize,
+        alias_out: Arc<AtomicUsize>,
+    ) -> Arc<dyn Fn() + Send + Sync> {
+        Arc::new(move || {
+            let sup = sup_addr as *mut HewSupervisor;
+            // SAFETY: the caller owns `sup` for the hook's lifetime; the retired
+            // incarnation is exclusively owned once pulled from the slot.
+            unsafe {
+                // Retire the resolved incarnation A and free it, so its masked
+                // `id` is vacant in LIVE_ACTORS for reuse.
+                let retired = take_child_slot(&mut *sup, 0);
+                assert!(!retired.is_null(), "hook must find the live incarnation");
+                let a_id = (*retired).id;
+                let a_serial = (*retired).spawn_serial;
+                (*retired)
+                    .actor_state
+                    .store(HewActorState::Stopped as i32, Ordering::Release);
+                assert_eq!(actor::hew_actor_free(retired), 0);
+
+                // Spawn a genuine actor B that ALIASES A's packed `id` (a 2^48
+                // serial wrap) but carries a distinct full serial — precisely
+                // the shape a real id-reuse produces.
+                actor::override_next_spawn_actor_identity(a_id, a_serial.wrapping_add(1u64 << 48));
+                let b = actor::hew_actor_spawn(ptr::null_mut(), 0, Some(noop_child_dispatch));
+                assert!(!b.is_null(), "alias actor B must spawn");
+                assert_eq!((*b).id, a_id, "B must reuse A's masked packed id");
+                assert_ne!(
+                    (*b).spawn_serial,
+                    a_serial,
+                    "B must carry a distinct full serial"
+                );
+                alias_out.store(b as usize, Ordering::Release);
+            }
+        })
+    }
+
+    #[test]
+    fn role_ask_masked_id_alias_refuses_closed_never_enqueues() {
+        for _ in 0..20 {
+            let _rt = crate::runtime_test_guard();
+            // SAFETY: the test owns the tree; the hook retires the resolved
+            // incarnation and installs a masked-`id`-aliasing replacement at the
+            // exact resolve→submit seam, then the test reclaims both.
+            unsafe {
+                let (sup, _child, _self_actor) = make_supervisor_with_child();
+                let supervisor_token = (*sup).local_pid_id;
+                let sup_addr = sup as usize;
+                // Carries the fabricated alias actor B out of the hook so the
+                // test can assert it never received the ask and then free it.
+                let alias_out = Arc::new(AtomicUsize::new(0));
+
+                // ── Channel twin: refuse closed with the named diagnostic. ──
+                *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() =
+                    Some(make_role_ask_alias_hook(sup_addr, Arc::clone(&alias_out)));
+                let before = crate::reply_channel::active_channel_count();
+                let ch = crate::reply_channel::hew_reply_channel_new();
+                crate::hew_clear_error();
+                let status = hew_supervisor_role_ask_with_channel(
+                    supervisor_token,
+                    0,
+                    7,
+                    ptr::null_mut(),
+                    0,
+                    ch.cast(),
+                );
+                *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() = None;
+                assert_eq!(
+                    status,
+                    crate::internal::types::HewError::ErrActorStopped as i32,
+                    "an aliased id must refuse closed, never submit to the wrong actor"
+                );
+                let err = crate::hew_last_error();
+                assert!(!err.is_null());
+                let msg = std::ffi::CStr::from_ptr(err).to_string_lossy();
+                assert!(
+                    msg.contains("retired during submission"),
+                    "the refusal must name the retirement; got: {msg}"
+                );
+                assert_eq!(
+                    crate::reply_channel::active_channel_count(),
+                    before + 1,
+                    "the refused ask must preserve the caller-owned channel reference"
+                );
+                crate::reply_channel::hew_reply_channel_free(ch);
+
+                // The aliasing actor B must NOT have received the ask.
+                let b_channel = alias_out.swap(0, Ordering::AcqRel) as *mut HewActor;
+                assert!(!b_channel.is_null(), "the channel-path hook must spawn B");
+                assert_eq!(
+                    crate::mailbox::hew_mailbox_len((*b_channel).mailbox.cast()),
+                    0,
+                    "the wrong-actor alias must never be enqueued (channel twin)"
+                );
+                (*b_channel)
+                    .actor_state
+                    .store(HewActorState::Stopped as i32, Ordering::Release);
+                assert_eq!(actor::hew_actor_free(b_channel), 0);
+
+                // ── Blocking twin: null reply + AskError::ActorStopped. ──
+                let respawned = restart_child_from_spec(&mut *sup, 0);
+                assert!(!respawned.is_null());
+                *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() =
+                    Some(make_role_ask_alias_hook(sup_addr, Arc::clone(&alias_out)));
+                let reply = hew_supervisor_role_ask(supervisor_token, 0, 7, ptr::null_mut(), 0);
+                *ROLE_ASK_PINNED_SUBMIT_HOOK.lock_or_recover() = None;
+                assert!(
+                    reply.is_null(),
+                    "the blocking role ask must refuse, never deliver to the aliased actor"
+                );
+                assert_eq!(
+                    actor::hew_actor_ask_take_last_error(),
+                    crate::internal::types::AskError::ActorStopped as i32,
+                    "the blocking refusal must bind AskError::ActorStopped"
+                );
+
+                let b_blocking = alias_out.swap(0, Ordering::AcqRel) as *mut HewActor;
+                assert!(!b_blocking.is_null(), "the blocking-path hook must spawn B");
+                assert_eq!(
+                    crate::mailbox::hew_mailbox_len((*b_blocking).mailbox.cast()),
+                    0,
+                    "the wrong-actor alias must never be enqueued (blocking twin)"
+                );
+                (*b_blocking)
+                    .actor_state
+                    .store(HewActorState::Stopped as i32, Ordering::Release);
+                assert_eq!(actor::hew_actor_free(b_blocking), 0);
+
+                hew_supervisor_stop(sup);
+            }
+        }
+    }
+
     /// An out-of-range key returns Dead(UnknownSlot).
     #[test]
     fn child_get_unknown_key_returns_dead_unknown_slot() {
@@ -6278,13 +6434,20 @@ fn role_ask_refuse(reason: u8, key: u32) -> i32 {
 /// the returned ID via the `LIVE_ACTORS` send pin (`with_actor_send_by_id`),
 /// the same liveness protocol every by-ID send uses: the pin guarantees the
 /// allocation outlives the submission, and a retirement that lands between
-/// the phases fails CLOSED (the ID is never reused) instead of touching
-/// reclaimed storage.
+/// the phases fails CLOSED instead of touching reclaimed storage.
+///
+/// The returned pair is `(packed id, full spawn serial)`. The packed `id`
+/// masks the serial to 48 bits (`pid::hew_pid_make`), so after 2^48
+/// allocations a fresh actor can carry a retired incarnation's `id`; phase two
+/// therefore matches the pinned actor's full serial against the resolved one
+/// (`live_actors::with_actor_send_by_identity`) so an aliased `id` refuses
+/// closed rather than delivering to the wrong actor. Both scalars are copied
+/// out under `children_lock`; no pointer crosses the lock boundary.
 #[cfg(not(target_arch = "wasm32"))]
 fn role_resolve_current_child_id(
     token: crate::lifetime::local_handles::HewLocalPidId,
     key: u32,
-) -> Result<u64, i32> {
+) -> Result<(u64, u64), i32> {
     let Some(pin) = crate::lifetime::local_handles::pin_current_supervisor(token) else {
         return Err(role_ask_refuse(
             ChildSlotReason::SupervisorShutdown as u8,
@@ -6333,9 +6496,11 @@ fn role_resolve_current_child_id(
     fire_role_ask_submit_gap_hook();
 
     // SAFETY: `child` is the slot's live incarnation and cannot be replaced or
-    // reclaimed while `children_lock` is held; only the scalar ID is copied
-    // out — no pointer crosses the lock boundary.
-    Ok(unsafe { (*child).id })
+    // reclaimed while `children_lock` is held; only the scalar id + full serial
+    // are copied out — no pointer crosses the lock boundary. The full serial is
+    // the aliasing-proof discriminator phase two re-checks against the pinned
+    // actor (the packed id alone can alias after 2^48 allocations).
+    Ok(unsafe { ((*child).id, (*child).spawn_serial) })
 }
 
 /// The classified refusal for a resolution that succeeded but whose
@@ -6390,15 +6555,17 @@ pub unsafe extern "C" fn hew_supervisor_role_ask_with_channel(
     size: usize,
     ch: *mut c_void,
 ) -> i32 {
-    let child_id = match role_resolve_current_child_id(token, key) {
-        Ok(id) => id,
+    let (child_id, child_serial) = match role_resolve_current_child_id(token, key) {
+        Ok(ids) => ids,
         Err(code) => return code,
     };
     #[cfg(test)]
     fire_role_ask_pinned_submit_hook();
-    crate::lifetime::live_actors::with_actor_send_by_id(child_id, |actor| {
+    crate::lifetime::live_actors::with_actor_send_by_identity(child_id, child_serial, |actor| {
         // SAFETY: the send pin keeps `actor` live for the submission;
-        // `data`/`ch` follow this fn's contract.
+        // `data`/`ch` follow this fn's contract. The identity-verified pin
+        // refuses closed (returns None) if the id aliased a different
+        // incarnation, so no wrong-actor enqueue can occur here.
         unsafe { crate::actor::ask_with_channel_pinned(actor, msg_type, data, size, ch) }
     })
     .unwrap_or_else(|| role_ask_refuse_retired(key))
@@ -6435,14 +6602,16 @@ pub unsafe extern "C" fn hew_supervisor_role_ask(
     data: *mut c_void,
     size: usize,
 ) -> *mut c_void {
-    let Ok(child_id) = role_resolve_current_child_id(token, key) else {
+    let Ok((child_id, child_serial)) = role_resolve_current_child_id(token, key) else {
         return crate::actor::actor_ask_null_actor_stopped();
     };
     #[cfg(test)]
     fire_role_ask_pinned_submit_hook();
-    // SAFETY: the by-ID ask pins the resolved actor for the submission and
-    // blocks on the reply channel; `data`/`size` follow this fn's contract.
-    unsafe { crate::actor::hew_actor_ask_by_id(child_id, msg_type, data, size) }
+    // SAFETY: the identity-verified by-ID ask pins the resolved actor for the
+    // submission and blocks on the reply channel; `data`/`size` follow this
+    // fn's contract. A serial mismatch (aliased id) fails closed to a null
+    // reply with `AskError::ActorStopped`, never a wrong-actor delivery.
+    unsafe { crate::actor::hew_actor_ask_by_identity(child_id, child_serial, msg_type, data, size) }
 }
 
 /// Supervisors are unavailable on the wasm runtime; the owner-scoped role ask

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -4645,8 +4645,8 @@ mod tests {
     /// TOOTH for the masked-`id` reuse finding: after 2^48 allocations a fresh
     /// actor can carry a retired incarnation's packed `id` (the serial is masked
     /// to 48 bits). If phase two pinned by `id` alone it would submit to that
-    /// DIFFERENT actor — the exact wrong-actor delivery this lane exists to make
-    /// impossible.
+    /// DIFFERENT actor — the exact wrong-actor delivery the identity check
+    /// exists to make impossible.
     ///
     /// This fabricates the alias at the resolve→submit seam: the hook retires
     /// the resolved incarnation A, then spawns a genuine actor B tracked under

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -418,16 +418,16 @@ pub unsafe extern "C" fn hew_trap_with_code(code: i32) {
 }
 
 /// Map a trap code to a human-readable trap kind name.
+///
+/// Delegates to the canonical [`ExitReason`] naming so every registered trap
+/// code (including additions) prints its real name here — the local table this
+/// replaces had drifted, printing bare "Trap" for codes 207+. A raw signal
+/// number (not a registered trap code) stays "Trap": this diagnostic names
+/// codegen-emitted trap kinds, not hardware signals.
 fn trap_kind_name(code: i32) -> &'static str {
-    match code {
-        HEW_TRAP_HEAP_EXCEEDED => "HeapExceeded",
-        HEW_TRAP_INTEGER_OVERFLOW => "IntegerOverflow",
-        HEW_TRAP_DIVIDE_BY_ZERO => "DivideByZero",
-        HEW_TRAP_SIGNED_MIN_DIV_NEG_ONE => "SignedMinDivNegOne",
-        HEW_TRAP_SHIFT_OUT_OF_RANGE => "ShiftOutOfRange",
-        HEW_TRAP_INDEX_OUT_OF_BOUNDS => "IndexOutOfBounds",
-        HEW_TRAP_ACTOR_SEND_FAILED => "ActorSendFailed",
-        _ => "Trap",
+    match ExitReason::from_error_code(code) {
+        ExitReason::Signal(_) | ExitReason::Normal => "Trap",
+        reason => reason.trap_kind_name(),
     }
 }
 
@@ -4269,6 +4269,11 @@ mod tests {
                 crate::reply_channel::hew_reply_channel_is_orphaned(ch2),
                 1,
                 "the orphaned marker is the only fact the null-only reply carries"
+            );
+            assert_eq!(
+                crate::reply_channel::hew_reply_channel_failure_kind(ch2),
+                crate::internal::types::HEW_REPLY_FAIL_ACTOR_STOPPED,
+                "the status-bearing surface classifies the retirement as an actor stop"
             );
             crate::reply_channel::hew_reply_channel_free(ch2);
 

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -4182,6 +4182,224 @@ mod tests {
         }
     }
 
+    /// The lookup-token-then-send shape loses the ask when the restart
+    /// machinery advances the slot inside the unlocked gap. Both faces of the
+    /// window, forced deterministically at the exact seam the two-call codegen
+    /// sequence exposed:
+    ///
+    /// 1. Token resolved, replacement lands, OLD incarnation stopped, THEN the
+    ///    send: refused (`ErrActorStopped`) even though the caller observed a
+    ///    Live slot at resolve time.
+    /// 2. Token resolved, ask ACCEPTED by the old incarnation, THEN the
+    ///    replacement wave retires it: the accepted ask's reply resolves null
+    ///    with only the orphaned marker — the input that surfaced as a silent
+    ///    join-site trap with no diagnostic.
+    #[test]
+    fn stale_role_token_send_after_replacement_loses_the_ask() {
+        let _rt = crate::runtime_test_guard();
+        // SAFETY: the test owns the supervisor tree and sequences the
+        // replacement wave by hand; no worker threads run.
+        unsafe {
+            let (sup, old_child, _self_actor) = make_supervisor_with_child();
+            let supervisor_token = (*sup).local_pid_id;
+
+            // Face 1: resolve → replace+stop → send.
+            let live = hew_local_pid_supervisor_child_get(supervisor_token, 0);
+            assert_eq!(live.tag, 0, "pre-race lookup must observe a Live slot");
+            let old_token = (*old_child).local_pid_id;
+            assert_eq!(
+                live.handle as usize,
+                usize::from(old_token),
+                "the lookup handle word is the incarnation's stable token"
+            );
+
+            let replacement = restart_child_from_spec(&mut *sup, 0);
+            assert!(!replacement.is_null(), "replacement spawn must succeed");
+            actor::hew_actor_stop(old_child);
+
+            let ch = crate::reply_channel::hew_reply_channel_new();
+            let status =
+                actor::hew_local_pid_ask_with_channel(old_token, 7, ptr::null_mut(), 0, ch.cast());
+            assert_eq!(
+                status,
+                crate::internal::types::HewError::ErrActorStopped as i32,
+                "a stale role token resolved before the replacement wave must refuse the send"
+            );
+            crate::reply_channel::hew_reply_channel_free(ch);
+            // The old incarnation stopped Idle → Stopped; reclaim it.
+            assert_eq!(actor::hew_actor_free(old_child), 0);
+
+            // Face 2: resolve → ask accepted → replacement wave retires the
+            // target. The accepted ask's reply resolves null + orphaned.
+            let live2 = hew_local_pid_supervisor_child_get(supervisor_token, 0);
+            assert_eq!(live2.tag, 0, "replacement slot must be Live");
+            let repl_token = (*replacement).local_pid_id;
+            assert_eq!(live2.handle as usize, usize::from(repl_token));
+            let ch2 = crate::reply_channel::hew_reply_channel_new();
+            let status2 = actor::hew_local_pid_ask_with_channel(
+                repl_token,
+                7,
+                ptr::null_mut(),
+                0,
+                ch2.cast(),
+            );
+            assert_eq!(
+                status2,
+                crate::internal::types::HewError::Ok as i32,
+                "the ask must be accepted while the incarnation is current"
+            );
+
+            // The replacement wave retires the accepted-ask target: pull it
+            // from the slot and tear it down (worker-less runtime: force the
+            // terminal state the drain would have produced, then free — the
+            // free path retires the queued ask's sender ref).
+            let retired = take_child_slot(&mut *sup, 0);
+            assert_eq!(retired, replacement);
+            (*retired)
+                .actor_state
+                .store(HewActorState::Stopped as i32, Ordering::Release);
+            assert_eq!(actor::hew_actor_free(retired), 0);
+
+            let reply = crate::reply_channel::hew_reply_wait(ch2);
+            assert!(
+                reply.is_null(),
+                "an ask orphaned by the replacement wave must resolve a null reply"
+            );
+            assert_eq!(
+                crate::reply_channel::hew_reply_channel_is_orphaned(ch2),
+                1,
+                "the orphaned marker is the only fact the null-only reply carries"
+            );
+            crate::reply_channel::hew_reply_channel_free(ch2);
+
+            hew_supervisor_stop(sup);
+        }
+    }
+
+    /// The owner-scoped role ask resolves the slot and submits under ONE
+    /// `children_lock` critical section: the slot writers cannot interpose
+    /// (probed at the seam), and the ask lands in the incarnation that was
+    /// current at resolve time — never a later one, never nowhere.
+    #[test]
+    fn role_ask_submits_to_resolved_incarnation_under_slot_lock() {
+        let _rt = crate::runtime_test_guard();
+        // SAFETY: the test owns the supervisor tree; the seam hook probes the
+        // lock from a joined helper thread (synchronization only, no sleeps).
+        unsafe {
+            let (sup, old_child, _self_actor) = make_supervisor_with_child();
+            let supervisor_token = (*sup).local_pid_id;
+            let sup_addr = sup as usize;
+
+            let probed = Arc::new(AtomicBool::new(false));
+            let probed_hook = Arc::clone(&probed);
+            *ROLE_ASK_SUBMIT_GAP_HOOK.lock_or_recover() = Some(Arc::new(move || {
+                let handle = std::thread::spawn(move || {
+                    // The supervisor outlives the ask call that fires this
+                    // hook; the probe only touches the lock word.
+                    let sup = sup_addr as *mut HewSupervisor;
+                    (*sup).children_lock.try_lock().is_err()
+                });
+                let writer_excluded = handle.join().expect("lock probe thread");
+                assert!(
+                    writer_excluded,
+                    "children_lock must be held at the resolve→submit seam so \
+                     store_child_slot/take_child_slot cannot interpose"
+                );
+                probed_hook.store(true, Ordering::Release);
+            }));
+
+            let ch = crate::reply_channel::hew_reply_channel_new();
+            let status = hew_supervisor_role_ask_with_channel(
+                supervisor_token,
+                0,
+                42,
+                ptr::null_mut(),
+                0,
+                ch.cast(),
+            );
+            *ROLE_ASK_SUBMIT_GAP_HOOK.lock_or_recover() = None;
+            assert_eq!(status, crate::internal::types::HewError::Ok as i32);
+            assert!(
+                probed.load(Ordering::Acquire),
+                "the seam hook must have run inside the critical section"
+            );
+
+            // A replacement landing AFTER the owner-scoped submission cannot
+            // repoint the already-enqueued ask.
+            let replacement = restart_child_from_spec(&mut *sup, 0);
+            assert!(!replacement.is_null());
+
+            let old_mb = (*old_child).mailbox.cast::<mailbox::HewMailbox>();
+            let node = mailbox::hew_mailbox_try_recv(old_mb);
+            assert!(
+                !node.is_null(),
+                "the ask must be enqueued in the incarnation resolved under the lock"
+            );
+            assert_eq!((*node).msg_type, 42);
+            assert_eq!(
+                (*node).reply_channel,
+                ch.cast(),
+                "the enqueued node must carry the caller's reply channel"
+            );
+            let repl_mb = (*replacement).mailbox.cast::<mailbox::HewMailbox>();
+            assert!(
+                mailbox::hew_mailbox_try_recv(repl_mb).is_null(),
+                "the replacement incarnation must not receive the pre-swap ask"
+            );
+
+            // Node free retires the queued sender ref (orphan path) so the
+            // creator-side wait resolves; then reclaim both incarnations.
+            mailbox::hew_msg_node_free(node);
+            assert!(crate::reply_channel::hew_reply_wait(ch).is_null());
+            crate::reply_channel::hew_reply_channel_free(ch);
+
+            (*old_child)
+                .actor_state
+                .store(HewActorState::Stopped as i32, Ordering::Release);
+            assert_eq!(actor::hew_actor_free(old_child), 0);
+            hew_supervisor_stop(sup);
+        }
+    }
+
+    /// A mid-restart (null) slot refuses the owner-scoped ask closed: nothing
+    /// is enqueued and the caller's channel reference survives.
+    #[test]
+    fn role_ask_mid_restart_slot_fails_closed() {
+        let _rt = crate::runtime_test_guard();
+        // SAFETY: test owns the tree; nulls the slot to model the restart
+        // window, then restores it for teardown.
+        unsafe {
+            let (sup, child, _self_actor) = make_supervisor_with_child();
+            let supervisor_token = (*sup).local_pid_id;
+            store_child_slot(&mut *sup, 0, ptr::null_mut());
+
+            let before = crate::reply_channel::active_channel_count();
+            let ch = crate::reply_channel::hew_reply_channel_new();
+            let status = hew_supervisor_role_ask_with_channel(
+                supervisor_token,
+                0,
+                7,
+                ptr::null_mut(),
+                0,
+                ch.cast(),
+            );
+            assert_eq!(
+                status,
+                crate::internal::types::HewError::ErrActorStopped as i32,
+                "a mid-restart slot must refuse, never guess a future incarnation"
+            );
+            assert_eq!(
+                crate::reply_channel::active_channel_count(),
+                before + 1,
+                "the refused ask must preserve the caller-owned channel reference"
+            );
+            crate::reply_channel::hew_reply_channel_free(ch);
+
+            store_child_slot(&mut *sup, 0, child);
+            hew_supervisor_stop(sup);
+        }
+    }
+
     /// An out-of-range key returns Dead(UnknownSlot).
     #[test]
     fn child_get_unknown_key_returns_dead_unknown_slot() {
@@ -5727,6 +5945,126 @@ pub extern "C" fn hew_local_pid_supervisor_child_get(
     _key: u32,
 ) -> ChildLookupResult {
     ChildLookupResult::dead(ChildSlotReason::SupervisorShutdown)
+}
+
+/// Test-only hook fired inside [`hew_supervisor_role_ask_with_channel`] in the
+/// gap between resolving the current child slot and submitting the ask — with
+/// `children_lock` HELD. The forced-interleaving regression installs a closure
+/// that probes the lock from another thread at this exact point, proving the
+/// restart machinery's slot writers (`store_child_slot` / `take_child_slot`)
+/// cannot interpose between resolution and submission.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+static ROLE_ASK_SUBMIT_GAP_HOOK: Mutex<Option<Arc<dyn Fn() + Send + Sync>>> = Mutex::new(None);
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn fire_role_ask_submit_gap_hook() {
+    let hook = ROLE_ASK_SUBMIT_GAP_HOOK.lock_or_recover().clone();
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+/// Submit an ask through a fungible `(stable supervisor token, static slot)`
+/// role as ONE owner-scoped operation: pin the supervisor identity, resolve
+/// the slot, and enqueue into the CURRENT incarnation's mailbox — all inside
+/// one `children_lock` critical section.
+///
+/// This replaces the lookup-token-then-send shape
+/// (`hew_local_pid_supervisor_child_get` followed by
+/// `hew_local_pid_ask_with_channel`), whose unlocked gap let the restart
+/// machinery advance the slot between resolution and submission: the resolved
+/// token either went stale (send refused after the caller observed a live
+/// slot) or — worse — the ask was accepted by an incarnation the supervisor
+/// was about to retire, orphaning the reply with no diagnostic at the join
+/// site. The doctrinal sibling is the connection-manager
+/// refresh-identity-under-owner-lock fix: identity resolution and use happen
+/// under the owner's lock, never across it.
+///
+/// Locking: `children_lock` is the slot writers' exclusion
+/// (`store_child_slot` / `take_child_slot`), and a non-null slot's allocation
+/// is owned by the supervisor and cannot be reclaimed while the lock is held —
+/// the same liveness contract `child_get_from_supervisor` documents for the
+/// token copy. The mailbox submission inside the critical section takes only
+/// the mailbox and scheduler queue locks, which are never held while a thread
+/// waits on `children_lock` (slot writers acquire it with no locks held).
+///
+/// Returns `HewError::Ok` on submission. A dead, unknown, or mid-restart slot
+/// fails closed with `HewError::ErrActorStopped` and enqueues nothing —
+/// matching the refusal the retired-token path produced. The channel-reference
+/// discipline matches [`crate::actor::hew_actor_ask_with_channel`]: the
+/// caller's creator ref survives failure.
+///
+/// # Safety
+///
+/// `data` and `ch` must satisfy
+/// [`crate::actor::hew_actor_ask_with_channel`]'s contract.
+#[cfg(not(target_arch = "wasm32"))]
+#[no_mangle]
+pub unsafe extern "C" fn hew_supervisor_role_ask_with_channel(
+    token: crate::lifetime::local_handles::HewLocalPidId,
+    key: u32,
+    msg_type: i32,
+    data: *mut c_void,
+    size: usize,
+    ch: *mut c_void,
+) -> i32 {
+    use crate::internal::types::HewError;
+
+    let Some(pin) = crate::lifetime::local_handles::pin_current_supervisor(token) else {
+        return HewError::ErrActorStopped as i32;
+    };
+    let sup = pin.supervisor();
+    // SAFETY: the stable-identity pin prevents supervisor reclamation for the
+    // complete lookup + submission, including the children-lock section.
+    let s = unsafe { &*sup };
+
+    // Fast-path shutdown check (atomics, no lock).
+    if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
+        return HewError::ErrActorStopped as i32;
+    }
+    let i = key as usize;
+    if i >= s.child_count {
+        return HewError::ErrActorStopped as i32;
+    }
+
+    let _guard = s.children_lock.lock_or_recover();
+
+    // Re-check shutdown under the lock (the supervisor can be cancelled
+    // between the atomic check above and acquiring the lock).
+    if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
+        return HewError::ErrActorStopped as i32;
+    }
+
+    let child = s.children.get(i).copied().unwrap_or(ptr::null_mut());
+    if child.is_null() {
+        // Mid-restart (Transient) or permanently dead: refuse rather than
+        // guess a future incarnation. Nothing was enqueued; the caller's
+        // fail-closed surface names the refusal.
+        return HewError::ErrActorStopped as i32;
+    }
+
+    #[cfg(test)]
+    fire_role_ask_submit_gap_hook();
+
+    // SAFETY: `child` is the slot's live incarnation and cannot be replaced or
+    // reclaimed while `children_lock` is held; `data`/`ch` follow this fn's
+    // contract.
+    unsafe { crate::actor::ask_with_channel_pinned(child, msg_type, data, size, ch) }
+}
+
+/// Supervisors are unavailable on the wasm runtime; the owner-scoped role ask
+/// keeps symbol parity and fails closed exactly like the lookup twin above.
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn hew_supervisor_role_ask_with_channel(
+    _token: crate::lifetime::local_handles::HewLocalPidId,
+    _key: u32,
+    _msg_type: i32,
+    _data: *mut c_void,
+    _size: usize,
+    _ch: *mut c_void,
+) -> i32 {
+    crate::internal::types::HewError::ErrActorStopped as i32
 }
 
 /// Look up a nested child supervisor by its compile-time-assigned slot index.

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -727,6 +727,7 @@ mod tests {
             send_pin_count: std::sync::atomic::AtomicU32::new(0),
             gen_sink: AtomicPtr::new(std::ptr::null_mut()),
             local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+            spawn_serial: id,
         }
     }
 

--- a/hew-runtime/src/timer_periodic_wasm.rs
+++ b/hew-runtime/src/timer_periodic_wasm.rs
@@ -533,6 +533,7 @@ mod tests {
                 send_pin_count: std::sync::atomic::AtomicU32::new(0),
                 gen_sink: AtomicPtr::new(ptr::null_mut()),
                 local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+                spawn_serial: id,
             }));
             Self { actor, counter }
         }

--- a/hew-runtime/src/wasm_parity_tests.rs
+++ b/hew-runtime/src/wasm_parity_tests.rs
@@ -352,6 +352,7 @@ fn stub_wasm_actor(mailbox: *mut c_void) -> Box<HewActor> {
         send_pin_count: std::sync::atomic::AtomicU32::new(0),
         gen_sink: AtomicPtr::new(std::ptr::null_mut()),
         local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+        spawn_serial: 1,
     })
 }
 

--- a/hew-runtime/src/wasm_parity_tests.rs
+++ b/hew-runtime/src/wasm_parity_tests.rs
@@ -1642,10 +1642,18 @@ fn wasm_trap_exit_code_mapping_wire_decode_failed_is_allowlisted_as_210() {
 }
 
 #[test]
+fn wasm_trap_exit_code_mapping_join_branch_failed_is_allowlisted_as_211() {
+    assert_canonical_wasi_trap_exit(
+        crate::internal::types::HEW_TRAP_JOIN_BRANCH_FAILED,
+        crate::internal::types::ExitReason::JoinBranchFailed,
+    );
+}
+
+#[test]
 fn wasm_unknown_non_actor_trap_code_is_not_mapped_to_process_exit() {
-    // 210 (HEW_TRAP_WIRE_DECODE_FAILED) is now a Hew-owned discriminator and is
-    // allowlisted; 211 takes its place as the first unused code.
-    for unknown in [-1, 1, 101, 199, 211, i32::MAX] {
+    // 211 (HEW_TRAP_JOIN_BRANCH_FAILED) is now a Hew-owned discriminator and is
+    // allowlisted; 212 takes its place as the first unused code.
+    for unknown in [-1, 1, 101, 199, 212, i32::MAX] {
         assert_eq!(
             crate::internal::types::canonical_trap_wasi_exit_code(unknown),
             None,

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -609,6 +609,7 @@ stable = [
   "hew_supervisor_restart_await_blocking",
   "hew_supervisor_restart_await_detach",
   "hew_supervisor_restart_await_suspend",
+  "hew_supervisor_role_ask",
   "hew_supervisor_role_ask_with_channel",
   "hew_supervisor_set_child_init_fn",
   "hew_supervisor_set_child_lifecycle",
@@ -4912,6 +4913,16 @@ result = "none"
 params = ["borrow", "borrow", "borrow", "borrow", "borrow", "retain"]
 release-symbol = ""
 discharge-depth = "none"
+
+# hew-runtime/src/supervisor.rs: blocking owner-scoped stable-role ask. The
+# payload is deep-copied by the mailbox; the reply buffer transfers to the
+# caller (null on refusal/failure with the ask error recorded).
+[[ownership.contracts]]
+symbol = "hew_supervisor_role_ask"
+result = "fresh"
+params = ["borrow", "borrow", "borrow", "borrow", "borrow"]
+release-symbol = "hew_reply_payload_free"
+discharge-depth = "shallow"
 
 # hew-runtime/src/reply_channel.rs: reads classification flags only.
 [[ownership.contracts]]

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -309,6 +309,7 @@ stable = [
   "hew_iter_value_ptr",
   "hew_iter_value_str",
   "hew_iter_vec",
+  "hew_join_branch_failed",
   "hew_lambda_actor_ask",
   "hew_lambda_actor_clone",
   "hew_lambda_actor_downgrade",
@@ -473,6 +474,7 @@ stable = [
   "hew_registry_unregister",
   "hew_reply",
   "hew_reply_channel_cancel",
+  "hew_reply_channel_failure_kind",
   "hew_reply_channel_free",
   "hew_reply_channel_is_orphaned",
   "hew_reply_channel_new",
@@ -607,6 +609,7 @@ stable = [
   "hew_supervisor_restart_await_blocking",
   "hew_supervisor_restart_await_detach",
   "hew_supervisor_restart_await_suspend",
+  "hew_supervisor_role_ask_with_channel",
   "hew_supervisor_set_child_init_fn",
   "hew_supervisor_set_child_lifecycle",
   "hew_supervisor_set_child_state_clone",
@@ -4898,3 +4901,31 @@ result = "fresh"
 params = ["borrow"]
 release-symbol = "hew_vec_free"
 discharge-depth = "shallow"
+
+# hew-runtime/src/supervisor.rs: owner-scoped stable-role ask. The payload is
+# deep-copied by the mailbox; the reply channel gains one queued sender ref
+# (retain), released internally on a failed submission — the caller's creator
+# ref survives either way.
+[[ownership.contracts]]
+symbol = "hew_supervisor_role_ask_with_channel"
+result = "none"
+params = ["borrow", "borrow", "borrow", "borrow", "borrow", "retain"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-runtime/src/reply_channel.rs: reads classification flags only.
+[[ownership.contracts]]
+symbol = "hew_reply_channel_failure_kind"
+result = "none"
+params = ["borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-runtime/src/reply_channel.rs: reads classification flags, writes the
+# error slot, prints the diagnostic; the channel ref stays caller-owned.
+[[ownership.contracts]]
+symbol = "hew_join_branch_failed"
+result = "none"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"


### PR DESCRIPTION
## Summary

A stable-role join/select could silently deliver to a retired incarnation on Windows: under a fungible restart the racy token-then-send lowering let the supervisor's replacement advance between token resolution and enqueue, so an accepted ask resolved to a null reply channel and the join trapped with empty output and no diagnostic. The stable-role ask is now owner-scoped. A two-phase pin resolves and classifies the child under the slot lock, copies out the actor id plus its full un-masked spawn serial, and submits by identity with the lock free; a mismatch — including the 2^48 masked-id-reuse alias — refuses closed with a named retirement diagnostic. The join reply is now status-bearing (actor-stopped / cancelled / handler-trapped / payload-alloc-failed) with an honest trap code (211, JoinBranchFailed) replacing the bare trap, and the previously-unflagged scheduler crash-fallback is stamped. Both the with-channel and blocking ask paths, plus the select arm, are cut over; the racy token-then-send lowering is deleted.

## Verification

- `cargo nextest run -p hew-runtime --no-fail-fast`: 2674/2674 passed (1 benign leaky)
- Alias tooth with proven negative control: 20x, 0 failures
- `run_e2e` restart/join family incl. the reproducing test: pass
- `make test-hew-ratchet`: PASSED (0 expected / 0 actual failures)
- `cargo fmt --check`: clean
- `make lint`: clean (new FFI symbols carry ownership contracts)
- Three independent cross-model review rounds: ACCEPT

## Out of scope

- The fungible TELL path retains the same same-turn window; the same owner-scoped pattern applies there and is tracked as a follow-up.
- Malformed-MIR `stable_role` token hardening is a separate follow-up.
