### PR TITLE
build: verify the archive identity once per archive, not once per link

### DIFF
--- a/hew-cli/src/build_identity.rs
+++ b/hew-cli/src/build_identity.rs
@@ -18,10 +18,30 @@
 //!
 //! Fail closed means fail closed: a missing, truncated or unreadable stamp is
 //! refused, never accepted as a match.
+//!
+//! # Cost
+//!
+//! Establishing the answer means reading the whole archive: refusing an archive
+//! that carries two different identities requires knowing whether a second one
+//! exists, so there is no early exit. On a 160 MB debug `libhew.a` that is
+//! roughly a quarter of a second, and the vertical slice and the ratchets link
+//! thousands of programs.
+//!
+//! The answer, though, is a property of the archive *file*. It cannot change
+//! between two links unless the file changes. So the scan is memoized on a
+//! fingerprint of the file itself (see [`ArchiveFingerprint`]) at two levels:
+//! an in-process map, so one driver process linking N programs scans once, and
+//! a marker file beside the archive, so the next `hew` process does not scan at
+//! all. Both are keyed strictly enough that a rebuilt or replaced archive
+//! misses and is scanned again, and both only ever record a *success* — the
+//! memo can assert "this exact file matched this exact driver" and nothing
+//! else. Anything the memo cannot vouch for falls through to the full scan.
 
 use std::collections::BTreeSet;
-use std::io::Read;
-use std::path::Path;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use hew_build_identity::{digest_from_stamp, STAMP_LEN, STAMP_PREFIX};
 
@@ -30,6 +50,13 @@ pub(crate) const DRIVER_IDENTITY: &str = env!("HEW_BUILD_IDENTITY");
 
 /// Bytes read per filesystem round trip while scanning for the stamp.
 const CHUNK_BYTES: usize = 1 << 20;
+
+/// First line of the marker file, and the only version of it this driver reads.
+///
+/// Bump this whenever the scan's verdict for a fixed archive could change —
+/// a new stamp format, a change to what counts as a conflict — so markers
+/// written by the old rules are misses rather than silently honoured answers.
+const MARKER_VERSION: &str = "HEW_IDENTITY_MEMO_V1";
 
 /// Why an archive's build identity could not be established.
 #[derive(Debug)]
