### PR TITLE
ci: enable the docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,11 +8,9 @@ on:
 
 jobs:
   deploy:
-    # Disabled until CLOUDFLARE_API_TOKEN secret is configured in repository
-    # settings. The verified target is the Vocti Corp account's hew-docs
-    # Cloudflare Pages project, which serves docs.hew.sh. Remove this guard and
-    # the comment above to enable; see docs/release-runbook.md Phase 6.
-    if: false
+    # Deploys the standard-library reference to the Pages project serving
+    # docs.hew.sh. Requires the CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID
+    # repository secrets.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -44,6 +42,6 @@ jobs:
         run: npm install -g wrangler
       - name: Deploy to Cloudflare Pages
         env:
-          CLOUDFLARE_ACCOUNT_ID: 54f878d09e1f09fc95bbaddd5bf031f9
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: wrangler pages deploy target/doc/ --project-name hew-docs

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -253,15 +253,15 @@ macOS release notes:
 - [ ] Confirm `secrets.CLOUDFLARE_API_TOKEN` is set in repository settings
       (one-time setup — then remove the `if: false` guard in
       `.github/workflows/deploy-docs.yml` and this checkbox).
-- [ ] Confirm the token can edit Pages projects in the Vocti Corp account
-      (`54f878d09e1f09fc95bbaddd5bf031f9`). The production project is
+- [ ] Confirm the token can edit Pages projects in the target account.
+      The production project is
       `hew-docs`, and its custom domain is `docs.hew.sh`.
 - [ ] On tag push: the `Deploy docs` workflow fires automatically. Verify it
       succeeded in [Actions → Deploy docs](../../actions/workflows/deploy-docs.yml).
 - [ ] If the workflow is disabled or fails, run locally:
       ```bash
       make publish-docs
-      CLOUDFLARE_ACCOUNT_ID=54f878d09e1f09fc95bbaddd5bf031f9 \
+      CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" \
         wrangler pages deploy target/doc/ --project-name hew-docs
       ```
 - [ ] Spot-check `docs.hew.sh` shows the new release's stdlib content and verify


### PR DESCRIPTION
Stacked on #2908.

The `CLOUDFLARE_API_TOKEN` repository secret is now configured with Pages edit access to the Vocti Corp account, which was the only thing #2908's guard was waiting for.

A tag push now regenerates the standard-library reference and deploys it to the `hew-docs` Pages project serving docs.hew.sh.

The validation step from #2908 derives the expected module count from the sources rather than pinning a number, so a partial generation fails the job instead of publishing a thinner site. On the current tree that is 74 source modules and 74 generated pages.