### PR TITLE
fix(ci): inspect generic function bodies for lane roots

### DIFF
--- a/scripts/sys-lane-closure.py
+++ b/scripts/sys-lane-closure.py
@@ -96,10 +96,12 @@ SYSTEM_LANE_TOKENS = (
     "Origin::Sys",
 )
 
-# Names that are Rust/std/libc plumbing rather than runtime functions. Excluded
-# from the defined-function set so a method call like `.len()` cannot fuse two
-# unrelated types together through a shared method name.
-GRAPH_NAME_DENYLIST = {
+# Names that are Rust/std/libc plumbing rather than unambiguous runtime
+# functions. Exclude them ONLY as call targets so a method call like `.len()`
+# cannot fuse two unrelated types through a shared method name. Their own
+# bodies remain root candidates: a `drop` or `default` body that directly
+# touches system-lane state is a finding, not a graph edge.
+GRAPH_EDGE_NAME_DENYLIST = {
     "new",
     "default",
     "drop",
@@ -473,7 +475,7 @@ def build_graph(scan_dirs: list[Path] | None = None) -> Graph:
             "cannot report a verdict:\n  " + "\n  ".join(unparseable)
         )
 
-    defined = graph.defined() - GRAPH_NAME_DENYLIST
+    defined = graph.defined() - GRAPH_EDGE_NAME_DENYLIST
 
     # Pass 2: call edges. A callee is any defined name appearing in call
     # position (`name(`, `name::<T>(`, `.name(`, `Type::name(`) inside a body.
@@ -518,7 +520,7 @@ def find_roots(graph: Graph, non_roots: dict[str, str]) -> dict[str, list[str]]:
     """Functions whose OWN body touches the system-lane state set."""
     roots: dict[str, list[str]] = {}
     for name, bodies in graph.bodies.items():
-        if name in non_roots or name in GRAPH_NAME_DENYLIST:
+        if name in non_roots:
             continue
         hits: set[str] = set()
         for body in bodies:

--- a/scripts/tests/test_sys_lane_closure.py
+++ b/scripts/tests/test_sys_lane_closure.py
@@ -203,6 +203,52 @@ CFG_FIELD_TOML = """
     internal = []
 """
 
+# Generic method names such as `drop` are too ambiguous to form call-graph
+# edges: `.drop()` may name any one of many unrelated implementations. That
+# does not make a body named `drop` invisible when the body ITSELF touches
+# system-lane state.
+DENYLISTED_ROOT_CRATE = """
+    struct LaneOwner {
+        sys_queue: Queue,
+    }
+
+    impl Drop for LaneOwner {
+        fn drop(&mut self) {
+            self.sys_queue.drain_and_free(None);
+        }
+    }
+"""
+
+DENYLISTED_ROOT_TOML = """
+    stable = ["drop"]
+    stable-stdlib = []
+    codegen-stable = []
+    internal = []
+"""
+
+DENYLISTED_EDGE_CRATE = """
+    pub unsafe extern "C" fn hew_toy_drop_wrapper(value: &mut Ordinary) {
+        value.drop();
+    }
+
+    struct LaneOwner {
+        sys_queue: Queue,
+    }
+
+    impl Drop for LaneOwner {
+        fn drop(&mut self) {
+            self.sys_queue.drain_and_free(None);
+        }
+    }
+"""
+
+DENYLISTED_EDGE_TOML = """
+    stable = ["hew_toy_drop_wrapper"]
+    stable-stdlib = []
+    codegen-stable = []
+    internal = []
+"""
+
 
 def check_parser_fails_closed(root: Path) -> None:
     """F1: an unparseable body is a hard error, never a skip."""
@@ -404,6 +450,36 @@ def main() -> int:
         # 10. The parser fails CLOSED: valid Rust it cannot balance is a hard
         #     error naming the symbol, and braces that are data are read as data.
         check_parser_fails_closed(root)
+
+        # 11. The generic-name denylist is ONLY a call-edge rule. A denylisted
+        #     body that directly names system-lane state is still a root and, if
+        #     stable, must fail with a direct witness.
+        tree = root / "denylisted-root" / "src"
+        write(tree, "lib.rs", DENYLISTED_ROOT_CRATE)
+        toml = root / "denylisted-root.toml"
+        toml.write_text(textwrap.dedent(DENYLISTED_ROOT_TOML), encoding="utf-8")
+        code, output = run_gate(tree, toml)
+        check(
+            "a denylisted body that touches lane state is still a root",
+            code == 1 and "drop: drop" in output and "[sys_queue at " in output,
+            output,
+        )
+
+        # The body above becoming visible must not reconnect every generic
+        # `.drop()` call to it. This stable wrapper calls an unrelated method;
+        # the gate sees the `drop` root but does not fuse the wrapper to it.
+        tree = root / "denylisted-edge" / "src"
+        write(tree, "lib.rs", DENYLISTED_EDGE_CRATE)
+        toml = root / "denylisted-edge.toml"
+        toml.write_text(textwrap.dedent(DENYLISTED_EDGE_TOML), encoding="utf-8")
+        code, output = run_gate(tree, toml)
+        check(
+            "generic method calls remain excluded from call-edge fusion",
+            code == 0
+            and "1 roots, 1 reaching functions" in output
+            and "0 stable violations" in output,
+            output,
+        )
 
     if FAILURES:
         print(f"\n{len(FAILURES)} check(s) failed", file=sys.stderr)


### PR DESCRIPTION
Closes #2832.

The system-lane closure gate now treats generic function names such as `drop`
as ambiguous only when constructing call edges. Their own bodies remain
eligible roots, so an `impl Drop::drop` that directly touches `sys_queue` or
another system-lane token cannot disappear from the report.

The regression suite proves both sides of the boundary:

- a stable denylisted body that directly touches lane state fails with its
  concrete root witness;
- an unrelated generic `.drop()` call remains excluded from call-edge fusion.

Verification:

- `make verify-sys-lane-closure` — 26 checks pass; the production tree remains
  at 24 roots, 58 reaching functions, 17 authenticated edges, and zero stable
  violations;
- the pre-fix implementation turns both new checks falsely green with zero
  roots;
- `make lint` and `git diff --check` pass;
- independent Claude Sonnet 5 review: ACCEPT.
