### PR TITLE
cleanup(codegen): delete dead emit_struct_literal and two stale dead_code allows

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -24882,8 +24882,8 @@ pub(crate) fn emit_node_lookup_call<'ctx>(
 // Composite-return spine — Lane W2.004 Stage 1
 // ----------------------------------------------------------------------------
 //
-// Four substrate helpers that synthesize user-visible composite return values
-// (`Result<T, E>`, struct literals, enum-variant literals) into a destination
+// Three substrate helpers that synthesize user-visible composite return values
+// (`Result<T, E>`, enum-variant literals) into a destination
 // `Place`. Each helper resolves the destination's registered layout
 // (`EnumLayout` via `machine_layouts`, `RecordLayout` via `record_layouts`)
 // and stores the tag + per-field payload through the existing
@@ -24895,21 +24895,8 @@ pub(crate) fn emit_node_lookup_call<'ctx>(
 //   - `emit_remote_pid_send_call` Err-arm `llvm.rs:~7553-7641` — `emit_result_err`
 //   - `emit_node_lookup_call`     Ok-arm `llvm.rs:~7783-7819` — `emit_result_ok`
 //   - `emit_node_lookup_call`     Err-arm `llvm.rs:~7747-7781` — `emit_result_err`
-//   - `Instr::RecordInit` `lower_record_init` — `emit_struct_literal`
-//     (no in-scope refactor; helper is the substrate for future Cluster-2
-//     consumers per audit §C.3)
 //   - `emit_enum_variant_literal` — no precedent; new substrate for Stage 3
 //     MIR producers (W2.005).
-//
-// Helper signatures (push-back per A259 #3(b) vs the plan):
-//   - `emit_struct_literal` uses `&[(FieldOffset, Place)]` (the MIR
-//     primitive used by `Instr::RecordInit`) rather than the plan's
-//     `&[(FieldName, Place)]`. `FieldName` is not a type in the MIR model;
-//     name → offset resolution happens at MIR-producer time per the
-//     `RecordInit` docstring (`hew-mir/src/model.rs:1747`).
-//   - `emit_struct_literal` does not take `struct_name`: the registered
-//     record name is recovered from `place_resolved_ty(dest)`'s
-//     `ResolvedTy::Named { name, .. }`, identically to `lower_record_init`.
 //
 // Constraints (CLAUDE.md customs):
 //   - **#2 Fail-closed Codegen**: any missing layout / mismatched type /
