### PR TITLE
fix(runtime): observe the actor shutdown sentinel instead of routing it to user code

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -7238,26 +7238,31 @@ mod tests {
     unsafe extern "C-unwind" fn drain_trap_on_stop_dispatch(
         _ctx: *mut crate::execution_context::HewExecutionContext,
         _state: *mut c_void,
-        msg_type: i32,
+        _msg_type: i32,
         _data: *mut c_void,
         _size: usize,
         _borrow_mode: i32,
     ) -> *mut c_void {
-        if msg_type == -1 {
-            // SAFETY: this runs on the actor's own dispatch thread while its context is installed.
-            unsafe { hew_actor_trap(hew_actor_self(), 77) };
-            return std::ptr::null_mut();
-        }
         DRAIN_TRAP_ON_STOP_STARTED.store(true, Ordering::Release);
-        // Hold in Running until the test sets the release flag. This prevents
-        // the dispatch from finishing before drain_actors calls hew_actor_stop,
-        // which would let the actor transition Running→Idle→Stopped instead of
-        // Running→Crashed, causing drain to return Drained rather than
+        // Hold in Running until the test's release thread observes that
+        // drain_actors has called hew_actor_stop (the shutdown system message is
+        // queued). This prevents the dispatch from finishing before the stop is
+        // requested, which would let the actor transition Running→Idle→Stopped
+        // instead of crashing mid-drain and yield Drained rather than
         // Incomplete{crashed}.
         while !DRAIN_TRAP_ON_STOP_RELEASE.load(Ordering::Acquire) {
             std::hint::spin_loop();
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
+
+        // Crash from within this still-Running dispatch, modelling an actor that
+        // faults as it is being drained. The crash trigger is a self-trap rather
+        // than handling the shutdown sentinel: the scheduler now intercepts the
+        // `msg_type == -1` shutdown signal as a clean self-stop and never
+        // delivers it to a handler (a real codegen actor has no arm for it and
+        // would trap on the dispatch default arm).
+        // SAFETY: this runs on the actor's own dispatch thread while its context is installed.
+        unsafe { hew_actor_trap(hew_actor_self(), 77) };
 
         std::ptr::null_mut()
     }

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -6753,6 +6753,107 @@ mod tests {
     /// returns `Drained` instead of `Incomplete { crashed }`.
     static DRAIN_TRAP_ON_STOP_RELEASE: AtomicBool = AtomicBool::new(false);
 
+    // Probes for `shutdown_sentinel_is_never_delivered_to_handler`.
+    static SENTINEL_PROBE_STARTED: AtomicBool = AtomicBool::new(false);
+    static SENTINEL_PROBE_RELEASE: AtomicBool = AtomicBool::new(false);
+    static SENTINEL_PROBE_SAW_SENTINEL: AtomicBool = AtomicBool::new(false);
+
+    /// Handler that records whether it is ever handed the `msg_type == -1`
+    /// shutdown sentinel. A real codegen actor has no `match` arm for it and
+    /// would trap on the dispatch default arm, so the scheduler must intercept
+    /// the sentinel as a self-stop and never reach this handler with it.
+    unsafe extern "C-unwind" fn sentinel_probe_dispatch(
+        _ctx: *mut crate::execution_context::HewExecutionContext,
+        _state: *mut c_void,
+        msg_type: i32,
+        _data: *mut c_void,
+        _size: usize,
+        _borrow_mode: i32,
+    ) -> *mut c_void {
+        if msg_type == -1 {
+            SENTINEL_PROBE_SAW_SENTINEL.store(true, Ordering::Release);
+            return std::ptr::null_mut();
+        }
+        SENTINEL_PROBE_STARTED.store(true, Ordering::Release);
+        // Hold in Running until the release thread observes the stop is queued,
+        // so `hew_actor_stop` runs against a Running actor (the branch that
+        // enqueues the -1 sentinel).
+        while !SENTINEL_PROBE_RELEASE.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        std::ptr::null_mut()
+    }
+
+    #[test]
+    fn shutdown_sentinel_is_never_delivered_to_handler() {
+        let _guard = crate::runtime_test_guard();
+        let _scheduler = NativeSchedulerGuard::new();
+
+        SENTINEL_PROBE_STARTED.store(false, Ordering::Release);
+        SENTINEL_PROBE_RELEASE.store(false, Ordering::Release);
+        SENTINEL_PROBE_SAW_SENTINEL.store(false, Ordering::Release);
+
+        // SAFETY: null state + valid dispatch are valid spawn args.
+        let actor = unsafe { hew_actor_spawn(ptr::null_mut(), 0, Some(sentinel_probe_dispatch)) };
+        assert!(!actor.is_null());
+
+        // SAFETY: actor is a valid live actor pointer returned by spawn.
+        unsafe { hew_actor_send(actor, 1, ptr::null_mut(), 0) };
+        assert!(
+            wait_for_condition(std::time::Duration::from_secs(1), || {
+                SENTINEL_PROBE_STARTED.load(Ordering::Acquire)
+            }),
+            "handler should begin running before the stop is issued"
+        );
+
+        // Release the dispatch spin only once `hew_actor_stop` has enqueued the
+        // shutdown sentinel (sys-queue length becomes non-zero), so the actor is
+        // stopped while Running — the branch that emits the -1 sentinel.
+        // SAFETY: the mailbox outlives the joined release thread.
+        let mailbox_addr = unsafe { (*actor).mailbox } as usize;
+        let release_handle = std::thread::spawn(move || {
+            let mb = mailbox_addr as *const HewMailbox;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            loop {
+                // SAFETY: `mb` stays valid until the test joins this thread.
+                let stop_queued = !mb.is_null() && unsafe { mailbox::hew_mailbox_sys_len(mb) > 0 };
+                if stop_queued || std::time::Instant::now() >= deadline {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            SENTINEL_PROBE_RELEASE.store(true, Ordering::Release);
+        });
+
+        // SAFETY: actor is live and Running; stop enqueues the -1 sentinel.
+        unsafe { hew_actor_stop(actor) };
+        release_handle
+            .join()
+            .expect("release thread must not panic");
+
+        // The actor must reach a clean terminal Stopped state...
+        assert!(
+            wait_for_condition(std::time::Duration::from_secs(2), || {
+                // SAFETY: actor remains tracked until the explicit free below.
+                let s = unsafe { (*actor).actor_state.load(Ordering::Acquire) };
+                s == HewActorState::Stopped as i32
+            }),
+            "actor should self-stop cleanly after the shutdown sentinel is observed"
+        );
+        // ...and the sentinel must NEVER have reached the handler.
+        assert!(
+            !SENTINEL_PROBE_SAW_SENTINEL.load(Ordering::Acquire),
+            "the msg_type == -1 shutdown sentinel must be observed by the scheduler \
+             as a self-stop, never delivered to the actor handler"
+        );
+
+        // SAFETY: actor is terminal and still tracked; free it exactly once.
+        unsafe {
+            let _ = hew_actor_free(actor);
+        }
+    }
+
     #[test]
     fn spawned_actor_direct_identity_retires_before_reclamation() {
         let _guard = crate::runtime_test_guard();

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -6758,6 +6758,72 @@ mod tests {
     static SENTINEL_PROBE_RELEASE: AtomicBool = AtomicBool::new(false);
     static SENTINEL_PROBE_SAW_SENTINEL: AtomicBool = AtomicBool::new(false);
 
+    // Probe for `user_msg_type_minus_one_reaches_handler_and_does_not_terminate`.
+    static USER_MINUS_ONE_HANDLED: AtomicBool = AtomicBool::new(false);
+
+    /// Handler that records receiving `msg_type == -1`. Used to prove that a
+    /// USER-queue message carrying the shutdown-sentinel VALUE is delivered
+    /// normally (the value is only reserved on the system queue).
+    unsafe extern "C-unwind" fn user_minus_one_probe_dispatch(
+        _ctx: *mut crate::execution_context::HewExecutionContext,
+        _state: *mut c_void,
+        msg_type: i32,
+        _data: *mut c_void,
+        _size: usize,
+        _borrow_mode: i32,
+    ) -> *mut c_void {
+        if msg_type == -1 {
+            USER_MINUS_ONE_HANDLED.store(true, Ordering::Release);
+        }
+        std::ptr::null_mut()
+    }
+
+    #[test]
+    fn user_msg_type_minus_one_reaches_handler_and_does_not_terminate() {
+        // Regression guard for the provenance fix: `msg_type` is unrestricted in
+        // the public C ABI and codegen tags are full-range hashes, so a USER send
+        // of `-1` (WITHOUT a stop) is a real message. The scheduler's shutdown
+        // interception gates on SYSTEM-queue provenance, so this must reach the
+        // handler and must NOT terminate the actor. (Keying the interception on
+        // the value alone silently dropped this message and stopped the actor.)
+        let _guard = crate::runtime_test_guard();
+        let _scheduler = NativeSchedulerGuard::new();
+
+        USER_MINUS_ONE_HANDLED.store(false, Ordering::Release);
+
+        // SAFETY: null state + valid dispatch are valid spawn args.
+        let actor =
+            unsafe { hew_actor_spawn(ptr::null_mut(), 0, Some(user_minus_one_probe_dispatch)) };
+        assert!(!actor.is_null());
+
+        // A USER-queue send (hew_actor_send routes to the user queue) with the
+        // reserved sentinel value.
+        // SAFETY: actor is a valid live actor pointer returned by spawn.
+        unsafe { hew_actor_send(actor, -1, ptr::null_mut(), 0) };
+
+        assert!(
+            wait_for_condition(std::time::Duration::from_secs(2), || {
+                USER_MINUS_ONE_HANDLED.load(Ordering::Acquire)
+            }),
+            "a user-queue message with msg_type == -1 must reach the handler, \
+             not be intercepted as a shutdown signal"
+        );
+
+        // The actor must still be alive — no spurious sentinel-driven self-stop.
+        // SAFETY: actor remains tracked until the explicit free below.
+        let state = unsafe { (*actor).actor_state.load(Ordering::Acquire) };
+        assert!(
+            state != HewActorState::Stopped as i32 && state != HewActorState::Crashed as i32,
+            "delivering a user-queue msg_type == -1 must not terminate the actor (state={state})"
+        );
+
+        // SAFETY: actor is live and tracked; stop then free it exactly once.
+        unsafe {
+            hew_actor_stop(actor);
+            let _ = hew_actor_free(actor);
+        }
+    }
+
     /// Handler that records whether it is ever handed the `msg_type == -1`
     /// shutdown sentinel. A real codegen actor has no `match` arm for it and
     /// would trap on the dispatch default arm, so the scheduler must intercept

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -2311,6 +2311,16 @@ unsafe fn enqueue_sys_node(mb: &HewMailbox, node: *mut HewMsgNode) {
     MESSAGES_SENT.fetch_add(1, Ordering::Relaxed);
 }
 
+/// System `msg_type` reserved for the shutdown sentinel that
+/// [`mailbox_send_stop_sys_once`] enqueues onto a Running actor's system queue.
+///
+/// It is a **lifecycle signal**, not an application message: the scheduler must
+/// OBSERVE it as a self-stop request and free it, never hand it to the actor's
+/// user dispatch trampoline. The generated dispatch `match` has no arm for it,
+/// so dispatching it lands on the trapping default arm (`ud2` → SIGILL). See the
+/// interception in `scheduler::activate_actor`.
+pub(crate) const HEW_MAILBOX_SHUTDOWN_SENTINEL: i32 = -1;
+
 pub(crate) unsafe fn mailbox_send_stop_sys_once(mb: *mut HewMailbox) -> bool {
     if mb.is_null() {
         return false;
@@ -2319,7 +2329,14 @@ pub(crate) unsafe fn mailbox_send_stop_sys_once(mb: *mut HewMailbox) -> bool {
     let mb = unsafe { &*mb };
 
     // SAFETY: stop signals carry no payload.
-    let node = unsafe { msg_node_alloc(-1, ptr::null(), 0, ptr::null_mut()) };
+    let node = unsafe {
+        msg_node_alloc(
+            HEW_MAILBOX_SHUTDOWN_SENTINEL,
+            ptr::null(),
+            0,
+            ptr::null_mut(),
+        )
+    };
     if node.is_null() {
         set_last_error("hew_actor_stop: failed to enqueue shutdown system message");
         eprintln!("hew_actor_stop: failed to enqueue shutdown system message");

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -2439,6 +2439,34 @@ pub(crate) unsafe fn mailbox_is_closed(mb: *mut HewMailbox) -> bool {
 /// functions at a time (single-consumer invariant).
 #[no_mangle]
 pub unsafe extern "C" fn hew_mailbox_try_recv(mb: *mut HewMailbox) -> *mut HewMsgNode {
+    // SAFETY: caller upholds the `mb`-valid + single-consumer contract.
+    unsafe { mailbox_try_recv_with_origin(mb) }.node
+}
+
+/// A received node plus the queue it came from.
+///
+/// The origin bit is load-bearing: the shutdown sentinel
+/// ([`HEW_MAILBOX_SHUTDOWN_SENTINEL`]) is disambiguated from an application
+/// message that merely shares its numeric value by which queue it arrived on,
+/// NOT by the value. `msg_type` is unrestricted `i32` in the public C ABI
+/// ([`hew_actor_send`] / `HewDispatchFn`) and codegen message tags are hashes,
+/// so a user message may legitimately carry `-1`; only a node dequeued from the
+/// **system** queue is the internal shutdown signal.
+pub(crate) struct RecvNode {
+    pub node: *mut HewMsgNode,
+    pub from_sys: bool,
+}
+
+/// Single-consumer receive that preserves system-vs-user provenance.
+///
+/// System messages keep priority (dequeued first), exactly as
+/// [`hew_mailbox_try_recv`] — this is its provenance-carrying core.
+///
+/// # Safety
+///
+/// `mb` must be a valid mailbox pointer. Only one thread may call recv
+/// functions at a time (single-consumer invariant).
+pub(crate) unsafe fn mailbox_try_recv_with_origin(mb: *mut HewMailbox) -> RecvNode {
     // SAFETY: Caller guarantees `mb` is valid and single-consumer.
     let mb = unsafe { &*mb };
 
@@ -2448,7 +2476,10 @@ pub unsafe extern "C" fn hew_mailbox_try_recv(mb: *mut HewMailbox) -> *mut HewMs
     if !sys_node.is_null() {
         mb.sys_count.fetch_sub(1, Ordering::AcqRel);
         MESSAGES_RECEIVED.fetch_add(1, Ordering::Relaxed);
-        return sys_node;
+        return RecvNode {
+            node: sys_node,
+            from_sys: true,
+        };
     }
 
     // User messages: slow path uses mutex, fast path uses lock-free queue.
@@ -2459,7 +2490,10 @@ pub unsafe extern "C" fn hew_mailbox_try_recv(mb: *mut HewMailbox) -> *mut HewMs
             MESSAGES_RECEIVED.fetch_add(1, Ordering::Relaxed);
             drop(q);
             mb.not_full.notify_one();
-            return node;
+            return RecvNode {
+                node,
+                from_sys: false,
+            };
         }
     } else {
         // SAFETY: single-consumer invariant satisfied by caller.
@@ -2467,11 +2501,17 @@ pub unsafe extern "C" fn hew_mailbox_try_recv(mb: *mut HewMailbox) -> *mut HewMs
         if !node.is_null() {
             mb.count.fetch_sub(1, Ordering::Release);
             MESSAGES_RECEIVED.fetch_add(1, Ordering::Relaxed);
-            return node;
+            return RecvNode {
+                node,
+                from_sys: false,
+            };
         }
     }
 
-    ptr::null_mut()
+    RecvNode {
+        node: ptr::null_mut(),
+        from_sys: false,
+    }
 }
 
 /// Try to receive a system message only.

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -2311,15 +2311,13 @@ unsafe fn enqueue_sys_node(mb: &HewMailbox, node: *mut HewMsgNode) {
     MESSAGES_SENT.fetch_add(1, Ordering::Relaxed);
 }
 
-/// System `msg_type` reserved for the shutdown sentinel that
-/// [`mailbox_send_stop_sys_once`] enqueues onto a Running actor's system queue.
-///
-/// It is a **lifecycle signal**, not an application message: the scheduler must
-/// OBSERVE it as a self-stop request and free it, never hand it to the actor's
-/// user dispatch trampoline. The generated dispatch `match` has no arm for it,
-/// so dispatching it lands on the trapping default arm (`ud2` → SIGILL). See the
-/// interception in `scheduler::activate_actor`.
-pub(crate) const HEW_MAILBOX_SHUTDOWN_SENTINEL: i32 = -1;
+/// Shutdown sentinel `msg_type` — re-exported from the target-independent
+/// [`crate::mailbox_header`] module (the single authority, shared with the WASM
+/// mailbox so the two cannot drift; the native `mailbox` module is
+/// `#[cfg(not(wasm32))]` and unavailable on wasm32). See
+/// [`mailbox_send_stop_sys_once`] and the interception in
+/// `scheduler::activate_actor`.
+pub(crate) use crate::mailbox_header::HEW_MAILBOX_SHUTDOWN_SENTINEL;
 
 pub(crate) unsafe fn mailbox_send_stop_sys_once(mb: *mut HewMailbox) -> bool {
     if mb.is_null() {

--- a/hew-runtime/src/mailbox_header.rs
+++ b/hew-runtime/src/mailbox_header.rs
@@ -27,6 +27,20 @@ pub const HEW_MSG_ENVELOPE_RESERVED_DELTA_B: u32 = 1 << 8;
 /// All bits at or above bit 9 must read zero on every header load.
 pub const HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK: u32 = !((1u32 << 9) - 1);
 
+/// System `msg_type` reserved for the shutdown sentinel that a mailbox enqueues
+/// onto a Running actor's system queue (native `mailbox::mailbox_send_stop_sys_once`
+/// and `mailbox_wasm::mailbox_send_stop_sys_once`).
+///
+/// It is a **lifecycle signal**, not an application message: each scheduler must
+/// OBSERVE it as a self-stop request (gated on system-queue provenance) and free
+/// it, never hand it to the actor's user dispatch trampoline. The generated
+/// dispatch `match` has no arm for it, so dispatching it lands on the trapping
+/// default arm (`ud2`). Lives here — the target-independent header module
+/// compiled on BOTH native and wasm32 — so the native (`mailbox.rs`) and WASM
+/// (`mailbox_wasm.rs`) paths share ONE authority and cannot drift (D159); the
+/// native `mailbox` module is `#[cfg(not(wasm32))]` and unavailable on wasm32.
+pub(crate) const HEW_MAILBOX_SHUTDOWN_SENTINEL: i32 = -1;
+
 /// Validate that reserved header bits are zero.
 ///
 /// A newer runtime assigning one of these bits would otherwise let an older

--- a/hew-runtime/src/mailbox_wasm.rs
+++ b/hew-runtime/src/mailbox_wasm.rs
@@ -1192,7 +1192,7 @@ pub(crate) unsafe fn mailbox_send_stop_sys_once(mb: *mut HewMailboxWasm) -> bool
     // SAFETY: stop signals carry no payload.
     let node = unsafe {
         msg_node_alloc(
-            crate::mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL,
+            crate::mailbox_header::HEW_MAILBOX_SHUTDOWN_SENTINEL,
             ptr::null(),
             0,
         )
@@ -1243,7 +1243,7 @@ wasm_no_mangle! {
 /// [`crate::mailbox::RecvNode`].
 ///
 /// The origin bit is load-bearing for the same reason as the native path: the
-/// shutdown sentinel ([`crate::mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL`]) is a
+/// shutdown sentinel ([`crate::mailbox_header::HEW_MAILBOX_SHUTDOWN_SENTINEL`]) is a
 /// system-queue-only lifecycle signal, disambiguated from an application
 /// message that shares its numeric value by PROVENANCE, not by the value.
 /// `msg_type` is unrestricted `i32` and codegen tags are hashes, so a user

--- a/hew-runtime/src/mailbox_wasm.rs
+++ b/hew-runtime/src/mailbox_wasm.rs
@@ -1190,7 +1190,13 @@ pub(crate) unsafe fn mailbox_send_stop_sys_once(mb: *mut HewMailboxWasm) -> bool
     let mb = unsafe { &mut *mb };
 
     // SAFETY: stop signals carry no payload.
-    let node = unsafe { msg_node_alloc(-1, ptr::null(), 0) };
+    let node = unsafe {
+        msg_node_alloc(
+            crate::mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL,
+            ptr::null(),
+            0,
+        )
+    };
     if node.is_null() {
         report_stop_enqueue_failure();
         return false;
@@ -1228,23 +1234,58 @@ wasm_no_mangle! {
     pub unsafe extern "C" fn hew_mailbox_try_recv(
         mb: *mut HewMailboxWasm,
     ) -> *mut HewMsgNode {
-        // SAFETY: Caller guarantees `mb` is valid.
-        let mb = unsafe { &mut *mb };
+        // SAFETY: caller upholds the `mb`-valid contract.
+        unsafe { mailbox_try_recv_with_origin(mb) }.node
+    }
+}
 
-        // System messages have priority.
-        if let Some(node) = mb.sys_queue.pop_front() {
-            crate::scheduler_wasm::record_message_received();
-            return node;
-        }
+/// A received WASM node plus the queue it came from — the WASM twin of
+/// [`crate::mailbox::RecvNode`].
+///
+/// The origin bit is load-bearing for the same reason as the native path: the
+/// shutdown sentinel ([`crate::mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL`]) is a
+/// system-queue-only lifecycle signal, disambiguated from an application
+/// message that shares its numeric value by PROVENANCE, not by the value.
+/// `msg_type` is unrestricted `i32` and codegen tags are hashes, so a user
+/// message may legitimately carry `-1`.
+pub(crate) struct RecvNode {
+    pub node: *mut HewMsgNode,
+    pub from_sys: bool,
+}
 
-        // User messages.
-        if let Some(node) = mb.user_queue.pop_front() {
-            mb.count -= 1;
-            crate::scheduler_wasm::record_message_received();
-            return node;
-        }
+/// Single-consumer receive that preserves system-vs-user provenance — the WASM
+/// twin of [`crate::mailbox::mailbox_try_recv_with_origin`]. System messages
+/// keep priority (dequeued first), exactly as [`hew_mailbox_try_recv`].
+///
+/// # Safety
+///
+/// `mb` must be a valid mailbox pointer.
+pub(crate) unsafe fn mailbox_try_recv_with_origin(mb: *mut HewMailboxWasm) -> RecvNode {
+    // SAFETY: Caller guarantees `mb` is valid.
+    let mb = unsafe { &mut *mb };
 
-        ptr::null_mut()
+    // System messages have priority.
+    if let Some(node) = mb.sys_queue.pop_front() {
+        crate::scheduler_wasm::record_message_received();
+        return RecvNode {
+            node,
+            from_sys: true,
+        };
+    }
+
+    // User messages.
+    if let Some(node) = mb.user_queue.pop_front() {
+        mb.count -= 1;
+        crate::scheduler_wasm::record_message_received();
+        return RecvNode {
+            node,
+            from_sys: false,
+        };
+    }
+
+    RecvNode {
+        node: ptr::null_mut(),
+        from_sys: false,
     }
 }
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -1980,6 +1980,34 @@ fn activate_actor(actor: *mut HewActor) {
                 break;
             }
 
+            // Shutdown sentinel: `hew_actor_stop` enqueues a
+            // `HEW_MAILBOX_SHUTDOWN_SENTINEL` (msg_type == -1) system message so a
+            // *Running* actor's next mailbox poll OBSERVES the close request. It
+            // is a lifecycle signal, not an application message — the generated
+            // dispatch `match` has no arm for it, so handing it to the user
+            // trampoline lands on the trapping default arm (`ud2` → SIGILL). This
+            // reproduced ~0.75% of the time when a supervised actor was stopped
+            // while a worker was mid-drain of its mailbox: the settle path saw the
+            // queued sentinel via `hew_mailbox_has_messages`, re-enqueued the
+            // actor Runnable, and the next activation dispatched the sentinel.
+            // Observe it here as a self-stop and free it; never dispatch it.
+            //
+            // SAFETY: `msg` is the non-null node just returned by
+            // `hew_mailbox_try_recv`, exclusively owned by this worker.
+            if unsafe { (*msg).msg_type } == mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL {
+                // SAFETY: `msg` is exclusively owned by this worker.
+                unsafe { hew_msg_node_free(msg) };
+                // Drive Running -> Stopping so the post-loop settle finalizes the
+                // Stopping -> Stopped terminal transition (monitors/terminate).
+                let _ = a.actor_state.compare_exchange(
+                    HewActorState::Running as i32,
+                    HewActorState::Stopping as i32,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                );
+                break;
+            }
+
             // Dispatch the message (with profiling and crash recovery).
             if let Some(dispatch) = a.dispatch {
                 let t0 = std::time::Instant::now();

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -38,9 +38,7 @@ use crate::deterministic::hew_deterministic_set_seed;
 use crate::execution_context::HewExecutionContext;
 use crate::internal::types::HewActorState;
 use crate::lifetime::poison_safe::PoisonSafe;
-use crate::mailbox::{
-    self, hew_mailbox_has_messages, hew_mailbox_try_recv, hew_msg_node_free, HewMailbox,
-};
+use crate::mailbox::{self, hew_mailbox_has_messages, hew_msg_node_free, HewMailbox};
 use crate::set_last_error;
 use crate::util::MutexExt;
 
@@ -1975,14 +1973,19 @@ fn activate_actor(actor: *mut HewActor) {
         // Process up to `budget` messages.
         for _ in 0..budget {
             // SAFETY: mailbox pointer is valid for the lifetime of the actor.
-            let msg = unsafe { hew_mailbox_try_recv(mailbox) };
+            // Receive WITH provenance so a SYSTEM-queue shutdown sentinel is not
+            // confused with an application message that shares its value.
+            let mailbox::RecvNode {
+                node: msg,
+                from_sys,
+            } = unsafe { mailbox::mailbox_try_recv_with_origin(mailbox) };
             if msg.is_null() {
                 break;
             }
 
             // Shutdown sentinel: `hew_actor_stop` enqueues a
-            // `HEW_MAILBOX_SHUTDOWN_SENTINEL` (msg_type == -1) system message so a
-            // *Running* actor's next mailbox poll OBSERVES the close request. It
+            // `HEW_MAILBOX_SHUTDOWN_SENTINEL` (msg_type == -1) *system* message so
+            // a Running actor's next mailbox poll OBSERVES the close request. It
             // is a lifecycle signal, not an application message — the generated
             // dispatch `match` has no arm for it, so handing it to the user
             // trampoline lands on the trapping default arm (`ud2` → SIGILL). This
@@ -1990,11 +1993,16 @@ fn activate_actor(actor: *mut HewActor) {
             // while a worker was mid-drain of its mailbox: the settle path saw the
             // queued sentinel via `hew_mailbox_has_messages`, re-enqueued the
             // actor Runnable, and the next activation dispatched the sentinel.
-            // Observe it here as a self-stop and free it; never dispatch it.
             //
-            // SAFETY: `msg` is the non-null node just returned by
-            // `hew_mailbox_try_recv`, exclusively owned by this worker.
-            if unsafe { (*msg).msg_type } == mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL {
+            // Gate on `from_sys`: the sentinel value is reserved only on the
+            // SYSTEM queue. `msg_type` is unrestricted `i32` in the public C ABI
+            // (`hew_actor_send` / `HewDispatchFn`) and codegen tags are hashes, so
+            // a USER-queue node carrying `-1` is a real message that MUST reach
+            // the handler — it is never intercepted here.
+            //
+            // SAFETY: `msg` is the non-null node just returned, exclusively owned
+            // by this worker.
+            if from_sys && unsafe { (*msg).msg_type } == mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL {
                 // SAFETY: `msg` is exclusively owned by this worker.
                 unsafe { hew_msg_node_free(msg) };
                 // Drive Running -> Stopping so the post-loop settle finalizes the
@@ -4282,7 +4290,7 @@ mod tests {
         // Teardown: drain the queued message + free the mailbox safely.
         // SAFETY: single-threaded test; nothing else references the mailbox.
         unsafe {
-            let msg = hew_mailbox_try_recv(mailbox.cast::<HewMailbox>());
+            let msg = mailbox::hew_mailbox_try_recv(mailbox.cast::<HewMailbox>());
             if !msg.is_null() {
                 hew_msg_node_free(msg);
             }
@@ -4748,7 +4756,7 @@ mod tests {
         assert!(unsafe { crate::coro_exec::destroy_parked(&actor) }.is_ok());
         // SAFETY: single-threaded test; mailbox unused afterwards.
         unsafe {
-            let msg = hew_mailbox_try_recv(mailbox.cast::<HewMailbox>());
+            let msg = mailbox::hew_mailbox_try_recv(mailbox.cast::<HewMailbox>());
             if !msg.is_null() {
                 hew_msg_node_free(msg);
             }
@@ -4825,7 +4833,7 @@ mod tests {
         // SAFETY: single-threaded test; mailbox unused afterwards.
         unsafe {
             loop {
-                let msg = hew_mailbox_try_recv(mailbox.cast::<HewMailbox>());
+                let msg = mailbox::hew_mailbox_try_recv(mailbox.cast::<HewMailbox>());
                 if msg.is_null() {
                     break;
                 }

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -265,16 +265,8 @@ const _: () = {
 
 #[cfg(target_arch = "wasm32")]
 extern "C" {
-    fn hew_mailbox_try_recv(mb: *mut c_void) -> *mut HewMsgNode;
     fn hew_mailbox_has_messages(mb: *mut c_void) -> i32;
     fn hew_msg_node_free(node: *mut HewMsgNode);
-}
-
-#[cfg(all(test, not(target_arch = "wasm32")))]
-unsafe fn hew_mailbox_try_recv(mb: *mut c_void) -> *mut HewMsgNode {
-    // SAFETY: Tests pass a mailbox allocated by mailbox_wasm with the same
-    // message-node layout as scheduler_wasm's local copy.
-    unsafe { crate::mailbox_wasm::hew_mailbox_try_recv(mb.cast()).cast() }
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
@@ -1574,8 +1566,44 @@ unsafe fn activate_actor_wasm(actor: *mut HewActor) {
         // Process up to `budget` messages.
         for _ in 0..budget {
             // SAFETY: mailbox pointer is valid for the lifetime of the actor.
-            let msg = unsafe { hew_mailbox_try_recv(mailbox) };
+            // Receive WITH provenance so a SYSTEM-queue shutdown sentinel is not
+            // confused with an application message sharing its value. Mirrors the
+            // native `mailbox::mailbox_try_recv_with_origin` path (sync parity).
+            let recv = unsafe { crate::mailbox_wasm::mailbox_try_recv_with_origin(mailbox.cast()) };
+            let from_sys = recv.from_sys;
+            let msg = recv.node.cast::<HewMsgNode>();
             if msg.is_null() {
+                break;
+            }
+
+            // Shutdown sentinel: `hew_actor_stop` enqueues a
+            // `HEW_MAILBOX_SHUTDOWN_SENTINEL` (msg_type == -1) *system* message so
+            // a Running actor's next mailbox poll OBSERVES the close request. It
+            // is a lifecycle signal, not an application message — the generated
+            // dispatch `match` has no arm for it, so handing it to the user
+            // trampoline lands on the trapping default arm (`ud2`). On WASM this
+            // fires DETERMINISTICALLY (no concurrency): a handler that calls
+            // `hew_actor_stop(self)` leaves the actor Running, queues the
+            // sentinel, and the next loop iteration would dispatch it.
+            //
+            // Gate on `from_sys`: the sentinel value is reserved only on the
+            // SYSTEM queue; a USER-queue node carrying `-1` is a real message that
+            // MUST reach the handler.
+            //
+            // SAFETY: `msg` is the non-null node just returned, exclusively owned
+            // by this scheduler tick.
+            let msg_type = unsafe { (*msg).msg_type };
+            if from_sys && msg_type == crate::mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL {
+                // SAFETY: `msg` is exclusively owned by this scheduler tick.
+                unsafe { hew_msg_node_free(msg) };
+                // Drive Running -> Stopping so the post-loop settle finalizes the
+                // Stopping -> Stopped terminal transition (terminate callback).
+                let _ = a.actor_state.compare_exchange(
+                    HewActorState::Running as i32,
+                    HewActorState::Stopping as i32,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                );
                 break;
             }
 
@@ -2886,6 +2914,133 @@ mod tests {
             "crashed actor should remain crashed"
         );
 
+        hew_sched_shutdown();
+    }
+
+    // WASM twin of the native `shutdown_sentinel_is_never_delivered_to_handler`.
+    // Fails on the pre-fix wasm path (the sentinel was dispatched to the handler
+    // and the actor stayed Running).
+    #[test]
+    fn wasm_shutdown_sentinel_is_never_delivered_to_handler() {
+        static SAW_SENTINEL: AtomicI32 = AtomicI32::new(0);
+        unsafe extern "C-unwind" fn sentinel_probe_dispatch(
+            _ctx: *mut crate::execution_context::HewExecutionContext,
+            _state: *mut c_void,
+            msg_type: i32,
+            _data: *mut c_void,
+            _data_size: usize,
+            _borrow_mode: i32,
+        ) -> *mut c_void {
+            if msg_type == crate::mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL {
+                SAW_SENTINEL.fetch_add(1, Ordering::Relaxed);
+            }
+            std::ptr::null_mut()
+        }
+
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK — no concurrent access.
+        unsafe { reset_globals() };
+        hew_sched_init();
+        SAW_SENTINEL.store(0, Ordering::Relaxed);
+
+        // SAFETY: hew_mailbox_new returns a valid heap-allocated mailbox.
+        let mailbox = unsafe { crate::mailbox_wasm::hew_mailbox_new() };
+        let mut a = stub_actor();
+        a.dispatch = Some(sentinel_probe_dispatch);
+        a.mailbox = mailbox.cast();
+        a.actor_state
+            .store(HewActorState::Runnable as i32, Ordering::Relaxed);
+        let a_ptr: *mut HewActor = (&raw mut a);
+
+        // `hew_actor_stop` on a Running actor enqueues the -1 sentinel on the
+        // SYSTEM queue. Enqueue it directly — on wasm this reproduces
+        // deterministically (no concurrency needed).
+        // SAFETY: mailbox is a valid live wasm mailbox.
+        assert!(unsafe { crate::mailbox_wasm::mailbox_send_stop_sys_once(mailbox) });
+
+        // SAFETY: actor is valid and Runnable.
+        unsafe { activate_actor_wasm(a_ptr) };
+
+        assert_eq!(
+            SAW_SENTINEL.load(Ordering::Relaxed),
+            0,
+            "the system shutdown sentinel must be observed as a self-stop, never dispatched"
+        );
+        assert_eq!(
+            a.actor_state.load(Ordering::Relaxed),
+            HewActorState::Stopped as i32,
+            "observing the shutdown sentinel must self-stop the actor"
+        );
+
+        // SAFETY: actor is terminal; the mailbox is drained and freed once.
+        unsafe { crate::mailbox_wasm::hew_mailbox_free(mailbox) };
+        hew_sched_shutdown();
+    }
+
+    // WASM twin of the native
+    // `user_msg_type_minus_one_reaches_handler_and_does_not_terminate`: a
+    // USER-queue send of `-1` (no stop) must reach the handler and leave the
+    // actor live. Fails on the pre-fix wasm path (value-only interception would
+    // drop it and stop the actor) — here it also proves the provenance gate.
+    #[test]
+    fn wasm_user_msg_type_minus_one_reaches_handler_and_does_not_terminate() {
+        static USER_HANDLED: AtomicI32 = AtomicI32::new(0);
+        unsafe extern "C-unwind" fn user_minus_one_probe_dispatch(
+            _ctx: *mut crate::execution_context::HewExecutionContext,
+            _state: *mut c_void,
+            msg_type: i32,
+            _data: *mut c_void,
+            _data_size: usize,
+            _borrow_mode: i32,
+        ) -> *mut c_void {
+            if msg_type == -1 {
+                USER_HANDLED.fetch_add(1, Ordering::Relaxed);
+            }
+            std::ptr::null_mut()
+        }
+
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK — no concurrent access.
+        unsafe { reset_globals() };
+        hew_sched_init();
+        USER_HANDLED.store(0, Ordering::Relaxed);
+
+        // SAFETY: hew_mailbox_new returns a valid heap-allocated mailbox.
+        let mailbox = unsafe { crate::mailbox_wasm::hew_mailbox_new() };
+        let mut a = stub_actor();
+        a.dispatch = Some(user_minus_one_probe_dispatch);
+        a.mailbox = mailbox.cast();
+        a.actor_state
+            .store(HewActorState::Runnable as i32, Ordering::Relaxed);
+        let a_ptr: *mut HewActor = (&raw mut a);
+
+        // A USER-queue send (hew_mailbox_send routes to the user queue) carrying
+        // the reserved sentinel VALUE — a legitimate application message.
+        // SAFETY: mailbox is valid; null payload with size 0.
+        let rc =
+            unsafe { crate::mailbox_wasm::hew_mailbox_send(mailbox, -1, std::ptr::null_mut(), 0) };
+        assert_eq!(
+            rc, 0,
+            "user send of msg_type == -1 must enqueue successfully"
+        );
+
+        // SAFETY: actor is valid and Runnable.
+        unsafe { activate_actor_wasm(a_ptr) };
+
+        assert_eq!(
+            USER_HANDLED.load(Ordering::Relaxed),
+            1,
+            "a user-queue message with msg_type == -1 must reach the handler, \
+             not be intercepted as a shutdown signal"
+        );
+        let state = a.actor_state.load(Ordering::Relaxed);
+        assert!(
+            state != HewActorState::Stopped as i32 && state != HewActorState::Crashed as i32,
+            "delivering a user-queue msg_type == -1 must not terminate the actor (state={state})"
+        );
+
+        // SAFETY: mailbox is drained and freed once.
+        unsafe { crate::mailbox_wasm::hew_mailbox_free(mailbox) };
         hew_sched_shutdown();
     }
 

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -1593,7 +1593,7 @@ unsafe fn activate_actor_wasm(actor: *mut HewActor) {
             // SAFETY: `msg` is the non-null node just returned, exclusively owned
             // by this scheduler tick.
             let msg_type = unsafe { (*msg).msg_type };
-            if from_sys && msg_type == crate::mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL {
+            if from_sys && msg_type == crate::mailbox_header::HEW_MAILBOX_SHUTDOWN_SENTINEL {
                 // SAFETY: `msg` is exclusively owned by this scheduler tick.
                 unsafe { hew_msg_node_free(msg) };
                 // Drive Running -> Stopping so the post-loop settle finalizes the
@@ -2931,7 +2931,7 @@ mod tests {
             _data_size: usize,
             _borrow_mode: i32,
         ) -> *mut c_void {
-            if msg_type == crate::mailbox::HEW_MAILBOX_SHUTDOWN_SENTINEL {
+            if msg_type == crate::mailbox_header::HEW_MAILBOX_SHUTDOWN_SENTINEL {
                 SAW_SENTINEL.fetch_add(1, Ordering::Relaxed);
             }
             std::ptr::null_mut()


### PR DESCRIPTION
## Summary

This closes a P0 lifecycle bug where an actor stopped mid-worker-drain could dispatch its own shutdown sentinel to a user handler and trap. `hew_actor_stop` enqueues a `msg_type == -1` shutdown sentinel on the system queue; the scheduler handed it to the user dispatch trampoline, whose match has no arm for it, hitting the trapping default (SIGILL on a worker thread, empty output — reproduced on Windows at ~0.75% under concurrency; a WASM handler that self-stops hits it deterministically). The scheduler now recognizes the sentinel as a self-stop and never dispatches it, gated on system-queue provenance so an application message that legitimately carries `-1` still reaches its handler. This applies identically to the native and WASM runtimes; the sentinel constant is hosted in the shared header module so both targets share one definition.

## Verification

- Windows 20x-concurrency repro: 0/20000 (was 0.75%)
- Linux ASan: 0/400
- Full `hew-runtime` suite: 2668 passed
- `wasm32-wasip1` build (debug + release): exit 0
- Native and WASM regression teeth (system-sentinel-never-dispatched and user-`-1`-reaches-handler), each red-proofed
- `make lint` incl. sandbox-parity: passed

It was originally investigated as a use-after-free; poison-on-free and ring-buffer instrumentation proved it is a routing bug, not memory corruption, so no lock-free reclamation change was needed.

## Out of scope

- Making the dispatch default arm fail closed with a diagnostic instead of a raw trap, so a future routing regression is observable rather than a silent SIGILL. Tracked as a follow-up.

Unblocks #2798.