### PR TITLE
fix(mir): borrow the vec handle when a for loop iterates a live root's record field

### DIFF
--- a/hew-cli/tests/param_record_field_loop_drop_leak_oracle.rs
+++ b/hew-cli/tests/param_record_field_loop_drop_leak_oracle.rs
@@ -244,6 +244,87 @@ fn main() {
 }
 "#;
 
+/// The projection-store bypass: assigning the ITERATED field mid-loop
+/// replaced the slot holding the borrowed handle while the cursor's own handle
+/// copy kept dereferencing the old storage — an abort under the poisoned
+/// allocator and reused-handle reads (`40,40,40,40` from `[40, 2]`) without
+/// it. The store now rejects at check-time (`vec_iter_borrowed_projections`
+/// prefix guard), so the runtime scenario is unreachable by construction.
+const PROJECTION_STORE_MID_LOOP_SOURCE: &str = r#"
+record Holder {
+    items: Vec<i64>,
+}
+
+fn main() {
+    var items: Vec<i64> = Vec::new();
+    items.push(40);
+    items.push(2);
+    var holder = Holder { items: items };
+    for value in holder.items {
+        println(f"{value}");
+        holder.items = Vec::new();
+    }
+}
+"#;
+
+/// Element-level mutation of the iterated field through the SHARED handle:
+/// `push` mid-loop extends the live view (the appended element is visited),
+/// `clear` ends it (the next length probe reads 0). Every `next` re-loads the
+/// handle from the cursor and clones the element out, so neither operation
+/// can leave the cursor holding a stale buffer pointer.
+const ITERATED_FIELD_PUSH_CLEAR_SOURCE: &str = r#"
+record Holder {
+    items: Vec<i64>,
+}
+
+fn main() {
+    var items: Vec<i64> = Vec::new();
+    items.push(40);
+    items.push(2);
+    var holder = Holder { items: items };
+    var seen: i64 = 0;
+    var total: i64 = 0;
+    for value in holder.items {
+        seen = seen + 1;
+        total = total + value;
+        if seen == 1 {
+            holder.items.push(7);
+        }
+        if seen == 3 {
+            holder.items.clear();
+        }
+    }
+    println(f"seen={seen} total={total} len={holder.items.len()}");
+}
+"#;
+
+/// Index assignment INTO the iterated field (`holder.items[1] = 9`) is an
+/// in-place element store through the shared handle — bounds-checked, no
+/// handle replacement — so the cursor observes the new element on the next
+/// clone-out: a live view, not a stale read.
+const ITERATED_FIELD_INDEX_SET_SOURCE: &str = r#"
+record Holder {
+    items: Vec<i64>,
+}
+
+fn main() {
+    var items: Vec<i64> = Vec::new();
+    items.push(40);
+    items.push(2);
+    var holder = Holder { items: items };
+    var seen: i64 = 0;
+    var total: i64 = 0;
+    for value in holder.items {
+        if seen == 0 {
+            holder.items[1] = 9;
+        }
+        seen = seen + 1;
+        total = total + value;
+    }
+    println(f"seen={seen} total={total}");
+}
+"#;
+
 fn param_field_loop_source(frames: usize) -> String {
     PARAM_FIELD_LOOP_TEMPLATE.replace("__FRAMES__", &frames.to_string())
 }
@@ -262,6 +343,94 @@ fn compile_and_run(source: &str, dir: &std::path::Path, name: &str) -> std::path
         describe_output(&output)
     );
     bin
