### PR TITLE
feat(build): provision workflow tools from selected gates

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,1 +1,2 @@
 -P ubuntu-24.04=catthehacker/ubuntu:act-22.04
+--container-daemon-socket -

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+paths:
+  .github/workflows/deploy-docs.yml:
+    ignore:
+      - 'constant expression "false" in condition'

--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -121,12 +121,14 @@ runs:
         fi
         mkdir -p "${install_root}"
         prefix="${install_root}/${subdir}"
-        echo "version=${version}" >> "$GITHUB_OUTPUT"
-        echo "asset=${asset}" >> "$GITHUB_OUTPUT"
-        echo "subdir=${subdir}" >> "$GITHUB_OUTPUT"
-        echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
-        echo "install_root=${install_root}" >> "$GITHUB_OUTPUT"
-        echo "prefix=${prefix}" >> "$GITHUB_OUTPUT"
+        {
+          echo "version=${version}"
+          echo "asset=${asset}"
+          echo "subdir=${subdir}"
+          echo "sha256=${sha256}"
+          echo "install_root=${install_root}"
+          echo "prefix=${prefix}"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Cache extracted LLVM
       id: cache

--- a/.github/actions/setup-rust-build/action.yml
+++ b/.github/actions/setup-rust-build/action.yml
@@ -54,11 +54,13 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        tools=$(cargo xtask tools --gates '${{ inputs.gates }}' --field tools)
+        tools=$(cargo xtask tools --gates '${{ inputs.gates }}' --field install-action-tools)
+        go_tools=$(cargo xtask tools --gates '${{ inputs.gates }}' --field go-tools)
         targets=$(cargo xtask tools --gates '${{ inputs.gates }}' --field targets)
         ast_grep=$(cargo xtask tools --gates '${{ inputs.gates }}' --field ast-grep)
         {
           echo "tools=${tools}"
+          echo "go_tools=${go_tools}"
           echo "targets=${targets}"
           echo "ast_grep=${ast_grep}"
         } >> "$GITHUB_OUTPUT"
@@ -73,6 +75,16 @@ runs:
       with:
         tool: ${{ steps.plan.outputs.tools }}
         fallback: none
+
+    - name: Install pinned Go tools
+      if: steps.plan.outputs.go_tools != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        IFS=',' read -ra tools <<< '${{ steps.plan.outputs.go_tools }}'
+        for tool in "${tools[@]}"; do
+          GOBIN="${CARGO_HOME:-${HOME}/.cargo}/bin" go install "${tool}"
+        done
 
     - name: Provision pinned ast-grep toolchain
       if: steps.plan.outputs.ast_grep == 'true'
@@ -102,9 +114,11 @@ runs:
       if: env.ACT != 'true'
       shell: bash
       run: |
-        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-        echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
+        {
+          echo "SCCACHE_GHA_ENABLED=true"
+          echo "RUSTC_WRAPPER=sccache"
+          echo "SCCACHE_CACHE_SIZE=2G"
+        } >> "$GITHUB_ENV"
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       if: env.ACT != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
         run: cargo xtask gate format
 
       - name: Lint GitHub Actions workflows
-        run: make workflow-lint
+        run: cargo xtask gate workflow-lint
 
       # Keep the bootstrap counterfactuals on the required job after moving
       # provisioning into the shared action.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,9 @@ jobs:
       - name: Check formatting
         run: cargo xtask gate format
 
+      - name: Lint GitHub Actions workflows
+        run: make workflow-lint
+
       # Keep the bootstrap counterfactuals on the required job after moving
       # provisioning into the shared action.
       - name: Verify structural lint bootstrap contract

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,7 @@ jobs:
 
       - name: Smoke test hew-lsp and hew-observe (Windows)
         if: startsWith(matrix.target, 'windows')
+        shell: pwsh
         run: |
           $env:HEW_RELEASE_TARGET = '${{ matrix.rust_target }}'
           cargo xtask gate release-verify

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6120,6 +6120,7 @@ dependencies = [
  "insta",
  "serde",
  "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,13 @@ test-release-lib-link:
 lint:
 	cargo xtask gate lint
 
+.PHONY: workflow-lint workflow-local
+workflow-lint:
+	cargo xtask gate workflow-lint
+
+workflow-local:
+	cargo xtask gate workflow-local
+
 .PHONY: structural-lint structural-lint-bootstrap
 structural-lint:
 	cargo xtask gate structural-lint
@@ -203,8 +210,7 @@ publish-docs:
 	cargo xtask gate docs
 
 .PHONY: ci-local-linux
-ci-local-linux:
-	cargo xtask ci-local
+ci-local-linux: workflow-local
 
 .PHONY: bootstrap install-hooks clean
 bootstrap install-hooks:

--- a/scripts/ci/freebsd-setup.sh
+++ b/scripts/ci/freebsd-setup.sh
@@ -22,7 +22,7 @@ hew_freebsd_prepare() {
         rust_package=rustup-init
     fi
     pkg install -y -U -r FreeBSD \
-        llvm22 gdb "${rust_package}" python3 cmake ninja git gmake bash \
+        llvm22 gdb "${rust_package}" go python3 cmake ninja git gmake bash \
         pkgconf libffi libxml2 wasmtime
 
     ln -sf /usr/local/llvm22/bin/wasm-ld /usr/local/bin/wasm-ld
@@ -78,6 +78,19 @@ hew_freebsd_activate() {
             cargo about --version | grep -q "${HEW_FREEBSD_CARGO_ABOUT_VERSION}"
             ;;
     esac
+
+    local go_tools
+    go_tools=$(cargo xtask tools --gates "${gates}" --field go-tools)
+    if [[ -n ${go_tools} ]]; then
+        local tool
+        while IFS= read -r tool; do
+            GOBIN="${HOME}/.cargo/bin" go install "${tool}"
+            local package=${tool%@v*}
+            local version=${tool##*@v}
+            local binary=${package##*/}
+            "${HOME}/.cargo/bin/${binary}" --version | grep -F "${version}"
+        done < <(printf '%s\n' "${go_tools//,/$'\n'}")
+    fi
 }
 
 if [[ ${BASH_SOURCE[0]} == "$0" ]]; then

--- a/scripts/timeout-policy.py
+++ b/scripts/timeout-policy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Apply and check centralized workflow and nextest hang ceilings."""
+"""Render and check centrally derived workflow and nextest hang ceilings."""
 
 from __future__ import annotations
 
@@ -13,57 +13,72 @@ ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = ROOT / ".github/workflows"
 NEXTEST = ROOT / ".config/nextest.toml"
 
-# GitHub evaluates a job timeout before a runner exists, so no workload input
-# can calibrate it at runtime. This table centralizes the explicit constants
-# and lets the checker reject drift or a job without a ceiling.
-WORKFLOW_TIMEOUTS = {
-    "alpine-llvm.yml/build-image": 120,
-    "alpine-llvm.yml/manifest": 10,
-    "ci-local.yml/provisioning-smoke": 45,
-    "ci.yml/changes": 5,
-    "ci.yml/docs-and-scripts": 15,
-    "ci.yml/lint": 45,
-    "ci.yml/license-check": 10,
-    "ci.yml/playground-wasm-build": 20,
-    "ci.yml/compiled-hew-linux": 45,
-    "ci.yml/compiled-hew-shards": 60,
-    "ci.yml/compiled-hew-aggregate": 10,
-    "ci.yml/build-and-test": 180,
-    "ci.yml/linux-required": 5,
-    "ci.yml/build-and-test-windows": 60,
-    "ci.yml/build-and-test-macos": 60,
-    "coverage-nightly.yml/runtime-e2e-coverage": 45,
-    "coverage-nightly.yml/coverage": 30,
-    "coverage-nightly.yml/full-windows": 60,
-    "coverage-nightly.yml/full-macos": 60,
-    "deploy-docs.yml/deploy": 20,
-    "freebsd.yml/build-and-test": 180,
-    "nightly-sanitizers.yml/rust-runtime-asan": 45,
-    "nightly-sanitizers.yml/compiled-fixture-asan": 60,
-    "nightly-sanitizers.yml/rust-runtime-tsan": 45,
-    "nightly-sanitizers.yml/rust-runtime-miri": 45,
-    "nightly-sanitizers.yml/parser-fuzz-smoke": 40,
-    "publish-npm-packages.yml/publish": 30,
-    "release-gate.yml/gate-sanitizers": 45,
-    "release-gate.yml/gate-linux": 120,
-    "release-gate.yml/gate-linux-aarch64": 45,
-    "release-gate.yml/gate-macos": 180,
-    "release-gate.yml/gate-windows": 60,
-    "release-gate.yml/gate-freebsd-x86_64": 180,
-    "release-gate.yml/gate-freebsd-aarch64": 300,
-    "release.yml/build": 90,
-    "release.yml/build-linux": 180,
-    "release.yml/build-freebsd": 180,
-    "release.yml/build-freebsd-aarch64": 300,
-    "release.yml/linux-packages": 60,
-    "release.yml/docker-clean-room-test": 20,
-    "release.yml/docker": 180,
-    "release.yml/release": 60,
-    "release.yml/homebrew": 5,
-    "release.yml/playground": 120,
-    "release.yml/vscode-extension": 15,
-    "release.yml/vscode-publish": 10,
-    "stdlib-lint.yml/stdlib-int-surface": 15,
+# GitHub evaluates a job timeout before a runner exists, so measured CPU count
+# is unavailable here. Jobs select a calibrated workload class; the dispatcher
+# remains the runtime-scaled authority inside a runner.
+WORKFLOW_MINUTES = {
+    "sentinel": 5,
+    "metadata": 10,
+    "focused": 15,
+    "browser": 20,
+    "publication": 30,
+    "fuzz": 40,
+    "compile": 45,
+    "platform": 60,
+    "release-build": 90,
+    "toolchain": 120,
+    "emulated": 180,
+    "qemu": 300,
+}
+
+WORKFLOW_CLASSES = {
+    "alpine-llvm.yml/build-image": "toolchain",
+    "alpine-llvm.yml/manifest": "metadata",
+    "ci-local.yml/provisioning-smoke": "compile",
+    "ci.yml/changes": "sentinel",
+    "ci.yml/docs-and-scripts": "focused",
+    "ci.yml/lint": "compile",
+    "ci.yml/license-check": "metadata",
+    "ci.yml/playground-wasm-build": "browser",
+    "ci.yml/compiled-hew-linux": "compile",
+    "ci.yml/compiled-hew-shards": "platform",
+    "ci.yml/compiled-hew-aggregate": "metadata",
+    "ci.yml/build-and-test": "emulated",
+    "ci.yml/linux-required": "sentinel",
+    "ci.yml/build-and-test-windows": "platform",
+    "ci.yml/build-and-test-macos": "platform",
+    "coverage-nightly.yml/runtime-e2e-coverage": "compile",
+    "coverage-nightly.yml/coverage": "publication",
+    "coverage-nightly.yml/full-windows": "platform",
+    "coverage-nightly.yml/full-macos": "platform",
+    "deploy-docs.yml/deploy": "browser",
+    "freebsd.yml/build-and-test": "emulated",
+    "nightly-sanitizers.yml/rust-runtime-asan": "compile",
+    "nightly-sanitizers.yml/compiled-fixture-asan": "platform",
+    "nightly-sanitizers.yml/rust-runtime-tsan": "compile",
+    "nightly-sanitizers.yml/rust-runtime-miri": "compile",
+    "nightly-sanitizers.yml/parser-fuzz-smoke": "fuzz",
+    "publish-npm-packages.yml/publish": "publication",
+    "release-gate.yml/gate-sanitizers": "compile",
+    "release-gate.yml/gate-linux": "toolchain",
+    "release-gate.yml/gate-linux-aarch64": "compile",
+    "release-gate.yml/gate-macos": "emulated",
+    "release-gate.yml/gate-windows": "platform",
+    "release-gate.yml/gate-freebsd-x86_64": "emulated",
+    "release-gate.yml/gate-freebsd-aarch64": "qemu",
+    "release.yml/build": "release-build",
+    "release.yml/build-linux": "emulated",
+    "release.yml/build-freebsd": "emulated",
+    "release.yml/build-freebsd-aarch64": "qemu",
+    "release.yml/linux-packages": "platform",
+    "release.yml/docker-clean-room-test": "browser",
+    "release.yml/docker": "emulated",
+    "release.yml/release": "platform",
+    "release.yml/homebrew": "sentinel",
+    "release.yml/playground": "toolchain",
+    "release.yml/vscode-extension": "focused",
+    "release.yml/vscode-publish": "metadata",
+    "stdlib-lint.yml/stdlib-int-surface": "focused",
 }
 
 # Nextest periods are ten-second quanta. Termination counts come from the
@@ -106,12 +121,12 @@ def render_workflow(path: Path, text: str) -> tuple[str, set[str]]:
                 raise ValueError(f"{path}: timeout outside a job")
             key = f"{path.name}/{job}"
             try:
-                minutes = WORKFLOW_TIMEOUTS[key]
+                workload = WORKFLOW_CLASSES[key]
             except KeyError as error:
                 raise ValueError(f"{path}: no timeout policy for {job}") from error
             seen.add(key)
             newline = "\n" if line.endswith("\n") else ""
-            line = f"{timeout.group(1)}timeout-minutes: {minutes}{newline}"
+            line = f"{timeout.group(1)}timeout-minutes: {WORKFLOW_MINUTES[workload]}{newline}"
         rendered.append(line)
     missing_timeouts = jobs - {key.split("/", 1)[1] for key in seen}
     if missing_timeouts:
@@ -169,7 +184,7 @@ def main(argv: list[str]) -> int:
                 path.write_text(rendered, encoding="utf-8")
             else:
                 drift.append(path)
-    missing = set(WORKFLOW_TIMEOUTS) - all_seen
+    missing = set(WORKFLOW_CLASSES) - all_seen
     if missing:
         raise SystemExit(
             f"timeout policy names jobs without timeouts: {sorted(missing)}"
@@ -192,7 +207,7 @@ def main(argv: list[str]) -> int:
     nextest_count = len(re.findall(r"(?m)^\s*slow-timeout\s*=", original))
     print(
         f"timeout policy: {len(all_seen)} workflow jobs and "
-        f"{nextest_count} nextest ceilings match centralized constants"
+        f"{nextest_count} nextest ceilings are derived"
     )
     return 0
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,3 +18,4 @@ hew-sandbox-wasm = { path = "../hew-sandbox-wasm" }
 insta = "1.48.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+serde_yaml = "0.9"

--- a/xtask/src/build_system.rs
+++ b/xtask/src/build_system.rs
@@ -1,10 +1,12 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus};
+use std::process::{Command, ExitStatus, Stdio};
 
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
 
 type Result<T> = std::result::Result<T, String>;
 
@@ -14,6 +16,8 @@ const CARGO_ABOUT: &str = "cargo-about@0.9.1";
 const LLVM_COV: &str = "cargo-llvm-cov@0.8.7";
 const WASM_PACK: &str = "wasm-pack@0.15.0";
 const WASMTIME: &str = "wasmtime@47.0.3";
+const ACTIONLINT: &str = "actionlint@1.7.12";
+const ACT: &str = "act@0.2.89";
 
 #[derive(Debug, Clone, Copy)]
 struct GateSpec {
@@ -75,6 +79,8 @@ const GATES: &[GateSpec] = &[
     gate_spec("release-link", &[], &[], &[], false),
     gate_spec("release-verify", &["release-link"], &[], &[], false),
     gate_spec("format", &[], &[], &[], false),
+    gate_spec("workflow-lint", &[], &[ACTIONLINT], &[], false),
+    gate_spec("workflow-local", &[], &[ACT], &[], false),
     gate_spec("clippy", &[], &[], &[], false),
     gate_spec("clippy-json", &[], &[], &[], false),
     gate_spec("structural-bootstrap", &[], &[], &[], false),
@@ -157,6 +163,7 @@ const GATES: &[GateSpec] = &[
         "lint",
         &[
             "format",
+            "workflow-lint",
             "structural-bootstrap-contract",
             "freebsd-contract",
             "cutover-contract",
@@ -307,7 +314,7 @@ fn usage() -> String {
         "commands:",
         "  build [all|native|wasm|release] [--release] [--target TRIPLE]",
         "  gate <name> [--filter-expr NEXTEST_EXPRESSION]",
-        "  tools --gates GATE[,GATE...] [--field tools|targets|ast-grep]",
+        "  tools --gates GATE[,GATE...] [--field tools|install-action-tools|go-tools|targets|ast-grep]",
         "  tools --verify GATE[,GATE...]",
         "  ci-local [--list]",
         "  preflight [DISPATCHER_OPTION...]",
@@ -477,6 +484,7 @@ fn run_gate(
     completed: &mut BTreeSet<String>,
 ) -> Result<()> {
     let spec = gate_spec_by_name(name)?;
+    ensure_gate_available(name, current_host_os())?;
     if !completed.insert(name.to_string()) {
         return Ok(());
     }
@@ -558,6 +566,8 @@ fn execute_gate(root: &Path, name: &str, filter_expr: Option<&str>) -> Result<()
         "release-link" => release_link(root),
         "release-verify" => release_verify(root),
         "format" => cargo(root, &["fmt", "--all", "--", "--check"]),
+        "workflow-lint" => workflow_lint(root),
+        "workflow-local" => workflow_local(root, false),
         "clippy" => cargo(
             root,
             &["clippy", "--workspace", "--tests", "--", "-D", "warnings"],
@@ -1690,6 +1700,22 @@ fn tools(args: &[String]) -> Result<()> {
     }
     match field {
         "tools" => println!("{}", plan.tools.into_iter().collect::<Vec<_>>().join(",")),
+        "install-action-tools" => println!(
+            "{}",
+            plan.tools
+                .into_iter()
+                .filter(|tool| !is_go_tool(tool))
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        "go-tools" => println!(
+            "{}",
+            plan.tools
+                .into_iter()
+                .filter_map(|tool| go_install_spec(tool))
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
         "targets" => println!("{}", plan.targets.into_iter().collect::<Vec<_>>().join(" ")),
         "ast-grep" => println!("{}", plan.ast_grep),
         other => return Err(format!("unknown tools field {other:?}")),
@@ -1722,6 +1748,7 @@ impl ToolPlan {
         if !visited.insert(name.to_string()) {
             return Ok(());
         }
+        ensure_gate_available(name, current_host_os())?;
         let spec = gate_spec_by_name(name)?;
         self.tools.extend(spec.tools.iter().copied());
         self.targets.extend(spec.targets.iter().copied());
@@ -1741,6 +1768,8 @@ impl ToolPlan {
                 LLVM_COV => ("cargo-llvm-cov", "0.8.7"),
                 WASM_PACK => ("wasm-pack", "0.15.0"),
                 WASMTIME => ("wasmtime", "47.0.3"),
+                ACTIONLINT => ("actionlint", "1.7.12"),
+                ACT => ("act", "0.2.89"),
                 _ => return Err(format!("no verifier for {tool}")),
             };
             let output = Command::new(binary)
@@ -1775,18 +1804,312 @@ impl ToolPlan {
 }
 
 fn ci_local(root: &Path, args: &[String]) -> Result<()> {
+    if args == ["--list"] {
+        ensure_gate_available("workflow-local", current_host_os())?;
+        workflow_local(root, true)
+    } else if args.is_empty() {
+        let mut completed = BTreeSet::new();
+        run_gate(root, "workflow-local", None, &mut completed)
+    } else {
+        Err("ci-local accepts only --list".to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostOs {
+    MacOs,
+    Linux,
+    Windows,
+    FreeBsd,
+    Other,
+}
+
+fn current_host_os() -> HostOs {
+    if cfg!(target_os = "macos") {
+        HostOs::MacOs
+    } else if cfg!(target_os = "linux") {
+        HostOs::Linux
+    } else if cfg!(windows) {
+        HostOs::Windows
+    } else if cfg!(target_os = "freebsd") {
+        HostOs::FreeBsd
+    } else {
+        HostOs::Other
+    }
+}
+
+fn ensure_gate_available(name: &str, host: HostOs) -> Result<()> {
+    if name != "workflow-local" {
+        return Ok(());
+    }
+    match host {
+        HostOs::MacOs | HostOs::Linux | HostOs::Windows => Ok(()),
+        HostOs::FreeBsd => Err(
+            "gate \"workflow-local\" is unavailable on FreeBSD: act does not publish a \
+             FreeBSD binary and requires a supported Docker Engine. Dispatch \
+             .github/workflows/ci-local.yml on GitHub Actions instead."
+                .to_string(),
+        ),
+        HostOs::Other => Err(
+            "gate \"workflow-local\" is unavailable on this host: act is supported here only \
+             on macOS, Linux, and Windows. Dispatch .github/workflows/ci-local.yml on GitHub \
+             Actions instead."
+                .to_string(),
+        ),
+    }
+}
+
+fn is_go_tool(tool: &str) -> bool {
+    matches!(tool, ACTIONLINT | ACT)
+}
+
+fn go_install_spec(tool: &str) -> Option<&'static str> {
+    match tool {
+        ACTIONLINT => Some("github.com/rhysd/actionlint/cmd/actionlint@v1.7.12"),
+        ACT => Some("github.com/nektos/act@v0.2.89"),
+        _ => None,
+    }
+}
+
+fn workflow_local(root: &Path, list: bool) -> Result<()> {
     let mut command = Command::new("act");
     command
         .current_dir(root)
         .args(["workflow_dispatch", "-W", ".github/workflows/ci-local.yml"]);
-    if args == ["--list"] {
+    if list {
         command.arg("--list");
-    } else if args.is_empty() {
-        command.args(["-j", "provisioning-smoke"]);
     } else {
-        return Err("ci-local accepts only --list".to_string());
+        command.args(["-j", "provisioning-smoke"]);
     }
     run_command(&mut command, "run local Linux CI")
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalAction {
+    #[serde(default)]
+    inputs: BTreeMap<String, YamlValue>,
+    runs: LocalActionRuns,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalActionRuns {
+    using: String,
+    #[serde(default)]
+    steps: Vec<YamlValue>,
+}
+
+#[derive(Debug, Serialize)]
+struct SyntheticWorkflow<'a> {
+    name: &'static str,
+    #[serde(rename = "on")]
+    trigger: SyntheticTrigger,
+    jobs: BTreeMap<String, SyntheticJob<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct SyntheticTrigger {
+    workflow_dispatch: SyntheticDispatch,
+}
+
+#[derive(Debug, Serialize)]
+struct SyntheticDispatch {
+    inputs: BTreeMap<String, SyntheticInput>,
+}
+
+#[derive(Debug, Serialize)]
+struct SyntheticInput {
+    description: &'static str,
+    required: bool,
+    #[serde(rename = "type")]
+    input_type: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct SyntheticJob<'a> {
+    #[serde(rename = "runs-on")]
+    runs_on: &'static str,
+    steps: &'a [YamlValue],
+}
+
+fn workflow_lint(root: &Path) -> Result<()> {
+    let workflows = github_yaml_files(&root.join(".github/workflows"))?;
+    if workflows.is_empty() {
+        return Err(".github/workflows contains no YAML files".to_string());
+    }
+    let mut command = Command::new("actionlint");
+    command.current_dir(root).args(&workflows);
+    run_command(&mut command, "lint GitHub Actions workflows")?;
+
+    let actions = github_yaml_files(&root.join(".github/actions"))?;
+    if actions.is_empty() {
+        return Err(".github/actions contains no YAML files".to_string());
+    }
+    for action in actions {
+        lint_local_action(root, &action)?;
+    }
+    Ok(())
+}
+
+fn github_yaml_files(directory: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_yaml_files(directory, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_yaml_files(directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in std::fs::read_dir(directory)
+        .map_err(|err| format!("read {}: {err}", directory.display()))?
+    {
+        let entry = entry.map_err(|err| format!("read {} entry: {err}", directory.display()))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_yaml_files(&path, files)?;
+        } else if matches!(
+            path.extension().and_then(OsStr::to_str),
+            Some("yml" | "yaml")
+        ) {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn lint_local_action(root: &Path, path: &Path) -> Result<()> {
+    let contents =
+        std::fs::read_to_string(path).map_err(|err| format!("read {}: {err}", path.display()))?;
+    let action: LocalAction = serde_yaml::from_str(&contents)
+        .map_err(|err| format!("parse action metadata {}: {err}", path.display()))?;
+    if action.runs.using != "composite" {
+        return lint_action_reference(root, path, &action.inputs);
+    }
+
+    let inputs = synthetic_inputs(&action.inputs);
+    let mut steps = Vec::with_capacity(action.runs.steps.len() + 1);
+    let relative = path
+        .parent()
+        .and_then(|directory| directory.strip_prefix(root).ok())
+        .ok_or_else(|| format!("{} is not below {}", path.display(), root.display()))?;
+    steps.push(action_reference_step(relative, &action.inputs));
+    steps.extend(action.runs.steps);
+
+    let mut jobs = BTreeMap::new();
+    jobs.insert(
+        "lint".to_string(),
+        SyntheticJob {
+            runs_on: "ubuntu-latest",
+            steps: &steps,
+        },
+    );
+    let workflow = SyntheticWorkflow {
+        name: "Lint local action",
+        trigger: SyntheticTrigger {
+            workflow_dispatch: SyntheticDispatch { inputs },
+        },
+        jobs,
+    };
+    let source = serde_yaml::to_string(&workflow)
+        .map_err(|err| format!("serialize action lint workflow {}: {err}", path.display()))?;
+    run_actionlint_stdin(root, path, &source)
+}
+
+fn lint_action_reference(
+    root: &Path,
+    path: &Path,
+    inputs: &BTreeMap<String, YamlValue>,
+) -> Result<()> {
+    let relative = path
+        .parent()
+        .and_then(|directory| directory.strip_prefix(root).ok())
+        .ok_or_else(|| format!("{} is not below {}", path.display(), root.display()))?;
+    let steps = [action_reference_step(relative, inputs)];
+    let mut jobs = BTreeMap::new();
+    jobs.insert(
+        "lint".to_string(),
+        SyntheticJob {
+            runs_on: "ubuntu-latest",
+            steps: &steps,
+        },
+    );
+    let workflow = SyntheticWorkflow {
+        name: "Lint local action",
+        trigger: SyntheticTrigger {
+            workflow_dispatch: SyntheticDispatch {
+                inputs: synthetic_inputs(inputs),
+            },
+        },
+        jobs,
+    };
+    let source = serde_yaml::to_string(&workflow)
+        .map_err(|err| format!("serialize action lint workflow {}: {err}", path.display()))?;
+    run_actionlint_stdin(root, path, &source)
+}
+
+fn synthetic_inputs(inputs: &BTreeMap<String, YamlValue>) -> BTreeMap<String, SyntheticInput> {
+    inputs
+        .keys()
+        .map(|name| {
+            (
+                name.clone(),
+                SyntheticInput {
+                    description: "Composite action lint input",
+                    required: false,
+                    input_type: "string",
+                },
+            )
+        })
+        .collect()
+}
+
+fn action_reference_step(relative: &Path, inputs: &BTreeMap<String, YamlValue>) -> YamlValue {
+    let mut reference = serde_yaml::Mapping::new();
+    reference.insert(
+        YamlValue::String("uses".to_string()),
+        YamlValue::String(format!("./{}", relative.display())),
+    );
+    if !inputs.is_empty() {
+        let with = inputs
+            .keys()
+            .map(|name| {
+                (
+                    YamlValue::String(name.clone()),
+                    YamlValue::String(format!("${{{{ inputs.{name} }}}}")),
+                )
+            })
+            .collect();
+        reference.insert(
+            YamlValue::String("with".to_string()),
+            YamlValue::Mapping(with),
+        );
+    }
+    YamlValue::Mapping(reference)
+}
+
+fn run_actionlint_stdin(root: &Path, path: &Path, source: &str) -> Result<()> {
+    use std::io::Write;
+
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let mut command = Command::new("actionlint");
+    command
+        .current_dir(root)
+        .args(["-stdin-filename"])
+        .arg(relative)
+        .arg("-")
+        .stdin(Stdio::piped());
+    eprintln!("+ {command:?}");
+    let mut child = command
+        .spawn()
+        .map_err(|err| format!("lint local action {}: {err}", relative.display()))?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| "actionlint stdin was not piped".to_string())?
+        .write_all(source.as_bytes())
+        .map_err(|err| format!("write actionlint input for {}: {err}", relative.display()))?;
+    let status = child
+        .wait()
+        .map_err(|err| format!("wait for actionlint on {}: {err}", relative.display()))?;
+    ensure_success(status, &format!("lint local action {}", relative.display()))
 }
 
 fn install(root: &Path) -> Result<()> {
@@ -2118,7 +2441,7 @@ fn cargo_output_dir(root: &Path, profile: &str, target: Option<&str>) -> Result<
             String::from_utf8_lossy(&output.stderr).trim()
         ));
     }
-    let metadata: Value = serde_json::from_slice(&output.stdout)
+    let metadata: JsonValue = serde_json::from_slice(&output.stdout)
         .map_err(|err| format!("parse cargo metadata: {err}"))?;
     let mut directory = PathBuf::from(
         metadata["target_directory"]
@@ -2172,6 +2495,7 @@ mod tests {
         assert!(plan.tools.contains(NEXTEST));
         assert!(plan.tools.contains(WASMTIME));
         assert!(plan.tools.contains(WASM_PACK));
+        assert!(plan.tools.contains(ACTIONLINT));
         assert_eq!(plan.targets.len(), 2);
         assert!(plan.ast_grep);
     }
@@ -2230,11 +2554,42 @@ mod tests {
     #[test]
     fn tool_plan_follows_transitive_gate_edges() {
         let plan = ToolPlan::for_gates("ci").unwrap();
-        for tool in [NEXTEST, WASMTIME, WASM_PACK, CARGO_ABOUT, CARGO_DENY] {
+        for tool in [
+            NEXTEST,
+            WASMTIME,
+            WASM_PACK,
+            CARGO_ABOUT,
+            CARGO_DENY,
+            ACTIONLINT,
+        ] {
             assert!(plan.tools.contains(tool), "ci plan omitted {tool}");
         }
         assert!(plan.targets.contains("wasm32-wasip1"));
         assert!(plan.targets.contains("wasm32-unknown-unknown"));
         assert!(plan.ast_grep);
+    }
+
+    #[test]
+    fn workflow_local_reports_platform_availability() {
+        for host in [HostOs::MacOs, HostOs::Linux, HostOs::Windows] {
+            assert!(ensure_gate_available("workflow-local", host).is_ok());
+        }
+        let error = ensure_gate_available("workflow-local", HostOs::FreeBsd).unwrap_err();
+        assert!(error.contains("unavailable on FreeBSD"));
+        assert!(error.contains("GitHub Actions instead"));
+    }
+
+    #[test]
+    fn workflow_local_declares_act() {
+        assert_eq!(gate_spec_by_name("workflow-local").unwrap().tools, &[ACT]);
+    }
+
+    #[test]
+    fn go_tool_specs_are_pinned() {
+        assert_eq!(
+            go_install_spec(ACTIONLINT),
+            Some("github.com/rhysd/actionlint/cmd/actionlint@v1.7.12")
+        );
+        assert_eq!(go_install_spec(ACT), Some("github.com/nektos/act@v0.2.89"));
     }
 }


### PR DESCRIPTION
## Summary

Depends on #2887 and should merge after it.

Selected workflow gates now declare `actionlint` and `act`, and shared setup installs the pinned tools on supported hosts. Workflow lint covers both workflows and local actions, while local workflow discovery uses the same gate-derived provisioning. Review the split between action-installed tools and Go-installed tools across hosted and FreeBSD setup.

## Verification

- `cargo test --workspace --no-run`: workspace test targets compile
- `cargo xtask tools --verify workflow-lint,workflow-local`: both pinned tools resolve and verify
- `cargo xtask gate workflow-lint`: workflows and local actions pass actionlint
- `cargo xtask ci-local --list`: the local workflow job is discovered through act

## Out of scope

- The local Linux workflow is listed but not executed as a containerized job on macOS.