### PR TITLE
fix(cli): stop hew init blocking the safe case and silently destroying files in the unsafe one

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1837,15 +1837,23 @@ fn format_for_display(input_name: &str, source: &str) -> Option<String> {
 fn cmd_init(a: &args::InitArgs) {
     let (project_name, project_dir) = if let Some(ref name) = a.name {
         let dir = std::path::PathBuf::from(name);
-        let pname = dir
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("hew-project")
-            .to_string();
         if let Err(e) = std::fs::create_dir_all(&dir) {
             eprintln!("Error: cannot create directory '{}': {e}", dir.display());
             std::process::exit(1);
         }
+        // Derive the name from the canonicalized directory so `hew init .`
+        // and `hew init` (no arg) agree — `.` alone has no file_name(), and
+        // canonicalize needs the directory to exist, which create_dir_all
+        // above guarantees.
+        let pname = dir
+            .canonicalize()
+            .ok()
+            .as_deref()
+            .and_then(std::path::Path::file_name)
+            .or_else(|| dir.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("hew-project")
+            .to_string();
         (pname, dir)
     } else {
         // No name given — use current directory name as project name.

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1865,15 +1865,23 @@ fn cmd_init(a: &args::InitArgs) {
     let readme = project_dir.join("README.md");
 
     // Guard against overwriting existing files unless --force is given.
+    // Name every conflicting file in one message rather than stopping at the
+    // first, so the user sees the full blast radius before deciding.
     if !a.force {
-        for path in [&main_hew, &readme] {
-            if path.exists() {
-                eprintln!(
-                    "Error: '{}' already exists (use --force to overwrite)",
-                    path.display()
-                );
-                std::process::exit(1);
-            }
+        let conflicts: Vec<String> = [&main_hew, &readme]
+            .into_iter()
+            .filter(|p| p.exists())
+            .map(|p| format!("'{}'", p.display()))
+            .collect();
+        if !conflicts.is_empty() {
+            eprintln!(
+                "Error: {} already exists (use --force to overwrite)",
+                conflicts.join(", ")
+            );
+            eprintln!(
+                "Overwrite with --force, or run `hew init` in a directory without these files."
+            );
+            std::process::exit(1);
         }
     }
 

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1917,6 +1917,11 @@ hew run main.hew
 "
     );
 
+    // Record which files pre-existed before --force overwrites them, so the
+    // forced path can report what it replaced.
+    let main_hew_replaced = a.force && main_hew.exists();
+    let readme_replaced = a.force && readme.exists();
+
     if let Err(e) = std::fs::write(&main_hew, main_content) {
         eprintln!("Error: cannot write {}: {e}", main_hew.display());
         std::process::exit(1);
@@ -1928,6 +1933,17 @@ hew run main.hew
 
     println!("Created source-only project \"{project_name}\" with main.hew and README.md");
     println!("No hew.toml was created; use `adze init` for manifest-first bootstrap.");
+
+    let replaced: Vec<&str> = [
+        main_hew_replaced.then_some("main.hew"),
+        readme_replaced.then_some("README.md"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    if !replaced.is_empty() {
+        println!("--force replaced existing: {}", replaced.join(", "));
+    }
 }
 
 fn cmd_completions(a: &args::CompletionsArgs) {

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1882,8 +1882,15 @@ fn cmd_init(a: &args::InitArgs) {
             .map(|p| format!("'{}'", p.display()))
             .collect();
         if !conflicts.is_empty() {
+            // Agree the verb with the number of conflicts so a multi-file list
+            // does not read as if it were a single file.
+            let verb = if conflicts.len() == 1 {
+                "already exists"
+            } else {
+                "already exist"
+            };
             eprintln!(
-                "Error: {} already exists (use --force to overwrite)",
+                "Error: {} {verb} (use --force to overwrite)",
                 conflicts.join(", ")
             );
             eprintln!(

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1842,13 +1842,6 @@ fn cmd_init(a: &args::InitArgs) {
             .and_then(|n| n.to_str())
             .unwrap_or("hew-project")
             .to_string();
-        if dir.exists() && !a.force {
-            eprintln!(
-                "Error: directory '{}' already exists (use --force to overwrite)",
-                dir.display()
-            );
-            std::process::exit(1);
-        }
         if let Err(e) = std::fs::create_dir_all(&dir) {
             eprintln!("Error: cannot create directory '{}': {e}", dir.display());
             std::process::exit(1);

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -240,6 +240,37 @@ fn init_existing_scaffold_files_without_force_exit_one() {
 }
 
 #[test]
+fn init_existing_scaffold_files_names_every_conflict_in_one_message() {
+    let tmp = support::tempdir();
+    fs::write(tmp.path().join("main.hew"), "sentinel main").unwrap();
+    fs::write(tmp.path().join("README.md"), "sentinel readme").unwrap();
+
+    let out = run_hew(tmp.path(), &["init"]);
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "hew init should exit 1 when both scaffold files already exist:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("main.hew"),
+        "stderr should name main.hew; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("README.md"),
+        "stderr should name README.md; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("already exists (use --force to overwrite)"),
+        "stderr should explain how to recover; got:\n{stderr}"
+    );
+}
+
+#[test]
 fn init_force_overwrites_existing_scaffold() {
     let tmp = support::tempdir();
     let main_hew = tmp.path().join("main.hew");

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -256,6 +256,10 @@ fn init_existing_scaffold_files_without_force_exit_one() {
             )),
             "stderr should explain how to recover for {file_name}; got:\n{stderr}"
         );
+        assert!(
+            !stderr.contains("already exist (use --force to overwrite)"),
+            "a single conflict should use the singular verb; got:\n{stderr}"
+        );
         assert_eq!(
             fs::read_to_string(&existing_path).unwrap(),
             "sentinel",
@@ -290,8 +294,13 @@ fn init_existing_scaffold_files_names_every_conflict_in_one_message() {
         "stderr should name README.md; got:\n{stderr}"
     );
     assert!(
-        stderr.contains("already exists (use --force to overwrite)"),
-        "stderr should explain how to recover; got:\n{stderr}"
+        stderr.contains("README.md' already exist (use --force to overwrite)"),
+        "stderr should explain how to recover, with the verb agreeing with the two \
+         conflicting files; got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("already exists"),
+        "two conflicts should use the plural verb; got:\n{stderr}"
     );
 }
 

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -155,33 +155,55 @@ fn init_without_name_creates_files_in_cwd() {
 }
 
 #[test]
-fn init_existing_directory_without_force_exits_one() {
+fn init_existing_empty_directory_without_force_succeeds() {
     let tmp = support::tempdir();
     let existing = tmp.path().join("existing");
     fs::create_dir(&existing).unwrap();
 
     let out = run_init(tmp.path(), "existing");
 
+    assert!(
+        out.status.success(),
+        "hew init should succeed when the target directory exists but is empty:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        existing.join("main.hew").exists(),
+        "hew init should write main.hew into the pre-existing empty directory"
+    );
+    assert!(
+        existing.join("README.md").exists(),
+        "hew init should write README.md into the pre-existing empty directory"
+    );
+}
+
+#[test]
+fn init_existing_directory_with_real_main_hew_exits_one_naming_the_file() {
+    let tmp = support::tempdir();
+    let existing = tmp.path().join("existing");
+    fs::create_dir(&existing).unwrap();
+    fs::write(existing.join("main.hew"), "fn main() {}\n").unwrap();
+
+    let out = run_init(tmp.path(), "existing");
+
     assert_eq!(
         out.status.code(),
         Some(1),
-        "hew init should exit 1 when the target directory already exists:\nstdout: {}\nstderr: {}",
+        "hew init should exit 1 when main.hew already exists in the target directory:\nstdout: {}\nstderr: {}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr),
     );
 
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("Error: directory 'existing' already exists (use --force to overwrite)"),
-        "stderr should explain how to recover; got:\n{stderr}"
+        stderr.contains("main.hew"),
+        "stderr should name the conflicting file, not the directory; got:\n{stderr}"
     );
-    assert!(
-        !existing.join("main.hew").exists(),
-        "hew init should not write main.hew when the directory-exists guard trips"
-    );
-    assert!(
-        !existing.join("README.md").exists(),
-        "hew init should not write README.md when the directory-exists guard trips"
+    assert_eq!(
+        fs::read_to_string(existing.join("main.hew")).unwrap(),
+        "fn main() {}\n",
+        "hew init should leave the pre-existing main.hew untouched when refusing to overwrite"
     );
 }
 

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -179,6 +179,31 @@ fn init_existing_empty_directory_without_force_succeeds() {
 }
 
 #[test]
+fn init_dot_and_no_arg_produce_the_same_project_name() {
+    let tmp = support::tempdir();
+    let out = run_hew(tmp.path(), &["init", "."]);
+
+    assert!(
+        out.status.success(),
+        "hew init . failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let project_name = tmp
+        .path()
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(&format!("Created source-only project \"{project_name}\"")),
+        "hew init . should name the project after the target directory, matching `hew init` \
+         with no argument; got:\n{stdout}"
+    );
+}
+
+#[test]
 fn init_existing_directory_with_real_main_hew_exits_one_naming_the_file() {
     let tmp = support::tempdir();
     let existing = tmp.path().join("existing");

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -331,4 +331,29 @@ fn init_force_overwrites_existing_scaffold() {
         readme_src.contains("It does not create `hew.toml`"),
         "forced scaffold should restore the starter README; got:\n{readme_src}"
     );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--force replaced existing: main.hew, README.md"),
+        "stdout should report which pre-existing files --force replaced; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn init_force_into_empty_directory_prints_no_replacement_notice() {
+    let tmp = support::tempdir();
+    let out = run_hew(tmp.path(), &["init", "--force"]);
+
+    assert!(
+        out.status.success(),
+        "hew init --force failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("--force replaced existing"),
+        "stdout should not claim a replacement when no scaffold file pre-existed; got:\n{stdout}"
+    );
 }


### PR DESCRIPTION
I hit this writing a calculator in Hew on Windows. `hew init .` in a directory I'd just made refused to run:

```
Error: directory '.' already exists (use --force to overwrite)
```

So I added `--force` — and it silently destroyed the `main.hew` I'd been working in. No diff, no backup, no confirmation, not even a mention in the success message.

The trap is the sequence. The error names the *directory*, which is the harmless thing, and never mentions the file that actually matters. Learning to add `--force` is the natural response, and `--force` is exactly what destroys your work.

## What was wrong

`--force` gated two unrelated things at once: whether the directory may already exist, and whether existing files may be clobbered. There was no way to say "yes, this directory exists" without also saying "yes, overwrite my files."

The two entry paths had drifted, too. `hew init` (no argument) already implemented the behaviour I wanted — it tolerates an existing directory, guards per-file, and names the project after the directory. Only `hew init <name>` carried the extra directory check. And because `PathBuf::from(".").file_name()` returns `None`, `hew init .` produced a project called `hew-project` while `hew init` in the same directory produced one named after the directory.

That is also not how any comparable tool behaves. `git init`, `cargo init`, `npm init` and `go mod init` all treat directory existence as irrelevant, error only on file conflicts, name the conflicting file, and default the project name to the directory.

## What changed

**The directory-existence guard is gone.** `create_dir_all` is already idempotent, and the per-file guard covering both paths was always the one doing real work. The named path now collapses onto the no-argument path that was already correct. `hew init .` into an empty or unrelated-file directory succeeds; a real `main.hew` still stops it.

**Refusals name the files.** Instead of naming the directory, for `hew init .`:

```
Error: './main.hew', './README.md' already exist (use --force to overwrite)
Overwrite with --force, or run `hew init` in a directory without these files.
```

The paths are shown as joined against the target directory, so `hew init myproj` reports `'myproj/main.hew'` and a bare `hew init` reports the absolute path. The verb agrees with the count — a single conflict reads `already exists`.

**The project name comes from the target directory**, so `hew init` and `hew init .` finally agree.

**`--force` says what it replaced**, listing only files that were actually there:

```
--force replaced existing: main.hew, README.md
```

## Verification

The safety property is the point of this change, so I checked it against a built binary rather than trusting the tests. `main.hew` and `README.md` are written at exactly two sites, both unconditionally downstream of the single shared `!force` guard, and both entry paths converge before it — so removing the directory check cannot open a write path around the file check. A refusal preserves the conflicting file byte-for-byte and writes nothing at all, verified with `main.hew`-only and `README.md`-only conflicts. A `main.hew` symlinked to real code outside the directory still trips the guard, since `Path::exists()` follows symlinks.

One residual, unchanged by this PR: `Path::exists()` is false for a *broken* symlink, so a `main.hew` pointing at a missing target passes the guard. That was true before and after; I am noting it rather than fixing it here.

On Windows, `canonicalize` fails on paths that do not exist yet, so the name derivation runs after `create_dir_all`; the fallback chain still terminates at `hew-project`, and no canonicalized `\\?\` path reaches any user-facing message — it is consumed only by `file_name()`.

One test pinned the old behaviour and had to be replaced. `init_existing_directory_without_force_exits_one` asserted the exact string about the directory. It is now two tests: one for the newly-correct case (existing empty directory succeeds), and one preserving the real safety property — an existing `main.hew` still exits 1, now naming the file and asserting its contents survive byte-for-byte. That second assertion is stronger than the existence check it replaced.

Both verb forms are pinned in both directions — each has a positive assertion and a negative that fails if the other verb is substituted.

`cargo fmt`, `clippy -D warnings`, the init suite (run three times for flake), and `make lint` all pass. `hew-cli` only; no compiler crate is touched.

## Out of scope

Making `--force` per-file or skip-if-exists. It is the right hardening — `--force` still replaces a real `README.md` without asking — but it is the one change that breaks a correct existing test, and it needs a decision about what `--force` should then mean. Tracked in #2809 together with the `hew init` / `adze init` reconciliation.
