### PR TITLE
perf(ci): remove duplicate verdict coverage from the Linux gates job

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -395,7 +395,7 @@ path = "junit.xml"
 [profile.smoke]
 # Smoke profile: curated deterministic in-process oracle only.  Designed to
 # give a pass/fail signal before committing to the full Rust workspace body.
-# Used by the `ci-preflight-smoke` tier in the dispatcher's fallback lane.
+# Used by the direct local `ci-preflight-smoke` target.
 #
 # What it runs: a small deterministic oracle complement to fmt/clippy that does
 # not spawn the full `hew` compiler binary or the sandbox Node runner, does not
@@ -415,9 +415,8 @@ path = "junit.xml"
 #     profile.default/profile.ci (whole-binary, not per-test — see there).
 #   hew-wasm      — requires wasmtime
 #
-# Coverage contract: the smoke tier is a FAST FAIL-EARLY gate; the heavy tier
-# (test-rust / make test) still runs on smoke pass and provides full coverage.
-# The smoke tier does NOT replace the ci profile — it precedes it.
+# Coverage contract: the smoke target is a FAST local signal, while the ci
+# profile provides full coverage and includes this selected test.
 default-filter = "test(every_hew_file_roundtrips_through_formatter)"
 test-threads = "num-cpus"
 slow-timeout = { period = "60s", terminate-after = 2 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,9 +579,11 @@ jobs:
 
       - name: List the independent full suite inventory
         if: env.RUN_CODE_PATH == 'true'
-        run: >-
-          "${{ runner.temp }}/compiled-hew-artifact/compiled-hew/debug/hew"
-          test tests/hew --list > "${{ runner.temp }}/compiled-hew-full.txt"
+        run: |
+          for fixture in tests/hew/*.hew; do
+            "${{ runner.temp }}/compiled-hew-artifact/compiled-hew/debug/hew" \
+              test "$fixture" --list --allow-empty
+          done | LC_ALL=C sort > "${{ runner.temp }}/compiled-hew-full.txt"
 
       # >>> CI-PARITY-STEPS
       - name: Assert shard union and Hew ratchet
@@ -740,6 +742,7 @@ jobs:
         if: env.RUN_CODE_PATH == 'true'
         env:
           CI_PREFLIGHT_BASE: origin/main
+          COMPILED_HEW_GATE_OWNER: aggregate
           HEW_O0_OUTCOMES_FILE: ${{ runner.temp }}/hew-o0-outcomes.txt
         run: scripts/ci-preflight-dispatcher.sh --base origin/main
 

--- a/Makefile
+++ b/Makefile
@@ -373,13 +373,13 @@ ci-preflight:
 	scripts/ci-preflight-dispatcher.sh $(ARGS)
 
 # Fast smoke preflight: Rust fmt + the workspace's deterministic in-process
-# tests (nextest smoke profile).  Designed to complete in <5 min and surface
-# format and fast oracle failures before the full heavy tier is invoked.
-# Clippy runs in the lint target; the fallback lane runs both sequentially.
+# tests (nextest smoke profile). Designed to complete in <5 min and surface
+# format and fast oracle failures during local iteration. Clippy remains in
+# the lint target and is not duplicated here.
 #
-# This target is invoked by the dispatcher as the first step of the fallback/heavy
-# lane; the full suite (make test) still runs on smoke pass.  Run it directly for
-# a quick sanity pass on any diff without waiting for E2E compilation.
+# Run this target directly for a quick sanity pass on any diff without waiting
+# for E2E compilation. The comprehensive dispatcher reserves it for that local
+# opt-in because its full workspace run already includes the smoke test.
 #
 # The smoke nextest profile excludes subprocess-intensive tests (eval_e2e,
 # test_runner_e2e, parity) and hew-wasm; see .config/nextest.toml [profile.smoke].

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -207,14 +207,21 @@ collect_paths_from_command() {
 }
 
 add_command() {
+    local command="$1"
+    local existing
     if [[ "${COMPILED_HEW_GATE_OWNER:-dispatcher}" == "aggregate" ]]; then
-        case "$1" in
+        case "$command" in
             "make test-hew-ratchet"|"make test-o2-differential")
                 return 0
                 ;;
         esac
     fi
-    COMMANDS+=("$1")
+    if [[ ${COMMANDS[0]+set} == set ]]; then
+        for existing in "${COMMANDS[@]}"; do
+            [[ "$existing" == "$command" ]] && return 0
+        done
+    fi
+    COMMANDS+=("$command")
 }
 
 has_commands() {

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -894,23 +894,18 @@ case "$LANE" in
         add_command "make playground-check"
         ;;
     fallback)
-        # Smoke tier first: fast fail-early on format, clippy, and deterministic
-        # in-process oracles (including fmt_roundtrip_corpus) before committing
-        # to the heavy build + E2E suite.  The smoke tier completes in <5 min and
-        # catches the most common regression classes (bad formatting, clippy
-        # violations, formatter-AST bugs) without building and running test-codegen.
-        #
-        # On smoke pass, the heavy tier runs in full — no coverage is dropped.
-        # make lint follows smoke because it adds structural-lint,
-        # hew-fmt-check (Hew file formatting), runtime-poison-safe-lint,
-        # lint-wasm-todo, and verify-ffi which the smoke tier does not include.
+        # Keep the fast smoke target as a direct local opt-in. Its nextest
+        # selection is a subset of the full workspace run below, so running it
+        # here would make it a serial prefix of its own superset. Format checking
+        # remains first for quick feedback, and make lint supplies clippy,
+        # structural-lint, Hew formatting, and the remaining static checks.
         #
         # Hew-language suites run after the Rust workspace to keep the ratchet
         # verdict separate from the Rust test verdict.
         #
         # The sequence below mirrors CI's build-and-test job exactly so a green
         # fallback preflight predicts a green merge-queue outcome.
-        add_command "make ci-preflight-smoke"
+        add_command "cargo fmt --all -- --check"
         add_command "make lint"
         add_command "make freebsd-workflow-contract-check"
         add_command "make playground-check"

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -207,6 +207,13 @@ collect_paths_from_command() {
 }
 
 add_command() {
+    if [[ "${COMPILED_HEW_GATE_OWNER:-dispatcher}" == "aggregate" ]]; then
+        case "$1" in
+            "make test-hew-ratchet"|"make test-o2-differential")
+                return 0
+                ;;
+        esac
+    fi
     COMMANDS+=("$1")
 }
 

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -901,9 +901,9 @@ case "$LANE" in
         # violations, formatter-AST bugs) without building and running test-codegen.
         #
         # On smoke pass, the heavy tier runs in full — no coverage is dropped.
-        # make lint follows smoke because it adds hew-fmt-check (Hew file
-        # formatting), runtime-poison-safe-lint, lint-wasm-todo, and verify-ffi
-        # which the smoke tier does not include.
+        # make lint follows smoke because it adds structural-lint,
+        # hew-fmt-check (Hew file formatting), runtime-poison-safe-lint,
+        # lint-wasm-todo, and verify-ffi which the smoke tier does not include.
         #
         # Hew-language suites run after the Rust workspace to keep the ratchet
         # verdict separate from the Rust test verdict.
@@ -911,7 +911,6 @@ case "$LANE" in
         # The sequence below mirrors CI's build-and-test job exactly so a green
         # fallback preflight predicts a green merge-queue outcome.
         add_command "make ci-preflight-smoke"
-        add_command "make structural-lint"
         add_command "make lint"
         add_command "make freebsd-workflow-contract-check"
         add_command "make playground-check"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -111,6 +111,14 @@ def test_structural_lint_label_matches_dispatched_command_and_ci_bootstraps() ->
     assert "  - make structural-lint " in local.stdout, local.stdout
     assert "make structural-lint-bootstrap" not in local.stdout, local.stdout
 
+    fallback = run_dispatcher("Cargo.toml")
+    assert fallback.returncode == 0, fallback.stderr
+    assert "  - make structural-lint " not in fallback.stdout, fallback.stdout
+    assert "  - make lint " in fallback.stdout, fallback.stdout
+
+    makefile = (ROOT / "Makefile").read_text()
+    assert re.search(r"^lint:.*\bstructural-lint\b", makefile, re.MULTILINE), makefile
+
     workflow = (ROOT / ".github/workflows/ci.yml").read_text()
     assert re.search(
         r"name: Provision pinned ast-grep toolchain\s+uses: ./\.github/actions/setup-ast-grep",

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -828,6 +828,24 @@ def test_hosted_linux_executes_the_dispatcher_directly() -> None:
     assert "run: make test-hew-ratchet" not in workflow
 
 
+def test_compiled_hew_aggregate_owns_hosted_full_suite_verdicts() -> None:
+    local = run_dispatcher("some-unclassified-root-file.txt")
+    assert local.returncode == 0, local.stderr
+    assert "  - make test-hew-ratchet " in local.stdout, local.stdout
+    assert "  - make test-o2-differential " in local.stdout, local.stdout
+
+    hosted = run_dispatcher(
+        "some-unclassified-root-file.txt",
+        env={"COMPILED_HEW_GATE_OWNER": "aggregate"},
+    )
+    assert hosted.returncode == 0, hosted.stderr
+    assert "make test-hew-ratchet" not in hosted.stdout, hosted.stdout
+    assert "make test-o2-differential" not in hosted.stdout, hosted.stdout
+
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+    assert "COMPILED_HEW_GATE_OWNER: aggregate" in workflow, workflow
+
+
 def test_selector_exports_fail_closed_compile_requirement() -> None:
     with tempfile.NamedTemporaryFile() as output:
         result = run_dispatcher(
@@ -902,6 +920,7 @@ _TESTS = [
     test_leaf_crate_runs_only_its_reverse_dependency_closure,
     test_analysis_change_runs_known_dependents_without_workspace,
     test_hosted_linux_executes_the_dispatcher_directly,
+    test_compiled_hew_aggregate_owns_hosted_full_suite_verdicts,
     test_selector_exports_fail_closed_compile_requirement,
 ]
 

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -555,35 +555,35 @@ def test_docs_only_change_does_not_include_vertical_slice_oracle() -> None:
     assert "cargo clippy" not in result.stdout, result.stdout
 
 
-def test_fallback_lane_includes_smoke_tier_before_heavy() -> None:
-    """Fallback lane runs the smoke tier (make ci-preflight-smoke) before make lint and make test.
-
-    The smoke tier surfaces fmt/clippy/fast-oracle failures in <5 min before
-    the expensive full suite (make lint + make playground-check + make test) is
-    invoked.  Coverage is unchanged: the heavy tier runs on smoke pass.
-    """
-    # An unclassified path routes to the fallback (comprehensive) lane.
+def test_comprehensive_profile_reserves_smoke_for_local_opt_in() -> None:
     result = run_dispatcher("some-unclassified-root-file.txt")
     assert result.returncode == 0, result.stderr
     assert "Selected profile: comprehensive" in result.stdout, result.stdout
-    assert "make ci-preflight-smoke" in result.stdout, (
-        "Expected 'make ci-preflight-smoke' in fallback lane commands.\n"
-        f"stdout:\n{result.stdout}"
-    )
-    assert "make lint" in result.stdout, (
-        f"Expected 'make lint' in fallback lane commands.\nstdout:\n{result.stdout}"
-    )
-    assert "make test" in result.stdout, (
-        f"Expected 'make test' in fallback lane commands.\nstdout:\n{result.stdout}"
-    )
-    # Smoke tier must appear before make lint in the command list.
-    smoke_pos = result.stdout.index("make ci-preflight-smoke")
+    assert "make ci-preflight-smoke" not in result.stdout, result.stdout
+    assert "cargo fmt --all -- --check" in result.stdout, result.stdout
+    assert "make lint" in result.stdout, result.stdout
+    assert "make test" in result.stdout, result.stdout
+
+    fmt_pos = result.stdout.index("cargo fmt --all -- --check")
     lint_pos = result.stdout.index("make lint")
     test_pos = result.stdout.index("make test")
-    assert smoke_pos < lint_pos < test_pos, (
-        f"Expected order: make ci-preflight-smoke < make lint < make test.\n"
-        f"smoke_pos={smoke_pos}, lint_pos={lint_pos}, test_pos={test_pos}\n"
-        f"stdout:\n{result.stdout}"
+    assert fmt_pos < lint_pos < test_pos, result.stdout
+
+    makefile = (ROOT / "Makefile").read_text()
+    assert "cargo nextest run --workspace --profile smoke" in makefile, makefile
+    assert (
+        "cargo nextest run --workspace --exclude hew-cabi --profile ci --no-fail-fast"
+        in makefile
+    ), makefile
+
+    nextest = (ROOT / ".config/nextest.toml").read_text()
+    assert (
+        'default-filter = "test(every_hew_file_roundtrips_through_formatter)"'
+        in nextest
+    )
+    assert (
+        "hew-parser/tests/fmt_roundtrip_corpus.rs"
+        not in nextest.split("[profile.ci]", 1)[1].split("[profile.ci.junit]", 1)[0]
     )
 
 
@@ -926,7 +926,7 @@ _TESTS = [
     test_types_lane_includes_checked_mir_verify,
     test_make_test_compiler_pipeline_recipe_keeps_consumer_corpus_packages,
     test_docs_only_change_does_not_include_vertical_slice_oracle,
-    test_fallback_lane_includes_smoke_tier_before_heavy,
+    test_comprehensive_profile_reserves_smoke_for_local_opt_in,
     test_parser_plus_types_narrow_multi_bucket_uses_types_lane,
     test_hew_tests_path_routes_to_hew_tests_lane,
     test_parser_path_runs_formatter_property,

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -354,8 +354,8 @@ def test_profile_json_records_elapsed_for_each_command() -> None:
         profile_entries = json.loads(Path(profile.name).read_text())
 
     assert result.returncode == 1, result.stdout
-    assert [entry["cmd"] for entry in profile_entries] == ["true", "false", "true"]
-    assert [entry["status"] for entry in profile_entries] == [0, 1, 0]
+    assert [entry["cmd"] for entry in profile_entries] == ["true", "false"]
+    assert [entry["status"] for entry in profile_entries] == [0, 1]
     for entry in profile_entries:
         assert isinstance(entry["elapsed_s"], int), profile_entries
         assert entry["elapsed_s"] >= 0, profile_entries
@@ -846,6 +846,23 @@ def test_compiled_hew_aggregate_owns_hosted_full_suite_verdicts() -> None:
     assert "COMPILED_HEW_GATE_OWNER: aggregate" in workflow, workflow
 
 
+def test_selected_commands_are_unique() -> None:
+    result = run_dispatcher(
+        "Cargo.toml",
+        "hew-sandbox-vm/src/interpreter/parity-runner.ts",
+        "std/string.hew",
+        "tests/fuzz-oracle/bounds.hew",
+    )
+    assert result.returncode == 0, result.stderr
+    commands = [
+        line.removeprefix("  - ").split("  (budget:", 1)[0]
+        for line in result.stdout.splitlines()
+        if line.startswith("  - ") and "  (budget:" in line
+    ]
+    assert len(commands) == len(set(commands)), commands
+    assert commands.count("make sandbox-parity") == 1, commands
+
+
 def test_selector_exports_fail_closed_compile_requirement() -> None:
     with tempfile.NamedTemporaryFile() as output:
         result = run_dispatcher(
@@ -921,6 +938,7 @@ _TESTS = [
     test_analysis_change_runs_known_dependents_without_workspace,
     test_hosted_linux_executes_the_dispatcher_directly,
     test_compiled_hew_aggregate_owns_hosted_full_suite_verdicts,
+    test_selected_commands_are_unique,
     test_selector_exports_fail_closed_compile_requirement,
 ]
 

--- a/scripts/tests/test_compiled_hew_shards.py
+++ b/scripts/tests/test_compiled_hew_shards.py
@@ -165,8 +165,10 @@ class CompiledHewWorkflowContractTests(unittest.TestCase):
         )
 
     def test_aggregate_uses_an_independent_full_inventory_and_both_gates(self) -> None:
+        self.assertIn("for fixture in tests/hew/*.hew; do", self.workflow)
+        self.assertIn('test "$fixture" --list --allow-empty', self.workflow)
         self.assertIn(
-            'test tests/hew --list > "${{ runner.temp }}/compiled-hew-full.txt"',
+            'LC_ALL=C sort > "${{ runner.temp }}/compiled-hew-full.txt"',
             self.workflow,
         )
         self.assertIn("make test-hew-ratchet", self.workflow)


### PR DESCRIPTION
Four commands in the Linux gates job recompute verdicts another job already owns.

`test-hew-ratchet` and `test-o2-differential` ran in the dispatcher while the sharded job's four shards already execute O0 and O2 across the same inventory, and its aggregate verifies inventory closure, the O0 ratchet, and per-test O0/O2 identity. `linux-required` waits for both jobs, so nothing stops being required.

Inventory equality was established before removing them: the dispatcher's per-fixture list, the directory list, and the four hash partitions all contain the same 1,326 identities with empty set differences, split 318/312/344/352. The aggregate now compares its union against that inventory permanently, so a future divergence fails rather than silently narrowing coverage.

`sandbox-parity` ran twice because `add_command` performed no uniqueness check; fixed at `add_command` so the class cannot recur. `structural-lint` ran standalone and again as a prerequisite of the lint target. `ci-preflight-smoke` was a serial prefix of the full workspace test run that follows it, and stays available as a local opt-in.

The comprehensive dry run goes from 39 commands to 36 with no duplicates.

Projected saving 56.5 to 69.2 minutes; the 54.0 and 2.5 minute components are measured, the rest are ranges because cold-start work may move rather than disappear. The shard contract suite proves disjoint union closure, O0 ratchet enforcement and O0/O2 identity; 52 dispatcher, 85 release-workflow and 55 reachability tests pass, and all 68 gate targets remain reachable.