@@ -46,8 +73,212 @@ enum IdentityReadError {
 ///
 /// Returns the caller-facing error text on refusal so the resolution path can
 /// surface it exactly like any other link failure.
+///
+/// The scan runs at most once per distinct archive file. A memo hit is only
+/// ever "this file, byte-for-byte as it is right now, was scanned and matched
+/// *this* driver"; every other outcome — including a refusal — is recomputed.
+/// Refusals are deliberately not cached: they are terminal and rare, so their
+/// cost does not matter, and not caching them removes any way for the memo to
+/// manufacture a verdict it did not observe.
 pub(crate) fn verify_archive(archive: &Path) -> Result<(), String> {
-    verdict(archive, read_archive_identity(archive))
+    let before = ArchiveFingerprint::of(archive);
+
+    if let Some(fingerprint) = &before {
+        if in_process_memo_confirms(fingerprint) || marker_confirms(archive, fingerprint) {
+            remember_in_process(fingerprint);
+            return Ok(());
+        }
+    }
+
+    let outcome = verdict(archive, read_archive_identity(archive));
+
+    if outcome.is_ok() {
+        if let Some(fingerprint) = before {
+            // Only publish an answer for a file that held still for the whole
+            // scan. If the archive was rewritten underneath the read, the
+            // bytes the scan saw are not the bytes now on disk, so there is
+            // nothing to memoize — the next link scans again.
+            if ArchiveFingerprint::of(archive).as_ref() == Some(&fingerprint) {
+                remember_in_process(&fingerprint);
+                write_marker(archive, &fingerprint);
+            }
+        }
+    }
+
+    outcome
+}
+
+/// The filesystem facts that pin down *which bytes* live at a path.
+///
+/// This is the memo key, so what it must guarantee is narrow and absolute: if
+/// the contents at `path` differ from the contents that were scanned, at least
+/// one field differs.
+///
+/// * `len` and the modification time catch every ordinary rebuild — Cargo
+///   writes a new archive, `cp` writes a new archive, both move the mtime.
+/// * `dev` and `ino` catch replacement by rename or copy-onto-a-new-file, which
+///   is how Cargo and every install step actually put an archive in place: the
+///   path is the same and the file behind it is not.
+/// * `ctime` catches the one case the others could in principle be talked out
+///   of — an in-place rewrite that restores the old length and back-dates the
+///   mtime with `touch`. `ctime` is stamped by the kernel on any change to the
+///   inode or its contents and userspace cannot move it backwards, so a forged
+///   mtime does not buy a memo hit.
+///
+/// Off Unix there is no `ctime`; creation time stands in for it. That is a
+/// weaker key against deliberate back-dating and a fully adequate one against
+/// the failure this whole check exists for, which is an ordinary stale build
+/// artefact.
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct ArchiveFingerprint {
+    /// Absolute path the fingerprint was taken from.
+    path: String,
+    /// The filesystem facts above, rendered as one comparable line.
+    stat: String,
+}
+
+impl ArchiveFingerprint {
+    /// Fingerprints the file at `archive`, or `None` if it cannot be pinned
+    /// down.
+    ///
+    /// Every `None` here costs a rescan and nothing else, so anything even
+    /// slightly ambiguous — an unstattable file, a path that does not survive a
+    /// round trip through the marker's line-oriented format — returns `None`
+    /// rather than a key that might collide.
+    fn of(archive: &Path) -> Option<Self> {
+        let metadata = std::fs::metadata(archive).ok()?;
+        if !metadata.is_file() {
+            return None;
+        }
+
+        let path = std::path::absolute(archive).ok()?.to_str()?.to_owned();
+        if path.contains('\n') {
+            return None;
+        }
+
+        Some(Self {
+            path,
+            stat: stat_key(&metadata)?,
+        })
+    }
+}
+
+#[cfg(unix)]
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "shares one signature with the non-Unix arm, which genuinely has no key when the \
+              platform cannot report a modification or creation time"
+)]
+fn stat_key(metadata: &std::fs::Metadata) -> Option<String> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some(format!(
+        "len={} mtime={}.{:09} ctime={}.{:09} dev={} ino={}",
+        metadata.len(),
+        metadata.mtime(),
+        metadata.mtime_nsec(),
+        metadata.ctime(),
+        metadata.ctime_nsec(),
+        metadata.dev(),
+        metadata.ino(),
+    ))
+}
+
+#[cfg(not(unix))]
+fn stat_key(metadata: &std::fs::Metadata) -> Option<String> {
+    let modified = metadata.modified().ok()?;
+    let created = metadata.created().ok()?;
+    Some(format!(
+        "len={} mtime={modified:?} created={created:?}",
+        metadata.len(),
+    ))
+}
+
+/// Archives this process has already scanned and matched, keyed by path.
+///
+/// The stored fingerprint is checked in full on every hit, so an entry for a
+/// path that has since been rebuilt does not answer for the new file.
+fn in_process_memo() -> &'static Mutex<HashMap<String, String>> {
+    static MEMO: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn in_process_memo_confirms(fingerprint: &ArchiveFingerprint) -> bool {
+    // A poisoned lock means some other thread panicked mid-update, so the map
+    // is not something to take an answer from: rescan.
+    in_process_memo()
+        .lock()
+        .is_ok_and(|memo| memo.get(&fingerprint.path) == Some(&fingerprint.stat))
+}
+
+fn remember_in_process(fingerprint: &ArchiveFingerprint) {
+    if let Ok(mut memo) = in_process_memo().lock() {
+        memo.insert(fingerprint.path.clone(), fingerprint.stat.clone());
+    }
+}
+
+/// Where the cross-process marker for `archive` lives.
+///
+/// Beside the archive, because that is the one place whose lifetime is tied to
+/// it: a target directory that gets wiped, or a checkout that gets deleted,
+/// takes the marker with it. A marker in a user-wide cache would outlive the
+/// archive it describes, which is exactly the property that must not hold.
+fn marker_path(archive: &Path) -> Option<PathBuf> {
+    let name = archive.file_name()?.to_str()?;
+    Some(archive.with_file_name(format!(".{name}.hew-identity")))
+}
+
+/// Reports whether a marker vouches for exactly this file and this driver.
+///
+/// Every line must match. The version pins the scan rules, the path and stat
+/// pin the file, and the digest pins the driver — a driver rebuilt from
+/// different runtime sources carries a different [`DRIVER_IDENTITY`] and so
+/// finds no marker it can use, even though the archive never moved.
+fn marker_confirms(archive: &Path, fingerprint: &ArchiveFingerprint) -> bool {
+    let Some(path) = marker_path(archive) else {
+        return false;
+    };
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return false;
+    };
+
+    let mut lines = text.lines();
+    lines.next() == Some(MARKER_VERSION)
+        && lines.next() == Some(fingerprint.path.as_str())
+        && lines.next() == Some(fingerprint.stat.as_str())
+        && lines.next() == Some(DRIVER_IDENTITY)
+        && lines.next().is_none()
+}
+
+/// Records a verified archive for the next process, best effort.
+///
+/// Every failure path here is silent and harmless: no marker means the next
+/// link scans, which is the behaviour this whole change is optimising away and
+/// never the behaviour it is weakening. Read-only target directories and
+/// concurrent linkers therefore need no special handling beyond not crashing.
+///
+/// The write is a create-then-rename so a reader never observes a half-written
+/// marker, and the temporary name carries the pid so two linkers racing on the
+/// same archive cannot truncate each other's file.
+fn write_marker(archive: &Path, fingerprint: &ArchiveFingerprint) {
+    let Some(path) = marker_path(archive) else {
+        return;
+    };
+    let temporary = path.with_extension(format!("tmp{}", std::process::id()));
+
+    let body = format!(
+        "{MARKER_VERSION}\n{}\n{}\n{DRIVER_IDENTITY}\n",
+        fingerprint.path, fingerprint.stat
+    );
+
+    let written = std::fs::File::create(&temporary).and_then(|mut file| {
+        file.write_all(body.as_bytes())?;
+        file.sync_all()
+    });
+
+    if written.is_err() || std::fs::rename(&temporary, &path).is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
 }
 
 /// Turns a read result into the caller-facing verdict for `archive`.
