### PR TITLE
fix(ci): retry pinned toolchain downloads

### DIFF
--- a/.github/scripts/retry-download.sh
+++ b/.github/scripts/retry-download.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Retry an artifact download.
+#
+# Every toolchain download here names an immutable, version-pinned release
+# asset, so fetching it again after a network failure returns the same bytes.
+# That makes this resilience, not the flake-tolerance the test suites refuse:
+# there is no outcome to re-roll, only a transfer to complete.
+#
+# A single blip currently fails a job minutes into a multi-hour run.
+#
+# Usage: retry-download.sh <command> [args...]
+set -euo pipefail
+
+attempts="${RETRY_ATTEMPTS:-4}"
+delay="${RETRY_INITIAL_DELAY:-5}"
+
+for attempt in $(seq 1 "$attempts"); do
+  if "$@"; then
+    [ "$attempt" -gt 1 ] && echo "retry-download: succeeded on attempt $attempt"
+    exit 0
+  fi
+  if [ "$attempt" -eq "$attempts" ]; then
+    echo "retry-download: failed after $attempts attempts: $*" >&2
+    exit 1
+  fi
+  echo "retry-download: attempt $attempt failed, retrying in ${delay}s" >&2
+  sleep "$delay"
+  delay=$((delay * 2))
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,9 +248,11 @@ jobs:
 
       - name: Install SARIF tools
         run: |
-          gh release download clippy-sarif-latest --repo psastras/sarif-rs \
+          .github/scripts/retry-download.sh \
+            gh release download clippy-sarif-latest --repo psastras/sarif-rs \
             --pattern "clippy-sarif-x86_64-unknown-linux-gnu" --output clippy-sarif --clobber
-          gh release download sarif-fmt-latest --repo psastras/sarif-rs \
+          .github/scripts/retry-download.sh \
+            gh release download sarif-fmt-latest --repo psastras/sarif-rs \
             --pattern "sarif-fmt-x86_64-unknown-linux-gnu" --output sarif-fmt --clobber
           chmod +x clippy-sarif sarif-fmt
           mv clippy-sarif sarif-fmt /usr/local/bin/
@@ -706,7 +708,8 @@ jobs:
         run: |
           set -euo pipefail
           WASMTIME_DIR="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
-          gh release download "$WASMTIME_VERSION" --repo bytecodealliance/wasmtime \
+          .github/scripts/retry-download.sh \
+            gh release download "$WASMTIME_VERSION" --repo bytecodealliance/wasmtime \
             --pattern "${WASMTIME_DIR}.tar.xz" --clobber
           tar -xJf "${WASMTIME_DIR}.tar.xz"
           echo "$PWD/${WASMTIME_DIR}" >> "$GITHUB_PATH"
@@ -1059,7 +1062,8 @@ jobs:
           set -euo pipefail
           rustup target add wasm32-wasip1
           WASMTIME_DIR="wasmtime-${WASMTIME_VERSION}-aarch64-macos"
-          gh release download "$WASMTIME_VERSION" --repo bytecodealliance/wasmtime \
+          .github/scripts/retry-download.sh \
+            gh release download "$WASMTIME_VERSION" --repo bytecodealliance/wasmtime \
             --pattern "${WASMTIME_DIR}.tar.xz" --clobber
           tar -xJf "${WASMTIME_DIR}.tar.xz"
           echo "$PWD/${WASMTIME_DIR}" >> "$GITHUB_PATH"

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -155,7 +155,8 @@ jobs:
           rustup target add wasm32-wasip1
           WASMTIME_TAG="$(gh release view --repo bytecodealliance/wasmtime --json tagName --jq .tagName)"
           WASMTIME_DIR="wasmtime-${WASMTIME_TAG}-x86_64-linux"
-          gh release download "$WASMTIME_TAG" --repo bytecodealliance/wasmtime \
+          .github/scripts/retry-download.sh \
+            gh release download "$WASMTIME_TAG" --repo bytecodealliance/wasmtime \
             --pattern "${WASMTIME_DIR}.tar.xz" --clobber
           tar -xJf "${WASMTIME_DIR}.tar.xz"
           echo "$PWD/${WASMTIME_DIR}" >> "$GITHUB_PATH"


### PR DESCRIPTION
Toolchain downloads had no retry, so a single failed transfer failed the job.

Every download wrapped here names an immutable, version-pinned release asset, so fetching it again returns the same bytes. This is distinct from the retries removed from the test suites: a retried test re-rolls an outcome and can turn a real failure green, while a retried download completes a transfer with exactly one correct result.

Four attempts with exponential backoff, then failure naming the command.

Covers five bash invocations in `ci.yml` and `coverage-nightly.yml`. The PowerShell downloads use different syntax and are untouched.

The helper was exercised directly: success on first attempt exits 0, exhausting attempts exits 1, and a command that fails once then succeeds returns 0.