### PR TITLE
fix: fail closed on exhausted actor serials, reserved route slots, and unissued handler discriminants

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -11281,9 +11281,12 @@ impl LowerCtx {
         // resolve the descriptor and the cycle-capability flag under the
         // module-short key first and fall back to the bare root key. Without
         // the module-scoped lookup every spliced multi-handler actor lost its
-        // descriptor and MIR collapsed all message-kind discriminants to the
-        // i32::MAX sentinel — LLVM rejected the dispatch switch with
-        // "Duplicate integer as switch case". Package-module actors overwrite
+        // descriptor and MIR collapsed all message-kind discriminants onto one
+        // fabricated tag — LLVM rejected the dispatch switch with "Duplicate
+        // integer as switch case". MIR no longer fabricates a discriminant, so
+        // that regression now surfaces as a hard
+        // `ActorProtocolDescriptorMissing` instead; this lookup is still what
+        // keeps a correct program from tripping it. Package-module actors overwrite
         // both fields in `lower_imported_actor` with the same qualified keys,
         // so this lookup is identity-preserving for them.
         let module_scoped_key = self

--- a/hew-mir/src/lower/machine_synth.rs
+++ b/hew-mir/src/lower/machine_synth.rs
@@ -2571,6 +2571,25 @@ pub(super) fn lower_supervisor_bootstrap(
         Rc::clone(task_entry_adapter_symbols),
     ))
 }
+/// Why [`lower_actor_handler_layouts`] could not assign a message-kind
+/// discriminant to every `receive fn` on an actor.
+///
+/// This is the out-of-band channel that replaced the `i32::MAX` fallback:
+/// absence of a discriminant is a distinct value, not a reserved point in
+/// the discriminant's own `i32` range, so the whole `i32` range stays
+/// available to real protocols and no consumer has to recognise a magic id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ProtocolDescriptorMissing {
+    /// The actor declares `receive fn` handlers but carries no protocol
+    /// descriptor at all — the checker refused to publish one (an
+    /// `ActorProtocolCollision`, or an unresolved handler signature), or a
+    /// lowering path dropped it.
+    NoDescriptor,
+    /// A descriptor is attached but issues no `msg_id` for this handler, so
+    /// the actor's HIR handler set and its published protocol disagree.
+    NoHandlerId { handler: String },
+}
+
 /// Build the MIR `ActorHandlerLayout` row for every `receive fn` on this
 /// actor, drawing the `msg_type` from the checker's protocol descriptor.
 ///
@@ -2581,17 +2600,39 @@ pub(super) fn lower_supervisor_bootstrap(
 /// `HirActorDecl::protocol_descriptor`. Source-order rearrangement no
 /// longer affects the protocol.
 ///
-/// Fail-closed: an actor that carries `receive_handlers` but no descriptor
-/// (the checker emitted an `ActorProtocolCollision` and refused to publish
-/// the protocol, a lowering path failed to attach the checker's descriptor,
-/// or an upstream bug) falls back to `i32::MAX` here — but the layout pass
-/// pairs that fallback with a hard `ActorProtocolDescriptorMissing`
-/// diagnostic (see the guard before the `ActorLayout` push in
-/// `lower_hir_module`), so no compiled program ever dispatches on the
-/// sentinel. The sentinel rows exist only to keep the MIR shape well-formed
-/// behind that hard error.
-pub(super) fn lower_actor_handler_layouts(actor: &HirActorDecl) -> Vec<ActorHandlerLayout> {
-    let descriptor = actor.protocol_descriptor.as_ref();
+/// Fail-closed by construction: the protocol descriptor is the ONLY source of
+/// a `msg_type`, so a row that no descriptor issued cannot be built. An actor
+/// that carries `receive_handlers` without an issuable id — the checker
+/// emitted an `ActorProtocolCollision` and refused to publish the protocol, a
+/// lowering path failed to attach the checker's descriptor, or a handler name
+/// is absent from an otherwise-present descriptor — yields
+/// [`ProtocolDescriptorMissing`] instead of a fabricated discriminant, and the
+/// caller turns that into a hard `ActorProtocolDescriptorMissing` diagnostic.
+///
+/// This replaces a `map_or(i32::MAX, ..)` fallback whose rows were meant to
+/// be unreachable behind a caller-side guard. They were not: the guard tested
+/// only whole-descriptor absence, so a descriptor missing a single handler
+/// name shipped a fabricated `i32::MAX` discriminant with no diagnostic at
+/// all. There is no fabricated `msg_type` anywhere in this crate now — every
+/// `ActorHandlerLayout.msg_type` is a value some descriptor issued.
+///
+/// # Errors
+///
+/// Returns [`ProtocolDescriptorMissing`] when the actor declares at least one
+/// `receive fn` and any of them has no protocol-issued `msg_id`.
+pub(super) fn lower_actor_handler_layouts(
+    actor: &HirActorDecl,
+) -> Result<Vec<ActorHandlerLayout>, ProtocolDescriptorMissing> {
+    if actor.receive_handlers.is_empty() {
+        // No handlers means no discriminants to assign; a handler-less actor
+        // legitimately carries no descriptor (the checker skips publishing
+        // one), so this is not the missing-descriptor condition.
+        return Ok(Vec::new());
+    }
+    let descriptor = actor
+        .protocol_descriptor
+        .as_ref()
+        .ok_or(ProtocolDescriptorMissing::NoDescriptor)?;
     let mut layouts = Vec::with_capacity(actor.receive_handlers.len());
     for handler in &actor.receive_handlers {
         // The checker is the only authority for state-guard facts.
@@ -2604,8 +2645,11 @@ pub(super) fn lower_actor_handler_layouts(actor: &HirActorDecl) -> Vec<ActorHand
             hew_hir::HirActorStateGuard::Exclusive => true,
         };
         let msg_type = descriptor
-            .and_then(|d| d.msg_id_for(&handler.name))
-            .map_or(i32::MAX, |id| i32::from_ne_bytes(id.to_ne_bytes()));
+            .msg_id_for(&handler.name)
+            .map(|id| i32::from_ne_bytes(id.to_ne_bytes()))
+            .ok_or_else(|| ProtocolDescriptorMissing::NoHandlerId {
+                handler: handler.name.clone(),
+            })?;
 
         if handler.is_generator {
             // A `receive gen fn` IS a message-dispatch handler — the third
@@ -2671,7 +2715,7 @@ pub(super) fn lower_actor_handler_layouts(actor: &HirActorDecl) -> Vec<ActorHand
             is_stream_producer: false,
         });
     }
-    layouts
+    Ok(layouts)
 }
 fn unknown_self_fields_in_block(block: &HirBlock, state_fields: &HashSet<String>) -> Vec<String> {
     let mut seen = HashSet::new();

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -132,7 +132,7 @@ use self::machine_synth::{
     mangle_actor_crash_handler, mangle_actor_down_handler, mangle_actor_exit_handler,
     mangle_actor_init_handler, mangle_actor_lifecycle_wrapper, mangle_actor_start_handler,
     mangle_actor_stop_handler_indexed, mangle_machine_step, mangle_supervisor_bootstrap,
-    synthesize_machine_step_fn,
+    synthesize_machine_step_fn, ProtocolDescriptorMissing,
 };
 #[cfg(not(test))]
 use self::split_consume::{
@@ -2256,32 +2256,43 @@ pub fn lower_hir_module_with_facts(module: &HirModule, pointer_width: PointerWid
                 }
             }
         };
-        let handlers = lower_actor_handler_layouts(actor);
+        // Fail closed when a `receive fn` has no protocol-issued
+        // discriminant. `lower_actor_handler_layouts` cannot invent one — a
+        // fabricated `msg_type` is a duplicate-switch-case LLVM verify reject
+        // at two-plus handlers and silent wire-protocol corruption (wrong
+        // discriminant, in-process-only dispatch) at exactly one — so it
+        // refuses the whole layout instead. The `ActorLayout` is still
+        // published, with zero handler rows: downstream lookups
+        // (`actor_method_info`, the coalesce key plan) already fail closed on
+        // an absent row, and the hard error below is what stops the compile.
+        let handlers = match lower_actor_handler_layouts(actor) {
+            Ok(handlers) => handlers,
+            Err(reason) => {
+                let detail = match reason {
+                    ProtocolDescriptorMissing::NoDescriptor => {
+                        "carries no protocol descriptor".to_string()
+                    }
+                    ProtocolDescriptorMissing::NoHandlerId { handler } => format!(
+                        "carries a protocol descriptor that issues no msg_id for handler `{handler}`"
+                    ),
+                };
+                diagnostics.push(crate::model::MirDiagnostic {
+                    kind: crate::model::MirDiagnosticKind::ActorProtocolDescriptorMissing {
+                        actor: actor.qualified_name(),
+                        handler_count: actor.receive_handlers.len(),
+                    },
+                    note: format!(
+                        "actor `{}` declares {} `receive fn` handler(s) but {detail}; \
+                         message-kind discriminants cannot be assigned, so lowering \
+                         refuses instead of fabricating one",
+                        actor.qualified_name(),
+                        actor.receive_handlers.len()
+                    ),
+                });
+                Vec::new()
+            }
+        };
         let coalesce_key_plan = resolve_coalesce_key_plan(actor, &handlers, &mut diagnostics);
