### PR TITLE
ci: close the preflight parity gap for ll-identity-selftest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,11 @@ jobs:
         run: cargo install cargo-about --locked --version 0.9.0 --features cli
 
       - name: Verify THIRD-PARTY-LICENSES is current
+        # Placed outside CI-PARITY-STEPS, and deliberately absent from
+        # CI_REQUIRED_CHECKS, so the preflight↔CI parity assertion is
+        # unaffected: this gate needs cargo-about, which the step above
+        # installs at a pinned version. Requiring every local preflight to
+        # install a pinned cargo subcommand is a cost the gate does not repay.
         run: make licenses-check
 
   # ─────────────────────────────────────────────────────────────────────────

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -42,6 +42,7 @@ command_timeout_floor() {
         "make test-o2-differential") echo 1200 ;;
         "make o2-differential-selftest") echo 30 ;;
         "make doc-ratchet-selftest") echo 45 ;;
+        "make ll-identity-selftest") echo 15 ;;
         "make test-release-workflow-contract") echo 30 ;;
         "make test-stdlib-ratchet") echo 45 ;;
         "make test-doc-examples") echo 45 ;;
@@ -117,6 +118,7 @@ CI_REQUIRED_CHECKS=(
     "Package-install consumer oracle (ci.yml: make test-package-install)	make test-package-install"
     "Runtime tests without QUIC/TLS/profiler (ci.yml: make test-runtime-unit)	make test-runtime-unit"
     "Fuzz-oracle gate self-test (ci.yml: make fuzz-oracle-selftest)	make fuzz-oracle-selftest"
+    "ll-byte-identity normaliser self-test (ci.yml: make ll-identity-selftest)	make ll-identity-selftest"
     "libhew link-race gate (ci.yml: make libhew-link-race-test)	make libhew-link-race-test"
 )
 
@@ -865,6 +867,7 @@ case "$LANE" in
         add_command "make test-package-install"
         add_command "make test-runtime-unit"
         add_command "make fuzz-oracle-selftest"
+        add_command "make ll-identity-selftest"
         add_command "make libhew-link-race-test"
         ;;
     *)

--- a/scripts/corpus-floors.tsv
+++ b/scripts/corpus-floors.tsv
@@ -32,7 +32,7 @@
 asan-fixture-gates	exact	17	-	ASan/LSan fixture verdicts asserted by scripts/asan-fixture-check.sh
 checked-mir-fixtures	exact	57	-	golden-MIR fixtures under examples/v05/checked-mir
 ci-parity-marked-steps	exact	28	-	steps inside the CI-PARITY-STEPS blocks of .github/workflows/ci.yml
-ci-required-checks	exact	32	-	entries returned by scripts/ci-preflight-dispatcher.sh --ci-required
+ci-required-checks	exact	33	-	entries returned by scripts/ci-preflight-dispatcher.sh --ci-required
 corpus-floor-registry	exact	21	-	rows in this registry, asserted by scripts/check-corpus-floors.sh
 coverage-e2e-programs	min	70	30	self-contained examples/*.hew programs the runtime coverage report executes
 doc-hew-fences	min	297	60	hew fences extracted from the language guide and the spec


### PR DESCRIPTION
`make ll-identity-selftest` is an unconditional step in ci.yml but was absent
from CI_REQUIRED_CHECKS and from the dispatcher's fallback lane, so
`make ci-preflight` never executed it. A change to scripts/ll-byte-identity.sh
passed local preflight and only failed in CI -- the exact drift the parity
self-test exists to prevent. The step also sits outside every CI-PARITY-STEPS
marker block, so the parity checker could not see the omission either.

Wire it in properly rather than exempt it: the target runs
scripts/ll-identity-selftest.sh against synthetic .ll snippets, needs no
compiler build, and completes in ~0.1s, so it costs local preflight nothing.

- CI_REQUIRED_CHECKS: add the ll-identity-selftest entry
- fallback lane: add_command "make ll-identity-selftest" + 15s estimate
- corpus-floors.tsv: ci-required-checks 32 -> 33, in this same commit as the
  floor's own failure message instructs

Also document the one remaining genuine exemption. `make licenses-check`
(ci.yml) is likewise unconditional, outside the markers, and absent from
CI_REQUIRED_CHECKS -- but there it is the right call, because it needs
cargo-about at a pinned version, installed by the step immediately above.
Record that rationale inline following the existing leak-scan convention, so
the next person auditing this does not have to re-derive it.

The other six unconditional out-of-marker `run: make` steps are already
covered via `make lint` or an existing add_command, so the residual after
this commit is zero.

Verification: check-preflight-ci-parity.sh 33/33 and 28/28 (rc=0),
preflight-parity-selftest.sh 5/5, ll-identity-selftest.sh 6/6,
check-corpus-floors.sh 21/21, ci.yml parses, dispatcher passes bash -n.

Closes #2860