### PR TITLE
fix(ci): resolve release machinery from the workflow ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,12 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
 
+      - name: Checkout release machinery
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: release-machinery
+
       - name: Install archive inspection tools
         run: |
           sudo apt-get update
@@ -147,7 +153,7 @@ jobs:
         run: |
           set -euo pipefail
           archive="target/${{ matrix.rust_target }}/release-lib/${{ matrix.archive }}"
-          scripts/verify-cross-release-lib.sh "${{ matrix.rust_target }}" "${archive}"
+          release-machinery/scripts/verify-cross-release-lib.sh "${{ matrix.rust_target }}" "${archive}"
 
           destination="cross-release-libs/${{ matrix.rust_target }}"
           mkdir -p "${destination}"

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -605,6 +605,26 @@ def test_every_release_lane_executes_the_library_consumer_proof() -> None:
         assert "llvm-ar t " not in text
 
 
+def test_cross_release_machinery_resolves_from_workflow_ref() -> None:
+    text = workflow()
+    start = text.index("  build-cross-release-libs:\n")
+    end = text.index("  # Build — macOS and Windows release artifacts\n", start)
+    job = text[start:end]
+    assert (
+        """      - name: Checkout release machinery
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: release-machinery
+"""
+        in job
+    )
+    assert (
+        "release-machinery/scripts/verify-cross-release-lib.sh "
+        '"${{ matrix.rust_target }}" "${archive}"' in job
+    )
+
+
 def test_cross_release_libraries_are_target_keyed_and_natively_proved() -> None:
     release = workflow()
     cross_start = release.index("  build-cross-release-libs:\n")
@@ -1466,6 +1486,7 @@ _TESTS = [
     test_release_checksums_require_every_platform_asset,
     test_prerelease_validator_proves_external_staticlib_linking,
     test_every_release_lane_executes_the_library_consumer_proof,
+    test_cross_release_machinery_resolves_from_workflow_ref,
     test_cross_release_libraries_are_target_keyed_and_natively_proved,
     test_freebsd_release_lanes_provision_bash_and_package_with_posix_sh,
     test_sanitizer_gate_is_behavioral_and_release_scoped,


### PR DESCRIPTION
## Summary

Dispatching a Release run whose workflow is newer than the tag being released previously resolved verify scripts from the tag's tree, so runs against older tags failed with missing-file errors. The cross-archive jobs now check out the workflow's own commit into a separate path and invoke machinery from there, while product content still builds from the tag. A contract test pins the machinery checkout and invocation path.

## Verification

- `make test-release-workflow-contract`: 87/87 pass
- `actionlint`: clean
- Preflight: ready-to-push

## Out of scope

- No changes to what gets built or verified per archive — only where the verify machinery is resolved from.