### PR TITLE
test(runtime): shut the peer down before dropping it in the broken-pipe test

### DIFF
--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -2126,7 +2126,19 @@ mod tests {
         // macOS SIGPIPE suppression the connection-store path applies.
         let sock: Socket = OwnedFd::from(near).into();
         suppress_sigpipe(&sock);
-        drop(far); // fully close the peer
+        // Tear the peer down at the SOCKET level before releasing its fd.
+        //
+        // `drop(far)` alone returns that fd NUMBER to the process while this
+        // suite is running many threads that open sockets and files. If another
+        // thread is handed the just-freed number before the send below, the
+        // near end is once again connected to something live, `framed_send`
+        // writes the whole payload and returns 4096 instead of -1 — a spurious
+        // failure of a test whose subject is the SIGPIPE defenses, not fd
+        // allocation (see hew-lang/hew#2877). `shutdown` breaks the connection
+        // itself, so the precondition no longer depends on the fd slot
+        // staying free.
+        far.shutdown(Shutdown::Both).expect("shutdown peer");
+        drop(far); // release the now-disconnected peer
 
         // The peer is gone, so the header write inside framed_send hits EPIPE
         // and the function fails closed. Reaching the assertion proves the


### PR DESCRIPTION
Closes #2877.

## What was wrong

`framed_send_to_broken_pipe_fails_closed_without_signal` established its "peer is gone" precondition with `drop(far)` alone. That returns the fd **number** to the process while the rest of the suite opens sockets and files across many threads. If another thread receives the just-freed number before the send, the near end is connected to something live again — `framed_send` writes the whole payload and returns `4096` instead of `-1`.

The reported value is the tell: `left: 4096` is a fully successful write, not an error code. So this is a **harness fd-reuse race**, not a regression in the `MSG_NOSIGNAL` / `SO_NOSIGPIPE` defenses the test exists to guard. Those defenses are fine; the precondition silently stops holding.

## Fix

Shut the peer down at the **socket** level before releasing its fd, so the connection is torn down rather than relying on the fd slot staying free. This is option 1 of the three the issue suggested — the smallest change, and it removes the race rather than narrowing it.

The test still deliberately omits the process-wide SIGPIPE ignore, so a genuine regression in either per-socket defense still kills the process loudly. That design is preserved.

## Evidence

⚠️ **A green run does not prove a flake fixed**, so the load-bearing evidence is a control that models fd reuse faithfully — the peer end kept **live** across the send, which is what a reused fd number amounts to from the near end's point of view:

| variant | `send` rc | |
|---|---|---|
| `drop`-only (pre-fix) | **4096** | reproduces the reported value exactly |
| `shutdown` + `drop` (this PR) | **-1** | fails closed even with the peer live |

So the change **discriminates** rather than passing vacuously.

An earlier probe that `dup2`d another socketpair onto the freed number returned `-1` in *both* arms and was discarded as invalid: it leaves `near` genuinely disconnected, so it cannot reproduce the bug. Recording it because it is an easy control to write and to believe.

Green bare (exit codes read directly, not through a pipe):

- `cargo test -p hew-runtime --lib` — **8 full-suite runs**, the broken-pipe test **8/8 ok** (baseline in the issue: 5 ok / 1 FAILED over 6).
- `cargo clippy -p hew-runtime --all-targets -- -D warnings` — RC=0
- `cargo fmt --all --check` — RC=0

## Side finding, deliberately not folded in

One of the 8 runs failed on an unrelated test, `scheduler_wasm::tests::actor_is_parked_after_sleep_request_in_dispatch` (`scheduler_wasm.rs:8208`, `left: 1 / right: 0`). Different test, different module, untouched by this change. Flagging rather than bundling it.

Scope check: this is the only `UnixStream::pair()` site in `transport.rs`, so no sibling test carries the same pattern.