### PR TITLE
fix(runtime): bound worker joins during scheduler teardown

### DIFF
--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -28,7 +28,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::atomic::AtomicPtr;
 use std::sync::{Condvar, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use rand::RngExt;
 
@@ -805,6 +805,17 @@ pub extern "C" fn hew_sched_init() -> c_int {
 /// scheduler — deques, parkers, stealers — as the final teardown step). The
 /// scheduler is owned by the runtime, so detaching the runtime is what frees
 /// the scheduler.
+/// Maximum total time worker teardown will wait for ALL workers to exit.
+///
+/// Chosen to match `shutdown::DEFAULT_DRAIN_TIMEOUT_MS` (5s): by the time
+/// teardown runs, the drain phase has already had its own budget, so this is a
+/// backstop against a worker that cannot return (parked in a blocking syscall),
+/// not a second drain window.
+const WORKER_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Poll interval while waiting for a worker to finish.
+const WORKER_JOIN_POLL_INTERVAL: Duration = Duration::from_millis(2);
+
 fn teardown_workers(
     scheduler: Option<*const Scheduler>,
     handles: Option<Vec<Option<JoinHandle<()>>>>,
@@ -832,6 +843,10 @@ fn teardown_workers(
         })
     });
     let current_id = thread::current().id();
+    // ONE deadline for the whole set, not per-handle: N workers each parked in a
+    // blocking syscall must not multiply the bound by N.
+    let deadline = Instant::now() + WORKER_JOIN_TIMEOUT;
+    let mut abandoned = 0usize;
     for handle in &mut handles {
         if let Some(ref h) = handle {
             if h.thread().id() == current_id {
@@ -839,9 +854,36 @@ fn teardown_workers(
                 continue;
             }
         }
-        if let Some(h) = handle.take() {
-            crate::util::report_join_panic("scheduler worker thread", h.join());
+        let Some(h) = handle.take() else { continue };
+        // A worker parked in a runtime-owned blocking op (e.g. `accept()`) never
+        // reaches the park-recheck, so an unconditional `join()` is unbounded and
+        // would hang an embedding host's shutdown forever. Poll `is_finished()`
+        // to a deadline, and join only once the thread is known to be done so the
+        // join itself cannot block.
+        loop {
+            if h.is_finished() {
+                crate::util::report_join_panic("scheduler worker thread", h.join());
+                break;
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                // Deliberately LEAK the handle rather than force-kill: the worker
+                // may still be touching scheduler-owned memory, and there is no
+                // safe way to interrupt it. Detaching is the fail-closed choice —
+                // it bounds shutdown without introducing a use-after-free.
+                abandoned += 1;
+                std::mem::forget(h);
+                break;
+            }
+            thread::sleep(WORKER_JOIN_POLL_INTERVAL.min(remaining));
         }
+    }
+    if abandoned > 0 {
+        eprintln!(
+            "hew: scheduler shutdown timed out joining {abandoned} worker thread(s) after \
+             {WORKER_JOIN_TIMEOUT:?}; detaching them (a worker is likely parked in a \
+             blocking syscall)"
+        );
     }
 
     // No joined worker can consume the global injector now. Retire its
@@ -876,8 +918,11 @@ fn teardown_after_spawn_failure(handles: Vec<Option<JoinHandle<()>>>) {
 
 /// Gracefully shut down the scheduler.
 ///
-/// Sets the shutdown flag, wakes all parked workers, then joins every
-/// worker thread. Safe to call if the scheduler was never initialized.
+/// Sets the shutdown flag, wakes all parked workers, then joins every worker
+/// thread subject to a bounded overall deadline (`WORKER_JOIN_TIMEOUT`). A
+/// worker that has not exited by the deadline is detached rather than joined,
+/// so shutdown always terminates. Safe to call if the scheduler was never
+/// initialized.
 #[no_mangle]
 pub extern "C" fn hew_sched_shutdown() {
     let Some(sched) = get_scheduler() else {
@@ -4514,10 +4559,103 @@ mod tests {
     use super::*;
     use std::ptr;
     use std::sync::atomic::AtomicI32;
+    use std::sync::Arc;
 
     // `SCHED_TEST_MUTEX` is defined at module scope (see above) so the
     // cross-module `NoWorkerSchedulerForTest` guard serializes against these
     // tests too; `use super::*` brings it into scope here.
+
+    // Bounded worker join (#2508).
+    //
+    // `teardown_workers` with `scheduler: None` and explicit `handles` exercises
+    // only the join loop, with no global scheduler state involved.
+
+    /// CONTROL: a worker that exits normally is still JOINED, not abandoned,
+    /// and teardown returns promptly rather than burning the timeout.
+    #[test]
+    fn teardown_joins_workers_that_exit() {
+        let done = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&done);
+        let h = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(20));
+            flag.store(true, Ordering::SeqCst);
+        });
+
+        let start = Instant::now();
+        teardown_workers(None, Some(vec![Some(h)]), false);
+        let elapsed = start.elapsed();
+
+        // Joined means the worker's write is visible on return.
+        assert!(
+            done.load(Ordering::SeqCst),
+            "a normally-exiting worker must be joined, not abandoned"
+        );
+        assert!(
+            elapsed < WORKER_JOIN_TIMEOUT,
+            "teardown must return as soon as workers exit, took {elapsed:?}"
+        );
+    }
+
+    /// A worker that never returns must NOT hang teardown: it is detached once
+    /// the deadline expires. This is the #2508 defect -- without the bound this
+    /// test never terminates.
+    #[test]
+    fn teardown_abandons_a_worker_that_never_exits() {
+        let release = Arc::new(AtomicBool::new(false));
+        let stuck = Arc::clone(&release);
+        let h = thread::spawn(move || {
+            // Stands in for a worker parked in a blocking syscall: it does not
+            // observe the shutdown flag at all.
+            while !stuck.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_millis(5));
+            }
+        });
+
+        let start = Instant::now();
+        teardown_workers(None, Some(vec![Some(h)]), false);
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= WORKER_JOIN_TIMEOUT,
+            "teardown must actually wait out the deadline, took {elapsed:?}"
+        );
+        // The bound is the point: teardown RETURNED.
+        assert!(
+            elapsed < WORKER_JOIN_TIMEOUT * 3,
+            "teardown must be bounded near the deadline, took {elapsed:?}"
+        );
+
+        // Let the detached thread go so it does not outlive the test run.
+        release.store(true, Ordering::SeqCst);
+    }
+
+    /// The deadline is shared across the whole set, not applied per handle:
+    /// three stuck workers must not cost 3x the timeout.
+    #[test]
+    fn teardown_deadline_is_shared_across_workers() {
+        let release = Arc::new(AtomicBool::new(false));
+        let handles: Vec<Option<JoinHandle<()>>> = (0..3)
+            .map(|_| {
+                let stuck = Arc::clone(&release);
+                Some(thread::spawn(move || {
+                    while !stuck.load(Ordering::SeqCst) {
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                }))
+            })
+            .collect();
+
+        let start = Instant::now();
+        teardown_workers(None, Some(handles), false);
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < WORKER_JOIN_TIMEOUT * 2,
+            "3 stuck workers must share one deadline, not multiply it: took {elapsed:?}"
+        );
+
+        release.store(true, Ordering::SeqCst);
+    }
 
     struct ActivatePreReenqueueHookGuard;
 


