### PR TITLE
fix(mir): settle *_last_error result retention by measurement, mint on it

### DIFF
--- a/hew-cli/tests/stdlib_corpus_release_count_differential.rs
+++ b/hew-cli/tests/stdlib_corpus_release_count_differential.rs
@@ -83,40 +83,15 @@ const REJECTED: &str = "REJECTED";
 /// release fails this test and forces the entry to be removed rather than
 /// letting the debt quietly become the new normal.
 const ACCOUNTED_BELOW_BASELINE: &[(&str, &str, usize, &str)] = &[
-    (
-        "examples/net/tls_client.hew",
-        "main",
-        48,
-        "`match tls.read(..)` over a `Result<bytes, net.NetError>`: the \
-         call-scrutinee owner mint is declined because `net.NetError`'s string \
-         payload is laundered out of `hew_tls_last_error`, a heap-returning \
-         extern with no MINT-side audited row. Deleting the `LegacyModuleCall` \
-         fail-open that used to mint here was deliberate — it minted a \
-         caller-side release over values a Hew wrapper had laundered out of an \
-         ownership-opaque extern, which frees a pointer this program may not \
-         own. The replacement is an audited fresh-RETURN row source for the \
-         `*_last_error` family, which licenses a release instead of guessing \
-         one; until it lands this is an error-path leak, which is the safe \
-         side of that trade.",
-    ),
-    (
-        "examples/smtp_client.hew",
-        "main",
-        35,
-        "Same shape, via `hew_smtp_last_error`: `match send_plain(..)`'s \
-         `Err(msg)` payload gets no release. `send_plain` forwards an error \
-         string built by `smtp_err`, which reads the opaque extern, so the \
-         freshness fixpoint cannot prove the returned `Result` fresh.",
-    ),
-    (
-        "std/time/cron/cron.hew",
-        "Expr::next",
-        3,
-        "Same shape, via `hew_cron_last_error` behind `cron_error_message`. \
-         The Err arm of `Expr::next` panics, so the withheld scrutinee release \
-         is unreachable on the normal path; it is listed because the count \
-         moved, not because the program leaks in practice.",
-    ),
+    // Empty, and it is meant to stay that way. The three cells that stood here
+    // — `examples/net/tls_client.hew::main` at 48, `examples/smtp_client.hew::main`
+    // at 35 and `std/time/cron/cron.hew::Expr::next` at 3 — all named an
+    // unlanded answer to "who owns the buffer a `*_last_error` extern returns?"
+    // as their reason. That answer landed (hew-lang/hew#2828): it is recorded
+    // per symbol as `result-retention` on the `[[ownership.contracts]]` rows in
+    // scripts/jit-symbol-classification.toml, measured by the oracles named
+    // there, and read by `build_extern_contract_table`'s Clause C. All three
+    // cells are back at their `main` counts.
 ];
 
 fn capture_mode() -> bool {

--- a/hew-mir/build.rs
+++ b/hew-mir/build.rs
@@ -149,10 +149,16 @@ fn generate_ffi_ownership_table(contracts: &BTreeMap<String, ContractRow>) {
             "none" => "ReleaseDischargeDepth::None",
             other => panic!("unmapped discharge depth: {other}"),
         };
+        let retention = match row.result_retention.as_str() {
+            "transferred" => "ExternResultRetention::Transferred",
+            "" => "ExternResultRetention::Unspecified",
+            other => panic!("unmapped result retention: {other}"),
+        };
         writeln!(
             generated,
             "    (\"{symbol}\", ExternOwnershipContract {{ params: &[{params}], \
-             result: {result}, release_symbol: \"{}\", discharge_depth: {depth} }}),",
+             result: {result}, release_symbol: \"{}\", discharge_depth: {depth}, \
+             result_retention: {retention} }}),",
             row.release_symbol
         )
         .expect("write generated contract row");

--- a/hew-mir/build_support/ownership_contract_parse.rs
+++ b/hew-mir/build_support/ownership_contract_parse.rs
@@ -11,6 +11,13 @@ struct ContractRow {
     params: Vec<String>,
     release_symbol: String,
     discharge_depth: String,
+    /// The RETENTION answer for an owned result: `"transferred"` when the
+    /// callee provably keeps no pointer into the returned allocation, empty
+    /// when the question has not been answered for this symbol. Empty is the
+    /// fail-closed default and is what every row carries unless an executable
+    /// oracle established otherwise — see the `result-retention` section of
+    /// `scripts/jit-symbol-classification.toml`.
+    result_retention: String,
 }
 
 fn quoted_value(line: &str) -> Option<&str> {
@@ -42,6 +49,55 @@ fn quoted_list(body: &str) -> Vec<String> {
         .collect()
 }
 
+/// Fail-closed schema check for one accumulated row.
+///
+/// Every axis is validated against a closed vocabulary — an unknown spelling
+/// aborts the build rather than degrading to a default — and the
+/// owned-result couplings from `verify-ffi-symbols.py` are re-checked here so
+/// the generated compiler table can never carry a row the out-of-band
+/// validator would reject.
+fn validate_contract_row(symbol: &str, row: &ContractRow) {
+    assert!(
+        ["fresh", "retained", "borrowed", "none"].contains(&row.result.as_str()),
+        "unknown ownership result for {symbol}: {}",
+        row.result
+    );
+    for param in &row.params {
+        assert!(
+            ["borrow", "consume", "retain"].contains(&param.as_str()),
+            "unknown param ownership for {symbol}: {param}"
+        );
+    }
+    assert!(
+        ["shallow", "deep", "none"].contains(&row.discharge_depth.as_str()),
+        "unknown discharge depth for {symbol}: {}",
+        row.discharge_depth
+    );
+    if matches!(row.result.as_str(), "fresh" | "retained") {
+        assert!(
+            !row.release_symbol.is_empty() && row.discharge_depth != "none",
+            "owned result for {symbol} requires release-symbol and discharge depth"
+        );
+    } else {
+        assert!(
+            row.release_symbol.is_empty() && row.discharge_depth == "none",
+            "borrowed/none result for {symbol} must carry no release axis"
+        );
+    }
+    // The RETENTION axis. Absence is the fail-closed answer "not established",
+    // so the only spelling is the positive one, and it is only meaningful about
+    // an allocation the caller was actually given.
+    assert!(
+        ["", "transferred"].contains(&row.result_retention.as_str()),
+        "unknown result-retention for {symbol}: {}",
+        row.result_retention
+    );
+    assert!(
+        row.result_retention.is_empty() || matches!(row.result.as_str(), "fresh" | "retained"),
+        "result-retention for {symbol} is meaningless without an owned result"
+    );
+}
+
 /// Parse the full `[[ownership.contracts]]` table from TOML source. Every
 /// axis is validated against the closed schema vocabularies here
 /// (fail-closed: an unknown spelling aborts rather than degrading to a
@@ -63,33 +119,7 @@ fn parse_ownership_contracts(
                   contracts: &mut std::collections::BTreeMap<String, ContractRow>| {
         if let Some((symbol, row)) = entry {
             let symbol = symbol.expect("ownership contract missing `symbol`");
-            assert!(
-                ["fresh", "retained", "borrowed", "none"].contains(&row.result.as_str()),
-                "unknown ownership result for {symbol}: {}",
-                row.result
-            );
-            for param in &row.params {
-                assert!(
-                    ["borrow", "consume", "retain"].contains(&param.as_str()),
-                    "unknown param ownership for {symbol}: {param}"
-                );
-            }
-            assert!(
-                ["shallow", "deep", "none"].contains(&row.discharge_depth.as_str()),
-                "unknown discharge depth for {symbol}: {}",
-                row.discharge_depth
-            );
-            if matches!(row.result.as_str(), "fresh" | "retained") {
-                assert!(
-                    !row.release_symbol.is_empty() && row.discharge_depth != "none",
-                    "owned result for {symbol} requires release-symbol and discharge depth"
-                );
-            } else {
-                assert!(
-                    row.release_symbol.is_empty() && row.discharge_depth == "none",
-                    "borrowed/none result for {symbol} must carry no release axis"
-                );
-            }
+            validate_contract_row(&symbol, &row);
             assert!(
                 contracts.insert(symbol.clone(), row).is_none(),
                 "duplicate TOML ownership contract for {symbol}"
@@ -109,6 +139,7 @@ fn parse_ownership_contracts(
                     params: Vec::new(),
                     release_symbol: String::new(),
                     discharge_depth: String::new(),
+                    result_retention: String::new(),
                 },
             ));
             continue;
@@ -153,6 +184,10 @@ fn parse_ownership_contracts(
             quoted_value(line)
                 .expect("contract discharge-depth must be quoted")
                 .clone_into(&mut row.discharge_depth);
+        } else if line.starts_with("result-retention =") {
+            quoted_value(line)
+                .expect("contract result-retention must be quoted")
+                .clone_into(&mut row.result_retention);
         }
     }
     finish(current.take(), &mut contracts);

--- a/hew-mir/src/ffi_contracts.rs
+++ b/hew-mir/src/ffi_contracts.rs
@@ -54,6 +54,43 @@ pub enum ReleaseDischargeDepth {
     None,
 }
 
+/// Whether the callee keeps a pointer into the allocation it returned.
+///
+/// This is the RETENTION axis, and it is a different question from
+/// [`ExternResultOwnership`]. `Fresh` says the result is a newly owned
+/// allocation; it does not by itself say the callee stopped referring to it.
+/// A callee that allocates and *also* keeps the pointer — to free it later, to
+/// overwrite it on the next call, or to hand the same address out again —
+/// produces a value the caller must not release, and the distinction is
+/// invisible on the ownership axis alone.
+///
+/// The axis exists because that difference is real inside this very runtime.
+/// `hew_process_last_error` copies its thread-local message into a fresh
+/// header-aware allocation and keeps nothing; `hew_last_error` hands back the
+/// interior of the `CString` the runtime stores and keeps everything. Both are
+/// `hew_*` exports, both return a C string, and only the first is the caller's
+/// to release.
+///
+/// # `Unspecified` is fail-closed, not "probably fine"
+///
+/// A row carries `Transferred` only when an executable oracle established it
+/// for that symbol — see `hew-runtime/tests/last_error_result_retention.rs` and
+/// `hew-std/src/last_error_retention.rs`, which measure distinct-address,
+/// sole-ownership (`rc == 1`) and slot-survives-release per symbol. Every other
+/// row is `Unspecified`, which licenses no caller-side release; the cost of
+/// being wrong that way is a leak, and the cost of the other way is a double
+/// free.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExternResultRetention {
+    /// The callee provably keeps no pointer into the returned allocation: the
+    /// caller holds the sole owner and the contract's release symbol is the
+    /// balancing release.
+    Transferred,
+    /// The question has not been answered for this symbol. No caller-side
+    /// release may be minted from this row.
+    Unspecified,
+}
+
 /// One extern symbol's machine-checked ownership contract.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ExternOwnershipContract {
@@ -66,6 +103,8 @@ pub struct ExternOwnershipContract {
     pub release_symbol: &'static str,
     /// Recursion depth of the release symbol's discharge.
     pub discharge_depth: ReleaseDischargeDepth,
+    /// Whether the callee provably keeps no pointer into an owned result.
+    pub result_retention: ExternResultRetention,
 }
 
 /// The fact available at a lowering position for an extern callee symbol.
@@ -153,6 +192,66 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn retention_axis_only_on_owned_results() {
+        // Mirror of the verify-ffi-symbols.py coupling rule: the retention
+        // question ("does the callee still hold a pointer into what it just
+        // returned?") is only meaningful about an allocation the caller was
+        // given, so an unowned result may never claim to have transferred one.
+        for (symbol, contract) in FFI_OWNERSHIP_CONTRACTS {
+            if contract.result_retention == ExternResultRetention::Transferred {
+                assert!(
+                    matches!(
+                        contract.result,
+                        ExternResultOwnership::Fresh | ExternResultOwnership::Retained
+                    ),
+                    "{symbol}: result-retention is meaningless without an owned result"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn last_error_family_answer_is_readable_and_not_uniform() {
+        // hew-lang/hew#2828. The answer lives in the table, per symbol, so the
+        // ownership authority reads it rather than inferring one from the
+        // shared name shape.
+        let transferring = extern_ownership_contract("hew_process_last_error")
+            .contract()
+            .expect("hew_process_last_error is classified");
+        assert_eq!(transferring.result, ExternResultOwnership::Fresh);
+        assert_eq!(transferring.release_symbol, "hew_string_drop");
+        assert_eq!(
+            transferring.result_retention,
+            ExternResultRetention::Transferred
+        );
+
+        // The member of the same family whose answer is the other one: it
+        // returns the interior of a CString the runtime keeps.
+        let borrowing = extern_ownership_contract("hew_last_error")
+            .contract()
+            .expect("hew_last_error is classified");
+        assert_eq!(borrowing.result, ExternResultOwnership::Borrowed);
+        assert_eq!(
+            borrowing.result_retention,
+            ExternResultRetention::Unspecified
+        );
+    }
+
+    #[test]
+    fn retention_defaults_to_unspecified() {
+        // Absence is the fail-closed answer, and it is the common case: a row
+        // that has never been measured must not read as a transfer.
+        let bytes_to_string = extern_ownership_contract("hew_bytes_to_string")
+            .contract()
+            .expect("hew_bytes_to_string is classified");
+        assert_eq!(bytes_to_string.result, ExternResultOwnership::Fresh);
+        assert_eq!(
+            bytes_to_string.result_retention,
+            ExternResultRetention::Unspecified
+        );
     }
 
     #[test]

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -1844,6 +1844,23 @@ impl ExternContractTable {
 /// declaration is a pointer-width slot that IS the foreign-handle shape this
 /// whole authority exists to refuse. The narrow structural predicate answers
 /// `false` for anything unresolved.
+///
+/// # Clause C — the measured transfer, and the only MINT for a pointer
+///
+/// `fresh_return_names` additionally admits a name under
+/// [`extern_result_is_measured_transfer`]. That is a strictly stronger bar than
+/// Clauses A and B, because it is the only admission here that hands a
+/// pointer-bearing result to the drop plan as a fresh sole owner. It requires
+/// Clause A, a declared return type whose type-directed drop plan discharges
+/// through exactly the audited release symbol, and — the load-bearing part — an
+/// audited `result-retention = "transferred"`, which is recorded only where an
+/// executable oracle measured the runtime's actual retention behaviour. See
+/// that function for the clause-by-clause argument.
+///
+/// Clause C deliberately widens ONLY the name-keyed `fresh_return_names` beyond
+/// the `AliasBits::EMPTY` row it already writes: an extern call site's
+/// `ResolvedRef::Item` carries a placeholder id, so the name-keyed set is the
+/// one every reader of this authority actually consults for an extern.
 #[must_use]
 pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContractTable {
     let mut rows: HashMap<hew_hir::ItemId, ReturnProvenance> = HashMap::new();
@@ -1855,6 +1872,14 @@ pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContrac
     let mut borrowing_arg_names: HashSet<String> = HashSet::new();
     let mut audited_domestic_return_names: HashSet<String> = HashSet::new();
     let pointer_free_records = PointerFreeRecords::from_module(module);
+    let type_decls: HashMap<&str, &hew_hir::HirTypeDecl> = module
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            hew_hir::HirItem::TypeDecl(decl) => Some((decl.name.as_str(), decl)),
+            _ => None,
+        })
+        .collect();
     for item in &module.items {
         if let hew_hir::HirItem::ExternFn(ef) = item {
             names.insert(ef.name.clone());
@@ -1871,7 +1896,7 @@ pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContrac
             {
                 audited_domestic_return_names.insert(ef.name.clone());
             }
-            // The MINT-side admission, and the only line here the strict
+            // The MINT-side admission, and the only lines here the strict
             // policy reads. `ty_is_scalar_non_heap` is the degenerate case of
             // `ty_is_pointer_free`: an `i64` return is admitted because it
             // cannot carry a handle, and a record whose fields are
@@ -1884,8 +1909,13 @@ pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContrac
             // foreign handle, the taint travels out through
             // `cron_error_from_result`, and the ordinary `+1` string the error
             // carrier holds gets no owner at all.
+            //
+            // The third disjunct is the only one that mints for a value that
+            // DOES carry a pointer, and it mints solely on a measured retention
+            // answer — see `extern_result_is_measured_transfer`.
             if ty_is_scalar_non_heap(&ef.return_ty)
                 || pointer_free_records.ty_is_pointer_free(&ef.return_ty)
+                || extern_result_is_measured_transfer(&ef.name, ef, &type_decls)
             {
                 rows.insert(ef.id, AliasBits::EMPTY);
                 fresh_return_names.insert(ef.name.clone());
@@ -1921,6 +1951,156 @@ fn extern_result_is_audited_owned_transfer(symbol: &str, declared_arity: usize) 
                 && contract.params.len() == declared_arity
         })
 }
+
+/// Clause C of the RESULT-axis admission, and the ONLY clause that mints a
+/// caller-side release for a POINTER-BEARING extern result.
+///
+/// Clauses A and B answer "this result is not proof of foreignness", which only
+/// ever suppresses a taint. Minting is the other direction and needs the harder
+/// fact: that the buffer handed back is the caller's to release, and that
+/// releasing it exactly once balances the runtime. Getting that wrong upward is
+/// a reachable double free, so every conjunct below is load-bearing.
+///
+/// C1. Clause A holds — an audited `[[ownership.contracts]]` row exists for a
+///     symbol this compiler's own runtime claims, its result is owned, it names
+///     a release, and the declaration's arity matches the audited signature. A
+///     declaration that disagrees with the audited signature is not a
+///     declaration of the audited callee.
+///
+/// C2. the row's RETENTION axis reads `transferred`. This is the conjunct that
+///     carries the answer, and it is a strictly different question from C1:
+///     `fresh` says the allocation is new, not that the callee stopped
+///     referring to it. A callee that allocates AND keeps the pointer — to free
+///     it later, to overwrite it on the next call, or to hand the same address
+///     back again — yields a value the caller must not release. Both members of
+///     the `*_last_error` family are `hew_*` C-string returns and only one of
+///     them transfers (hew-lang/hew#2828): `hew_process_last_error` copies its
+///     thread-local into a fresh header-aware allocation and keeps nothing,
+///     while `hew_last_error` hands back the interior of the `CString` the
+///     runtime stores. Absence of the axis is the fail-closed reading and is
+///     the state of nearly every row, so this clause admits only what an
+///     executable oracle has actually measured.
+///
+/// C3. the audited release symbol is EXACTLY the release the compiler's own
+///     type-directed drop plan emits for the declared return type, at `Shallow`
+///     depth. This is what ties the AUDITED release to the release that will
+///     actually run. The mint does not emit the row's release symbol; it marks
+///     the value a fresh sole owner and lets the drop plan derive the release
+///     from the declared type. Without this conjunct a row naming
+///     `hew_json_free` would license a `hew_string_drop` against an allocation
+///     that release never balances. See [`declared_return_release`] for the
+///     derivation and for why a type whose discharge is not a single release is
+///     refused.
+///
+/// Fail-closed in every direction: any conjunct answering `false` restores the
+/// pre-existing verdict, which is `{OPAQUE}` ⇒ no mint ⇒ a leak. A leak is
+/// bounded and is measured file by file by the release-count differential; a
+/// double free is neither.
+fn extern_result_is_measured_transfer(
+    symbol: &str,
+    decl: &hew_hir::HirExternFn,
+    decls: &HashMap<&str, &hew_hir::HirTypeDecl>,
+) -> bool {
+    let ReturnRelease::One(planned) = declared_return_release(&decl.return_ty, decls, 0) else {
+        return false;
+    };
+    if !extern_result_is_audited_owned_transfer(symbol, decl.param_tys.len()) {
+        return false;
+    }
+    crate::ffi_contracts::extern_ownership_contract(symbol)
+        .contract()
+        .is_some_and(|contract| {
+            contract.result_retention == crate::ffi_contracts::ExternResultRetention::Transferred
+                && contract.release_symbol == planned
+                && contract.discharge_depth == crate::ffi_contracts::ReleaseDischargeDepth::Shallow
+        })
+}
+
+/// What the compiler's type-directed drop plan will emit for a declared type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReturnRelease {
+    /// Nothing is released: the value owns no heap.
+    Nothing,
+    /// The whole value discharges through exactly this one release symbol.
+    One(&'static str),
+    /// The type is unresolvable here, or its discharge is not a single release
+    /// (an `#[opaque]` handle, a generic instantiation, a record mixing two
+    /// release symbols, a shape this function does not model). Never admitted.
+    Unresolved,
+}
+
+/// The single release symbol the type-directed drop plan emits for `ty`,
+/// resolved from THIS module's own type declarations.
+///
+/// Same discipline as [`PointerFreeRecords`]: structural, module-local, and
+/// `Unresolved` for anything it cannot resolve. It never consults a layout
+/// registry, because an absent or partial registry reads a composite as
+/// non-heap, which is the permissive direction.
+///
+/// `Nothing` is not a licence either — a value with no heap in it is Clause B's
+/// business, and Clause C requires `One`, so a contract can only ever be
+/// honoured against a release the plan will really emit. A record mixing two
+/// release symbols answers `Unresolved`: the contract names ONE release symbol,
+/// so it cannot be the balancing release for a value that needs two, and the
+/// audit is then not describing what the caller would do.
+fn declared_return_release(
+    ty: &ResolvedTy,
+    decls: &HashMap<&str, &hew_hir::HirTypeDecl>,
+    depth: usize,
+) -> ReturnRelease {
+    /// Bounds the record walk. A record cannot contain itself by value, but the
+    /// walk must terminate on a malformed or mutually recursive declaration
+    /// without trusting that.
+    const MAX_RECORD_DEPTH: usize = 8;
+
+    if ty_is_scalar_non_heap(ty) {
+        return ReturnRelease::Nothing;
+    }
+    match ty {
+        ResolvedTy::String => ReturnRelease::One(STRING_RELEASE_SYMBOL),
+        ResolvedTy::Bytes => ReturnRelease::One(BYTES_RELEASE_SYMBOL),
+        ResolvedTy::Named {
+            name,
+            args,
+            is_opaque,
+            ..
+        } => {
+            if *is_opaque || !args.is_empty() || depth >= MAX_RECORD_DEPTH {
+                return ReturnRelease::Unresolved;
+            }
+            let Some(decl) = decls
+                .get(name.as_str())
+                .or_else(|| decls.get(hew_types::short_name(name)))
+            else {
+                return ReturnRelease::Unresolved;
+            };
+            if decl.is_opaque || decl.fields.is_empty() {
+                return ReturnRelease::Unresolved;
+            }
+            let mut planned = ReturnRelease::Nothing;
+            for field in &decl.fields {
+                match declared_return_release(&field.ty, decls, depth + 1) {
+                    ReturnRelease::Nothing => {}
+                    ReturnRelease::Unresolved => return ReturnRelease::Unresolved,
+                    ReturnRelease::One(symbol) => match planned {
+                        ReturnRelease::One(seen) if seen != symbol => {
+                            return ReturnRelease::Unresolved;
+                        }
+                        _ => planned = ReturnRelease::One(symbol),
+                    },
+                }
+            }
+            planned
+        }
+        _ => ReturnRelease::Unresolved,
+    }
+}
+
+/// The one release the type-directed drop plan emits for a `string`.
+const STRING_RELEASE_SYMBOL: &str = "hew_string_drop";
+
+/// The one release the type-directed drop plan emits for `bytes`.
+const BYTES_RELEASE_SYMBOL: &str = "hew_bytes_drop";
 
 /// Clause B of the RESULT-axis admission: the module's records that provably
 /// contain no pointer, resolved from the module's own type declarations.
@@ -4199,13 +4379,32 @@ impl LeafPolicy for PrecisePolicy<'_> {
         // Clause 0: an extern call dispatches by NAME — its call-site id is the
         // PLACEHOLDER `ItemId(0)`, so an id lookup would collide with a real
         // module fn's summary (leaking that fn's `PARAM` bits into the extern
-        // caller — the jwt/encrypt false-reject contamination). No
-        // heap-returning extern is trusted in the interim → `{OPAQUE}`; a
-        // scalar-returning extern also lands here (sound: over-approximation
-        // only widens toward Opaque, and its consumers' scalar results are
-        // short-circuited by type at the leaves).
+        // caller — the jwt/encrypt false-reject contamination). The name-keyed
+        // audited authority is exactly the query that avoids that collision, so
+        // it is the one asked here, and it is the SAME set
+        // `OpaqueExternTaintPolicy` reads: an extern admitted as an audited
+        // fresh owner hands back a value that aliases no parameter and carries
+        // no opaque origin, which is what `∅` means. Everything else stays
+        // `{OPAQUE}`.
+        //
+        // The set is narrow by construction: a pointer-free result (a scalar,
+        // or a module record of scalar leaves) which owns no heap at all and so
+        // is vacuously `∅`; and — the only pointer-bearing case — a result
+        // whose contract carries a MEASURED `result-retention = "transferred"`
+        // and whose audited release is the one the drop plan will emit for the
+        // declared type (see `build_extern_contract_table` Clause C).
+        //
+        // Reading `{OPAQUE}` for those was an over-approximation, and it is the
+        // one that withheld the release from every Hew wrapper around the
+        // `*_last_error` family: such a wrapper's whole body is the extern
+        // call, so `{OPAQUE}` here propagates to every caller and no owner is
+        // ever minted for the error string.
         if self.extern_table.is_extern_name(name) {
-            return CallClass::Opaque;
+            return if self.extern_table.extern_return_is_audited_fresh_owner(name) {
+                CallClass::Fresh
+            } else {
+                CallClass::Opaque
+            };
         }
         // Clause 1: a resolved module fn → its summary (with arg substitution).
         if let Some(bits) = self.provenance.get(id) {
@@ -5770,5 +5969,289 @@ fn main() {}
         assert!(!t.is_extern_name("not_declared"));
         assert!(!t.extern_return_is_audited_fresh_owner("not_declared"));
         assert!(!t.extern_borrows_audited_heap_args("not_declared"));
+    }
+}
+
+#[cfg(test)]
+mod measured_extern_result_transfer {
+    //! Clause C — the only MINT-side admission for a pointer-bearing extern
+    //! result, and the compiler half of hew-lang/hew#2828.
+    //!
+    //! The point of these tests is that the admission tracks the RECORDED
+    //! ANSWER and nothing else. Not the name shape, not `result = "fresh"`, not
+    //! the fact that the return type happens to own heap.
+    use super::*;
+
+    fn table_for(source: &str) -> ExternContractTable {
+        build_extern_contract_table(&tests::lower_source(source))
+    }
+
+    #[test]
+    fn a_measured_transfer_is_minted() {
+        const SOURCE: &str = r#"extern "C" {
+    fn hew_process_last_error() -> string;
+}
+fn main() {}
+"#;
+        let t = table_for(SOURCE);
+        assert!(
+            t.extern_return_is_audited_fresh_owner("hew_process_last_error"),
+            "the runtime copies its thread-local message into a fresh \
+             header-aware allocation and keeps no pointer into it, so the \
+             caller holds the sole owner and owes exactly one release"
+        );
+    }
+
+    #[test]
+    fn the_whole_measured_family_is_minted() {
+        // Every symbol the oracles established, read back through the same
+        // admission path a real declaration takes.
+        const SOURCE: &str = r#"extern "C" {
+    fn hew_tls_last_error() -> string;
+    fn hew_smtp_last_error() -> string;
+    fn hew_cron_last_error() -> string;
+    fn hew_datetime_last_error() -> string;
+    fn hew_json_last_error() -> string;
+    fn hew_toml_last_error() -> string;
+    fn hew_yaml_last_error() -> string;
+    fn hew_xml_last_error() -> string;
+    fn hew_msgpack_last_error() -> string;
+    fn hew_http_last_error() -> string;
+    fn hew_quic_last_error() -> string;
+    fn hew_stream_last_error() -> string;
+}
+fn main() {}
+"#;
+        let t = table_for(SOURCE);
+        for name in [
+            "hew_tls_last_error",
+            "hew_smtp_last_error",
+            "hew_cron_last_error",
+            "hew_datetime_last_error",
+            "hew_json_last_error",
+            "hew_toml_last_error",
+            "hew_yaml_last_error",
+            "hew_xml_last_error",
+            "hew_msgpack_last_error",
+            "hew_http_last_error",
+            "hew_quic_last_error",
+            "hew_stream_last_error",
+        ] {
+            assert!(
+                t.extern_return_is_audited_fresh_owner(name),
+                "`{name}` carries a measured `result-retention = \"transferred\"` \
+                 row, so its result is the caller's to release"
+            );
+        }
+    }
+
+    #[test]
+    fn a_measured_record_return_is_minted_through_its_heap_field() {
+        // `TlsReadFfiResult { data: bytes; status: i32 }` is not pointer-free,
+        // so Clause B refuses it. Its whole discharge is one `hew_bytes_drop`,
+        // which is exactly what the audited row names, and the retention answer
+        // is measured — so Clause C admits it, and the `Result<bytes, ..>` that
+        // `tls.read` builds from it regains its scrutinee release.
+        const SOURCE: &str = r#"type TlsReadFfiResult {
+    data: bytes;
+    status: i32;
+}
+extern "C" {
+    fn hew_tls_read_result(stream: i64, size: i32) -> TlsReadFfiResult;
+}
+fn main() {}
+"#;
+        assert!(
+            table_for(SOURCE).extern_return_is_audited_fresh_owner("hew_tls_read_result"),
+            "a record whose only heap field discharges through the audited \
+             release symbol is the caller's to release"
+        );
+    }
+
+    #[test]
+    fn a_fresh_result_without_a_measured_retention_is_refused() {
+        // `hew_bytes_to_string` is audited `result = "fresh"`, released by
+        // `hew_string_drop`, shallow — identical on every axis Clause A reads.
+        // It is refused for the one reason that matters: nobody has established
+        // that the callee keeps no pointer into what it returned. Absence is
+        // the answer "not established", and that costs a leak rather than a
+        // double free.
+        const SOURCE: &str = r#"extern "C" {
+    fn hew_bytes_to_string(b: bytes) -> string;
+}
+fn main() {}
+"#;
+        let contract = crate::ffi_contracts::extern_ownership_contract("hew_bytes_to_string")
+            .contract()
+            .expect("guard: hew_bytes_to_string must be audited, or this proves nothing");
+        assert_eq!(
+            contract.result,
+            crate::ffi_contracts::ExternResultOwnership::Fresh
+        );
+        assert_eq!(contract.release_symbol, STRING_RELEASE_SYMBOL);
+        assert_eq!(
+            contract.result_retention,
+            crate::ffi_contracts::ExternResultRetention::Unspecified
+        );
+        assert!(
+            !table_for(SOURCE).extern_return_is_audited_fresh_owner("hew_bytes_to_string"),
+            "`fresh` says the allocation is new, not that the callee stopped \
+             referring to it; only the retention axis answers that"
+        );
+    }
+
+    #[test]
+    fn the_borrowing_member_of_the_family_is_refused() {
+        // `hew_last_error` shares the family's name shape and its C-string
+        // return, and hands back the interior of a `CString` the runtime keeps.
+        // The recorded answer is `borrowed`, which fails Clause A before the
+        // retention axis is even consulted.
+        const SOURCE: &str = r#"extern "C" {
+    fn hew_last_error() -> string;
+}
+fn main() {}
+"#;
+        assert!(
+            !table_for(SOURCE).extern_return_is_audited_fresh_owner("hew_last_error"),
+            "the family is not uniform, and the authority must read the answer \
+             per symbol rather than generalise from the shared prefix"
+        );
+    }
+
+    #[test]
+    fn a_release_the_drop_plan_would_not_emit_is_refused() {
+        // Clause C3. `hew_json_array_new` is audited `fresh`, but its release is
+        // `hew_json_free` at `deep` depth. Declaring it `-> string` would have
+        // the drop plan emit `hew_string_drop` against an allocation that
+        // release does not balance, so the audited release must be exactly the
+        // one the declared type's drop plan emits.
+        const SOURCE: &str = r#"extern "C" {
+    fn hew_json_array_new() -> string;
+}
+fn main() {}
+"#;
+        let contract = crate::ffi_contracts::extern_ownership_contract("hew_json_array_new")
+            .contract()
+            .expect("guard: hew_json_array_new must be audited, or this proves nothing");
+        assert_eq!(
+            contract.result,
+            crate::ffi_contracts::ExternResultOwnership::Fresh
+        );
+        assert_ne!(contract.release_symbol, STRING_RELEASE_SYMBOL);
+        assert!(
+            !table_for(SOURCE).extern_return_is_audited_fresh_owner("hew_json_array_new"),
+            "an audited release the type-directed drop plan will not emit \
+             licenses nothing"
+        );
+    }
+
+    #[test]
+    fn an_arity_that_disagrees_with_the_audited_signature_is_refused() {
+        // The row is a fact about the audited callee. A block declaring a
+        // different function under the same name is not a declaration of it.
+        const SOURCE: &str = r#"extern "C" {
+    fn hew_process_last_error(unexpected: i64) -> string;
+}
+fn main() {}
+"#;
+        assert!(
+            !table_for(SOURCE).extern_return_is_audited_fresh_owner("hew_process_last_error"),
+            "a measured answer about a zero-argument callee says nothing about \
+             a one-argument declaration wearing its name"
+        );
+    }
+
+    #[test]
+    fn an_unclassified_host_symbol_is_refused() {
+        const SOURCE: &str = r#"extern "C" {
+    fn host_last_error() -> string;
+}
+fn main() {}
+"#;
+        assert!(
+            !table_for(SOURCE).extern_return_is_audited_fresh_owner("host_last_error"),
+            "a foreign host symbol has no measured row, so its result stays \
+             ownership-opaque"
+        );
+    }
+
+    #[test]
+    fn a_declared_return_resolves_to_the_release_the_plan_emits() {
+        // The C3 derivation, exercised directly so the refusals above are
+        // pinned to a stated rule rather than to whatever the table happens to
+        // hold. An `#[opaque]` handle, a generic instantiation and a record
+        // mixing two release symbols are all `Unresolved`, which Clause C
+        // refuses.
+        const SOURCE: &str = r"type Pod {
+    a: i32;
+    b: i64;
+}
+type OneHeap {
+    data: bytes;
+    status: i32;
+}
+type MixedHeap {
+    text: string;
+    data: bytes;
+}
+#[opaque]
+type Handle {
+}
+fn main() {}
+";
+        let module = tests::lower_source(SOURCE);
+        let decls: HashMap<&str, &hew_hir::HirTypeDecl> = module
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                hew_hir::HirItem::TypeDecl(decl) => Some((decl.name.as_str(), decl)),
+                _ => None,
+            })
+            .collect();
+        let named = |name: &str| ResolvedTy::Named {
+            name: name.to_string(),
+            args: vec![],
+            is_opaque: false,
+            builtin: None,
+        };
+
+        assert_eq!(
+            declared_return_release(&ResolvedTy::String, &decls, 0),
+            ReturnRelease::One("hew_string_drop")
+        );
+        assert_eq!(
+            declared_return_release(&ResolvedTy::Bytes, &decls, 0),
+            ReturnRelease::One("hew_bytes_drop")
+        );
+        assert_eq!(
+            declared_return_release(&ResolvedTy::I64, &decls, 0),
+            ReturnRelease::Nothing
+        );
+        assert_eq!(
+            declared_return_release(&named("Pod"), &decls, 0),
+            ReturnRelease::Nothing,
+            "a record of scalar leaves releases nothing — Clause B's business, \
+             and never a licence under Clause C"
+        );
+        assert_eq!(
+            declared_return_release(&named("OneHeap"), &decls, 0),
+            ReturnRelease::One("hew_bytes_drop")
+        );
+        assert_eq!(
+            declared_return_release(&named("MixedHeap"), &decls, 0),
+            ReturnRelease::Unresolved,
+            "a contract names ONE release symbol, so it cannot be the balancing \
+             release for a value that needs two"
+        );
+        assert_eq!(
+            declared_return_release(&named("Handle"), &decls, 0),
+            ReturnRelease::Unresolved,
+            "an `#[opaque]` declaration is the foreign-handle shape this \
+             authority exists to refuse"
+        );
+        assert_eq!(
+            declared_return_release(&named("NotDeclaredHere"), &decls, 0),
+            ReturnRelease::Unresolved
+        );
     }
 }

