### PR TITLE
fix(runtime): reclaim actors parked at a suspend point during shutdown

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1987,7 +1987,7 @@ pub(crate) unsafe fn cleanup_all_actors() {
         // the handle), a sweep reached by some other route than
         // `hew_runtime_cleanup`, or the WASM sweep, which has no abandonment
         // path of its own yet.
-        // WASM-TODO: the WASM scheduler has no `retire_parked_activations`
+        // WASM-TODO(#2825): the WASM scheduler has no `retire_parked_activations`
         // equivalent, so a WASM actor parked at a suspend point still takes the
         // fail-closed leak below.
         // Leaking those remains correct: the frame that

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1813,8 +1813,21 @@ pub(crate) unsafe fn cleanup_all_actors() {
     // before finalizing each actor.  LIVE_ACTORS is not held here, so
     // pinned senders can re-acquire it freely (e.g. enqueue_resume).
 
+    let mut skipped_free_for_selftest = false;
+
     for live_actors::ActorPtr(actor) in actors.into_values() {
         if actor.is_null() {
+            continue;
+        }
+        // Counterfactual for the actor-box balance oracle: with
+        // `HEW_ACTOR_LEAK_SELFTEST=skip-free` armed, omit the free of exactly
+        // one actor this sweep would otherwise reclaim. The same program must
+        // then exit `HEW_EXIT_ACTOR_LEAK`; if it still exits cleanly, the
+        // accounting in `actor_balance` has stopped proving anything and the
+        // corpus gate that relies on it fails. Inert unless
+        // `HEW_ACTOR_LEAK_CHECK=1` is also set — see `actor_balance`.
+        if !skipped_free_for_selftest && crate::actor_balance::leak_selftest_skips_free() {
+            skipped_free_for_selftest = true;
             continue;
         }
         // SAFETY: actor is valid (from LIVE_ACTORS); scheduler is shut down.
@@ -2118,6 +2131,9 @@ unsafe fn free_actor_resources_with_options(actor: *mut HewActor, suppress_state
         unsafe { mailbox::hew_mailbox_free(mb) };
     }
 
+    // The single site that reclaims an actor box; the balancing half of the
+    // `record_actor_box_alloc` in `spawn_actor_internal`.
+    crate::actor_balance::record_actor_box_free();
     // SAFETY: Actor was allocated with Box::new / Box::into_raw.
     drop(unsafe { Box::from_raw(actor) });
 }
@@ -2238,6 +2254,9 @@ pub(crate) unsafe fn free_actor_resources_wasm_with_options(
         unsafe { crate::mailbox_wasm::hew_mailbox_free(mb) };
     }
 
+    // The single site that reclaims an actor box; the balancing half of the
+    // `record_actor_box_alloc` in `spawn_actor_internal`.
+    crate::actor_balance::record_actor_box_free();
     // SAFETY: Actor was allocated with Box::new / Box::into_raw.
     drop(unsafe { Box::from_raw(actor) });
 }
@@ -2845,6 +2864,11 @@ unsafe fn spawn_actor_internal(config: ActorSpawnConfig) -> *mut HewActor {
     };
     let actor = build_spawned_actor(config, identity, init_state, arena);
     let raw = Box::into_raw(actor);
+    // The single site that mints an actor box. Counted here, at the allocation
+    // itself, so the balance in `actor_balance` is over the boxes the runtime
+    // actually handed out (see that module for why exit status alone cannot
+    // see a leaked actor).
+    crate::actor_balance::record_actor_box_alloc();
     register_actor_state_lock(raw);
     // SAFETY: `raw` comes from `Box::into_raw` and has not yet been tracked.
     if !unsafe { finalize_spawned_actor(raw, identity.id) } {
@@ -2909,6 +2933,11 @@ unsafe fn spawn_actor_internal(config: ActorSpawnConfig) -> *mut HewActor {
     };
     let actor = build_spawned_actor(config, identity, init_state, arena);
     let raw = Box::into_raw(actor);
+    // The single site that mints an actor box. Counted here, at the allocation
+    // itself, so the balance in `actor_balance` is over the boxes the runtime
+    // actually handed out (see that module for why exit status alone cannot
+    // see a leaked actor).
+    crate::actor_balance::record_actor_box_alloc();
     register_actor_state_lock(raw);
     // SAFETY: `raw` comes from `Box::into_raw` and has not yet been tracked.
     if !unsafe { finalize_spawned_actor(raw, identity.id) } {

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1675,6 +1675,111 @@ unsafe fn scrub_actor_relationships_after_pin_drain(actor: *mut HewActor) {
     let _ = actor;
 }
 
+/// Release the continuation frame of an actor that is being abandoned mid-suspend,
+/// and latch it out of the non-quiescent `Suspended` window.
+///
+/// C1 abandonment teardown (D-C1, R326/R327). A `Suspended` actor (`cont_tag`
+/// `Parked`) holds a live continuation frame in `suspended_cont`. That frame is
+/// a reference to the actor that outlives every ordinary teardown decision:
+/// `Suspended` is deliberately NOT quiescent
+/// (`actor_free_state_is_quiescent` excludes it), so a teardown path that only
+/// knows how to finalize quiescent actors cannot touch it and must leak both
+/// the frame and the actor box fail-closed.
+///
+/// Destroying the frame is what makes the actor reachable by that decision
+/// again: `destroy_parked` wins the single `… → Destroyed` CAS (FG1), runs the
+/// `coro.destroy` cleanup outline, and nulls the slot (FG4); the CAS serialises
+/// against any concurrent resume waking the actor at the same instant (FG2).
+/// Only the winner of that CAS reaches the `Suspended → Stopped` latch, so the
+/// state transition cannot race a resume — a resume would have refused the
+/// destroy.
+///
+/// Every teardown route that abandons an actor must call this, and for the same
+/// reason. `hew_actor_free_inner` calls it before its bounded quiescence wait,
+/// which would otherwise spin to the 2 s deadline and return `-2`.
+/// [`retire_parked_activations`] calls it for every still-parked actor at the
+/// head of runtime cleanup, so the shutdown sweep meets those actors quiescent
+/// instead of leaking them fail-closed.
+///
+/// ORDERING, and it is load-bearing: the `coro.destroy` cleanup outline this
+/// runs re-enters the runtime. A frame parked on `sleep` cancels its await
+/// registration, which cancels through the global periodic timer wheel. So this
+/// may only run while that machinery is still alive — before
+/// `hew_periodic_shutdown` frees the wheel and before `reactor_shutdown` joins
+/// the reactor. Running it later dereferences a freed wheel and crashes. It
+/// must equally run after the worker threads are joined, so no resume can be
+/// attempted concurrently. That leaves exactly one window during shutdown, and
+/// [`retire_parked_activations`] is called in it.
+///
+/// A no-op for the overwhelmingly common actor that never suspended.
+#[cfg(not(target_arch = "wasm32"))]
+fn abandon_parked_activation(a: &HewActor) {
+    if !crate::coro_exec::has_live_parked_cont(a) {
+        return;
+    }
+    // SAFETY: `a` is the actor being torn down; `destroy_parked`'s CAS guards
+    // serialise against any concurrent resume (FG1/FG2).
+    let destroyed = unsafe { crate::coro_exec::destroy_parked(a) };
+    if !destroyed.is_ok() {
+        // A concurrent resume holds the handle, or the frame was already
+        // reclaimed. Leave the state alone: latching a resuming actor to
+        // `Stopped` would strand its activation.
+        return;
+    }
+    clear_suspended_cancel_token(a);
+    // `destroy_parked` above just ran the pump frame's `coro.destroy` cleanup
+    // outline, which releases the generator companion (heap env + coro handle)
+    // living as a local INSIDE that frame via its normal scope-exit drop
+    // (`hew_gen_coro_destroy`) — exactly once, and NOT touched here. This call's
+    // sole job is the separate SINK: if this parked activation was a
+    // `receive gen fn` pump, fault-close its still-registered sink so the
+    // consumer awaiting the stream observes the fault instead of hanging on a
+    // stream whose producer will never resume. A no-op if nothing is registered
+    // (this was not a gen-stream pump).
+    fault_close_registered_gen_sink(a);
+    let _ = a.actor_state.compare_exchange(
+        HewActorState::Suspended as i32,
+        HewActorState::Stopped as i32,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    );
+}
+
+/// Abandon every activation still parked at a suspend point, before the rest of
+/// runtime cleanup runs.
+///
+/// Called once from `hew_runtime_cleanup`, at the head, and only from there.
+/// Shutdown IS abandonment: no worker survives to resume a parked activation,
+/// so every live continuation frame at this point is a reference that would
+/// otherwise outlive teardown and pin its actor in the non-quiescent
+/// `Suspended` state — where `cleanup_all_actors` can only leak both, fail
+/// closed. Releasing the frames here hands that sweep ordinary quiescent actors
+/// it can reclaim.
+///
+/// This is deliberately NOT folded into `cleanup_all_actors`, and the position
+/// is the whole point: see the ORDERING note on [`abandon_parked_activation`].
+/// By the time the sweep runs, `hew_periodic_shutdown` has freed the global
+/// timer wheel, and a frame parked on `sleep` cancels through that wheel as it
+/// unwinds. Iterating without draining also matters — the actors stay tracked so
+/// `cleanup_all_actors` still owns reclamation, and this pass owns only the
+/// frames.
+///
+/// # Safety
+///
+/// All worker threads must be joined (the documented precondition of
+/// `hew_runtime_cleanup`), so no activation can be resumed concurrently.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) unsafe fn retire_parked_activations() {
+    for actor in crate::lifetime::live_actors::snapshot_live_actor_ptrs() {
+        if actor.is_null() {
+            continue;
+        }
+        // SAFETY: the pointer came from the live-actor registry and workers are
+        // joined, so nothing can free it underneath this call.
+        abandon_parked_activation(unsafe { &*actor });
+    }
+}
+
 /// Outcome of [`decide_finalize_by_latch`] — the canonical "is it safe to
 /// finalize this quiescent-but-possibly-re-enqueued actor?" decision.
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
@@ -1873,13 +1978,20 @@ pub(crate) unsafe fn cleanup_all_actors() {
         // decision uses the actual state at CAS time, so neither window can
         // finalize a re-enqueued actor.
         //
-        // The same quiescence gate routes a still-`Suspended` actor (one parked
-        // at a non-final `coro.suspend` with a live continuation frame) to the
-        // fail-closed leak: `actor_free_state_is_quiescent` excludes `Suspended`,
-        // so cleanup never finalizes a parked actor (which would free its box
-        // and leak the frame). Unlike `hew_actor_free_inner`, the shutdown sweep
-        // cannot block to destroy the parked frame (workers are joined), so it
-        // leaks-not-frees — the correct fail-closed shutdown behaviour.
+        // A still-`Suspended` actor normally does NOT reach this decision on the
+        // native shutdown path: `retire_parked_activations` runs at the head of
+        // `hew_runtime_cleanup` and has already destroyed the parked frame and
+        // latched the actor to `Stopped`, so it arrives here quiescent and is
+        // reclaimed like any other. What still reaches the fail-closed branch is
+        // an actor whose frame could not be released (a concurrent resume held
+        // the handle), a sweep reached by some other route than
+        // `hew_runtime_cleanup`, or the WASM sweep, which has no abandonment
+        // path of its own yet.
+        // WASM-TODO: the WASM scheduler has no `retire_parked_activations`
+        // equivalent, so a WASM actor parked at a suspend point still takes the
+        // fail-closed leak below.
+        // Leaking those remains correct: the frame that
+        // survived still owns the actor.
         let finalize_state = match decide_finalize_by_latch(a) {
             FinalizeDecision::Finalize(state) => Some(state),
             FinalizeDecision::Skip => {
@@ -3976,39 +4088,8 @@ unsafe fn hew_actor_free_inner(actor: *mut HewActor, suppress_state_drop: bool) 
     // This is the single-DESTROY plumbing only. The single-task cancellation
     // FLOW (unregister-readiness + resume-with-cancellation + the two-phase
     // park lost-wake-vs-cancel race) is NEW-6; this teardown is the minimum that
-    // makes the live suspend edge non-leaking. Dormant today (no actor reaches
-    // `Suspended` while the source surface stays thread-parked).
-    if crate::coro_exec::has_live_parked_cont(a) {
-        // SAFETY: `a` is the actor being freed; `destroy_parked`'s CAS guards
-        // serialise against any concurrent resume (FG1/FG2).
-        let destroyed = unsafe { crate::coro_exec::destroy_parked(a) };
-        // The parked frame is gone; latch the abandoned actor out of the
-        // non-quiescent `Suspended` window into `Stopped` so the quiescence wait
-        // below passes instead of spinning to the deadline. Only this teardown
-        // owns the slot (it won the `… → Destroyed` CAS), so the state CAS is
-        // race-free against a resume (which would have refused the destroy).
-        if destroyed.is_ok() {
-            clear_suspended_cancel_token(a);
-            // Risk 1: `destroy_parked` above just ran the pump frame's
-            // `coro.destroy` cleanup outline, which releases the generator
-            // companion (heap env + coro handle) living as a local INSIDE
-            // that frame via its normal scope-exit drop
-            // (`hew_gen_coro_destroy`) — exactly once, and NOT touched here.
-            // This call's sole job is the separate SINK: if this parked
-            // activation was a `receive gen fn` pump, fault-close its
-            // still-registered sink so the consumer awaiting the stream
-            // observes the fault instead of hanging on a stream whose
-            // producer will never resume. A no-op if nothing is registered
-            // (this was not a gen-stream pump).
-            fault_close_registered_gen_sink(a);
-            let _ = a.actor_state.compare_exchange(
-                HewActorState::Suspended as i32,
-                HewActorState::Stopped as i32,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            );
-        }
-    }
+    // makes the live suspend edge non-leaking.
+    abandon_parked_activation(a);
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
     let state = loop {
@@ -7889,6 +7970,63 @@ mod tests {
                 spawn_serial: id,
             }));
             (actor, mailbox)
+        }
+    }
+
+    /// The shutdown-leak regression for the `ask`-race fixture (#2817).
+    ///
+    /// An actor parked at a suspend point is NOT quiescent, so the shutdown
+    /// sweep's finalize decision can only leak it — box and frame both. That is
+    /// correct as a last resort but wrong as the outcome of a normal exit, and
+    /// it is exactly what `actor_ask_race.hew` produced: the actor that lost the
+    /// race was still parked on `sleep` when `main` returned.
+    ///
+    /// This pins the two halves of the fix: the leak is real if nothing runs
+    /// abandonment first, and `abandon_parked_activation` — which
+    /// `retire_parked_activations` runs over every live actor at the head of
+    /// `hew_runtime_cleanup` — releases the frame and returns the actor to a
+    /// state the sweep reclaims.
+    #[test]
+    fn abandoning_a_parked_activation_makes_it_reclaimable() {
+        let (actor, mailbox) = make_stop_test_actor(HewActorState::Suspended);
+        // SAFETY: the helper hands over sole ownership; nothing else can see it.
+        let a = unsafe { &*actor };
+
+        let mut frame = Box::new(crate::coro_exec::test_support::ScratchFrame::new(1));
+        let handle = (&raw mut *frame).cast::<std::ffi::c_void>();
+        assert!(crate::coro_exec::begin_park(a).is_ok());
+        // SAFETY: `frame` outlives this test body.
+        unsafe { crate::coro_exec::finish_park(a, handle) };
+        assert!(crate::coro_exec::has_live_parked_cont(a));
+
+        // Without abandonment the sweep has no choice but the fail-closed leak.
+        assert!(
+            matches!(decide_finalize_by_latch(a), FinalizeDecision::Skip),
+            "a parked actor must not be finalizable while its frame is live"
+        );
+
+        abandon_parked_activation(a);
+
+        assert_eq!(
+            frame.destroyed.load(Ordering::Acquire),
+            1,
+            "abandonment must run the parked frame's destroy outline exactly once"
+        );
+        assert!(!crate::coro_exec::has_live_parked_cont(a));
+        assert_eq!(
+            a.actor_state.load(Ordering::Acquire),
+            HewActorState::Stopped as i32,
+            "abandonment must latch the actor out of the non-quiescent Suspended window"
+        );
+        assert!(
+            matches!(decide_finalize_by_latch(a), FinalizeDecision::Finalize(_)),
+            "after abandonment the shutdown sweep must reclaim the actor, not leak it"
+        );
+
+        // SAFETY: sole owner; the parked frame is already destroyed.
+        unsafe {
+            drop(Box::from_raw(actor));
+            mailbox::hew_mailbox_free(mailbox);
         }
     }
 

--- a/hew-runtime/src/actor_balance.rs
+++ b/hew-runtime/src/actor_balance.rs
@@ -1,0 +1,172 @@
+//! Exact allocation-count balance for actor boxes, and the process-exit
+//! verdict built on it.
+//!
+//! # Why this exists
+//!
+//! Exit status is not a leak oracle. An actor that is spawned and never
+//! reclaimed still lets its program produce the right output and return the
+//! right code, so a corpus that only builds a fixture, runs it and diffs
+//! `exit status + stdout` is structurally blind to a leaked actor — which is
+//! exactly how `examples/v05/checked-mir/actor_ask_race.hew` kept a leaked
+//! loser through both the MIR-text gate and the execution gate.
+//!
+//! `leaks --atExit` is not the answer either: it deadlocks (0% CPU, tracee
+//! wedged in `T`, still stuck after its target is killed), and it does not
+//! exist on Linux, FreeBSD or under `wasmtime`.
+//!
+//! What does work is an exact allocation-count balance instrumented at the
+//! REAL alloc/free sites. [`record_actor_box_alloc`] is called at the
+//! `Box::into_raw` in `spawn_actor_internal` — the single site that mints an
+//! actor box — and [`record_actor_box_free`] at the `Box::from_raw` in
+//! `free_actor_resources_with_options` — the single site that reclaims one.
+//! Nothing wraps or shims the allocator, so the counts are of the actual boxes
+//! the runtime handed out, not of a wrapper's idea of them.
+//!
+//! # The verdict
+//!
+//! Armed by `HEW_ACTOR_LEAK_CHECK=1` and read once, at the end of
+//! `hew_runtime_cleanup` (see [`verdict_after_runtime_cleanup`]). Unbalanced ⇒
+//! a diagnostic naming both counts and [`HEW_EXIT_ACTOR_LEAK`] as the process
+//! exit status, so the leak is visible to any exit-status oracle — including
+//! the checked-MIR execution gate, which arms the check for every fixture it
+//! runs.
+//!
+//! It is opt-in rather than always-on because a fail-closed leak at teardown is
+//! an existing, deliberate runtime policy on some paths (an actor that cannot
+//! be proven wake-proof is leaked rather than freed); turning every such case
+//! into a non-zero exit for every program is a behaviour change well beyond a
+//! test oracle.
+//!
+//! # Keeping the oracle honest
+//!
+//! Accounting that silently stops counting — a moved call site, a bump sunk
+//! into a branch nothing takes — passes every assertion while proving nothing.
+//! [`leak_selftest_skips_free`] is the counterfactual: with
+//! `HEW_ACTOR_LEAK_SELFTEST=skip-free` the shutdown sweep omits the free of one
+//! actor it would otherwise reclaim, and the same program must then exit
+//! [`HEW_EXIT_ACTOR_LEAK`]. `scripts/checked-mir-corpus.sh run` runs that
+//! counterfactual before it trusts the check on any fixture, and fails the gate
+//! if the deliberately leaked actor still exits cleanly.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process exit status published when the actor-box balance check finds
+/// unreclaimed actors at runtime cleanup.
+///
+/// Distinct from every status the runtime already uses (0/1 for traps and
+/// scheduler faults, 101 for the actor-context abort, 124/137 for the corpus
+/// wall-clock cap, 128+signo for faults) so a counterfactual cannot pass by
+/// failing for an unrelated reason.
+pub const HEW_EXIT_ACTOR_LEAK: i32 = 93;
+
+/// Environment variable that arms the balance verdict.
+const LEAK_CHECK_VAR: &str = "HEW_ACTOR_LEAK_CHECK";
+
+/// Environment variable that drives the oracle's own counterfactual.
+const LEAK_SELFTEST_VAR: &str = "HEW_ACTOR_LEAK_SELFTEST";
+
+/// Actor boxes minted by `spawn_actor_internal`.
+static ACTOR_BOXES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
+
+/// Actor boxes reclaimed by `free_actor_resources_with_options`.
+static ACTOR_BOXES_FREED: AtomicU64 = AtomicU64::new(0);
+
+/// Count one actor box handed out. Called at the `Box::into_raw` itself.
+pub(crate) fn record_actor_box_alloc() {
+    ACTOR_BOXES_ALLOCATED.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Count one actor box reclaimed. Called at the `Box::from_raw` itself.
+pub(crate) fn record_actor_box_free() {
+    ACTOR_BOXES_FREED.fetch_add(1, Ordering::Relaxed);
+}
+
+/// `(allocated, freed)` actor boxes for this process so far.
+#[must_use]
+pub fn actor_box_counts() -> (u64, u64) {
+    (
+        ACTOR_BOXES_ALLOCATED.load(Ordering::Relaxed),
+        ACTOR_BOXES_FREED.load(Ordering::Relaxed),
+    )
+}
+
+/// Is the balance verdict armed for this process?
+#[must_use]
+pub fn leak_check_armed() -> bool {
+    std::env::var(LEAK_CHECK_VAR).is_ok_and(|v| v == "1")
+}
+
+/// Counterfactual knob: should the shutdown sweep omit one actor's free?
+///
+/// Only honoured when the check is armed, so it cannot change the behaviour of
+/// a program that is not running the oracle against itself.
+#[must_use]
+pub fn leak_selftest_skips_free() -> bool {
+    leak_check_armed() && std::env::var(LEAK_SELFTEST_VAR).is_ok_and(|v| v == "skip-free")
+}
+
+/// Read the balance once runtime cleanup has finished and publish the verdict.
+///
+/// Returns normally when the check is disarmed or the counts balance. An
+/// imbalance is terminal: the diagnostic goes to stderr and the process exits
+/// [`HEW_EXIT_ACTOR_LEAK`] rather than returning, because the whole point is to
+/// be visible to a caller that can only see exit status.
+///
+/// Called at the end of `hew_runtime_cleanup`, which is the point at which
+/// every actor the runtime intends to reclaim has been reclaimed. A program
+/// whose graceful drain does not converge never reaches runtime cleanup at all
+/// (the runtime deliberately leaves workers live and lets process exit do the
+/// teardown); the check cannot speak for that path and does not claim to.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn verdict_after_runtime_cleanup() {
+    if !leak_check_armed() {
+        return;
+    }
+    let (allocated, freed) = actor_box_counts();
+    if allocated == freed {
+        return;
+    }
+    eprintln!(
+        "hew: actor leak: {allocated} actor(s) spawned, {freed} reclaimed, \
+         {live} still allocated after runtime cleanup",
+        live = allocated.saturating_sub(freed),
+    );
+    std::process::exit(HEW_EXIT_ACTOR_LEAK);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The counters are monotonic and independent: a recorded alloc moves only
+    /// the alloc count, a recorded free only the free count. Guards the shape
+    /// the verdict subtracts, without asserting an absolute value (other tests
+    /// in this process spawn and free actors concurrently).
+    #[test]
+    fn actor_box_counters_move_independently() {
+        let (a0, f0) = actor_box_counts();
+        record_actor_box_alloc();
+        let (a1, f1) = actor_box_counts();
+        assert!(a1 > a0, "recording an alloc must raise the alloc count");
+        assert!(f1 >= f0, "counts are monotonic");
+        record_actor_box_free();
+        let (a2, f2) = actor_box_counts();
+        assert!(a2 >= a1, "counts are monotonic");
+        assert!(f2 > f1, "recording a free must raise the free count");
+    }
+
+    /// The counterfactual knob cannot fire unless the check itself is armed —
+    /// a stray `HEW_ACTOR_LEAK_SELFTEST` in an unrelated environment must not
+    /// make an ordinary program skip an actor free.
+    #[test]
+    fn selftest_knob_requires_the_check_to_be_armed() {
+        assert!(
+            !leak_check_armed(),
+            "the runtime test process must not run with the leak check armed",
+        );
+        assert!(
+            !leak_selftest_skips_free(),
+            "the selftest knob must be inert while the check is disarmed",
+        );
+    }
+}

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -720,6 +720,7 @@ pub mod shutdown;
 pub mod signal;
 
 pub mod actor;
+pub mod actor_balance;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod actor_group;
 #[cfg(not(target_arch = "wasm32"))]

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -534,6 +534,25 @@ pub(crate) fn is_actor_live_with_id(actor_id: u64, expected: *mut HewActor) -> b
     with_live_actor_by_id(actor_id, expected, |_| ()).is_some()
 }
 
+/// Copy the currently tracked actor pointers without removing them.
+///
+/// Unlike [`drain_all_for_cleanup`] this leaves the registry intact, so the
+/// caller can act on live actors while reclamation ownership stays with the
+/// cleanup sweep. Used by `actor::retire_parked_activations`, which must run
+/// before the sweep but must not take the actors from it.
+///
+/// Safe to call only once worker threads are joined: the returned pointers are
+/// unpinned, so a concurrent free would dangle them.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn snapshot_live_actor_ptrs() -> Vec<*mut HewActor> {
+    with_live_actors_opt(|map| {
+        map.as_ref()
+            .map(|m| m.values().map(|ActorPtr(actor)| *actor).collect())
+            .unwrap_or_default()
+    })
+    .unwrap_or_default()
+}
+
 /// Take all currently tracked actors out of the live map.
 ///
 /// Returns the drained map so the caller can free each actor.

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -653,6 +653,17 @@ pub(crate) fn shutdown_requested() -> bool {
 /// shutdown. It is a no-op if the scheduler was never initialized.
 #[no_mangle]
 pub extern "C" fn hew_runtime_cleanup() {
+    // Release any activation still parked at a suspend point FIRST, while the
+    // machinery its continuation frame unwinds through is still alive. A frame
+    // parked on `sleep` cancels its await registration through the global
+    // periodic timer wheel, which `hew_periodic_shutdown` below frees; doing
+    // this after that call dereferences freed memory. Workers are joined before
+    // this function runs (see the doc comment above), so nothing can resume an
+    // activation while the frames are destroyed. Without this, a parked actor
+    // stays non-quiescent and `cleanup_all_actors` leaks it fail-closed.
+    // SAFETY: worker threads are joined, per this function's precondition.
+    unsafe { crate::actor::retire_parked_activations() };
+
     // Stop the active-mode I/O reactor BEFORE any actors are freed. The reactor
     // thread delivers socket data into actor mailboxes; joining it here ensures
     // no in-flight readiness event can target an actor that cleanup_all_actors

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -730,6 +730,13 @@ pub extern "C" fn hew_runtime_cleanup() {
     // can still reference it. Dropping it frees the scheduler (deques, parkers,
     // stealers, global queue) and the now-empty live-actor registry.
     drop(runtime::take_default());
+
+    // Every actor this runtime intended to reclaim has now been reclaimed, so
+    // this is the one point where the actor-box balance is a statement about
+    // the whole program. Disarmed by default; `HEW_ACTOR_LEAK_CHECK=1` turns an
+    // imbalance into a diagnostic and a distinct exit status, which is what
+    // makes a leaked actor visible to a caller that can only see exit status.
+    crate::actor_balance::verdict_after_runtime_cleanup();
 }
 
 /// Run the canonical runtime cleanup chain from a compiled native `main` return.

--- a/scripts/checked-mir-corpus.sh
+++ b/scripts/checked-mir-corpus.sh
@@ -51,6 +51,9 @@ STAGES=(raw elab)
 # the gate rather than hang the build; 124/137 land in the transcript and
 # mismatch the committed exit status.
 RUN_TIMEOUT_SECS="${CHECKED_MIR_RUN_TIMEOUT_SECS:-60}"
+# Per-execution environment overlay consumed by execute_fixture; empty for
+# every ordinary fixture run and set only by the leak-oracle counterfactual.
+EXTRA_RUN_ENV=()
 
 # sha256 over stdin-named files; `sha256sum` on Linux, `shasum -a 256` on
 # macOS. Both print `<hash>  <name>`, so the manifest format is identical.
@@ -144,6 +147,16 @@ render_transcript() {
 # Compile a fixture and, if it links, execute it under a wall-clock cap in
 # a scratch working directory (fixtures that persist node identity files
 # must not write into the checkout). Fills the caller's transcript path.
+#
+# Every execution runs with the runtime's actor-box balance check armed
+# (HEW_ACTOR_LEAK_CHECK=1). Exit status and stdout cannot see a leaked
+# actor — a fixture that never reclaims one still prints the right thing
+# and returns the right code — so without the check this gate is
+# structurally blind to the exact defect issue #2817 reports. With it, an
+# actor that outlives runtime cleanup lands in the transcript as
+# `exit: 93` and mismatches the committed expectation. Extra environment
+# for a single execution can be passed in EXTRA_RUN_ENV (name=value
+# entries).
 execute_fixture() {
     local fixture="$1" name="$2" workdir="$3" transcript="$4"
     local emit="$workdir/emit" scratch="$workdir/cwd"
@@ -161,13 +174,68 @@ execute_fixture() {
         # being printed by this script's shell across the gate's own output.
         # The status still arrives as 128+signo.
         # shellcheck disable=SC2016  # positional parameters expand in inner bash.
-        "$TIMEOUT_BIN" --kill-after=5s "${RUN_TIMEOUT_SECS}s" \
+        env HEW_ACTOR_LEAK_CHECK=1 ${EXTRA_RUN_ENV[@]+"${EXTRA_RUN_ENV[@]}"} \
+            "$TIMEOUT_BIN" --kill-after=5s "${RUN_TIMEOUT_SECS}s" \
             bash -c 'cd "$1" && "$2"; exit $?' _ "$scratch" "$emit/$name" \
             >"$stdout_path" 2>"$workdir/$name.stderr" || run_status=$?
     fi
     render_transcript "$compile_status" "$compile_log" "$run_status" "$stdout_path" "$transcript"
     LAST_COMPILE_STATUS="$compile_status"
     LAST_RUN_STATUS="$run_status"
+}
+
+# Exit status the runtime publishes when its actor-box balance check finds
+# an actor still allocated after runtime cleanup. Must match
+# `HEW_EXIT_ACTOR_LEAK` in hew-runtime/src/actor_balance.rs.
+ACTOR_LEAK_EXIT=93
+
+# Counterfactual for the leak check: accounting that has quietly stopped
+# counting passes every fixture while proving nothing, so prove it can
+# still fail before trusting it on any fixture.
+#
+# `HEW_ACTOR_LEAK_SELFTEST=skip-free` makes the runtime's shutdown sweep
+# omit the free of exactly one actor it would otherwise reclaim — the same
+# program, with the free left out. It must then exit ACTOR_LEAK_EXIT. The
+# specific status matters: a counterfactual that merely exits non-zero
+# could be failing for an unrelated reason and would prove nothing.
+#
+# Picks a runnable fixture that spawns an actor. Chosen by asking the
+# runtime, not by trusting a name: the baseline run must first exit
+# something OTHER than ACTOR_LEAK_EXIT, which is only possible if the
+# fixture reaches runtime cleanup with a balanced count.
+leak_oracle_selftest() {
+    local workdir="$1"
+    local fixture name baseline_status leaked_status
+    for fixture in "${fixtures[@]}"; do
+        name="$(basename "$fixture" .hew)"
+        [[ -f "$CORPUS/$name.expected" ]] || continue
+        grep -q '^actor ' "$fixture" || continue
+
+        local sub="$workdir/selftest-$name"
+        mkdir -p "$sub"
+        EXTRA_RUN_ENV=()
+        execute_fixture "$fixture" "$name" "$sub" "$sub/$name.baseline"
+        [[ "$LAST_COMPILE_STATUS" -eq 0 ]] || continue
+        baseline_status="$LAST_RUN_STATUS"
+        if [[ "$baseline_status" -eq "$ACTOR_LEAK_EXIT" ]] || is_crash_status "$baseline_status"; then
+            continue
+        fi
+
+        EXTRA_RUN_ENV=(HEW_ACTOR_LEAK_SELFTEST=skip-free)
+        execute_fixture "$fixture" "$name" "$sub" "$sub/$name.leaked"
+        EXTRA_RUN_ENV=()
+        leaked_status="$LAST_RUN_STATUS"
+        if [[ "$leaked_status" -ne "$ACTOR_LEAK_EXIT" ]]; then
+            echo "LEAK ORACLE SELFTEST FAILED: $name with one actor free omitted exited $leaked_status, expected $ACTOR_LEAK_EXIT" >&2
+            echo "  the actor-box balance check is not catching a leaked actor, so every PASS below is meaningless" >&2
+            head -20 "$sub/$name.stderr" >&2
+            return 1
+        fi
+        echo "SELFTEST $name (baseline exit $baseline_status; one free omitted -> exit $leaked_status)"
+        return 0
+    done
+    echo "LEAK ORACLE SELFTEST FAILED: no runnable actor-spawning fixture available to run the counterfactual against" >&2
+    return 1
 }
 
 fixtures=()
@@ -283,6 +351,13 @@ run)
     nonrunnable=0
     tmpdir="$(mktemp -d)"
     trap 'rm -rf "$tmpdir"' EXIT
+    # The leak check below is only evidence if it can still fail. Prove that
+    # first, against a deliberately leaked actor, and refuse to report on the
+    # corpus at all if the counterfactual comes back green.
+    if ! leak_oracle_selftest "$tmpdir"; then
+        echo "checked-mir-run: FAILED (leak oracle selftest)" >&2
+        exit 1
+    fi
     for f in "${fixtures[@]}"; do
         name="$(basename "$f" .hew)"
         expected="$CORPUS/$name.expected"
@@ -385,6 +460,13 @@ expect)
             refused+=("$name (compile exit $LAST_COMPILE_STATUS, run exit $LAST_RUN_STATUS)")
             continue
         fi
+        # A leaked actor is a defect this gate exists to catch, so capturing
+        # `exit: 93` as the expectation would bless it. Same rule as a crash:
+        # recording one has to be a deliberate hand-written act.
+        if [[ "$LAST_RUN_STATUS" -eq "$ACTOR_LEAK_EXIT" ]]; then
+            refused+=("$name (leaked an actor: run exit $LAST_RUN_STATUS)")
+            continue
+        fi
         if [[ ! -f "$expected" ]]; then
             added+=("$name.expected")
         elif cmp -s "$expected" "$tmpdir/$name.actual"; then
@@ -403,7 +485,7 @@ expect)
         echo "  CHANGED $entry"
     done
     for entry in ${refused[@]+"${refused[@]}"}; do
-        echo "  REFUSED $entry — does not build or died on a signal; write the expectation by hand" >&2
+        echo "  REFUSED $entry — does not build, died on a signal, or leaked an actor; write the expectation by hand" >&2
     done
     ;;
 *)


