### PR TITLE
fix(cli): suppress REPL prompts for scripted input

### DIFF
--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1598,11 +1598,24 @@ fn run_wasm_eval_compiled(
     }
 }
 
+fn prompts_for_terminal_state(
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+) -> (&'static str, &'static str) {
+    if stdin_is_terminal && stdout_is_terminal {
+        ("hew> ", "... ")
+    } else {
+        ("", "")
+    }
+}
+
 /// Run the interactive REPL with a custom execution timeout.
 ///
 /// The startup banner and help line are printed only when both stdin and stdout
 /// are interactive terminals and `quiet` is `false`; piped/redirected stdin or
-/// stdout, or an explicit `quiet`, suppresses them.
+/// stdout, or an explicit `quiet`, suppresses them. Primary and continuation
+/// prompts also require both terminals, but remain visible for an interactive
+/// `--quiet` session.
 ///
 /// # Errors
 ///
@@ -1618,15 +1631,19 @@ pub fn run_interactive(
     let mut rl = rustyline::DefaultEditor::new()?;
     let mut session = ReplSession::with_timeout_and_target(timeout, target);
     session.set_jit_mode(jit);
+    let (primary_prompt, continuation_prompt) = prompts_for_terminal_state(
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+    );
+    let interactive_terminals = !primary_prompt.is_empty();
 
-    if !quiet && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+    if !quiet && interactive_terminals {
         println!("Hew REPL v{}", env!("CARGO_PKG_VERSION"));
         println!("Type :help for commands, :items to list definitions, :quit to exit.\n");
     }
 
     loop {
-        let prompt = "hew> ";
-        let line = match rl.readline(prompt) {
+        let line = match rl.readline(primary_prompt) {
             Ok(line) => line,
             Err(
                 rustyline::error::ReadlineError::Interrupted | rustyline::error::ReadlineError::Eof,
@@ -1646,7 +1663,7 @@ pub fn run_interactive(
             classify::input_completeness(&input),
             InputCompleteness::Incomplete
         ) {
-            match rl.readline("... ") {
+            match rl.readline(continuation_prompt) {
                 Ok(cont) => {
                     input.push('\n');
                     input.push_str(&cont);
@@ -1817,6 +1834,18 @@ fn pluralize_session_entry(count: usize, singular: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn repl_prompts_require_terminal_stdin_and_stdout() {
+        assert_eq!(
+            prompts_for_terminal_state(true, true),
+            ("hew> ", "... "),
+            "an interactive terminal must retain both REPL prompts"
+        );
+        assert_eq!(prompts_for_terminal_state(false, true), ("", ""));
+        assert_eq!(prompts_for_terminal_state(true, false), ("", ""));
+        assert_eq!(prompts_for_terminal_state(false, false), ("", ""));
+    }
 
     #[test]
     fn describe_runtime_failure_names_arithmetic_signal() {

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -709,7 +709,7 @@ fn statement_replay_repl_does_not_repeat_one_shot_statement() {
 
 #[cfg(unix)]
 #[test]
-fn repl_suppresses_startup_banner_when_only_stdout_is_a_terminal() {
+fn repl_suppresses_interactive_chrome_when_only_stdout_is_a_terminal() {
     let output = run_eval_with_piped_stdin_and_pty_stdout(&["eval"], ":quit\n");
 
     assert!(
@@ -727,6 +727,10 @@ fn repl_suppresses_startup_banner_when_only_stdout_is_a_terminal() {
     assert!(
         !stdout.contains("Type :help for commands"),
         "piped stdin must suppress the startup help even when stdout is a terminal; stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("hew>"),
+        "piped stdin must suppress the primary prompt even when stdout is a terminal; stdout: {stdout}"
     );
 }
 
@@ -2693,7 +2697,7 @@ fn eval_repl_piped_stdout_flushes_per_submission() {
 /// output. Regression test for the boilerplate leaking into piped/redirected
 /// consumption of `hew eval`.
 #[test]
-fn eval_repl_non_tty_suppresses_startup_boilerplate() {
+fn eval_repl_non_tty_suppresses_interactive_chrome() {
     require_codegen();
 
     let output = run_eval_with_stdin(&["eval"], ":quit\n");
@@ -2706,6 +2710,34 @@ fn eval_repl_non_tty_suppresses_startup_boilerplate() {
     assert!(
         !stdout.contains("Type :help"),
         "piped hew eval must not print the startup help line: {stdout}"
+    );
+    assert!(
+        !stdout.contains("hew>"),
+        "piped hew eval must not print the primary prompt: {stdout}"
+    );
+}
+
+/// Scripted multi-line input must not leak either interactive prompt into
+/// captured stdout. The continuation prompt needs the same terminal gate as
+/// the primary prompt.
+#[test]
+fn eval_repl_non_tty_suppresses_primary_and_continuation_prompts() {
+    require_codegen();
+
+    let output = run_eval_with_stdin(
+        &["eval"],
+        "fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\nadd(20, 22)\n:quit\n",
+    );
+
+    assert_repl_emits_line(&output, "42");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("hew>"),
+        "piped hew eval must not print the primary prompt: {stdout}"
+    );
+    assert!(
+        !stdout.contains("... "),
+        "piped hew eval must not print the continuation prompt: {stdout}"
     );
 }
 


### PR DESCRIPTION
## Summary

- emit primary and continuation REPL prompts only when both stdin and stdout are terminals
- preserve prompts for true interactive sessions, including `--quiet`
- cover fully piped input, piped stdin with terminal stdout, multiline continuation, and the complete terminal-state truth table

## Root cause

Rustyline renders the prompt passed to `readline` even for scripted input. The REPL suppressed its banner when stdin was piped but still supplied `hew> ` and `... `, so those prompts were concatenated with captured program output.

## Validation

- focused REPL tests: 34 passed
- `cargo nextest run --profile ci -p hew-cli`: 1,606 passed, none skipped
- `cargo clippy -p hew-cli --all-targets -- -D warnings`
- workspace `make lint`
- `cargo fmt --all -- --check`
- `git diff --check`
