### PR TITLE
test: restore the ignored tests that actually pass, and make a missing runner fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ env:
   # llvm-sys-221) build script. Bumps must be reflected in
   # .github/actions/setup-llvm/action.yml (asset SHA256 pins) too.
   LLVM_VERSION: "22.1.5"
+  # Pinned wasmtime release tag. Every job that provisions a WASI runner
+  # downloads its per-platform asset from THIS tag. It is pinned, and pinned in
+  # one place, for two reasons: resolving "latest" per job (as the Linux job
+  # did) or taking whatever a package manager ships (as macOS did with brew)
+  # let the three platforms straddle different wasmtime releases inside a
+  # single run, so a WASI behaviour difference could be read as a platform
+  # difference; and an unpinned runtime changes the tested surface without a
+  # commit. Assets used: x86_64-linux.tar.xz, aarch64-macos.tar.xz,
+  # x86_64-windows.zip.
+  WASMTIME_VERSION: "v47.0.2"
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -484,9 +494,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          WASMTIME_TAG="$(gh release view --repo bytecodealliance/wasmtime --json tagName --jq .tagName)"
-          WASMTIME_DIR="wasmtime-${WASMTIME_TAG}-x86_64-linux"
-          gh release download "$WASMTIME_TAG" --repo bytecodealliance/wasmtime \
+          set -euo pipefail
+          WASMTIME_DIR="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          gh release download "$WASMTIME_VERSION" --repo bytecodealliance/wasmtime \
             --pattern "${WASMTIME_DIR}.tar.xz" --clobber
           tar -xJf "${WASMTIME_DIR}.tar.xz"
           echo "$PWD/${WASMTIME_DIR}" >> "$GITHUB_PATH"
@@ -799,6 +809,60 @@ jobs:
         # because the upstream LLVM tarball is provisioned above.
         run: cargo build -p adze-cli -p hew-runtime -p hew-lsp -p hew-cli --release
 
+      - name: Install WASI runner prerequisites
+        # Windows had no equivalent of the Linux tarball / macOS brew install,
+        # so `wasmtime` was absent here and every WASI-dependent hew-cli test
+        # either failed with "`wasmtime` not found" or — via the deleted
+        # try_require_wasi_runner — passed having asserted nothing. Provision
+        # the runner from the same pinned WASMTIME_VERSION the other two jobs
+        # use, and prove it runs inside this step: a broken install must fail
+        # the job here, not resurface as "not found" inside a test.
+        if: env.RUN_CODE_PATH == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          rustup target add wasm32-wasip1
+          if ($LASTEXITCODE -ne 0) { throw "rustup target add wasm32-wasip1 failed" }
+
+          $dir = "wasmtime-${env:WASMTIME_VERSION}-x86_64-windows"
+          gh release download "${env:WASMTIME_VERSION}" --repo bytecodealliance/wasmtime --pattern "$dir.zip" --clobber
+          if ($LASTEXITCODE -ne 0) { throw "downloading $dir.zip from bytecodealliance/wasmtime failed" }
+
+          Expand-Archive -Path "$dir.zip" -DestinationPath . -Force
+          $wasmtimeBin = Join-Path (Get-Location).Path $dir
+          $wasmtimeExe = Join-Path $wasmtimeBin "wasmtime.exe"
+          if (-not (Test-Path -LiteralPath $wasmtimeExe)) {
+            throw "wasmtime.exe not found at $wasmtimeExe after extracting $dir.zip"
+          }
+          Add-Content -Path $env:GITHUB_PATH -Value $wasmtimeBin
+
+          & $wasmtimeExe --version
+          if ($LASTEXITCODE -ne 0) { throw "wasmtime installed but 'wasmtime --version' exited $LASTEXITCODE" }
+
+          # wasm-ld comes from the LLVM install provisioned above; hew's WASM
+          # link step shells out to it, so an unreachable wasm-ld is the same
+          # class of silent gap as a missing runtime.
+          $wasmLd = Get-Command wasm-ld -ErrorAction SilentlyContinue
+          if (-not $wasmLd) { throw "wasm-ld not found on PATH (expected from the LLVM ${env:LLVM_VERSION} install)" }
+          & $wasmLd.Source --version
+          if ($LASTEXITCODE -ne 0) { throw "wasm-ld found at $($wasmLd.Source) but 'wasm-ld --version' exited $LASTEXITCODE" }
+
+      - name: Build hew-runtime for wasm32-wasip1 (debug)
+        # Mirrors the macOS job. The WASI tests run as debug binaries and
+        # bootstrap_wasi_runner builds this archive on demand when it is
+        # absent, so without a pre-build every parallel nextest process races
+        # to cargo-build the same non-atomically written staticlib and wasm-ld
+        # intermittently fails to open it.
+        if: env.RUN_CODE_PATH == 'true'
+        run: cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features
+
+      - name: Build hew-std for wasm32-wasip1 (debug)
+        # Same race, same medicine: bootstrap_wasi_runner also builds
+        # libhew_std.a on demand when it is missing.
+        if: env.RUN_CODE_PATH == 'true'
+        run: cargo build -p hew-std --target wasm32-wasip1
+
       - name: Run platform smoke tests
         # Default Windows path: prove the platform build links and the
         # platform-sensitive crates pass on windows-msvc, without re-running the
