### PR TITLE
ci(release): cross-build runtime archives for FreeBSD and Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,16 @@ jobs:
           - rust_target: x86_64-unknown-freebsd
             builder: zig
             archive: libhew.a
+            build_std: false
           - rust_target: x86_64-pc-windows-msvc
             builder: xwin
             archive: hew.lib
+            build_std: false
+          - rust_target: aarch64-unknown-freebsd
+            builder: zig
+            archive: libhew.a
+            build_std: true
+            zig_target: aarch64-freebsd
 
     steps:
       - name: Checkout code
@@ -80,11 +87,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends llvm
 
-      - name: Install Rust
+      - name: Install Rust target
+        if: ${{ !matrix.build_std }}
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master 2026-03-27
         with:
           toolchain: "1.96.0"
           targets: ${{ matrix.rust_target }}
+
+      - name: Install Rust sources
+        if: matrix.build_std
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master 2026-03-27
+        with:
+          toolchain: "1.96.0"
+          components: rust-src
 
       - name: Install Zig
         if: matrix.builder == 'zig'
@@ -101,14 +116,31 @@ jobs:
         run: cargo install cargo-xwin --locked --version 0.23.0
 
       - name: Build FreeBSD release library
-        if: matrix.builder == 'zig'
+        if: matrix.builder == 'zig' && !matrix.build_std
         run: cargo zigbuild -p hew-lib --profile release-lib --target ${{ matrix.rust_target }}
+
+      - name: Build FreeBSD release library with standard library
+        if: matrix.build_std
+        env:
+          RUSTC_BOOTSTRAP: "1"
+        run: cargo zigbuild -Zbuild-std=std,panic_abort -p hew-lib --profile release-lib --target ${{ matrix.rust_target }}
 
       - name: Build Windows release library
         if: matrix.builder == 'xwin'
         env:
           AWS_LC_SYS_PREBUILT_NASM: "1"
         run: cargo xwin build -p hew-lib --profile release-lib --target ${{ matrix.rust_target }}
+
+      - name: Record FreeBSD ABI baseline
+        if: matrix.build_std
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s\n' 'int main(void) { return 0; }' > freebsd-abi-probe.c
+          zig cc -target "${{ matrix.zig_target }}" freebsd-abi-probe.c -o freebsd-abi-probe
+          abi=$(file freebsd-abi-probe)
+          echo "${abi}" | tee -a "${GITHUB_STEP_SUMMARY}"
+          echo "${abi}" | grep -q 'for FreeBSD 14.0 (1400500)'
 
       - name: Verify and stage cross-built archive
         shell: bash
@@ -1026,6 +1058,7 @@ jobs:
   # locally; CI is the proving gate for this toolchain asset.
   # ─────────────────────────────────────────────────────────────────────────
   build-freebsd-aarch64:
+    needs: build-cross-release-libs
     runs-on: ubuntu-24.04
     timeout-minutes: 300
 
@@ -1041,6 +1074,12 @@ jobs:
           VERSION="${RELEASE_TAG#v}"
           echo "name=hew-v${VERSION}-freebsd-aarch64" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Download cross-built release library
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: libhew-aarch64-unknown-freebsd
+          path: cross-release-libs/aarch64-unknown-freebsd
 
       - name: Build on FreeBSD aarch64
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
@@ -1075,10 +1114,9 @@ jobs:
 
             # ── Rust builds (release) ──────────────────────────────────────
             cargo build -p hew-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --profile release-lib
             bash scripts/test-release-lib-link.sh \
               --hew target/release/hew \
-              --archive target/release-lib/libhew.a
+              --archive cross-release-libs/aarch64-unknown-freebsd/libhew.a
 
             # ── Third-party license attribution ────────────────────────────
             cargo install cargo-about --locked --features cli --version 0.9.0
@@ -1098,7 +1136,10 @@ jobs:
 
             # The executable consumer proof above is the authority; cp fails
             # closed if the validated archive is absent.
-            cp target/release-lib/libhew.a "${ARCHIVE_NAME}/lib/"
+            cp cross-release-libs/aarch64-unknown-freebsd/libhew.a "${ARCHIVE_NAME}/lib/"
+            mkdir -p "${ARCHIVE_NAME}/lib/aarch64-unknown-freebsd"
+            cp cross-release-libs/aarch64-unknown-freebsd/libhew.a \
+              "${ARCHIVE_NAME}/lib/aarch64-unknown-freebsd/"
 
             # Standard library sources (all .hew files, including subdirectories)
             cp -r std/. "${ARCHIVE_NAME}/std/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,86 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