-        // Fail closed when receive handlers exist but no protocol descriptor
-        // was attached: `lower_actor_handler_layouts` would fall back to the
-        // `i32::MAX` sentinel for EVERY handler — a duplicate-switch-case
-        // LLVM verify reject at two-plus handlers, and silent wire-protocol
-        // corruption (wrong discriminant, in-process-only dispatch) at
-        // exactly one. A known handler must never ride the sentinel; the
-        // sentinel rows below exist only to keep the MIR shape well-formed
-        // behind this hard error.
-        if !actor.receive_handlers.is_empty() && actor.protocol_descriptor.is_none() {
-            diagnostics.push(crate::model::MirDiagnostic {
-                kind: crate::model::MirDiagnosticKind::ActorProtocolDescriptorMissing {
-                    actor: actor.qualified_name(),
-                    handler_count: actor.receive_handlers.len(),
-                },
-                note: format!(
-                    "actor `{}` declares {} `receive fn` handler(s) but carries no \
-                     protocol descriptor; message-kind discriminants cannot be \
-                     assigned, so lowering refuses instead of emitting the \
-                     unknown-message sentinel for known handlers",
-                    actor.qualified_name(),
-                    actor.receive_handlers.len()
-                ),
-            });
-        }
         actor_layouts.push(crate::model::ActorLayout {
             // The registry key is the actor's qualified identity: dotted
             // `module.Name` for module actors, bare for root actors. It

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -6983,18 +6983,24 @@ pub enum MirDiagnosticKind {
         key_field: String,
         reason: String,
     },
-    /// An actor reached MIR layout lowering with `receive fn` handlers but no
-    /// protocol descriptor, so no handler can be assigned its real
-    /// message-kind discriminant. Emitting the `i32::MAX` sentinel instead
-    /// collapses every handler onto one tag: with two or more handlers LLVM
-    /// rejects the dispatch switch ("Duplicate integer as switch case"), and
-    /// with exactly one the program compiles but carries a wrong wire
-    /// discriminant — silent protocol corruption. Fail closed here; the
-    /// sentinel rows exist only to keep the MIR shape well-formed behind this
-    /// hard error. Reachable when a lowering path fails to attach the
-    /// checker's descriptor (the checker's own `ActorProtocolCollision`
-    /// reject empties the descriptor too, but that path already carries its
-    /// user-facing diagnostic).
+    /// An actor reached MIR layout lowering with `receive fn` handlers that no
+    /// protocol descriptor can assign a message-kind discriminant to: either
+    /// no descriptor is attached at all, or an attached descriptor issues no
+    /// `msg_id` for some handler name. The free-form `note` says which.
+    ///
+    /// Assigning a placeholder discriminant instead collapses handlers onto
+    /// one tag: with two or more affected handlers LLVM rejects the dispatch
+    /// switch ("Duplicate integer as switch case"), and with exactly one the
+    /// program compiles but carries a wrong wire discriminant — silent
+    /// protocol corruption. `lower_actor_handler_layouts` therefore cannot
+    /// build such a row at all; the `ActorLayout` is published with zero
+    /// handler rows behind this hard error. Reachable when a lowering path
+    /// fails to attach the checker's descriptor (the checker's own
+    /// `ActorProtocolCollision` reject empties the descriptor too, but that
+    /// path already carries its user-facing diagnostic).
+    ///
+    /// `handler_count` is the actor's declared `receive fn` count, not the
+    /// number of unassignable handlers — lowering stops at the first one.
     ActorProtocolDescriptorMissing { actor: String, handler_count: usize },
     /// W3.022 V10: A `CallTraitMethodStatic` reached MIR with no concrete
     /// substitution for its `receiver_type_param`. After Stage 3 (impl-level

--- a/hew-mir/tests/actor/actor_handler_lowering.rs
+++ b/hew-mir/tests/actor/actor_handler_lowering.rs
@@ -424,6 +424,11 @@ fn root_actor_layout_carries_no_defining_module() {
 /// unknown-message sentinel for every handler — is a duplicate-switch-case
 /// LLVM verify reject at two-plus handlers and a silent wire-discriminant
 /// corruption at exactly one, so lowering fails closed instead.
+///
+/// The layout must come back with ZERO handler rows: refusing is the whole
+/// point, and a row can only exist if a protocol descriptor issued its
+/// `msg_type`. A row carrying a fabricated discriminant behind the
+/// diagnostic is the failure this asserts against.
 #[test]
 fn missing_protocol_descriptor_with_handlers_fails_closed() {
     let mut ids = IdGen::default();
@@ -447,6 +452,83 @@ fn missing_protocol_descriptor_with_handlers_fails_closed() {
         )),
         "descriptor-less actor with handlers must fail closed: {:?}",
         pipeline.diagnostics
+    );
+    let layout = pipeline
+        .actor_layouts
+        .iter()
+        .find(|l| l.name == "Counter")
+        .expect("a zero-handler ActorLayout is still published for downstream lookups");
+    assert!(
+        layout.handlers.is_empty(),
+        "no handler row may survive without a protocol-issued msg_type: {:?}",
+        layout
+            .handlers
+            .iter()
+            .map(|h| (h.name.clone(), h.msg_type))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The narrower hole in the same producer: a descriptor IS attached, but it
+/// issues no `msg_id` for one of the actor's handlers (a name the checker
+/// never published). The `map_or(i32::MAX, ..)` fallback covered this case
+/// too, and the descriptor-presence guard did not — an actor here lowered
+/// with one real discriminant and one fabricated one, and no diagnostic.
+/// Taking the id with `ok_or(..)?` makes the row unconstructable, so the
+/// same hard error fires.
+#[test]
+fn descriptor_without_handler_id_fails_closed() {
+    let mut ids = IdGen::default();
+    let bump_body = block(&mut ids, vec![], None, ResolvedTy::Unit);
+    let drain_body = block(&mut ids, vec![], None, ResolvedTy::Unit);
+    let mut counter = actor(
+        &mut ids,
+        "Counter",
+        vec![
+            receive("bump", false, vec![], ResolvedTy::Unit, bump_body),
+            receive("drain", false, vec![], ResolvedTy::Unit, drain_body),
+        ],
+    );
+    // Publish a descriptor that covers only `bump`; `drain` has no issued id.
+    counter.protocol_descriptor = Some(
+        ActorProtocolDescriptor::from_handlers(
+            "Counter".to_string(),
+            &[ActorHandlerSpec {
+                name: "bump".to_string(),
+                param_tys: vec![],
+                return_ty: ResolvedTy::Unit,
+                symbol: "Counter__bump".to_string(),
+            }],
+        )
+        .expect("single-handler descriptor cannot collide"),
+    );
+
+    let pipeline = lower_hir_module(&empty_module(vec![HirItem::Actor(counter)]));
+
+    assert!(
+        pipeline.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            MirDiagnosticKind::ActorProtocolDescriptorMissing {
+                actor,
+                handler_count,
+            } if actor == "Counter" && *handler_count == 2
+        )),
+        "a handler with no protocol-issued msg_id must fail closed: {:?}",
+        pipeline.diagnostics
+    );
+    let layout = pipeline
+        .actor_layouts
+        .iter()
+        .find(|l| l.name == "Counter")
+        .expect("a zero-handler ActorLayout is still published for downstream lookups");
+    assert!(
+        layout.handlers.is_empty(),
+        "the partially-issuable actor must publish no rows at all: {:?}",
+        layout
+            .handlers
+            .iter()
+            .map(|h| (h.name.clone(), h.msg_type))
+            .collect::<Vec<_>>()
     );
 }
 

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1404,6 +1404,66 @@ impl std::fmt::Debug for HewActor {
 /// Monotonically increasing actor serial counter.
 static NEXT_ACTOR_SERIAL: AtomicU64 = AtomicU64::new(1);
 
+/// The largest serial the spawn allocator will issue.
+///
+/// Native packs the serial into the low 48 bits of the actor id
+/// (`pid::hew_pid_make`), so `pid::MAX_ACTOR_SERIAL` is the last value that
+/// survives the pack. WASM stores the raw serial as the id — nothing is packed,
+/// so the only unrepresentable value is `0` (the invalid-actor sentinel) and the
+/// bound is the last serial short of the `u64` wrap that would reach it.
+#[cfg(not(target_arch = "wasm32"))]
+const MAX_SPAWN_SERIAL: u64 = crate::pid::MAX_ACTOR_SERIAL;
+#[cfg(target_arch = "wasm32")]
+const MAX_SPAWN_SERIAL: u64 = u64::MAX - 1;
+
+/// Take the next representable actor serial from `counter`, or `None` once the
+/// serial space is exhausted.
+///
+/// The counter STOPS at `MAX_SPAWN_SERIAL + 1` instead of running on: past that
+/// point every value it could hand out is unrepresentable, so continuing to
+/// increment would only walk toward a `u64` wrap that re-enters the valid range
+/// and re-issues ids already live. Refusing is the only outcome that cannot
+/// alias.
+fn take_actor_serial(counter: &AtomicU64) -> Option<u64> {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |serial| {
+            (serial <= MAX_SPAWN_SERIAL).then_some(serial + 1)
+        })
+        .ok()
+}
+
+// Thread-local one-shot seed for the allocator's counter, mirroring
+// `FAIL_ARENA_ALLOC_NEXT`.
+//
+// WHY: the exhaustion boundary is 2^48 allocations away; a test cannot reach it
+// by spawning. Seeding a private counter drives the real `take_actor_serial` at
+// the real boundary without mutating the process-global one (which would race
+// sibling tests under threaded execution).
+// WHEN OBSOLETE: when actor identity stops being a packed 48-bit alias (the
+// Stage 3b compiler aggregate migration named in `pid.rs`), the boundary and
+// this seam both disappear.
+// WHAT THE REAL SOLUTION LOOKS LIKE: a per-runtime serial counter a test can
+// construct directly, instead of one process-global static.
+#[cfg(test)]
+thread_local! {
+    static NEXT_ACTOR_SERIAL_SEED: Cell<Option<u64>> = const { Cell::new(None) };
+}
+
+/// Seed the next actor-serial allocation on this thread. One-shot.
+#[cfg(test)]
+fn seed_next_actor_serial(serial: u64) {
+    NEXT_ACTOR_SERIAL_SEED.with(|slot| slot.set(Some(serial)));
+}
+
+/// Allocate the next actor serial, or `None` when the serial space is exhausted.
+fn allocate_actor_serial() -> Option<u64> {
+    #[cfg(test)]
+    if let Some(seed) = NEXT_ACTOR_SERIAL_SEED.with(Cell::take) {
+        return take_actor_serial(&AtomicU64::new(seed));
+    }
+    take_actor_serial(&NEXT_ACTOR_SERIAL)
+}
+
 // PID is now unified with id — actors use location-transparent IDs everywhere.
 
 // ── Live actor tracking (delegated to lifetime::live_actors) ──────────────
@@ -2515,24 +2575,39 @@ struct SpawnIdentity {
     serial: u64,
 }
 
-fn next_spawn_actor_identity() -> SpawnIdentity {
+/// Allocate the next spawn identity, or `None` when the serial space is
+/// exhausted.
+///
+/// Exhaustion is a hard refusal, not a wrap: the packed `id` masks the serial to
+/// 48 bits, so the allocation after `MAX_ACTOR_SERIAL` would mint PID `0` (the
+/// invalid-actor sentinel) and every one after that would alias an id already
+/// issued. The caller turns the `None` into a failed spawn.
+///
+/// The test override is checked FIRST and is deliberately not validated: its
+/// whole purpose is to fabricate the out-of-range serial that proves the
+/// downstream identity checks refuse an aliased `id` (`supervisor.rs`
+/// `role_ask_masked_id_alias_refuses_closed_never_enqueues`).
+fn next_spawn_actor_identity() -> Option<SpawnIdentity> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         #[cfg(test)]
         if let Some((id, serial)) = NEXT_SPAWN_ACTOR_ID_OVERRIDE.with(Cell::take) {
-            return SpawnIdentity { id, serial };
+            return Some(SpawnIdentity { id, serial });
         }
-        let serial = NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed);
-        SpawnIdentity {
-            id: crate::pid::next_actor_id(serial),
+        let serial = allocate_actor_serial()?;
+        Some(SpawnIdentity {
+            id: crate::pid::next_actor_id(serial)?,
             serial,
-        }
+        })
     }
 
