### PR TITLE
fix(test): stop a prose backlog reference matching the WASM-TODO marker

### DIFF
--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -695,7 +695,7 @@ fn native_cooperative_sleep_matches_wasi_output() {
 }
 
 // An actor with an `#[every]` periodic handler. No `await` is used: awaiting
-// inside an actor is still gated on wasm (WASM-TODO(#1451)), so an ask-based
+// inside an actor is still gated on wasm (see backlog #1451), so an ask-based
 // variant would fail at codegen and prove nothing about the timer.
 const COOPERATIVE_PERIODIC_SOURCE: &str = r#"actor Pulse {
     var count: i64 = 0;


### PR DESCRIPTION
The marker lint fails on `main`:

    lint-wasm-todo: hew-cli/tests/wasi_run_e2e.rs:698: malformed marker;
    expected `WASM-TODO(<stable-backlog-id>):`

A comment names the backlog id inside a sentence as a cross-reference, not as a marker. The lint matches on the `WASM-TODO(` prefix and requires a trailing colon, so the reference reads as malformed and reddens the Clippy job on every open pull request.

Reword it to name the backlog id plainly. The lint's authority over real markers is unchanged.

`scripts/lint-wasm-todo.py` reproduces the failure on `main` and reports `ok (75 markers, 30 backlog ids)` with this change.