### PR DESCRIPTION
Closes #2508.

## The defect

`teardown_workers` (`hew-runtime/src/scheduler.rs`) hard-joined every worker thread with no timeout:

```rust
if let Some(h) = handle.take() {
    if h.join().is_err() { ... }
}
```

A worker genuinely parked in a blocking syscall (e.g. `accept()`) never reaches the park-recheck, so `join()` never returns and shutdown hangs forever.

## Scope correction

The issue says this "does NOT affect any compiled `.hew` binary today" and is latent hardening for the not-yet-wired host-embedder path. **That understates it.**

`teardown_workers` has three callers, and one is `hew_sched_shutdown` — which codegen emits *directly into native `main`* for supervisor programs (`hew-codegen-rs/src/llvm.rs`, `emit_immediate_shutdown_epilogue`, alongside the `hew_sched_shutdown` ABI declaration in `runtime_abi.rs`). Supervisor programs deliberately bypass the generic idle drain and go straight to closing and joining workers, so they reach the unbounded join today. `hew_runtime_cleanup` being unreachable is true but is not the only route.

The fix is the same either way; the reachability is just wider than filed.

## The fix

Poll `is_finished()` against a deadline, and `join()` only once the thread is known finished so the join itself cannot block.

Two deliberate choices:

- **One deadline for the whole worker set**, not per-handle — N workers each parked in a blocking syscall must not multiply the bound by N. Covered by a dedicated test.
- **Detach, do not force-kill.** A worker past the deadline may still be touching scheduler-owned memory and there is no safe way to interrupt it, so the handle is leaked via `mem::forget` and reported on stderr. Bounding shutdown must not introduce a use-after-free; leaking a thread is the fail-closed choice. This mirrors the existing task-scope reaper precedent.