+    // WASM stores the raw serial as the `id` rather than packing a route slot,
+    // so `MAX_SPAWN_SERIAL` is the wrap boundary rather than the pack boundary;
+    // the refusal keeps `id == 0` (the invalid-actor sentinel) unreachable.
     #[cfg(target_arch = "wasm32")]
     {
-        let serial = NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed);
-        SpawnIdentity { id: serial, serial }
+        let serial = allocate_actor_serial()?;
+        Some(SpawnIdentity { id: serial, serial })
     }
 }
 
@@ -2752,7 +2827,17 @@ unsafe fn spawn_actor_internal(config: ActorSpawnConfig) -> *mut HewActor {
         unsafe { cleanup_failed_spawn(&config, init_state) };
         return ptr::null_mut();
     }
-    let identity = next_spawn_actor_identity();
+    let Some(identity) = next_spawn_actor_identity() else {
+        crate::set_last_error(
+            "hew_actor_spawn: actor serial space exhausted; refusing to mint an aliased actor id",
+        );
+        // SAFETY: the arena was allocated above and its ownership has not been
+        // transferred to an actor.
+        unsafe { crate::arena::hew_arena_free_all(arena) };
+        // SAFETY: `config` still owns the transferred state/mailbox on this failure path.
+        unsafe { cleanup_failed_spawn(&config, init_state) };
+        return ptr::null_mut();
+    };
     let actor = build_spawned_actor(config, identity, init_state, arena);
     let raw = Box::into_raw(actor);
     register_actor_state_lock(raw);
@@ -2806,7 +2891,17 @@ unsafe fn spawn_actor_internal(config: ActorSpawnConfig) -> *mut HewActor {
         return ptr::null_mut();
     }
 
-    let identity = next_spawn_actor_identity();
+    let Some(identity) = next_spawn_actor_identity() else {
+        crate::set_last_error(
+            "hew_actor_spawn: actor serial space exhausted; refusing to mint an aliased actor id",
+        );
+        // SAFETY: the arena was allocated above and its ownership has not been
+        // transferred to an actor.
+        unsafe { crate::arena::hew_arena_free_all(arena) };
+        // SAFETY: `config` still owns the transferred state/mailbox on this failure path.
+        unsafe { cleanup_failed_spawn(&config, init_state) };
+        return ptr::null_mut();
+    };
     let actor = build_spawned_actor(config, identity, init_state, arena);
     let raw = Box::into_raw(actor);
     register_actor_state_lock(raw);
