### PR TITLE
Pin the release FreeBSD builds to the FreeBSD package repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -826,7 +826,13 @@ jobs:
             printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
               > /usr/local/etc/pkg/repos/FreeBSD.conf
             pkg update -f
-            pkg install -y llvm22 rust cmake ninja git bash pkgconf libffi libxml2
+            # Pin to the FreeBSD repo written above. Without -r, pkg resolves across
+            # every configured repo, decides it must upgrade itself first, finds
+            # nothing to upgrade, and retries forever: the v0.6.0-rc1 tag build spent
+            # 50 minutes emitting "New version of pkg detected" until the VM's ssh
+            # channel died. release-gate.yml and freebsd.yml already pass -U -r
+            # FreeBSD; this is the copy that drifted.
+            pkg install -y -U -r FreeBSD llvm22 rust cmake ninja git bash pkgconf libffi libxml2
 
           run: |
             set -eux
@@ -950,7 +956,13 @@ jobs:
             printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
               > /usr/local/etc/pkg/repos/FreeBSD.conf
             pkg update -f
-            pkg install -y llvm22 rust cmake ninja git bash pkgconf libffi libxml2
+            # Pin to the FreeBSD repo written above. Without -r, pkg resolves across
+            # every configured repo, decides it must upgrade itself first, finds
+            # nothing to upgrade, and retries forever: the v0.6.0-rc1 tag build spent
+            # 50 minutes emitting "New version of pkg detected" until the VM's ssh
+            # channel died. release-gate.yml and freebsd.yml already pass -U -r
+            # FreeBSD; this is the copy that drifted.
+            pkg install -y -U -r FreeBSD llvm22 rust cmake ninja git bash pkgconf libffi libxml2
 
           run: |
             set -eux


### PR DESCRIPTION
Both FreeBSD jobs in the release workflow ran `pkg install` without `-r`, so pkg resolved across every configured repository, decided it had to upgrade itself before installing anything, found nothing to upgrade, and retried indefinitely.

The v0.6.0-rc1 tag build looped for fifty minutes emitting `New version of pkg detected; it needs to be installed first.` until the VM closed its ssh channel. Both FreeBSD builds failed, and because the release job depends on them, no GitHub Release or binaries were published for the tag.

`release-gate.yml` and `freebsd.yml` already pass `-U -r FreeBSD` and both succeed on the same VM image. This aligns the third copy.

## Verification

The failing invocation and the working one differ only in the repo pin, and the two workflows that carry the pin passed on this same commit — release-gate FreeBSD x86_64 in 1h52m and FreeBSD aarch64 to completion. Re-running the release workflow against the tag exercises the fix directly.