### PR TITLE
test(cli): stabilize actor string ownership oracle

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -65,6 +65,18 @@ test-threads = "num-cpus"
 filter = "binary(eval_e2e)"
 test-group = "subprocess-intensive"
 
+[[profile.default.overrides]]
+# This executable ownership oracle runs a complete compiler + codegen + native
+# link + actor execution under a strict 30-second child deadline. On a hosted
+# runner the same healthy test twice exhausted that deadline while competing
+# with the full workspace's other LLVM/link subprocesses; isolated exact-host
+# runs completed in under a second. Reserve the whole nextest thread pool for
+# this one compiler subprocess so the deadline continues to mean "the ownership
+# oracle hung", not "the compiler was starved". The executable keeps strict
+# free_cstring abort and value assertions and carries no retry.
+filter = "binary(run_e2e) and test(/^run_actor_sent_string_not_double_freed$/)"
+threads-required = "num-test-threads"
+
 [profile.ci]
 # CI profile: runs all tests and produces JUnit XML for GitHub Actions reporting.
 # `test_runner_e2e` used to be excluded here against "the ctest E2E suite";

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2561,14 +2561,14 @@ fn check_carrier_conditional_consume_shared_exit_fails_closed() {
     );
 }
 
-/// The mailbox takes ownership of the buffer (no retain-on-send on the M-COW
-/// spine), so a sender that also scope-dropped it would free a buffer the live
-/// mailbox still owns — a use-after-free on the receiving side or a double-free
-/// when the handler later releases it. The fail-closed sole-owner derivation
-/// excludes the sent string because the send surfaces its backing local as a
-/// terminator/instr source operand (`terminator_source_places` /
-/// `instr_source_places`). A double-free trips the runtime's `free_cstring`
-/// sentinel (SIGABRT); a clean exit across many sends is the behavioural proof.
+/// A last-use string sent to an actor moves into the prepared outbound carrier
+/// and neutralizes the sender slot. The fixture's handler consumes that string
+/// into actor state; a FIFO ask verifies its exact length, and final actor
+/// teardown releases the receiver-owned buffer. If the sender also releases the
+/// prepared carrier after enqueue, teardown trips the runtime's `free_cstring`
+/// sentinel (SIGABRT). One transfer exercises the ownership edge completely;
+/// repeating it only amplifies runtime work under the shared subprocess
+/// deadline.
 #[test]
 fn run_actor_sent_string_not_double_freed() {
     require_codegen();
@@ -2582,8 +2582,8 @@ fn run_actor_sent_string_not_double_freed() {
 
     let output = run_bounded_hew_run(&source, repo_root());
 
-    // A double-free aborts the process (SIGABRT) via the runtime's
-    // `free_cstring` sentinel check, so `success()` is itself the proof.
+    // Wrong length returns non-zero; a double-free aborts via `free_cstring`.
+    // `success()` therefore preserves both the value and release oracles.
     assert!(
         output.status.success(),
         "actor_sent_string_not_double_freed should run cleanly (a double-free \

--- a/tests/vertical-slice/accept/actor_sent_string_not_double_freed.hew
+++ b/tests/vertical-slice/accept/actor_sent_string_not_double_freed.hew
@@ -1,51 +1,41 @@
-//! W5-011 P3 actor-context drop-safety proof — a heap-owning `string` moved
-//! into an actor mailbox must NOT be scope-dropped by the sending function,
-//! on ANY exit path (normal return, panic, or scope cancellation).
+//! Actor-send ownership proof — a heap-owning `string` moved into an actor
+//! mailbox must not be reclaimed by the sender after a successful enqueue.
 //!
-//! The mailbox takes ownership of the buffer (no retain-on-send on the M-COW
-//! spine), so the sent string is bit-aliased into the envelope. The fail-closed
-//! sole-owner derivation excludes it because the send surfaces its backing
-//! local as a terminator source operand (`Send`/`Ask` `value`, or
-//! `SpawnActor` `init_args`) — see `terminator_source_places` /
-//! `instr_source_places` in hew-mir/src/lower.rs. A regressed derivation that
-//! scope-dropped the sent string would free a buffer the live mailbox still
-//! owns: a use-after-free on the receiving side, or a double-free when the
-//! handler later releases it.
+//! Outbound preparation proves `s` is a last-use transfer, moves it into the
+//! prepared carrier, and neutralizes the sender slot. The copy-mode mailbox
+//! copies the carrier bytes into its node. `Echoer.note` then consumes the
+//! received string into actor state, making the receiver's release authority
+//! executable at actor teardown instead of leaving an unused handler parameter
+//! with no observable owned sink.
 //!
-//! Observable contract: the driver sends many heap strings into the actor and
-//! the program prints `done` and exits 0 with no abort. A double-free trips the
-//! runtime's `free_cstring` header-sentinel check (SIGABRT); a use-after-free
-//! trips Guard Malloc. A clean exit is the behavioural proof that the sender
-//! never reclaims a buffer it handed to the mailbox.
+//! Observable contract: the driver moves one heap string into the actor, then
+//! queues an ask behind it. Mailbox FIFO makes the ask observe the stored
+//! string's exact length before `main` exits; dropping the final actor handle
+//! then releases the state-owned string. The program prints `done` and exits 0
+//! only when the receiver saw all 11 bytes. A sender-side release after enqueue
+//! leaves the state owning freed storage and trips the runtime's `free_cstring`
+//! header sentinel at teardown.
 
 actor Echoer {
-    var seen: i64;
+    var last: string;
 
-    init() {
-        seen = 0;
-    }
-
-    receive fn note(_label: string) {
-        seen = seen + 1;
+    receive fn note(label: string) {
+        last = label;
     }
 
     receive fn count() -> i64 {
-        seen
+        last.len() as i64
     }
 }
 
 fn main() -> i64 {
-    let e = spawn Echoer;
-    var i: i64 = 0;
-    while i < 1000 {
-        let s = string_concat("msg-", "payload");
-        e.note(s);
-        i = i + 1;
-    }
-    println("done");
+    let e = spawn Echoer(last: "");
+    let s = string_concat("msg-", "payload");
+    e.note(s);
     let c = match await e.count() {
         Ok(v) => v,
         Err(_e) => 0,
     };
-    c * 0
+    println("done");
+    c - 11
 }


### PR DESCRIPTION
## Summary

Replace the actor-sent string ownership oracle's 1,000-send amplification with
one authoritative mailbox transfer, FIFO state verification, and actor
teardown. Reserve the full nextest execution pool for this
compiler/link/runtime subprocess without widening its 30-second deadline.

The former fixture repeatedly exhausted the shared hosted deadline while its
unused receive parameter no longer supplied the claimed receiver-side release
proof. The replacement keeps the fact that matters visible across the complete
boundary: the sender relinquishes the string, the actor observes the exact
payload in state, and teardown releases the receiver-owned value.

## Verification

- Exact signed rebased head: `c9b7d6bbac0dee0c9926254a3c2cfae028c10a22`
  on current main `581e3075c5f9cd0ef3e35db3fd76f4a2ef16349d`
- Focused nextest filter matches exactly one test under default and CI profiles
- Focused oracle and direct fixture execution pass on a freshly rebuilt
  compiler; the fixture remains within its unchanged deadline
- Independently injected post-enqueue carrier release: replacement detects
  30/30; former fixture detects 0/30
- Replacement fixture is leak-free; former fixture leaked 1,000 allocations
- Strict Clippy, Rust/Hew formatting, signature, scope, and clean-tree checks
- Claude Sonnet 5 post-rebase exact-head review: PASS

This is a test-only change. The separately discovered unused owned
actor-handler parameter leak is tracked independently and does not change the
oracle repair.
