### PR TITLE
fix(mir): release returned members on branch-around guard-returns

### DIFF
--- a/examples/v05/checked-mir/golden/channel_auto_close_scope.elab.mir
+++ b/examples/v05/checked-mir/golden/channel_auto_close_scope.elab.mir
@@ -211,7 +211,7 @@ fn channel$try_new -> Result<(Sender, Receiver), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -467,5 +467,3 @@ fn duration::fmt -> string
     return[bb1] ->
       (none)
 
-diagnostics:
-  diagnostic: ObligationUnderReleased channel$try_new bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
@@ -603,5 +603,3 @@ fn duration::fmt(duration) -> string [conv=default]
     ret = move _4
     return
 
-diagnostics:
-  diagnostic: ObligationUnderReleased channel$try_new bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/channel_recv_select.elab.mir
+++ b/examples/v05/checked-mir/golden/channel_recv_select.elab.mir
@@ -296,7 +296,7 @@ fn channel$try_new -> Result<(Sender, Receiver), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -552,5 +552,3 @@ fn duration::fmt -> string
     return[bb1] ->
       (none)
 
-diagnostics:
-  diagnostic: ObligationUnderReleased channel$try_new bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
@@ -724,5 +724,3 @@ fn duration::fmt(duration) -> string [conv=default]
     ret = move _4
     return
 
-diagnostics:
-  diagnostic: ObligationUnderReleased channel$try_new bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
@@ -1051,7 +1051,7 @@ fn stream$try_pipe -> Result<(Sink<string>, Stream<string>), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -1171,7 +1171,7 @@ fn stream$try_bytes_pipe -> Result<(Sink<bytes>, Stream<bytes>), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -1578,6 +1578,3 @@ fn duration::fmt -> string
     return[bb1] ->
       (none)
 
-diagnostics:
-  diagnostic: ObligationUnderReleased stream$try_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"
-  diagnostic: ObligationUnderReleased stream$try_bytes_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -2530,6 +2530,3 @@ fn duration::fmt(duration) -> string [conv=default]
     ret = move _4
     return
 
-diagnostics:
-  diagnostic: ObligationUnderReleased stream$try_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"
-  diagnostic: ObligationUnderReleased stream$try_bytes_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
@@ -1085,7 +1085,7 @@ fn stream$try_pipe -> Result<(Sink<string>, Stream<string>), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -1205,7 +1205,7 @@ fn stream$try_bytes_pipe -> Result<(Sink<bytes>, Stream<bytes>), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -1612,6 +1612,3 @@ fn duration::fmt -> string
     return[bb1] ->
       (none)
 
-diagnostics:
-  diagnostic: ObligationUnderReleased stream$try_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"
-  diagnostic: ObligationUnderReleased stream$try_bytes_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -2590,6 +2590,3 @@ fn duration::fmt(duration) -> string [conv=default]
     ret = move _4
     return
 
-diagnostics:
-  diagnostic: ObligationUnderReleased stream$try_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"
-  diagnostic: ObligationUnderReleased stream$try_bytes_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
@@ -1018,7 +1018,7 @@ fn stream$try_pipe -> Result<(Sink<string>, Stream<string>), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -1138,7 +1138,7 @@ fn stream$try_bytes_pipe -> Result<(Sink<bytes>, Stream<bytes>), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -1545,6 +1545,3 @@ fn duration::fmt -> string
     return[bb1] ->
       (none)
 
-diagnostics:
-  diagnostic: ObligationUnderReleased stream$try_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"
-  diagnostic: ObligationUnderReleased stream$try_bytes_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -2476,6 +2476,3 @@ fn duration::fmt(duration) -> string [conv=default]
     ret = move _4
     return
 
-diagnostics:
-  diagnostic: ObligationUnderReleased stream$try_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"
-  diagnostic: ObligationUnderReleased stream$try_bytes_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.elab.mir
@@ -1003,7 +1003,7 @@ fn stream$try_pipe -> Result<(Sink<string>, Stream<string>), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -1123,7 +1123,7 @@ fn stream$try_bytes_pipe -> Result<(Sink<bytes>, Stream<bytes>), string>
     branch[bb13: bb14/bb15] ->
       (none)
     return[bb14] ->
-      (none)
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
     goto[bb15->bb16] ->
       (none)
     return[bb16] ->
@@ -1530,6 +1530,3 @@ fn duration::fmt -> string
     return[bb1] ->
       (none)
 
-diagnostics:
-  diagnostic: ObligationUnderReleased stream$try_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"
-  diagnostic: ObligationUnderReleased stream$try_bytes_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send_blocking.raw.mir
@@ -2454,6 +2454,3 @@ fn duration::fmt(duration) -> string [conv=default]
     ret = move _4
     return
 
-diagnostics:
-  diagnostic: ObligationUnderReleased stream$try_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"
-  diagnostic: ObligationUnderReleased stream$try_bytes_pipe bb14 detail "owned local `detail` reaches return[bb14] with zero discharges on every path modelling: no terminal drop in this exit's plan and no ownership transfer before the exit (mint without discharge = leak)" — "every heap-owning owned value must be released exactly once on every reachable exit path; this exit path never discharges the mint (leak). This is an advisory warning, not a build error — fix the drop plan (release on every exit) to silence it"