+}
+
+#[test]
+fn projection_store_mid_loop_rejects_at_check_time() {
+    let dir = tempfile::Builder::new()
+        .prefix("projection-store-mid-loop-")
+        .tempdir()
+        .expect("tempdir");
+    let hew_src = dir.path().join("projection_store_mid_loop.hew");
+    std::fs::write(&hew_src, PROJECTION_STORE_MID_LOOP_SOURCE).expect("write hew source");
+
+    let output = std::process::Command::new(support::hew_binary())
+        .args(["check", hew_src.to_str().expect("hew src utf-8")])
+        .current_dir(support::repo_root())
+        .output()
+        .expect("invoke hew check");
+    assert!(
+        !output.status.success(),
+        "storing to the iterated field projection mid-loop must reject at \
+         check-time — accepting it re-opens the mid-loop handle replacement \
+         (poisoned-allocator abort / reused-handle reads):\n{}",
+        describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("assigning `holder.items` while a VecIter cursor borrows it"),
+        "the rejection must name the projected path and the borrowing cursor:\n{}",
+        describe_output(&output)
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the poisoned allocator contract is macOS-only; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn iterated_field_push_and_clear_run_as_live_view() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("iterated-field-push-clear-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_and_run(
+        ITERATED_FIELD_PUSH_CLEAR_SOURCE,
+        dir.path(),
+        "iterated_field_push_clear",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "seen=3 total=49 len=0\n",
+        "a mid-loop push must extend the live view (the appended 7 is visited) \
+         and a mid-loop clear must end it at the next length probe"
+    );
+    assert_eq!(
+        measure_leaks_exact(&bin),
+        (0, 0),
+        "element mutation through the shared handle must not strand cleared or \
+         reallocated element storage"
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the poisoned allocator contract is macOS-only; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn iterated_field_index_set_runs_in_place() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("iterated-field-index-set-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_and_run(
+        ITERATED_FIELD_INDEX_SET_SOURCE,
+        dir.path(),
+        "iterated_field_index_set",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "seen=2 total=49\n",
+        "an in-place element store into the iterated field must be observed by \
+         the cursor's next clone-out (40 then the stored 9)"
+    );
+    assert_eq!(measure_leaks_exact(&bin), (0, 0));
 }
 
 #[cfg_attr(

--- a/hew-cli/tests/param_record_field_loop_drop_leak_oracle.rs
+++ b/hew-cli/tests/param_record_field_loop_drop_leak_oracle.rs
@@ -1,0 +1,423 @@
+//! Regression oracle for a `for` loop iterating a field of a BY-VALUE record
+//! parameter.
+//!
+//! `for claim in ledger.claims` inside `fn f(ledger: ClaimsLedger)` used to
+//! hand the field's Vec handle to a sole-owner cursor that freed it at
+//! exhaustion, while the parameter's guarded carrier drop
+//! (`append_owned_carrier_param_drops` → `__hew_record_drop_inplace_<R>`)
+//! still released the whole record at normal return — the guard tracks only
+//! whole-value transfer, never a field-level move, so every call double-freed
+//! the iterated field's buffer (a silent SIGABRT under the macOS poisoned
+//! allocator; `hew check` was clean). A LOCAL record root had the sibling
+//! defect: the composite-drop prover classified the cursor ingress as a field
+//! escape, excluded the whole root, and leaked every non-iterated field.
+//!
+//! The fix makes such a cursor BORROW the field handle
+//! (`vec_iter_source_live_binding_record_field_root`, the third member of the
+//! projection-borrow family after #2540/#2545): the root's single drop
+//! authority — carrier drop for parameters, `RecordInPlace` for locals —
+//! frees every field exactly once, and the borrow-ingress exemption
+//! (`vec_iter_projection_borrow_inits`) keeps the local root admitted.
+//!
+//! Covered behaviours: full iteration at both call boundaries, an early
+//! `break` partial iteration with post-loop reads of BOTH fields, repeated
+//! iteration of the same parameter field, the local two-field partial-loop
+//! sibling leak, and the rvalue-rooted projection control that must KEEP its
+//! sole-owner cursor free. A panic-mid-loop edge is pinned structurally by the
+//! elaborated drop plans (the guarded `vec_iter_cursor` entries on panic /
+//! cancel edges), not by this process-level oracle — an aborting process
+//! cannot host the `leaks(1)` atExit probe.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance_exact_lines, compile_to_native, measure_leaks_exact,
+    run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+/// The original failing shape: a two-field record consumed by value, one field
+/// iterated, the record rebuilt and returned. One helper frame per iteration so
+/// leaked storage is unreachable from `main`'s final frame.
+const PARAM_FIELD_LOOP_TEMPLATE: &str = r#"
+record Claim {
+    run_id: string,
+    amount: i64,
+}
+
+record ClaimsLedger {
+    claims: Vec<Claim>,
+    terminal_runs: Vec<string>,
+}
+
+fn without_terminal_claims(ledger: ClaimsLedger) -> ClaimsLedger {
+    let terminal_runs = ledger.terminal_runs;
+    var claims: Vec<Claim> = Vec::new();
+    for claim in ledger.claims {
+        if !terminal_runs.contains(claim.run_id) {
+            claims.push(claim);
+        }
+    }
+    ClaimsLedger { claims: claims, terminal_runs: terminal_runs }
+}
+
+fn run_case(seed: i64) -> i64 {
+    var claims: Vec<Claim> = Vec::new();
+    claims.push(Claim { run_id: "r1", amount: 10 + seed });
+    claims.push(Claim { run_id: "r2", amount: 20 + seed });
+    claims.push(Claim { run_id: "r3", amount: 30 + seed });
+    var terminal: Vec<string> = Vec::new();
+    terminal.push("r2");
+    let ledger = ClaimsLedger { claims: claims, terminal_runs: terminal };
+    let pruned = without_terminal_claims(ledger);
+    var total: i64 = 0;
+    for claim in pruned.claims {
+        total = total + claim.amount;
+    }
+    total + pruned.claims.len() + pruned.terminal_runs.len()
+}
+
+fn main() -> i64 {
+    var checksum = 0;
+    for frame in 0..__FRAMES__ {
+        checksum = checksum + run_case(frame);
+        println("frame");
+    }
+    if checksum >= 0 { 0 } else { 91 }
+}
+"#;
+
+/// Minimal double-free repro: by-value single-field record, field iterated with
+/// a no-op body, record never touched again. Crashed at `count_claims` return.
+const PARAM_MINIMAL_SOURCE: &str = r#"
+record Claim {
+    run_id: string,
+    amount: i64,
+}
+
+record ClaimsLedger {
+    claims: Vec<Claim>,
+}
+
+fn count_claims(ledger: ClaimsLedger) -> i64 {
+    var n: i64 = 0;
+    for claim in ledger.claims {
+        n = n + 1;
+    }
+    n
+}
+
+fn main() {
+    var claims: Vec<Claim> = Vec::new();
+    claims.push(Claim { run_id: "r1", amount: 10 });
+    claims.push(Claim { run_id: "r2", amount: 20 });
+    claims.push(Claim { run_id: "r3", amount: 30 });
+    let ledger = ClaimsLedger { claims: claims };
+    let n = count_claims(ledger);
+    println(f"kept {n} claims");
+}
+"#;
+
+/// Early `break` abandons the cursor mid-iteration; the borrow contract means
+/// BOTH fields — including the partially iterated one — stay readable after
+/// the loop and release exactly once at the carrier drop.
+const PARAM_EARLY_BREAK_SOURCE: &str = r#"
+record Claim {
+    run_id: string,
+    amount: i64,
+}
+
+record ClaimsLedger {
+    claims: Vec<Claim>,
+    terminal_runs: Vec<string>,
+}
+
+fn first_amount(ledger: ClaimsLedger) -> i64 {
+    var found: i64 = 0;
+    for claim in ledger.claims {
+        found = claim.amount;
+        break;
+    }
+    found + ledger.claims.len() + ledger.terminal_runs.len()
+}
+
+fn main() {
+    var claims: Vec<Claim> = Vec::new();
+    claims.push(Claim { run_id: "r1", amount: 10 });
+    claims.push(Claim { run_id: "r2", amount: 20 });
+    var terminal: Vec<string> = Vec::new();
+    terminal.push("r2");
+    let ledger = ClaimsLedger { claims: claims, terminal_runs: terminal };
+    println(f"v={first_amount(ledger)}");
+}
+"#;
+
+/// Iterating the same parameter field twice proves the cursor left the handle
+/// live (a sole-owner cursor freed it at first exhaustion — use-after-free).
+const PARAM_DOUBLE_ITERATION_SOURCE: &str = r#"
+record Claim {
+    run_id: string,
+    amount: i64,
+}
+
+record ClaimsLedger {
+    claims: Vec<Claim>,
+}
+
+fn sum_twice(ledger: ClaimsLedger) -> i64 {
+    var total: i64 = 0;
+    for claim in ledger.claims {
+        total = total + claim.amount;
+    }
+    for claim in ledger.claims {
+        total = total + claim.amount;
+    }
+    total
+}
+
+fn main() {
+    var claims: Vec<Claim> = Vec::new();
+    claims.push(Claim { run_id: "r1", amount: 10 });
+    claims.push(Claim { run_id: "r2", amount: 20 });
+    let ledger = ClaimsLedger { claims: claims };
+    println(f"total={sum_twice(ledger)}");
+}
+"#;
+
+/// The LOCAL-root sibling defect: iterating one field of a two-field local
+/// record excluded the root's composite drop wholesale and leaked the
+/// non-iterated `terminal_runs` Vec (3 nodes / 176 bytes per frame).
+const LOCAL_TWO_FIELD_PARTIAL_SOURCE: &str = r#"
+record Claim {
+    run_id: string,
+    amount: i64,
+}
+
+record ClaimsLedger {
+    claims: Vec<Claim>,
+    terminal_runs: Vec<string>,
+}
+
+fn main() {
+    var claims: Vec<Claim> = Vec::new();
+    claims.push(Claim { run_id: "r1", amount: 10 });
+    claims.push(Claim { run_id: "r2", amount: 20 });
+    var terminal: Vec<string> = Vec::new();
+    terminal.push("r2");
+    let ledger = ClaimsLedger { claims: claims, terminal_runs: terminal };
+    var n: i64 = 0;
+    for claim in ledger.claims {
+        n = n + 1;
+    }
+    println(f"kept {n} claims, {ledger.terminal_runs.len()} terminal");
+}
+"#;
+
+/// Control: an RVALUE-rooted projection has no surviving owner, so its cursor
+/// must KEEP the sole-owner free — the borrow verdict is scoped to live
+/// binding roots and must not flip this shape into a leak.
+const RVALUE_ROOT_PROJECTION_CONTROL_SOURCE: &str = r#"
+record Claim {
+    run_id: string,
+    amount: i64,
+}
+
+record ClaimsLedger {
+    claims: Vec<Claim>,
+}
+
+fn make_ledger() -> ClaimsLedger {
+    var claims: Vec<Claim> = Vec::new();
+    claims.push(Claim { run_id: "r1", amount: 10 });
+    claims.push(Claim { run_id: "r2", amount: 20 });
+    ClaimsLedger { claims: claims }
+}
+
+fn main() {
+    var total: i64 = 0;
+    for claim in make_ledger().claims {
+        total = total + claim.amount;
+    }
+    println(f"total={total}");
+}
+"#;
+
+fn param_field_loop_source(frames: usize) -> String {
+    PARAM_FIELD_LOOP_TEMPLATE.replace("__FRAMES__", &frames.to_string())
+}
+
+fn expected_lines(frames: usize) -> usize {
+    frames
+}
+
+fn compile_and_run(source: &str, dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let bin = compile_to_native(source, dir, name);
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "{name} must survive the poisoned allocator — an abort here is the \
+         field-loop double-free / use-after-free this oracle pins:\n{}",
+        describe_output(&output)
+    );
+    bin
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn param_record_field_loop_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance_exact_lines(
+        "param_record_field_loop",
+        param_field_loop_source,
+        expected_lines,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the poisoned allocator contract is macOS-only; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn param_field_loop_minimal_runs_clean_and_leak_free() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("param-field-loop-minimal-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_and_run(PARAM_MINIMAL_SOURCE, dir.path(), "param_field_loop_minimal");
+    let output = run_under_malloc_scribble(&bin);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "kept 3 claims\n",
+        "full iteration of the parameter field must visit every element"
+    );
+    assert_eq!(
+        measure_leaks_exact(&bin),
+        (0, 0),
+        "the carrier drop is the single release authority for the iterated field"
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the poisoned allocator contract is macOS-only; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn param_field_loop_early_break_keeps_both_fields_live_and_leak_free() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("param-field-loop-early-break-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_and_run(
+        PARAM_EARLY_BREAK_SOURCE,
+        dir.path(),
+        "param_field_loop_early_break",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "v=13\n",
+        "a partial iteration must leave the iterated field readable (len=2) \
+         alongside its sibling (len=1)"
+    );
+    assert_eq!(
+        measure_leaks_exact(&bin),
+        (0, 0),
+        "an abandoned borrow-cursor must not strand the un-iterated remainder"
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the poisoned allocator contract is macOS-only; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn param_field_double_iteration_reads_live_handle_twice() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("param-field-double-iteration-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_and_run(
+        PARAM_DOUBLE_ITERATION_SOURCE,
+        dir.path(),
+        "param_field_double_iteration",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "total=60\n",
+        "the second loop must observe the same live elements as the first"
+    );
+    assert_eq!(measure_leaks_exact(&bin), (0, 0));
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the poisoned allocator contract is macOS-only; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn local_two_field_partial_loop_releases_the_non_iterated_sibling() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("local-two-field-partial-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_and_run(
+        LOCAL_TWO_FIELD_PARTIAL_SOURCE,
+        dir.path(),
+        "local_two_field_partial",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "kept 2 claims, 1 terminal\n",
+        "the sibling field must stay readable after the field loop"
+    );
+    assert_eq!(
+        measure_leaks_exact(&bin),
+        (0, 0),
+        "the local root keeps its RecordInPlace composite: the iterated field is \
+         borrowed by the cursor and the sibling must not leak"
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the poisoned allocator contract is macOS-only; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn rvalue_rooted_projection_cursor_still_frees_its_snapshot() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("rvalue-root-projection-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_and_run(
+        RVALUE_ROOT_PROJECTION_CONTROL_SOURCE,
+        dir.path(),
+        "rvalue_root_projection",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "total=30\n",
+        "an rvalue-rooted projection loop must still visit every element"
+    );
+    assert_eq!(
+        measure_leaks_exact(&bin),
+        (0, 0),
+        "with no surviving root binding the cursor remains the sole owner and \
+         must free the projected handle"
+    );
+}

--- a/hew-mir/src/lower/assign.rs
+++ b/hew-mir/src/lower/assign.rs
@@ -41,6 +41,44 @@ impl Builder {
                 return;
             }
         }
+        // A record-field store whose target path is a borrowed field-projection
+        // cursor's source — or ANY prefix of it — overwrites the slot the
+        // borrowed handle lives in. The cursor's own handle copy (cursor
+        // field 0) keeps dereferencing the replaced handle's storage on every
+        // `next`, so a bypass here is a use-after-free the moment the old
+        // handle is released (the poisoned-allocator abort). The whole-root
+        // guard above already rejects `root = …`; this is the same boundary
+        // one projection level down. Element-level mutation through the SAME
+        // handle (`root.f[i] = …`, `.push`, `.clear`) stays allowed — `next`
+        // re-loads the handle and re-probes the length, so in-place mutation
+        // is a live view, never a stale pointer.
+        if let Some((target_root, target_path, rendered)) = field_store_target_path(target) {
+            if self
+                .vec_iter_borrowed_projections
+                .iter()
+                .any(|(_, borrowed_root, borrowed_path)| {
+                    *borrowed_root == target_root
+                        && target_path.len() <= borrowed_path.len()
+                        && borrowed_path[..target_path.len()] == target_path[..]
+                })
+            {
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::NotYetImplemented {
+                        construct: format!(
+                            "assigning `{rendered}` while a VecIter cursor borrows it"
+                        ),
+                        site: target.site,
+                    },
+                    note: "the active for-loop cursor reads this field's Vec handle directly; \
+                           storing to the projected field (or any record containing it) would \
+                           replace that handle while the cursor can still execute. Mutate \
+                           elements through Vec methods or index assignment, or store after \
+                           the loop has finished"
+                        .to_string(),
+                });
+                return;
+            }
+        }
         // A `string`/`bytes` assignment whose RHS is an ACTIVE yield binder is
         // a retained SHARE, mirroring the `let x = <binding>` share-site
         // registration above in `stmt`. The binder's release authority is the
@@ -666,6 +704,40 @@ impl Builder {
                 },
                 note: "assignment target did not lower to a writable place".to_string(),
             }),
