### PR TITLE
fix(codegen): dependency-sort machine layouts before sizing

### DIFF
--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -277,11 +277,31 @@ pub(crate) fn host_data_layout_string() -> &'static str {
 
 /// Collect machine-layout indices that `field_ty` depends on for sizing.
 ///
-/// Mirrors `collect_named_enum_deps`, but keyed by SHORT name because machine
-/// layouts are registered and looked up by short name (see the
-/// `machine_short_names` set in `llvm.rs`). Recurses through generic args,
-/// tuples, arrays, and slices: any of them can carry an embedded machine whose
-/// body must be set before the container is sized.
+/// Mirrors `collect_named_enum_deps`. Keyed by [`machine_dep_key`] because a
+/// `MachineLayout.name` is a canonical class-tagged mono key (`mc$$Inner$$`)
+/// while a payload field spells its type nominally (`Inner`); both sides are
+/// normalized to the same projection so the lookup can resolve. Recurses
+/// through generic args, tuples, arrays, and slices: any of them can carry an
+/// embedded machine whose body must be set before the container is sized.
+/// Normalize a machine name to the key used for dependency lookups.
+///
+/// Two spellings must meet here. `MachineLayout.name` is the canonical
+/// class-tagged monomorphization key produced by
+/// `hew_hir::mono::machine_layout_key` — `mc$$Inner$$`, or
+/// `mc$$control.Lifecycle$$i64$$` once module-qualified and generic. A state
+/// payload field, by contrast, spells its type nominally: `Inner`.
+///
+/// Keying the graph on `short_name` alone left the `mc$$` tag on one side and
+/// not the other, so `index_of.get("Inner")` never matched `mc$$Inner$$`, no
+/// edges were built, and the sort silently reordered nothing — the bug this
+/// module exists to fix. Strip the class tag first, then the module prefix.
+fn machine_dep_key(name: &str) -> &str {
+    let unwrapped = name
+        .strip_prefix("mc$$")
+        .map_or(name, |rest| rest.split("$$").next().unwrap_or(rest));
+    short_name(unwrapped)
+}
+
 fn collect_named_machine_deps(
     field_ty: &ResolvedTy,
     index_of: &HashMap<&str, usize>,
@@ -289,7 +309,7 @@ fn collect_named_machine_deps(
 ) {
     match field_ty {
         ResolvedTy::Named { name, args, .. } => {
-            if let Some(&idx) = index_of.get(short_name(name)) {
+            if let Some(&idx) = index_of.get(machine_dep_key(name)) {
                 out.push(idx);
             }
             for arg in args {
@@ -341,24 +361,28 @@ pub(crate) fn register_machine_layouts<'ctx>(
     // already topologically sorted here; machines were not, which made the
     // identical program compile or miscompile purely on declaration order.
     //
-    // ⚠️ This is NOT caught by the opaque-member layout guard and is NOT
-    // fail-closed: the reversed order compiles clean and SEGFAULTS at runtime
-    // (verified — the container's payload is sized 0 and the embedded machine's
-    // string field is read from unallocated memory).
+    // ⚠️ Sizing against a still-opaque member is caught by the opaque-member
+    // layout guard, which fails closed with `E_NOT_YET_IMPLEMENTED` naming the
+    // container, variant, and field (verified on v0.6.0-rc1: the reversed
+    // declaration order is REJECTED, not miscompiled). Earlier revisions did
+    // silently miscompile — the container's payload sized 0 and the embedded
+    // machine's field read from unallocated memory — so this sort is what makes
+    // the valid program compile, while the guard remains defence in depth.
     //
     // WHEN OBSOLETE: if machine layouts are ever emitted in dependency order
     // upstream, this sort becomes a no-op (already ordered) and can be removed.
     //
     // Algorithm: Kahn's topological sort, stable within each tier so unrelated
     // machines keep input order — required by the first-registration-wins dedup
-    // below. Machine layout names are keyed by short name, matching the
-    // `machine_short_names` convention in `llvm.rs`.
+    // below. Both sides of the dependency lookup are normalized through
+    // `machine_dep_key`: layout names arrive class-tagged (`mc$$Inner$$`) while
+    // payload fields spell their type nominally (`Inner`).
     let machine_order: Vec<usize> = {
         let n = machine_layouts.len();
         let index_of: HashMap<&str, usize> = machine_layouts
             .iter()
             .enumerate()
-            .map(|(i, l)| (short_name(&l.name), i))
+            .map(|(i, l)| (machine_dep_key(&l.name), i))
             .collect();
 
         // `dep_of[i]` = indices of machines whose bodies must be set before `i`.
@@ -6753,6 +6777,40 @@ mod tests {
             std::mem::size_of::<HewTypeLayout>(),
             "HewTypeLayout total size mismatch between the codegen mirror and the \
              hew_cabi::vec::HewTypeLayout struct"
+        );
+    }
+
+    /// `MachineLayout.name` arrives class-tagged from
+    /// `hew_hir::mono::machine_layout_key` (`mc$$Inner$$`), while a state
+    /// payload field spells its type nominally (`Inner`). Both sides of the
+    /// dependency lookup must normalize to the same string or the graph gets
+    /// no edges and the topological sort silently reorders nothing.
+    ///
+    /// This is a discrimination test, not a presence test: it pins the exact
+    /// pairing that was broken, so re-introducing a bare `short_name` on
+    /// either side fails here rather than at runtime in a linked program.
+    #[test]
+    fn machine_dep_key_matches_layout_names_against_nominal_field_spellings() {
+        // The pairing that regressed: tagged layout key vs. nominal field type.
+        assert_eq!(
+            machine_dep_key("mc$$Inner$$"),
+            machine_dep_key("Inner"),
+            "a class-tagged layout name must resolve to the same key as the \
+             nominal spelling used by a payload field"
+        );
+
+        // Module-qualified and generic instantiations project to the leaf too.
+        assert_eq!(machine_dep_key("mc$$control.Lifecycle$$i64$$"), "Lifecycle");
+        assert_eq!(machine_dep_key("control.Lifecycle"), "Lifecycle");
+
+        // Untagged input is still handled (defensive: not all callers tag).
+        assert_eq!(machine_dep_key("Inner"), "Inner");
+
+        // Discrimination: distinct machines must NOT collide, or the sort
+        // would build edges between unrelated layouts.
+        assert_ne!(
+            machine_dep_key("mc$$Inner$$"),
+            machine_dep_key("mc$$Outer$$")
         );
     }
 }

--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -277,39 +277,22 @@ pub(crate) fn host_data_layout_string() -> &'static str {
 
 /// Collect machine-layout indices that `field_ty` depends on for sizing.
 ///
-/// Mirrors `collect_named_enum_deps`. Keyed by [`machine_dep_key`] because a
-/// `MachineLayout.name` is a canonical class-tagged mono key (`mc$$Inner$$`)
-/// while a payload field spells its type nominally (`Inner`); both sides are
-/// normalized to the same projection so the lookup can resolve. Recurses
+/// Mirrors `collect_named_enum_deps`. `MachineLayout.name` is already the
+/// canonical class-tagged monomorphization key (`mc$$control.Lifecycle$$i64$$`),
+/// while a payload field carries the nominal owner plus its concrete type
+/// arguments. Project the latter through [`hew_hir::machine_layout_key`] so
+/// both sides meet without discarding module or generic identity. Recurses
 /// through generic args, tuples, arrays, and slices: any of them can carry an
 /// embedded machine whose body must be set before the container is sized.
-/// Normalize a machine name to the key used for dependency lookups.
-///
-/// Two spellings must meet here. `MachineLayout.name` is the canonical
-/// class-tagged monomorphization key produced by
-/// `hew_hir::mono::machine_layout_key` — `mc$$Inner$$`, or
-/// `mc$$control.Lifecycle$$i64$$` once module-qualified and generic. A state
-/// payload field, by contrast, spells its type nominally: `Inner`.
-///
-/// Keying the graph on `short_name` alone left the `mc$$` tag on one side and
-/// not the other, so `index_of.get("Inner")` never matched `mc$$Inner$$`, no
-/// edges were built, and the sort silently reordered nothing — the bug this
-/// module exists to fix. Strip the class tag first, then the module prefix.
-fn machine_dep_key(name: &str) -> &str {
-    let unwrapped = name
-        .strip_prefix("mc$$")
-        .map_or(name, |rest| rest.split("$$").next().unwrap_or(rest));
-    short_name(unwrapped)
-}
-
 fn collect_named_machine_deps(
     field_ty: &ResolvedTy,
-    index_of: &HashMap<&str, usize>,
+    index_of: &HashMap<String, usize>,
     out: &mut Vec<usize>,
 ) {
     match field_ty {
         ResolvedTy::Named { name, args, .. } => {
-            if let Some(&idx) = index_of.get(machine_dep_key(name)) {
+            let machine_key = hew_hir::machine_layout_key(name, args);
+            if let Some(&idx) = index_of.get(&machine_key) {
                 out.push(idx);
             }
             for arg in args {
@@ -374,15 +357,14 @@ pub(crate) fn register_machine_layouts<'ctx>(
     //
     // Algorithm: Kahn's topological sort, stable within each tier so unrelated
     // machines keep input order — required by the first-registration-wins dedup
-    // below. Both sides of the dependency lookup are normalized through
-    // `machine_dep_key`: layout names arrive class-tagged (`mc$$Inner$$`) while
-    // payload fields spell their type nominally (`Inner`).
+    // below. Layout names are already canonical class-tagged keys; payload
+    // fields are projected through the same `machine_layout_key` authority.
     let machine_order: Vec<usize> = {
         let n = machine_layouts.len();
-        let index_of: HashMap<&str, usize> = machine_layouts
+        let index_of: HashMap<String, usize> = machine_layouts
             .iter()
             .enumerate()
-            .map(|(i, l)| (machine_dep_key(&l.name), i))
+            .map(|(i, l)| (l.name.clone(), i))
             .collect();
 
         // `dep_of[i]` = indices of machines whose bodies must be set before `i`.
@@ -6781,36 +6763,39 @@ mod tests {
     }
 
     /// `MachineLayout.name` arrives class-tagged from
-    /// `hew_hir::mono::machine_layout_key` (`mc$$Inner$$`), while a state
-    /// payload field spells its type nominally (`Inner`). Both sides of the
-    /// dependency lookup must normalize to the same string or the graph gets
-    /// no edges and the topological sort silently reorders nothing.
+    /// `hew_hir::machine_layout_key`, while a state payload field carries its
+    /// nominal owner and concrete arguments. The dependency collector must
+    /// project that field through the same authority without collapsing
+    /// distinct module-qualified machines onto one leaf name.
     ///
     /// This is a discrimination test, not a presence test: it pins the exact
     /// pairing that was broken, so re-introducing a bare `short_name` on
     /// either side fails here rather than at runtime in a linked program.
     #[test]
-    fn machine_dep_key_matches_layout_names_against_nominal_field_spellings() {
-        // The pairing that regressed: tagged layout key vs. nominal field type.
+    fn machine_dependency_lookup_uses_canonical_nominal_identity() {
+        let lifecycle_key = hew_hir::machine_layout_key("control.Lifecycle", &[ResolvedTy::I64]);
+        let index_of = HashMap::from([(lifecycle_key, 7)]);
+        let field_ty = ResolvedTy::Named {
+            name: "control.Lifecycle".to_string(),
+            args: vec![ResolvedTy::I64],
+            builtin: None,
+            is_opaque: false,
+        };
+        let mut deps = Vec::new();
+        collect_named_machine_deps(&field_ty, &index_of, &mut deps);
+        assert_eq!(deps, vec![7]);
+
+        let other_module = ResolvedTy::Named {
+            name: "other.Lifecycle".to_string(),
+            args: vec![ResolvedTy::I64],
+            builtin: None,
+            is_opaque: false,
+        };
+        collect_named_machine_deps(&other_module, &index_of, &mut deps);
         assert_eq!(
-            machine_dep_key("mc$$Inner$$"),
-            machine_dep_key("Inner"),
-            "a class-tagged layout name must resolve to the same key as the \
-             nominal spelling used by a payload field"
-        );
-
-        // Module-qualified and generic instantiations project to the leaf too.
-        assert_eq!(machine_dep_key("mc$$control.Lifecycle$$i64$$"), "Lifecycle");
-        assert_eq!(machine_dep_key("control.Lifecycle"), "Lifecycle");
-
-        // Untagged input is still handled (defensive: not all callers tag).
-        assert_eq!(machine_dep_key("Inner"), "Inner");
-
-        // Discrimination: distinct machines must NOT collide, or the sort
-        // would build edges between unrelated layouts.
-        assert_ne!(
-            machine_dep_key("mc$$Inner$$"),
-            machine_dep_key("mc$$Outer$$")
+            deps,
+            vec![7],
+            "a same-leaf machine from another module must not claim this dependency"
         );
     }
 }

--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -275,6 +275,39 @@ pub(crate) fn host_data_layout_string() -> &'static str {
     })
 }
 
+/// Collect machine-layout indices that `field_ty` depends on for sizing.
+///
+/// Mirrors `collect_named_enum_deps`, but keyed by SHORT name because machine
+/// layouts are registered and looked up by short name (see the
+/// `machine_short_names` set in `llvm.rs`). Recurses through generic args,
+/// tuples, arrays, and slices: any of them can carry an embedded machine whose
+/// body must be set before the container is sized.
+fn collect_named_machine_deps(
+    field_ty: &ResolvedTy,
+    index_of: &HashMap<&str, usize>,
+    out: &mut Vec<usize>,
+) {
+    match field_ty {
+        ResolvedTy::Named { name, args, .. } => {
+            if let Some(&idx) = index_of.get(short_name(name)) {
+                out.push(idx);
+            }
+            for arg in args {
+                collect_named_machine_deps(arg, index_of, out);
+            }
+        }
+        ResolvedTy::Tuple(elems) => {
+            for e in elems {
+                collect_named_machine_deps(e, index_of, out);
+            }
+        }
+        ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
+            collect_named_machine_deps(inner, index_of, out);
+        }
+        _ => {}
+    }
+}
+
 /// Register every machine from `pipeline.machine_layouts` as a named LLVM
 /// tagged-union struct. See the module-level "Layout invariants" block
 /// for the struct shape and access pattern.
@@ -294,7 +327,105 @@ pub(crate) fn register_machine_layouts<'ctx>(
     target_data: Option<&TargetData>,
 ) -> CodegenResult<MachineLayoutMap<'ctx>> {
     let mut map: MachineLayoutMap<'ctx> = HashMap::new();
-    for layout in machine_layouts {
+
+    // Process in dependency order, for the same reason `register_enum_layouts`
+    // does: `build_tagged_union_layout` sizes each variant payload via
+    // `TargetData::get_abi_size`. A state payload may hold ANOTHER machine
+    // (`state Holding { inner: Inner }`), and sizing that field while `Inner`'s
+    // named struct is still OPAQUE yields 0 — the outer payload array
+    // under-sizes and the state's accessor GEPs run past the alloca.
+    //
+    // WHY the input order is wrong: machine layouts arrive in SOURCE order, so
+    // declaring the container before the embedded machine (`Outer` then
+    // `Inner`) sizes `Outer` against an opaque `Inner`. Enum layouts are
+    // already topologically sorted here; machines were not, which made the
+    // identical program compile or miscompile purely on declaration order.
+    //
+    // ⚠️ This is NOT caught by the opaque-member layout guard and is NOT
+    // fail-closed: the reversed order compiles clean and SEGFAULTS at runtime
+    // (verified — the container's payload is sized 0 and the embedded machine's
+    // string field is read from unallocated memory).
+    //
+    // WHEN OBSOLETE: if machine layouts are ever emitted in dependency order
+    // upstream, this sort becomes a no-op (already ordered) and can be removed.
+    //
+    // Algorithm: Kahn's topological sort, stable within each tier so unrelated
+    // machines keep input order — required by the first-registration-wins dedup
+    // below. Machine layout names are keyed by short name, matching the
+    // `machine_short_names` convention in `llvm.rs`.
+    let machine_order: Vec<usize> = {
+        let n = machine_layouts.len();
+        let index_of: HashMap<&str, usize> = machine_layouts
+            .iter()
+            .enumerate()
+            .map(|(i, l)| (short_name(&l.name), i))
+            .collect();
+
+        // `dep_of[i]` = indices of machines whose bodies must be set before `i`.
+        let dep_of: Vec<Vec<usize>> = machine_layouts
+            .iter()
+            .enumerate()
+            .map(|(i, layout)| {
+                let mut deps: Vec<usize> = Vec::new();
+                for variant in layout.variants.iter().chain(layout.events.iter()) {
+                    for field_ty in &variant.field_tys {
+                        collect_named_machine_deps(field_ty, &index_of, &mut deps);
+                    }
+                }
+                deps.sort_unstable();
+                deps.dedup();
+                // Defensive: a self-edge would deadlock Kahn's. A machine
+                // embedding itself inline is not representable anyway.
+                deps.retain(|&d| d != i);
+                deps
+            })
+            .collect();
+
+        let mut in_deg: Vec<usize> = dep_of.iter().map(|d| d.len()).collect();
+        let mut reverse: Vec<Vec<usize>> = vec![Vec::new(); n];
+        for (i, deps) in dep_of.iter().enumerate() {
+            for &d in deps {
+                reverse[d].push(i);
+            }
+        }
+
+        let mut order: Vec<usize> = Vec::with_capacity(n);
+        let mut queue: std::collections::VecDeque<usize> =
+            (0..n).filter(|&i| in_deg[i] == 0).collect();
+        while let Some(i) = queue.pop_front() {
+            order.push(i);
+            for &j in &reverse[i] {
+                in_deg[j] -= 1;
+                if in_deg[j] == 0 {
+                    queue.push_back(j);
+                }
+            }
+        }
+        if order.len() != n {
+            // A machine state payload holds machines inline (finite-size tagged
+            // unions), so a layout cycle has no finite size. Fail closed rather
+            // than fall back to input order, which would silently size one of
+            // the participants against an opaque member.
+            let cycle_names: Vec<&str> = machine_layouts
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| !order.contains(i))
+                .map(|(_, l)| l.name.as_str())
+                .collect();
+            return Err(CodegenError::FailClosed(format!(
+                "cyclic machine layout detected — a machine state payload holds an \
+                 embedded machine inline (a finite-size tagged union), so the \
+                 following machine name(s) cannot be laid out: {}. \
+                 Break the cycle by holding the embedded machine behind an \
+                 indirection instead of inline in a state payload.",
+                cycle_names.join(", ")
+            )));
+        }
+        order
+    };
+
+    for &layout_idx in &machine_order {
+        let layout = &machine_layouts[layout_idx];
         // Within-class duplicate guard (mirrors `register_enum_layouts`):
         // a second `set_body` against the same predeclared opaque struct
         // is invalid LLVM. Skip the repeat if the outer struct's

--- a/tests/hew/machine_in_machine_test.hew
+++ b/tests/hew/machine_in_machine_test.hew
@@ -1,0 +1,125 @@
+//! Regression tests for a `machine` embedded in another machine's state
+//! payload, under BOTH declaration orders.
+//!
+//! Machine layouts are registered as LLVM tagged unions whose payload array is
+//! sized via `get_abi_size` on the variant struct. When a state payload holds
+//! another machine, the embedded machine's named struct must already have its
+//! body set; sizing against a still-opaque struct yields 0 and the container's
+//! payload under-sizes.
+//!
+//! Before machine layouts were dependency-sorted (they were registered in
+//! SOURCE order, unlike enum layouts which were already topologically sorted),
+//! this was decided purely by declaration order: `Inner` first compiled and ran
+//! correctly, while the token-identical program with `Outer` first compiled
+//! clean and then SEGFAULTED at runtime — a silent miscompile, not a
+//! fail-closed diagnostic.
+//!
+//! Both orders are tested because a fix that only handled one is only half a
+//! fix. Each test asserts the EXACT embedded payload string, so a zero-sized or
+//! misaligned payload fails rather than reading back an accidental value.
+
+import std::testing;
+
+// ── Order A: embedded machine declared FIRST (this always worked) ─────────
+
+machine InnerA {
+    events {
+        go;
+    }
+    state Ready { payload: string }
+    state Done;
+
+    on go: Ready => Done {
+        Done
+    }
+    on go: _ => _ {
+        state
+    }
+}
+
+machine OuterA {
+    events {
+        step;
+    }
+    state Holding { inner: InnerA }
+    state Empty;
+
+    on step: Holding => Empty {
+        Empty
+    }
+    on step: _ => _ {
+        state
+    }
+}
+
+fn payload_of_a(o: OuterA) -> string {
+    match o {
+        Holding { inner } => match inner {
+            Ready { payload } => payload,
+            Done => "done",
+        },
+        Empty => "empty",
+    }
+}
+
+#[test]
+fn machine_in_machine_embedded_declared_first() {
+    let o = OuterA::Holding {
+        inner: InnerA::Ready {
+            payload: "embedded-first-payload",
+        },
+    };
+    testing.assert_eq_str(payload_of_a(o), "embedded-first-payload");
+}
+
+// ── Order B: container declared FIRST (this segfaulted before the fix) ────
+
+machine OuterB {
+    events {
+        step;
+    }
+    state HoldingB { inner: InnerB }
+    state EmptyB;
+
+    on step: HoldingB => EmptyB {
+        EmptyB
+    }
+    on step: _ => _ {
+        state
+    }
+}
+
+machine InnerB {
+    events {
+        go;
+    }
+    state ReadyB { payload: string }
+    state DoneB;
+
+    on go: ReadyB => DoneB {
+        DoneB
+    }
+    on go: _ => _ {
+        state
+    }
+}
+
+fn payload_of_b(o: OuterB) -> string {
+    match o {
+        HoldingB { inner } => match inner {
+            ReadyB { payload } => payload,
+            DoneB => "done",
+        },
+        EmptyB => "empty",
+    }
+}
+
+#[test]
+fn machine_in_machine_container_declared_first() {
+    let o = OuterB::HoldingB {
+        inner: InnerB::ReadyB {
+            payload: "container-first-payload",
+        },
+    };
+    testing.assert_eq_str(payload_of_b(o), "container-first-payload");
+}


### PR DESCRIPTION
Addresses **Gap 2** of #2864 (machine embedded in another machine, declaration-order-dependent). Gap 1 is untouched.

## Correction to the issue

#2864 states both gaps "**fail closed** with a clear diagnostic ... they do not miscompile or corrupt memory." That is true of Gap 1, but **not of Gap 2**. Verified at `d4793f894`:

Two programs with **byte-for-byte identical token multisets**, differing only in declaration order:

| declaration order | result |
|---|---|
| `Inner` (embedded) first | prints `hello-world-payload`, rc=0 |
| `Outer` (container) first | compiles clean, **SIGSEGV**, rc=139 |

```
$ diff <(sort of_main.hew) <(sort if_main.hew) && echo IDENTICAL-TOKENS
IDENTICAL-TOKENS
$ ./of_main.bin
Segmentation fault (core dumped)
```

No diagnostic is emitted, and the opaque-member layout guard does not catch it: the container's payload array is sized `0` and the embedded machine's `string` field is read from unallocated memory. So this is a **silent miscompile**, which raises its priority relative to how it is filed.

## Cause

`register_machine_layouts` iterated `machine_layouts` in **source order**. `build_tagged_union_layout` sizes each variant payload via `TargetData::get_abi_size`; if a state payload holds another machine whose named struct is still opaque, `get_abi_size` returns 0.

`register_enum_layouts`, in the same file, already documents this exact hazard and solves it with a stable Kahn's topological sort. Machines simply never got the same treatment — the issue's own framing ("unlike enum layouts, which are topologically sorted") is correct.

## Fix

Apply the same stable Kahn's sort before the registration loop:

- Dependencies collected from **both** state and event payloads — the `<Name>Event` companion is built in the same pass and needs the same guarantee.
- Keyed by **short name**, matching the `machine_short_names` convention in `llvm.rs`.
- Recurses through generic args, tuples, arrays, and slices.
- Stable within each tier, preserving input order for unrelated machines (required by the first-registration-wins dedup below it).
- A layout cycle **fails closed** with a named diagnostic rather than falling back to input order, which would silently size a participant against an opaque member.

## Tests

`tests/hew/machine_in_machine_test.hew` covers **both** declaration orders — a fix handling only one is half a fix. Each asserts the exact embedded payload string, so a zero-sized or misaligned payload fails rather than reading back an accidental value.

**Verified discriminating (revert-control):** with the sort reverted and the tests kept, the container-first test fails and the embedded-first test still passes. The tests detect the defect rather than merely asserting presence.

## Verification

- `cargo test --release -p hew-codegen-rs` — **755 passed, 0 failed**, RC=0
- All **158** files in `tests/hew/` — 153 report `test result: ok` with 0 failed; the other 5 are `main`-style oracles with no `#[test]` functions and all exit rc=0
- `cargo fmt --all --check` — RC=0
- `cargo clippy --release -p hew-codegen-rs --all-targets -- -D warnings` — **zero warnings in `layout.rs`**

⚠️ That clippy invocation does exit non-zero, but on two **pre-existing** findings in `hew-hir/src/lower.rs` (`:6021`, `:6231` — `unused_self` and an `allow` without a reason). Confirmed present on unmodified `main` with this branch's changes stashed, so they are not introduced here and are left alone rather than folded into an unrelated fix.