### PR TITLE
docs(runtime): record why the wasm32 build reports unused symbols

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1564,6 +1564,14 @@ pub(crate) unsafe fn record_dispatch_state_drop_consumed(actor: *mut HewActor) {
 /// # Safety
 ///
 /// `actor` must be a live, newly spawned actor not yet visible to dispatch.
+// KEEP(wasm32): production caller in supervisor.rs marks a shallow-template
+// restart incarnation as borrowing state from the persistent child spec.
+// lib.rs gates `pub mod supervisor` behind
+// `#[cfg(not(target_arch = "wasm32"))]` while `pub mod actor` is ungated — the
+// same asymmetry already annotated elsewhere in this file. The bit it writes,
+// `HewActor::state_drop_borrowed`, is READ on both targets and is ABI
+// layout-asserted for wasm parity in scheduler_wasm.rs.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) unsafe fn mark_state_drop_borrowed(actor: *mut HewActor) {
     if actor.is_null() {
         eprintln!("fatal: null actor while recording borrowed state provenance");
@@ -1583,6 +1591,11 @@ pub(crate) unsafe fn mark_state_drop_borrowed(actor: *mut HewActor) {
 /// # Safety
 ///
 /// `actor` must be the live child whose former template alias was just broken.
+// KEEP(wasm32): production caller is `hew_supervisor_set_child_state_clone` in
+// the native-only supervisor module; it flips provenance to owned once the
+// template deep-clone breaks the alias. Same cfg asymmetry as
+// `mark_state_drop_borrowed`.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) unsafe fn mark_state_drop_owned(actor: *mut HewActor) {
     if actor.is_null() {
         eprintln!("fatal: null actor while recording owned state provenance");

--- a/hew-runtime/src/bridge.rs
+++ b/hew-runtime/src/bridge.rs
@@ -174,8 +174,17 @@ struct HandlerMetaEntry {
     return_size: u32,
 }
 
-// live on wasm32 + test; dead on native non-test; caller tracing.rs:854 (cfg(any(wasm32,test)))
-#[cfg_attr(not(any(target_arch = "wasm32", test)), allow(dead_code))]
+// KEEP: this is the wasm32/test arm of `tracing::drain_events_json`, which is
+// itself `#[cfg(feature = "profiler")]`. The arm is selected by
+// `cfg(any(target_arch = "wasm32", test))`, so `cargo test -p hew-runtime`
+// compiles and runs it on native (profiler is in the default feature set) —
+// `test` is a live target here, not just wasm. The fields are read by
+// `resolve_actor_trace_attribution` below. It is genuinely uncalled only where
+// that arm is not compiled: native non-test, or any build without `profiler`.
+#[cfg_attr(
+    not(all(any(target_arch = "wasm32", test), feature = "profiler")),
+    allow(dead_code)
+)]
 #[derive(Clone)]
 struct ActorTraceAttribution {
     actor_type_id: u64,
@@ -243,8 +252,13 @@ pub(crate) fn register_bridge_reset_hook() {
 /// NOTE: last-registered wins on `msg_type` collision across actor types.
 /// This is a pre-existing ambiguity in the AOT model — see the `handler_names`
 /// field documentation on [`MetaState`] for details.
-// live on wasm32 + test; dead on native non-test; caller tracing.rs:857 (cfg(any(wasm32,test)))
-#[cfg_attr(not(any(target_arch = "wasm32", test)), allow(dead_code))]
+// KEEP: same seam as `ActorTraceAttribution` above — reached from the
+// `cfg(any(wasm32, test))` arm of the profiler-gated `drain_events_json`, and
+// covered by the drain_events_json_includes_handler_name test.
+#[cfg_attr(
+    not(all(any(target_arch = "wasm32", test), feature = "profiler")),
+    allow(dead_code)
+)]
 pub(crate) fn resolve_handler_name(msg_type: i32) -> Option<String> {
     meta_state().handler_names.get(&msg_type).cloned()
 }
@@ -273,8 +287,14 @@ fn wasm_actor_type_id(actor_name: &str) -> u64 {
 ///
 /// NOTE: last-registered wins on flat `msg_type` collisions, matching
 /// [`resolve_handler_name`] and the current AOT bridge model.
-// live on wasm32 + test; dead on native non-test; caller tracing.rs:856 (cfg(any(wasm32,test)))
-#[cfg_attr(not(any(target_arch = "wasm32", test)), allow(dead_code))]
+// KEEP: same seam as `ActorTraceAttribution` above — the only coverage proving
+// wasm-side trace JSON carries the same attribution shape as native
+// (drain_events_json_includes_wasm_registered_actor_type, plus the bridge
+// registration and session-reset tests).
+#[cfg_attr(
+    not(all(any(target_arch = "wasm32", test), feature = "profiler")),
+    allow(dead_code)
+)]
 pub(crate) fn resolve_actor_trace_attribution(
     msg_type: i32,
 ) -> Option<(u64, String, Option<String>)> {

--- a/hew-runtime/src/cont.rs
+++ b/hew-runtime/src/cont.rs
@@ -286,6 +286,14 @@ thread_local! {
 /// at unwind, and until then its storage is held so its address cannot be reused
 /// mid-drain. A crash-cleanup escrow thunk that also owns this frame observes it
 /// as quarantined and skips its own (would-be double) free.
+// KEEP(wasm32): called from `drain_active_coroutine_frames_excluding`, whose
+// only caller `reclaim_active_coroutine_frames_excluding` is
+// `#[cfg(not(target_arch = "wasm32"))]` — the native crash-drain path taken
+// after a signal longjmp abandons a stack. This module is ungated, so wasm32 is
+// the only build where the drain has no entry point. Deleting it reopens the
+// same-drain ABA / tcache double-free closed by PR #2865 (LESSONS.md
+// `crash-recovery-frame-owner-is-single-authority`).
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 fn quarantine_reclaimed_frame(frame: *mut c_void) {
     if frame.is_null() {
         return;
@@ -769,6 +777,10 @@ unsafe fn discard_frame_crash_cleanup_registry(frame: *mut c_void) {
     }
 }
 
+// KEEP(wasm32): same native crash-drain path as `quarantine_reclaimed_frame`;
+// this half discharges the frame's typed escrow owners before the storage is
+// released.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 unsafe fn run_frame_crash_cleanups(frame: *mut c_void) {
     // Detach before running user/resource thunks so recursive runtime calls
     // cannot observe a half-drained registry.

--- a/hew-runtime/src/lifetime/local_handles.rs
+++ b/hew-runtime/src/lifetime/local_handles.rs
@@ -2,7 +2,17 @@
 
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+// KEEP(wasm32 non-test): `AtomicBool` types `SupervisorControl::teardown_claimed`,
+// the single-shot claim that makes supervisor reclamation happen exactly once —
+// but `SupervisorControl` and its impl are `#[cfg(not(target_arch = "wasm32"))]`
+// while this import is unconditional. It is also used by
+// `LocalHandles::fail_next_registration` under `cfg(test)`. A wasm32 non-test
+// build is therefore the only configuration with no user for this one name;
+// `AtomicUsize` and `Ordering` still have users there, which is why rustc flags
+// the name and not the line. Split out so the allow covers `AtomicBool` alone.
+#[cfg_attr(all(target_arch = "wasm32", not(test)), allow(unused_imports))]
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 use std::sync::{Condvar, Mutex, PoisonError};

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -139,6 +139,12 @@ pub struct RuntimeHookSnapshot {
 ///
 /// Accepted true values are `1`, `true`, `yes`, `on`, and `hot`. Empty/unset
 /// leaves the tier disabled. This is called during scheduler initialization.
+//
+// KEEP(wasm32): called from `scheduler::hew_sched_init`. `pub mod scheduler` is
+// `#[cfg(not(target_arch = "wasm32"))]` in lib.rs while `pub mod observe` is
+// ungated, so the caller vanishes on wasm32 (which ships `scheduler_wasm`) and
+// only there. Live on macOS, Linux, FreeBSD and Windows.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn configure_from_env() {
     let enabled = std::env::var("HEW_OBSERVE")
         .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "yes" | "on" | "hot"));
@@ -200,6 +206,11 @@ pub(crate) fn record_heap_free(size: u64) {
     }
 }
 
+// KEEP(wasm32): called from the native scheduler's actor dispatch path
+// (`scheduler.rs`), which lib.rs gates behind `#[cfg(not(target_arch =
+// "wasm32"))]`; this module is ungated, so wasm32 sees a definition with no
+// caller. Deleting it breaks every native build.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_actor_turn(duration_ns: u64) {
     if observe_hot_tier_enabled() {
         shard_add(&ACTOR_TURNS_TOTAL, 1);
@@ -316,10 +327,24 @@ pub(crate) fn observe_dispatch_abandon(ticket: ObserveDispatchTicket) {
     observe_dispatch_close(ticket);
 }
 
+// The recorders below carry `KEEP(wasm32)`: each has live callers on every
+// native target, and each of those caller modules — `scheduler`, `reactor`,
+// `crash`, `supervisor`, `arena`, `blocking_pool` — is declared
+// `#[cfg(not(target_arch = "wasm32"))]` in lib.rs, while `pub mod observe` is
+// declared unconditionally. On wasm32 the definitions therefore compile with
+// zero callers (that build ships `scheduler_wasm`/`arena_wasm` and has no
+// reactor, crash handler or blocking pool); on native, deleting any of them is
+// an immediate compile error. The allow is per-symbol and wasm32-only so a
+// genuinely-unused recorder still warns on the primary target.
+
+// KEEP(wasm32): scheduler.rs park path.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_scheduler_park() {
     SCHEDULER_PARKS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): scheduler.rs unpark path.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_scheduler_unpark() {
     SCHEDULER_UNPARKS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
@@ -334,11 +359,15 @@ pub(crate) fn record_coroutine_frame_free(frame_bytes: u64) {
     COROUTINES_FRAME_BYTES_LIVE.fetch_sub(frame_bytes, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): scheduler.rs coroutine suspend path.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_coroutine_suspend() {
     COROUTINES_SUSPENDS_TOTAL.fetch_add(1, Ordering::Relaxed);
     COROUTINES_SUSPENDED.fetch_add(1, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): scheduler.rs coroutine resume path.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_coroutine_resume() {
     COROUTINES_RESUMES_TOTAL.fetch_add(1, Ordering::Relaxed);
     let _ = COROUTINES_SUSPENDED.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
@@ -346,10 +375,14 @@ pub(crate) fn record_coroutine_resume() {
     });
 }
 
+// KEEP(wasm32): reactor.rs registration path.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_reactor_registration() {
     REACTOR_REGISTRATIONS_LIVE.fetch_add(1, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): reactor.rs deregistration path.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_reactor_unregistration(count: u64) {
     let _ =
         REACTOR_REGISTRATIONS_LIVE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
@@ -357,26 +390,38 @@ pub(crate) fn record_reactor_unregistration(count: u64) {
         });
 }
 
+// KEEP(wasm32): reactor.rs readiness dispatch.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_reactor_ready_event() {
     REACTOR_READY_EVENTS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): crash.rs fault handler.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_actor_crash() {
     ACTORS_CRASHES_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): supervisor.rs restart path.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_actor_restart() {
     ACTORS_RESTARTS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): arena.rs reset path.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_arena_reset() {
     ARENA_RESETS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): blocking_pool.rs job entry.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_blocking_start() {
     THREADS_BLOCKING_COUNT.fetch_add(1, Ordering::Relaxed);
 }
 
+// KEEP(wasm32): blocking_pool.rs job exit.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_blocking_finish() {
     let _ = THREADS_BLOCKING_COUNT.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
         value.checked_sub(1)

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -1087,6 +1087,12 @@ pub unsafe extern "C" fn hew_observe_string_free(ptr: *mut c_char) {
 /// In particular, this deliberately does **not** reset live gauges or the
 /// dispatch-ticket/barrier state.  Those values have active writers and are
 /// reset only by [`reset_all`] after scheduler shutdown has joined workers.
+///
+/// KEEP(wasm32): called from `scheduler::hew_sched_metrics_reset`, the
+/// counter-reset half of the public metrics C ABI. lib.rs gates `pub mod
+/// scheduler` behind `#[cfg(not(target_arch = "wasm32"))]` while `pub mod
+/// observe` is unconditional, so only wasm32 sees no caller.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn reset_live_safe_counters() {
     shard_reset(&HEAP_ALLOCATED_TOTAL);
     shard_reset(&HEAP_FREED_TOTAL);
@@ -1115,6 +1121,13 @@ pub(crate) fn reset_live_safe_counters() {
 /// workers before firing `session_reset`, which invokes this hook.  Do not call
 /// this from a live metrics API: clearing a dispatch ticket while its worker
 /// still owns it makes that worker panic when it closes the ticket.
+///
+/// KEEP(wasm32): registered on `session::RESET_HOOKS` by
+/// [`register_reset_hooks`] and fired from `scheduler::hew_sched_shutdown`
+/// after workers are joined — both in the native-only `scheduler` module.
+/// Dropping it would silently leak a prior session's metrics registry and
+/// dispatch-ticket state into the next JIT/AOT reload cycle.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn reset_all() {
     reset_live_safe_counters();
     COROUTINES_LIVE.store(0, Ordering::Relaxed);
@@ -1141,6 +1154,11 @@ pub(crate) fn reset_all() {
     }
 }
 
+/// KEEP(wasm32): called from `scheduler::hew_sched_init`, which lib.rs gates
+/// behind `#[cfg(not(target_arch = "wasm32"))]`. Structurally identical to the
+/// sibling registrations in bridge.rs, tracing.rs and profiler/mod.rs on the
+/// same shared `session::RESET_HOOKS` registry.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn register_reset_hooks() {
     use std::sync::Once;
     static ONCE: Once = Once::new();

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -160,11 +160,28 @@ pub fn set_hot_tier_enabled(enabled: bool) {
     HOT_TIER_ENABLED.store(enabled, Ordering::Release);
 }
 
+/// Pin the calling thread to its own counter shard.
+///
+/// KEEP(wasm32): the caller is `scheduler::worker_loop`, which every thread
+/// spawned by `hew_sched_init` runs; lib.rs declares `pub mod scheduler` under
+/// `#[cfg(not(target_arch = "wasm32"))]` while `pub mod observe` is
+/// unconditional, so only a wasm32 build sees no caller.
+///
+/// This is a correctness seam, not only a contention one: `current_shard`
+/// indexes `DISPATCH_ACTIVE_TICKETS` in `observe_dispatch_begin` and
+/// `clear_active_dispatch_ticket`. With every worker left on shard 0 they would
+/// overwrite each other's in-flight tickets, `computed_dispatch_watermark`
+/// would advance past live dispatches, and `hew_observe_barrier` could return
+/// OK while work is still running.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn set_current_worker_shard(worker_id: usize) {
     let shard = worker_id.saturating_add(1).min(SHARD_COUNT - 1);
     WORKER_SHARD.with(|slot| slot.set(shard));
 }
 
+// `current_shard`/`shard_add` carry no target gate and no `profiler` gate:
+// `record_actor_turn` reaches them on every target whenever the hot tier is on,
+// so they need no allow of their own — they die only if that recorder does.
 fn current_shard() -> usize {
     WORKER_SHARD.with(Cell::get)
 }
@@ -180,6 +197,8 @@ fn shard_sum(shards: &[AtomicU64; SHARD_COUNT]) -> u64 {
         .sum()
 }
 
+// Reached unconditionally from `reset_live_safe_counters`, whose own KEEP note
+// explains why that entry point is native-only; no allow of its own is needed.
 fn shard_reset(shards: &[AtomicU64; SHARD_COUNT]) {
     for counter in shards {
         counter.store(0, Ordering::Relaxed);

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -22,7 +22,16 @@ use crate::util::{CondvarExt, MutexExt};
 
 const SHARD_COUNT: usize = HEW_MAX_WORKERS + 1;
 const OBSERVE_BARRIER_OK: i64 = 0;
+// The two failure codes of the `hew_observe_barrier` runtime call. They are read
+// only inside that function's `#[cfg(not(target_arch = "wasm32"))]` body, while
+// this module is compiled for every target — so wasm32, whose `hew_observe_barrier`
+// is a documented no-op returning `OBSERVE_BARRIER_OK`, is the only build with no
+// reader. They are the fail-closed half of a shipping surface: `std/observe.hew`
+// declares the call, `hew-types` maps `RuntimeCall::ObserveBarrier` to the symbol,
+// and `hew-codegen-rs` emits its i64 signature.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 const OBSERVE_BARRIER_ERR_WORKER_CONTEXT: i64 = -1;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 const OBSERVE_BARRIER_ERR_TIMEOUT: i64 = -2;
 #[cfg(not(target_arch = "wasm32"))]
 const OBSERVE_BARRIER_TIMEOUT: Duration = Duration::from_secs(30);

--- a/hew-runtime/src/timer_wheel.rs
+++ b/hew-runtime/src/timer_wheel.rs
@@ -63,6 +63,15 @@ static TICKER_NOTIFY_HOOK: OnceLock<fn()> = OnceLock::new();
 
 /// Register the ticker's wakeup function.  Called once from
 /// `timer_periodic::start_ticker_thread`.  Subsequent calls are ignored.
+//
+// KEEP(wasm32): `timer_periodic` is declared
+// `#[cfg(not(target_arch = "wasm32"))]` in lib.rs while `timer_wheel` compiles
+// for both targets by design (wasm ticks are host-driven), so wasm32 is the
+// only build where nobody registers. `notify_ticker` degrades correctly there:
+// `OnceLock::get()` returns `None` and the call is a no-op. On native the hook
+// is what stops the ticker parking on a stale deadline — without it a timer
+// scheduled onto an empty wheel would not fire until an unrelated wake.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn register_ticker_notify_hook(f: fn()) {
     // OnceLock: only the first registration wins; safe to call again.
     let _ = TICKER_NOTIFY_HOOK.set(f);

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -415,6 +415,11 @@ fn record_lifecycle_event(actor_id: u64, event_type: i32, msg_type: i32) {
 /// `discriminator` is carried in the event's `msg_type` slot and is
 /// decision-specific (restart strategy, within-window restart count, or
 /// scheduled backoff delay in ms).
+// KEEP(wasm32): ten call sites in supervisor.rs (restart, escalate, give-up).
+// lib.rs gates `pub mod supervisor` behind `#[cfg(not(target_arch = "wasm32"))]`
+// while `pub mod tracing` is unconditional, so wasm32 is the only build where
+// the callers are compiled out.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn record_supervisor_event(actor_id: u64, event_type: i32, discriminator: i32) {
     record_lifecycle_event(actor_id, event_type, discriminator);
 }
@@ -624,6 +629,11 @@ pub(crate) fn system_context() -> HewTraceContext {
 ///
 /// Read-only side effect: no-op when tracing is disabled or no context slot is
 /// installed; never gates supervisor control flow.
+// KEEP(wasm32): three call sites in supervisor.rs, plus the
+// supervisor_trace_export_e2e integration test. Same cfg asymmetry as
+// `record_supervisor_event`: the supervisor module is native-only, this module
+// is not.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn ensure_supervisor_trace_root() {
     if !TRACING_ENABLED.load(Ordering::Relaxed) {
         return;

--- a/hew-runtime/src/util.rs
+++ b/hew-runtime/src/util.rs
@@ -60,6 +60,10 @@ pub(crate) fn push_json_string(out: &mut String, s: &str) {
 }
 
 /// Extract a readable message from a panic payload.
+//
+// KEEP(wasm32): reached from `take_panic_payload_message`, whose own note
+// explains why the whole pair is native-only.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn panic_payload_message(panic_payload: &(dyn std::any::Any + Send)) -> String {
     if let Some(s) = panic_payload.downcast_ref::<&str>() {
         (*s).to_string()
@@ -97,6 +101,16 @@ pub(crate) fn quarantine_panic_payload(mut payload: Box<dyn std::any::Any + Send
 
 /// Extract a diagnostic string, then release the owned payload through the
 /// runtime's containment authority.
+//
+// KEEP(wasm32): six call sites across `lambda_actor.rs`, `timer_periodic.rs`,
+// `task_scope.rs` and `blocking_pool.rs`, plus `report_join_panic` in this
+// file. All five of those are declared `#[cfg(not(target_arch = "wasm32"))]`
+// while `pub mod util` is unconditional, so wasm32 is the only build with no
+// caller. The behaviour is load-bearing: a background-thread panic becomes a
+// diagnostic and the payload is released through `quarantine_panic_payload`,
+// which contains a hostile `Drop` rather than letting a second unwind escape
+// the runtime boundary.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn take_panic_payload_message(payload: Box<dyn std::any::Any + Send>) -> String {
     let message = panic_payload_message(payload.as_ref());
     quarantine_panic_payload(payload);

--- a/hew-runtime/src/xnode_serial.rs
+++ b/hew-runtime/src/xnode_serial.rs
@@ -242,6 +242,17 @@ fn register_codec_into(
     }
 }
 
+// KEEP(wasm32): this is the live cross-node actor wire codec. `pub mod
+// xnode_serial` is unconditional in lib.rs while its only consumer,
+// `pub mod hew_node`, is `#[cfg(not(target_arch = "wasm32"))]`, so a wasm32
+// build — which compiles no cross-node transport — is the one place these
+// entry points have no caller. On native every remote actor send or ask
+// reaches them, and the fail-closed rule of the wire-format doctrine (no
+// registered codec means the send is refused) is enforced here.
+//
+// The four `lookup_*` resolvers below are the codec-key layer those entry
+// points call, so they stay reachable without an allow of their own.
+
 /// Look up the deserialize thunk for `(dispatch, msg_type)`, if registered.
 pub(crate) fn lookup_deserialize(
     dispatch: *const c_void,
@@ -284,6 +295,8 @@ pub(crate) fn lookup_reply_deserialize(
 ///
 /// # Safety
 /// `data` must be valid for `len` bytes (or null when `len == 0`).
+// KEEP(wasm32): see the codec note above; caller is hew_node.rs.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) unsafe fn decode_reply(
     dispatch: *const c_void,
     msg_type: i32,
@@ -307,6 +320,8 @@ pub(crate) unsafe fn decode_reply(
 ///
 /// # Safety
 /// `data` must be valid for `len` bytes (or null when `len == 0`).
+// KEEP(wasm32): see the codec note above; caller is hew_node.rs.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) unsafe fn decode_payload(
     dispatch: *const c_void,
     msg_type: i32,
@@ -339,6 +354,8 @@ pub(crate) fn lookup_serialize(dispatch: *const c_void, msg_type: i32) -> Option
 /// # Safety
 /// `value_ptr` must point to a valid value of the message type for `msg_type`;
 /// `out_len` must be a valid writable pointer.
+// KEEP(wasm32): see the codec note above; caller is hew_node.rs.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) unsafe fn encode_payload(
     dispatch: *const c_void,
     msg_type: i32,
@@ -364,6 +381,8 @@ pub(crate) unsafe fn encode_payload(
 /// # Safety
 /// `value_ptr` must point to a valid value of the reply type for `msg_type`;
 /// `out_len` must be a valid writable pointer.
+// KEEP(wasm32): see the codec note above; caller is hew_node.rs.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) unsafe fn encode_reply(
     dispatch: *const c_void,
     msg_type: i32,


### PR DESCRIPTION
The wasm32-wasip1 build of `hew-runtime` emits 44 unused-symbol warnings. None is dead code.

Each is native-only machinery whose callers live in modules gated `#[cfg(not(target_arch = "wasm32"))]` while the definitions are not. On native every symbol has a live call site; on wasm32 the callers vanish and the definitions remain.

- **Observability recorders** — the wasm build ships `scheduler_wasm`/`mailbox_wasm`/`arena_wasm` and has no reactor, crash handler or blocking pool to instrument.
- **Worker-shard fan-out** — per-worker counter sharding avoids cache-line contention in the native work-stealing scheduler; wasm32 runs one cooperative thread.
- **Attribution-barrier failure codes** — returned by `hew_observe_barrier`, which needs `Condvar`/`Mutex`/`Instant` and is itself gated off wasm32. `OBSERVE_BARRIER_OK` does not warn, because wasm-visible code still reads it.
- **Session reset hooks** — driven by scheduler shutdown, a path wasm32 never reaches.
- **Cross-node payload/reply codec** — called only from `hew_node`, which is not compiled for wasm32 because there is no cross-node transport there.
- **Supervisor tracing, panic-payload containment, crash-drain escrow, restart state-drop marks, ticker notify hook** — same shape.

Each site gets a comment naming the mechanism and a `#[cfg_attr(target_arch = "wasm32", allow(dead_code))]` scoped to wasm32 alone, so genuine dead code on native is still reported.

Zero warnings across four configurations: default features with `--all-targets`, `--no-default-features --all-targets`, `wasm32-wasip1 --no-default-features`, and `--workspace --all-targets`. Each attribute is load-bearing: reverting `hew-runtime/src` to the merge base reproduces all 44 warnings. Nothing was deleted.