### PR TITLE
ci(freebsd): drop unused wasm provisioning from the aarch64 release gate

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -705,10 +705,14 @@ jobs:
             # Bootstrap pkg through the base utility before reading package catalogues.
             /usr/sbin/pkg bootstrap -fy -r FreeBSD
             pkg update -f -r FreeBSD
-            # wasmtime executes the eval_wasm_* / wasi_run_e2e modules; the
-            # FreeBSD pkg ships it the same way brew/wasmtime.dev provide it on
-            # the macOS and Linux gates.
-            pkg install -y -r FreeBSD llvm22 gdb rust python3 cmake ninja git gmake bash pkgconf libffi libxml2 wasmtime
+            # No wasmtime here, unlike gate-freebsd-x86_64: this leg runs no
+            # test binaries at all (see the scope note above), so the
+            # eval_wasm_* / wasi_run_e2e modules that need a wasm engine never
+            # execute on it. Provisioning one would cost emulated-guest time in
+            # the leg that is already the CPU-bound bottleneck. If this leg's
+            # scope is ever widened to run tests, re-add wasmtime and the
+            # wasm-ld symlink from the x86_64 leg together with them.
+            pkg install -y -r FreeBSD llvm22 gdb rust python3 cmake ninja git gmake bash pkgconf libffi libxml2
 
           run: |
             set -eux
@@ -726,13 +730,10 @@ jobs:
             test -x "$PYTHON"
             /usr/local/llvm22/bin/llvm-config --version
 
-            # The wasm codegen tests link with `wasm-ld`; llvm22 ships it in its
-            # own bin dir, which is not on PATH. Expose it like the macOS gate's
-            # lld@22 so the linker probe finds it instead of failing to spawn
-            # rust-lld (not shipped by the pkg rust toolchain).
-            ln -sf /usr/local/llvm22/bin/wasm-ld /usr/local/bin/wasm-ld
-            command -v wasmtime && wasmtime --version
-            command -v wasm-ld && wasm-ld --version
+            # The `wasm-ld` symlink the x86_64 leg installs is omitted for the
+            # same reason as wasmtime: nothing on this leg links a wasm module.
+            # The smoke test below links natively via the llvm22 toolchain
+            # already on PATH.
 
             # Only the CLI release binary, not hew-lsp/hew-observe or the
             # release-lib profile: this leg proves the compiler builds and


### PR DESCRIPTION
`gate-freebsd-aarch64` installs the `wasmtime` package and symlinks `wasm-ld` out of the llvm22 tree, with comments stating both serve the `eval_wasm_*` / `wasi_run_e2e` modules.

**That leg runs no test binaries at all.** Its documented scope is a release build of `hew-cli` plus a compile+run smoke test, so those modules never execute there and neither tool was ever used. Parsing the job confirms it: `nextest` appears 0 times in `gate-freebsd-aarch64` and 6 times in `gate-freebsd-x86_64`.

The provisioning was copied from `gate-freebsd-x86_64`, where it *is* load-bearing — that leg runs the suite and is **left unchanged by this PR**.

### Why it's worth removing
This is the leg documented as the CPU-bound bottleneck: six observed runs never finished inside the prior 180-minute timeout, and it now carries a 300-minute budget. Installing an unused wasm engine spends emulated-guest time there for nothing. The two comments also actively mislead — they tell a future reader the tools are required.

### Why removal is safe
- The smoke test links **natively**; `hew-cli` only invokes `wasm-ld` for WASM targets (`hew-cli/src/link.rs`).
- Even so, the resolver already probes `/usr/local/llvm{version}/bin/wasm-ld` — the exact FreeBSD path — so a future wasm build on this host would find the linker **without** the symlink.
- Replacement comments record how to restore both together if the leg's scope ever widens to run tests.

### Verification
- `yaml.safe_load` parses the workflow; all 7 jobs intact.
- Diff is confined to `gate-freebsd-aarch64` (+12/-11, comments plus one package name).
- `gate-freebsd-x86_64` retains its wasm tooling and all 6 nextest invocations.

CI is the proving gate here — this job cannot be reproduced locally.