### PR TITLE
docs: state what the retention oracles cannot see

### DIFF
--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -49,6 +49,19 @@
 # hew-runtime/tests/last_error_result_retention.rs and
 # hew-std/src/last_error_retention.rs (hew-lang/hew#2828).
 #
+# What those oracles CANNOT see: they are black-box probes over live results,
+# so they establish that two results occupy distinct addresses, that the
+# caller's handle is the sole owner at handoff, and that the callee's own
+# state survives the caller's release. Together those still miss one shape — a
+# callee that allocates fresh, hands back a genuinely sole-owned buffer, and
+# separately stashes a raw non-refcounted pointer to it that it frees at
+# process teardown. Every probe passes, the caller's release is correct at the
+# call site, and the buffer is freed twice at shutdown. No symbol in this file
+# does that today; the rows below were corroborated against their
+# implementation sites. But "measured" here means measured by those oracles,
+# not proved sole-owned for all time: anyone adding a row must read the
+# callee's teardown path as well as running the oracle.
+#
 # Three-tier model (rationale: Option A chosen over Option B for substrate
 # clarity — the tier boundary is a compile-time contract, not just a doc claim):
 #


### PR DESCRIPTION
Closes #2839.

The `result-retention` axis documents its rows as *measured* and names the
oracles that establish them (`hew-runtime/tests/last_error_result_retention.rs`,
`hew-std/src/last_error_retention.rs`, #2828). Those oracles are black-box
probes over live results: distinct addresses for two live results, sole
ownership of the caller's handle at handoff, and callee state surviving the
caller's release.

Those three together do not catch one shape — a callee that allocates fresh,
hands the caller a genuinely sole-owned buffer, and separately stashes a raw
non-refcounted pointer to it that it frees at process teardown. Every probe
passes and the caller's release is still correct at the call site, but the
buffer is freed twice at shutdown.

Nothing in the family does this today and the rows were corroborated against
their implementation sites, so this is a documentation change only: it states
the boundary so a reader adding the sixteenth symbol knows what "measured"
covers, rather than inferring that a passing oracle proves sole ownership for
all time. It also names the concrete extra step (read the callee's teardown
path, not just run the oracle).

## Scope

One paragraph in the axis header of `scripts/jit-symbol-classification.toml`,
placed immediately after the existing sentence that names the oracles — the
location the issue asked for.

## Verification

- Comment-only: +13 lines, no contract row touched.
- `tomllib` parse clean; all 6 top-level tables present and all 494
  `[[ownership.contracts]]` entries intact after the edit.