### PR TITLE
fix(ci): harden setup-llvm and setup-rust-build against transient download failures

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -142,6 +142,15 @@ runs:
     - name: Download and verify LLVM tarball
       if: runner.os != 'macOS' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
+      # Runner egress to github.com's release-asset CDN has shown mid-transfer
+      # drops (curl exit 56, "Connection died") and empty replies (exit 52)
+      # even while GitHub's own status page reports operational -- see the
+      # observed 2026-08-08/2026-08-12 CI incidents. curl's default --retry
+      # does not retry those two error classes without --retry-all-errors,
+      # and a single exhausted transfer previously failed the whole job.
+      # retry-download.sh adds an outer exponential-backoff loop (5 attempts,
+      # 10/20/40/80s) around the full download+checksum-verify+extract unit;
+      # download-verify-llvm.sh adds --retry-all-errors to the inner curl.
       run: |
         set -euo pipefail
         asset="${{ steps.layout.outputs.asset }}"
@@ -155,26 +164,10 @@ runs:
         if command -v cygpath >/dev/null 2>&1; then
           tarball="$(cygpath -u "${tarball}")"
         fi
-        echo "Downloading ${url}"
-        curl -fL --retry 3 --retry-delay 5 -o "${tarball}" "${url}"
-        expected="${{ steps.layout.outputs.sha256 }}"
-        if [ "${expected}" = "companion" ]; then
-          curl -fL --retry 3 -o "${tarball}.companion" "${url}.sha256"
-          expected="$(awk '{print $1}' "${tarball}.companion")"
-        fi
-        echo "${expected}  ${tarball}" > "${tarball}.sha256"
-        if command -v sha256sum >/dev/null 2>&1; then
-          sha256sum -c "${tarball}.sha256"
-        else
-          # macOS shasum fallback
-          shasum -a 256 -c "${tarball}.sha256"
-        fi
-        echo "Extracting to ${install_root}"
-        case "${tarball}" in
-          *.tar.gz) tar -xzf "${tarball}" -C "${install_root}" ;;
-          *) tar -xJf "${tarball}" -C "${install_root}" ;;
-        esac
-        rm -f "${tarball}" "${tarball}.sha256"
+        RETRY_ATTEMPTS=5 RETRY_INITIAL_DELAY=10 \
+          "${GITHUB_ACTION_PATH}/../../scripts/retry-download.sh" \
+          "${GITHUB_ACTION_PATH}/../../scripts/download-verify-llvm.sh" \
+          "${url}" "${{ steps.layout.outputs.sha256 }}" "${tarball}" "${install_root}"
 
     - name: Stub xml2s.lib for the upstream Windows tarball
       if: runner.os == 'Windows'

--- a/.github/actions/setup-rust-build/action.yml
+++ b/.github/actions/setup-rust-build/action.yml
@@ -50,8 +50,44 @@ runs:
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
 
-    - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
+    # Retried up to 3x: 2026-08-08/2026-08-12 CI incidents showed
+    # taiki-e/install-action's own binary fetch (cargo-nextest et al., from
+    # GitHub release assets) failing with curl exit 52 "Empty reply from
+    # server" while GitHub's status page reported operational. The action is
+    # a third-party `uses:` step with no exposed retry-count input, so the
+    # retry lives at this composite-action level rather than inside it.
+    - id: install-tools-attempt-1
+      uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
       if: inputs.tools != ''
+      continue-on-error: true
+      with:
+        tool: ${{ inputs.tools }}
+
+    - name: Wait before retrying tool install
+      if: inputs.tools != '' && steps.install-tools-attempt-1.outcome == 'failure'
+      shell: bash
+      run: sleep 15
+
+    - id: install-tools-attempt-2
+      uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
+      if: inputs.tools != '' && steps.install-tools-attempt-1.outcome == 'failure'
+      continue-on-error: true
+      with:
+        tool: ${{ inputs.tools }}
+
+    - name: Wait before final tool install attempt
+      if: >-
+        inputs.tools != '' &&
+        steps.install-tools-attempt-1.outcome == 'failure' &&
+        steps.install-tools-attempt-2.outcome == 'failure'
+      shell: bash
+      run: sleep 30
+
+    - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912  # v2.81.10
+      if: >-
+        inputs.tools != '' &&
+        steps.install-tools-attempt-1.outcome == 'failure' &&
+        steps.install-tools-attempt-2.outcome == 'failure'
       with:
         tool: ${{ inputs.tools }}
 
@@ -64,10 +100,41 @@ runs:
     # crate compilation.  The two compose: sccache caches compiler
     # invocations; Swatinem caches the registry.  SCCACHE_CACHE_SIZE bounds
     # the on-disk buffer; the GHA cache has its own 10 GB/repo ceiling.
-    - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+    #
+    # Retried up to 3x for the same reason as install-tools above: the
+    # 2026-08-08/2026-08-12 incidents showed this action's own sccache
+    # binary fetch failing with "socket hang up". The action already retries
+    # twice internally before giving up; this outer loop covers an egress
+    # blip that outlasts its built-in window. No exposed retry-count input
+    # (node action, dist/setup/index.js), so the retry wraps the step.
+    - id: sccache-attempt-1
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      continue-on-error: true
       with:
         # Always pull the latest released sccache binary unless we need to
         # pin for a specific fix.  The action itself is SHA-pinned above.