+  # Cross-built release libraries — proved by their target-native consumers
+  # ─────────────────────────────────────────────────────────────────────────
+  build-cross-release-libs:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rust_target: x86_64-unknown-freebsd
+            builder: zig
+            archive: libhew.a
+          - rust_target: x86_64-pc-windows-msvc
+            builder: xwin
+            archive: hew.lib
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install archive inspection tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends llvm
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master 2026-03-27
+        with:
+          toolchain: "1.96.0"
+          targets: ${{ matrix.rust_target }}
+
+      - name: Install Zig
+        if: matrix.builder == 'zig'
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29  # v2
+        with:
+          version: 0.16.0
+
+      - name: Install cargo-zigbuild
+        if: matrix.builder == 'zig'
+        run: cargo install cargo-zigbuild --locked --version 0.22.3
+
+      - name: Install cargo-xwin
+        if: matrix.builder == 'xwin'
+        run: cargo install cargo-xwin --locked --version 0.23.0
+
+      - name: Build FreeBSD release library
+        if: matrix.builder == 'zig'
+        run: cargo zigbuild -p hew-lib --profile release-lib --target ${{ matrix.rust_target }}
+
+      - name: Build Windows release library
+        if: matrix.builder == 'xwin'
+        env:
+          AWS_LC_SYS_PREBUILT_NASM: "1"
+        run: cargo xwin build -p hew-lib --profile release-lib --target ${{ matrix.rust_target }}
+
+      - name: Verify and stage cross-built archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="target/${{ matrix.rust_target }}/release-lib/${{ matrix.archive }}"
+          scripts/verify-cross-release-lib.sh "${{ matrix.rust_target }}" "${archive}"
+
+          destination="cross-release-libs/${{ matrix.rust_target }}"
+          mkdir -p "${destination}"
+          cp "${archive}" "${destination}/${{ matrix.archive }}"
+
+      - name: Upload cross-built archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: libhew-${{ matrix.rust_target }}
+          path: cross-release-libs/${{ matrix.rust_target }}/${{ matrix.archive }}
+          if-no-files-found: error
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Build — macOS and Windows release artifacts
   # ─────────────────────────────────────────────────────────────────────────
   build:
+    needs: build-cross-release-libs
     strategy:
       fail-fast: false
       matrix:
@@ -81,6 +158,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: ${{ env.RELEASE_TAG }}
+
+      - name: Download cross-built release library (Windows)
+        if: startsWith(matrix.target, 'windows')
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: libhew-${{ matrix.rust_target }}
+          path: cross-release-libs/${{ matrix.rust_target }}
 
       # ── LLVM toolchain installation ─────────────────────────────────────
 
@@ -261,6 +345,7 @@ jobs:
         run: cargo build -p hew-cli -p hew-lsp -p hew-observe --release --target ${{ matrix.rust_target }}
 
       - name: Build libhew.a (runtime + stdlib)
+        if: startsWith(matrix.target, 'darwin')
         # The shipped archive builds under the non-LTO release-lib profile:
         # external Rust staticlibs (--link-lib packages) cannot dedupe their
         # verbatim libstd members against a fat-LTO archive.
@@ -279,7 +364,7 @@ jobs:
         run: |
           ./scripts/test-release-lib-link.ps1 `
             -Hew "target/${{ matrix.rust_target }}/release/hew.exe" `
-            -Archive "target/${{ matrix.rust_target }}/release-lib/hew.lib"
+            -Archive "cross-release-libs/${{ matrix.rust_target }}/hew.lib"
 
       - name: Smoke test hew-lsp and hew-observe (Unix)
         if: "!startsWith(matrix.target, 'windows')"
@@ -381,7 +466,7 @@ jobs:
 
           $Version = $env:RELEASE_TAG.TrimStart("v")
           $ArchiveName = "hew-v${Version}-${{ matrix.target }}"
-          $ReleaseLibDir = "target/${{ matrix.rust_target }}/release-lib"
+          $ReleaseLibDir = "cross-release-libs/${{ matrix.rust_target }}"
 
           New-Item -ItemType Directory -Path "${ArchiveName}/bin", "${ArchiveName}/lib", "${ArchiveName}/std", "${ArchiveName}/completions" -Force | Out-Null
 
@@ -392,6 +477,11 @@ jobs:
           # The executable consumer proof above is the authority for the
           # release library contract. Copy-Item fails closed if it is absent.
           Copy-Item "${ReleaseLibDir}/hew.lib"                                   "${ArchiveName}/lib/"
