### PR TITLE
ci: document the licenses-check preflight-parity exemption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,11 @@ jobs:
         run: cargo install cargo-about --locked --version 0.9.0 --features cli
 
       - name: Verify THIRD-PARTY-LICENSES is current
+        # Deliberately outside CI-PARITY-STEPS and absent from CI_REQUIRED_CHECKS:
+        # this target needs cargo-about, installed by the step above at a pinned
+        # version.  Requiring every local preflight run to install a pinned cargo
+        # subcommand is not worth the parity coverage, so the exemption is recorded
+        # here rather than left for the next parity audit to re-derive.
         run: make licenses-check
 
   # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the second of the two residuals I enumerated in #2860.

## Context

[My follow-up on #2860](https://github.com/hew-lang/hew/issues/2860#issuecomment-5167033677) enumerated every unconditional `run: make <target>` in `ci.yml` outside the `CI-PARITY-STEPS` marker regions and found **two** genuine residuals, not one:

- `ll-identity-selftest` — fixed in #2867 (open).
- `licenses-check` — this PR.

The other five apparent gaps are all covered via the `make lint` prerequisite chain (`Makefile:1099`), which the marker-scoped assertion cannot see. That invisibility is the whole problem: "covered by `make lint`" and "genuinely uncovered" look identical from inside the gate, so an inline comment is the only thing distinguishing them.

## What this changes

`make licenses-check` (`ci.yml:359`) is unconditional, outside the markers, absent from `CI_REQUIRED_CHECKS`, has no `add_command` in the dispatcher, and is not a prerequisite of any other target (`Makefile:311`).

Unlike `ll-identity-selftest`, this one has a **good** reason to be exempt: it needs `cargo-about`, which CI installs immediately before it at a pinned version (`cargo install cargo-about --locked --version 0.9.0`). Requiring every local preflight run to install a pinned cargo subcommand is not worth the parity coverage.

So the right fix is not to add it to the lane — it is to record the exemption, exactly as the `leak-scan` step already does a few blocks up (`ci.yml:286-289`). This applies that existing convention.

## Verification

Comment-only, +5 lines, no behaviour change.

- YAML parses clean (`yaml.safe_load`).
- `scripts/check-preflight-ci-parity.sh` — exit **0**; 32/32 required checks present in the fallback lane, 28/28 marked CI steps mapped, 5/5 GAP-2 lane→gate assertions pass.
- `make preflight-parity-selftest` — exit **0**, all 5 cases PASS (so the checker above is not passing by vacuum).

Refs #2860