### PR TITLE
perf(ci): cancel superseded runs on the same ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# A push to a branch makes any run still going for that same ref obsolete:
+# its verdict can no longer gate anything, because a newer commit exists.
+# Those runs were still holding runners, so 15 open pull requests could
+# starve the queue and nothing scheduled at all. Never cancel on main —
+# a push there must complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   checks: write

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,6 +12,15 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
+# A push to a branch makes any run still going for that same ref obsolete:
+# its verdict can no longer gate anything, because a newer commit exists.
+# Those runs were still holding runners, so 15 open pull requests could
+# starve the queue and nothing scheduled at all. Never cancel on main —
+# a push there must complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   checks: write

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -27,6 +27,15 @@ on:
       - 'release-*'
   workflow_dispatch:
 
+# A push to a branch makes any run still going for that same ref obsolete:
+# its verdict can no longer gate anything, because a newer commit exists.
+# Those runs were still holding runners, so 15 open pull requests could
+# starve the queue and nothing scheduled at all. Never cancel on main —
+# a push there must complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   checks: write

--- a/.github/workflows/stdlib-lint.yml
+++ b/.github/workflows/stdlib-lint.yml
@@ -7,6 +7,12 @@ on:
       - 'scripts/lint-stdlib-int-surface.sh'
       - 'docs/stdlib-style-contract.md'
 
+# A superseded run on the same ref cannot gate anything, because a newer
+# commit already exists. Cancel it so it stops holding a runner.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   stdlib-int-surface:
     runs-on: ubuntu-latest


### PR DESCRIPTION
None of the heavy pull-request workflows declared a concurrency group, so a push left the previous run for that ref running to completion. Superseded runs held runners until they finished, and with a full queue jobs stopped being scheduled.

A run for a ref that has since moved cannot gate anything, because a newer commit exists. Cancelling it returns the runner.

`ci.yml`, `freebsd.yml`, `release-gate.yml` and `stdlib-lint.yml` gain a group keyed on workflow and ref. `cancel-in-progress` is conditioned on `pull_request`, so a push to `main` always completes — a cancelled main run would leave the branch unverified.

All four parse with the expected concurrency mapping. FreeBSD and release workflow contracts pass, 28/28 and 41/41.