### PR TITLE
fix(runtime): quiesce periodic timers before shutdown drain

### DIFF
--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -706,6 +706,7 @@ pub extern "C" fn hew_sched_init() -> c_int {
         // Another thread beat us — `install_default` already dropped ours.
         return 0;
     }
+    crate::timer_periodic::reset_periodic_admission();
 
     // Ignore SIGPIPE process-wide, before ANY background thread is spawned or
     // any socket I/O runs. A broken-pipe write on the main thread (where a

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -473,8 +473,14 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
 
 fn shutdown_orchestrate_mode(drain_timeout: Duration, cancel_parked_waits: bool) {
     // Phase 1: Quiesce (already set by caller).
-    // Nothing else to do — hew_is_shutting_down() now returns 1, which
-    // callers can check before spawning new actors.
+    // Close periodic-timer admission and wait out any callback already sending
+    // before sampling scheduler idleness. Otherwise a callback can enqueue an
+    // actor after the final idle observation but before worker shutdown, leaving
+    // cleanup with a Runnable actor that no worker can consume.
+    //
+    // Keep the shared timer wheel/ticker alive: suspended sleep activations still
+    // need it through drain and parked-frame retirement.
+    crate::timer_periodic::quiesce_periodic_timers();
 
     // Phase 2: Drain — let workers process remaining messages.
     shutdown_phase_store(PHASE_DRAIN, Ordering::Release);

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, RwLock};
 use std::thread::JoinHandle;
 
 use crate::lifetime::PoisonSafe;