### PR DESCRIPTION
Closes #2817.

`examples/v05/checked-mir/actor_ask_race.hew` races two actors on an `ask`. The loser is parked at a suspend point when shutdown arrives, and is never reclaimed. The program prints the right answer and exits 0, so nothing noticed.

That is the shape worth naming: an exit-status oracle cannot see a leak. The fixture was invisible while the corpus was only compiled and its MIR diffed, and it stayed invisible once the corpus began executing, because executing it still only asks whether it exited cleanly.

## The oracle comes first

Before any fix, the corpus needed a check that could go red on this. It now runs the fixture under an allocation-count balance instrumented at the real alloc and free sites, and reports its own discriminating power:

```
SELFTEST actor_ask_race (baseline exit 42; one free omitted -> exit 93)
```

The self-test omits one free and requires exit 93, so the oracle cannot decay into a tautology — if it ever stops distinguishing the leaking case, the self-test fails rather than the corpus silently passing. It selects the fixture itself rather than naming it in a list.

`leaks --atExit` is not used and should not be: it deadlocks, leaving the tracee wedged with the process pinned even after its target is killed.

## The fix

Shutdown reached a parked activation and took `FinalizeDecision::Skip` — declining to finalize, because finalizing a frame that a suspend point still owns risks a use-after-free. Skipping is the right answer to that hazard and the wrong answer to the memory: the actor is never reclaimed.

Abandoning a parked activation now makes it reclaimable, so shutdown can `Finalize` and destroy it exactly once. `abandoning_a_parked_activation_makes_it_reclaimable` asserts `Skip` before and `Finalize` plus destroy-exactly-once after.

WASM still takes the fail-closed leak, marked as such.

## Relationship to the system-channel work

#2815 touches the same `Skip` arm and the two are independent. That change discharges the *reply* obligation, so a thread waiting on a stopped actor's `ask` is not stranded; this one discharges the *memory* obligation, from a different point in the shutdown order. Its own comment is explicit that it is keeping this leak deliberately — leaking the box was the right fail-closed answer to a possible use-after-free, but it is an answer about memory, and a parked `ask` handler owes a reply as well.

Expect a textual conflict in that arm. The fixes compose.
