### PR TITLE
ci(docs): deploy the stdlib reference on tag push

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,11 +8,9 @@ on:
 
 jobs:
   deploy:
-    # Disabled until CLOUDFLARE_API_TOKEN secret is configured in repository
-    # settings and the operator has verified the deploy command against the
-    # hew-docs Cloudflare Pages project.  Remove this guard and the comment
-    # above to enable; see docs/release-runbook.md Phase 7 for the checklist.
-    if: false
+    # Deploys the standard-library reference to the Pages project serving
+    # docs.hew.sh. Requires the CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID
+    # repository secrets.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -23,9 +21,27 @@ jobs:
         run: cargo build -p hew-cli --bin hew --release
       - name: Generate stdlib docs
         run: ./target/release/hew doc std/ --output-dir target/doc/
+      - name: Validate generated docs
+        run: |
+          source_modules="$(find std -type f -name '*.hew' | wc -l | tr -d ' ')"
+          generated_modules="$(find target/doc -maxdepth 1 -type f -name 'std.*.html' | wc -l | tr -d ' ')"
+          if [ "$source_modules" -eq 0 ] || [ "$generated_modules" -ne "$source_modules" ]; then
+            echo "::error::Expected $source_modules generated module pages, found $generated_modules"
+            exit 1
+          fi
+          if [ ! -s target/doc/index.html ]; then
+            echo "::error::Generated documentation index is missing or empty"
+            exit 1
+          fi
+          empty_file="$(find target/doc -type f -empty -print -quit)"
+          if [ -n "$empty_file" ]; then
+            echo "::error::Generated documentation contains an empty file: $empty_file"
+            exit 1
+          fi
       - name: Install wrangler
         run: npm install -g wrangler
       - name: Deploy to Cloudflare Pages
         env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: wrangler pages deploy target/doc/ --project-name hew-docs

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -253,15 +253,19 @@ macOS release notes:
 - [ ] Confirm `secrets.CLOUDFLARE_API_TOKEN` is set in repository settings
       (one-time setup — then remove the `if: false` guard in
       `.github/workflows/deploy-docs.yml` and this checkbox).
+- [ ] Confirm the token can edit Pages projects in the target account.
+      The production project is
+      `hew-docs`, and its custom domain is `docs.hew.sh`.
 - [ ] On tag push: the `Deploy docs` workflow fires automatically. Verify it
       succeeded in [Actions → Deploy docs](../../actions/workflows/deploy-docs.yml).
 - [ ] If the workflow is disabled or fails, run locally:
       ```bash
       make publish-docs
-      wrangler pages deploy target/doc/ --project-name hew-docs
+      CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" \
+        wrangler pages deploy target/doc/ --project-name hew-docs
       ```
-- [ ] Spot-check `hew-docs.pages.dev` shows the new release's stdlib content
-      (verify module count matches `hew doc` output: currently 55 modules).
+- [ ] Spot-check `docs.hew.sh` shows the new release's stdlib content and verify
+      its module count matches the `hew doc` output.
 
 ## Phase 7 — Post-release verification
 


### PR DESCRIPTION
Generates the standard-library reference and publishes it to the Pages project serving docs.hew.sh when a version tag is pushed.

Validation compares the generated page count against the source module count and rejects empty output, so a partial generation fails the job rather than publishing a thinner site. On the current tree that is 74 modules.

Credentials and account selection come from repository secrets.

Replaces #2908 and #2909, which are superseded.