@@ -425,5 +656,253 @@ mod tests {
     #[test]
     fn stamp_len_matches_the_shared_format() {
         assert_eq!(STAMP_LEN, STAMP_PREFIX.len() + DIGEST_HEX_LEN);
+    }
+
+    // ── memoization ───────────────────────────────────────────────────
+    //
+    // The memo may only ever turn a scan that would have said "matches this
+    // driver" into no scan at all. These cover the two things that would make
+    // it something else: answering for a file it did not scan, and answering
+    // for a driver it did not match.
+
+    use super::{marker_confirms, marker_path, verify_archive, ArchiveFingerprint, MARKER_VERSION};
+    use std::path::Path;
+
+    /// Writes a plausible archive: filler, a stamp, more filler.
+    fn write_archive(path: &Path, digest: &str, filler: usize) {
+        let mut bytes = vec![b'.'; filler];
+        bytes.extend_from_slice(&stamp(digest));
+        bytes.extend_from_slice(&[b'.'; 64]);
+        std::fs::write(path, bytes).expect("archive written");
+    }
+
+    fn scratch() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn a_matching_archive_is_verified_once_and_then_remembered() {
+        let dir = scratch();
+        let archive = dir.path().join("libhew.a");
+        write_archive(&archive, DRIVER_IDENTITY, 512);
+
+        verify_archive(&archive).expect("a matching archive links");
+
+        let marker = marker_path(&archive).expect("marker path");
+        assert!(marker.exists(), "a verified archive leaves a marker");
+
+        let fingerprint = ArchiveFingerprint::of(&archive).expect("fingerprint");
+        assert!(
+            marker_confirms(&archive, &fingerprint),
+            "the marker vouches for the file it was written for"
+        );
+
+        verify_archive(&archive).expect("the remembered archive still links");
+    }
+
+    /// The counterfactual that the memo has to survive: verify an archive,
+    /// swap a mismatched one into its place, link again. The stale marker is
+    /// still sitting there and must not be able to speak for the new file.
+    #[test]
+    fn a_replaced_archive_is_re_verified_and_refused() {
+        let dir = scratch();
+        let archive = dir.path().join("libhew.a");
+
+        write_archive(&archive, DRIVER_IDENTITY, 512);
+        verify_archive(&archive).expect("the matching archive links");
+        let marker = marker_path(&archive).expect("marker path");
+        assert!(marker.exists(), "precondition: a marker was written");
+
+        let other = "7".repeat(DIGEST_HEX_LEN);
+        write_archive(&archive, &other, 4096);
+
+        let message = verify_archive(&archive)
+            .expect_err("a replaced, mismatched archive must be refused, not served from cache");
+        assert!(message.contains(&other), "{message}");
+        assert!(message.contains(DRIVER_IDENTITY), "{message}");
+        assert!(message.contains("refusing to link"), "{message}");
+
+        let fingerprint = ArchiveFingerprint::of(&archive).expect("fingerprint");
+        assert!(
+            !marker_confirms(&archive, &fingerprint),
+            "the marker must not vouch for a file it never described"
+        );
+    }
+
+    /// Rebuilding in place can land the same byte count at the same path. The
+    /// key still has to move, or the memo answers for bytes it never read.
+    #[test]
+    fn an_in_place_rewrite_of_the_same_size_changes_the_key() {
+        let dir = scratch();
+        let archive = dir.path().join("libhew.a");
+
+        write_archive(&archive, &"a".repeat(DIGEST_HEX_LEN), 512);
+        let before = ArchiveFingerprint::of(&archive).expect("fingerprint");
+
+        write_archive(&archive, &"b".repeat(DIGEST_HEX_LEN), 512);
+        let after = ArchiveFingerprint::of(&archive).expect("fingerprint");
+
+        assert_eq!(
+            std::fs::metadata(&archive).expect("metadata").len(),
+            std::fs::metadata(&archive).expect("metadata").len(),
+        );
+        assert_ne!(
+            before, after,
+            "a same-size in-place rewrite must still miss the memo"
+        );
+    }
+
+    /// A conflicted archive is refused on every link, not once. Caching only
+    /// successes is what makes that automatic.
+    #[test]
+    fn a_conflicted_archive_is_refused_every_time_and_leaves_no_marker() {
+        let dir = scratch();
+        let archive = dir.path().join("libhew.a");
+
+        let mut bytes = stamp(DRIVER_IDENTITY);
+        bytes.extend_from_slice(&[b'.'; 64]);
+        bytes.extend_from_slice(&stamp(&"8".repeat(DIGEST_HEX_LEN)));
+        std::fs::write(&archive, bytes).expect("archive written");
+
+        for _ in 0..2 {
+            let message = verify_archive(&archive).expect_err("must refuse");
+            assert!(message.contains("ambiguous"), "{message}");
+        }
+
+        assert!(
+            !marker_path(&archive).expect("marker path").exists(),
+            "a refusal is never memoized"
+        );
+    }
+
+    #[test]
+    fn a_marker_naming_another_driver_is_not_honoured() {
+        let dir = scratch();
+        let archive = dir.path().join("libhew.a");
+        write_archive(&archive, DRIVER_IDENTITY, 512);
+
+        let fingerprint = ArchiveFingerprint::of(&archive).expect("fingerprint");
+        let marker = marker_path(&archive).expect("marker path");
+        std::fs::write(
+            &marker,
+            format!(
+                "{MARKER_VERSION}\n{}\n{}\n{}\n",
+                fingerprint.path,
+                fingerprint.stat,
+                "9".repeat(DIGEST_HEX_LEN)
+            ),
+        )
+        .expect("marker written");
+
+        assert!(
+            !marker_confirms(&archive, &fingerprint),
+            "a marker written by a differently-built driver is a miss"
+        );
+    }
+
+    /// Each line of the marker is load-bearing: a marker that agrees on
+    /// everything but one field is a miss, not a near-enough hit.
+    #[test]
+    fn a_marker_disagreeing_on_any_line_is_not_honoured() {
+        let dir = scratch();
+        let archive = dir.path().join("libhew.a");
+        write_archive(&archive, DRIVER_IDENTITY, 512);
+
+        let fingerprint = ArchiveFingerprint::of(&archive).expect("fingerprint");
+        let marker = marker_path(&archive).expect("marker path");
+        let good = [
+            MARKER_VERSION.to_string(),
+            fingerprint.path.clone(),
+            fingerprint.stat.clone(),
+            DRIVER_IDENTITY.to_string(),
+        ];
+
+        for corrupt in 0..good.len() {
+            let mut lines = good.clone();
+            lines[corrupt] = format!("{}-tampered", lines[corrupt]);
+            std::fs::write(&marker, lines.join("\n") + "\n").expect("marker written");
+            assert!(
+                !marker_confirms(&archive, &fingerprint),
+                "line {corrupt} must be load-bearing"
+            );
+        }
+
+        // Truncated and over-long markers are misses too.
+        std::fs::write(&marker, good[..3].join("\n") + "\n").expect("marker written");
+        assert!(!marker_confirms(&archive, &fingerprint));
+
+        std::fs::write(&marker, good.join("\n") + "\nextra\n").expect("marker written");
+        assert!(!marker_confirms(&archive, &fingerprint));
+
+        std::fs::write(&marker, good.join("\n") + "\n").expect("marker written");
+        assert!(
+            marker_confirms(&archive, &fingerprint),
+            "the intact marker is a hit"
+        );
+    }
+
+    /// A marker carried over to a different archive describes a path that is
+    /// not the one being linked, so it cannot vouch for it.
+    #[test]
+    fn a_marker_copied_beside_another_archive_is_not_honoured() {
+        let dir = scratch();
+        let original = dir.path().join("libhew.a");
+        write_archive(&original, DRIVER_IDENTITY, 512);
+        verify_archive(&original).expect("the matching archive links");
+
+        let elsewhere = scratch();
+        let copy = elsewhere.path().join("libhew.a");
+        std::fs::copy(&original, &copy).expect("archive copied");
+        std::fs::copy(
+            marker_path(&original).expect("marker path"),
+            marker_path(&copy).expect("marker path"),
+        )
+        .expect("marker copied");
+
+        let fingerprint = ArchiveFingerprint::of(&copy).expect("fingerprint");
+        assert!(
+            !marker_confirms(&copy, &fingerprint),
+            "a marker names the one file it was written for"
+        );
+    }
+
+    #[test]
+    fn an_unstamped_archive_is_refused_and_not_memoized() {
+        let dir = scratch();
+        let archive = dir.path().join("libhew.a");
+        std::fs::write(&archive, vec![0u8; 4096]).expect("archive written");
+
+        let message = verify_archive(&archive).expect_err("must refuse");
+        assert!(message.contains("missing"), "{message}");
+        assert!(!marker_path(&archive).expect("marker path").exists());
+    }
+
+    #[test]
+    fn a_directory_is_never_fingerprinted() {
+        let dir = scratch();
+        assert!(ArchiveFingerprint::of(dir.path()).is_none());
+        assert!(ArchiveFingerprint::of(&dir.path().join("absent.a")).is_none());
+    }
+
+    /// The in-process tier is what makes one driver process linking N programs
+    /// scan once. It answers for a path only while the file behind that path is
+    /// still the one that was scanned.
+    #[test]
+    fn the_in_process_memo_answers_for_one_file_and_not_its_successor() {
+        let dir = scratch();
+        let archive = dir.path().join("libhew.a");
+        write_archive(&archive, DRIVER_IDENTITY, 512);
+
+        let first = ArchiveFingerprint::of(&archive).expect("fingerprint");
+        assert!(!super::in_process_memo_confirms(&first));
+
+        super::remember_in_process(&first);
+        assert!(super::in_process_memo_confirms(&first));
+
+        // Same path, rebuilt file: the remembered entry must not answer.
+        write_archive(&archive, DRIVER_IDENTITY, 8192);
+        let second = ArchiveFingerprint::of(&archive).expect("fingerprint");
+        assert_ne!(first.stat, second.stat);
+        assert!(!super::in_process_memo_confirms(&second));
     }
 }