+
+          # Keep the full Rust triple in the installed layout so target-aware
+          # lookup chooses the proved archive before the native fallback.
+          New-Item -ItemType Directory -Path "${ArchiveName}/lib/${{ matrix.rust_target }}" -Force | Out-Null
+          Copy-Item "${ReleaseLibDir}/hew.lib" "${ArchiveName}/lib/${{ matrix.rust_target }}/"
 
           # Standard library sources (all .hew files, including subdirectories)
           Copy-Item "std" "${ArchiveName}/std" -Recurse
@@ -800,6 +890,7 @@ jobs:
   # FreeBSD build — x86_64 via QEMU VM (tier-1, required release gate)
   # ─────────────────────────────────────────────────────────────────────────
   build-freebsd:
+    needs: build-cross-release-libs
     runs-on: ubuntu-24.04
     timeout-minutes: 180
 
@@ -815,6 +906,12 @@ jobs:
           VERSION="${RELEASE_TAG#v}"
           echo "name=hew-v${VERSION}-freebsd-x86_64" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Download cross-built release library
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: libhew-x86_64-unknown-freebsd
+          path: cross-release-libs/x86_64-unknown-freebsd
 
       - name: Build on FreeBSD
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
@@ -848,10 +945,9 @@ jobs:
 
             # ── Rust builds (release) ──────────────────────────────────────
             cargo build -p hew-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --profile release-lib
             bash scripts/test-release-lib-link.sh \
               --hew target/release/hew \
-              --archive target/release-lib/libhew.a
+              --archive cross-release-libs/x86_64-unknown-freebsd/libhew.a
 
             # ── Third-party license attribution ────────────────────────────
             cargo install cargo-about --locked --features cli --version 0.9.0
@@ -871,7 +967,10 @@ jobs:
 
             # The executable consumer proof above is the authority; cp fails
             # closed if the validated archive is absent.
-            cp target/release-lib/libhew.a "${ARCHIVE_NAME}/lib/"
+            cp cross-release-libs/x86_64-unknown-freebsd/libhew.a "${ARCHIVE_NAME}/lib/"
+            mkdir -p "${ARCHIVE_NAME}/lib/x86_64-unknown-freebsd"
+            cp cross-release-libs/x86_64-unknown-freebsd/libhew.a \
+              "${ARCHIVE_NAME}/lib/x86_64-unknown-freebsd/"
 
             # Standard library sources (all .hew files, including subdirectories)
             cp -r std/. "${ARCHIVE_NAME}/std/"

--- a/docs/cross-platform-build-guide.md
+++ b/docs/cross-platform-build-guide.md
@@ -128,6 +128,14 @@ LLVM_PREFIX="$(brew --prefix llvm)" make release
 
 **Status:** Tier 2 — builds and tests pass on FreeBSD 15.0 x86_64.
 
+Tag releases build `libhew.a` on Linux with Rust 1.96.0,
+`cargo-zigbuild` 0.22.3, and Zig 0.16.0. The archive is published between
+jobs under the full `x86_64-unknown-freebsd` Rust triple. The FreeBSD 15.0
+job still builds the compiler and support binaries natively, links a real Hew
+consumer against the downloaded archive, and runs the packaged compile/run
+smoke before that cross-built library can ship. Zig currently targets the
+FreeBSD 14 ABI baseline, so the native FreeBSD 15.0 proof is required.
+
 ### Prerequisites
 
 Install LLVM 22 from the FreeBSD package collection:
@@ -170,6 +178,13 @@ paths have Windows implementations (`VirtualAlloc` / `VirtualFree`). Windows
 is fail-soft / Tier 2 in `release.yml` today: the tag-release Windows job
 remains `continue-on-error: true` until this validation path has proven itself
 through a full release cycle.
+
+Tag releases build `hew.lib` on Linux with Rust 1.96.0 and `cargo-xwin`
+0.23.0, then publish it between jobs under the full
+`x86_64-pc-windows-msvc` Rust triple. The Windows job keeps the native
+compiler and support-binary builds, links a real Hew consumer against the
+downloaded library, and runs the packaged compile/run smoke before the
+cross-built library becomes the packaged authority.
 
 ### Prerequisites
 

--- a/docs/cross-platform-build-guide.md
+++ b/docs/cross-platform-build-guide.md
@@ -170,6 +170,24 @@ LLVM_SYS_221_PREFIX=/usr/local/llvm22 make release
 
 ### Quick Reference (updated table below)
 
