### PR TITLE
fix(codegen): descend through record fields when sorting machine layouts

### DIFF
--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -281,31 +281,60 @@ pub(crate) fn host_data_layout_string() -> &'static str {
 /// canonical class-tagged monomorphization key (`mc$$control.Lifecycle$$i64$$`),
 /// while a payload field carries the nominal owner plus its concrete type
 /// arguments. Project the latter through [`hew_hir::machine_layout_key`] so
-/// both sides meet without discarding module or generic identity. Recurses
-/// through generic args, tuples, arrays, and slices: any of them can carry an
-/// embedded machine whose body must be set before the container is sized.
+/// both sides meet without discarding module or generic identity. Records use
+/// the parallel [`hew_hir::layout_key_for_named`] authority before the walk
+/// descends through their fields. Recurses through generic args, tuples,
+/// arrays, and slices: any of them can carry an embedded machine whose body
+/// must be set before the container is sized.
 fn collect_named_machine_deps(
     field_ty: &ResolvedTy,
     index_of: &HashMap<String, usize>,
+    record_fields: &HashMap<String, &[ResolvedTy]>,
+    visiting: &mut Vec<String>,
     out: &mut Vec<usize>,
 ) {
     match field_ty {
-        ResolvedTy::Named { name, args, .. } => {
+        ResolvedTy::Named {
+            name,
+            args,
+            builtin,
+            ..
+        } => {
             let machine_key = hew_hir::machine_layout_key(name, args);
             if let Some(&idx) = index_of.get(&machine_key) {
                 out.push(idx);
+            } else if let Some(record_key) = hew_hir::layout_key_for_named(name, args, *builtin) {
+                if let Some(fields) = record_fields.get(&record_key) {
+                    // A machine can be reached only THROUGH a record field
+                    // (`state Holding { w: Wrap }` where `type Wrap { inner: Inner }`).
+                    // The record is not itself a machine, so it misses `index_of`;
+                    // without descending here the embedded machine is never seen as
+                    // a dependency and the container is sized against an opaque
+                    // struct — the record-wrapped half of #2864.
+                    //
+                    // A record cycle is not representable by value, but recursion is
+                    // guarded rather than trusted: `visiting` makes a malformed or
+                    // indirect layout terminate instead of overflowing the stack.
+                    if !visiting.contains(&record_key) {
+                        visiting.push(record_key);
+                        for fty in *fields {
+                            collect_named_machine_deps(fty, index_of, record_fields, visiting, out);
+                        }
+                        visiting.pop();
+                    }
+                }
             }
             for arg in args {
-                collect_named_machine_deps(arg, index_of, out);
+                collect_named_machine_deps(arg, index_of, record_fields, visiting, out);
             }
         }
         ResolvedTy::Tuple(elems) => {
             for e in elems {
-                collect_named_machine_deps(e, index_of, out);
+                collect_named_machine_deps(e, index_of, record_fields, visiting, out);
             }
         }
         ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
-            collect_named_machine_deps(inner, index_of, out);
+            collect_named_machine_deps(inner, index_of, record_fields, visiting, out);
         }
         _ => {}
     }
@@ -325,6 +354,7 @@ pub(crate) fn register_machine_layouts<'ctx>(
     ctx: &'ctx Context,
     llvm_mod: &LlvmModule<'ctx>,
     machine_layouts: &[MachineLayout],
+    record_layouts: &[hew_mir::RecordLayout],
     record_layout_map: &mut RecordLayoutMap<'ctx>,
     enum_layouts: &[EnumLayout],
     target_data: Option<&TargetData>,
@@ -367,6 +397,15 @@ pub(crate) fn register_machine_layouts<'ctx>(
             .map(|(i, l)| (l.name.clone(), i))
             .collect();
 
+        // Records are not machines, so they never appear in `index_of` — but a
+        // state payload may reach a machine only by way of one. Preserve each
+        // record's canonical registry key so module-qualified and generic
+        // identities remain disjoint during the dependency walk.
+        let record_fields: HashMap<String, &[ResolvedTy]> = record_layouts
+            .iter()
+            .map(|r| (r.name.clone(), r.field_tys.as_slice()))
+            .collect();
+
         // `dep_of[i]` = indices of machines whose bodies must be set before `i`.
         let dep_of: Vec<Vec<usize>> = machine_layouts
             .iter()
@@ -375,7 +414,13 @@ pub(crate) fn register_machine_layouts<'ctx>(
                 let mut deps: Vec<usize> = Vec::new();
                 for variant in layout.variants.iter().chain(layout.events.iter()) {
                     for field_ty in &variant.field_tys {
-                        collect_named_machine_deps(field_ty, &index_of, &mut deps);
+                        collect_named_machine_deps(
+                            field_ty,
+                            &index_of,
+                            &record_fields,
+                            &mut Vec::new(),
+                            &mut deps,
+                        );
                     }
                 }
                 deps.sort_unstable();
@@ -6782,7 +6827,15 @@ mod tests {
             is_opaque: false,
         };
         let mut deps = Vec::new();
-        collect_named_machine_deps(&field_ty, &index_of, &mut deps);
+        let record_fields = HashMap::new();
+        let mut visiting = Vec::new();
+        collect_named_machine_deps(
+            &field_ty,
+            &index_of,
+            &record_fields,
+            &mut visiting,
+            &mut deps,
+        );
         assert_eq!(deps, vec![7]);
 
         let other_module = ResolvedTy::Named {
@@ -6791,7 +6844,13 @@ mod tests {
             builtin: None,
             is_opaque: false,
         };
-        collect_named_machine_deps(&other_module, &index_of, &mut deps);
+        collect_named_machine_deps(
+            &other_module,
+            &index_of,
+            &record_fields,
+            &mut visiting,
+            &mut deps,
+        );
         assert_eq!(
             deps,
             vec![7],

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -35281,6 +35281,7 @@ fn build_module_for_target<'ctx>(
         ctx,
         &llvm_mod,
         &pipeline.machine_layouts,
+        &pipeline.record_layouts,
         &mut record_layouts,
         &pipeline.enum_layouts,
         Some(&target_data),

--- a/tests/hew/machine_in_record_ordering_test.hew
+++ b/tests/hew/machine_in_record_ordering_test.hew
@@ -1,0 +1,140 @@
+//! Regression tests for a `machine` reached only THROUGH a record field, under
+//! BOTH declaration orders — the record-wrapped half of #2864 ("Gap 1").
+//!
+//! `machine_in_machine_test.hew` covers a machine embedded DIRECTLY in another
+//! machine's state payload. This file covers the indirect case:
+//!
+//!     state HoldingG { w: WrapG }   +   type WrapG { inner: InnerG }
+//!
+//! `register_machine_layouts` dependency-sorts machines so a container is never
+//! sized against a still-opaque embedded machine. That sort walks state/event
+//! payload field types looking for names that resolve to machines — but a
+//! RECORD is not a machine, so it misses that lookup. Without descending into
+//! the record's own field types, `InnerG` is never seen as a dependency of
+//! `OuterG` and the container is sized against an opaque struct.
+//!
+//! Unlike the direct case (which segfaulted), this one failed SILENTLY: the
+//! container-first program compiled clean, emitted no diagnostic, produced no
+//! output, and exited 1.
+//!
+//! Both orders are tested because a fix handling only one is half a fix, and
+//! each asserts the EXACT embedded payload string so a zero-sized or misaligned
+//! payload fails rather than reading back an accidental value.
+
+import std::testing;
+
+// ── Order A: container declared FIRST (this failed silently before the fix) ──
+
+machine OuterG {
+    events {
+        step;
+    }
+    state HoldingG { w: WrapG }
+    state EmptyG;
+
+    on step: HoldingG => EmptyG {
+        EmptyG
+    }
+    on step: _ => _ {
+        state
+    }
+}
+
+type WrapG {
+    inner: InnerG;
+}
+
+machine InnerG {
+    events {
+        go;
+    }
+    state ReadyG { payload: string }
+    state DoneG;
+
+    on go: ReadyG => DoneG {
+        DoneG
+    }
+    on go: _ => _ {
+        state
+    }
+}
+
+fn payload_of_g(o: OuterG) -> string {
+    match o {
+        HoldingG { w } => match w.inner {
+            ReadyG { payload } => payload,
+            DoneG => "done",
+        },
+        EmptyG => "empty",
+    }
+}
+
+#[test]
+fn machine_through_record_container_declared_first() {
+    let o = OuterG::HoldingG {
+        w: WrapG {
+            inner: InnerG::ReadyG {
+                payload: "container-first-through-record",
+            },
+        },
+    };
+    testing.assert_eq_str(payload_of_g(o), "container-first-through-record");
+}
+
+// ── Order B: embedded machine declared FIRST (this always worked) ────────────
+
+machine InnerH {
+    events {
+        go;
+    }
+    state ReadyH { payload: string }
+    state DoneH;
+
+    on go: ReadyH => DoneH {
+        DoneH
+    }
+    on go: _ => _ {
+        state
+    }
+}
+
+type WrapH {
+    inner: InnerH;
+}
+
+machine OuterH {
+    events {
+        step;
+    }
+    state HoldingH { w: WrapH }
+    state EmptyH;
+
+    on step: HoldingH => EmptyH {
+        EmptyH
+    }
+    on step: _ => _ {
+        state
+    }
+}
+
+fn payload_of_h(o: OuterH) -> string {
+    match o {
+        HoldingH { w } => match w.inner {
+            ReadyH { payload } => payload,
+            DoneH => "done",
+        },
+        EmptyH => "empty",
+    }
+}
+
+#[test]
+fn machine_through_record_embedded_declared_first() {
+    let o = OuterH::HoldingH {
+        w: WrapH {
+            inner: InnerH::ReadyH {
+                payload: "embedded-first-through-record",
+            },
+        },
+    };
+    testing.assert_eq_str(payload_of_h(o), "embedded-first-through-record");
+}


### PR DESCRIPTION
Related to #2864, but does **not** close it — corrected during review.

This fixes a third shape the issue does not name: a machine state payload reaching a machine *through a record field*. "Gap 1" as filed is the enum-side classifier (`resolved_ty_references_machine`, `hew-codegen-rs/src/llvm.rs:2593`), which does not descend records either and is untouched here — the issue's own example still fails on this branch with `E_NOT_YET_IMPLEMENTED: indirect-enum free synthesis`. #2864 stays open for the enum side.

⚠️ **Stacked on #2879.** The fix lives *inside* the dependency sort that #2879 introduces, so this branch contains that commit as its parent. Review/merge #2879 first; this diff is the 43-line descent on top of it.

## The gap

`register_machine_layouts` sorts machines so a container is never sized against a still-opaque embedded machine. That walk looks for payload field types whose name resolves to a machine — but a **record is not a machine**, so it missed the lookup and stopped. A machine reached only *through* a record field was never registered as a dependency:

```hew
machine OuterG { state HoldingG { w: WrapG } ... }
type WrapG { inner: InnerG; }
machine InnerG { state ReadyG { payload: string } ... }
```

## It fails SILENTLY — worse than Gap 2

Gap 2 segfaulted. This one produces **no diagnostic, no output, and exit 1**. Two programs with byte-for-byte identical token multisets, differing only in declaration order:

```
$ diff <(tr -s ' \n' '\n\n' <gap1.hew|sort) <(tr -s ' \n' '\n\n' <gap1_ctl.hew|sort)
IDENTICAL-TOKENS

$ hew run gap1_ctl.hew    # embedded declared first
gap1-payload              # rc=0

$ hew run gap1.hew        # container declared first
                          # rc=1, no stdout, no diagnostic
```

This is worth noting against #2864's claim that both gaps "fail closed ... do not miscompile". A silent empty exit-1 is arguably harder to diagnose than the segfault, since nothing points at layout at all.

## Fix

`collect_named_machine_deps` now descends into a named type's record field types, keyed off `pipeline.record_layouts` (already threaded into codegen). A `visiting` stack guards recursion rather than trusting acyclicity — a malformed or indirect layout terminates instead of overflowing the stack.

## Evidence

⚠️ **Load-bearing: the tests are revert-verified to discriminate.** With the record descent disabled and the tests kept, the container-first test **FAILS** while embedded-first still passes — so they test the fix, not merely its presence.

Both declaration orders are covered, each asserting the exact payload string so a zero-sized or misaligned payload fails rather than reading back an accidental value.

Green bare (exit codes read directly, not through a pipe):
- `hew-codegen-rs` — 755 tests, RC=0
- all **159** `tests/hew/` files — 159 ok / 0 fail
- `cargo fmt --all --check` — RC=0 (caught a reflow pre-push; the lane that cost #2874/#2878 a red run)
- `cargo clippy -p hew-codegen-rs --all-targets -- -D warnings` — RC=0, zero findings
- pre-existing `machine_in_machine_test.hew` and `machine_in_record_test.hew` both still green