+        }
+    }
+}
+
+/// The `(root binding, field path, rendered spelling)` of a record-field
+/// store target — a pure `FieldAccess` chain over a local `BindingRef` root
+/// (`outer.inner.items = …` → `(outer, ["inner", "items"],
+/// "outer.inner.items")`). Mirrors the source-side walk in
+/// [`Builder::vec_iter_source_live_binding_record_field_path`] so the
+/// borrowed-projection store guard compares like against like. `None` for any
+/// other target shape (bare bindings, index targets, actor state) — those
+/// have their own guards or lowering arms.
+fn field_store_target_path(target: &HirExpr) -> Option<(hew_hir::BindingId, Vec<String>, String)> {
+    let mut cur = target;
+    let mut path: Vec<String> = Vec::new();
+    loop {
+        match &cur.kind {
+            HirExprKind::SubsumedValue { source, .. } => cur = source,
+            HirExprKind::FieldAccess { object, field } => {
+                path.push(field.clone());
+                cur = object;
+            }
+            HirExprKind::BindingRef {
+                name,
+                resolved: ResolvedRef::Binding(id),
+            } => {
+                if path.is_empty() {
+                    return None;
+                }
+                path.reverse();
+                let rendered = format!("{name}.{}", path.join("."));
+                return Some((*id, path, rendered));
+            }
+            _ => return None,
         }
     }
 }

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -160,6 +160,7 @@ pub(super) fn apply_escaped_record_sibling_field_drops(
     lifecycle_registry: &hew_hir::LifecycleRegistry,
     alias_chain: &[(u32, u32, u32)],
     aggregate_clone_sites: &HashSet<(u32, usize, Place)>,
+    projection_borrow_cursor_inits: &HashSet<Place>,
     is_owned_record: &dyn Fn(&ResolvedTy) -> bool,
     owned_field_list: &dyn Fn(&ResolvedTy) -> Vec<(u32, ResolvedTy)>,
     owned_tuple_field_list: &dyn Fn(&ResolvedTy) -> Vec<(u32, ResolvedTy)>,
@@ -304,7 +305,26 @@ pub(super) fn apply_escaped_record_sibling_field_drops(
                     }
                 }
                 Instr::RecordInit { fields, dest, .. } => {
+                    // A live-root field-projection cursor init BORROWS its
+                    // `vec`-field binder (`vec_iter_projection_borrow_inits`):
+                    // the root keeps sole ownership, so the read is a use
+                    // site, never an escape event — mirroring the exemption in
+                    // `derive_owned_record_drop_allowed` so admission and
+                    // discharge cannot disagree.
+                    let borrowed_cursor_vec_src = if projection_borrow_cursor_inits.contains(dest) {
+                        vec_iter_record_init_vec_source(instr)
+                    } else {
+                        None
+                    };
                     for (_, p) in fields {
+                        if borrowed_cursor_vec_src == Some(*p) {
+                            if let Some(l) = base_local(*p) {
+                                if field_binders.contains(&l) {
+                                    site!(binder_root(l), Some(idx));
+                                }
+                            }
+                            continue;
+                        }
                         if aggregate_borrowed_ingress_sink_clones_source(
                             block,
                             idx,
@@ -2078,6 +2098,7 @@ pub(super) fn derive_owned_record_drop_allowed(
     lifecycle_registry: &hew_hir::LifecycleRegistry,
     alias_field_binders: &[(u32, u32)],
     proven_borrow_call_args: &HashMap<u32, HashSet<usize>>,
+    projection_borrow_cursor_inits: &HashSet<Place>,
 ) -> HashSet<BindingId> {
     // A local carries a heap-owning value iff its registered type says so. Used
     // to decide whether a `RecordFieldLoad` dest is an owned-field binder (a
@@ -2532,7 +2553,27 @@ pub(super) fn derive_owned_record_drop_allowed(
                     // tip because the no-clone control leaked the identical floor).
                     | Instr::RecordCloneInplace { .. }
             ) {
+                // A `record_init VecIter { vec, idx }` whose registration
+                // proved a live-root field-projection BORROW
+                // (`vec_iter_projection_borrow_inits`) reads the field binder
+                // without taking ownership: the cursor never frees the handle
+                // (its ownership bit is born moved), so the root record keeps
+                // its single release authority. The verdict comes from the
+                // Builder ledger, not structure — an owning rvalue-rooted
+                // projection cursor produces the identical MIR shape and must
+                // still exclude the root (its cursor DOES free the handle).
+                let borrowed_cursor_vec_src = match instr {
+                    Instr::RecordInit { dest, .. }
+                        if projection_borrow_cursor_inits.contains(dest) =>
+                    {
+                        vec_iter_record_init_vec_source(instr)
+                    }
+                    _ => None,
+                };
                 for p in instr_source_places(instr) {
+                    if borrowed_cursor_vec_src == Some(p) {
+                        continue;
+                    }
                     if let Some(l) = base_local(p) {
                         let cloned_borrowed_ingress =
                             aggregate_borrowed_ingress_sink_clones_source(
@@ -6782,6 +6823,7 @@ mod owned_record_drop_derivation {
             &hew_hir::LifecycleRegistry::default(),
             &[],
             &HashMap::new(),
+            &HashSet::new(),
         )
     }
 
@@ -6876,6 +6918,7 @@ mod owned_record_drop_derivation {
             &hew_hir::LifecycleRegistry::default(),
             &[],
             proven_borrow_call_args,
+            &HashSet::new(),
         )
     }
 
@@ -7656,6 +7699,7 @@ mod escaped_sibling_field_discharge {
             &hew_hir::LifecycleRegistry::default(),
             alias_chain,
             &HashSet::new(),
+            &HashSet::new(),
             is_owned_record,
             owned_field_list,
             &owned_tuple_fields,
@@ -8163,6 +8207,7 @@ mod escaped_sibling_field_discharge {
             &[],
             &hew_hir::LifecycleRegistry::default(),
             &[],
+            &HashSet::new(),
             &HashSet::new(),
             &is_rec,
             &three_fields,

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -606,6 +606,7 @@ pub(super) fn elaborate(
         builder.type_classes.lifecycle_registry(),
         &alias_field_binders,
         &builder.proven_borrow_call_args,
+        &builder.vec_iter_projection_borrow_inits,
     );
     // A flagged fresh String/BitCopy record has an explicit runtime owner
     // discriminator. The ordinary escape scan excludes it because one path

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -2192,6 +2192,7 @@ impl Builder {
                     value,
                     &binding_ty,
                     pending || value_place.is_some(),
+                    value_place,
                 );
                 if owned_string_record_key.is_some() && value_place.is_some() {
                     self.owned_string_record_bindings.insert(binding.id);

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -838,6 +838,19 @@ struct Builder {
     /// invalidate `cursor.vec`; those ownership boundaries reject until the
     /// cursor scope closes.
     pub(crate) vec_iter_borrowed_sources: Vec<(ScopeId, hew_hir::BindingId)>,
+    /// `RecordInit` destination places of `for x in root.field` cursor inits
+    /// whose `vec` handle BORROWS a field projection rooted at a live
+    /// local/param binding
+    /// ([`Builder::vec_iter_source_live_binding_record_field_root`]). The
+    /// root's own drop authority — a by-value parameter's guarded carrier drop
+    /// (`append_owned_carrier_param_drops`) or a local record's `RecordInPlace`
+    /// composite — releases the field exactly once, so the composite-drop
+    /// provers must not classify the cursor-init read of the field binder as an
+    /// ownership escape (which would exclude the root and leak every field).
+    /// Recorded at cursor registration, where the HIR borrow verdict is known;
+    /// the provers cannot re-derive it structurally because an owning
+    /// rvalue-rooted projection produces the identical MIR shape.
+    pub(crate) vec_iter_projection_borrow_inits: HashSet<Place>,
     /// Runtime ownership bit for every first-class `VecIter<T>` local.
     ///
     /// `0` means this binding currently owns its `vec` snapshot and must release
@@ -5533,6 +5546,7 @@ pub(crate) fn lower_function(
             builder.type_classes.lifecycle_registry(),
             &alias_chain,
             &aggregate_clone_sites,
+            &builder.vec_iter_projection_borrow_inits,
             &is_owned_record,
             &owned_field_list,
             &owned_tuple_field_list,
@@ -5964,6 +5978,7 @@ pub(crate) fn lower_function(
         builder.type_classes.lifecycle_registry(),
         &alias_field_binders,
         &builder.proven_borrow_call_args,
+        &builder.vec_iter_projection_borrow_inits,
     );
     let mut composite_drop_allowed = tuple_composite_drop_allowed;
     composite_drop_allowed.extend(owned_record_drop_allowed);

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -838,6 +838,21 @@ struct Builder {
     /// invalidate `cursor.vec`; those ownership boundaries reject until the
     /// cursor scope closes.
     pub(crate) vec_iter_borrowed_sources: Vec<(ScopeId, hew_hir::BindingId)>,
+    /// Full field paths (root binding + field-name chain, root→leaf) of
+    /// `for x in root.f…` cursors whose `vec` handle BORROWS a record-field
+    /// projection. `vec_iter_borrowed_sources` holds the ROOT for the
+    /// whole-value move/reassign guards; this twin holds the PATH for the
+    /// record-field-store guard. While an entry is active, a store whose
+    /// target path is the projection itself or ANY prefix of it
+    /// (`root.f = …`; `root.mid = …` while iterating `root.mid.f`) would
+    /// overwrite the slot holding the borrowed handle — the cursor's own
+    /// handle copy (cursor field 0) then dereferences released storage — so
+    /// those stores reject until the cursor scope closes. Element-level
+    /// mutation through the SAME handle (`root.f[i] = …`, `root.f.push(…)`,
+    /// `root.f.clear()`) stays allowed: every `next` re-loads the handle,
+    /// re-probes `hew_vec_len`, and clones the element out, so in-place
+    /// mutation is a memory-safe live view.
+    pub(crate) vec_iter_borrowed_projections: Vec<(ScopeId, hew_hir::BindingId, Vec<String>)>,
     /// `RecordInit` destination places of `for x in root.field` cursor inits
     /// whose `vec` handle BORROWS a field projection rooted at a live
     /// local/param binding

--- a/hew-mir/src/lower/scope.rs
+++ b/hew-mir/src/lower/scope.rs
@@ -16,7 +16,10 @@ impl Builder {
         if matches!(value.kind, HirExprKind::StructInit { .. }) {
             return vec_iter_let_cursor_owns_handle(value)
                 && !self.vec_iter_source_projects_actor_state_field(value)
-                && !self.vec_iter_source_indexes_owned_element_vec(value);
+                && !self.vec_iter_source_indexes_owned_element_vec(value)
+                && self
+                    .vec_iter_source_live_binding_record_field_root(value)
+                    .is_none();
         }
         // A `VecIter<T>` returned through the Hew call ABI is an ownership
         // transfer. The callee's return edge suppresses its local cursor drop,
@@ -234,6 +237,7 @@ impl Builder {
         value: &HirExpr,
         binding_ty: &ResolvedTy,
         slot_is_wired: bool,
+        value_place: Option<Place>,
     ) {
         if !slot_is_wired
             || self.vec_iter_cursor_release_symbol(binding_ty).is_none()
@@ -258,6 +262,17 @@ impl Builder {
                         self.vec_iter_borrowed_sources
                             .push((scope, *source_binding));
                     }
+                }
+            }
+            // A field-projection cursor rooted at a live binding borrows the
+            // root's field handle: pin the ROOT against mid-loop moves /
+            // reassignment, and mark the cursor init so the composite-drop
+            // provers keep the root's single release authority admitted
+            // (`vec_iter_projection_borrow_inits`).
+            if let Some(root) = self.vec_iter_source_live_binding_record_field_root(value) {
+                self.vec_iter_borrowed_sources.push((scope, root));
+                if let Some(init) = value_place {
+                    self.vec_iter_projection_borrow_inits.insert(init);
                 }
             }
         }
@@ -541,6 +556,62 @@ impl Builder {
                         && self.current_actor_state_fields.contains_key(name);
                 }
                 _ => return false,
+            }
+        }
+    }
+    /// The live local/param ROOT binding of a `for x in root.f` cursor whose
+    /// `vec` source is a pure `FieldAccess` chain over a function-local
+    /// binding, or `None` for any other source shape.
+    ///
+    /// The third sibling of the projection-borrow family —
+    /// [`Self::vec_iter_source_projects_actor_state_field`] (#2540, actor-state
+    /// root) and [`Self::vec_iter_source_indexes_owned_element_vec`] (#2545,
+    /// owned-element Vec index). A record-field projection rooted at a LIVE
+    /// binding is owned by that binding's storage:
+    ///   - a by-value parameter's guarded carrier drop
+    ///     (`append_owned_carrier_param_drops`) runs
+    ///     `__hew_record_drop_inplace_<R>` on the whole record at every
+    ///     return/trap/cancel edge unless the WHOLE value transferred — the
+    ///     guard never tracks a field-level move, so a cursor that took the
+    ///     field handle and freed it at exhaustion double-freed the buffer at
+    ///     normal return (the poisoned-allocator SIGABRT);
+    ///   - a local record root fares no better as an owner donor: the
+    ///     composite-drop prover sees the field escape into the cursor init,
+    ///     excludes the WHOLE root, and every non-iterated sibling field leaks.
+    ///
+    /// The cursor must BORROW — the root's one drop authority frees every
+    /// field exactly once, mirroring what the bare-`BindingRef` arm of
+    /// [`vec_iter_let_cursor_owns_handle`] already grants `for x in v`.
+    /// Registration also records the root in `vec_iter_borrowed_sources`, so
+    /// moving or reassigning it mid-loop is rejected while the cursor reads
+    /// the shared handle.
+    ///
+    /// Only `FieldAccess` hops are admitted. A `TupleIndex` hop keeps today's
+    /// sole-owner disposition: the tuple composite prover has no
+    /// borrow-ingress exemption yet, so flipping it would trade its current
+    /// behaviour for a whole-tuple leak. A non-`BindingRef` root (an rvalue
+    /// call, a block result) has no surviving owner and the cursor stays the
+    /// sole owner as before.
+    pub(crate) fn vec_iter_source_live_binding_record_field_root(
+        &self,
+        value: &HirExpr,
+    ) -> Option<hew_hir::BindingId> {
+        let mut cur = vec_iter_init_vec_source_expr(value)?;
+        let mut projected = false;
+        loop {
+            match &cur.kind {
+                HirExprKind::SubsumedValue { source, .. } => cur = source,
+                HirExprKind::FieldAccess { object, .. } => {
+                    projected = true;
+                    cur = object;
+                }
+                HirExprKind::BindingRef {
+                    resolved: ResolvedRef::Binding(id),
+                    ..
+                } => {
+                    return (projected && self.binding_locals.contains_key(id)).then_some(*id);
+                }
+                _ => return None,
             }
         }
     }

--- a/hew-mir/src/lower/scope.rs
+++ b/hew-mir/src/lower/scope.rs
@@ -269,8 +269,9 @@ impl Builder {
             // reassignment, and mark the cursor init so the composite-drop
             // provers keep the root's single release authority admitted
             // (`vec_iter_projection_borrow_inits`).
-            if let Some(root) = self.vec_iter_source_live_binding_record_field_root(value) {
+            if let Some((root, path)) = self.vec_iter_source_live_binding_record_field_path(value) {
                 self.vec_iter_borrowed_sources.push((scope, root));
+                self.vec_iter_borrowed_projections.push((scope, root, path));
                 if let Some(init) = value_place {
                     self.vec_iter_projection_borrow_inits.insert(init);
                 }
@@ -332,6 +333,8 @@ impl Builder {
         }
         self.vec_iter_borrowed_sources
             .retain(|(scope, _)| *scope != scope_id);
+        self.vec_iter_borrowed_projections
+            .retain(|(scope, ..)| *scope != scope_id);
     }
 
     /// Release the `vec` handle of every registered `for x in …` cursor
@@ -596,20 +599,38 @@ impl Builder {
         &self,
         value: &HirExpr,
     ) -> Option<hew_hir::BindingId> {
+        self.vec_iter_source_live_binding_record_field_path(value)
+            .map(|(root, _)| root)
+    }
+    /// Path-carrying sibling of
+    /// [`Self::vec_iter_source_live_binding_record_field_root`]: the live root
+    /// binding AND the projected field-name chain in root→leaf order
+    /// (`outer.inner.items` → `(outer, ["inner", "items"])`). The chain feeds
+    /// `vec_iter_borrowed_projections`, whose prefix guard rejects
+    /// record-field stores that would overwrite the borrowed handle's slot
+    /// mid-loop.
+    pub(crate) fn vec_iter_source_live_binding_record_field_path(
+        &self,
+        value: &HirExpr,
+    ) -> Option<(hew_hir::BindingId, Vec<String>)> {
         let mut cur = vec_iter_init_vec_source_expr(value)?;
-        let mut projected = false;
+        let mut path: Vec<String> = Vec::new();
         loop {
             match &cur.kind {
                 HirExprKind::SubsumedValue { source, .. } => cur = source,
-                HirExprKind::FieldAccess { object, .. } => {
-                    projected = true;
+                HirExprKind::FieldAccess { object, field } => {
+                    path.push(field.clone());
                     cur = object;
                 }
                 HirExprKind::BindingRef {
                     resolved: ResolvedRef::Binding(id),
                     ..
                 } => {
-                    return (projected && self.binding_locals.contains_key(id)).then_some(*id);
+                    if path.is_empty() || !self.binding_locals.contains_key(id) {
+                        return None;
+                    }
+                    path.reverse();
+                    return Some((*id, path));
                 }
                 _ => return None,
             }

--- a/hew-mir/tests/lowering_calls/vec_iter_clone_out.rs
+++ b/hew-mir/tests/lowering_calls/vec_iter_clone_out.rs
@@ -370,6 +370,95 @@ fn borrowed_for_source_cannot_move_or_reassign_until_cursor_scope_closes() {
 }
 
 #[test]
+fn borrowed_projection_prefix_stores_reject_while_cursor_active() {
+    let pipeline = pipeline_allowing_mir_diagnostics(
+        r"
+        record Holder {
+            items: Vec<i64>,
+        }
+
+        record Inner {
+            items: Vec<i64>,
+        }
+
+        record Outer {
+            inner: Inner,
+            spare: Vec<i64>,
+        }
+
+        fn make() -> Vec<i64> {
+            [1, 2, 3]
+        }
+
+        fn direct_store() {
+            var holder = Holder { items: make() };
+            for value in holder.items {
+                holder.items = make();
+                print(value);
+            }
+        }
+
+        fn nested_store() {
+            var outer = Outer { inner: Inner { items: make() }, spare: make() };
+            for value in outer.inner.items {
+                outer.inner.items = make();
+                print(value);
+            }
+        }
+
+        fn prefix_store() {
+            var outer = Outer { inner: Inner { items: make() }, spare: make() };
+            for value in outer.inner.items {
+                outer.inner = Inner { items: make() };
+                print(value);
+            }
+        }
+
+        fn sibling_store_stays_valid() {
+            var outer = Outer { inner: Inner { items: make() }, spare: make() };
+            for value in outer.inner.items {
+                outer.spare = make();
+                print(value);
+            }
+        }
+        ",
+    );
+
+    let constructs: Vec<_> = pipeline
+        .diagnostics
+        .iter()
+        .filter_map(|diagnostic| match &diagnostic.kind {
+            hew_mir::MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("while a VecIter cursor borrows it") =>
+            {
+                Some(construct.as_str())
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        constructs.len(),
+        3,
+        "the projection itself, its full nested path, and every prefix must \
+         reject while the borrowed field cursor is active, while a disjoint \
+         sibling field store stays valid: {:#?}",
+        pipeline.diagnostics
+    );
+    for expected in [
+        "assigning `holder.items`",
+        "assigning `outer.inner.items`",
+        "assigning `outer.inner`",
+    ] {
+        assert!(
+            constructs
+                .iter()
+                .any(|construct| construct.starts_with(expected)),
+            "missing rejection for {expected}: {constructs:#?}"
+        );
+    }
+}
+
+#[test]
 fn vec_iter_yield_cancel_cleanup_is_path_exact_or_rejected() {
     let pipeline = pipeline_allowing_mir_diagnostics(
         r"


### PR DESCRIPTION
## Summary

`for x in root.field` over a record field handed the field's Vec handle to a sole-owner cursor that freed it at exhaustion, while the root's drop authority still covered the whole record:

- **By-value parameter (P0 double-free)**: the guarded carrier drop (`append_owned_carrier_param_drops`) runs `__hew_record_drop_inplace_<R>` unconditionally at every return/trap/cancel edge unless the *whole* value transferred — the exactly-once guard never tracks a field-level move, so every call double-freed the iterated field's buffer. Silent SIGABRT under the macOS poisoned allocator; `hew check` clean. Reproduces on **v0.6.0-rc1** and current main — release-note-worthy: any rc1 program that passes a record by value and iterates one of its `Vec` fields aborts.
- **Local record root (sibling leak)**: the composite-drop prover classified the cursor ingress as a field escape, excluded the whole root from its `RecordInPlace` drop, and leaked every non-iterated sibling field (3 nodes / 176 B per frame on a two-field record).

Both shapes now join the projection-borrow family that #2540 (actor-state roots) and #2545 (owned-element Vec index) already ship: a field-projection cursor rooted at a **live local/param binding borrows** the handle (`vec_iter_source_live_binding_record_field_root`; ownership bit born moved) and the root's single drop authority frees every field exactly once. The borrow verdict is recorded per cursor init (`Builder::vec_iter_projection_borrow_inits`) and threaded to `derive_owned_record_drop_allowed` / `apply_escaped_record_sibling_field_drops`, which treat exactly those `record_init VecIter { vec, idx }` reads as uses, not escapes (mirroring the enum prover's #2725b exemption). The ledger, not MIR structure, carries the verdict: an owning rvalue-rooted projection cursor produces identical MIR and must keep excluding the root.

Cancellation and panic mid-loop stay exactly-once: the elaborated `vec_iter_cursor` abandon drops keep their (now-moved) guard bit, and the carrier / composite drop covers the record wholesale — no leak of the un-iterated remainder, no double-free of the consumed part. Registration also pins the root in `vec_iter_borrowed_sources`, so moving/reassigning it mid-loop is rejected with the existing cursor-borrow diagnostic instead of compiling into a use-after-free.

## Verification

- Original repros (bisection ladder d/e/g/h + full prune-and-rebuild loop shape): previously rc=134 (SIGABRT), now correct output, `MallocScribble` clean, `leaks --atExit` exact 0 on all.
- Local two-field partial-loop shape: previously 3 leaks / 176 B, now 0 leaks with the sibling field readable after the loop.
- Edge probes: early `break` + post-loop reads of both fields (works, 0 leaks), double iteration of the same field (handle stays live), rvalue-rooted projection control (cursor still owns and frees, 0 leaks), whole-root move mid-loop (rejected at compile).
- New oracle `hew-cli/tests/param_record_field_loop_drop_leak_oracle.rs` (frame-slope + exact-leaks + poisoned-allocator, 6 tests): passed 3 consecutive runs.
- `cargo test -p hew-mir -p hew-codegen-rs`: 21 suites, 2551 passed, 0 failed.
- `make test-hew-ratchet`: PASSED, 0 failures.
- `make ci-preflight` (compiler-pipeline profile): fmt, clippy `-D warnings`, nextest across the six pipeline crates, vertical slice, pkg-import, fuzz oracle, checked-MIR verify/run, leak-scan all green. (`test-opaque-resource-lifecycle-matrix` needed the pinned ast-grep bootstrap in the fresh worktree; green after `make structural-lint-bootstrap-install`.)

## Out of scope

- `TupleIndex`-rooted projections (`for v in pair.0`) keep today's sole-owner cursor disposition; the tuple composite prover has no borrow-ingress exemption yet.
- Rvalue-rooted projections (`for v in make().claims`) keep their sole-owner cursor by design.
- A process-level panic-mid-loop leak probe (an aborting process cannot host the `leaks(1)` atExit probe); the panic/cancel edges are pinned by the elaborated drop plans.