+## FreeBSD aarch64
+
+**Status:** Tier 2 — the release package is proved on FreeBSD 15.0 aarch64
+under QEMU.
+
+Rust 1.96.0 does not publish a standard-library component for
+`aarch64-unknown-freebsd`. Tag releases therefore install the matching
+`rust-src` component and scope `RUSTC_BOOTSTRAP=1` with
+`-Zbuild-std=std,panic_abort` to the `cargo-zigbuild` 0.22.3 archive command.
+The producer records and checks Zig 0.16.0's FreeBSD 14.0 ABI baseline before
+uploading the full-triple-keyed archive.
+
+The FreeBSD 15.0 aarch64 job keeps the native compiler and support-binary
+builds. It links a real Hew consumer against the downloaded `libhew.a`,
+packages that exact archive under both `lib/` and
+`lib/aarch64-unknown-freebsd/`, and executes the packaged compile/run smoke.
+A failed native link or smoke rejects the release.
+
 ## Windows
 
 **Status:** Supported for release builds when LLVM 22 is installed locally

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -611,10 +611,12 @@ def test_cross_release_libraries_are_target_keyed_and_natively_proved() -> None:
     build_start = release.index("  build:\n", cross_start)
     freebsd_start = release.index("  build-freebsd:\n", build_start)
     freebsd_aarch64_start = release.index("  build-freebsd-aarch64:\n", freebsd_start)
+    linux_packages_start = release.index("  linux-packages:\n", freebsd_aarch64_start)
 
     cross = release[cross_start:build_start]
     build = release[build_start:freebsd_start]
     freebsd = release[freebsd_start:freebsd_aarch64_start]
+    freebsd_aarch64 = release[freebsd_aarch64_start:linux_packages_start]
     verifier = (ROOT / "scripts" / "verify-cross-release-lib.sh").read_text()
 
     assert 'toolchain: "1.96.0"' in cross
@@ -630,11 +632,24 @@ def test_cross_release_libraries_are_target_keyed_and_natively_proved() -> None:
         " ${{ matrix.rust_target }}" in cross
     )
     assert 'AWS_LC_SYS_PREBUILT_NASM: "1"' in cross
+    assert "components: rust-src" in cross
+    assert cross.count('RUSTC_BOOTSTRAP: "1"') == 1
+    assert (
+        "cargo zigbuild -Zbuild-std=std,panic_abort -p hew-lib"
+        " --profile release-lib --target ${{ matrix.rust_target }}" in cross
+    )
+    assert 'zig cc -target "${{ matrix.zig_target }}"' in cross
+    assert "for FreeBSD 14.0 (1400500)" in cross
+    assert 'tee -a "${GITHUB_STEP_SUMMARY}"' in cross
     assert "name: libhew-${{ matrix.rust_target }}" in cross
     assert "cross-release-libs/${{ matrix.rust_target }}" in cross
     assert "if-no-files-found: error" in cross
 
-    for target in ("x86_64-unknown-freebsd", "x86_64-pc-windows-msvc"):
+    for target in (
+        "x86_64-unknown-freebsd",
+        "aarch64-unknown-freebsd",
+        "x86_64-pc-windows-msvc",
+    ):
         assert target in cross
     for required in (
         "llvm-readobj --file-headers",
@@ -642,6 +657,7 @@ def test_cross_release_libraries_are_target_keyed_and_natively_proved() -> None:
         "expected exactly one release archive",
         "hew_alloc",
         "OS/ABI: ${expected_os_abi}",
+        "elf64-littleaarch64",
     ):
         assert required in verifier
 
@@ -663,6 +679,20 @@ def test_cross_release_libraries_are_target_keyed_and_natively_proved() -> None:
     assert freebsd.count("cp cross-release-libs/x86_64-unknown-freebsd/libhew.a") == 2
     assert '"${ARCHIVE_NAME}/lib/x86_64-unknown-freebsd/"' in freebsd
     assert "pkg-smoke-ok" in freebsd
+
+    assert "needs: build-cross-release-libs" in freebsd_aarch64
+    assert "name: libhew-aarch64-unknown-freebsd" in freebsd_aarch64
+    assert "cargo build -p hew-lib --profile release-lib" not in freebsd_aarch64
+    assert (
+        "--archive cross-release-libs/aarch64-unknown-freebsd/libhew.a"
+        in freebsd_aarch64
+    )
+    assert (
+        freebsd_aarch64.count("cp cross-release-libs/aarch64-unknown-freebsd/libhew.a")
+        == 2
+    )
+    assert '"${ARCHIVE_NAME}/lib/aarch64-unknown-freebsd/"' in freebsd_aarch64
+    assert "pkg-smoke-ok" in freebsd_aarch64
 
 
 def test_freebsd_release_lanes_provision_bash_and_package_with_posix_sh() -> None:

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -605,6 +605,66 @@ def test_every_release_lane_executes_the_library_consumer_proof() -> None:
         assert "llvm-ar t " not in text
 
 