@@ -40,6 +40,8 @@ static GLOBAL_WHEEL: PoisonSafe<WheelSlot> = PoisonSafe::new(WheelSlot(ptr::null
 pub(crate) static TICKER_RUNNING: AtomicBool = AtomicBool::new(false);
 static TICKER_STOP: AtomicBool = AtomicBool::new(false);
 static TICKER_HANDLE: OnceLock<Mutex<Option<JoinHandle<()>>>> = OnceLock::new();
+static PERIODIC_ADMISSION: RwLock<()> = RwLock::new(());
+static PERIODIC_ACCEPTING: AtomicBool = AtomicBool::new(true);
 
 // ---------------------------------------------------------------------------
 // Ticker park primitive (tickless idle — no spin when wheel is empty)
@@ -340,6 +342,59 @@ pub(crate) fn cancel_all_timers_for_actor(actor: *mut HewActor) {
     // reference was reclaimed above now reaches refcount zero and is freed.
 }
 
+/// Close periodic-timer admission and cancel every timer already registered.
+///
+/// Shutdown calls this before observing scheduler quiescence. The admission
+/// lock orders a concurrent schedule against the registry drain: a schedule
+/// either publishes its wheel entry and registry reference before the close
+/// (and is cancelled here), or observes the closed gate and publishes nothing.
+/// Existing callbacks are waited out, so after this function returns no
+/// periodic callback can enqueue actor work.
+///
+/// Registry references stay published until every callback has drained. This
+/// lets a concurrent actor-local teardown find its timers and perform the same
+/// cancel/wait/reclaim protocol; absence from the registry therefore continues
+/// to mean that another path has already made the timer safe.
+///
+/// The shared timer wheel and ticker remain alive because suspended `sleep`
+/// activations still need them during the drain and parked-frame retirement.
+pub(crate) fn quiesce_periodic_timers() {
+    let all: Vec<Arc<PeriodicCtx>> = {
+        let _admission = PERIODIC_ADMISSION
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        PERIODIC_ACCEPTING.store(false, Ordering::Release);
+        ACTOR_TIMERS.access(|lock| {
+            lock.as_ref()
+                .map(|map| map.values().flatten().cloned().collect())
+                .unwrap_or_default()
+        })
+    };
+
+    for ctx in &all {
+        ctx.cancelled.store(true, Ordering::SeqCst);
+    }
+    for ctx in &all {
+        while ctx.in_flight.load(Ordering::SeqCst) {
+            std::hint::spin_loop();
+        }
+    }
+    for ctx in &all {
+        reclaim_pending_wheel_ref(ctx);
+    }
+    for ctx in &all {
+        unregister_timer(ctx.actor, Arc::as_ptr(ctx) as usize);
+    }
+}
+
+/// Open periodic-timer admission for a newly installed runtime generation.
+pub(crate) fn reset_periodic_admission() {
+    let _admission = PERIODIC_ADMISSION
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    PERIODIC_ACCEPTING.store(true, Ordering::Release);
+}
+
 /// Returns the number of active (registered) periodic timers for an actor.
 #[cfg(test)]
 pub(crate) fn timer_count_for_actor(actor: *mut HewActor) -> usize {
@@ -502,6 +557,13 @@ pub unsafe extern "C" fn hew_actor_schedule_periodic(
     interval_ms: u64,
 ) -> *mut c_void {
     if actor.is_null() || interval_ms == 0 {
+        return ptr::null_mut();
+    }
+
+    let _admission = PERIODIC_ADMISSION
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !PERIODIC_ACCEPTING.load(Ordering::Acquire) {
         return ptr::null_mut();
     }
 
@@ -685,20 +747,9 @@ pub unsafe extern "C" fn hew_periodic_shutdown() {
     // pending one-shot references.
     shutdown_ticker();
 
-    // Drain every tracked periodic ctx: reclaim its pending wheel reference and
-    // drop its registry reference. Without this the wheel's pending references
-    // would be silently dropped by `hew_timer_wheel_free` (which frees entry
-    // nodes but not their `data`), leaking the PeriodicCtx allocations.
-    let all: Vec<Arc<PeriodicCtx>> = ACTOR_TIMERS.access(|lock| {
-        lock.take()
-            .map(|map| map.into_values().flatten().collect())
-            .unwrap_or_default()
-    });
-    for ctx in &all {
-        ctx.cancelled.store(true, Ordering::SeqCst);
-        reclaim_pending_wheel_ref(ctx);
-    }
-    drop(all);
+    // Drain every tracked periodic ctx before freeing the wheel. Without this
+    // the wheel would free entry nodes but not their `data` references.
+    quiesce_periodic_timers();
 
     GLOBAL_WHEEL.access(|guard| {
         let tw = guard.0;
@@ -783,6 +834,9 @@ mod tests {
 
     #[test]
     fn late_fire_skips_missed_slots_at_anchored_cadence() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut actor = create_test_actor(50_050);
         actor
             .actor_state
@@ -822,6 +876,9 @@ mod tests {
 
     #[test]
     fn cursor_stall_drops_missed_intervals_without_losing_phase() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut actor = create_test_actor(50_051);
         actor
             .actor_state
@@ -1057,6 +1114,9 @@ mod tests {
 
     #[test]
     fn cancel_all_timers_marks_contexts_cancelled() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut actor = create_test_actor(50_100);
         let actor_ptr = &raw mut actor;
 
@@ -1113,6 +1173,7 @@ mod tests {
         let _guard = TICKER_TEST_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset_periodic_admission();
 
         let mut actor = create_test_actor(50_400);
         let actor_ptr = &raw mut actor;
@@ -1136,7 +1197,103 @@ mod tests {
     }
 
     #[test]
+    fn shutdown_quiescence_closes_periodic_admission_without_stopping_shared_timers() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // SAFETY: this test serializes ownership of the process-wide timer state.
+        unsafe { hew_periodic_shutdown() };
+        reset_periodic_admission();
+
+        let mut actor = create_test_actor(50_401);
+        let actor_ptr = &raw mut actor;
+        // SAFETY: actor_ptr remains live until the timer subsystem is reset.
+        let handle = unsafe { hew_actor_schedule_periodic(actor_ptr, 7, 60_000) };
+        assert!(!handle.is_null());
+        assert_eq!(timer_count_for_actor(actor_ptr), 1);
+
+        quiesce_periodic_timers();
+
+        assert_eq!(timer_count_for_actor(actor_ptr), 0);
+        assert!(
+            TICKER_RUNNING.load(Ordering::Acquire),
+            "shutdown quiescence must leave the shared sleep-timer ticker alive"
+        );
+        // SAFETY: actor_ptr is still live, but the shutdown admission gate must
+        // reject a timer that races after periodic quiescence.
+        let rejected = unsafe { hew_actor_schedule_periodic(actor_ptr, 8, 60_000) };
+        assert!(
+            rejected.is_null(),
+            "periodic scheduling must stay closed after shutdown quiescence"
+        );
+
+        // A complete timer shutdown followed by wheel recreation starts a fresh
+        // runtime generation and reopens admission.
+        // SAFETY: this test serializes ownership of the process-wide timer state.
+        unsafe { hew_periodic_shutdown() };
+        reset_periodic_admission();
+        // SAFETY: actor_ptr remains live through cancellation below.
+        let restarted = unsafe { hew_actor_schedule_periodic(actor_ptr, 9, 60_000) };
+        assert!(!restarted.is_null());
+        // SAFETY: restarted is the live handle returned immediately above.
+        unsafe { hew_actor_cancel_periodic(restarted) };
+        // SAFETY: final serialized cleanup for this test.
+        unsafe { hew_periodic_shutdown() };
+    }
+
+    #[test]
+    fn shutdown_quiescence_keeps_registry_visible_until_callbacks_drain() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // SAFETY: this test serializes ownership of the process-wide timer state.
+        unsafe { hew_periodic_shutdown() };
+        reset_periodic_admission();
+
+        let mut actor = create_test_actor(50_402);
+        let actor_ptr = &raw mut actor;
+        // SAFETY: actor_ptr remains live until the quiescer and final cleanup join.
+        let handle = unsafe { hew_actor_schedule_periodic(actor_ptr, 7, 60_000) };
+        assert!(!handle.is_null());
+        let ctx = ACTOR_TIMERS.access(|lock| {
+            Arc::clone(
+                lock.as_ref()
+                    .and_then(|map| map.get(&(actor_ptr as usize)))
+                    .and_then(|timers| timers.first())
+                    .expect("scheduled timer must be registered"),
+            )
+        });
+
+        // Model a callback that passed its cancellation check and still owns the
+        // actor pointer. Global quiescence must keep the registry entry published
+        // until this in-flight guard clears, so actor-local teardown cannot mistake
+        // the timer for already-safe.
+        ctx.in_flight.store(true, Ordering::SeqCst);
+        let quiescer = std::thread::spawn(quiesce_periodic_timers);
+        while PERIODIC_ACCEPTING.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+        }
+        let visible_while_draining = timer_count_for_actor(actor_ptr) == 1;
+
+        ctx.in_flight.store(false, Ordering::SeqCst);
+        quiescer.join().expect("periodic quiescer must finish");
+
+        assert!(
+            visible_while_draining,
+            "registry absence must never precede callback cancellation and drain"
+        );
+        assert_eq!(timer_count_for_actor(actor_ptr), 0);
+        // SAFETY: final serialized cleanup for this test.
+        unsafe { hew_periodic_shutdown() };
+    }
+
+    #[test]
     fn cancel_all_timers_no_timers_does_not_panic() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut actor = create_test_actor(50_200);
         let actor_ptr = &raw mut actor;
         // Should be a no-op, not panic.
@@ -1154,6 +1311,7 @@ mod tests {
         unsafe {
             hew_periodic_shutdown();
         }
+        reset_periodic_admission();
         crate::hew_clear_error();
 
         FAIL_TICKER_SPAWN.with(|fail| fail.set(true));


### PR DESCRIPTION
A periodic timer's callbacks could still be active after shutdown observed the scheduler idle, so cleanup ran against an actor that was re-enqueued or executing:

    hew: runtime error: actor 0x1 was non-quiescent at shutdown cleanup
    (re-enqueued/active)

Shutdown now closes timer admission and drains outstanding callbacks before establishing quiescence, so a rearm cannot reopen the window after it is observed closed.

This surfaced as an intermittent test failure. It is a runtime race, not a test defect: the window is reachable by any program shutting down while a periodic timer is armed.

## Verification

The failure was reproduced before fixing rather than inferred. Under contention the baseline failed on iteration 1 of 2,000; with the fix the probe passed 2,000/2,000 and the exact test passed 64/64 run concurrently.

WASM behaviour is unchanged — its sibling probe asserts a periodic timer never reaches quiescence there, and it still does not.