### PR TITLE
fix(runtime): close scheduler parker lost wakes

### DIFF
--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -377,6 +377,10 @@ struct Parker {
     /// Published under `mutex` before the final queue probe and cleared under
     /// the same mutex after wake/timeout or a refused park.
     parked: AtomicBool,
+    /// Number of work-path notifications issued to this parker. Tests use this
+    /// to distinguish a real notification from a permitted spurious wake.
+    #[cfg(test)]
+    work_notifications: AtomicU64,
 }
 
 impl Parker {
@@ -403,6 +407,8 @@ impl Parker {
         if !self.parked.load(Ordering::SeqCst) {
             return false;
         }
+        #[cfg(test)]
+        self.work_notifications.fetch_add(1, Ordering::Relaxed);
         self.cond.notify_one();
         true
     }
@@ -509,6 +515,8 @@ pub extern "C" fn hew_sched_init() -> c_int {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
             parked: AtomicBool::new(false),
+            #[cfg(test)]
+            work_notifications: AtomicU64::new(0),
         })
         .collect();
 
@@ -3269,6 +3277,7 @@ pub(crate) fn worker_less_scheduler() -> Scheduler {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
             parked: AtomicBool::new(false),
+            work_notifications: AtomicU64::new(0),
         }],
         stealers: Vec::new(),
         worker_handles: PoisonSafe::new(Vec::new()),
@@ -3917,8 +3926,10 @@ mod tests {
     /// wait-registration gap must not be lost. The hook pins that exact gap:
     /// it enqueues first, then `sched_try_wake` observes that no worker has
     /// published a park yet. The fixed final probe sees the work and never
-    /// enters `wait_timeout`; omitting only that probe reproduces the old full
-    /// `PARK_TIMEOUT` delay.
+    /// enters `wait_timeout`; omitting only that probe enters the wait with the
+    /// work still stranded. A condvar may wake spuriously, so the negative
+    /// control also records real work-path notifications rather than requiring
+    /// an exact timeout result.
     #[test]
     fn pre_park_enqueue_and_wake_cannot_be_lost() {
         fn enqueue_in_final_probe_gap() {
@@ -3942,15 +3953,26 @@ mod tests {
             "the fixed path must leave the exact enqueued work for the next worker-loop probe"
         );
 
+        let notifications_before = sched.parkers[0].work_notifications.load(Ordering::Relaxed);
+        let counterfactual = park_worker(sched, 0, &local, false);
+        assert!(
+            matches!(
+                counterfactual,
+                WorkerParkOutcome::TimedOut | WorkerParkOutcome::Notified
+            ),
+            "counterfactual omission must enter the condvar wait instead of observing work; \
+             got {counterfactual:?}"
+        );
         assert_eq!(
-            park_worker(sched, 0, &local, false),
-            WorkerParkOutcome::TimedOut,
-            "counterfactual omission of the final queue probe must consume PARK_TIMEOUT"
+            sched.parkers[0].work_notifications.load(Ordering::Relaxed),
+            notifications_before,
+            "the pre-publication wake must not issue a real parker notification; \
+             a Notified outcome here can only be a permitted spurious wake"
         );
         assert_eq!(
             sched_guard.pop_global(),
             Some(ptr::dangling_mut::<HewActor>()),
-            "the counterfactual timeout must leave the runnable work stranded until the late probe"
+            "the counterfactual wait must leave the runnable work stranded until the late probe"
         );
     }
 
@@ -3970,11 +3992,13 @@ mod tests {
                     mutex: Mutex::new(()),
                     cond: Condvar::new(),
                     parked: AtomicBool::new(true),
+                    work_notifications: AtomicU64::new(0),
                 },
                 Parker {
                     mutex: Mutex::new(()),
                     cond: Condvar::new(),
                     parked: AtomicBool::new(false),
+                    work_notifications: AtomicU64::new(0),
                 },
             ],
             stealers: Vec::new(),
@@ -6365,6 +6389,7 @@ mod tests {
                 mutex: Mutex::new(()),
                 cond: Condvar::new(),
                 parked: AtomicBool::new(false),
+                work_notifications: AtomicU64::new(0),
             }],
             stealers: Vec::new(),
             worker_handles: PoisonSafe::new(Vec::new()),