### PR DESCRIPTION
The build-identity check I added in #2812 must read the whole archive rather than stopping at the first stamp, because refusing an archive that carries two different identities requires knowing whether a second exists. On the 160 MB debug archive that is ~261 ms, and it ran on every resolution.

`tests/vertical-slice/run.sh` invokes the driver as a fresh process per case, so "once per resolution" and "once per link" are the same number, and the cost scaled with the number of programs linked. `Build & test (Linux)` on `main` went from 66 minutes to the 90-minute job ceiling, where it now cancels — taking every open PR with it, since a cancelled required check does not re-trigger itself.

## What changed

The verification answer is a property of the archive **file**, not of the link, so it is computed once and reused. The memo is keyed on the filesystem facts that pin down which bytes live at a path: length, mtime, ctime, device and inode.

Each field is there for a reason:

- **length and mtime** catch every ordinary rebuild — Cargo writes a new archive, `cp` writes a new archive, both move the mtime.
- **device and inode** catch replacement by rename or copy-onto-a-new-file, which is how Cargo and every install step actually put an archive in place: the path is the same and the file behind it is not.
- **ctime** catches the one case the others could be talked out of — an in-place rewrite that restores the old length and back-dates the mtime with `touch`. The kernel stamps ctime on any change to the inode or its contents and userspace cannot move it backwards, so a forged mtime does not buy a memo hit.