+def test_cross_release_libraries_are_target_keyed_and_natively_proved() -> None:
+    release = workflow()
+    cross_start = release.index("  build-cross-release-libs:\n")
+    build_start = release.index("  build:\n", cross_start)
+    freebsd_start = release.index("  build-freebsd:\n", build_start)
+    freebsd_aarch64_start = release.index("  build-freebsd-aarch64:\n", freebsd_start)
+
+    cross = release[cross_start:build_start]
+    build = release[build_start:freebsd_start]
+    freebsd = release[freebsd_start:freebsd_aarch64_start]
+    verifier = (ROOT / "scripts" / "verify-cross-release-lib.sh").read_text()
+
+    assert 'toolchain: "1.96.0"' in cross
+    assert "version: 0.16.0" in cross
+    assert "cargo install cargo-zigbuild --locked --version 0.22.3" in cross
+    assert "cargo install cargo-xwin --locked --version 0.23.0" in cross
+    assert (
+        "cargo zigbuild -p hew-lib --profile release-lib --target"
+        " ${{ matrix.rust_target }}" in cross
+    )
+    assert (
+        "cargo xwin build -p hew-lib --profile release-lib --target"
+        " ${{ matrix.rust_target }}" in cross
+    )
+    assert 'AWS_LC_SYS_PREBUILT_NASM: "1"' in cross
+    assert "name: libhew-${{ matrix.rust_target }}" in cross
+    assert "cross-release-libs/${{ matrix.rust_target }}" in cross
+    assert "if-no-files-found: error" in cross
+
+    for target in ("x86_64-unknown-freebsd", "x86_64-pc-windows-msvc"):
+        assert target in cross
+    for required in (
+        "llvm-readobj --file-headers",
+        "llvm-nm --defined-only --extern-only",
+        "expected exactly one release archive",
+        "hew_alloc",
+        "OS/ABI: ${expected_os_abi}",
+    ):
+        assert required in verifier
+
+    native_lib_step = build[
+        build.index("      - name: Build libhew.a (runtime + stdlib)\n") : build.index(
+            "      - name: Prove release library consumer linking",
+            build.index("      - name: Build libhew.a (runtime + stdlib)\n"),
+        )
+    ]
+    assert "if: startsWith(matrix.target, 'darwin')" in native_lib_step
+    assert '-Archive "cross-release-libs/${{ matrix.rust_target }}/hew.lib"' in build
+    assert 'Copy-Item "${ReleaseLibDir}/hew.lib"' in build
+    assert '"${ArchiveName}/lib/${{ matrix.rust_target }}"' in build
+
+    assert "needs: build-cross-release-libs" in freebsd
+    assert "name: libhew-x86_64-unknown-freebsd" in freebsd
+    assert "cargo build -p hew-lib --profile release-lib" not in freebsd
+    assert "--archive cross-release-libs/x86_64-unknown-freebsd/libhew.a" in freebsd
+    assert freebsd.count("cp cross-release-libs/x86_64-unknown-freebsd/libhew.a") == 2
+    assert '"${ARCHIVE_NAME}/lib/x86_64-unknown-freebsd/"' in freebsd
+    assert "pkg-smoke-ok" in freebsd
+
+
 def test_freebsd_release_lanes_provision_bash_and_package_with_posix_sh() -> None:
     release = workflow()
     gate = RELEASE_GATE.read_text()
@@ -1376,6 +1436,7 @@ _TESTS = [
     test_release_checksums_require_every_platform_asset,
     test_prerelease_validator_proves_external_staticlib_linking,
     test_every_release_lane_executes_the_library_consumer_proof,
+    test_cross_release_libraries_are_target_keyed_and_natively_proved,
     test_freebsd_release_lanes_provision_bash_and_package_with_posix_sh,
     test_sanitizer_gate_is_behavioral_and_release_scoped,
     test_release_record_is_durable_and_tag_ready,

--- a/scripts/verify-cross-release-lib.sh
+++ b/scripts/verify-cross-release-lib.sh
@@ -18,6 +18,12 @@ case "${target}" in
         expected_arch='x86_64'
         expected_os_abi='FreeBSD'
         ;;
+    aarch64-unknown-freebsd)
+        expected_name=libhew.a
+        expected_formats='elf64-littleaarch64'
+        expected_arch='aarch64'
+        expected_os_abi='FreeBSD'
+        ;;
     x86_64-pc-windows-msvc)
         expected_name=hew.lib
         expected_formats='COFF-import-file-x86-64 COFF-x86-64'