@@ -6413,6 +6438,7 @@ mod tests {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
             parked: AtomicBool::new(false),
+            work_notifications: AtomicU64::new(0),
         };
         let sched = Scheduler {
             worker_count: 1,
@@ -6480,6 +6506,7 @@ mod tests {
                 mutex: Mutex::new(()),
                 cond: Condvar::new(),
                 parked: AtomicBool::new(false),
+                work_notifications: AtomicU64::new(0),
             }],
             stealers: Vec::new(),
             worker_handles: PoisonSafe::new(Vec::new()),
@@ -6824,6 +6851,7 @@ mod tests {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
             parked: AtomicBool::new(false),
+            work_notifications: AtomicU64::new(0),
         };
         // SAFETY: single-threaded test setup; the deque lives for the whole test.
         let (queued_work, queued_stealer) = unsafe { crate::deque::WorkDeque::new() };
@@ -6923,6 +6951,7 @@ mod tests {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
             parked: AtomicBool::new(false),
+            work_notifications: AtomicU64::new(0),
         };
         let sched = Scheduler {
             worker_count: 1,

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -41,7 +41,7 @@ use crate::lifetime::poison_safe::PoisonSafe;
 use crate::mailbox::{self, hew_mailbox_has_messages, hew_msg_node_free, HewMailbox};
 use crate::mailbox_header::{HewSysMsg, Origin};
 use crate::set_last_error;
-use crate::util::MutexExt;
+use crate::util::{CondvarExt, MutexExt};
 
 // ── Constants ───────────────────────────────────────────────────────────
 
@@ -95,6 +95,12 @@ static ACTIVATE_POST_CAS_HOOK: PoisonSafe<Option<fn(*mut HewActor)>> = PoisonSaf
 /// stranding the actor `Suspended` with a set marker.
 #[cfg(test)]
 static ENQUEUE_RESUME_CAS_FAIL_HOOK: PoisonSafe<Option<fn(*mut HewActor)>> = PoisonSafe::new(None);
+
+/// Fires after a worker's last ordinary queue probe and before it acquires its
+/// parker mutex. Tests enqueue and wake in this exact gap to pin the scheduler
+/// lost-wakeup interleaving deterministically.
+#[cfg(test)]
+static WORKER_PRE_PARK_HOOK: PoisonSafe<Option<fn()>> = PoisonSafe::new(None);
 
 #[cfg(any(test, debug_assertions))]
 static INJECT_NULL_LOCK_SEAT_ONCE: AtomicBool = AtomicBool::new(false);
@@ -342,6 +348,10 @@ pub(crate) struct Scheduler {
     global_queue: GlobalQueue,
     stealers: Vec<WorkStealer>,
     shutdown: AtomicBool,
+    /// Number of workers that published their parker state before the final
+    /// under-lock queue probe. Keeps the busy enqueue path from scanning every
+    /// parker when no worker can be waiting.
+    parked_workers: AtomicU64,
     /// Per-worker parking primitives. Each worker parks on its own
     /// `Mutex/Condvar` to avoid contention on a single global lock.
     parkers: Vec<Parker>,
@@ -364,6 +374,44 @@ impl Scheduler {
 struct Parker {
     mutex: Mutex<()>,
     cond: Condvar,
+    /// Published under `mutex` before the final queue probe and cleared under
+    /// the same mutex after wake/timeout or a refused park.
+    parked: AtomicBool,
+}
+
+impl Parker {
+    /// Notify one waiter while participating in the waiter's mutex protocol.
+    ///
+    /// The worker probes queues again while holding this mutex. A notifier that
+    /// wins the mutex first publishes its queue write before that probe; a
+    /// notifier that arrives second cannot notify until `Condvar::wait_timeout`
+    /// has atomically registered the waiter and released the mutex.
+    fn notify_one(&self) {
+        let _guard = self.mutex.lock_or_recover();
+        self.cond.notify_one();
+    }
+
+    /// Notify this parker only if its worker is still registered as parked.
+    ///
+    /// The optimistic atomic read avoids taking unrelated parker mutexes while
+    /// scanning. The under-lock recheck closes the timeout/return race.
+    fn notify_one_if_parked(&self) -> bool {
+        if !self.parked.load(Ordering::SeqCst) {
+            return false;
+        }
+        let _guard = self.mutex.lock_or_recover();
+        if !self.parked.load(Ordering::SeqCst) {
+            return false;
+        }
+        self.cond.notify_one();
+        true
+    }
+
+    #[cfg(test)]
+    fn notify_all(&self) {
+        let _guard = self.mutex.lock_or_recover();
+        self.cond.notify_all();
+    }
 }
 
 // SAFETY: All fields are either `Sync` (`AtomicBool`, `Mutex`, `Condvar`,
@@ -460,6 +508,7 @@ pub extern "C" fn hew_sched_init() -> c_int {
         .map(|_| Parker {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
+            parked: AtomicBool::new(false),
         })
         .collect();
 
@@ -468,6 +517,7 @@ pub extern "C" fn hew_sched_init() -> c_int {
         global_queue,
         stealers,
         shutdown: AtomicBool::new(false),
+        parked_workers: AtomicU64::new(0),
         parkers,
         worker_count,
     });
@@ -597,7 +647,7 @@ fn teardown_workers(
         let sched = unsafe { &*sched_ptr };
         sched.shutdown.store(true, Ordering::Release);
         for parker in &sched.parkers {
-            parker.cond.notify_one();
+            parker.notify_one();
         }
     }
 
@@ -1052,11 +1102,41 @@ pub fn sched_try_wake() {
             clippy::cast_possible_truncation,
             reason = "modulo by worker_count keeps result within usize range"
         )]
-        let idx =
+        let start =
             (WAKE_COUNTER.fetch_add(1, Ordering::Relaxed) % sched.worker_count as u64) as usize;
         crate::observe::record_scheduler_unpark();
-        sched.parkers[idx].cond.notify_one();
+        let _ = notify_parked_worker(sched, start);
     }
+}
+
+/// Notify exactly one published parker, scanning from `start`.
+///
+/// Returns the selected worker id for deterministic scheduler tests.
+fn notify_parked_worker(sched: &Scheduler, start: usize) -> Option<usize> {
+    // With no published waiter, a worker racing toward park will observe the
+    // completed queue push in its final under-lock probe. The SeqCst hint
+    // participates in the same total order as the queue position publication
+    // and final `is_empty` probe, so the notifier and worker cannot both miss
+    // each other's publication. Avoid a mutex acquisition (and an
+    // O(worker_count) scan) on that busy path.
+    if sched.parked_workers.load(Ordering::SeqCst) == 0 {
+        return None;
+    }
+
+    // Round-robin supplies the scan origin, not an unchecked wake target: a
+    // busy worker has no waiter, so keep looking for an actually parked worker
+    // instead of dropping the notification on the busy parker.
+    for offset in 0..sched.worker_count {
+        let idx = (start + offset) % sched.worker_count;
+        if sched.parkers[idx].notify_one_if_parked() {
+            return Some(idx);
+        }
+    }
+
+    // Every waiter counted by the initial hint returned or timed out during the
+    // scan. Those workers are already re-probing queues, so no notification is
+    // required.
+    None
 }
 
 // ── Worker loop ─────────────────────────────────────────────────────────