Off Unix there is no ctime and creation time stands in. That is weaker against deliberate back-dating and fully adequate against the failure this check exists for, which is an ordinary stale build artefact.

`make test-vertical-slice` goes from 4m26s to 2m9s.

## The guarantee is unchanged

Two different stamps in one archive is still an unconditional refusal; a missing, unreadable or unparseable stamp is still a refusal; and a replaced archive re-verifies rather than serving a cached pass.

That last one is the risk in caching a safety check, so it is the one to demonstrate. With a warm memo, replacing the archive with stamp-free bytes is refused before the linker sees it:

```
Error: libhew.a does not match this compiler — refusing to link.
  archive               : …/target/debug/libhew.a
  archive build identity: missing — no `HEW_BUILD_IDENTITY_V1=` stamp
  driver  build identity: bc890b6227bec6595438f8a10f845fe7096e29e2b41491873665c90a254e1a88
```

## Where the check belongs

It stays exactly where it is. The check already lives inside archive resolution rather than at the call site, so there is no per-link check to hoist. The axis was never the call site — it was process lifetime.

It should not move earlier either. A build-system step is the position `check-libhew-fresh.sh` already occupies, and its own header explains why that is not sufficient alone: the driver's check runs at the moment of link and therefore also covers direct `cargo build`, IDE builds and copied-in artefacts. Enforcing this anywhere but on the path to the link line reintroduces the holes #2812 closed.

## Remaining cost

The first link after any rebuild still pays the full scan. That is one-shot per archive build and does not scale with link count, so it is not addressed here — but if the debug archive grows substantially, the right answer is to attack the constant directly rather than to weaken the memo key.
