### PR TITLE
fix(ci): bootstrap pkg before installing FreeBSD build tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -825,14 +825,12 @@ jobs:
             mkdir -p /usr/local/etc/pkg/repos
             printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
               > /usr/local/etc/pkg/repos/FreeBSD.conf
-            pkg update -f
-            # Pin to the FreeBSD repo written above. Without -r, pkg resolves across
-            # every configured repo, decides it must upgrade itself first, finds
-            # nothing to upgrade, and retries forever: the v0.6.0-rc1 tag build spent
-            # 50 minutes emitting "New version of pkg detected" until the VM's ssh
-            # channel died. release-gate.yml and freebsd.yml already pass -U -r
-            # FreeBSD; this is the copy that drifted.
-            pkg install -y -U -r FreeBSD llvm22 rust cmake ninja git bash pkgconf libffi libxml2
+            # Bootstrap pkg through the base utility before reading package catalogues.
+            # Without this, pkg self-upgrades mid-install and the new binary cannot
+            # read the catalogue the old one wrote, so every package reports missing.
+            /usr/sbin/pkg bootstrap -fy -r FreeBSD
+            pkg update -f -r FreeBSD
+            pkg install -y -r FreeBSD llvm22 rust cmake ninja git bash pkgconf libffi libxml2
 
           run: |
             set -eux
@@ -955,14 +953,12 @@ jobs:
             mkdir -p /usr/local/etc/pkg/repos
             printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
               > /usr/local/etc/pkg/repos/FreeBSD.conf
-            pkg update -f
-            # Pin to the FreeBSD repo written above. Without -r, pkg resolves across
-            # every configured repo, decides it must upgrade itself first, finds
-            # nothing to upgrade, and retries forever: the v0.6.0-rc1 tag build spent
-            # 50 minutes emitting "New version of pkg detected" until the VM's ssh
-            # channel died. release-gate.yml and freebsd.yml already pass -U -r
-            # FreeBSD; this is the copy that drifted.
-            pkg install -y -U -r FreeBSD llvm22 rust cmake ninja git bash pkgconf libffi libxml2
+            # Bootstrap pkg through the base utility before reading package catalogues.
+            # Without this, pkg self-upgrades mid-install and the new binary cannot
+            # read the catalogue the old one wrote, so every package reports missing.
+            /usr/sbin/pkg bootstrap -fy -r FreeBSD
+            pkg update -f -r FreeBSD
+            pkg install -y -r FreeBSD llvm22 rust cmake ninja git bash pkgconf libffi libxml2
 
           run: |
             set -eux


### PR DESCRIPTION
The release workflow's FreeBSD jobs let `pkg` upgrade itself during the install command. The upgraded binary uses a newer catalogue schema than the one the previous binary wrote, so it refuses to open the repository and reports every requested package as missing.

Adopt the sequence `release-gate.yml` already uses and the workflow contract requires: bootstrap `pkg` through the base utility from the named repository, refresh only that repository, then install the exact tool set. Bootstrapping first settles `pkg`'s own version before any catalogue is read.

`make freebsd-workflow-contract-check` passes 28/28 and the release workflow contract 41/41.