@@ -7764,8 +7859,8 @@ mod tests {
     }
 
     fn make_tracked_wasm_free_test_actor(initial_state: HewActorState) -> *mut HewActor {
-        let spawn_serial = NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed);
-        let actor_id = crate::pid::next_actor_id(spawn_serial);
+        let spawn_serial = allocate_actor_serial().expect("serial space is not exhausted");
+        let actor_id = crate::pid::next_actor_id(spawn_serial).expect("serial is representable");
         let actor = Box::into_raw(Box::new(HewActor {
             sched_link_next: AtomicPtr::new(ptr::null_mut()),
             id: actor_id,
@@ -11799,8 +11894,8 @@ mod tests {
         // Capture the address before transferring ownership to the actor struct.
         let arena_addr = arena as usize;
 
-        let spawn_serial = NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed);
-        let actor_id = crate::pid::next_actor_id(spawn_serial);
+        let spawn_serial = allocate_actor_serial().expect("serial space is not exhausted");
+        let actor_id = crate::pid::next_actor_id(spawn_serial).expect("serial is representable");
         let actor = Box::into_raw(Box::new(HewActor {
             sched_link_next: AtomicPtr::new(ptr::null_mut()),
             id: actor_id,
@@ -12150,6 +12245,93 @@ mod tests {
         // SAFETY: ok_actor is a valid pointer from hew_actor_spawn.
         let rc = unsafe { hew_actor_free(ok_actor) };
         assert_eq!(rc, 0, "hew_actor_free on the recovery actor must succeed");
+    }
+
+    // ── actor-serial exhaustion: the packed id must never alias ──────────
+    //
+    // `pid::hew_pid_make` masks the serial to 48 bits, so the allocation after
+    // `MAX_ACTOR_SERIAL` packs to PID 0 (the invalid-actor sentinel that
+    // `hew_node_api_register_by_pid` and the pool lookups read as "no actor")
+    // and every allocation after that re-issues an id already live. The
+    // allocator refuses instead.
+
+    #[test]
+    fn actor_serial_allocator_stops_at_the_representable_boundary() {
+        let counter = AtomicU64::new(MAX_SPAWN_SERIAL);
+        assert_eq!(
+            take_actor_serial(&counter),
+            Some(MAX_SPAWN_SERIAL),
+            "the last representable serial must still be issued"
+        );
+        assert_eq!(
+            take_actor_serial(&counter),
+            None,
+            "the allocation past the boundary must be refused"
+        );
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            MAX_SPAWN_SERIAL + 1,
+            "a refused allocation must not advance the counter — an unbounded \
+             counter wraps back into the live id range"
+        );
+        // Refusal is sticky: it does not clear itself on the next call.
+        assert_eq!(take_actor_serial(&counter), None);
+    }
+
+    #[test]
+    fn spawn_with_exhausted_serial_space_returns_null() {
+        let _guard = crate::runtime_test_guard();
+
+        crate::hew_clear_error();
+        seed_next_actor_serial(MAX_SPAWN_SERIAL + 1);
+        // SAFETY: null state with size=0 is valid; dispatch is a valid fn ptr.
+        let actor = unsafe { hew_actor_spawn(ptr::null_mut(), 0, Some(noop_dispatch)) };
+        assert!(
+            actor.is_null(),
+            "spawn must refuse once the serial space is exhausted, never mint PID 0"
+        );
+        let err = crate::hew_last_error();
+        assert!(!err.is_null(), "the refusal must record a diagnostic");
+        // SAFETY: `hew_last_error` returned a non-null, NUL-terminated C string
+        // owned by the thread-local slot; it stays valid until the next write.
+        let msg = unsafe { std::ffi::CStr::from_ptr(err) }
+            .to_str()
+            .expect("last-error message is valid UTF-8");
+        assert!(
+            msg.contains("serial space exhausted"),
+            "the refusal must name its cause, got: {msg}"
+        );
+
+        // The seed is one-shot: the very next spawn uses the real counter and
+        // succeeds, so exhaustion cannot leak into sibling tests.
+        // SAFETY: null state with size=0 is valid; dispatch is a valid fn ptr.
+        let ok_actor = unsafe { hew_actor_spawn(ptr::null_mut(), 0, Some(noop_dispatch)) };
+        assert!(
+            !ok_actor.is_null(),
+            "the next spawn must be unaffected by the one-shot seed"
+        );
+        // SAFETY: ok_actor is a valid pointer from hew_actor_spawn.
+        assert_eq!(unsafe { hew_actor_free(ok_actor) }, 0);
+    }
+
+    #[test]
+    fn spawn_at_the_last_representable_serial_still_succeeds() {
+        let _guard = crate::runtime_test_guard();
+
+        seed_next_actor_serial(MAX_SPAWN_SERIAL);
+        // SAFETY: null state with size=0 is valid; dispatch is a valid fn ptr.
+        let actor = unsafe { hew_actor_spawn(ptr::null_mut(), 0, Some(noop_dispatch)) };
+        assert!(!actor.is_null(), "the boundary serial must still spawn");
+        // SAFETY: actor is a live allocation from hew_actor_spawn.
+        let (id, serial) = unsafe { ((*actor).id, (*actor).spawn_serial) };
+        assert_eq!(serial, MAX_SPAWN_SERIAL);
+        assert_ne!(
+            id, 0,
+            "a boundary spawn must not carry the invalid sentinel"
+        );
+        assert_eq!(crate::pid::hew_pid_serial(id), MAX_SPAWN_SERIAL);
+        // SAFETY: actor is a valid pointer from hew_actor_spawn.
+        assert_eq!(unsafe { hew_actor_free(actor) }, 0);
     }
 
     // ── gen_sink CAS-race double-free regression (PR #2401 finding) ──────

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1338,16 +1338,21 @@ pub struct HewActor {
     /// discriminator.
     ///
     /// `id` packs only the low 48 bits of the serial (`pid::hew_pid_make`
-    /// masks with `SERIAL_MASK`), so after 2^48 allocations a fresh actor can
-    /// carry a retired incarnation's masked `id`. The two-phase owner-scoped
-    /// role ask copies this full serial out under `children_lock`
+    /// masks with `SERIAL_MASK`), so two incarnations can in principle collide
+    /// on the masked `id`. The two-phase owner-scoped role ask copies this full
+    /// serial out under `children_lock`
     /// (`supervisor::role_resolve_current_child_id`) and re-checks it against
     /// the pinned actor before enqueue
     /// (`live_actors::with_actor_send_by_identity`): an aliased `id` pins a
     /// DIFFERENT incarnation whose serial differs, so the submission refuses
-    /// closed instead of delivering to the wrong actor. Runtime-internal; not
-    /// mirrored by codegen. Appended at the struct tail so no codegen-mirrored
-    /// offset (`id` at 8, `state` at 16) moves.
+    /// closed instead of delivering to the wrong actor.
+    ///
+    /// [`take_actor_serial`] refuses past `MAX_SPAWN_SERIAL` rather than
+    /// wrapping, so the collision is not reachable in production; this field is
+    /// what makes wrong-actor delivery unrepresentable at the seam regardless,
+    /// and the supervisor alias tooth fabricates the collision to prove it.
+    /// Runtime-internal; not mirrored by codegen. Appended at the struct tail so
+    /// no codegen-mirrored offset (`id` at 8, `state` at 16) moves.
     pub spawn_serial: u64,
 }
 

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -436,15 +436,20 @@ pub(crate) fn with_actor_send_by_id<R>(
 /// IS the resolved incarnation by matching its full [`HewActor::spawn_serial`]
 /// against `expected_serial` before running `f`.
 ///
-/// The by-ID pin resolves through `LIVE_ACTORS`, keyed by the packed `id`,
-/// whose serial portion is masked to 48 bits (`pid::hew_pid_make`). After 2^48
-/// allocations a fresh actor can carry a retired incarnation's masked `id`, so
-/// a pin by `id` alone could hand `f` the WRONG actor. The two-phase
-/// owner-scoped role ask copies the resolved incarnation's full serial out
-/// under `children_lock` and passes it here; on serial mismatch this returns
+/// The by-ID pin resolves through `LIVE_ACTORS`, keyed by the packed `id`, whose
+/// serial portion is masked to 48 bits (`pid::hew_pid_make`), so a pin by `id`
+/// alone could hand `f` an actor that merely collides on the masked value. The
+/// two-phase owner-scoped role ask copies the resolved incarnation's full serial
+/// out under `children_lock` and passes it here; on serial mismatch this returns
 /// `None` WITHOUT calling `f` — fail closed, treated exactly like a retirement
 /// (the ID aliased a different incarnation). Only used where the caller holds
 /// the resolved incarnation's authoritative serial.
+///
+/// The spawn allocator now refuses past `MAX_ACTOR_SERIAL` rather than wrapping
+/// into already-issued ids, so production cannot reach the collision this
+/// guards; the check stays because it is what makes wrong-actor delivery
+/// unrepresentable at the resolve→submit seam rather than merely unlikely, and
+/// `supervisor.rs` fabricates the collision to keep it honest.
 // live on not(wasm32) — supervisor role ask + by-id ask; dead on wasm32.
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn with_actor_send_by_identity<R>(

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -696,14 +696,18 @@ pub unsafe extern "C" fn hew_msg_node_free(node: *mut HewMsgNode) {
 
 /// `msg_type` stamped on the MPSC stable stub.
 ///
+/// This value is ARBITRARY and carries no invariant. The whole `i32` space is
+/// live and user-reachable, so no number here could be a sentinel: the public
+/// mailbox contract leaves `msg_type` an unrestricted `i32` that
+/// [`hew_mailbox_send`] forwards verbatim, [`msg_node_alloc`] copies the
+/// caller's value unchanged, and protocol tags are the low 32 bits of a
+/// `SipHash` reinterpreted bit-for-bit as `i32` — a hash ending in
+/// `0x8000_0000` yields exactly `i32::MIN`. A C-ABI caller can enqueue a real
+/// message stamped with this constant today, and that is fine.
+///
 /// The stub is told apart from a real message by POINTER IDENTITY
-/// ([`MpscQueue::stub_ptr`]) and never by this value — no code anywhere reads
-/// a stub's `msg_type`. It is nonetheless chosen so that two independent
-/// invariants do not share one number on the same queue: `-1` is
-/// [`HEW_MAILBOX_SHUTDOWN_SENTINEL`], which the system queue genuinely
-/// transports, and `0` is the by-convention `msg_type` of a reply envelope.
-/// `i32::MIN` is claimed by neither, so a stamp read by mistake matches no
-/// live protocol value rather than impersonating the stop signal.
+/// ([`MpscQueue::stub_ptr`]) alone. No code anywhere reads a stub's
+/// `msg_type`, and correctness must never come to depend on it.
 const MPSC_STUB_MSG_TYPE: i32 = i32::MIN;
 
 /// Allocate the stable stub node for an intrusive MPSC queue.
@@ -3884,25 +3888,51 @@ mod tests {
     }
 
     /// The MPSC stable stub is disambiguated from a real message by POINTER
-    /// IDENTITY, never by its `msg_type`. That stamp must nonetheless alias no
-    /// value that carries meaning on the queues the stub lives in: `-1` is the
-    /// shutdown signal ([`HEW_MAILBOX_SHUTDOWN_SENTINEL`]) that the system
-    /// queue genuinely transports, and `0` is the by-convention `msg_type` of a
-    /// reply envelope. Two independent invariants must not share a number.
+    /// IDENTITY, never by its `msg_type`. `MPSC_STUB_MSG_TYPE` is an arbitrary
+    /// stamp with no reserved status: the whole `i32` space is live and
+    /// user-reachable, so a real message may legitimately carry exactly that
+    /// value. This pins the property that actually holds — a message stamped
+    /// identically to the stub still round-trips as an ordinary node and is
+    /// never mistaken for the stub, and the stub is never handed out.
     #[test]
-    fn stub_stamp_aliases_no_meaningful_msg_type() {
+    fn stub_stamp_value_is_not_reserved_against_real_messages() {
         let q = MpscQueue::new().expect("queue allocation should succeed");
+        let stub = q.stub_ptr();
         // SAFETY: the stub stays live for the queue's lifetime and this thread
         // exclusively owns `q`.
-        let stamp = unsafe { (*q.stub_ptr()).msg_type };
-        assert_ne!(
-            stamp, HEW_MAILBOX_SHUTDOWN_SENTINEL,
-            "stub stamp must not equal the shutdown signal carried on the same queue"
-        );
-        assert_ne!(
-            stamp, 0,
-            "stub stamp must not equal the reply-envelope msg_type"
-        );
+        let stamp = unsafe { (*stub).msg_type };
+
+        for _round in 0..3 {
+            // A real message carrying the stub's own stamp: legal on the public
+            // ABI, and the queue must treat it as any other message.
+            // SAFETY: null payload + zero size is a valid message.
+            let node = unsafe { msg_node_alloc(stamp, ptr::null(), 0, ptr::null_mut()) };
+            assert!(!node.is_null(), "message allocation must succeed");
+            assert_ne!(node, stub, "a real node is never the stub allocation");
+            // SAFETY: freshly allocated and exclusively owned until publish.
+            unsafe { q.enqueue(node) };
+
+            // SAFETY: this thread is the sole consumer.
+            let received = unsafe { q.try_dequeue() };
+            assert_eq!(
+                received, node,
+                "a message stamped like the stub must still be delivered"
+            );
+            assert_ne!(
+                received, stub,
+                "disambiguation is by pointer identity, so the stub is not returned"
+            );
+            // SAFETY: the queue handed ownership of `received` to the consumer.
+            unsafe { hew_msg_node_free(received) };
+
+            // SAFETY: this thread is the sole consumer.
+            let drained = unsafe { q.try_dequeue() };
+            assert!(
+                drained.is_null(),
+                "queue must read empty once the message is consumed"
+            );
+        }
+
         // SAFETY: the queue is exclusively owned and holds only the stub.
         unsafe { q.drain_and_free(None) };
     }

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -3848,6 +3848,75 @@ mod tests {
         }
     }
 
+    /// The MPSC stable stub is disambiguated from a real message by POINTER
+    /// IDENTITY, never by its `msg_type`. That stamp must nonetheless alias no
+    /// value that carries meaning on the queues the stub lives in: `-1` is the
+    /// shutdown signal ([`HEW_MAILBOX_SHUTDOWN_SENTINEL`]) that the system
+    /// queue genuinely transports, and `0` is the by-convention `msg_type` of a
+    /// reply envelope. Two independent invariants must not share a number.
+    #[test]
+    fn stub_stamp_aliases_no_meaningful_msg_type() {
+        let q = MpscQueue::new().expect("queue allocation should succeed");
+        // SAFETY: the stub stays live for the queue's lifetime and this thread
+        // exclusively owns `q`.
+        let stamp = unsafe { (*q.stub_ptr()).msg_type };
+        assert_ne!(
+            stamp, HEW_MAILBOX_SHUTDOWN_SENTINEL,
+            "stub stamp must not equal the shutdown signal carried on the same queue"
+        );
+        assert_ne!(
+            stamp, 0,
+            "stub stamp must not equal the reply-envelope msg_type"
+        );
+        // SAFETY: the queue is exclusively owned and holds only the stub.
+        unsafe { q.drain_and_free(None) };
+    }
+
+    /// Release-visible counterpart of the `debug_assert!` in
+    /// [`MpscQueue::consumer_success`]: the stable stub is re-injected by the
+    /// consumer on every drain-to-empty, so every dequeue path must step over
+    /// it. Handing it out would let the caller free a node the producers still
+    /// hold a live pointer to.
+    #[test]
+    fn stable_stub_never_escapes_to_the_consumer() {
+        // burst 1 exercises the single-real-node re-injection path; larger
+        // bursts exercise the linked-successor path. Repeated rounds start the
+        // second and third burst from a tail that IS the re-injected stub.
+        for burst in [1usize, 2, 5] {
+            let q = MpscQueue::new().expect("queue allocation should succeed");
+            let stub = q.stub_ptr();
+            for _round in 0..3 {
+                for seq in 0..burst {
+                    let msg_type = i32::try_from(seq).expect("test payload id fits in i32");
+                    // SAFETY: null payload + zero size is a valid message.
+                    let node = unsafe { msg_node_alloc(msg_type, ptr::null(), 0, ptr::null_mut()) };
+                    assert!(!node.is_null(), "message allocation must succeed");
+                    // SAFETY: freshly allocated and exclusively owned until publish.
+                    unsafe { q.enqueue(node) };
+                }
+                for _ in 0..burst {
+                    // SAFETY: this thread is the sole consumer.
+                    let node = unsafe { q.try_dequeue() };
+                    assert!(!node.is_null(), "published node must be observable");
+                    assert_ne!(
+                        node, stub,
+                        "the stable stub must never be handed to a consumer"
+                    );
+                    // SAFETY: the queue handed ownership of `node` to the consumer.
+                    unsafe { hew_msg_node_free(node) };
+                }
+                // SAFETY: this thread is the sole consumer.
+                let drained = unsafe { q.try_dequeue() };
+                assert!(
+                    drained.is_null(),
+                    "queue must read empty once the burst is consumed"
+                );
+            }
+            // SAFETY: the queue is exclusively owned and holds only the stub.
+            unsafe { q.drain_and_free(None) };
+        }
+    }
+
     #[test]
     fn trace_context_preserved_in_dequeue() {
         // Test that trace_context is properly copied during dequeue

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -694,11 +694,24 @@ pub unsafe extern "C" fn hew_msg_node_free(node: *mut HewMsgNode) {
 
 // ── Lock-free MPSC queue ────────────────────────────────────────────────
 
-/// Allocate a sentinel (dummy) node for an intrusive MPSC queue.
+/// `msg_type` stamped on the MPSC stable stub.
 ///
-/// The sentinel has `msg_type = -1` and null data. It is never returned
-/// to consumers — it exists only to simplify empty/non-empty transitions.
-fn alloc_sentinel() -> *mut HewMsgNode {
+/// The stub is told apart from a real message by POINTER IDENTITY
+/// ([`MpscQueue::stub_ptr`]) and never by this value — no code anywhere reads
+/// a stub's `msg_type`. It is nonetheless chosen so that two independent
+/// invariants do not share one number on the same queue: `-1` is
+/// [`HEW_MAILBOX_SHUTDOWN_SENTINEL`], which the system queue genuinely
+/// transports, and `0` is the by-convention `msg_type` of a reply envelope.
+/// `i32::MIN` is claimed by neither, so a stamp read by mistake matches no
+/// live protocol value rather than impersonating the stop signal.
+const MPSC_STUB_MSG_TYPE: i32 = i32::MIN;
+
+/// Allocate the stable stub node for an intrusive MPSC queue.
+///
+/// The stub is a permanently-live placeholder that exists only to simplify the
+/// empty/non-empty transitions of the Vyukov algorithm. It is never returned to
+/// a consumer, so it carries no payload: null data and [`MPSC_STUB_MSG_TYPE`].
+fn alloc_stub_node() -> *mut HewMsgNode {
     // SAFETY: malloc(sizeof HewMsgNode) — POD-like struct, no drop glue.
     let node = mailbox_malloc(std::mem::size_of::<HewMsgNode>()).cast::<HewMsgNode>();
     if node.is_null() {
@@ -707,11 +720,11 @@ fn alloc_sentinel() -> *mut HewMsgNode {
     // SAFETY: `node` is non-null, properly aligned, and we own it exclusively.
     unsafe {
         ptr::write(&raw mut (*node).next, AtomicPtr::new(ptr::null_mut()));
-        (*node).msg_type = -1;
+        (*node).msg_type = MPSC_STUB_MSG_TYPE;
         (*node).data = ptr::null_mut();
         (*node).data_size = 0;
         (*node).reply_channel = ptr::null_mut();
-        // Sentinels never carry an envelope payload; zero so that
+        // The stub never carries an envelope payload; zero so that
         // hew_msg_node_free routes through the legacy `libc::free` path.
         (*node).envelope = ptr::null_mut();
         (*node).trace_context = HewTraceContext::default();
@@ -727,9 +740,8 @@ fn alloc_sentinel() -> *mut HewMsgNode {
 /// Lock-free MPSC queue using a stable-stub Vyukov-style algorithm.
 ///
 /// Multiple producers enqueue via an atomic swap on `head`. A single
-/// consumer dequeues from `tail`. A heap-allocated stub sentinel remains
-/// live for the queue's full lifetime so producers never race a freed
-/// former sentinel.
+/// consumer dequeues from `tail`. A heap-allocated stub node remains live for
+/// the queue's full lifetime so producers never race a freed former stub.
 struct MpscQueue {
     head: AtomicPtr<HewMsgNode>,
     tail: UnsafeCell<*mut HewMsgNode>,
@@ -765,7 +777,7 @@ enum DequeueState {
 
 impl MpscQueue {
     fn new() -> Option<Self> {
-        let stub = alloc_sentinel();
+        let stub = alloc_stub_node();
         if stub.is_null() {
             return None;
         }
@@ -779,6 +791,29 @@ impl MpscQueue {
     #[inline]
     fn stub_ptr(&self) -> *mut HewMsgNode {
         self.stub
+    }
+
+    /// Build the [`DequeueState::Success`] handed back to the single consumer.
+    ///
+    /// Every success return routes through here so the stub-escape invariant
+    /// has exactly one statement instead of one per exit. The consumer
+    /// re-injects the stable stub on each drain-to-empty and must always step
+    /// over it: the caller frees what it receives, while producers hold a live
+    /// pointer to the stub for the queue's whole lifetime, so handing it out
+    /// would leave them linking through freed memory.
+    ///
+    /// `debug_assert!` rather than a release check — this is the per-message
+    /// dequeue hot path, and the algorithm already keeps the invariant by
+    /// construction (a stub tail is stepped over before any pop, and the single
+    /// consumer is the only party that re-enqueues it). The assertion exists to
+    /// catch a future edit to that algorithm, not a condition reachable today.
+    #[inline]
+    fn consumer_success(&self, node: *mut HewMsgNode) -> DequeueState {
+        debug_assert!(
+            node != self.stub_ptr(),
+            "MPSC stable stub escaped to the consumer; freeing it would leave producers linking through freed memory"
+        );
+        DequeueState::Success(node)
     }
 
     /// Enqueue a node. Safe for concurrent producers.
@@ -813,7 +848,7 @@ impl MpscQueue {
             if next.is_null() {
                 return DequeueState::Empty;
             }
-            // SAFETY: `next` is the first real node after the stub sentinel.
+            // SAFETY: `next` is the first real node after the stable stub.
             unsafe { *self.tail.get() = next };
             // SAFETY: `next` became the consumer tail, so pop_inner sees a
             // valid live node under the same single-consumer invariant.
@@ -824,7 +859,7 @@ impl MpscQueue {
             // SAFETY: advance consumer tail to the successor before returning
             // the current tail node to the caller for freeing.
             unsafe { *self.tail.get() = next };
-            return DequeueState::Success(tail);
+            return self.consumer_success(tail);
         }
 
         let head = self.head.load(Ordering::Acquire);
@@ -833,7 +868,7 @@ impl MpscQueue {
         }
 
         // Queue holds a single real node. Re-inject the stable stub so the
-        // consumer can pop the last node without ever freeing the sentinel
+        // consumer can pop the last node without ever freeing the stub
         // seen by producers.
         // SAFETY: the stable stub stays live for the queue lifetime and may be
         // re-enqueued by the single consumer.
@@ -845,22 +880,22 @@ impl MpscQueue {
             // SAFETY: `next` is the successor just observed from the current
             // consumer tail, so updating the tail preserves the invariant.
             unsafe { *self.tail.get() = next };
-            return DequeueState::Success(tail);
+            return self.consumer_success(tail);
         }
 
         DequeueState::Inconsistent
     }
 
-    /// Helper after advancing past the stub sentinel.
+    /// Helper after advancing past the stable stub.
     unsafe fn pop_inner(&self, tail: *mut HewMsgNode) -> DequeueState {
-        // SAFETY: `tail` is the first real node after the stub sentinel.
+        // SAFETY: `tail` is the first real node after the stable stub.
         let next = unsafe { (*tail).next.load(Ordering::Acquire) };
 
         if !next.is_null() {
             // SAFETY: `next` is the successor just observed from the current
             // consumer tail, so updating the tail preserves the invariant.
             unsafe { *self.tail.get() = next };
-            return DequeueState::Success(tail);
+            return self.consumer_success(tail);
         }
 
         let head = self.head.load(Ordering::Acquire);
@@ -878,7 +913,7 @@ impl MpscQueue {
             // SAFETY: `next` is the successor just observed from the current
             // consumer tail, so updating the tail preserves the invariant.
             unsafe { *self.tail.get() = next };
-            return DequeueState::Success(tail);
+            return self.consumer_success(tail);
         }
 
         DequeueState::Inconsistent
@@ -907,12 +942,12 @@ impl MpscQueue {
         ptr::null_mut()
     }
 
-    /// Drain and free all remaining nodes (including the sentinel).
+    /// Drain and free all remaining nodes (including the stable stub).
     ///
     /// # Safety
     ///
     /// No concurrent access may occur. All nodes must have been allocated
-    /// by `msg_node_alloc` (or `alloc_sentinel`).
+    /// by `msg_node_alloc` (or `alloc_stub_node`).
     unsafe fn drain_and_free(&self, message_drop_fn: Option<HewMessageDropFn>) {
         loop {
             // SAFETY: caller guarantees exclusive teardown access, so dequeue
@@ -927,7 +962,7 @@ impl MpscQueue {
             // SAFETY: dequeue transferred exclusive ownership of `node`.
             unsafe { hew_msg_node_free_with_message_drop(node, message_drop_fn) };
         }
-        // Free the stable stub sentinel last.
+        // Free the stable stub last.
         // SAFETY: the stub was heap-allocated at queue creation and is still
         // exclusively owned during teardown.
         unsafe { hew_msg_node_free(self.stub_ptr()) };
@@ -2617,11 +2652,11 @@ pub unsafe extern "C" fn hew_mailbox_free(mb: *mut HewMailbox) {
         }
     }
 
-    // Drain lock-free user queue (sentinel + any remaining nodes).
+    // Drain lock-free user queue (stable stub + any remaining nodes).
     // SAFETY: No concurrent access — mailbox is exclusively owned.
     unsafe { mailbox.user_fast.drain_and_free(mailbox.message_drop_fn) };
 
-    // Drain lock-free system queue (sentinel + any remaining nodes).
+    // Drain lock-free system queue (stable stub + any remaining nodes).
     // SAFETY: No concurrent access — mailbox is exclusively owned.
     unsafe { mailbox.sys_queue.drain_and_free(None) };
 }

--- a/hew-runtime/src/peer_binding.rs
+++ b/hew-runtime/src/peer_binding.rs
@@ -763,7 +763,18 @@ impl PeerAuthSnapshot {
     ///
     /// * strict (`bindings` non-empty) requires a local route slot;
     /// * explicit opt-out (`unverified == true`) requires empty `bindings`;
-    /// * `unconfigured` (`unverified == false`, empty bindings) is legal.
+    /// * `unconfigured` (`unverified == false`, empty bindings) is legal;
+    /// * no peer may be bound to the local route slot.
+    ///
+    /// The last rule is an identity rule, not a tidiness rule. The local route
+    /// slot is the high half of every locally-minted actor id, so a peer sharing
+    /// it produces remote actor ids that `pid::hew_pid_is_local` reports as
+    /// LOCAL, and `routing::hew_routing_conn_for_route_slot` refuses to route to
+    /// it — the peer would be both mislabelled and unreachable. Slot `0` is
+    /// already reserved for local dispatch by [`PeerAuthConfig::pin_peer`].
+    /// `Node::start`'s own slot selection avoids bound slots
+    /// (`hew_node::select_local_route_slot`); this is the check that holds when
+    /// the slot is supplied rather than selected.
     ///
     /// # Errors
     ///
@@ -782,6 +793,15 @@ impl PeerAuthSnapshot {
                  (fail-closed)"
                     .to_string(),
             );
+        }
+        if let Some(local) = self.inner.local_route_slot {
+            if self.inner.bindings.contains_key(&local.get()) {
+                return Err(format!(
+                    "hew_node_start: peer binding occupies the local route slot {} — a peer \
+                     cannot share this node's route slot (fail-closed)",
+                    local.get()
+                ));
+            }
         }
         Ok(())
     }
@@ -1171,6 +1191,32 @@ mod tests {
     #[test]
     fn validate_snapshot_accepts_unconfigured() {
         assert!(PeerAuthSnapshot::unconfigured().validate().is_ok());
+    }
+
+    /// A peer bound to the local route slot would share the high half of every
+    /// locally-minted actor id, so its remote actors would answer
+    /// `pid::hew_pid_is_local` as local. The node refuses to start instead.
+    #[test]
+    fn validate_snapshot_rejects_peer_on_the_local_route_slot() {
+        let mut cfg = bound_config(&[(42, noise(0xBB))]);
+        cfg.local_route_slot = nz(42);
+        let err = cfg
+            .snapshot()
+            .validate()
+            .expect_err("a peer on the local route slot must be refused");
+        assert!(
+            err.contains("local route slot 42"),
+            "the refusal must name the colliding slot, got: {err}"
+        );
+    }
+
+    /// The refusal is exact: a distinct local slot alongside the same binding
+    /// stays valid, so the rule cannot degrade into "strict configs never start".
+    #[test]
+    fn validate_snapshot_accepts_local_route_slot_beside_a_peer_slot() {
+        let mut cfg = bound_config(&[(42, noise(0xBB))]);
+        cfg.local_route_slot = nz(43);
+        assert!(cfg.snapshot().validate().is_ok());
     }
 
     #[test]

--- a/hew-runtime/src/pid.rs
+++ b/hew-runtime/src/pid.rs
@@ -94,6 +94,27 @@ pub extern "C" fn hew_pid_serial(pid: u64) -> u64 {
 /// `LOCAL_NODE_ID` which defaulted to 0. This preserves the always-available
 /// semantics for callers that check locality before `hew_sched_init` or after
 /// teardown. The mutate path (`hew_pid_set_local_node`) stays fail-closed.
+///
+/// # Why route slot 0 answers local unconditionally
+///
+/// Route slot `0` is the local-dispatch reservation, not an addressable node.
+/// Actors spawned before `hew_node_start` publishes this process's slot
+/// (`hew_node.rs`, `hew_pid_set_local_node(node.route_slot)`) carry `0` in the
+/// high half and are still local afterwards, so the clause is load-bearing —
+/// dropping it strands every pre-node-start pid.
+///
+/// It is sound because a remote actor cannot be spelled with route slot `0`, and
+/// cannot be spelled with this node's slot either:
+///
+/// - No packed pid crosses the wire. The distributed vocabulary is
+///   `node_identity::Location` (`NodeId` + actor slot + session incarnation),
+///   whose decoder refuses actor slot `0` (`Location::new`); the packed form is
+///   minted receiver-side by `routing::hew_routing_lookup_location` and the
+///   `connection.rs` ingress handlers.
+/// - Those mint sites take the high half from a registered route slot, and
+///   `routing::hew_routing_add_route` refuses both `0` and the table's own
+///   `local_route_slot`. `peer_binding::PeerAuthSnapshot::validate` refuses the
+///   same collision one layer earlier, at node start.
 #[no_mangle]
 pub extern "C" fn hew_pid_is_local(pid: u64) -> c_int {
     let pid_node = hew_pid_node(pid);

--- a/hew-runtime/src/pid.rs
+++ b/hew-runtime/src/pid.rs
@@ -41,6 +41,12 @@ const SERIAL_MASK: u64 = (1u64 << SERIAL_BITS) - 1;
 
 /// Whether an exact actor slot can be represented by the temporary packed
 /// node-internal actor ID without truncation.
+///
+/// The single representability predicate for the packed alias: slot `0` is the
+/// invalid-actor sentinel (`hew_node_api_register_by_pid` and the pool lookups
+/// both read `pid == 0` as "no actor") and anything above [`SERIAL_MASK`] cannot
+/// survive the 48-bit pack. Every site that turns a serial into an actor ID
+/// passes it through here first, so a rejected slot never becomes a PID.
 pub(crate) const fn actor_slot_fits_internal_alias(slot: u64) -> bool {
     slot != 0 && slot <= SERIAL_MASK
 }
@@ -53,6 +59,15 @@ pub(crate) const fn actor_slot_fits_internal_alias(slot: u64) -> bool {
 /// // Remote actor on node 3, serial 100:
 /// let pid = hew_pid_make(3, 100); // == (3 << 48) | 100
 /// ```
+///
+/// # Truncation is why callers must pre-check
+///
+/// This is the raw packing primitive at a `#[no_mangle]` C ABI boundary; it has
+/// no error channel, so a serial wider than 48 bits is masked rather than
+/// refused and `serial == 1 << 48` packs to node-local PID `0` — the
+/// invalid-actor sentinel. Runtime composition therefore goes through
+/// [`next_actor_id`], which refuses an unrepresentable serial
+/// ([`actor_slot_fits_internal_alias`]) before it can reach this mask.
 #[no_mangle]
 pub extern "C" fn hew_pid_make(node_id: u16, serial: u64) -> u64 {
     (u64::from(node_id) << SERIAL_BITS) | (serial & SERIAL_MASK)
@@ -109,13 +124,24 @@ pub extern "C" fn hew_pid_local_node() -> u16 {
     crate::runtime::rt_current_opt().map_or(0, |rt| rt.node.local_route_slot())
 }
 
-/// Allocate the next actor ID for the local node.
+/// Compose the actor ID for `serial` on the local node, or `None` when `serial`
+/// cannot be represented in the packed alias.
 ///
-/// Combines the local node ID with a monotonically-increasing serial.
-pub(crate) fn next_actor_id(serial: u64) -> u64 {
+/// Fails closed instead of packing: [`hew_pid_make`] masks, so an exhausted
+/// serial space would otherwise mint node-local PID `0` (the invalid-actor
+/// sentinel) and then alias every subsequent allocation onto ids already in use.
+/// Callers propagate the `None` as a spawn failure.
+pub(crate) fn next_actor_id(serial: u64) -> Option<u64> {
+    if !actor_slot_fits_internal_alias(serial) {
+        return None;
+    }
     let node = crate::runtime::rt_current().node.local_route_slot();
-    hew_pid_make(node, serial)
+    Some(hew_pid_make(node, serial))
 }
+
+/// The largest serial the packed alias can carry — the exhaustion boundary the
+/// spawn allocator stops at.
+pub(crate) const MAX_ACTOR_SERIAL: u64 = SERIAL_MASK;
 
 // ── Tests ──────────────────────────────────────────────────────────────
 
@@ -169,12 +195,48 @@ mod tests {
         }
     }
 
+    /// The raw C ABI primitive masks, and that is exactly why composition is
+    /// checked one layer up: at `1 << 48` the mask produces node-local PID `0`,
+    /// the invalid-actor sentinel. Pinned here so a future edit that "fixes"
+    /// `hew_pid_make` by saturating instead has to confront the ABI contract.
     #[test]
-    fn serial_mask_truncation() {
-        // If serial exceeds 48 bits, the extra bits are masked off.
+    fn serial_mask_truncation_reaches_the_invalid_sentinel() {
         let too_large = 1u64 << 48;
         let pid = hew_pid_make(0, too_large);
         assert_eq!(hew_pid_serial(pid), 0);
+        assert_eq!(pid, 0, "the masked overflow IS the invalid-actor sentinel");
+    }
+
+    /// Composition refuses an exhausted serial rather than minting PID `0`.
+    #[test]
+    fn actor_id_for_exhausted_serial_is_refused() {
+        let _g = guard();
+        hew_pid_set_local_node(0);
+        assert_eq!(next_actor_id(1u64 << 48), None);
+        assert_eq!(next_actor_id(u64::MAX), None);
+    }
+
+    /// Serial `0` is the sentinel itself and is refused on every route slot —
+    /// including a non-zero one, where the packed id would be non-zero and so
+    /// would slip past a bare `id != 0` check.
+    #[test]
+    fn actor_id_for_zero_serial_is_refused() {
+        let _g = guard();
+        hew_pid_set_local_node(0);
+        assert_eq!(next_actor_id(0), None);
+        hew_pid_set_local_node(9);
+        assert_eq!(next_actor_id(0), None);
+        hew_pid_set_local_node(0);
+    }
+
+    /// The boundary itself still composes: exhaustion starts one past the mask.
+    #[test]
+    fn actor_id_at_the_serial_boundary_is_accepted() {
+        let _g = guard();
+        hew_pid_set_local_node(0);
+        let id = next_actor_id(MAX_ACTOR_SERIAL).expect("the last serial is representable");
+        assert_eq!(hew_pid_serial(id), MAX_ACTOR_SERIAL);
+        assert_eq!(hew_pid_node(id), 0);
     }
 
     #[test]
@@ -199,10 +261,10 @@ mod tests {
     fn next_actor_id_integration() {
         let _g = guard();
         hew_pid_set_local_node(0);
-        assert_eq!(next_actor_id(42), 42);
+        assert_eq!(next_actor_id(42), Some(42));
 
         hew_pid_set_local_node(7);
-        let id = next_actor_id(42);
+        let id = next_actor_id(42).expect("serial 42 is representable");
         assert_eq!(hew_pid_node(id), 7);
         assert_eq!(hew_pid_serial(id), 42);
 
@@ -217,7 +279,7 @@ mod tests {
                 std::thread::spawn(move || {
                     let _g = guard();
                     hew_pid_set_local_node(node);
-                    let actor_id = next_actor_id(42);
+                    let actor_id = next_actor_id(42).expect("serial 42 is representable");
                     (
                         hew_pid_local_node(),
                         hew_pid_node(actor_id),

--- a/hew-runtime/src/routing.rs
+++ b/hew-runtime/src/routing.rs
@@ -98,6 +98,16 @@ pub(crate) unsafe fn hew_routing_table_free(table: *mut HewRoutingTable) {
 /// Reusing a receiver-local route slot for a different `NodeId` tombstones the
 /// prior identity before the replacement becomes visible.
 ///
+/// # Reserved route slots
+///
+/// Slot `0` is local dispatch and the table's own `local_route_slot` names this
+/// process. Registering a peer on either is refused, because this function is
+/// what makes `LocationRoute::Remote`'s packed actor id: `hew_pid_make(slot, ..)`
+/// on a reserved slot yields a pid that `hew_pid_is_local` reports as LOCAL for
+/// an actor that lives on another node — and `hew_routing_conn_for_route_slot`
+/// would refuse to route to it, so the peer would also be silently unreachable.
+/// Refusing the registration is what keeps that pid unrepresentable.
+///
 /// # Safety
 ///
 /// `table` must point to a live routing table.
@@ -113,6 +123,9 @@ pub(crate) unsafe fn hew_routing_add_route(
     }
     // SAFETY: caller guarantees `table` validity.
     let table = unsafe { &*table };
+    if route_slot == table.local_route_slot {
+        return false;
+    }
     let mut state = table.state.write_or_recover();
 
     if let Some(previous_node) = state.by_slot.get(&route_slot).copied() {
@@ -396,5 +409,78 @@ mod tests {
             );
             hew_routing_table_free(table);
         }
+    }
+
+    /// A peer on the local route slot would mint `LocationRoute::Remote` actor
+    /// ids whose high half is this node's own slot, so `hew_pid_is_local` would
+    /// report a remote actor as local. Registration is refused, and the peer
+    /// stays classified `Partition` rather than acquiring an aliased identity.
+    #[test]
+    fn peer_on_the_local_route_slot_is_refused() {
+        let local = node(1);
+        let remote = node(2);
+        let table = hew_routing_table_new(7, Some(local), Some(11), &[(7, remote)]);
+
+        // SAFETY: table is live for the test.
+        unsafe {
+            assert!(
+                !hew_routing_add_route(table, remote, 7, 5, 55),
+                "a peer must not register on the local route slot"
+            );
+            assert_eq!(
+                hew_routing_lookup_location(table, location(remote, 42, 5)),
+                LocationRoute::Partition,
+                "the refused peer must stay unrouted, never resolve to an aliased id"
+            );
+            // The neighbouring slot is unaffected: the refusal is exact, not a
+            // blanket rejection that would strand every peer.
+            assert!(hew_routing_add_route(table, remote, 8, 5, 55));
+            assert_eq!(
+                hew_routing_lookup_location(table, location(remote, 42, 5)),
+                LocationRoute::Remote {
+                    actor_id: crate::pid::hew_pid_make(8, 42),
+                    route_slot: 8,
+                    conn: 55
+                }
+            );
+            hew_routing_table_free(table);
+        }
+    }
+
+    /// Every route slot a registration accepts yields a pid that
+    /// `hew_pid_is_local` classifies as remote — the property the reservation
+    /// exists to hold, asserted over the reserved values and a live one.
+    #[test]
+    fn accepted_route_slots_never_mint_a_locally_classified_pid() {
+        let _rt = crate::runtime_test_guard();
+        crate::pid::hew_pid_set_local_node(7);
+
+        let local = node(1);
+        let remote = node(2);
+        let table = hew_routing_table_new(7, Some(local), Some(11), &[(8, remote)]);
+
+        // SAFETY: table is live for the test.
+        unsafe {
+            for reserved in [0_u16, 7] {
+                assert!(
+                    !hew_routing_add_route(table, remote, reserved, 5, 55),
+                    "route slot {reserved} is reserved and must not be registrable"
+                );
+            }
+            assert!(hew_routing_add_route(table, remote, 8, 5, 55));
+            let LocationRoute::Remote { actor_id, .. } =
+                hew_routing_lookup_location(table, location(remote, 42, 5))
+            else {
+                panic!("the registered peer must resolve to a remote route");
+            };
+            assert_eq!(
+                crate::pid::hew_pid_is_local(actor_id),
+                0,
+                "a remote actor's pid must never classify as local"
+            );
+            hew_routing_table_free(table);
+        }
+
+        crate::pid::hew_pid_set_local_node(0);
     }
 }

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -6437,12 +6437,15 @@ fn role_ask_refuse(reason: u8, key: u32) -> i32 {
 /// the phases fails CLOSED instead of touching reclaimed storage.
 ///
 /// The returned pair is `(packed id, full spawn serial)`. The packed `id`
-/// masks the serial to 48 bits (`pid::hew_pid_make`), so after 2^48
-/// allocations a fresh actor can carry a retired incarnation's `id`; phase two
-/// therefore matches the pinned actor's full serial against the resolved one
+/// masks the serial to 48 bits (`pid::hew_pid_make`), so two incarnations can in
+/// principle collide on `id`; phase two therefore matches the pinned actor's
+/// full serial against the resolved one
 /// (`live_actors::with_actor_send_by_identity`) so an aliased `id` refuses
-/// closed rather than delivering to the wrong actor. Both scalars are copied
-/// out under `children_lock`; no pointer crosses the lock boundary.
+/// closed rather than delivering to the wrong actor. The spawn allocator refuses
+/// past `pid::MAX_ACTOR_SERIAL` rather than wrapping, so the collision is not
+/// reachable in production; the serial match is what keeps wrong-actor delivery
+/// unrepresentable at this seam regardless. Both scalars are copied out under
+/// `children_lock`; no pointer crosses the lock boundary.
 #[cfg(not(target_arch = "wasm32"))]
 fn role_resolve_current_child_id(
     token: crate::lifetime::local_handles::HewLocalPidId,

--- a/hew-runtime/tests/mailbox_envelope_abi.rs
+++ b/hew-runtime/tests/mailbox_envelope_abi.rs
@@ -245,7 +245,7 @@ fn cross_node_gate_release_build_enforcement_is_not_debug_only() {
 /// that an uninitialized `payload_class` byte cannot silently equal
 /// `SerializedCrossNode` (3) and bypass the cross-node gate.
 ///
-/// `alloc_sentinel` is also patched but is never returned to consumers
+/// `alloc_stub_node` is also patched but is never returned to consumers
 /// (it lives inside the MPSC queue structure); it is covered by code review
 /// and the explicit zero-init in the source, not by a separate observable test.
 /// `msg_node_alloc_aliased` is Phase-α fail-closed (dead production path) and


### PR DESCRIPTION
I audited the reserved and sentinel values across the runtime and MIR lowering, and fixed three places where a reserved value could be minted, aliased, or fabricated. Each is independent; they share only the theme.

## Actor identity fails closed

`hew_pid_make` masked the actor serial to 48 bits with no overflow check, so serial `1 << 48` minted PID 0 — which is the invalid-actor sentinel. The serial allocator now fails closed at exhaustion and stays refusing: on refusal it writes nothing, so the counter pins at the maximum permanently. This holds on both the native and wasm bounds, and serial 0 is never re-issued.

Separately, `hew_routing_add_route` refused route slot 0 but not the node's *own* local route slot, and `PeerAuthSnapshot::validate` checked that a local route slot exists rather than that it is free. A peer bound to the local slot produced a `LocationRoute::Remote` whose packed PID `hew_pid_is_local` reported as local, while `hew_routing_conn_for_route_slot` already refused to route to that slot — mislabelled and silently unreachable at once. Both layers now refuse, which restores the symmetry that was the actual gap.

## The MPSC stable stub no longer shares a value with a real message

The intrusive MPSC queue's permanent stub node was stamped `msg_type = -1`, numerically identical to the shutdown value carried in the same queue. Nothing reads the stub's `msg_type` — the queue tells it apart by pointer identity — so this was a latent overlap rather than a live defect, but it is the kind of coincidence that turns a future refactor bug into a silent misclassification.

The stub is now stamped `i32::MIN`, all four dequeue success exits are funnelled through a single helper carrying a debug assertion that the returned node is not the stub, and `alloc_sentinel` is renamed to `alloc_stub_node` to stop implying protocol meaning.

I want to be precise about what the documentation now claims, because my first version of it was wrong. There is no unclaimed `msg_type` value: `msg_type` is an unrestricted `i32` on the public mailbox API, node allocation copies the caller's value through unchanged, and protocol tags are the low 32 bits of a SipHash reinterpreted bit-preservingly — so a real message can carry `i32::MIN`, and a protocol hash of `0x8000_0000` produces it. The stamp value is arbitrary; the guarantee is pointer identity, and the docs and tests now say exactly that. The test that pinned the old, unsatisfiable invariant is replaced by one that enqueues a real message carrying the stub's own stamp and requires it to round-trip normally.

## Handler layouts refuse an unissued discriminant

Actor handler layouts fabricated `msg_type = i32::MAX` when the protocol descriptor issued no discriminant for a handler. A guard was added for this previously, but its predicate was narrower than the fabrication's trigger: the fabrication fired when the descriptor was absent **or** present-but-not-issuing-an-id-for-this-handler, while the guard tested only descriptor-absent. An actor whose descriptor covered handler A but not handler B therefore lowered B with a fabricated discriminant and emitted no diagnostic at all.

`lower_actor_handler_layouts` now returns a `Result` with two error variants that exhaust the ways an id can be absent, and emits `ActorProtocolDescriptorMissing`. The whole `i32` range is reclaimed as legal discriminant space — a real SipHash id landing on `0x7FFF_FFFF` is now unambiguous, where before it was indistinguishable from the fabricated row. The condition is reachable only through a compiler-internal invariant violation, never from source, so the hard error stays; what was removed is the fabricated value, not the check.

## Verification

Full `make ci-preflight` passes with every step executed, including `make test`, `make test-vertical-slice`, `make test-hew-ratchet`, `make test-o2-differential`, `make sandbox-parity`, `make fuzz-oracle`, and `make hew-check-all`. Runtime and MIR crate suites are green (2692 and 1208). `make lint` confirms no `hew_*` FFI symbol was added or removed, and no exported signature, `repr(C)` field, struct offset, or wire encoding changes in this branch.

Each fix carries a red-first test: `assert_ne!(next_actor_id(1u64 << 48), 0)` failed before the serial bound; `hew_routing_add_route` returned true for the local slot before the reservation; the handler-layout tests observed a fabricated `2147483647` row and an empty diagnostics list before the `Result` widening.

## Out of scope

Handling the refused route slot at the connection-publication call site — that result is currently discarded — turns out to need atomic close-ownership and serialized cluster retirement, because the underlying teardown paths already race on `main` independently of this change. That is a connection-lifecycle change with its own interleaving test matrix, so it is a separate branch rather than a rider here.
