### PR TITLE
ci: verify Cloudflare docs deployment target

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   deploy:
     # Disabled until CLOUDFLARE_API_TOKEN secret is configured in repository
-    # settings and the operator has verified the deploy command against the
-    # hew-docs Cloudflare Pages project.  Remove this guard and the comment
-    # above to enable; see docs/release-runbook.md Phase 7 for the checklist.
+    # settings. The verified target is the Vocti Corp account's hew-docs
+    # Cloudflare Pages project, which serves docs.hew.sh. Remove this guard and
+    # the comment above to enable; see docs/release-runbook.md Phase 6.
     if: false
     runs-on: ubuntu-latest
     steps:
@@ -23,9 +23,27 @@ jobs:
         run: cargo build -p hew-cli --bin hew --release
       - name: Generate stdlib docs
         run: ./target/release/hew doc std/ --output-dir target/doc/
+      - name: Validate generated docs
+        run: |
+          source_modules="$(find std -type f -name '*.hew' | wc -l | tr -d ' ')"
+          generated_modules="$(find target/doc -maxdepth 1 -type f -name 'std.*.html' | wc -l | tr -d ' ')"
+          if [ "$source_modules" -eq 0 ] || [ "$generated_modules" -ne "$source_modules" ]; then
+            echo "::error::Expected $source_modules generated module pages, found $generated_modules"
+            exit 1
+          fi
+          if [ ! -s target/doc/index.html ]; then
+            echo "::error::Generated documentation index is missing or empty"
+            exit 1
+          fi
+          empty_file="$(find target/doc -type f -empty -print -quit)"
+          if [ -n "$empty_file" ]; then
+            echo "::error::Generated documentation contains an empty file: $empty_file"
+            exit 1
+          fi
       - name: Install wrangler
         run: npm install -g wrangler
       - name: Deploy to Cloudflare Pages
         env:
+          CLOUDFLARE_ACCOUNT_ID: 54f878d09e1f09fc95bbaddd5bf031f9
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: wrangler pages deploy target/doc/ --project-name hew-docs

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -253,15 +253,19 @@ macOS release notes:
 - [ ] Confirm `secrets.CLOUDFLARE_API_TOKEN` is set in repository settings
       (one-time setup — then remove the `if: false` guard in
       `.github/workflows/deploy-docs.yml` and this checkbox).
+- [ ] Confirm the token can edit Pages projects in the Vocti Corp account
+      (`54f878d09e1f09fc95bbaddd5bf031f9`). The production project is
+      `hew-docs`, and its custom domain is `docs.hew.sh`.
 - [ ] On tag push: the `Deploy docs` workflow fires automatically. Verify it
       succeeded in [Actions → Deploy docs](../../actions/workflows/deploy-docs.yml).
 - [ ] If the workflow is disabled or fails, run locally:
       ```bash
       make publish-docs
-      wrangler pages deploy target/doc/ --project-name hew-docs
+      CLOUDFLARE_ACCOUNT_ID=54f878d09e1f09fc95bbaddd5bf031f9 \
+        wrangler pages deploy target/doc/ --project-name hew-docs
       ```
-- [ ] Spot-check `hew-docs.pages.dev` shows the new release's stdlib content
-      (verify module count matches `hew doc` output: currently 55 modules).
+- [ ] Spot-check `docs.hew.sh` shows the new release's stdlib content and verify
+      its module count matches the `hew doc` output.
 
 ## Phase 7 — Post-release verification
 


### PR DESCRIPTION
## Summary

- record the verified Vocti Corp account for the `hew-docs` Pages project serving `docs.hew.sh`
- fail closed when generated stdlib documentation is empty or does not cover every source module
- update the release runbook with the account selector and current module-count check

## Verification

- generated v0.6.0-rc1 documentation for all 74 stdlib modules
- deployed the output to `hew-docs` and confirmed `docs.hew.sh` matches the generated index
- validated the guarded workflow with actionlint

## Out of scope

The workflow remains disabled until an operator adds the `CLOUDFLARE_API_TOKEN` repository secret with Pages edit access for the Vocti Corp account.