@@ -25064,7 +25051,6 @@ pub(crate) fn emit_result_ok(
 /// NodeRoutingNotWired`), the caller constructs the source local with
 /// the discriminant already set; this helper does not synthesise
 /// variant tags for the payload type.
-#[allow(dead_code)] // W2.004 Stage 1 substrate; consumers in Stage 2/3 + W2.005
 pub(crate) fn emit_result_err(
     fn_ctx: &FnCtx<'_, '_>,
     dest: Place,
@@ -25074,46 +25060,6 @@ pub(crate) fn emit_result_err(
     store_composite_tag(fn_ctx, dest_local, 1, "emit_result_err")?;
     copy_into_variant_field(fn_ctx, error_payload, dest_local, 1, 0, "emit_result_err")?;
     Ok(())
-}
-
-/// Emit a struct literal into a `Place::Local(N)` whose registered
-/// layout is a `RecordLayout`. Each `(offset, src)` pair copies the
-/// source field's loaded value into the destination's struct GEP at the
-/// matching field index.
-///
-/// This helper is the substrate face of the existing `lower_record_init`
-/// inlined codegen path (`llvm.rs:5052`); it intentionally mirrors that
-/// shape so a later refactor can route the inline path through this helper.
-///
-/// It has NO production consumer today (only the unit test below). The
-/// `monitor()` composite-return spine does NOT go through here: `monitor()`
-/// builds `MonitorRef { ref_id }` via the MIR producer's `Instr::RecordInit`,
-/// which codegen lowers through `lower_record_init` directly — the same
-/// underlying path this helper delegates to, reached without this wrapper.
-/// The `#[allow(dead_code)]` is therefore load-bearing until a consumer
-/// adopts the wrapper.
-///
-/// `dest`'s resolved type must be `ResolvedTy::Named { name, .. }`
-/// keyed to a registered `RecordLayout`; the struct's field order is
-/// authoritative — `field_offset.0` indexes directly into the LLVM
-/// struct.
-#[allow(dead_code)] // substrate wrapper over lower_record_init; no production consumer yet
-fn emit_struct_literal(
-    fn_ctx: &FnCtx<'_, '_>,
-    dest: Place,
-    fields: &[(FieldOffset, Place)],
-) -> CodegenResult<()> {
-    let dest_ty = place_resolved_ty(fn_ctx, dest)?.clone();
-    // Delegate to the established record-init path. Reusing
-    // `lower_record_init` guarantees byte-identical IR shape for any
-    // RecordLayout the helper consumes (the Stage 2 refactor target).
-    // `lower_record_init` already enforces:
-    //   - dest slot type matches the registered struct (fail-closed if
-    //     producer/codegen disagree),
-    //   - source slot type matches the field type at each offset,
-    //   - field offsets are in-bounds.
-    // No additional validation needed here — substrate-by-delegation.
-    lower_record_init(fn_ctx, &dest_ty, fields, dest)
 }
 
 /// Emit an arbitrary-variant enum literal into a `Place::Local(N)`
@@ -25132,7 +25078,6 @@ fn emit_struct_literal(
 /// registered `EnumLayout`; mismatched arities are caught downstream by
 /// `place_pointer`'s `MachineVariant` field-index bounds check
 /// (`llvm.rs:~2092`).
-#[allow(dead_code)] // W2.004 Stage 1 substrate; consumers in Stage 2/3 + W2.005
 pub(crate) fn emit_enum_variant_literal(
     fn_ctx: &FnCtx<'_, '_>,
     dest: Place,

--- a/hew-codegen-rs/src/llvm_tests.rs
+++ b/hew-codegen-rs/src/llvm_tests.rs
@@ -5145,14 +5145,6 @@ fn fixture_lookup_error_layout() -> MirEnumLayout {
     }
 }
 
-fn fixture_monitor_ref_layout() -> MirRecordLayout {
-    MirRecordLayout {
-        name: "MonitorRef".to_string(),
-        field_tys: vec![ResolvedTy::I64],
-        field_names: vec![],
-    }
-}
-
 /// A tri-variant payload-carrying user enum for `emit_enum_variant_literal`:
 ///   enum Sample { Empty, OneInt(i64), TwoInts(i64, i64) }
 fn fixture_sample_enum_layout() -> MirEnumLayout {
@@ -6790,47 +6782,6 @@ fn emit_send_result_from_rc_rejects_non_i32_status() {
         }
         other => panic!("expected FailClosed, got {other:?}"),
     }
-}
-
-// ---- emit_struct_literal -----------------------------------------------
-
-#[test]
-fn emit_struct_literal_monitor_ref_writes_ref_id_field() {
-    let ctx = Context::create();
-    let m = ctx.create_module("emit_struct_literal_test");
-    let harness = build_harness(&ctx, &[fixture_monitor_ref_layout()], &[]);
-    let mut fn_ctx = make_test_fn_ctx(&ctx, &m, &harness, "drv");
-    alloc_local(
-        &mut fn_ctx,
-        0,
-        ResolvedTy::Named {
-            name: "MonitorRef".to_string(),
-            args: vec![],
-            builtin: None,
-            is_opaque: false,
-        },
-    );
-    alloc_local(&mut fn_ctx, 1, ResolvedTy::I64);
-    emit_struct_literal(
-        &fn_ctx,
-        Place::Local(0),
-        &[(FieldOffset(0), Place::Local(1))],
-    )
-    .expect("emit_struct_literal MonitorRef{ref_id:i64} must succeed");
-    finish_test_fn(&fn_ctx);
-    assert!(
-        m.verify().is_ok(),
-        "module must verify:\n{}",
-        m.print_to_string().to_string()
-    );
-    let ir = m.print_to_string().to_string();
-    // The delegated `lower_record_init` path uses field_{idx}_init_ptr /
-    // field_{idx}_init_src labels — assert the substrate-delegation is live.
-    assert!(
-        ir.contains("field_0_init_ptr") && ir.contains("field_0_init_src"),
-        "expected lower_record_init field-0 init labels (substrate delegation); \
-             got IR:\n{ir}"
-    );
 }
 
 // ---- emit_enum_variant_literal -----------------------------------------


### PR DESCRIPTION
Picks up the "dead code" lane of #1885 (the "near-free" starter), re-derived against current `main` (`d4793f894`) rather than taken from the audit text — the line numbers there have drifted and the claimed "8 stale suppressions" is now **2**, but the substantive finding holds and one part of it turned out to be the opposite of what was filed.

### Genuinely dead: `emit_struct_literal`

No production consumer. Its only caller was a unit test of the helper itself, and its own docstring already recorded why: `monitor()` builds `MonitorRef { ref_id }` through `Instr::RecordInit` → `lower_record_init` directly, reaching the same underlying path without the wrapper.

Deleted the function, that test, and `fixture_monitor_ref_layout` — the fixture had no other caller and clippy flagged it the instant the test was removed, which is exactly the restored dead-code signal this lane is about.

### Stale, and masking *live* code

The other two `#[allow(dead_code)]` attributes in `llvm.rs` were annotated `W2.004 Stage 1 substrate; consumers in Stage 2/3 + W2.005`. Those consumers **have landed**, so the suppressions were no longer describing dead code at all:

| helper | production call sites |
|---|---|
| `emit_result_err` | `suspend.rs:6095,6152`; `runtime_abi.rs:1005,1151` (9 total) |
| `emit_enum_variant_literal` | `layout.rs:4717,4725,4850,4858` (14 total) |

Both removed. `cargo clippy -p hew-codegen-rs --lib --all-features --all-targets` is clean, which is the proof neither was load-bearing — had either still been dead, `-D warnings` would have caught it.

This is worth noting for #1885 generally: the audit's dead-code section assumed the suppressions were stale *because the helpers were still dead*. For two of three, they were stale because the helpers came alive and nobody removed the annotation.

### Also

Updated the substrate header comment (`llvm.rs:~24885`) from "Four substrate helpers" to three, dropped the `emit_struct_literal` precedent bullet, and removed the now-orphaned signature-rationale block that explained its `FieldOffset`/`struct_name` choices.

### Verification

- `cargo clippy -p hew-codegen-rs --lib --all-features --all-targets` — clean, no warnings
- `cargo test -p hew-codegen-rs --lib` — **239 passed, 0 failed**

No behavior change; deletions only (+2/−106).

Does not close #1885 (the duplication lanes and the `MembershipCallbackGeneration` decision-gated item remain).