### PR TITLE
test(runtime): restore Rust 1.96 OTel authorities

### DIFF
--- a/hew-runtime/src/otel.rs
+++ b/hew-runtime/src/otel.rs
@@ -167,10 +167,7 @@ pub fn maybe_start() {
     // Guard: if the profiler is also active and draining traces, refuse to
     // start to avoid silent event loss. The user must choose one path.
     #[cfg(feature = "profiler")]
-    if std::env::var("HEW_PPROF")
-        .map(|v| !v.trim().is_empty())
-        .unwrap_or(false)
-    {
+    if std::env::var("HEW_PPROF").is_ok_and(|v| !v.trim().is_empty()) {
         eprintln!(
             "[hew-otel] WARNING: both HEW_PPROF and HEW_OTEL_ENDPOINT are set. \
              Both consumers share the same trace-event ring buffer and will each \
@@ -494,10 +491,7 @@ fn post_spans(endpoint: &str, json: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
-    use crate::tracing::{SPAN_BEGIN, SPAN_END, SPAN_SPAWN};
 
     fn make_event(
         span_id: u64,
@@ -694,11 +688,11 @@ mod tests {
         let expected_end = (2_000_000_000_u64 + offset).to_string();
 
         assert!(
-            json.contains(&format!("\"{}\"", expected_start)),
+            json.contains(&format!("\"{expected_start}\"")),
             "start timestamp should have epoch offset applied"
         );
         assert!(
-            json.contains(&format!("\"{}\"", expected_end)),
+            json.contains(&format!("\"{expected_end}\"")),
             "end timestamp should have epoch offset applied"
         );
         assert!(is_valid_json(&json));

--- a/hew-runtime/tests/otel_integration.rs
+++ b/hew-runtime/tests/otel_integration.rs
@@ -133,7 +133,9 @@ impl Drop for ContextGuard {
     fn drop(&mut self) {
         let raw: *mut HewExecutionContext = self.context.as_mut();
         let restored = set_current_context(self.previous);
-        assert_eq!(restored, raw);
+        if !std::thread::panicking() {
+            assert_eq!(restored, raw);
+        }
     }
 }
 

--- a/hew-runtime/tests/otel_integration.rs
+++ b/hew-runtime/tests/otel_integration.rs
@@ -123,7 +123,7 @@ struct ContextGuard {
 impl ContextGuard {
     fn install() -> Self {
         let mut context = Box::new(HewExecutionContext::default());
-        let raw = (&raw mut *context).cast::<HewExecutionContext>();
+        let raw: *mut HewExecutionContext = context.as_mut();
         let previous = set_current_context(raw);
         Self { context, previous }
     }
@@ -131,9 +131,9 @@ impl ContextGuard {
 
 impl Drop for ContextGuard {
     fn drop(&mut self) {
-        let raw = (&raw mut *self.context).cast::<HewExecutionContext>();
+        let raw: *mut HewExecutionContext = self.context.as_mut();
         let restored = set_current_context(self.previous);
-        debug_assert_eq!(restored, raw);
+        assert_eq!(restored, raw);
     }
 }
 

--- a/hew-runtime/tests/otel_integration.rs
+++ b/hew-runtime/tests/otel_integration.rs
@@ -24,6 +24,7 @@ use hew_runtime::tracing::{
     drain_events, hew_trace_begin, hew_trace_enable, hew_trace_end, hew_trace_lifecycle,
     hew_trace_reset, trace_now_ns, SPAN_SPAWN,
 };
+use hew_runtime::{set_current_context, HewExecutionContext};
 
 // ── Mock OTLP receiver ────────────────────────────────────────────────────────
 
@@ -114,10 +115,33 @@ fn read_http_post_body(stream: &mut TcpStream) -> String {
 
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
+struct ContextGuard {
+    context: Box<HewExecutionContext>,
+    previous: *mut HewExecutionContext,
+}
+
+impl ContextGuard {
+    fn install() -> Self {
+        let mut context = Box::new(HewExecutionContext::default());
+        let raw = (&raw mut *context).cast::<HewExecutionContext>();
+        let previous = set_current_context(raw);
+        Self { context, previous }
+    }
+}
+
+impl Drop for ContextGuard {
+    fn drop(&mut self) {
+        let raw = (&raw mut *self.context).cast::<HewExecutionContext>();
+        let restored = set_current_context(self.previous);
+        debug_assert_eq!(restored, raw);
+    }
+}
+
 /// Verify that a begin/end span pair is correctly exported to a mock OTLP receiver.
 #[test]
 fn otel_exporter_posts_valid_otlp_json() {
     let _guard = TEST_LOCK.lock().unwrap();
+    let _context = ContextGuard::install();
 
     // 1. Reset tracing state and enable recording.
     hew_trace_reset();
@@ -193,21 +217,21 @@ fn otel_exporter_posts_valid_otlp_json() {
     );
 
     // 8. Verify the mock received the body.
-    let received = receiver
+    let request_body = receiver
         .wait_for_body(Duration::from_secs(3))
         .expect("mock receiver did not receive a request within 3 seconds");
 
-    assert!(!received.is_empty(), "received body was empty");
+    assert!(!request_body.is_empty(), "received body was empty");
     assert!(
-        received.contains("resourceSpans"),
-        "received body does not contain resourceSpans: {received}"
+        request_body.contains("resourceSpans"),
+        "received body does not contain resourceSpans: {request_body}"
     );
     assert!(
-        received.contains("test-service"),
+        request_body.contains("test-service"),
         "service name not in received body"
     );
     assert!(
-        received.contains("hew.actor_id"),
+        request_body.contains("hew.actor_id"),
         "actor_id attribute missing from received body"
     );
 
@@ -225,6 +249,7 @@ fn otel_exporter_posts_valid_otlp_json() {
 #[test]
 fn span_reconstruction_pairs_begin_and_end_events() {
     let _guard = TEST_LOCK.lock().unwrap();
+    let _context = ContextGuard::install();
     hew_trace_reset();
     hew_trace_enable(1);
 


### PR DESCRIPTION
Summary

- use the direct Rust 1.96 Result predicate in the OTel/profiler conflict guard
- clear the remaining pinned-toolchain OTel test lints without allowances
- install and restore the execution context required by optional-feature trace integration tests

Validation

- exporter-only OTel integration tests: 2 passed
- profiler-plus-exporter integration tests: 2 passed
- workspace all-target/all-feature Clippy with warnings denied
- workspace formatting and signed-commit hooks