--- a/hew-cli/tests/branch_around_return_member_leak_oracle.rs
+++ b/hew-cli/tests/branch_around_return_member_leak_oracle.rs
@@ -1,0 +1,263 @@
+//! Branch-around returned-member leak — slope oracles plus poisoned-allocator
+//! exactly-once pins.
+//!
+//! Empirical oracle for the branch-around under-release class the S1
+//! obligation-balance census surfaced in `semver::try_parse` (44 MB / 500k
+//! error-path calls) and `base64::decode` (30 MB / 500k reject-path calls).
+//!
+//! ## The defect
+//!
+//! A value handed to the caller through the return flow — either an aggregate
+//! member folded into a returned record (`return Version { pre, build }`) or a
+//! whole-value return (`return out`) — is removed from the scope-exit drop plan
+//! **path-insensitively**: the aggregate-member handoff derivation strips it
+//! from every drop class, and a whole-value return retracts its binding to
+//! `ConsumedAt`. That is correct on the return path (the caller owns it now),
+//! but a GUARD EARLY-RETURN that exits BEFORE the hand-off still owns the value
+//! locally and leaks it — the value reaches a `Return` exit live and
+//! undischarged.
+//!
+//! ## The fix
+//!
+//! `elaborate` re-admits the member's scope-exit drop on exactly the `Return`
+//! exits its transfer site provably cannot reach (CFG reachability from the
+//! hand-off block), gated on the dataflow proving it definitely `Live` at that
+//! exit. Purely additive: it never removes an existing drop and emits one only
+//! where the value is the still-live sole owner, so it leak-fixes without any
+//! double-free. Scoped to leaf `CoW` values (`string` / `bytes`).
+//!
+//! ## Slope methodology
+//!
+//! Shared harness (`support::leak_slope`): compile the same shape at LOW and
+//! HIGH iteration counts, measure leak NODE counts under `leaks --atExit` with
+//! the poisoned-allocator triple, assert the delta stays within tolerance. The
+//! pre-fix defect is PER-CALL GROWTH on the guard-return path.
+//!
+//! ## Exactly-once pins
+//!
+//! The return path must NOT double-free: on the tail return the caller owns the
+//! value and the re-admission must skip that exit. The pin binary runs both the
+//! guard-return and the tail-return paths (whole-value string/bytes and a
+//! returned-record member) to completion under
+//! `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges` and must print the
+//! exact checksum — a double-free aborts (or scribbles) before the output
+//! completes.
+//!
+//! ## Skip behaviour
+//!
+//! Slope oracles are macOS-only (`leaks(1)`); elsewhere they log `skip:` and
+//! return. The scribble pin runs on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+// ── slope fixtures — the guard-return path leaks per call pre-fix ────────────
+
+/// Whole-value `string` return (the `base64::decode` / `out` shape at the leaf
+/// level). `s` is a fresh owned string returned on the tail; on the `bail`
+/// guard-return it is live and undischarged. Pre-fix: one leaked string per
+/// bail call.
+fn whole_value_string_guard_return_source(frames: usize) -> String {
+    format!(
+        "fn build_or_bail(bail: bool, seed: string) -> string {{\n\
+         \x20   let payload = seed + \"-owned-heap-payload\";\n\
+         \x20   if bail {{\n\
+         \x20       return \"bailed\";\n\
+         \x20   }}\n\
+         \x20   payload\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let r = build_or_bail(true, \"per-call-seed\");\n\
+         \x20       total = total + r.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Whole-value `bytes` return (the exact `base64::decode` shape). `out`
+/// accumulates content, is returned on the tail, and on the reject guard-return
+/// is live and undischarged. Pre-fix: one leaked bytes buffer per reject call.
+fn whole_value_bytes_guard_return_source(frames: usize) -> String {
+    format!(
+        "fn decode_or_reject(reject: bool) -> bytes {{\n\
+         \x20   let out: bytes = bytes::new();\n\
+         \x20   out.push(1);\n\
+         \x20   out.push(2);\n\
+         \x20   out.push(3);\n\
+         \x20   if reject {{\n\
+         \x20       return bytes::new();\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let r = decode_or_reject(true);\n\
+         \x20       total = total + r.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Returned-record member (the `semver::try_parse` / `Version { pre, build }`
+/// shape). `pre` and `build` are owned string fields moved into a record
+/// returned on the tail; on the guard-return they are live and undischarged.
+/// Pre-fix: two leaked strings per bail call.
+fn returned_record_member_guard_return_source(frames: usize) -> String {
+    format!(
+        "type Parsed {{ pre: string; build: string; n: i64; }}\n\
+         \n\
+         fn parse_or_bail(bail: bool, seed: string) -> Parsed {{\n\
+         \x20   let pre = seed + \"-pre\";\n\
+         \x20   let build = seed + \"-build\";\n\
+         \x20   if bail {{\n\
+         \x20       return Parsed {{ pre: \"\", build: \"\", n: 0 }};\n\
+         \x20   }}\n\
+         \x20   Parsed {{ pre: pre, build: build, n: 1 }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let p = parse_or_bail(true, \"per-call-seed\");\n\
+         \x20       total = total + p.n;\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+// ── exactly-once pin — both paths, poisoned allocator ────────────────────────
+
+/// Both the guard-return AND the tail-return paths of every shape run to
+/// completion under the poisoned allocator. The tail return hands the value to
+/// the caller (the re-admission must SKIP that exit); the guard return keeps it
+/// local (the re-admission fires). A double-free on the tail path — the
+/// re-admitted drop firing where the value escaped — aborts or scribbles before
+/// `OK`.
+const EXACTLY_ONCE_PIN_SOURCE: &str = "\
+fn build_or_bail(bail: bool, seed: string) -> string {\n\
+\x20   let payload = seed + \"-owned-heap-payload\";\n\
+\x20   if bail {\n\
+\x20       return \"bailed\";\n\
+\x20   }\n\
+\x20   payload\n\
+}\n\
+\n\
+fn decode_or_reject(reject: bool) -> bytes {\n\
+\x20   let out: bytes = bytes::new();\n\
+\x20   out.push(1);\n\
+\x20   out.push(2);\n\
+\x20   out.push(3);\n\
+\x20   if reject {\n\
+\x20       return bytes::new();\n\
+\x20   }\n\
+\x20   out\n\
+}\n\
+\n\
+type Parsed { pre: string; build: string; n: i64; }\n\
+\n\
+fn parse_or_bail(bail: bool, seed: string) -> Parsed {\n\
+\x20   let pre = seed + \"-pre\";\n\
+\x20   let build = seed + \"-build\";\n\
+\x20   if bail {\n\
+\x20       return Parsed { pre: \"\", build: \"\", n: 0 };\n\
+\x20   }\n\
+\x20   Parsed { pre: pre, build: build, n: 1 }\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   print(build_or_bail(true, \"seed\").len());\n\
+\x20   print(build_or_bail(false, \"seed\").len());\n\
+\x20   print(decode_or_reject(true).len());\n\
+\x20   print(decode_or_reject(false).len());\n\
+\x20   print(parse_or_bail(true, \"seed\").n);\n\
+\x20   print(parse_or_bail(false, \"seed\").n);\n\
+\x20   print(\"OK\");\n\
+}\n";
+
+/// The concatenated `print` output of [`EXACTLY_ONCE_PIN_SOURCE`]:
+/// `build_or_bail` bail=`"bailed"`.len()=6, tail=`"seed-owned-heap-payload"`.len()=23 ·
+/// `decode_or_reject` reject=0, tail=3 · `parse_or_bail` bail n=0, tail n=1 · OK.
+const EXACTLY_ONCE_PIN_EXPECTED: &str = "6230301OK";
+
+// ── oracles ──────────────────────────────────────────────────────────────────
+
+/// Whole-value `string` return, guard-return path: no per-call leak.
+#[test]
+fn whole_value_string_guard_return_no_per_call_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "whole_value_string_guard_return",
+        whole_value_string_guard_return_source,
+    );
+}
+
+/// Whole-value `bytes` return (the `base64::decode` shape), reject path: no
+/// per-call leak.
+#[test]
+fn whole_value_bytes_guard_return_no_per_call_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "whole_value_bytes_guard_return",
+        whole_value_bytes_guard_return_source,
+    );
+}
+
+/// Returned-record member (the `semver::try_parse` shape), bail path: no
+/// per-call leak of the owned string fields.
+#[test]
+fn returned_record_member_guard_return_no_per_call_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "returned_record_member_guard_return",
+        returned_record_member_guard_return_source,
+    );
+}
+
+/// Exactly-once pin: both the guard-return and tail-return paths of every shape
+/// run to completion under the poisoned-allocator triple and print the exact
+/// checksums. A double-free — the re-admitted drop firing on the tail path
+/// where the value escaped to the caller — aborts or scribbles before `OK`.
+#[test]
+fn branch_around_return_shapes_run_clean_under_malloc_scribble() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("branch-around-return-pin-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(EXACTLY_ONCE_PIN_SOURCE, dir.path(), "exactly_once_pin");
+
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "branch-around-return shapes must run clean under the poisoned allocator \
+         — a crash indicates the re-admitted scope-exit drop fired on the tail \
+         return where the value escaped to the caller (double free);\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        EXACTLY_ONCE_PIN_EXPECTED,
+        "branch-around-return shapes must print the exact checksums — a \
+         scribbled value indicates a freed buffer was still read;\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-cli/tests/obligation_under_release_advisory_e2e.rs
+++ b/hew-cli/tests/obligation_under_release_advisory_e2e.rs
@@ -18,13 +18,25 @@
 //!
 //! These teeth pin three properties so no future allowlist can silently
 //! re-suppress a leak:
-//!   1. a root-unit user leak (`decode` / `out: bytes`) surfaces as a warning,
-//!      build stays green;
-//!   2. the EXACT module-mangled `base64$decode` symbol the deleted allowlist
-//!      keyed on surfaces as a warning (proves a `$`-mangled symbol is not
+//!   1. a root-unit user leak (`count_items` / owned-element `for` cursor)
+//!      surfaces as a warning, build stays green;
+//!   2. a `$`-mangled symbol (the generic monomorphisation `count_iter$$Item`)
+//!      surfaces as a warning (proves a `$`-containing symbol is not
 //!      special-cased back into suppression);
 //!   3. the advisory is flushed on EVERY output path, including
 //!      `--format json --dump-mir`, where an early return once dropped it.
+//!
+//! The fixtures originally pinned the `base64::decode` / `semver::try_parse`
+//! branch-around guard-return leak (a value returned on the tail path and
+//! removed from the drop plan globally, leaking on the guard early-returns).
+//! That family is now fixed by path-sensitive returned-member drop re-admission,
+//! so the fixtures were repointed to the remaining genuine under-release: a
+//! `for _ in v.iter()` over an OWNED-element `Vec` clones a receiver snapshot
+//! (`hew_vec_clone_owned`) whose owned elements the `VecIter` cursor never frees
+//! — a distinct MIR-seam leak (the cursor is misclassified as a borrower, not
+//! the owner of its cloned snapshot). Both fixtures still fire the advisory. (If
+//! that leak is ever fixed this test fails loudly at the lift event — repoint it
+//! to the next genuine under-release then.)
 
 #![cfg(unix)]
 
@@ -35,60 +47,53 @@ use std::process::{Command, Output};
 
 use support::{describe_output, hew_binary, repo_root, require_codegen, strip_ansi, tempdir};
 
-/// A self-contained user program whose `decode` builds a local `out: bytes` and
-/// returns it on the tail path while two guard paths return a fresh
-/// `bytes::new()`. The elaborator removes `out`'s terminal drop globally
-/// (because `out` is consumed on the tail return), so the guard early-returns
-/// reach a `Return` exit with `out` live and undischarged — the branch-around
-/// under-release the S1 gate flags. This is the user-code analogue of the
-/// former-allowlisted stdlib `base64$decode` / `out` / `bytes` triple; the
-/// root-unit symbol here is `decode`.
-const USER_DECODE_LEAK_SOURCE: &str = "\
-fn decode(s: string) -> bytes {\n\
-\x20   let slen = s.len();\n\
-\x20   let out: bytes = bytes::new();\n\
-\x20   if slen == 0 {\n\
-\x20       return out;\n\
+/// A self-contained user program that iterates an OWNED-element `Vec<Item>` with
+/// `for _ in xs.iter()`. `.iter()` clones the receiver into a `VecIter` snapshot
+/// (`hew_vec_clone_owned`) deep-copying each owned `Item`; the cursor is
+/// classified as a borrower of its source (the place-source `VecIter` model), so
+/// its cloned snapshot's owned elements are never released — the S1 gate flags
+/// the under-release on the loop-exit `Return`. The root-unit symbol is
+/// `count_items` and the leaked local renders as `_0` (the discarded `for`
+/// cursor element).
+const USER_ITER_LEAK_SOURCE: &str = "\
+type Item { name: string; n: i64; }\n\
+\n\
+fn count_items(xs: Vec<Item>) -> i64 {\n\
+\x20   let it = xs.iter();\n\
+\x20   var total = 0;\n\
+\x20   for _ in it {\n\
+\x20       total = total + 1;\n\
 \x20   }\n\
-\x20   let vals: bytes = bytes::new();\n\
-\x20   for i in 0 .. slen {\n\
-\x20       let v = s.slice(i, i + 1).len();\n\
-\x20       if v < 0 {\n\
-\x20           return bytes::new();\n\
-\x20       }\n\
-\x20       vals.push(v as u8);\n\
-\x20   }\n\
-\x20   let nvals = vals.len();\n\
-\x20   var i = 0;\n\
-\x20   while i + 4 <= nvals {\n\
-\x20       out.push(vals[i]);\n\
-\x20       i = i + 4;\n\
-\x20   }\n\
-\x20   let remaining = nvals - i;\n\
-\x20   if remaining == 1 {\n\
-\x20       return bytes::new();\n\
-\x20   }\n\
-\x20   out\n\
+\x20   total\n\
 }\n\
 \n\
 fn main() {\n\
-\x20   let b = decode(\"hello\");\n\
-\x20   print(b.len());\n\
+\x20   let xs: Vec<Item> = Vec::new();\n\
+\x20   xs.push(Item { name: \"a\", n: 1 });\n\
+\x20   print(count_items(xs));\n\
 }\n";
 
-/// A program that imports the stdlib `base64` module and calls `decode`. The
-/// stdlib `base64.decode` builds a local `out: bytes` and under-releases it on
-/// its guard-return paths — a tracked pre-existing leak. Its mangled symbol is
-/// exactly `base64$decode`, the EXACT `$`-mangled triple the deleted allowlist
-/// keyed on. This pins that a module-qualified (`$`-containing) symbol is not
-/// re-suppressed by a future allowlist. (If the stdlib leak is ever fixed this
-/// test fails loudly at precisely the lift event — update it then.)
-const STDLIB_BASE64_LEAK_SOURCE: &str = "\
-import std::encoding::base64;\n\
+/// A program whose GENERIC `count_iter<T>` iterates an owned-element `Vec<T>`,
+/// instantiated at the owned record `Item`. The monomorphised symbol is exactly
+/// `count_iter$$Item` — a `$`-containing symbol. This pins that a `$`-mangled
+/// (monomorphisation-qualified) symbol is not re-suppressed by a future
+/// allowlist. The same owned-element `VecIter` snapshot leak fires here.
+const GENERIC_ITER_LEAK_SOURCE: &str = "\
+type Item { name: string; n: i64; }\n\
+\n\
+fn count_iter<T>(xs: Vec<T>) -> i64 {\n\
+\x20   let it = xs.iter();\n\
+\x20   var total = 0;\n\
+\x20   for _ in it {\n\
+\x20       total = total + 1;\n\
+\x20   }\n\
+\x20   total\n\
+}\n\
 \n\
 fn main() {\n\
-\x20   let back = base64.decode(\"SGk=\");\n\
-\x20   print(back.len());\n\
+\x20   let xs: Vec<Item> = Vec::new();\n\
+\x20   xs.push(Item { name: \"a\", n: 1 });\n\
+\x20   print(count_iter(xs));\n\
 }\n";
 
 fn compile(dir: &Path, source: &str, name: &str, extra_args: &[&str]) -> Output {
@@ -138,7 +143,7 @@ fn json_under_release_severities(output: &Output) -> Vec<String> {
 fn user_under_release_leak_warns_but_builds_green() {
     require_codegen();
     let dir = tempdir();
-    let output = compile(dir.path(), USER_DECODE_LEAK_SOURCE, "user_decode_leak", &[]);
+    let output = compile(dir.path(), USER_ITER_LEAK_SOURCE, "user_iter_leak", &[]);
     let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
 
     assert!(
@@ -146,8 +151,8 @@ fn user_under_release_leak_warns_but_builds_green() {
         "an under-release leak must be advisory (warning), not a build error;\n{}",
         describe_output(&output)
     );
-    let names_the_leak = stderr.contains("obligation balance in `decode`")
-        && stderr.contains("`out`")
+    let names_the_leak = stderr.contains("obligation balance in `count_items`")
+        && stderr.contains("`_0`")
         && stderr.contains("never released")
         && stderr.contains("ObligationUnderReleased");
     assert!(
@@ -168,44 +173,48 @@ fn user_under_release_leak_warns_but_builds_green() {
     }
 }
 
-/// (2) The EXACT module-mangled `base64$decode` symbol the deleted allowlist
-/// keyed on surfaces as a warning at exit 0 — a `$`-containing (module-scoped)
-/// symbol is NOT re-suppressed.
+/// (2) A `$`-mangled symbol (the generic monomorphisation `count_iter$$Item`)
+/// surfaces as a warning at exit 0 — a `$`-containing symbol is NOT re-suppressed.
 #[test]
-fn module_mangled_base64_decode_leak_is_not_suppressed() {
+fn mangled_generic_iter_leak_is_not_suppressed() {
     require_codegen();
     let dir = tempdir();
-    let output = compile(dir.path(), STDLIB_BASE64_LEAK_SOURCE, "uses_base64", &[]);
+    let output = compile(
+        dir.path(),
+        GENERIC_ITER_LEAK_SOURCE,
+        "uses_generic_iter",
+        &[],
+    );
     let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
 
     assert!(
         output.status.success(),
-        "the stdlib base64$decode under-release is advisory — the build must stay \
-         green;\n{}",
+        "the generic count_iter$$Item under-release is advisory — the build must \
+         stay green;\n{}",
         describe_output(&output)
     );
 
     let mangled_lines: Vec<&str> = stderr
         .lines()
-        .filter(|l| l.contains("obligation balance in `base64$decode`"))
+        .filter(|l| l.contains("obligation balance in `count_iter$$Item`"))
         .collect();
     assert!(
         !mangled_lines.is_empty(),
-        "the exact module-mangled `base64$decode` under-release (the former \
-         forgeable-allowlist triple) must surface as a diagnostic, never be \
-         suppressed;\n{}",
+        "the `$`-mangled `count_iter$$Item` under-release must surface as a \
+         diagnostic, never be suppressed;\n{}",
         describe_output(&output)
     );
-    // The `$` proves this is the module-mangled symbol, not a root-unit name.
+    // The `$` proves this is the monomorphisation-mangled symbol, not a
+    // root-unit name.
     assert!(
         mangled_lines.iter().all(|l| l.contains('$')),
-        "the surfaced symbol must be the `$`-mangled `base64$decode`;\n{}",
+        "the surfaced symbol must be the `$`-mangled `count_iter$$Item`;\n{}",
         describe_output(&output)
     );
     for line in &mangled_lines {
         assert!(
             line.trim_start().starts_with("warning:"),
-            "the `base64$decode` advisory must render as `warning:`, never \
+            "the `count_iter$$Item` advisory must render as `warning:`, never \
              `error:` — offending line: {line:?}\n{}",
             describe_output(&output)
         );
@@ -244,7 +253,7 @@ fn json_advisory_survives_every_exit_path() {
 
     for (label, args, expected_code) in cases {
         let dir = tempdir();
-        let output = compile(dir.path(), USER_DECODE_LEAK_SOURCE, label, args);
+        let output = compile(dir.path(), USER_ITER_LEAK_SOURCE, label, args);
 
         assert_eq!(
             output.status.code(),
@@ -270,7 +279,7 @@ fn check_json_carries_under_release_advisory() {
     require_codegen();
     let dir = tempdir();
     let src = dir.path().join("check_leak.hew");
-    std::fs::write(&src, USER_DECODE_LEAK_SOURCE).expect("write hew source");
+    std::fs::write(&src, USER_ITER_LEAK_SOURCE).expect("write hew source");
     let output = Command::new(hew_binary())
         .args(["check", "--format", "json", src.to_str().expect("utf-8")])
         .current_dir(repo_root())
@@ -299,8 +308,8 @@ fn text_dump_mir_still_warns_on_stderr() {
     let dir = tempdir();
     let output = compile(
         dir.path(),
-        USER_DECODE_LEAK_SOURCE,
-        "user_decode_leak_textdump",
+        USER_ITER_LEAK_SOURCE,
+        "user_iter_leak_textdump",
         &["--dump-mir", "elab"],
     );
     let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
@@ -312,7 +321,7 @@ fn text_dump_mir_still_warns_on_stderr() {
         describe_output(&output)
     );
     assert!(
-        stderr.contains("obligation balance in `decode`")
+        stderr.contains("obligation balance in `count_items`")
             && stderr
                 .lines()
                 .filter(|l| l.contains("obligation balance in"))

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -3534,6 +3534,27 @@ pub(super) fn derive_returned_aggregate_member_bindings(
     owned_locals: &[(BindingId, String, ResolvedTy)],
     binding_locals: &HashMap<BindingId, Place>,
 ) -> HashSet<BindingId> {
+    let flows_to_return = compute_returned_flow_locals(blocks);
+    // Map member locals back to their owned bindings.
+    let mut returned_members = HashSet::new();
+    for (binding, _name, _ty) in owned_locals {
+        if let Some(place) = binding_locals.get(binding) {
+            if let Some(local) = base_local(*place) {
+                if flows_to_return.contains(&local) {
+                    returned_members.insert(*binding);
+                }
+            }
+        }
+    }
+    returned_members
+}
+
+/// The set of backing locals that whole-value flow into this function's
+/// `ReturnSlot` — either directly or as a member of an aggregate that does.
+/// Shared by [`derive_returned_aggregate_member_bindings`] (which maps the set
+/// back to owned bindings) and [`derive_returned_member_transfer_blocks`]
+/// (which locates the block where each member enters the flow).
+fn compute_returned_flow_locals(blocks: &[BasicBlock]) -> HashSet<u32> {
     // Seed: every owned hand-off slot (Local or handle place) whole-value
     // moved into the ReturnSlot.
     let mut flows_to_return: HashSet<u32> = HashSet::new();
@@ -3646,18 +3667,113 @@ pub(super) fn derive_returned_aggregate_member_bindings(
         }
     }
 
-    // Map member locals back to their owned bindings.
-    let mut returned_members = HashSet::new();
+    flows_to_return
+}
+
+/// Per-member map from a returned-aggregate member binding to the set of blocks
+/// where its value ENTERS the return flow — i.e. the block(s) containing the
+/// instruction that hands its local to the caller (a `Move` to the `ReturnSlot`,
+/// a rebind/variant store into a return-bound local, or an unretained placement
+/// into a `RecordInit`/`TupleConstruct`/`ClosureEnvInit` whose dest reaches the
+/// return).
+///
+/// [`derive_returned_aggregate_member_bindings`] removes these members from the
+/// scope-exit drop plan on EVERY exit — path-insensitively — because on the
+/// return path the caller now owns the value. But a guard early-return that
+/// exits BEFORE the aggregate is constructed still owns the member locally and
+/// must release it, so the path-insensitive removal leaks it there (the
+/// `semver::try_parse` guard-return / `base64::decode` reject-path family). The
+/// drop elaborator uses this map to re-admit a member's scope-exit drop at
+/// exactly the `Return` exits its transfer site provably cannot reach — the
+/// paths where the value is still the live sole owner.
+///
+/// Fail-closed: a member for which no transfer site is located maps to the empty
+/// set and is left under the path-insensitive removal (leak, never a re-admitted
+/// double-free). Over-recording a transfer block only suppresses re-admission on
+/// more exits (leak), so the direction of any imprecision is always leak-safe.
+pub(super) fn derive_returned_member_transfer_blocks(
+    blocks: &[BasicBlock],
+    owned_locals: &[(BindingId, String, ResolvedTy)],
+    binding_locals: &HashMap<BindingId, Place>,
+) -> HashMap<BindingId, HashSet<u32>> {
+    let flows_to_return = compute_returned_flow_locals(blocks);
+    if flows_to_return.is_empty() {
+        return HashMap::new();
+    }
+    // local -> owning binding, restricted to owned locals that are returned
+    // members (the only bindings the drop elaborator re-admits).
+    let mut local_to_binding: HashMap<u32, BindingId> = HashMap::new();
     for (binding, _name, _ty) in owned_locals {
         if let Some(place) = binding_locals.get(binding) {
             if let Some(local) = base_local(*place) {
                 if flows_to_return.contains(&local) {
-                    returned_members.insert(*binding);
+                    local_to_binding.insert(local, *binding);
                 }
             }
         }
     }
-    returned_members
+    let mut transfer_blocks: HashMap<BindingId, HashSet<u32>> = HashMap::new();
+    let record = |src: &Place, block_id: u32, out: &mut HashMap<BindingId, HashSet<u32>>| {
+        if let Some(local) = base_local(*src) {
+            if let Some(binding) = local_to_binding.get(&local) {
+                out.entry(*binding).or_default().insert(block_id);
+            }
+        }
+    };
+    for block in blocks {
+        for (instr_index, instr) in block.instructions.iter().enumerate() {
+            match instr {
+                // Whole-value return: `Move { dest: ReturnSlot, src }`.
+                Instr::Move {
+                    dest: Place::ReturnSlot,
+                    src,
+                } => {
+                    record(src, block.id, &mut transfer_blocks);
+                }
+                // Rebind / variant payload store into a return-bound local: the
+                // source enters the return flow here.
+                Instr::Move { dest, src }
+                    if base_local(*dest).is_some_and(|dl| flows_to_return.contains(&dl)) =>
+                {
+                    record(src, block.id, &mut transfer_blocks);
+                }
+                // Aggregate constructor whose dest reaches the return: each
+                // non-retained element/field source is handed off here.
+                Instr::TupleConstruct { elements, dest }
+                    if base_local(*dest).is_some_and(|dl| flows_to_return.contains(&dl)) =>
+                {
+                    let retained = retained_string_values_before(block, instr_index);
+                    for elem in elements {
+                        if !retained.contains(elem) {
+                            record(elem, block.id, &mut transfer_blocks);
+                        }
+                    }
+                }
+                Instr::RecordInit { fields, dest, .. }
+                    if base_local(*dest).is_some_and(|dl| flows_to_return.contains(&dl)) =>
+                {
+                    let retained = retained_string_values_before(block, instr_index);
+                    for (_offset, field) in fields {
+                        if !retained.contains(field) {
+                            record(field, block.id, &mut transfer_blocks);
+                        }
+                    }
+                }
+                Instr::ClosureEnvInit { fields, dest, .. }
+                    if base_local(*dest).is_some_and(|dl| flows_to_return.contains(&dl)) =>
+                {
+                    for field in fields
+                        .iter()
+                        .filter(|field| field.ownership == ClosureEnvFieldOwnership::OwnsMoved)
+                    {
+                        record(&field.src, block.id, &mut transfer_blocks);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    transfer_blocks
 }
 /// Fail-closed value-flow derivation of the owned-handle member bindings whose
 /// handle is moved into a LOCALLY-constructed aggregate and then extracted-and-

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -2,11 +2,12 @@
 use super::*;
 #[cfg(not(test))]
 use super::{
-    base_local, check_duplex_split_state, compute_collection_interior_alias_taint,
-    compute_projection_alias_taint, dataflow, derive_consumed_local_aggregate_member_bindings,
-    derive_cow_fresh_borrowed_owner, derive_cow_sole_owner, derive_enum_composite_drop_allowed,
-    derive_local_bytes_drop_allowed, derive_local_collection_drop_allowed,
-    derive_owned_record_drop_allowed, derive_returned_aggregate_member_bindings,
+    base_local, blocks_reachable_from, check_duplex_split_state,
+    compute_collection_interior_alias_taint, compute_projection_alias_taint, dataflow,
+    derive_consumed_local_aggregate_member_bindings, derive_cow_fresh_borrowed_owner,
+    derive_cow_sole_owner, derive_enum_composite_drop_allowed, derive_local_bytes_drop_allowed,
+    derive_local_collection_drop_allowed, derive_owned_record_drop_allowed,
+    derive_returned_aggregate_member_bindings, derive_returned_member_transfer_blocks,
     derive_spawn_consumed_handle_bindings, derive_tuple_composite_drop_allowed,
     instr_source_places, mangle_layout_key, place_is_interior_projection, place_refs_local,
     retained_string_terminator_drop_safe, short_name, terminator_is_suspend_carrier,
@@ -750,6 +751,21 @@ pub(super) fn elaborate(
         &owned_locals_snapshot,
         &builder.binding_locals,
     );
+    // Path-sensitive re-admission map for values handed to the caller through the
+    // return flow. The blanket exclusion (an aggregate member the return handoff
+    // removes, `semver::try_parse`; or a whole-value return that retracts its
+    // binding to `ConsumedAt`, `base64::decode`) is correct on the return path but
+    // leaks the value on a guard early-return that exits BEFORE the hand-off and
+    // still owns it locally. Sourced from the returned-candidate view (scope-exit
+    // OR consume-retracted owners) so BOTH shapes are covered; this locates where
+    // each candidate enters the return flow so the elaborator can restore its
+    // scope-exit drop on exactly the `Return` exits that transfer cannot reach.
+    let returned_member_candidates = builder.owned_locals_returned_candidates();
+    let returned_member_transfer_blocks = derive_returned_member_transfer_blocks(
+        &checked.blocks,
+        &returned_member_candidates,
+        &builder.binding_locals,
+    );
 
     // W3.053 — owned-handle members moved into a LOCAL aggregate and then
     // extracted-and-consumed back out (for-in / `let` extraction) by a downstream
@@ -919,6 +935,88 @@ pub(super) fn elaborate(
             }
             if let Some(drop) = lifo_drops.iter().find(|drop| drop.place == *place) {
                 plan.drops.push(drop.clone());
+            }
+        }
+    }
+
+    // Path-sensitive re-admission of returned-aggregate member drops. A member
+    // handed to the caller through the `ReturnSlot` is removed from EVERY drop
+    // class (`build_lifo_drops` skips `returned_aggregate_members` before any
+    // arm) because on the return path the caller owns it. But a guard
+    // early-return that exits BEFORE the aggregate is constructed still owns the
+    // member locally and must release it — the `semver::try_parse` guard-return
+    // and `base64::decode` reject-path leaks. Restore the scope-exit drop on
+    // exactly the `Return` exits the member's transfer site provably cannot
+    // reach (the value is not yet handed off), and only where the dataflow
+    // proves it definitely `Live` (owned) at that exit. This is purely additive:
+    // it never removes an existing drop, and it emits one only where the value
+    // is provably the still-live sole owner, so it can leak-fix without any
+    // double-free. Scoped to leaf CoW values (`string` / `bytes`) whose release
+    // is the unconditional `drop_kind_for` kind with no descriptor or
+    // path-flag; a member of any other type stays under the path-insensitive
+    // removal (leak, never a re-admitted double-free — fail-closed).
+    // LESSONS: cleanup-all-exits, raii-null-after-move, boundary-fail-closed,
+    // drop-allowset-from-value-flow.
+    if !returned_member_transfer_blocks.is_empty() {
+        let owned_ty_by_binding: HashMap<BindingId, &ResolvedTy> = returned_member_candidates
+            .iter()
+            .map(|(binding, _name, ty)| (*binding, ty))
+            .collect();
+        // Blocks each member's hand-off can reach (inclusive of the transfer
+        // block itself). A `Return` exit inside this set is at or downstream of
+        // the hand-off, so the caller owns the value there — no re-admission.
+        let mut member_transfer_reach: HashMap<BindingId, HashSet<u32>> = HashMap::new();
+        for (binding, transfer_blocks) in &returned_member_transfer_blocks {
+            if transfer_blocks.is_empty() {
+                continue;
+            }
+            let mut reach: HashSet<u32> = HashSet::new();
+            for &transfer_block in transfer_blocks {
+                reach.insert(transfer_block);
+                reach.extend(blocks_reachable_from(&checked.blocks, transfer_block));
+            }
+            member_transfer_reach.insert(*binding, reach);
+        }
+        for (exit, plan) in &mut drop_plans {
+            let ExitPath::Return { block } = exit else {
+                continue;
+            };
+            let Some(state_map) = dataflow_result.exit_states.get(block) else {
+                continue;
+            };
+            for (binding, reach) in &member_transfer_reach {
+                // This exit is at or after the hand-off: caller owns the value.
+                if reach.contains(block) {
+                    continue;
+                }
+                // Only re-admit where the value is definitely still owned. A
+                // `MaybeConsumed`/`Uninit`/`Consumed` state at this exit is
+                // ambiguous or already discharged — skip (fail-closed).
+                if !matches!(
+                    state_map.get(binding).copied(),
+                    Some(dataflow::BindingState::Live)
+                ) {
+                    continue;
+                }
+                let Some(ty) = owned_ty_by_binding.get(binding).copied() else {
+                    continue;
+                };
+                if !matches!(ty, ResolvedTy::String | ResolvedTy::Bytes) {
+                    continue;
+                }
+                let Some(&place) = builder.binding_locals.get(binding) else {
+                    continue;
+                };
+                if plan.drops.iter().any(|drop| drop.place == place) {
+                    continue;
+                }
+                plan.drops.push(ElabDrop {
+                    place,
+                    ty: ty.clone(),
+                    drop_fn: None,
+                    kind: drop_kind_for(place, ty, None),
+                    guard: None,
+                });
             }
         }
     }

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -91,10 +91,10 @@ use self::composite_own::{
     apply_escaped_record_sibling_field_drops, derive_consumed_local_aggregate_member_bindings,
     derive_enum_composite_drop_allowed, derive_local_bytes_drop_allowed,
     derive_local_collection_drop_allowed, derive_owned_record_drop_allowed,
-    derive_returned_aggregate_member_bindings, derive_spawn_consumed_handle_bindings,
-    derive_tuple_composite_drop_allowed, detect_actor_state_handle_consume,
-    detect_actor_state_resource_overwrite, detect_opaque_resource_field_misuse,
-    detect_unproven_aggregate_handle_double_free,
+    derive_returned_aggregate_member_bindings, derive_returned_member_transfer_blocks,
+    derive_spawn_consumed_handle_bindings, derive_tuple_composite_drop_allowed,
+    detect_actor_state_handle_consume, detect_actor_state_resource_overwrite,
+    detect_opaque_resource_field_misuse, detect_unproven_aggregate_handle_double_free,
 };
 #[cfg(not(test))]
 use self::consts::{

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -1058,6 +1058,29 @@ impl Builder {
             .map(|entry| (entry.binding, entry.name.clone(), entry.ty.clone()))
             .collect()
     }
+    /// The owned-locals whose release obligation is still SOLE-OWNED per binding —
+    /// either scope-exit-live (`ScopeExit`) or retracted only by a consume that
+    /// transfers the value out (`ConsumedAt`). A binding in this view is a
+    /// candidate for the path-sensitive returned-member re-admission in
+    /// `elaborate`: a value returned/handed-off on SOME paths (so it is either an
+    /// aggregate member the return handoff removes, or a whole-value return that
+    /// retracts it to `ConsumedAt`) can still be the live sole owner on a guard
+    /// early-return, where its scope-exit drop must be restored. `BodyEndReleased`
+    /// / `ScopeReleased` (already released mid-body) and `AliasOf` (a non-owning
+    /// interior alias — never its own drop) are excluded, so the re-admission
+    /// never resurrects a drop those dispositions deliberately elide.
+    pub(crate) fn owned_locals_returned_candidates(&self) -> Vec<(BindingId, String, ResolvedTy)> {
+        self.owned_locals
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    entry.disposition,
+                    Disposition::ScopeExit | Disposition::ConsumedAt { .. }
+                )
+            })
+            .map(|entry| (entry.binding, entry.name.clone(), entry.ty.clone()))
+            .collect()
+    }
     /// The WHOLE per-function owned-locals ledger — every entry regardless of
     /// disposition, in registration order — including bindings retracted off the
     /// scope-exit-live set by a [`Builder::set_owned_local_disposition`] write.


### PR DESCRIPTION
## Summary

Fixes two leaks where a returned owned value was dropped from the discharge set on its transfer exit, so guard and error early-returns that exit before the transfer left it undischarged. `semver`'s `try_parse` leaked the `pre`/`build` strings on its `Err` paths, and base64 `decode` leaked its `out` buffer on reject paths.

Drop re-admission is now path-sensitive: the scope-exit drop is re-admitted only on the return exits the transfer block provably cannot reach (CFG reachability), gated on the value being definitely live there. The change is purely additive, so it never double-frees the transferred value. Scoped to leaf copy-on-write string and bytes members.

## Verification

- New branch-around-return leak oracle (guard and tail paths under malloc-scribble, exactly-once pin): 4/4
- `semver` leaks: 3 to 1 per call (the residual is a separate pre-existing caller-side `Err`-payload leak, present on main)
- base64 leaks: 2000 to 0
- The obligation-balance validator's advisory warnings for both are gone
- `cargo nextest run -p hew-mir`: 1207 passed
- `make test-hew-ratchet`: green
- Preflight: ready-to-push

## Out of scope

- The owned-element `Vec<T>::iter()` snapshot-cursor leak — a distinct MIR reshape, tracked as a follow-up.
- The residual `semver` caller-side `Err`-payload leak noted above, which predates this change and lives on main.