`WORKER_JOIN_TIMEOUT` is 5s, matching `shutdown::DEFAULT_DRAIN_TIMEOUT_MS`. By the time teardown runs, the drain phase has already had its own budget, so this is a backstop against a worker that *cannot* return — not a second drain window. The polling shape follows the house convention in `shutdown::drain_until_idle`.

The stale doc comment on `hew_sched_shutdown` (which promised an unconditional join of every worker) is updated to state the bound.

## Verification

Three tests, proving discrimination rather than presence:

| test | proves |
|---|---|
| `teardown_joins_workers_that_exit` | **CONTROL** — a normally-exiting worker is still *joined* (its write is visible on return), and teardown returns well before the timeout |
| `teardown_abandons_a_worker_that_never_exits` | a stuck worker is bounded and teardown returns |
| `teardown_deadline_is_shared_across_workers` | 3 stuck workers cost ~1x, not 3x, the timeout |

**Revert-control:** with the join loop reverted to `h.join()` but the tests kept, `teardown_abandons_a_worker_that_never_exits` runs past 60s and has to be killed — i.e. it reproduces exactly the hang #2508 describes. With the fix it passes in ~5s. The test is a real discriminator, not a tautology.

Green bare (exit codes read directly, not through a pipe):

- `cargo test -p hew-runtime --lib` — **2243 passed**, RC=0
- `cargo clippy -p hew-runtime --all-targets -- -D warnings` — RC=0
- `cargo fmt -p hew-runtime -- --check` — RC=0

The pre-existing `spawn_failure_teardown_joins_partial_worker_set_and_drops_scheduler` regression test still passes.

## Unrelated flake found while verifying

`transport::tests::framed_send_to_broken_pipe_fails_closed_without_signal` fails intermittently in full-suite runs. I initially suspected my change and ran it down:

- **unmodified `main`, 6 full-suite runs: 5 ok / 1 FAILED** — so it is pre-existing and not caused by this PR.
- It passes in isolation on both branches; only concurrent full-suite runs trigger it.
- The assertion failure reports `left: 4096` — a *fully successful* 4096-byte write where `-1` was expected. So the send did not hit EPIPE at all: after `drop(far)` closes the peer fd, a concurrent thread elsewhere in the suite opens a new fd that reuses that number, and the write lands on a live socket. Classic fd-reuse race inherent to the test, not a defect in the SIGPIPE suppression it is meant to guard.

My diff contains no fd-touching code (only sleeps, `is_finished()`, `join`, and `mem::forget`), though the added ~5s of wall-clock does widen the window. Filing separately rather than folding an unrelated fix into this PR.