--- a/scripts/verify-cross-release-lib.sh
+++ b/scripts/verify-cross-release-lib.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+# Verify that a cross-built release archive matches its declared Rust target.
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <rust-target> <archive>" >&2
+    exit 2
+fi
+
+target=$1
+archive=$2
+
+case "${target}" in
+    x86_64-unknown-freebsd)
+        expected_name=libhew.a
+        expected_formats='elf64-x86-64'
+        expected_arch='x86_64'
+        expected_os_abi='FreeBSD'
+        ;;
+    x86_64-pc-windows-msvc)
+        expected_name=hew.lib
+        expected_formats='COFF-import-file-x86-64 COFF-x86-64'
+        expected_arch='x86_64'
+        expected_os_abi=''
+        ;;
+    *)
+        echo "unsupported cross-release target: ${target}" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$(basename "${archive}")" != "${expected_name}" ]; then
+    echo "archive name does not match ${target}: ${archive}" >&2
+    exit 1
+fi
+if [ ! -s "${archive}" ]; then
+    echo "missing or empty cross-release archive: ${archive}" >&2
+    exit 1
+fi
+
+archive_dir=$(dirname "${archive}")
+archive_count=$(find "${archive_dir}" -maxdepth 1 -type f \
+    \( -name libhew.a -o -name hew.lib \) | wc -l | tr -d ' ')
+if [ "${archive_count}" != 1 ]; then
+    echo "expected exactly one release archive in ${archive_dir}, found ${archive_count}" >&2
+    exit 1
+fi
+
+for tool in llvm-readobj llvm-nm; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "required archive inspection tool is unavailable: ${tool}" >&2
+        exit 1
+    fi
+done
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "${work_dir}"' EXIT HUP INT TERM
+headers=${work_dir}/headers.txt
+symbols=${work_dir}/symbols.txt
+
+llvm-readobj --file-headers "${archive}" > "${headers}"
+llvm-nm --defined-only --extern-only "${archive}" > "${symbols}"
+
+formats=$(sed -n 's/^Format: //p' "${headers}" | sort -u | tr '\n' ' ' | sed 's/ $//')
+if [ "${formats}" != "${expected_formats}" ]; then
+    echo "unexpected object formats for ${target}: ${formats}" >&2
+    exit 1
+fi
+if ! grep -q "^Arch: ${expected_arch}$" "${headers}"; then
+    echo "expected ${expected_arch} objects in ${archive}" >&2
+    exit 1
+fi
+if [ -n "${expected_os_abi}" ] && \
+    ! grep -q "OS/ABI: ${expected_os_abi}" "${headers}"; then
+    echo "expected ${expected_os_abi} object ABI in ${archive}" >&2
+    exit 1
+fi
+if ! grep -Eq '[[:space:]]T[[:space:]]hew_alloc$' "${symbols}"; then
+    echo "required hew_alloc export is missing from ${archive}" >&2
+    exit 1
+fi
+
+echo "verified ${target}: formats=${formats}, arch=${expected_arch}"


### PR DESCRIPTION
Executes the first two slices of the cross-release plan extending #254.

A new Linux job cross-builds the exact `release-lib` runtime archives — `x86_64-unknown-freebsd` and `x86_64-pc-windows-msvc` via pinned cargo-zigbuild and cargo-xwin, `aarch64-unknown-freebsd` via pinned `-Zbuild-std` since rustup ships no std component for it. Artifacts are keyed by full Rust triple and format/symbol-verified, failing on missing or duplicate outputs.

The native jobs remain the provers: each downloads its cross archive, runs the existing target-native consumer-link proof against it, and only then packages the cross archive under `lib/` and `lib/<target>/`. The redundant second native `hew-lib` build is removed; every native proof step stays. The QEMU jobs keep full build+smoke until three green package runs, per the plan.

All three cross builds were verified on this tree before the workflow was written, and the FreeBSD and release workflow contract suites pass along with workflow lint.

Holds until the in-flight rc1 release run completes — release-workflow changes do not land under a publishing run.