### PR TITLE
fix(runtime): retire asks left queued when a stop terminalises an actor

### DIFF
--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -663,6 +663,53 @@ unsafe fn retire_msg_node_ask_sender_ref(node: *mut HewMsgNode) {
     unsafe { retire_orphaned_ask_sender_ref(reply_channel) };
 }
 
+/// Reclaim every message still queued on the mailbox of an actor that is
+/// completing its terminal stop transition.
+///
+/// The system queue has dequeue priority over the user queue
+/// ([`mailbox_try_recv_with_origin`]), so `hew_actor_stop`'s shutdown sentinel
+/// is handed to the worker ahead of user messages that were enqueued BEFORE
+/// it. The worker breaks its message loop on the sentinel and finalizes the
+/// actor, leaving those user messages queued. A queued **ask** node owns a
+/// sender-side reply-channel reference, and that reference is what its caller
+/// is blocked on: until the node is freed, nothing marks the channel orphaned
+/// and nothing publishes the null reply that wakes the waiter. Left to
+/// `hew_mailbox_free` (which only runs at `hew_actor_free`) the caller blocks
+/// for its entire ask timeout — a stop that races a queued ask silently
+/// converts "actor stopped" into "caller hangs".
+///
+/// [`hew_msg_node_free`] retires each node's ask sender reference
+/// ([`retire_msg_node_ask_sender_ref`]), so draining here IS the wake: every
+/// stranded waiter is unblocked with the orphaned classification
+/// (`HEW_REPLY_FAIL_ACTOR_STOPPED`) it would have received had the mailbox been
+/// torn down. Any leftover system message (a second sentinel) is reclaimed on
+/// the same pass.
+///
+/// # Safety
+///
+/// `mb` must be null or a valid mailbox pointer, and the caller must be its
+/// SOLE consumer for the duration of the drain — the worker that owns the
+/// terminating activation, before it publishes the terminal state. `Stopping`
+/// is not quiescent (`actor_free_state_is_quiescent`), so a concurrent
+/// `hew_actor_free` cannot reach `hew_mailbox_free` while this runs.
+pub(crate) unsafe fn mailbox_reclaim_queued_on_stop(mb: *mut HewMailbox) {
+    if mb.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `mb` is valid.
+    let message_drop_fn = unsafe { (*mb).message_drop_fn };
+    loop {
+        // SAFETY: caller guarantees `mb` is valid and the sole-consumer
+        // invariant holds for this drain.
+        let node = unsafe { mailbox_try_recv_with_origin(mb) }.node;
+        if node.is_null() {
+            break;
+        }
+        // SAFETY: `node` was just dequeued and is exclusively owned here.
+        unsafe { hew_msg_node_free_with_message_drop(node, message_drop_fn) };
+    }
+}
+
 /// Free a [`HewMsgNode`] and its payload.
 ///
 /// # Safety

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -1725,6 +1725,16 @@ fn settle_after_activation(actor: *mut HewActor, msgs_processed: u32) {
 
     let cur_state = a.actor_state.load(Ordering::Acquire);
     if cur_state == HewActorState::Stopping as i32 {
+        // Reclaim anything still queued BEFORE the terminal state is published.
+        // The shutdown sentinel outranks the user queue, so this activation can
+        // reach `Stopping` with user messages — including asks whose callers are
+        // blocked on their reply channels — still in the mailbox. See
+        // `mailbox_reclaim_queued_on_stop` for why draining here is the wake.
+        //
+        // SAFETY: this worker owns the activation and is the mailbox's sole
+        // consumer; `Stopping` is not quiescent, so no concurrent
+        // `hew_actor_free` can be freeing the mailbox underneath the drain.
+        unsafe { mailbox::mailbox_reclaim_queued_on_stop(mailbox) };
         if a.actor_state
             .compare_exchange(
                 HewActorState::Stopping as i32,
@@ -2620,6 +2630,18 @@ fn activate_actor(actor: *mut HewActor) {
     // Check if actor transitioned to Stopping during dispatch (self-stop).
     let cur_state = a.actor_state.load(Ordering::Acquire);
     if cur_state == HewActorState::Stopping as i32 {
+        // Reclaim anything still queued BEFORE the terminal state is published.
+        // `hew_actor_stop` on a Running actor enqueues its shutdown sentinel on
+        // the SYSTEM queue, which `mailbox_try_recv_with_origin` dequeues ahead
+        // of user messages that were enqueued first — so the loop above breaks
+        // on the sentinel with those messages still queued. A queued ask holds
+        // the sender-side reply reference its caller is blocked on, and freeing
+        // the node is what retires it. See `mailbox_reclaim_queued_on_stop`.
+        //
+        // SAFETY: this worker owns the activation and is the mailbox's sole
+        // consumer; `Stopping` is not quiescent, so no concurrent
+        // `hew_actor_free` can be freeing the mailbox underneath the drain.
+        unsafe { mailbox::mailbox_reclaim_queued_on_stop(mailbox) };
         // Finalize: Stopping → Stopped.
         if a.actor_state
             .compare_exchange(

--- a/hew-runtime/tests/actor_lifecycle.rs
+++ b/hew-runtime/tests/actor_lifecycle.rs
@@ -487,6 +487,156 @@ fn ask_freed_queued_messages_unblock_caller() {
     unsafe { hew_runtime::reply_channel::hew_reply_channel_free(ch) };
 }
 
+/// Gate used by [`stop_during_dispatch_unblocks_queued_ask`] to hold an actor
+/// inside its dispatch function, so the test controls the interleaving instead
+/// of racing the scheduler for it.
+struct DispatchGate {
+    /// `(handler entered dispatch, test released the handler)`.
+    flags: Mutex<(bool, bool)>,
+    cond: Condvar,
+}
+
+impl DispatchGate {
+    const fn new() -> Self {
+        Self {
+            flags: Mutex::new((false, false)),
+            cond: Condvar::new(),
+        }
+    }
+
+    /// Called from the dispatch function: announce entry, then block until
+    /// released. The wait is bounded so a failed assertion in the test body
+    /// cannot wedge the actor's activation (and therefore `hew_actor_free`).
+    fn enter_and_block(&self) {
+        let mut flags = self.flags.lock().unwrap();
+        flags.0 = true;
+        self.cond.notify_all();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !flags.1 {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return;
+            }
+            let (guard, _) = self.cond.wait_timeout(flags, remaining).unwrap();
+            flags = guard;
+        }
+    }
+
+    fn wait_entered(&self, timeout: Duration) -> bool {
+        let mut flags = self.flags.lock().unwrap();
+        let deadline = Instant::now() + timeout;
+        while !flags.0 {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            let (guard, _) = self.cond.wait_timeout(flags, remaining).unwrap();
+            flags = guard;
+        }
+        true
+    }
+
+    fn release(&self) {
+        let mut flags = self.flags.lock().unwrap();
+        flags.1 = true;
+        self.cond.notify_all();
+    }
+}
+
+static STOP_DURING_DISPATCH_GATE: DispatchGate = DispatchGate::new();
+
+unsafe extern "C-unwind" fn gated_dispatch(
+    _ctx: *mut hew_runtime::execution_context::HewExecutionContext,
+    _state: *mut c_void,
+    _msg_type: i32,
+    _data: *mut c_void,
+    _data_size: usize,
+    _borrow_mode: i32,
+) -> *mut c_void {
+    STOP_DURING_DISPATCH_GATE.enter_and_block();
+    std::ptr::null_mut()
+}
+
+/// Stopping a *Running* actor must not strand an ask queued behind the
+/// in-flight message.
+///
+/// `hew_actor_stop` on a Running actor enqueues its shutdown sentinel on the
+/// SYSTEM queue, and the mailbox gives the system queue dequeue priority — so
+/// the worker's next poll returns the sentinel ahead of a user message that was
+/// enqueued *first*, breaks the message loop, and finalizes the actor. Any
+/// queued ask left behind owns the sender-side reply reference its caller is
+/// blocked on, so unless the terminal transition reclaims the mailbox the
+/// caller blocks for its entire ask timeout.
+///
+/// [`ask_freed_queued_messages_unblock_caller`] covers the same invariant but
+/// has to win a race against the scheduler to reach this interleaving (it does
+/// so only under load — the Windows CI runner hit it, the developer machines
+/// did not). This test pins the interleaving with a gate: the handler is held
+/// inside dispatch while the ask is queued and the stop is issued, so the
+/// sentinel is *guaranteed* to be ahead of the ask. It asserts the reason, not
+/// just the timing: the waiter must be released with the orphaned
+/// classification that mailbox teardown would have given it.
+#[test]
+fn stop_during_dispatch_unblocks_queued_ask() {
+    ensure_scheduler();
+
+    let actor = TestActor::spawn(gated_dispatch);
+
+    // Occupy the handler so the actor is unambiguously Running when we stop it.
+    let mut warm: i32 = 1;
+    actor.send(0, &mut warm);
+    let entered = STOP_DURING_DISPATCH_GATE.wait_entered(Duration::from_secs(10));
+    if !entered {
+        STOP_DURING_DISPATCH_GATE.release();
+    }
+    assert!(entered, "dispatch must start before the stop is issued");
+
+    // Queue an ask behind the in-flight message.
+    let ch = hew_runtime::reply_channel::hew_reply_channel_new();
+    assert!(!ch.is_null());
+    let mut val: i32 = 99;
+    let send_rc = actor.ask_with_channel(1, &mut val, ch);
+    assert_eq!(send_rc, 0, "the ask must enqueue on a still-running actor");
+
+    assert_eq!(
+        actor.state_raw(),
+        HewActorState::Running as i32,
+        "precondition: the stop must be issued against a Running actor so it \
+         takes the shutdown-sentinel path"
+    );
+    actor.stop();
+
+    // Let the in-flight dispatch finish. The worker's next poll takes the
+    // sentinel, never the queued ask.
+    STOP_DURING_DISPATCH_GATE.release();
+
+    let start = Instant::now();
+    // SAFETY: ch is a valid reply channel we still hold a reference to.
+    let reply = unsafe { hew_runtime::reply_channel::hew_reply_wait_timeout(ch, 2_000) };
+    let elapsed = start.elapsed();
+    // SAFETY: read on the caller-side reference before it is released.
+    let orphaned = unsafe { hew_runtime::reply_channel::hew_reply_channel_is_orphaned(ch) };
+
+    assert!(
+        elapsed.as_millis() < 500,
+        "an ask queued behind the shutdown sentinel must be retired by the \
+         terminal stop, not left for hew_actor_free; took {}ms of a 2000ms wait",
+        elapsed.as_millis()
+    );
+    assert!(
+        reply.is_null(),
+        "the queued ask was never dispatched, so no value can have been replied"
+    );
+    assert_eq!(
+        orphaned, 1,
+        "the waiter must be released with the mailbox-teardown classification, \
+         not an unexplained null"
+    );
+
+    // SAFETY: Release our reference to the reply channel.
+    unsafe { hew_runtime::reply_channel::hew_reply_channel_free(ch) };
+}
+
 /// Dispatch function that sleeps for 500ms before replying.
 ///
 /// Used to test ask timeout behaviour — the caller should time out


### PR DESCRIPTION
A caller blocked on an ask was never unblocked when the actor stopped with that
ask still queued. It waited out its full timeout and gave up.

`hew_actor_stop` on a Running actor enqueues its shutdown sentinel on the system
queue, and the system queue has dequeue priority — so the worker returns the
sentinel ahead of user messages enqueued before it, breaks the message loop, and
finalizes to Stopped with those messages still in the mailbox. A queued ask node
owns the sender-side reply-channel reference its caller is blocked on. Freeing
the node is what marks the channel orphaned and publishes the null reply, and
that free happened only in `hew_actor_free` — after the wait.

So no signal was lost; none was issued. The mailbox is now reclaimed at the
Stopping -> Stopped finalize, before the terminal state is published. Stopping is
not quiescent, so no concurrent free can take the mailbox out from under the
drain, and the finalizing worker is its sole consumer. Both finalize sites share
one reclaim path.

The existing `ask_freed_queued_messages_unblock_caller` needs a scheduler race to
reach this interleaving, which is why it only fired on loaded CI runners. The new
test pins the interleaving with a dispatch gate and asserts the reason rather
than the symptom: the waiter must come back orphaned, not merely unblocked.

Verified on the Windows host, same commit: 2004ms of a 2000ms wait before,
0.058s after.