### PR TITLE
fix(ci): run checks on pull requests against every base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+  # Every pull request, whatever its base. Restricting this to `main` meant a
+  # stacked PR (based on another branch) received no checks at all, so its
+  # merge gate could report READY with nothing having run. A stacked branch
+  # is exactly where a break is easiest to miss.
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The `pull_request` trigger was filtered to `main`, so a pull request stacked on another branch received no checks at all and its merge gate could report ready with nothing having run.

Stacked branches are where a break is easiest to miss, since the parent is itself untested on `main`.

Stacked pull requests now run CI twice: once against the parent, once after the parent merges and the child retargets `main`. That is the intended trade against merging a branch nothing has tested.