### PR TITLE
ci(freebsd): restore wasm-cross E2E parity on the x86_64 FreeBSD lanes

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -41,13 +41,30 @@ jobs:
             # Bootstrap pkg through the base utility before reading package catalogues.
             /usr/sbin/pkg bootstrap -fy -r FreeBSD
             pkg update -f -r FreeBSD
-            pkg install -y -U -r FreeBSD llvm22 rust cmake ninja git gmake bash pkgconf libffi libxml2 wasmtime
+            # `rust` is deliberately NOT installed from pkg: the pkg toolchain
+            # is not rustup-managed, so it ignores rust-toolchain.toml and cannot
+            # supply wasm32-wasip1 (#1960). `curl` fetches rustup below.
+            pkg install -y -U -r FreeBSD llvm22 cmake ninja git gmake bash pkgconf libffi libxml2 wasmtime curl
 
           run: |
             set -eux
 
             git config --global --add safe.directory "$(pwd)"
             test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+
+            # Install a rustup-managed toolchain so rust-toolchain.toml governs
+            # this job as it does the Linux/macOS/Windows ones. That file pins
+            # the channel and lists wasm32-wasip1 under `targets`, so the WASI
+            # runner target is provisioned automatically (no `rustup target add`).
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+            sh rustup-init.sh -y --no-modify-path --default-toolchain none
+            . "$HOME/.cargo/env"
+            rm -f rustup-init.sh
+
+            rustup show active-toolchain
+            rustup target list --installed | grep -qx wasm32-wasip1
+            rustc --version
+            cargo --version
 
             export LLVM_SYS_221_PREFIX=/usr/local/llvm22
             export MAKE=gmake
@@ -79,16 +96,16 @@ jobs:
             # does not yet carry cargo-nextest, so install via cargo).
             cargo install cargo-nextest --locked
 
-            # Rust workspace tests. Exclude only executable WASI cases that
-            # need a rustup-managed wasm32-wasip1 target; retain rejection and
-            # native parity coverage.
+            # Rust workspace tests, with no wasm-cross exclusions: the rustup
+            # toolchain above supplies wasm32-wasip1, so the executable WASI
+            # cases build the runner from source and run it under the pkg
+            # wasmtime, matching the rustup platforms (#1960).
             # Default features include "full" (encryption + profiler + quic),
             # so all QUIC transport tests run without an explicit flag.
             # The ci profile applies the same slow-timeout = 3x60 s envelope
             # as all other platforms, replacing the previous bare cargo test.
             cargo nextest run --workspace \
               --exclude hew-wasm --exclude hew-cabi \
-              -E 'not ((test(eval_wasm) & not test(reject)) | (binary(wasi_run_e2e) & not test(native_)))' \
               --profile ci --no-fail-fast
 
             # hew-cabi is excluded from the workspace run above because its

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -449,12 +449,34 @@ jobs:
             # wasmtime executes the eval_wasm_* / wasi_run_e2e modules; the
             # FreeBSD pkg ships it the same way brew/wasmtime.dev provide it on
             # the macOS and Linux gates.
-            pkg install -y -U -r FreeBSD llvm22 rust cmake ninja git pkgconf libffi libxml2 wasmtime
+            #
+            # `rust` is deliberately NOT installed from pkg here: the pkg
+            # toolchain is not rustup-managed, so it ignores rust-toolchain.toml
+            # and cannot supply wasm32-wasip1 (#1960). `curl` fetches rustup.
+            pkg install -y -U -r FreeBSD llvm22 cmake ninja git pkgconf libffi libxml2 wasmtime curl
 
           run: |
             set -eux
 
             git config --global --add safe.directory "$(pwd)"
