### PR TITLE
fix(ci): run checked-mir-verify in the compiler-pipeline preflight lane

### DIFF
--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -707,6 +707,11 @@ case "$LANE" in
         add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "make test-compiler-pipeline"
         add_command "make fuzz-oracle"
+        # A type-checker change reaches MIR lowering and can drift the checked-MIR
+        # golden corpus (examples/v05/checked-mir) just as a lowering edit can.
+        # Run the same golden diff here so the drift is caught locally rather than
+        # at hosted CI.  Fast (~45s), well within this lane's budget.
+        add_command "make checked-mir-verify"
         ;;
     cli)
         add_command "cargo fmt --all -- --check"
@@ -729,6 +734,12 @@ case "$LANE" in
         # fuzz-oracle catches trap signal-code regressions (SIGILL/SIGTRAP) and
         # ratchet mismatches invisible to the nextest workspace run (#2025).
         add_command "make fuzz-oracle"
+        # checked-mir-verify diffs every fixture's --dump-mir against the
+        # committed golden corpus (examples/v05/checked-mir).  A drop-plan or
+        # lowering edit that shifts the emitted MIR drifts these goldens; without
+        # this step the drift only surfaces at hosted CI's Build & test (Linux)
+        # job, costing a full hosted cycle.  Fast (compile-and-compare, ~45s).
+        add_command "make checked-mir-verify"
         ;;
     vertical-slice)
         add_command "cargo fmt --all -- --check"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -423,6 +423,39 @@ def test_compiler_pipeline_rs_change_includes_vertical_slice_oracle() -> None:
     assert "--test await_e2e" not in result.stdout, result.stdout
 
 
+def test_compiler_pipeline_lane_includes_checked_mir_verify() -> None:
+    """A MIR-changing (drop-plan / lowering) diff runs the checked-MIR golden diff.
+
+    A hew-mir edit that shifts emitted MIR drifts the committed
+    examples/v05/checked-mir goldens.  Without checked-mir-verify in this lane
+    the drift is invisible to the local preflight and only surfaces at hosted
+    CI's Build & test (Linux) job.  This ratchet locks the step into the lane so
+    it cannot be silently dropped.
+    """
+    result = run_dispatcher("hew-mir/src/lower/drop_plan.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: compiler-pipeline" in result.stdout, result.stdout
+    assert "make checked-mir-verify" in result.stdout, (
+        f"Expected 'make checked-mir-verify' in compiler-pipeline lane.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+def test_types_lane_includes_checked_mir_verify() -> None:
+    """A type-checker change runs the checked-MIR golden diff.
+
+    Type inference feeds MIR lowering, so a hew-types edit can drift the
+    examples/v05/checked-mir goldens.  The types lane runs checked-mir-verify so
+    that drift is caught locally rather than at hosted CI.
+    """
+    result = run_dispatcher("hew-types/src/lib.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: types" in result.stdout, result.stdout
+    assert "make checked-mir-verify" in result.stdout, (
+        f"Expected 'make checked-mir-verify' in types lane.\nstdout:\n{result.stdout}"
+    )
+
+
 def test_make_test_compiler_pipeline_recipe_keeps_consumer_corpus_packages() -> None:
     """The compiler-pipeline and types lanes delegate hew-cli consumer-corpus
     coverage to make test-compiler-pipeline: its nextest invocation must keep
@@ -728,6 +761,8 @@ _TESTS = [
     test_runtime_net_lane_rebuilds_libhew,
     test_zero_timeout_fails_closed,
     test_compiler_pipeline_rs_change_includes_vertical_slice_oracle,
+    test_compiler_pipeline_lane_includes_checked_mir_verify,
+    test_types_lane_includes_checked_mir_verify,
     test_make_test_compiler_pipeline_recipe_keeps_consumer_corpus_packages,
     test_docs_only_change_does_not_include_vertical_slice_oracle,
     test_fallback_lane_includes_smoke_tier_before_heavy,


### PR DESCRIPTION
## Summary

The pre-push preflight now runs `make checked-mir-verify` in the compiler-pipeline and types lanes. A MIR-lowering or type-checker change can drift the checked-MIR golden corpus, but until now those local lanes did not verify it — so the drift only surfaced at hosted CI's Build & test (Linux) step, costing a full remote cycle to catch. The gate is fast (~45s compile-and-compare) and is now emitted for both lanes, with dispatcher-test ratchets locking the membership in. The fallback lane already ran this check and is unchanged.

## Verification

- `python3 scripts/tests/test_ci_preflight_dispatcher.py`: 44/44 pass (2 new membership ratchets)
- Dry-run: confirms the `checked-mir-verify` step is emitted for a `hew-mir/src/lower` diff and a `hew-types` diff
- shellcheck: clean
- Preflight: ready-to-push

## Out of scope

None.