+        version: "v0.10.0"
+
+    - name: Wait before retrying sccache setup
+      if: steps.sccache-attempt-1.outcome == 'failure'
+      shell: bash
+      run: sleep 15
+
+    - id: sccache-attempt-2
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      if: steps.sccache-attempt-1.outcome == 'failure'
+      continue-on-error: true
+      with:
+        version: "v0.10.0"
+
+    - name: Wait before final sccache setup attempt
+      if: steps.sccache-attempt-1.outcome == 'failure' && steps.sccache-attempt-2.outcome == 'failure'
+      shell: bash
+      run: sleep 30
+
+    - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      if: steps.sccache-attempt-1.outcome == 'failure' && steps.sccache-attempt-2.outcome == 'failure'
+      with:
         version: "v0.10.0"
 
     - name: Export sccache environment variables

--- a/.github/scripts/download-verify-llvm.sh
+++ b/.github/scripts/download-verify-llvm.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Download, checksum-verify, and extract a pinned LLVM release tarball.
+#
+# The asset is an immutable, version-pinned release artifact, so a fresh
+# download after a network failure returns the same bytes as any prior
+# attempt. Callers wrap the whole unit (download + verify + extract) in
+# retry-download.sh: a transfer that dies mid-flight or an extraction that
+# aborts partway both leave the tarball/install_root in a state a second
+# attempt cleanly overwrites, so retrying the unit rather than only the
+# curl call is correct and keeps checksum verification mandatory on every
+# attempt, not just the first.
+#
+# Usage: download-verify-llvm.sh <url> <expected-sha256-or-companion> <tarball> <install_root>
+set -euo pipefail
+
+url="$1"
+expected="$2"
+tarball="$3"
+install_root="$4"
+
+echo "Downloading ${url}"
+curl -fL --retry 3 --retry-delay 5 --retry-all-errors -o "${tarball}" "${url}"
+
+if [ "${expected}" = "companion" ]; then
+  curl -fL --retry 3 --retry-all-errors -o "${tarball}.companion" "${url}.sha256"
+  expected="$(awk '{print $1}' "${tarball}.companion")"
+fi
+
+echo "${expected}  ${tarball}" >"${tarball}.sha256"
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c "${tarball}.sha256"
+else
+  # macOS shasum fallback
+  shasum -a 256 -c "${tarball}.sha256"
+fi
+
+echo "Extracting to ${install_root}"
+case "${tarball}" in
+*.tar.gz) tar -xzf "${tarball}" -C "${install_root}" ;;
+*) tar -xJf "${tarball}" -C "${install_root}" ;;
+esac
+
+rm -f "${tarball}" "${tarball}.sha256" "${tarball}.companion"


### PR DESCRIPTION
## Why

Runner egress to github.com's release-asset CDN dropped connections
mid-transfer (curl exit 56, "Connection died") and returned empty
replies (curl exit 52) during 2026-08-08 and 2026-08-12 CI runs, while
GitHub's status page reported operational throughout. Every download
hit here names an immutable, pinned release asset, so a retry after a
network blip returns the same bytes — this is resilience, not the
flake-tolerance test suites reject.

Two sites were hit:
- `setup-llvm`'s own curl for the LLVM tarball used `--retry 3` without
  `--retry-all-errors`, so exit 56/52 were never retried and a single
  exhausted transfer failed the whole job.
- `setup-rust-build`'s `taiki-e/install-action` (cargo-nextest fetch)
  and `mozilla-actions/sccache-action` (sccache binary fetch) hit the
  same failure class from inside third-party `uses:` steps that expose
  no retry-count input.

## What

- Extracted the LLVM download+checksum-verify+extract step into
  `.github/scripts/download-verify-llvm.sh`, wrapped in the existing
  `retry-download.sh` outer loop (5 attempts, exponential backoff
  10/20/40/80s) — the same mechanism #2896 added for the wasmtime
  downloads. Added `--retry-all-errors` to the inner curl calls.
  Checksum verification stays mandatory on every attempt.
- Wrapped `taiki-e/install-action` and `mozilla-actions/sccache-action`
  in `setup-rust-build` with up to three attempts each (15s/30s waits
  between), since neither third-party action exposes a retry-count
  input to tune from the caller side.

## Test

- `python3 scripts/tests/test_release_workflow_contract.py` — 41/41 pass
  (asserts the LLVM asset/checksum/version pins stay coherent; the
  extracted script preserves those strings unchanged).
- `python3 scripts/tests/test_freebsd_workflow_contract.py` — 28/28 pass.
- `python3 scripts/tests/test_rust_dependency_cache_contract.py` — 4/4 pass.
- `actionlint` on every workflow in `.github/workflows/` — clean.
- `shellcheck` on the new and existing retry scripts — clean.
- Manually exercised `retry-download.sh`'s outer loop against a command
  that fails twice then succeeds: confirmed it retries with growing
  backoff and returns success on the third attempt.

## Out of scope

- `dtolnay/rust-toolchain`'s own rustup bootstrap curl was not touched:
  every failed run log pulled from the incident windows shows it
  installing the toolchain successfully — the observed flakiness in
  `setup-rust-build` traced to the two third-party actions above, not
  the toolchain bootstrap the original report suspected.
- No new external dependency was added; the `setup-rust-build` retries
  use native step re-invocation rather than a marketplace retry action.

## Quality Checklist
- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [ ] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
- [ ] New allocations have cleanup paths for sync, async, and actor shutdown contexts
- [ ] Serialization changes include round-trip encode/decode tests
- [ ] New runtime features have a WASM implementation or an exact `// WASM-TODO(<stable-backlog-id>):` marker whose id is defined in `wasm-capability-manifest.toml`, and new `hew_*` exports are classified in `scripts/jit-symbol-classification.toml`
- [x] No duplicated logic — checked for existing helpers before adding new ones