--- a/hew-mir/tests/lowering_expr/binder_shape_release_sweep.rs
+++ b/hew-mir/tests/lowering_expr/binder_shape_release_sweep.rs
@@ -643,7 +643,13 @@ fn release_count_is_invariant_across_carrier_class() {
 /// * `audited_extern` is `std/process.hew`'s
 ///   `hew_process_last_error() -> string`: an audited `result = "fresh"` row
 ///   with `release-symbol = "hew_string_drop"`. It hands the caller a newly
-///   owned allocation, exactly as `mk()` does.
+///   owned allocation, exactly as `mk()` does. It was a DEFERRED cell until
+///   #2828 settled the retention question — the row now also carries
+///   `result-retention = "transferred"`, measured at the runtime's own
+///   alloc/free sites, and the mint side reads that rather than inferring it
+///   from "audited fresh". Before that answer existed this cell planned ZERO
+///   releases against the domestic one's; folding it back in is what pins the
+///   leak closed.
 /// * `pod_extern` is `std/time/cron/cron.hew`'s
 ///   `hew_cron_next_hew(...) -> CronNextResult`, consumed the way
 ///   `Err(cron_error_from_result(result))` consumes it: the POD is passed into
@@ -657,6 +663,11 @@ fn release_count_is_invariant_across_carrier_class() {
 const PAYLOAD_SOURCES: &[(&str, &str, &str)] = &[
     ("domestic", "", "mk()"),
     (
+        "audited_extern",
+        "extern \"C\" {\n    fn hew_process_last_error() -> string;\n}\n",
+        "unsafe { hew_process_last_error() }",
+    ),
+    (
         "pod_extern",
         "extern \"C\" {\n    fn host_pod() -> Pod;\n}\n\
          type Pod { status: i32; timestamp: i64 }\n\
@@ -664,36 +675,6 @@ const PAYLOAD_SOURCES: &[(&str, &str, &str)] = &[
         "from_pod(unsafe { host_pod() })",
     ),
 ];
-
-/// The DEFERRED half of the payload-provenance question, kept as a ratchet
-/// rather than deleted.
-///
-/// `hew_process_last_error() -> string` carries an audited `result = "fresh"`
-/// row with `release-symbol = "hew_string_drop"`, and
-/// `classify_extern_string_ownership` already reads it as `HeaderAware` from the
-/// same catalog key — so the caller holds a `+1` header-aware Hew string and
-/// owes exactly one `hew_string_drop`. The frame plans ZERO releases for it.
-/// That is a leak, and it is a real one: `std/process.hew` takes this path on
-/// every error.
-///
-/// It is NOT fixed here, and the reason is polarity. Every change this round
-/// makes is either on the suppression side (wrong ⇒ leak) or is the
-/// pointer-free admission, whose value has nothing to release at all. Minting
-/// an owner for an `extern` result that IS a pointer is the strict mint side —
-/// wrong ⇒ double free — and it is the specific fail-open this branch exists to
-/// close. Trusting a name-keyed audit for a MINT is a separate decision with a
-/// separate argument, and it is not required to make the compiler stop
-/// rejecting the standard library.
-///
-/// The ratchet: `audited_extern` must still diverge from `domestic`. If someone
-/// closes the mint side, this test fails and tells them to fold the source back
-/// into [`PAYLOAD_SOURCES`] — the finding cannot be quietly lost, and the fix
-/// cannot land unnoticed.
-const DEFERRED_PAYLOAD_SOURCE: (&str, &str, &str) = (
-    "audited_extern",
-    "extern \"C\" {\n    fn hew_process_last_error() -> string;\n}\n",
-    "unsafe { hew_process_last_error() }",
-);
 
 /// Plane 5: **payload provenance** × carrier class × binder shape.
 ///
@@ -748,43 +729,5 @@ fn release_count_and_acceptance_are_invariant_across_payload_provenance() {
          class — the compiler rejecting shipped code because an `extern` in its own \
          runtime ABI was read as a foreign host:\n{}",
         failures.join("\n")
-    );
-}
-
-/// The ratchet for [`DEFERRED_PAYLOAD_SOURCE`]. See its doc for why the fix is
-/// deferred; this pins that the finding is still there and still shaped the way
-/// it was recorded, so it can neither be forgotten nor silently fixed.
-#[test]
-fn the_audited_extern_payload_mint_gap_is_still_open() {
-    let (_, decls, heap) = DEFERRED_PAYLOAD_SOURCE;
-    let carrier = &CARRIERS[0];
-    let binder = BINDERS
-        .iter()
-        .find(|(n, _)| *n == "if_let")
-        .expect("if_let")
-        .1;
-    let domestic = cell_verdict(&pipeline_with_tc(&instantiate(
-        carrier,
-        binder,
-        "    HITEXPR\n",
-        PAYLOAD_SOURCES[0].2,
-        SCALAR[0].1,
-    )));
-    let audited = cell_verdict(&pipeline_with_tc(&format!(
-        "{decls}{}",
-        instantiate(carrier, binder, "    HITEXPR\n", heap, SCALAR[0].1)
-    )));
-    assert_eq!(
-        audited.refusals, 0,
-        "the audited `extern` payload must at least be ACCEPTED — that half IS fixed \
-         here, and a refusal returning is this round's defect coming back"
-    );
-    assert!(
-        audited.releases < domestic.releases,
-        "the deferred mint-side gap has closed: an audited `+1` `extern` payload now \
-         plans {} releases against the domestic {}. Fold DEFERRED_PAYLOAD_SOURCE back \
-         into PAYLOAD_SOURCES and delete this test.",
-        audited.releases,
-        domestic.releases
     );
 }

--- a/hew-runtime/src/bytes.rs
+++ b/hew-runtime/src/bytes.rs
@@ -170,6 +170,11 @@ unsafe fn alloc_buf(cap: u32) -> *mut u8 {
 ///
 /// If the buffer is uniquely owned (refcount == 1), returns `ptr` unchanged.
 ///
+/// The decrement on the fork path CONSUMES one owner of `ptr`: the caller is
+/// understood to be moving its own reference forward onto the returned buffer.
+/// A caller that keeps a separate live triple aimed at `ptr` must retain it
+/// again (hew-lang/hew#2833).
+///
 /// # Safety
 ///
 /// `ptr` must be a valid bytes data pointer (non-null).
@@ -327,6 +332,12 @@ pub unsafe extern "C" fn hew_bytes_drop(data_ptr: *mut u8) {
 }
 
 /// Push a single byte onto the buffer, using copy-on-write if shared.
+///
+/// On the copy-on-write path this CONSUMES `triple`'s reference to the old
+/// buffer and leaves `triple` owning the fork instead — the ordinary move
+/// semantics of a Hew `bytes` value. A caller holding a second triple that
+/// still points at the old buffer must retain it before pushing
+/// (hew-lang/hew#2833).
 ///
 /// # Safety
 ///
@@ -1388,6 +1399,48 @@ mod tests {
         unsafe {
             hew_bytes_drop(triple_a.ptr);
             hew_bytes_drop(triple_b.ptr);
+        }
+    }
+
+    /// A copy-on-write push CONSUMES the pusher's reference to the original.
+    ///
+    /// `ensure_unique` forks a private copy and then releases the shared
+    /// reference, because the triple it was handed now points at the fork and
+    /// has no further use for the old buffer. That is correct for the ordinary
+    /// caller — which is moving its value forward, as `cow_on_push` shows —
+    /// but it is a trap for a caller that keeps a *separate* triple aimed at
+    /// the original and expects `push` to have left the owner count alone.
+    ///
+    /// hew-lang/hew#2833: a sole-ownership probe in `hew-std` did exactly that
+    /// and lost a reference on every shared push, so the buffer reached zero
+    /// one release early and the next release wrote into freed memory. Pinned
+    /// here as an explicit fact about `hew_bytes_push`, not an inference from
+    /// its implementation.
+    #[test]
+    fn cow_push_consumes_the_pushers_reference_to_the_original() {
+        let data = b"original";
+        // SAFETY: data is valid for its length.
+        let base = unsafe { hew_bytes_from_static(data.as_ptr(), data.len() as u32) };
+        // SAFETY: base.ptr is valid; this is the second owner.
+        unsafe { hew_bytes_clone_ref(base.ptr) };
+        // SAFETY: base.ptr is a live buffer with two owners.
+        unsafe { assert_eq!(refcount(base.ptr).load(Ordering::Relaxed), 2) };
+
+        let mut pusher = base;
+        // SAFETY: pusher is a valid triple aimed at the shared buffer.
+        unsafe { hew_bytes_push(&mut pusher, b'!') };
+        assert_ne!(pusher.ptr, base.ptr, "a shared push must fork");
+
+        // The push released one owner of the ORIGINAL on the pusher's behalf.
+        // SAFETY: base.ptr is still live — one owner remains.
+        unsafe { assert_eq!(refcount(base.ptr).load(Ordering::Relaxed), 1) };
+        // SAFETY: the fork is uniquely owned by `pusher`.
+        unsafe { assert_eq!(refcount(pusher.ptr).load(Ordering::Relaxed), 1) };
+
+        // SAFETY: one balancing release each.
+        unsafe {
+            hew_bytes_drop(pusher.ptr);
+            hew_bytes_drop(base.ptr);
         }
     }
 

--- a/hew-runtime/tests/last_error_result_retention.rs
+++ b/hew-runtime/tests/last_error_result_retention.rs
@@ -1,0 +1,207 @@
+//! Who owns the buffer a `*_last_error` export hands back (hew-lang/hew#2828).
+//!
+//! # The question, and why it needs an instrument
+//!
+//! `hew_process_last_error() -> string` is *declared* a fresh owner by
+//! `scripts/jit-symbol-classification.toml`. A declaration is not evidence.
+//! Both readings of it are unsafe if guessed: withhold the caller's release and
+//! the buffer leaks; mint one over a pointer the runtime still owns and a double
+//! free becomes reachable. So the answer has to come from what the runtime
+//! actually does with the buffer after it returns it.
+//!
+//! # The instrument
+//!
+//! An owner-count / allocation-balance oracle read at the real allocation site.
+//! Every header-aware Hew string carries the runtime's own live-owner count in
+//! its 16-byte header: `alloc_cstring_data` stamps `rc = 1`, `free_cstring`
+//! decrements and releases the block at zero. [`cstring_ensure_unique`] is the
+//! public, non-destructive read of that count — it returns its argument
+//! unchanged exactly when `rc == 1`, and a *different* pointer (a copy-on-write
+//! fork) when any other owner exists. So `ensure_unique(p) == p` is a direct
+//! statement that no other owner of `p` exists anywhere in the process.
+//!
+//! Three probes per symbol, run by [`assert_result_is_transferred`]:
+//!
+//! * **R1 — distinct live addresses.** Two results obtained back to back, both
+//!   still live, must be different pointers. A borrow into storage the callee
+//!   keeps cannot satisfy this; a fresh allocation per call cannot fail it.
+//! * **R2 — sole ownership at handoff.** `rc == 1` on each result. If the
+//!   runtime had retained an owner the count would be at least two and the
+//!   caller's release would not be the balancing one.
+//! * **R3 — the callee's state survives the caller's release.** After the
+//!   caller releases both results through the named release symbol
+//!   (`hew_string_drop`), the next call still reports the same message. The
+//!   callee therefore held no pointer into what was freed.
+//!
+//! R1 ∧ R2 ∧ R3 is the transfer: exactly one owner exists, it is the caller's,
+//! and releasing it disturbs nothing the runtime kept.
+//!
+//! # The counterfactual that keeps the oracle load-bearing
+//!
+//! [`hew_last_error_is_a_borrow_not_a_transfer`] runs R1 against
+//! `hew_last_error`, the sibling export `hew_process_last_error` is built on
+//! top of. It FAILS R1 — repeated calls return the identical address, because
+//! the pointer is the interior of the thread-local `CString` the runtime keeps.
+//! That is a different answer for a symbol of the same family, established by
+//! the same probe, and it is why R1 is not a formality: a symbol that borrows
+//! is distinguishable here.
+//!
+//! The hew-std half of the family (`hew_tls_last_error`,
+//! `hew_smtp_last_error`, `hew_cron_last_error`, …) is probed by the identical
+//! harness in `hew-std/src/last_error_retention.rs`; it lives there because
+//! those exports are that crate's.
+
+use std::ffi::{c_char, CStr, CString};
+
+use hew_cabi::cabi::cstring_ensure_unique;
+use hew_runtime::process::hew_process_last_error;
+use hew_runtime::stream_error::hew_stream_last_error;
+use hew_runtime::string::hew_string_drop;
+
+/// Record an error in the runtime's thread-local process-error slot without
+/// touching the filesystem or spawning anything: a negative `argc` is rejected
+/// before any argument is read.
+fn induce_process_error() {
+    let cmd = CString::new("hew-2828-oracle").expect("literal has no NUL");
+    // SAFETY: `argc` is negative, so the export returns before dereferencing
+    // `cmd` or `args`; the pointers are valid regardless.
+    unsafe {
+        hew_runtime::process::hew_process_run_args(cmd.as_ptr(), std::ptr::null(), -1);
+    }
+}
+
+/// Record an error in the runtime's stream/sink slot. `hew_stream_last_error`
+/// TAKES the message, so this runs before every read rather than once.
+fn induce_stream_error() {
+    let msg = b"hew-2828-oracle: stream";
+    // SAFETY: `msg` is a valid initialized byte range of the stated length.
+    unsafe { hew_runtime::stream_error::hew_stream_set_last_error(msg.as_ptr(), msg.len()) };
+}
+
+/// Run R1/R2/R3 against one `-> string` export and assert the result is the
+/// caller's to release. `induce` runs before every read so a take-and-clear
+/// slot (`hew_stream_last_error`) and a clone-on-read slot
+/// (`hew_process_last_error`) are measured on the same terms.
+fn assert_result_is_transferred(
+    symbol: &str,
+    induce: fn(),
+    call: unsafe extern "C" fn() -> *mut c_char,
+) {
+    induce();
+    // SAFETY: the export takes no arguments and returns null or a header-aware
+    // Hew string.
+    let first = unsafe { call() };
+    assert!(
+        !first.is_null(),
+        "{symbol}: expected a message after inducing one"
+    );
+    induce();
+    // SAFETY: as above.
+    let second = unsafe { call() };
+    assert!(
+        !second.is_null(),
+        "{symbol}: expected a message after inducing one"
+    );
+
+    // R1 — both results are live at once and must be distinct allocations.
+    assert_ne!(
+        first, second,
+        "{symbol}: two live results share an address, so the export hands out a \
+         borrow into storage it keeps rather than a fresh allocation"
+    );
+
+    // R2 — the caller holds the sole owner of each.
+    for (label, ptr) in [("first", first), ("second", second)] {
+        // SAFETY: the pointer is a live header-aware Hew string from the export.
+        let unique = unsafe { cstring_ensure_unique(ptr) };
+        assert_eq!(
+            unique, ptr,
+            "{symbol}: the {label} result was not solely owned at handoff \
+             (rc > 1), so the caller's release would not balance it"
+        );
+    }
+
+    // SAFETY: `first` is a live header-aware Hew string.
+    let text = unsafe { CStr::from_ptr(first) }.to_owned();
+
+    // R3 — release both through the release symbol the contract names, then
+    // read again: the callee's own state must be untouched by the free.
+    // SAFETY: each pointer is a live, solely-owned header-aware Hew string
+    // (R2), so this is its balancing release.
+    unsafe {
+        hew_string_drop(first);
+        hew_string_drop(second);
+    }
+    induce();
+    // SAFETY: as above.
+    let third = unsafe { call() };
+    assert!(
+        !third.is_null(),
+        "{symbol}: the slot did not survive the release"
+    );
+    // SAFETY: `third` is a live header-aware Hew string.
+    let after = unsafe { CStr::from_ptr(third) }.to_owned();
+    assert_eq!(
+        text, after,
+        "{symbol}: the message changed after the caller released an earlier \
+         result, so the callee retained a pointer into the freed buffer"
+    );
+    // SAFETY: `third` is live and solely owned.
+    unsafe { hew_string_drop(third) };
+}
+
+/// `hew_process_last_error` transfers: it copies the thread-local message into
+/// a fresh header-aware allocation and keeps nothing.
+#[test]
+fn process_last_error_result_is_transferred() {
+    assert_result_is_transferred(
+        "hew_process_last_error",
+        induce_process_error,
+        hew_process_last_error,
+    );
+}
+
+/// `hew_stream_last_error` transfers: it TAKES the stored message and allocates
+/// the returned C string from it. The take-and-clear shape is why `induce` runs
+/// before every read — the answer to the ownership question is the same.
+#[test]
+fn stream_last_error_result_is_transferred() {
+    assert_result_is_transferred(
+        "hew_stream_last_error",
+        induce_stream_error,
+        hew_stream_last_error,
+    );
+}
+
+/// The counterfactual. `hew_last_error` is the same family and the same slot —
+/// `hew_process_last_error` reads it — but it returns the interior of the
+/// `CString` the runtime keeps, so two consecutive results are the SAME
+/// address. It fails R1, it is not the caller's to release, and no
+/// `[[ownership.contracts]]` row may call it an owned transfer.
+///
+/// Without this the R1 probe could be vacuous: if every `-> string` export in
+/// the process allocated afresh, "distinct addresses" would be a fact about the
+/// allocator rather than about retention. Here is a real export where the probe
+/// separates the two answers.
+#[test]
+fn hew_last_error_is_a_borrow_not_a_transfer() {
+    induce_process_error();
+    let first = hew_runtime::hew_last_error();
+    let second = hew_runtime::hew_last_error();
+    assert!(!first.is_null(), "the slot must hold a message");
+    assert_eq!(
+        first, second,
+        "hew_last_error must hand back the same interior pointer twice — it is a \
+         borrow into the runtime's thread-local, and the R1 probe must be able \
+         to see the difference"
+    );
+    // Deliberately NOT released: the buffer is the runtime's. Reading it after
+    // the next mutation would be the use-after-free the borrow contract warns
+    // about, which is why the symbol carries `result = "borrowed"`.
+    // SAFETY: `first` is a live NUL-terminated C string owned by the runtime.
+    let borrowed = unsafe { CStr::from_ptr(first) }.to_owned();
+    assert!(
+        borrowed.to_bytes().starts_with(b"hew_process_run_args"),
+        "the borrow must read back the message the runtime stored"
+    );
+}

--- a/hew-std/src/last_error_retention.rs
+++ b/hew-std/src/last_error_retention.rs
@@ -1,0 +1,256 @@
+//! Who owns the buffer a hew-std `*_last_error` export hands back
+//! (hew-lang/hew#2828).
+//!
+//! The hew-runtime half of the family — `hew_process_last_error`,
+//! `hew_stream_last_error`, and the `hew_last_error` counterfactual that proves
+//! the probes discriminate a borrow from a transfer — is measured by
+//! `hew-runtime/tests/last_error_result_retention.rs`. That file carries the
+//! full argument for the instrument; this one applies the identical three
+//! probes to the exports that live in this crate.
+//!
+//! R1 (two live results are distinct addresses), R2 (`rc == 1` at handoff, read
+//! through the non-destructive `cstring_ensure_unique`) and R3 (the slot
+//! survives the caller's release) together say the returned buffer is the
+//! caller's to release and nothing here retains a pointer into it.
+//!
+//! Each symbol names its own inducer. The slots backed by
+//! [`hew_runtime::parse_error_slot`] are driven directly through that public
+//! storage; the three with a module-private thread-local (`cron`, `xml`,
+//! `msgpack`) are driven through a public entry point instead. All of them are
+//! deterministic and free of I/O.
+//!
+//! `hew_http_last_error` has no reachable non-empty path from outside its own
+//! module — its slot is written only on an allocation failure the crate injects
+//! under `#[cfg(test)]` from inside that module — so it is probed on the
+//! empty-message path. That is not a weaker measurement of the question asked
+//! here: the export's single statement is
+//! `str_to_malloc(&get_http_last_error())`, so the empty path allocates through
+//! the identical call and R1/R2/R3 read the identical buffer.
+//!
+//! The three handle-scoped QUIC variants (`hew_quic_endpoint_last_error`,
+//! `hew_quic_conn_last_error`, `hew_quic_stream_last_error`) are deliberately
+//! absent: reaching their message requires a live endpoint, connection and
+//! stream, which this oracle cannot stand up without I/O. No evidence, no
+//! `result-retention` row, no mint — the fail-closed direction.
+
+use std::ffi::{c_char, CStr};
+
+use hew_cabi::cabi::{cstring_ensure_unique, free_cstring};
+use hew_runtime::parse_error_slot::{set_error, ErrorSlotKind};
+
+/// Run R1/R2/R3 against one `-> string` export and assert the returned buffer
+/// is transferred to the caller.
+///
+/// `induce` runs before every read, so a slot that clears on read and a slot
+/// that clones on read are measured on the same terms. `expected` is the
+/// message the export must report once `induce` has run.
+fn assert_result_is_transferred(
+    symbol: &str,
+    induce: &dyn Fn(),
+    expected: &str,
+    call: unsafe extern "C" fn() -> *mut c_char,
+) {
+    induce();
+    // SAFETY: the export takes no arguments and returns a header-aware Hew
+    // string allocated by `str_to_malloc`.
+    let first = unsafe { call() };
+    induce();
+    // SAFETY: as above.
+    let second = unsafe { call() };
+    assert!(
+        !first.is_null() && !second.is_null(),
+        "{symbol}: expected a message"
+    );
+
+    // R1 — both results are live at once, so a shared address would mean the
+    // export hands out a borrow into storage it keeps.
+    assert_ne!(
+        first, second,
+        "{symbol}: two live results share an address, so the export does not \
+         allocate a fresh buffer per call"
+    );
+
+    // R2 — the caller holds the sole owner of each result.
+    for (label, ptr) in [("first", first), ("second", second)] {
+        // SAFETY: the pointer is a live header-aware Hew string from the export.
+        let unique = unsafe { cstring_ensure_unique(ptr) };
+        assert_eq!(
+            unique, ptr,
+            "{symbol}: the {label} result was not solely owned at handoff \
+             (rc > 1), so the caller's release would not balance it"
+        );
+    }
+
+    // SAFETY: `first` is a live header-aware Hew string.
+    let text = unsafe { CStr::from_ptr(first) }.to_owned();
+    assert_eq!(
+        text.to_str().expect("the oracle message is UTF-8"),
+        expected,
+        "{symbol}: the export must report the message its slot holds"
+    );
+
+    // R3 — release both through the release symbol the contract names
+    // (`hew_string_drop` is `free_cstring` with the static-literal skip in
+    // front), then read again: the slot must be untouched by the free.
+    // SAFETY: each pointer is live and solely owned (R2), so this is its
+    // balancing release.
+    unsafe {
+        free_cstring(first);
+        free_cstring(second);
+    }
+    induce();
+    // SAFETY: as above.
+    let third = unsafe { call() };
+    assert!(
+        !third.is_null(),
+        "{symbol}: the slot did not survive the release"
+    );
+    // SAFETY: `third` is a live header-aware Hew string.
+    let after = unsafe { CStr::from_ptr(third) }.to_owned();
+    assert_eq!(
+        text, after,
+        "{symbol}: the message changed after the caller released an earlier \
+         result, so the export retained a pointer into the freed buffer"
+    );
+    // SAFETY: `third` is live and solely owned.
+    unsafe { free_cstring(third) };
+}
+
+/// Probe an export whose message lives in the shared
+/// [`hew_runtime::parse_error_slot`] storage.
+fn assert_slot_backed_result_is_transferred(
+    symbol: &str,
+    slot: ErrorSlotKind,
+    call: unsafe extern "C" fn() -> *mut c_char,
+) {
+    let message = format!("hew-2828-oracle: {symbol}");
+    let induce = || set_error(slot, message.clone());
+    assert_result_is_transferred(symbol, &induce, &message, call);
+}
+
+#[test]
+fn tls_last_error_result_is_transferred() {
+    assert_slot_backed_result_is_transferred(
+        "hew_tls_last_error",
+        ErrorSlotKind::Tls,
+        crate::tls::hew_tls_last_error,
+    );
+}
+
+#[test]
+fn smtp_last_error_result_is_transferred() {
+    assert_slot_backed_result_is_transferred(
+        "hew_smtp_last_error",
+        ErrorSlotKind::Smtp,
+        crate::smtp::hew_smtp_last_error,
+    );
+}
+
+#[test]
+fn datetime_last_error_result_is_transferred() {
+    assert_slot_backed_result_is_transferred(
+        "hew_datetime_last_error",
+        ErrorSlotKind::Datetime,
+        crate::time::datetime::hew_datetime_last_error,
+    );
+}
+
+#[test]
+fn json_last_error_result_is_transferred() {
+    assert_slot_backed_result_is_transferred(
+        "hew_json_last_error",
+        ErrorSlotKind::Json,
+        crate::json::hew_json_last_error,
+    );
+}
+
+#[test]
+fn toml_last_error_result_is_transferred() {
+    assert_slot_backed_result_is_transferred(
+        "hew_toml_last_error",
+        ErrorSlotKind::Toml,
+        crate::toml::hew_toml_last_error,
+    );
+}
+
+#[test]
+fn yaml_last_error_result_is_transferred() {
+    assert_slot_backed_result_is_transferred(
+        "hew_yaml_last_error",
+        ErrorSlotKind::Yaml,
+        crate::yaml::hew_yaml_last_error,
+    );
+}
+
+#[test]
+fn quic_last_error_result_is_transferred() {
+    assert_slot_backed_result_is_transferred(
+        "hew_quic_last_error",
+        ErrorSlotKind::Quic,
+        crate::quic::hew_quic_last_error,
+    );
+}
+
+/// `cron` keeps its message in a module-private thread-local, so the inducer is
+/// the public parse entry point rejecting a null expression.
+#[test]
+fn cron_last_error_result_is_transferred() {
+    let induce = || {
+        // SAFETY: a null expression is an accepted input; the export records
+        // the error and returns null without dereferencing it.
+        unsafe { crate::time::cron::hew_cron_parse(std::ptr::null()) };
+    };
+    assert_result_is_transferred(
+        "hew_cron_last_error",
+        &induce,
+        "invalid cron expression: null pointer or invalid UTF-8",
+        crate::time::cron::hew_cron_last_error,
+    );
+}
+
+/// `xml` keeps its message in a module-private thread-local; same shape.
+#[test]
+fn xml_last_error_result_is_transferred() {
+    let induce = || {
+        // SAFETY: a null document is an accepted input; the export records the
+        // error and returns null without dereferencing it.
+        unsafe { crate::xml::hew_xml_parse(std::ptr::null()) };
+    };
+    assert_result_is_transferred(
+        "hew_xml_last_error",
+        &induce,
+        "xml: invalid input: null pointer",
+        crate::xml::hew_xml_last_error,
+    );
+}
+
+/// `msgpack` keeps its message in a module-private thread-local; same shape.
+#[test]
+fn msgpack_last_error_result_is_transferred() {
+    let induce = || {
+        // SAFETY: a null triple is an accepted input; the export records the
+        // error and returns an empty string without dereferencing it.
+        let empty = unsafe { crate::msgpack::hew_msgpack_to_json_hew(std::ptr::null()) };
+        // SAFETY: `empty` is a live, solely-owned header-aware Hew string.
+        unsafe { free_cstring(empty) };
+    };
+    assert_result_is_transferred(
+        "hew_msgpack_last_error",
+        &induce,
+        "msgpack: invalid input buffer",
+        crate::msgpack::hew_msgpack_last_error,
+    );
+}
+
+/// `http` has no reachable non-empty path from outside its own module (see the
+/// module docs), so it is probed on the empty-message path — the same
+/// `str_to_malloc` call, the same buffer, the same three probes.
+#[test]
+fn http_last_error_result_is_transferred() {
+    assert_result_is_transferred(
+        "hew_http_last_error",
+        &|| {},
+        "",
+        crate::http::client::hew_http_last_error,
+    );
+}

--- a/hew-std/src/lib.rs
+++ b/hew-std/src/lib.rs
@@ -89,6 +89,13 @@ pub mod ipnet;
 // scheduler slot instead of racing on independent per-module locks.
 #[cfg(all(test, not(target_family = "wasm")))]
 mod net_error_slot_test_support;
+// The hew-std half of the `*_last_error` result-retention oracle (#2828) —
+// establishes, per symbol, that the returned buffer is transferred to the
+// caller rather than borrowed from storage this crate keeps. The hew-runtime
+// half and the counterfactual live in
+// `hew-runtime/tests/last_error_result_retention.rs`.
+#[cfg(all(test, not(target_family = "wasm")))]
+mod last_error_retention;
 #[cfg(not(target_family = "wasm"))]
 pub mod quic;
 #[cfg(not(target_family = "wasm"))]

--- a/hew-std/src/tls.rs
+++ b/hew-std/src/tls.rs
@@ -1793,11 +1793,22 @@ mod tests {
     /// True when `triple` is the SOLE owner of its allocation: a push that
     /// cannot grow the buffer moves the data pointer only by forking a shared
     /// one. Mutates the copy it is given, never the caller's triple.
+    ///
+    /// The probe is OWNER-COUNT NEUTRAL, and has to be, because callers keep
+    /// using the buffer afterwards. That is not free: on the shared reading
+    /// `hew_bytes_push` reaches `ensure_unique`, which forks a private copy and
+    /// *releases one reference to the original on the pusher's behalf* — the
+    /// pusher's triple now points at the fork, so it has no use for the old
+    /// reference. The probe kept the caller's triple pointing at the original,
+    /// so it must put that reference back; otherwise the caller's later release
+    /// is one too many and drops the buffer to zero early, and every subsequent
+    /// release is a write into freed memory. See hew-lang/hew#2833.
     fn bytes_owner_is_sole(triple: BytesTriple) -> bool {
         assert!(
-            !triple.ptr.is_null() && triple.len < 16,
-            "the probe needs a non-empty buffer below MIN_CAPACITY so a push \
-             cannot grow it: len={}",
+            !triple.ptr.is_null() && triple.offset == 0 && triple.len < 16,
+            "the probe needs a non-empty unsliced buffer below MIN_CAPACITY so \
+             a push cannot grow it: offset={} len={}",
+            triple.offset,
             triple.len
         );
         let mut probe = triple;
@@ -1805,9 +1816,15 @@ mod tests {
         unsafe { hew_bytes_push(&mut probe, b'!') };
         let unmoved = probe.ptr == triple.ptr;
         if !unmoved {
-            // The fork produced a second allocation; release it.
-            // SAFETY: the forked buffer is ours and released exactly once.
-            unsafe { hew_bytes_drop(probe.ptr) };
+            // Shared: restore the reference `ensure_unique` consumed from the
+            // caller's buffer, then release the fork it handed back. Both
+            // allocations end this call with the owner count they arrived with.
+            // SAFETY: `triple.ptr` is still live — the caller holds a
+            // reference to it — and the forked buffer is ours to release once.
+            unsafe {
+                hew_bytes_clone_ref(triple.ptr);
+                hew_bytes_drop(probe.ptr);
+            }
         }
         unmoved
     }
@@ -1864,14 +1881,16 @@ mod tests {
 
         // R2's counterfactual: with a second reference outstanding the same
         // probe reports NOT sole, so it is reading the owner count rather than
-        // reporting a constant.
+        // reporting a constant. `bytes_owner_is_sole` is owner-count neutral,
+        // so this reference is still outstanding when the probe returns.
         // SAFETY: `a.data.ptr` is a live bytes allocation.
         unsafe { hew_bytes_clone_ref(a.data.ptr) };
         assert!(
             !bytes_owner_is_sole(a.data),
             "the sole-ownership probe must be able to say no, or it proves nothing"
         );
-        // SAFETY: releases the reference taken immediately above.
+        // SAFETY: releases the reference taken immediately above, leaving the
+        // caller's own reference from `hew_tls_read_result` for R3.
         unsafe { hew_bytes_drop(a.data.ptr) };
 
         // R3 — release both results; the stream keeps working, so it kept no

--- a/hew-std/src/tls.rs
+++ b/hew-std/src/tls.rs
@@ -868,6 +868,7 @@ pub unsafe extern "C" fn hew_tls_attach(
 mod tests {
     use super::*;
     use hew_cabi::cabi::free_cstring;
+    use hew_runtime::bytes::{hew_bytes_clone_ref, hew_bytes_drop, hew_bytes_push};
     use hew_runtime::{actor, scheduler, transport};
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
     use std::cell::Cell;
@@ -1744,6 +1745,158 @@ mod tests {
         // SAFETY: `actor` is stopped above; free reclaims it exactly once.
         assert_eq!(unsafe { actor::hew_actor_free(actor) }, 0);
         unregister_tls_actor_events(test_id);
+    }
+
+    // ── Result retention: who owns the buffer hew_tls_read_result returns ────
+    //
+    // hew-lang/hew#2828. The compiler may only mint a caller-side release for
+    // an extern result once the callee is known to keep no pointer into it, and
+    // "the audit says fresh" is a proxy for that, not the answer. This measures
+    // it at the real allocation site over a real handshake, and the answer is
+    // recorded as `result-retention = "transferred"` on the symbol's
+    // [[ownership.contracts]] row in scripts/jit-symbol-classification.toml.
+    //
+    // Three probes, all on results obtained from a live stream:
+    //
+    //   R1  two results held live at once occupy DISTINCT allocations. A callee
+    //       handing back a pointer into storage it keeps cannot satisfy this.
+    //   R2  each result is SOLELY owned. `hew_bytes_push` forks a shared buffer
+    //       (refcount > 1) and writes in place otherwise, so "the data pointer
+    //       did not move" reads the runtime's own live-owner count at the real
+    //       allocation. The payload is shorter than MIN_CAPACITY, so a push can
+    //       never grow the buffer and the address can only move by forking.
+    //   R3  releasing both results leaves the stream fully usable, so nothing
+    //       the callee kept pointed into what the caller freed.
+    //
+    // R2's counterfactual is asserted inline: an explicitly retained second
+    // reference DOES move the pointer, which is what makes the probe evidence
+    // rather than a restatement of allocator behaviour.
+
+    /// Read from `stream_ptr` until a non-empty chunk arrives or the deadline
+    /// passes. A TLS record may not have been decrypted yet on the first call.
+    fn read_result_until_data(stream_ptr: *mut HewTlsStream, size: c_int) -> HewTlsReadResult {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            // SAFETY: `stream_ptr` is a live stream owned by the caller.
+            let result = unsafe { hew_tls_read_result(stream_ptr, size) };
+            if result.data.len > 0 {
+                return result;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "expected decrypted bytes from the loopback server within 5s"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    /// True when `triple` is the SOLE owner of its allocation: a push that
+    /// cannot grow the buffer moves the data pointer only by forking a shared
+    /// one. Mutates the copy it is given, never the caller's triple.
+    fn bytes_owner_is_sole(triple: BytesTriple) -> bool {
+        assert!(
+            !triple.ptr.is_null() && triple.len < 16,
+            "the probe needs a non-empty buffer below MIN_CAPACITY so a push \
+             cannot grow it: len={}",
+            triple.len
+        );
+        let mut probe = triple;
+        // SAFETY: `probe` is a valid triple; push is refcount-aware.
+        unsafe { hew_bytes_push(&mut probe, b'!') };
+        let unmoved = probe.ptr == triple.ptr;
+        if !unmoved {
+            // The fork produced a second allocation; release it.
+            // SAFETY: the forked buffer is ours and released exactly once.
+            unsafe { hew_bytes_drop(probe.ptr) };
+        }
+        unmoved
+    }
+
+    #[test]
+    fn read_result_transfers_the_decrypted_buffer() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let (server_config, cert_der) = self_signed_server_pair();
+
+        // Two records, each shorter than MIN_CAPACITY so the R2 push cannot
+        // grow the buffer, separated so the client sees them as two reads.
+        let first = b"alpha";
+        let second = b"bravo";
+        let server = thread::spawn(move || {
+            let (tcp, _) = listener.accept().expect("server accept");
+            let conn = rustls::ServerConnection::new(server_config).expect("server connection");
+            let mut tls = rustls::StreamOwned::new(conn, tcp);
+            tls.write_all(first).expect("server write 1");
+            tls.flush().expect("server flush 1");
+            thread::sleep(Duration::from_millis(100));
+            tls.write_all(second).expect("server write 2");
+            tls.flush().expect("server flush 2");
+            thread::sleep(Duration::from_millis(300));
+            tls.conn.send_close_notify();
+            let _ = tls.flush();
+            drop(tls);
+        });
+
+        let client = client_stream_trusting(addr, cert_der);
+        let stream_ptr = HewTlsStream::from_stream(client);
+
+        let a = read_result_until_data(stream_ptr, 8);
+        let b = read_result_until_data(stream_ptr, 8);
+        assert_eq!(a.status, TLS_STATUS_SUCCESS);
+        assert_eq!(b.status, TLS_STATUS_SUCCESS);
+
+        // R1 — two live results, two allocations.
+        assert_ne!(
+            a.data.ptr, b.data.ptr,
+            "two results held live at once must occupy distinct allocations; a \
+             shared address would mean the stream handed back storage it keeps"
+        );
+
+        // R2 — each is solely owned, so exactly one release balances each.
+        assert!(
+            bytes_owner_is_sole(a.data),
+            "the first result must be solely owned by the caller"
+        );
+        assert!(
+            bytes_owner_is_sole(b.data),
+            "the second result must be solely owned by the caller"
+        );
+
+        // R2's counterfactual: with a second reference outstanding the same
+        // probe reports NOT sole, so it is reading the owner count rather than
+        // reporting a constant.
+        // SAFETY: `a.data.ptr` is a live bytes allocation.
+        unsafe { hew_bytes_clone_ref(a.data.ptr) };
+        assert!(
+            !bytes_owner_is_sole(a.data),
+            "the sole-ownership probe must be able to say no, or it proves nothing"
+        );
+        // SAFETY: releases the reference taken immediately above.
+        unsafe { hew_bytes_drop(a.data.ptr) };
+
+        // R3 — release both results; the stream keeps working, so it kept no
+        // pointer into what the caller just freed.
+        // SAFETY: each result is released exactly once, by the release the
+        // audited contract names.
+        unsafe {
+            hew_bytes_drop(a.data.ptr);
+            hew_bytes_drop(b.data.ptr);
+        }
+        // SAFETY: `stream_ptr` is still live; this is a normal read.
+        let after = unsafe { hew_tls_read_result(stream_ptr, 8) };
+        assert_eq!(
+            after.status, TLS_STATUS_SUCCESS,
+            "the stream must remain usable after the caller released every \
+             buffer it was handed"
+        );
+        if !after.data.ptr.is_null() {
+            // SAFETY: a third result is ours to release on the same terms.
+            unsafe { hew_bytes_drop(after.data.ptr) };
+        }
+
+        // SAFETY: `stream_ptr` came from `from_stream` and is freed once.
+        unsafe { hew_tls_close(stream_ptr) };
+        server.join().expect("server thread");
     }
 
     #[test]

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -2,4 +2,4 @@
 #
 # This value must exactly match the verifier's computed count. Any classification
 # or contract change that changes the count must deliberately update this ratchet.
-unclassified = 831
+unclassified = 830

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -12,6 +12,7 @@
 #   params = ["borrow" | "consume" | "retain", ...]
 #   release-symbol = "<hew_* release function or type-directed drop thunk>" | ""
 #   discharge-depth = "shallow" | "deep" | "none"
+#   result-retention = "transferred"   (optional; owned results only)
 #
 # `fresh` transfers a newly owned allocation to the caller. `retained`
 # transfers an additional reference to an existing ref-counted allocation.
@@ -19,6 +20,34 @@
 # `none` carries no owned result. Fresh and retained results must name their
 # release symbol and whether that release recursively discharges children.
 # Borrowed and none results use an empty release symbol and depth "none".
+#
+# `result-retention` is the RETENTION axis and answers a DIFFERENT question
+# from `result`: does the callee keep a pointer into the allocation it just
+# returned? `fresh` says the allocation is new; it does not say the callee
+# stopped referring to it. A callee that allocates AND keeps the pointer — to
+# free it later, to overwrite it on the next call, or to hand the same address
+# back again — produces a value the caller must not release, and that
+# difference is invisible on the `result` axis alone. It is a real difference
+# inside this runtime: hew_process_last_error copies its thread-local message
+# into a fresh header-aware allocation and keeps nothing, while hew_last_error
+# hands back the interior of the CString the runtime stores and keeps
+# everything.
+#
+# "transferred" therefore means: the callee provably keeps no pointer into the
+# returned allocation, the caller holds the SOLE owner, and `release-symbol` is
+# the balancing release. It is the only spelling, it is only legal on an owned
+# result, and it is the ONLY thing that licenses the compiler to mint a
+# caller-side release for a pointer-bearing extern result
+# (hew_mir::return_provenance::build_extern_contract_table).
+#
+# ABSENCE is the fail-closed default and means the question has not been
+# answered for that symbol — no mint, which costs a leak rather than a double
+# free. A row may claim "transferred" only once an executable oracle has
+# established it for that symbol by measuring the runtime's actual retention
+# behaviour: distinct addresses for two live results, refcount 1 at handoff,
+# and the callee's own state surviving the caller's release. Those oracles are
+# hew-runtime/tests/last_error_result_retention.rs and
+# hew-std/src/last_error_retention.rs (hew-lang/hew#2828).
 #
 # Three-tier model (rationale: Option A chosen over Option B for substrate
 # clarity — the tier boundary is a compile-time contract, not just a doc claim):
@@ -1937,6 +1966,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 # hew-std/src/toml.rs:109-123 allocates a string value copy.
 [[ownership.contracts]]
@@ -2514,6 +2544,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_stream_last_error_kind"
@@ -2860,12 +2891,29 @@ params = ["borrow"]
 release-symbol = ""
 discharge-depth = "none"
 
+# hew_last_error (hew-runtime/src/lib.rs) is the slot hew_process_last_error
+# reads, and it is the member of the *_last_error family whose answer is the
+# OTHER one: it returns `LAST_ERROR.with(|e| s.as_ptr())` — the interior of the
+# thread-local CString the runtime keeps — so the pointer is valid only until
+# the next error mutation and is never the caller's to release. Two consecutive
+# calls hand back the SAME address, which is what
+# hew-runtime/tests/last_error_result_retention.rs measures. Recorded as a
+# borrow so the authority reads the answer instead of inferring one from the
+# name shape; `borrowed` is refused by every mint clause by construction.
+[[ownership.contracts]]
+symbol = "hew_last_error"
+result = "borrowed"
+params = []
+release-symbol = ""
+discharge-depth = "none"
+
 [[ownership.contracts]]
 symbol = "hew_process_last_error"
 result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_process_result_exit_code"
@@ -3414,6 +3462,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_msgpack_to_json_hew"
@@ -3594,6 +3643,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_datetime_minute"
@@ -3674,6 +3724,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_cron_next_hew"
@@ -3888,6 +3939,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_http_request_hew"
@@ -4086,13 +4138,20 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
+# The `data` field is a fresh refcount-1 bytes allocation copied out of the
+# decrypted read buffer (`read_tls_vec` -> `hew_bytes_from_static`); the stream
+# keeps no pointer into it, which
+# hew-std/src/tls.rs::read_result_transfers_the_decrypted_buffer measures over a
+# real loopback handshake.
 [[ownership.contracts]]
 symbol = "hew_tls_read_result"
 result = "fresh"
 params = ["borrow", "borrow"]
 release-symbol = "hew_bytes_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_tls_write_result"
@@ -4130,6 +4189,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_smtp_send"
@@ -4343,6 +4403,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_quic_new_client"
@@ -4600,6 +4661,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_json_object_keys"
@@ -4965,6 +5027,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_yaml_object_new"
@@ -5088,6 +5151,7 @@ result = "fresh"
 params = []
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+result-retention = "transferred"
 
 [[ownership.contracts]]
 symbol = "hew_xml_parse"

--- a/scripts/verify-ffi-symbols.py
+++ b/scripts/verify-ffi-symbols.py
@@ -46,6 +46,14 @@ SOURCE_ENCODING = "utf-8"
 OWNERSHIP_RESULTS = {"fresh", "retained", "borrowed", "none"}
 PARAM_OWNERSHIP = {"borrow", "consume", "retain"}
 DISCHARGE_DEPTHS = {"shallow", "deep", "none"}
+# The RETENTION axis: whether the callee provably keeps no pointer into the
+# allocation it returned. Only "transferred" is spellable, and only on an
+# owned result; the axis is absent by default because absent is the
+# fail-closed answer (no caller-side release is minted from an unanswered
+# row). A row may only claim "transferred" once an executable oracle has
+# established it for that symbol -- see hew-runtime/tests/
+# last_error_result_retention.rs and hew-std/src/last_error_retention.rs.
+RESULT_RETENTIONS = {"transferred"}
 
 # Exact function names that are codegen-internal (intercepted/rewritten, never linked).
 # For example, hew_log_debug is rewritten to hew_log_emit with a level argument.
@@ -399,6 +407,19 @@ def validate_ownership_contracts(
                 f"{location} borrowed/none result must use empty release-symbol "
                 'and discharge-depth = "none"'
             )
+
+        if "result-retention" in contract:
+            retention = contract.get("result-retention")
+            if retention not in RESULT_RETENTIONS:
+                errors.append(
+                    f"{location} result-retention must be one of "
+                    f"{sorted(RESULT_RETENTIONS)} when present"
+                )
+            elif result not in {"fresh", "retained"}:
+                errors.append(
+                    f"{location} result-retention is meaningless without an "
+                    "owned result"
+                )
 
     # The arity check above only bites for a symbol present in fn_param_counts.
     # That map is built by scanning Rust sources with a regex; if the sources


### PR DESCRIPTION
Closes #2828. Stacked on #2820.

#2820 declined to mint a caller-side owner for `*_last_error` results, which was
the safe direction and the leaking one: `std/process.hew`'s error path lost its
string, and three shipped programs sat below the release baseline.

The question that settles it is whether the runtime hands out a buffer the caller
must free or a pointer it keeps. That is a property of each symbol, so it was
measured per symbol rather than inferred from the audited row.

**The family is not uniform.** Fourteen symbols transfer: each allocates a copy
of the slot and retains no pointer. `hew_last_error` borrows — it returns the
interior pointer of a thread-local `CString` the runtime keeps and overwrites,
and two consecutive calls return the same address. Minting for that one would be
the double free the authority exists to prevent. Three QUIC symbols need a live
endpoint to reach their message; they are deliberately unmarked and fail closed.

The answer lives in a `result-retention` axis on `[[ownership.contracts]]`, with
each row naming the oracle that established it. Absence means not established
means no mint, so a new symbol leaks rather than double-frees until someone
measures it.

Two compiler blockers made the mint unreachable regardless of the contract:
`build_extern_contract_table` now mints only when retention is measured and the
audited release matches what the type-directed drop plan emits for the declared
return type, and `PrecisePolicy::classify_call` no longer short-circuits every
extern to opaque, which had made that clause inert.

`ACCOUNTED_BELOW_BASELINE` is empty. All three cells are back at baseline and
`std/process.hew::run` gains the release it was losing.

One correction to #2820's stated reasons: the tls cell was misattributed.
`net.NetError`'s variants carry `i64`, so `hew_tls_last_error` was never in that
path — the blocker was `hew_tls_read_result`'s `bytes` payload defeating the
scrutinee mint. The smtp and cron attributions were right.