@@ -821,8 +885,11 @@ jobs:
         # Platform/toolchain/ABI change: run the full workspace nextest on
         # Windows so a native-linking or cross-platform regression is caught
         # per-PR, not only by the nightly matrix.
-        # hew-wasm requires wasmtime; hew-cabi has #[no_mangle] symbols that
-        # conflict with hew-runtime when both link into a test binary.
+        # hew-wasm is excluded on every platform (profile.ci's default-filter
+        # does the same) — the browser/tooling WASM surface has its own
+        # playground-wasm-build job. hew-cabi has #[no_mangle] symbols that
+        # conflict with hew-runtime when both link into a test binary; the
+        # C-ABI step below is its coverage.
         # Default features include "full" (encryption + profiler + quic),
         # so all QUIC transport tests run without an explicit flag.
         if: env.RUN_CODE_PATH == 'true' && env.RUN_FULL_NEXTEST == 'true'
@@ -908,10 +975,17 @@ jobs:
 
       - name: Install WASI runner prerequisites
         if: env.RUN_CODE_PATH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           rustup target add wasm32-wasip1
-          brew install wasmtime
-          wasmtime --version
+          WASMTIME_DIR="wasmtime-${WASMTIME_VERSION}-aarch64-macos"
+          gh release download "$WASMTIME_VERSION" --repo bytecodealliance/wasmtime \
+            --pattern "${WASMTIME_DIR}.tar.xz" --clobber
+          tar -xJf "${WASMTIME_DIR}.tar.xz"
+          echo "$PWD/${WASMTIME_DIR}" >> "$GITHUB_PATH"
+          "./${WASMTIME_DIR}/wasmtime" --version
           command -v wasm-ld
           wasm-ld --version
 

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1502,8 +1502,6 @@ fn eval_file_type_errors_render_cli_diagnostics() {
 
 /// `hew eval --target wasm32-wasi <expr>` compiles and runs a simple inline
 /// expression through wasmtime, capturing stdout.
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_inline_expression_succeeds() {
     require_codegen();
@@ -1524,8 +1522,6 @@ fn eval_wasm_inline_expression_succeeds() {
 }
 
 /// `hew eval --target wasm32-wasi -f <file>` evaluates a .hew file via WASM.
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_file_succeeds() {
     require_codegen();
@@ -1552,9 +1548,7 @@ fn eval_wasm_file_succeeds() {
 
 fn assert_wasm_eval_file_output(test_name: &str, source: &str, expected_stdout: &str) {
     require_codegen();
-    if !support::try_require_wasi_runner() {
-        return;
-    }
+    support::require_wasi_runner();
 
     let dir = support::tempdir();
     let path = dir.path().join(format!("{test_name}.hew"));
@@ -1711,8 +1705,6 @@ fn eval_wasm_hashset_string_values_are_correct() {
 }
 
 /// A WASM eval that runs longer than the timeout exits with a timeout error.
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_timeout_is_reported() {
     require_codegen();
@@ -1748,9 +1740,7 @@ fn eval_wasm_timeout_is_reported() {
 #[test]
 fn eval_wasm_unsupported_feature_reports_diagnostic() {
     require_codegen();
-    if !support::try_require_wasi_runner() {
-        return;
-    }
+    support::require_wasi_runner();
 
     let dir = support::tempdir();
     let path = dir.path().join("wasm_eval_unsupported.hew");
@@ -1984,8 +1974,6 @@ fn eval_file_runtime_failure_preserves_pre_failure_stdout() {
 //   1. Stdout produced before failure must not be discarded.
 //   2. The child's exit code must be propagated, not hard-coded to 1.
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_inline_runtime_failure_exits_with_child_exit_code() {
     require_codegen();
@@ -2017,8 +2005,6 @@ fn eval_wasm_inline_runtime_failure_exits_with_child_exit_code() {
 // ratchet pins the narrower attributed-trap contract added before that cutover:
 // codegen still emits `hew_trap_with_code` followed by `llvm.trap`, and the
 // wasm32 runtime maps canonical non-actor trap code 201 to the child exit code.
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_integer_overflow_exits_with_trap_code_201() {
     require_codegen();
@@ -2039,8 +2025,6 @@ fn eval_wasm_integer_overflow_exits_with_trap_code_201() {
     );
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_file_runtime_failure_exits_with_child_exit_code() {
     require_codegen();
@@ -2070,8 +2054,6 @@ fn eval_wasm_file_runtime_failure_exits_with_child_exit_code() {
     );
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_file_runtime_failure_preserves_pre_failure_stdout() {
     require_codegen();
@@ -2231,8 +2213,6 @@ fn eval_json_runtime_failure_preserves_stdout() {
     );
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_json_ok_inline_expression() {
     require_codegen();
@@ -2261,8 +2241,6 @@ fn eval_wasm_json_ok_inline_expression() {
     assert_eq!(v["diagnostics"], "", "diagnostics must be empty on ok: {v}");
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn eval_wasm_json_runtime_failure_captures_stderr_without_leaking() {
     require_codegen();

--- a/hew-cli/tests/quic_service_smoke_e2e.rs
+++ b/hew-cli/tests/quic_service_smoke_e2e.rs
@@ -1,0 +1,327 @@
+mod support;
+
+use std::io::{ErrorKind, Read};
+use std::net::UdpSocket;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::time::{Duration, Instant};
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const SERVER_READY_TIMEOUT: Duration = Duration::from_secs(10);
+const EXAMPLE_TIMEOUT: Duration = Duration::from_secs(20);
+
+fn hew_std() -> PathBuf {
+    repo_root().join("std")
+}
+
+fn example_dir() -> PathBuf {
+    repo_root().join("examples/quic_service")
+}
+
+fn build_example_binary(source: &Path, output_path: &Path) {
+    let build_output = Command::new(hew_binary())
+        .arg("build")
+        .arg(source)
+        .arg("-o")
+        .arg(output_path)
+        .env("HEW_STD", hew_std())
+        .current_dir(repo_root())
+        .output()
+        .expect("run hew build");
+
+    assert!(
+        build_output.status.success(),
+        "hew build {} failed\n{}",
+        source.display(),
+        describe_output(&build_output),
+    );
+}
+
+/// Addresses the readiness probe tries, in order.
+///
+/// The example asks hew-std to listen on `":PORT"`, which resolves against the
+/// default bind host, so the server owns `0.0.0.0:PORT` and never
+/// `127.0.0.1:PORT`. Winsock rejects a second bind only on an exact address
+/// match, so a loopback-only probe on Windows keeps succeeding while the server
+/// holds the wildcard and the poll reports "not bound" until the deadline
+/// expires. BSD and Linux treat the wildcard as overlapping every specific
+/// address, which is why the same probe worked on macOS and hid the defect.
+/// Probing both makes the observation independent of that difference.
+const BIND_PROBE_HOSTS: [&str; 2] = ["0.0.0.0", "127.0.0.1"];
+
+fn probed_addresses(port: u16) -> String {
+    BIND_PROBE_HOSTS
+        .iter()
+        .map(|host| format!("{host}:{port}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Discover a port that is free on the wildcard, not merely on loopback: the
+/// server binds the wildcard, so a port free only on `127.0.0.1` would collide.
+fn pick_free_udp_port() -> u16 {
+    UdpSocket::bind("0.0.0.0:0")
+        .expect("bind udp socket for port discovery")
+        .local_addr()
+        .expect("discover local udp port")
+        .port()
+}
+
+fn udp_port_is_bound(port: u16) -> Result<bool, String> {
+    for host in BIND_PROBE_HOSTS {
+        match UdpSocket::bind((host, port)) {
+            Ok(socket) => drop(socket),
+            Err(error) if error.kind() == ErrorKind::AddrInUse => return Ok(true),
+            Err(error) => return Err(format!("cannot probe UDP {host}:{port}: {error}")),
+        }
+    }
+    Ok(false)
+}
+
+fn read_pipe<T: Read>(mut stream: T, name: &str) -> Result<Vec<u8>, String> {
+    let mut bytes = Vec::new();
+    stream
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!("cannot read child {name}: {e}"))?;
+    Ok(bytes)
+}
+
+fn collect_child_output(child: &mut Child, status: ExitStatus) -> Result<Output, String> {
+    let stdout = child
+        .stdout
+        .take()
+        .map_or_else(|| Ok(Vec::new()), |stream| read_pipe(stream, "stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .map_or_else(|| Ok(Vec::new()), |stream| read_pipe(stream, "stderr"))?;
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn terminate_child(child: &mut Child) -> Result<Output, String> {
+    match child.kill() {
+        Ok(()) => {}
+        Err(kill_error) => match child.try_wait() {
+            Ok(Some(status)) => return collect_child_output(child, status),
+            Ok(None) => return Err(format!("cannot kill child process: {kill_error}")),
+            Err(wait_error) => {
+                return Err(format!(
+                    "cannot kill child process: {kill_error}; cannot poll child after kill failure: {wait_error}"
+                ));
+            }
+        },
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("cannot reap child process: {e}"))?;
+    collect_child_output(child, status)
+}
+
+fn wait_for_child(child: &mut Child, timeout: Duration) -> Result<Output, String> {
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return collect_child_output(child, status),
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let timed_out_output = terminate_child(child).map_or_else(
+                        |error| format!("unable to collect timed-out child output: {error}"),
+                        |output| describe_output(&output),
+                    );
+                    return Err(format!("timed out after {timeout:?}\n{timed_out_output}"));
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(e) => return Err(format!("cannot poll child process: {e}")),
+        }
+    }
+}
+
+struct RunningChild {
+    child: Option<Child>,
+}
+
+impl RunningChild {
+    fn spawn(mut command: Command) -> Self {
+        let child = command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn child process");
+        Self { child: Some(child) }
+    }
+
+    fn assert_still_running(&mut self, context: &str) {
+        let child = self.child.as_mut().expect("child process missing");
+        match child.try_wait() {
+            Ok(None) => {}
+            Ok(Some(status)) => {
+                let output =
+                    collect_child_output(child, status).expect("collect exited child output");
+                panic!("{context}\n{}", describe_output(&output));
+            }
+            Err(error) => panic!("cannot poll child process: {error}"),
+        }
+    }
+
+    fn wait_for_udp_bind(&mut self, port: u16, timeout: Duration) {
+        let start = Instant::now();
+        loop {
+            self.assert_still_running("server exited before binding the QUIC port");
+            match udp_port_is_bound(port) {
+                Ok(true) => return,
+                Ok(false) => {
+                    assert!(
+                        start.elapsed() < timeout,
+                        "server did not bind UDP port {port} within {timeout:?} \
+                         (probed {}) — the server is still running, so either it \
+                         has not bound yet or it bound an address this probe \
+                         does not cover",
+                        probed_addresses(port),
+                    );
+                    std::thread::sleep(POLL_INTERVAL);
+                }
+                Err(error) => panic!("{error}"),
+            }
+        }
+    }
+
+    fn wait_with_timeout(&mut self, timeout: Duration) -> Output {
+        let mut child = self.child.take().expect("child process missing");
+        wait_for_child(&mut child, timeout).unwrap_or_else(|error| panic!("{error}"))
+    }
+}
+
+impl Drop for RunningChild {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            if let Ok(None) = child.try_wait() {
+                let _ = terminate_child(child);
+            }
+        }
+    }
+}
+
+/// The readiness probe must be able to observe a wildcard bind.
+///
+/// `wait_for_udp_bind` is the only thing between spawning the server and driving
+/// traffic at it, and its failure mode is a timeout — which reads as "the server
+/// never came up" when the truth may be "the probe cannot see the address the
+/// server bound". That is exactly how the loopback-only probe failed on Windows.
+/// Bind the wildcard here and require the probe to report it, so a probe that
+/// stops observing what it polls fails on its own terms instead of being
+/// misattributed to the server.
+#[test]
+fn udp_bind_probe_observes_a_wildcard_bind() {
+    let socket = UdpSocket::bind("0.0.0.0:0").expect("bind wildcard udp socket");
+    let port = socket.local_addr().expect("discover local udp port").port();
+
+    assert!(
+        udp_port_is_bound(port).unwrap_or_else(|error| panic!("{error}")),
+        "readiness probe reported UDP port {port} free while this test holds a \
+         live wildcard bind on it (probed {})",
+        probed_addresses(port),
+    );
+
+    drop(socket);
+
+    // And the probe must be able to say "free" too, or the assertion above
+    // would be satisfied by a probe that always answers "bound".
+    assert!(
+        !udp_port_is_bound(port).unwrap_or_else(|error| panic!("{error}")),
+        "readiness probe reported UDP port {port} bound after the wildcard bind \
+         was released (probed {})",
+        probed_addresses(port),
+    );
+}
+
+// The two blockers this test was parked behind are gone. `hew build` exists and
+// the host build/link path is exercised by `build_host_e2e`; the QUIC
+// stream/connection stdlib surface (`recv_string`/`send_string`/`finish`/
+// `disconnect`/`kind`) now resolves in HIR, so both server.hew and client.hew
+// pass `hew check`. The test builds both example binaries, spawns the server,
+// waits for the UDP bind and drives a real round trip.
+#[test]
+fn quic_service_example_round_trip_succeeds() {
+    require_codegen();
+
+    let example_dir = example_dir();
+    let workspace = tempfile::Builder::new()
+        .prefix("quic-service-smoke-")
+        .tempdir_in(repo_root())
+        .expect("create smoke workspace in repo root");
+    let server_binary = workspace
+        .path()
+        .join(format!("service_server{}", std::env::consts::EXE_SUFFIX));
+    let client_binary = workspace
+        .path()
+        .join(format!("service_client{}", std::env::consts::EXE_SUFFIX));
+
+    build_example_binary(&example_dir.join("server.hew"), &server_binary);
+    build_example_binary(&example_dir.join("client.hew"), &client_binary);
+
+    let port = pick_free_udp_port();
+    let port_str = port.to_string();
+
+    let mut server = RunningChild::spawn({
+        let mut command = Command::new(&server_binary);
+        command
+            .env("HEW_QUIC_SERVICE_PORT", &port_str)
+            .current_dir(&example_dir);
+        command
+    });
+
+    server.wait_for_udp_bind(port, SERVER_READY_TIMEOUT);
+
+    let mut client = Command::new(&client_binary)
+        .env("HEW_QUIC_SERVICE_PORT", &port_str)
+        .current_dir(&example_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn client process");
+    let client_output =
+        wait_for_child(&mut client, EXAMPLE_TIMEOUT).unwrap_or_else(|error| panic!("{error}"));
+    assert!(
+        client_output.status.success(),
+        "client example failed\n{}",
+        describe_output(&client_output),
+    );
+
+    let server_output = server.wait_with_timeout(EXAMPLE_TIMEOUT);
+    assert!(
+        server_output.status.success(),
+        "server example failed\n{}",
+        describe_output(&server_output),
+    );
+
+    let server_stdout = String::from_utf8_lossy(&server_output.stdout);
+    assert!(
+        server_stdout.contains("[server] accepted connection")
+            && server_stdout.contains("[server] accepted stream")
+            && server_stdout.contains("[server] received: Hello from client")
+            && server_stdout.contains("[server] sent response")
+            && server_stdout.contains("[server] shutdown complete"),
+        "unexpected server output\n{}",
+        describe_output(&server_output),
+    );
+
+    let client_stdout = String::from_utf8_lossy(&client_output.stdout);
+    assert!(
+        client_stdout.contains("[client] connected to server")
+            && client_stdout.contains("[client] opened stream")
+            && client_stdout.contains("[client] sent message")
+            && client_stdout.contains("[client] received: Echo from server")
+            && client_stdout.contains("[client] shutdown complete"),
+        "unexpected client output\n{}",
+        describe_output(&client_output),
+    );
+}

--- a/hew-cli/tests/sort_complexity_e2e.rs
+++ b/hew-cli/tests/sort_complexity_e2e.rs
@@ -164,8 +164,6 @@ fn sort_merge_authority_runs_at_native_o0_and_o2() {
     assert_authority_output(&run_native("2"), "native O2");
 }
 
-// WINDOWS-TODO: requires the Wasmtime runtime, which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn sort_merge_authority_runs_under_wasmtime() {
     support::require_wasi_runner();

--- a/hew-cli/tests/support/mod.rs
+++ b/hew-cli/tests/support/mod.rs
@@ -34,25 +34,21 @@ pub fn require_codegen() {
     }
 }
 
+/// Panics when the WASI toolchain or the `wasmtime` runtime is unavailable.
+///
+/// There is deliberately no non-panicking variant. A `try_require_wasi_runner`
+/// used to exist and returned `false` with a stderr SKIP notice; the callers
+/// early-returned green having asserted nothing, so on a runner without
+/// wasmtime — which is what the Windows job was until it was given one — those
+/// tests reported success while executing no WASM at all. A missing runner is a
+/// provisioning failure, and it must be reported as a failure.
+///
+/// A caller that genuinely wants to skip on an unsupported host must say so at
+/// its own site, where the condition is visible and reviewable, rather than
+/// inheriting it from a shared helper.
 pub fn require_wasi_runner() {
     if let Err(error) = WASI_RUNNER_STATUS.get_or_init(bootstrap_wasi_runner) {
         panic!("{error}");
-    }
-}
-
-/// Non-panicking variant of [`require_wasi_runner`].
-///
-/// Returns `false` (and emits a skip notice to stderr) when the WASI
-/// toolchain or `wasmtime` runtime is unavailable, allowing tests to
-/// early-return cleanly instead of panicking. Returns `true` when the
-/// bootstrap succeeds and the test should proceed.
-pub fn try_require_wasi_runner() -> bool {
-    match WASI_RUNNER_STATUS.get_or_init(bootstrap_wasi_runner) {
-        Ok(()) => true,
-        Err(error) => {
-            eprintln!("SKIP: WASI runner unavailable — {error}");
-            false
-        }
     }
 }
 

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -52,8 +52,6 @@ const EXPECTED_WASI_UNSUPPORTED: &[&str] = &[
     "types/method_clone",
 ];
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn curated_playground_examples_run_under_wasi() {
     require_wasi_runner();
@@ -117,8 +115,6 @@ fn curated_playground_examples_run_under_wasi() {
     }
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi() {
     require_wasi_runner();
@@ -153,8 +149,6 @@ fn supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi() {
     );
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn task_scope_stays_on_the_fail_closed_diagnostic_path_under_wasi() {
     require_wasi_runner();
@@ -215,8 +209,6 @@ fn main() -> i64 {
     );
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn toml_encoding_round_trips_under_wasi() {
     require_wasi_runner();
@@ -250,8 +242,6 @@ fn toml_encoding_round_trips_under_wasi() {
     assert_eq!(stdout.as_ref(), "hew\n", "stderr:\n{stderr}");
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn wasm_channel_send_full_traps_instead_of_dropping() {
     require_wasi_runner();
@@ -375,8 +365,6 @@ const HASHMAP_HASHSET_LAYOUT_EXPECTED: &str = "len=2\n\
      set_contains_removed=false\n\
      set_len_after_remove=1\n";
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn wasm_hashmap_hashset_layout_run_pass() {
     require_wasi_runner();
@@ -504,8 +492,6 @@ const HASHMAP_HASHSET_OWNERSHIP_EXPECTED: &str = "alpha=third\n\
      set_has_kept=true\n\
      set_len=2\n";
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn wasm_hashmap_hashset_layout_ownership_run_pass() {
     require_wasi_runner();
@@ -554,8 +540,6 @@ fn native_hashmap_hashset_ownership_matches_wasi_output() {
     );
 }
 
-// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn wasi_run_timeout_terminates_a_non_terminating_program() {
     require_wasi_runner();

--- a/hew-codegen-rs/tests/exec/machine_emit_exec.rs
+++ b/hew-codegen-rs/tests/exec/machine_emit_exec.rs
@@ -347,11 +347,14 @@ fn machine_emit_placeholder_lowers_to_push_call() {
 /// 7. Assert the outermost step exit drained the thread-local queue.
 ///
 /// This test is NOT `#[ignore]`d, unlike the MCJIT execution tests that were
-/// removed alongside it. They resolved runtime symbols through the engine's
-/// dynamic-symbol generator, which cannot see a Rust test binary's
-/// `#[no_mangle]` exports, so they SIGSEGV on the first runtime call. This one
-/// binds every symbol by address up front (step 3), which is exactly that gap
-/// closed, so it runs on every `cargo nextest run`.
+/// removed alongside it. Those also called `add_global_mapping` — the
+/// difference is completeness, not technique: each mapped only a subset, or
+/// mapped conditionally, and fell back to the engine's dynamic-symbol
+/// generator for the rest. That generator cannot see a Rust test binary's
+/// `#[no_mangle]` exports, so the first unmapped runtime call SIGSEGVs. This
+/// one binds every symbol it needs by address up front (step 3) and `.expect()`s
+/// each, so no symbol reaches the generator. Removing any one of those mappings
+/// reproduces the siblings' crash exactly.
 #[test]
 #[cfg(unix)]
 fn machine_emit_push_populates_thread_queue_in_fifo_order() {

--- a/hew-codegen-rs/tests/exec/machine_emit_exec.rs
+++ b/hew-codegen-rs/tests/exec/machine_emit_exec.rs
@@ -44,6 +44,7 @@ use hew_mir::{
     BasicBlock, FunctionCallConv, Instr, IrPipeline, MachineLayout, MachineVariantLayout, Place,
     RawMirFunction, Terminator,
 };
+use hew_runtime::machine_emit::{thread_emit_clear, thread_emit_pending};
 use hew_types::ResolvedTy;
 
 // ── Pipeline builder ──────────────────────────────────────────────────────────
@@ -321,5 +322,147 @@ fn machine_emit_placeholder_lowers_to_push_call() {
         !ir.contains("@hew_machine_emit_step_exit("),
         "codegen must NOT call the legacy drain-and-discard hew_machine_emit_step_exit \
          (only hew_machine_emit_step_exit_keep is codegen-reachable):\n{ir}"
+    );
+}
+
+// ── JIT execution test ────────────────────────────────────────────────────────
+
+/// JIT-compile and execute the caller; assert that the `__step` call is wrapped
+/// and the outermost exit drains the thread-local emit queue.
+///
+/// ## Method
+///
+/// 1. Emit the pipeline to `.ll`.
+/// 2. Parse the `.ll` back into an inkwell `Module`.
+/// 3. Create an MCJIT `ExecutionEngine` and wire machine emit runtime symbols
+///    through `add_global_mapping` against the linked dev-dep symbol. The
+///    macOS test-binary dynamic-symbol table does not expose `#[no_mangle]`
+///    runtime exports for JIT-host lookup, so the mapping is mandatory; see
+///    the inline comment at the mapping site for the platform rationale.
+/// 4. Clear any stale events from prior tests on this thread.
+/// 5. Invoke the `caller` function (which calls the step stub).
+/// 6. The step stub emits event 0 then event 1, stores `self` into the
+///    return slot, and returns cleanly (no trap). `caller` receives the
+///    return value and discards it.
+/// 7. Assert the outermost step exit drained the thread-local queue.
+///
+/// This test is NOT `#[ignore]`d, unlike the MCJIT execution tests that were
+/// removed alongside it. They resolved runtime symbols through the engine's
+/// dynamic-symbol generator, which cannot see a Rust test binary's
+/// `#[no_mangle]` exports, so they SIGSEGV on the first runtime call. This one
+/// binds every symbol by address up front (step 3), which is exactly that gap
+/// closed, so it runs on every `cargo nextest run`.
+#[test]
+#[cfg(unix)]
+fn machine_emit_push_populates_thread_queue_in_fifo_order() {
+    use inkwell::context::Context;
+    use inkwell::memory_buffer::MemoryBuffer;
+    use inkwell::targets::{InitializationConfig, Target};
+    use inkwell::OptimizationLevel;
+
+    // ── Compile to .ll ───────────────────────────────────────────────────────
+    let pipeline = tcp_handshake_emit_pipeline();
+    let tmp = std::env::temp_dir().join("hew-machine-emit-jit");
+    std::fs::create_dir_all(&tmp).expect("create scratch dir");
+    let options = EmitOptions {
+        module_name: "machine_emit_jit",
+        out_dir: &tmp,
+        native: false,
+        wasm: false,
+        target_triple: None,
+        debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
+        source_path: None,
+    };
+    let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");
+    let ll_path = artefacts
+        .ll_path
+        .as_deref()
+        .expect("emit_module must populate ll_path");
+
+    // ── Parse + JIT ──────────────────────────────────────────────────────────
+    Target::initialize_native(&InitializationConfig::default())
+        .expect("initialize_native must succeed on the host platform");
+
+    let ctx = Context::create();
+    let buf = MemoryBuffer::create_from_file(ll_path).expect("read emitted .ll into memory buffer");
+    let module = ctx
+        .create_module_from_ir(buf)
+        .expect("parse .ll into inkwell Module");
+
+    // Look up machine emit declarations before JIT takes ownership of the module.
+    let emit_push_decl = module
+        .get_function("hew_machine_emit_push")
+        .expect("emitted module must declare hew_machine_emit_push");
+    let step_enter_decl = module
+        .get_function("hew_machine_emit_step_enter")
+        .expect("emitted module must declare hew_machine_emit_step_enter");
+    let step_exit_decl = module
+        .get_function("hew_machine_emit_step_exit_keep")
+        .expect("emitted module must declare hew_machine_emit_step_exit_keep");
+
+    let ee = module
+        .create_jit_execution_engine(OptimizationLevel::None)
+        .expect("create_jit_execution_engine must succeed");
+
+    // Wire the JIT symbol resolver to the actual machine emit functions
+    // from the `hew-runtime` dev-dep.
+    //
+    // WHY add_global_mapping is required here: Rust test binaries on macOS
+    // (and Linux with default linker flags) do not export all `#[no_mangle]`
+    // symbols to the dynamic symbol table; the MCJIT engine's default symbol
+    // resolver cannot find them by name. `add_global_mapping` bypasses the
+    // resolver and directly wires the JIT reference to the in-process function
+    // pointer, which is always reachable by address.
+    extern "C" {
+        fn hew_machine_emit_push(
+            queue: *mut std::ffi::c_void,
+            machine_id: u64,
+            tag: u32,
+            payload: *const u8,
+        ) -> i32;
+        fn hew_machine_emit_step_enter(queue: *mut std::ffi::c_void) -> i32;
+        fn hew_machine_emit_step_exit_keep(queue: *mut std::ffi::c_void) -> i32;
+    }
+    ee.add_global_mapping(&emit_push_decl, hew_machine_emit_push as *const () as usize);
+    ee.add_global_mapping(
+        &step_enter_decl,
+        hew_machine_emit_step_enter as *const () as usize,
+    );
+    ee.add_global_mapping(
+        &step_exit_decl,
+        hew_machine_emit_step_exit_keep as *const () as usize,
+    );
+
+    // Clear any stale events from a prior test on this thread.
+    thread_emit_clear();
+    assert_eq!(
+        thread_emit_pending(),
+        0,
+        "thread queue must be empty before JIT call"
+    );
+
+    // Invoke `caller` which drives the step stub and triggers two pushes.
+    // The step stub returns cleanly (no trap path): after the two emit
+    // instructions it stores `self` into the return slot and returns.
+    //
+    // SAFETY: `caller` is compiled as `fn() -> i8` (unit mapped to i8 by
+    // the codegen); the JIT-compiled code is for the host triple.
+    let caller_fn = unsafe {
+        ee.get_function::<unsafe extern "C" fn() -> i8>("caller")
+            .expect("caller must be present in the JIT module")
+    };
+    unsafe { caller_fn.call() };
+
+    // ── Assertions ───────────────────────────────────────────────────────────
+
+    // The caller wrapped the step invocation; the deliver-design step-exit
+    // (`hew_machine_emit_step_exit_keep`) does NOT drain — both pushed
+    // events must still be queued for a later `take_emits`.
+    assert_eq!(
+        thread_emit_pending(),
+        2,
+        "the deliver-design step-exit must KEEP queued MachineEmitPlaceholder events, \
+         not drain them"
     );
 }


### PR DESCRIPTION
#2811 deleted 22 `#[ignore]`d tests on the reasoning that running them is the finding and that most of them segfault. That reasoning was right for most of them and wrong for several, and the wrong ones took real coverage with them.

Each test below was checked against current main rather than carried over on an earlier measurement:

- **`machine_emit_push_populates_thread_queue_in_fifo_order`** passes. Its deleted siblings also mapped symbols by address; the difference is that each mapped only a subset or mapped conditionally and fell back to the engine's dynamic-symbol generator, which cannot see a test binary's `#[no_mangle]` exports. This one binds every symbol it needs up front. Removing any one of those mappings reproduces the siblings' SIGSEGV exactly, so completeness is the separator rather than the technique.
- **The QUIC service round-trip** passes once its bind probe is fixed. It was never broken; the probe was.

The rest stay deleted. A test restored only to be re-ignored would be the thing this is undoing.

## The probe was wrong, not the test

`wait_for_udp_bind` polled `127.0.0.1:PORT` while the server binds `0.0.0.0:PORT`. Winsock rejects only exact-address collisions, so on Windows the probe could not observe the bind and the test timed out; macOS overlaps wildcard and specific, which hid it entirely.

It now probes both and discovers the port on the wildcard, and the timeout message names the addresses it tried. The guard test asserts a bound wildcard reads `true` **and** a released one reads `false`, so it cannot be satisfied by a probe that always answers "bound".

## A missing runner now fails

`try_require_wasi_runner` returned quietly when no WASI runner was present, so four tests reported success having asserted nothing. It is deleted; both call sites hard-require. No caller wanted skip-on-missing, so none got a site-local one.

Eighteen `#[cfg_attr(windows, ignore)]` attributes cited "wasmtime is not configured on Windows". That is no longer true, so they are gone; each of those tests calls `require_wasi_runner()`, which panics. Remaining Windows-conditional ignores carry different reasons that are still true.

## One pinned wasmtime for three platforms

Windows had no wasmtime at all, which is why its WASI tests either failed or passed vacuously. All three platforms now install from a single pinned tag rather than Linux resolving "latest" and macOS taking whatever brew had — three platforms can no longer drift onto three versions.

The Windows step verifies the executable exists before touching `PATH` and checks `$LASTEXITCODE` after every native command, because a failing native command inside a PowerShell script does not fail the step on its own.

## Verification

Both restored tests were run and pass, on macOS and on Windows. The reachability and preflight-parity checkers were run against the edited workflow.

The Windows job now runs 11252 tests with 12 skipped; those twelve are Windows-conditional ignores carrying reasons that are still true — COFF parsing, no `true(1)`, signed exit codes, SWIM simulated time, and an npm toolchain gap — none of them the wasmtime reason this change retires.