+
+            # Install a rustup-managed toolchain so rust-toolchain.toml governs
+            # this gate exactly as it does the Linux/macOS/Windows gates. That
+            # file already pins the channel and lists wasm32-wasip1 under
+            # `targets`, so the WASI runner target is provisioned automatically
+            # and no `rustup target add` is needed. Upstream publishes rustup
+            # and every pinned component for x86_64-unknown-freebsd.
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+            sh rustup-init.sh -y --no-modify-path --default-toolchain none
+            . "$HOME/.cargo/env"
+            rm -f rustup-init.sh
+
+            # Materialise the pinned toolchain and prove wasm32-wasip1 is
+            # actually present before the gate relies on it.
+            rustup show active-toolchain
+            rustup target list --installed | grep -qx wasm32-wasip1
+            rustc --version
+            cargo --version
 
             export LLVM_SYS_221_PREFIX=/usr/local/llvm22
             /usr/local/llvm22/bin/llvm-config --version
@@ -489,18 +511,12 @@ jobs:
             # cargo-nextest is not in FreeBSD pkg yet; install once via cargo
             cargo install cargo-nextest --locked
 
-            # Scope out only the eval/WASI E2E tests that build the WASI runner
-            # from source against wasm32-wasip1 — the FreeBSD pkg rust is not
-            # rustup-managed and cannot add that target. The wasm backend is
-            # host-independent and already gated on the four rustup platforms;
-            # full FreeBSD wasm-cross parity is tracked in #1960. The filter is
-            # deliberately narrow so the gate still covers what FreeBSD can run:
-            # it keeps the eval_wasm_* *rejection* paths (which build no wasm)
-            # and the wasi_run_e2e native_* codegen-parity tests (which run
-            # natively).
+            # Full workspace run with no wasm-cross exclusions: this gate now
+            # has a rustup toolchain with wasm32-wasip1, so the eval_wasm_* and
+            # wasi_run_e2e E2E tests build the WASI runner from source and run
+            # it under the pkg wasmtime, matching the rustup platforms (#1960).
             cargo nextest run --workspace \
               --exclude hew-wasm --exclude hew-cabi \
-              -E 'not ((test(eval_wasm) & not test(reject)) | (binary(wasi_run_e2e) & not test(native_)))' \
               --profile ci --no-fail-fast
 
             # hew-cabi is excluded from the workspace run above because its
@@ -580,14 +596,16 @@ jobs:
             cargo install cargo-nextest --locked
 
             # Scope out only the eval/WASI E2E tests that build the WASI runner
-            # from source against wasm32-wasip1 — the FreeBSD pkg rust is not
-            # rustup-managed and cannot add that target. The wasm backend is
-            # host-independent and already gated on the four rustup platforms;
-            # full FreeBSD wasm-cross parity is tracked in #1960. The filter is
-            # deliberately narrow so the gate still covers what FreeBSD can run:
-            # it keeps the eval_wasm_* *rejection* paths (which build no wasm)
-            # and the wasi_run_e2e native_* codegen-parity tests (which run
-            # natively).
+            # from source against wasm32-wasip1. Unlike the x86_64 gate, this
+            # exclusion is PERMANENT rather than pending: upstream Rust ships no
+            # aarch64-unknown-freebsd host at all — there is no rustup-init for
+            # it and no `rust` entry in the channel manifest — so the #1960 fix
+            # applied to the x86_64 gate cannot be applied here at any version.
+            # The wasm backend is host-independent and is gated on the four
+            # rustup platforms plus FreeBSD x86_64. The filter is deliberately
+            # narrow so the gate still covers what this platform can run: it
+            # keeps the eval_wasm_* *rejection* paths (which build no wasm) and
+            # the wasi_run_e2e native_* codegen-parity tests (which run natively).
             cargo nextest run --workspace \
               --exclude hew-wasm --exclude hew-cabi \
               -E 'not ((test(eval_wasm) & not test(reject)) | (binary(wasi_run_e2e) & not test(native_)))' \

--- a/scripts/tests/test_freebsd_workflow_contract.py
+++ b/scripts/tests/test_freebsd_workflow_contract.py
@@ -87,6 +87,72 @@ EXPECTED_NIGHTLY_PKG_PHASES = (
     EXPECTED_PKG_UPDATE,
     EXPECTED_NIGHTLY_PKG_INSTALL,
 )