@@ -1192,14 +1272,66 @@ fn worker_loop(id: usize, rt: WorkerRuntimePtr, local: &WorkDeque) {
         // 4. Check if a signal-initiated shutdown needs to be started.
         crate::shutdown::check_signal_shutdown();
 
-        // 5. Park on per-worker condvar until notified or timeout.
-        let parker = &sched.parkers[id];
-        let guard = parker.mutex.lock_or_recover();
-        if sched.shutdown.load(Ordering::Acquire) {
+        // 5. Park on the per-worker condvar until notified or timeout. Queue
+        // state is probed once more under the same mutex wake notifiers acquire,
+        // closing the final-probe -> wait-registration lost-wakeup window.
+        if park_worker(sched, id, local, true) == WorkerParkOutcome::Shutdown {
             break;
         }
-        crate::observe::record_scheduler_park();
-        let _ = parker.cond.wait_timeout(guard, PARK_TIMEOUT);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkerParkOutcome {
+    Shutdown,
+    WorkAvailable,
+    Notified,
+    TimedOut,
+}
+
+/// Park worker `id`, synchronizing queue publication with wait registration.
+///
+/// `probe_queues` exists solely for the deterministic counterfactual test. The
+/// production caller always passes `true`, which constant-folds the branch.
+fn park_worker(
+    sched: &Scheduler,
+    id: usize,
+    local: &WorkDeque,
+    probe_queues: bool,
+) -> WorkerParkOutcome {
+    #[cfg(test)]
+    if let Some(hook) = WORKER_PRE_PARK_HOOK.access(|hook| *hook) {
+        hook();
+    }
+
+    let parker = &sched.parkers[id];
+    let guard = parker.mutex.lock_or_recover();
+    parker.parked.store(true, Ordering::SeqCst);
+    sched.parked_workers.fetch_add(1, Ordering::SeqCst);
+
+    if sched.shutdown.load(Ordering::Acquire) {
+        parker.parked.store(false, Ordering::SeqCst);
+        sched.parked_workers.fetch_sub(1, Ordering::SeqCst);
+        return WorkerParkOutcome::Shutdown;
+    }
+    if probe_queues
+        && (!local.is_empty()
+            || !sched.global_queue.is_empty()
+            || sched.stealers.iter().any(|stealer| !stealer.is_empty()))
+    {
+        parker.parked.store(false, Ordering::SeqCst);
+        sched.parked_workers.fetch_sub(1, Ordering::SeqCst);
+        return WorkerParkOutcome::WorkAvailable;
+    }
+
+    crate::observe::record_scheduler_park();
+    let (_guard, result) = parker.cond.wait_timeout_or_recover(guard, PARK_TIMEOUT);
+    parker.parked.store(false, Ordering::SeqCst);
+    sched.parked_workers.fetch_sub(1, Ordering::SeqCst);
+    if result.timed_out() {
+        WorkerParkOutcome::TimedOut
+    } else {
+        WorkerParkOutcome::Notified
     }
 }
 
@@ -3136,12 +3268,14 @@ pub(crate) fn worker_less_scheduler() -> Scheduler {
         parkers: vec![Parker {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
+            parked: AtomicBool::new(false),
         }],
         stealers: Vec::new(),
         worker_handles: PoisonSafe::new(Vec::new()),
         // SAFETY: single-threaded test setup with scheduler-owned queue state.
         global_queue: unsafe { crate::deque::GlobalQueue::new() },
         shutdown: AtomicBool::new(false),
+        parked_workers: AtomicU64::new(0),
     }
 }
 
@@ -3304,7 +3438,7 @@ impl Drop for NoWorkerSchedulerForTest {
             // ones so they re-check promptly rather than waiting out PARK_TIMEOUT.
             installed.scheduler.shutdown.store(true, Ordering::Release);
             for parker in &installed.scheduler.parkers {
-                parker.cond.notify_all();
+                parker.notify_all();
             }
             // Deterministic drain (replaces the old timing-based sleep): spin
             // until every worker that entered the loop body bound to this
@@ -3643,6 +3777,23 @@ mod tests {
         }
     }
 
+    struct WorkerPreParkHookGuard;
+
+    impl WorkerPreParkHookGuard {
+        fn install(hook: fn()) -> Self {
+            WORKER_PRE_PARK_HOOK.access(|h| {
+                assert!(h.replace(hook).is_none(), "test hook already installed");
+            });
+            Self
+        }
+    }
+
+    impl Drop for WorkerPreParkHookGuard {
+        fn drop(&mut self) {
+            WORKER_PRE_PARK_HOOK.access(|h| *h = None);
+        }
+    }
+
     /// Helper: build a minimal `HewActor` with sensible defaults.
     fn stub_actor() -> HewActor {
         HewActor {
@@ -3759,6 +3910,89 @@ mod tests {
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
             HewActorState::Idle as i32
+        );
+    }
+
+    /// #2830: a queue publication and wake in the worker's final-probe ->
+    /// wait-registration gap must not be lost. The hook pins that exact gap:
+    /// it enqueues first, then `sched_try_wake` observes that no worker has
+    /// published a park yet. The fixed final probe sees the work and never
+    /// enters `wait_timeout`; omitting only that probe reproduces the old full
+    /// `PARK_TIMEOUT` delay.
+    #[test]
+    fn pre_park_enqueue_and_wake_cannot_be_lost() {
+        fn enqueue_in_final_probe_gap() {
+            sched_enqueue(ptr::dangling_mut::<HewActor>());
+        }
+
+        let sched_guard = NoWorkerSchedulerForTest::install();
+        let _hook = WorkerPreParkHookGuard::install(enqueue_in_final_probe_gap);
+        // SAFETY: the local deque stores no pointers in this test.
+        let (local, _stealer) = unsafe { WorkDeque::new() };
+        let sched = get_scheduler().expect("test scheduler installed");
+
+        assert_eq!(
+            park_worker(sched, 0, &local, true),
+            WorkerParkOutcome::WorkAvailable,
+            "the mutex-synchronized final probe must observe runnable work without waiting"
+        );
+        assert_eq!(
+            sched_guard.pop_global(),
+            Some(ptr::dangling_mut::<HewActor>()),
+            "the fixed path must leave the exact enqueued work for the next worker-loop probe"
+        );
+
+        assert_eq!(
+            park_worker(sched, 0, &local, false),
+            WorkerParkOutcome::TimedOut,
+            "counterfactual omission of the final queue probe must consume PARK_TIMEOUT"
+        );
+        assert_eq!(
+            sched_guard.pop_global(),
+            Some(ptr::dangling_mut::<HewActor>()),
+            "the counterfactual timeout must leave the runnable work stranded until the late probe"
+        );
+    }
+
+    /// #2830 busy-target strand: round-robin may start at a worker that is
+    /// running user code while a peer is already parked. The old direct-index
+    /// notify had no waiter and left the peer asleep until `PARK_TIMEOUT`.
+    ///
+    /// Published parker state makes the selection deterministic: starting at
+    /// busy worker 1 skips it and notifies exactly parked worker 0. Returning
+    /// one id (rather than broadcasting) pins the no-thundering-herd contract.
+    #[test]
+    fn wake_scan_skips_busy_target_for_parked_peer() {
+        let sched = Scheduler {
+            worker_count: 2,
+            parkers: vec![
+                Parker {
+                    mutex: Mutex::new(()),
+                    cond: Condvar::new(),
+                    parked: AtomicBool::new(true),
+                },
+                Parker {
+                    mutex: Mutex::new(()),
+                    cond: Condvar::new(),
+                    parked: AtomicBool::new(false),
+                },
+            ],
+            stealers: Vec::new(),
+            worker_handles: PoisonSafe::new(Vec::new()),
+            // SAFETY: no values are stored in this local scheduler queue.
+            global_queue: unsafe { GlobalQueue::new() },
+            shutdown: AtomicBool::new(false),
+            parked_workers: AtomicU64::new(1),
+        };
+
+        assert!(
+            !sched.parkers[1].notify_one_if_parked(),
+            "counterfactual direct round-robin target has no waiter and drops the wake"
+        );
+        assert_eq!(
+            notify_parked_worker(&sched, 1),
+            Some(0),
+            "wake scan must skip the busy start worker and select exactly the parked peer"
         );
     }
 
@@ -6130,12 +6364,14 @@ mod tests {
             parkers: vec![Parker {
                 mutex: Mutex::new(()),
                 cond: Condvar::new(),
+                parked: AtomicBool::new(false),
             }],
             stealers: Vec::new(),
             worker_handles: PoisonSafe::new(Vec::new()),
             // SAFETY: single-threaded test setup with scheduler-owned queue state.
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
+            parked_workers: AtomicU64::new(0),
         };
         let _rt_ptr = install_scheduler_for_test(sched);
 
@@ -6176,6 +6412,7 @@ mod tests {
         let parker = Parker {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
+            parked: AtomicBool::new(false),
         };
         let sched = Scheduler {
             worker_count: 1,
@@ -6185,6 +6422,7 @@ mod tests {
             // SAFETY: no preconditions for GlobalQueue::new().
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
+            parked_workers: AtomicU64::new(0),
         };
         let _rt_ptr = install_scheduler_for_test(sched);
 
@@ -6241,12 +6479,14 @@ mod tests {
             parkers: vec![Parker {
                 mutex: Mutex::new(()),
                 cond: Condvar::new(),
+                parked: AtomicBool::new(false),
             }],
             stealers: Vec::new(),
             worker_handles: PoisonSafe::new(Vec::new()),
             // SAFETY: single-threaded test setup with scheduler-owned queue state.
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
+            parked_workers: AtomicU64::new(0),
         };
         let rt_ptr = install_scheduler_for_test(sched);
         // Stable borrow of the installed scheduler for this test's field reads;
@@ -6583,6 +6823,7 @@ mod tests {
         let parker = Parker {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
+            parked: AtomicBool::new(false),
         };
         // SAFETY: single-threaded test setup; the deque lives for the whole test.
         let (queued_work, queued_stealer) = unsafe { crate::deque::WorkDeque::new() };
@@ -6594,6 +6835,7 @@ mod tests {
             // SAFETY: single-threaded test setup with scheduler-owned queue state.
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
+            parked_workers: AtomicU64::new(0),
         };
         let rt_ptr = install_scheduler_for_test(sched);
         // Stable borrow of the installed scheduler; valid until teardown below.
@@ -6680,6 +6922,7 @@ mod tests {
         let parker = Parker {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
+            parked: AtomicBool::new(false),
         };
         let sched = Scheduler {
             worker_count: 1,
@@ -6689,6 +6932,7 @@ mod tests {
             // SAFETY: single-threaded test setup with scheduler-owned queue state.
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
+            parked_workers: AtomicU64::new(0),
         };
         let rt_ptr = install_scheduler_for_test(sched);
         // Stable borrow of the installed scheduler; valid until teardown below.


### PR DESCRIPTION
## Summary

- synchronize worker notifications with each parker mutex and recheck every runnable queue under that same lock before registering the condition-variable wait
- publish parked-worker state so round-robin wake selection skips busy workers and notifies exactly one real waiter
- add deterministic witnesses for both the final-probe registration gap and the busy-target/parked-peer wake loss

The old scheduler could drop a wake between a worker's last queue probe and its wait registration. It could also choose a busy round-robin target while another worker was parked. Both cases delayed runnable work until the 10 ms park timeout.

The parker mutex now orders queue publication against the final queue probe and wait registration. A parked-worker count keeps the all-busy enqueue path free of parker scans, while the wake path selects one published waiter without broadcasting.

## Validation

- scheduler tests: 48 passed
- `hew-runtime` library tests: 2230 passed
- strict `hew-runtime` Clippy: passed
- Rust formatting: passed
- deterministic omission control: consumes one full park timeout and leaves the exact pointer queued
- deterministic busy-target control: skips the busy target and selects exactly one parked peer

The WASM scheduler is unchanged.

Closes #2830.