+
+# ── rustup lanes (#1960) ───────────────────────────────────────────────────
+# The x86_64 FreeBSD jobs install a rustup-managed toolchain instead of the
+# `rust` pkg, so rust-toolchain.toml governs them as it does every other
+# platform. That file pins the channel and lists wasm32-wasip1 under `targets`,
+# so those lanes provision the WASI target and run the wasm-cross E2E tests
+# with NO exclusion filter. aarch64 keeps the pkg toolchain and the filter:
+# upstream Rust publishes no aarch64-unknown-freebsd host at all.
+RUSTUP_JOBS = frozenset({"build-and-test", "gate-freebsd-x86_64"})
+
+EXPECTED_UNFILTERED_NEXTEST_COMMAND = (
+    "cargo",
+    "nextest",
+    "run",
+    "--workspace",
+    "--exclude",
+    "hew-wasm",
+    "--exclude",
+    "hew-cabi",
+    "--profile",
+    "ci",
+    "--no-fail-fast",
+)
+# `rust` is replaced by `curl` (to fetch rustup-init) on the rustup lanes.
+RUSTUP_TOOL_PACKAGES = tuple(
+    package for package in FREEBSD_TOOL_PACKAGES if package != "rust"
+) + ("curl",)
+RUSTUP_NIGHTLY_TOOL_PACKAGES = tuple(
+    package for package in NIGHTLY_TOOL_PACKAGES if package != "rust"
+) + ("curl",)
+EXPECTED_RUSTUP_PKG_PHASES = (
+    EXPECTED_PKG_BOOTSTRAP,
+    EXPECTED_PKG_UPDATE,
+    (*PKG_INSTALL_PREFIX, *RUSTUP_TOOL_PACKAGES),
+)
+EXPECTED_RUSTUP_NIGHTLY_PKG_PHASES = (
+    EXPECTED_PKG_BOOTSTRAP,
+    EXPECTED_PKG_UPDATE,
+    (*PKG_INSTALL_PREFIX, *RUSTUP_NIGHTLY_TOOL_PACKAGES),
+)
+# The target probe is the load-bearing assertion: without it a provisioning
+# regression would silently fall back to reduced coverage instead of failing.
+EXPECTED_RUSTUP_TARGET_PROBE = (
+    "rustup",
+    "target",
+    "list",
+    "--installed",
+    "|",
+    "grep",
+    "-qx",
+    "wasm32-wasip1",
+)
+EXPECTED_RUSTUP_INIT = (
+    "sh",
+    "rustup-init.sh",
+    "-y",
+    "--no-modify-path",
+    "--default-toolchain",
+    "none",
+)
+EXPECTED_RUSTUP_ACTIVE_TOOLCHAIN = ("rustup", "show", "active-toolchain")
+RUSTUP_PROVISION_COMMANDS = (
+    EXPECTED_RUSTUP_INIT,
+    EXPECTED_RUSTUP_ACTIVE_TOOLCHAIN,
+    EXPECTED_RUSTUP_TARGET_PROBE,
+)
 EXPECTED_WASM_LD_LINK = (
     "ln",
     "-sf",
@@ -320,8 +386,19 @@ def _rewrite_pkg_commands(
 
 def _expected_pkg_phases(job_name: str) -> tuple[tuple[str, ...], ...]:
     if job_name == "build-and-test":
+        if job_name in RUSTUP_JOBS:
+            return EXPECTED_RUSTUP_NIGHTLY_PKG_PHASES
         return EXPECTED_NIGHTLY_PKG_PHASES
+    if job_name in RUSTUP_JOBS:
+        return EXPECTED_RUSTUP_PKG_PHASES
     return EXPECTED_PKG_PHASES
+
+
+def _expected_nextest_command(job_name: str) -> tuple[str, ...]:
+    """Rustup lanes run unfiltered; the pkg-toolchain lane keeps the filter."""
+    if job_name in RUSTUP_JOBS:
+        return EXPECTED_UNFILTERED_NEXTEST_COMMAND
+    return EXPECTED_NEXTEST_COMMAND
 
 
 def _assert_wasi_tool_setup(
@@ -351,6 +428,8 @@ def _assert_wasi_tool_setup(
     ]
     if job_name == "build-and-test":
         required_commands.append(EXPECTED_BASH_PROBE)
+    if job_name in RUSTUP_JOBS:
+        required_commands.extend(RUSTUP_PROVISION_COMMANDS)
     for required in required_commands:
         assert run_commands.count(required) == 1, (
             f"{job_name} must run exactly one active command {required!r}"
@@ -398,7 +477,8 @@ def _nextest_commands(job: str) -> list[tuple[str, ...]]:
 
 
 def _assert_command_list(commands: list[tuple[str, ...]], job_name: str) -> None:
-    assert commands == [EXPECTED_NEXTEST_COMMAND], (
+    expected = _expected_nextest_command(job_name)
+    assert commands == [expected], (
         f"{job_name} must contain exactly the canonical FreeBSD nextest command; "
         f"got {commands!r}"
     )
@@ -419,7 +499,7 @@ def _assert_nightly_compiled_hew_authority(workflow: str) -> None:
         EXPECTED_LLVM_ENV,
         EXPECTED_GNU_MAKE_ENV,
         EXPECTED_BASH_PROBE,
-        EXPECTED_NEXTEST_COMMAND,
+        _expected_nextest_command(job_name),
         EXPECTED_VERTICAL_SLICE_GATE,
         EXPECTED_HEW_RATCHET_GATE,
     )
@@ -580,12 +660,13 @@ def test_nightly_bash_package_removal_is_rejected() -> None:
     job_name = "build-and-test"
     step_name = "Build and test on FreeBSD"
     step = _step_block(_job_block(workflow, job_name), step_name)
-    install_text = " ".join(EXPECTED_NIGHTLY_PKG_INSTALL)
+    install_phase = _expected_pkg_phases(job_name)[-1]
+    install_text = " ".join(install_phase)
     assert step.count(install_text) == 1
     mutated_install = tuple(
-        package for package in EXPECTED_NIGHTLY_PKG_INSTALL if package != "bash"
+        package for package in install_phase if package != "bash"
     )
-    assert len(mutated_install) + 1 == len(EXPECTED_NIGHTLY_PKG_INSTALL)
+    assert len(mutated_install) + 1 == len(install_phase)
     mutated_step = step.replace(install_text, " ".join(mutated_install), 1)
     mutated = workflow.replace(step, mutated_step, 1)
     assert "gmake" in mutated_step and "pkgconf" in mutated_step
@@ -622,10 +703,24 @@ def test_commented_nightly_tool_commands_are_rejected() -> None:
     job_name = "build-and-test"
     step_name = "Build and test on FreeBSD"
     step = _step_block(_job_block(workflow, job_name), step_name)
-    for command in WASI_TOOL_COMMANDS:
+    phases = _expected_pkg_phases(job_name)
+    tool_commands = (
+        EXPECTED_PKG_UPDATE,
+        EXPECTED_PKG_BOOTSTRAP,
+        phases[-1],
+        EXPECTED_WASM_LD_LINK,
+        EXPECTED_WASMTIME_PROBE,
+        EXPECTED_WASM_LD_PROBE,
+        EXPECTED_BASH_PROBE,
+    )
+    if job_name in RUSTUP_JOBS:
+        tool_commands += RUSTUP_PROVISION_COMMANDS
+    for command in tool_commands:
         command_text = " ".join(command)
-        expected_count = EXPECTED_NIGHTLY_PKG_PHASES.count(command) or 1
-        assert step.count(command_text) == expected_count
+        expected_count = phases.count(command) or 1
+        assert step.count(command_text) == expected_count, (
+            f"{command_text!r} must appear {expected_count} time(s) in {job_name}"
+        )
         mutated_step = step.replace(command_text, f"# {command_text}", 1)
         mutated = workflow.replace(step, mutated_step, 1)
         assert command_text in mutated, "comment mutation must preserve raw text"
@@ -644,10 +739,12 @@ def test_single_release_leg_missing_wasmtime_is_rejected() -> None:
     ):
         job = _job_block(release_gate, job_name)
         step = _step_block(job, step_name)
-        install_text = " ".join(EXPECTED_PKG_INSTALL)
+        install_phase = _expected_pkg_phases(job_name)[-1]
+        install_text = " ".join(install_phase)
         assert step.count(install_text) == 1
+        assert "wasmtime" in install_phase
         mutated_step = step.replace(
-            install_text, install_text.removesuffix(" wasmtime"), 1
+            install_text, install_text.replace(" wasmtime", "", 1), 1
         )
         mutated_job = job.replace(step, mutated_step, 1)
         mutated = release_gate.replace(job, mutated_job, 1)
@@ -656,7 +753,8 @@ def test_single_release_leg_missing_wasmtime_is_rejected() -> None:
             if job_name == "gate-freebsd-x86_64"
             else "gate-freebsd-x86_64"
         )
-        assert install_text in _job_block(mutated, other_job), (
+        other_install_text = " ".join(_expected_pkg_phases(other_job)[-1])
+        assert other_install_text in _job_block(mutated, other_job), (
             "the opposite release leg must remain intact in the mutation control"
         )
         _assert_rejected(


### PR DESCRIPTION
Closes #1960.

## What was wrong

The FreeBSD jobs install the `rust` **pkg**, which is not rustup-managed and therefore ignores `rust-toolchain.toml`. That file already pins the channel *and* lists `wasm32-wasip1` under `targets`, so every rustup platform provisions the WASI target automatically. FreeBSD was the sole outlier, so the `eval_wasm_*` / `wasi_run_e2e` E2E tests were filtered out with an `-E` expression to work around it.

Worth noting: the issue's suggested restore path was "install a rustup toolchain, then `rustup target add wasm32-wasip1`". The `rustup target add` step turns out to be unnecessary — `targets` in `rust-toolchain.toml` covers it.

## What this does

On the **two x86_64 FreeBSD lanes** (`release-gate.yml` and `freebsd.yml` — the CI workflow had the same exclusion, so fixing only the gate would have left the issue half-done):

- install rustup instead of the `rust` pkg (`curl` added, `rust` dropped)
- drop the `-E` exclusion so the lanes build the WASI runner from source and run it under the pkg `wasmtime`, like the other platforms
- assert `rustup target list --installed | grep -qx wasm32-wasip1` **before** the suite relies on it, so a provisioning regression fails loudly instead of silently reverting to reduced coverage

`LLVM_SYS_221_PREFIX` still points at the pkg `llvm22`; only the Rust toolchain source changes.

## Availability, verified against the pinned channel

`rust-toolchain.toml` pins `1.96.0`. Against `channel-rust-1.96.0.toml`, all of `rust`, `clippy-preview`, `rustfmt-preview` for `x86_64-unknown-freebsd` and `rust-std` for `wasm32-wasip1` are `available = true`, and `rustup-init` for `x86_64-unknown-freebsd` returns HTTP 200.

## The aarch64 lane keeps the exclusion — permanently

Upstream Rust ships **no `aarch64-unknown-freebsd` host at all**: `rustup-init` 404s and there is no `rust` entry in the channel manifest. This fix cannot apply there at any version, so that lane keeps the filter and its comment now records the reason as permanent rather than pending #1960. The issue did not distinguish the two architectures; that asymmetry is the main finding here.

## Verification

- `scripts/check-preflight-ci-parity.sh` → exit 0 (32/32 checks, 28/28 steps, 5/5 lane→gate)
- `scripts/check-gate-reachability.py` → exit 0; A3d drops 8 → 6 filtered nextest runs, all still compensated
- both workflow files parse as YAML

CI on this PR does not exercise the FreeBSD release-gate lane, so the FreeBSD legs are proven by the release-gate workflow rather than here.