### PR TITLE
fix: give imported declarations their registered identities across the import surfaces

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -5254,6 +5254,108 @@ fn run_file_imported_actor_spawns_and_calls() {
     assert_eq!(String::from_utf8_lossy(&output.stdout), "bumped: 1\n");
 }
 
+/// A selectively-imported pub const must bind bare at root exactly like a
+/// selectively-imported pub fn from the same module. The HIR pre-pass
+/// registers imported consts only under the qualified `{module}.{CONST}` key;
+/// the importer-visible binding aliases to the same entry. Before the alias,
+/// `import m::{MAX_RETRIES};` + bare `MAX_RETRIES` failed with
+/// `E_HIR: identifier has no binding in resolved HIR` while the sibling fn
+/// import and the dotted spelling both worked.
+#[test]
+fn run_selectively_imported_const_binds_bare_like_fn() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    std::fs::create_dir_all(dir.path().join("src/reasons")).unwrap();
+    std::fs::write(
+        dir.path().join("src/reasons/reasons.hew"),
+        "pub const MAX_RETRIES: i64 = 5;\n\
+         pub fn retries_label() -> string {\n\
+         \x20   \"retries\"\n\
+         }\n",
+    )
+    .unwrap();
+    let main = dir.path().join("main.hew");
+    std::fs::write(
+        &main,
+        "import src::reasons::reasons::{MAX_RETRIES, retries_label};\n\
+         fn main() {\n\
+         \x20   println(retries_label());\n\
+         \x20   println(f\"max: {MAX_RETRIES}\");\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = run_bounded_hew_run(&main, dir.path());
+    assert!(
+        output.status.success(),
+        "selectively-imported const and fn should both bind bare; \
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "retries\nmax: 5\n");
+}
+
+/// A record reaching root through a string-path import (`import "file.hew";`)
+/// is spelled bare at the surface but keyed by its defining file's module
+/// identity in the MIR layout registries. The bare parameter annotation was
+/// the failing site: construction and inferred locals resolved, while
+/// `fn f(w: WorkflowState)` froze a bare binding type that missed the
+/// qualified field-order/value-class entries (doubled
+/// `E_NOT_YET_IMPLEMENTED … field access on unregistered record type` +
+/// `E_MIR: unknown type`). Root annotations now project through the
+/// flat-file bare→qualified alias table, so field access through an
+/// annotated parameter, construction, and a defining-module factory all
+/// agree on one identity.
+#[test]
+fn run_string_path_imported_record_annotated_param_field_access() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    std::fs::create_dir_all(dir.path().join("src/workflow")).unwrap();
+    std::fs::write(
+        dir.path().join("src/workflow/machine.hew"),
+        "pub type WorkflowState {\n\
+         \x20   name: string,\n\
+         \x20   count: i64,\n\
+         }\n\
+         pub fn make_state(name: string, count: i64) -> WorkflowState {\n\
+         \x20   WorkflowState { name: name, count: count }\n\
+         }\n",
+    )
+    .unwrap();
+    let main = dir.path().join("main.hew");
+    std::fs::write(
+        &main,
+        "import \"src/workflow/machine.hew\";\n\
+         fn read_name(w: WorkflowState) -> string {\n\
+         \x20   w.name\n\
+         }\n\
+         fn main() {\n\
+         \x20   let annotated = WorkflowState { name: \"annotated\", count: 3 };\n\
+         \x20   println(read_name(annotated));\n\
+         \x20   let made = make_state(\"made\", 7);\n\
+         \x20   println(made.name);\n\
+         \x20   println(f\"count: {made.count}\");\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = run_bounded_hew_run(&main, dir.path());
+    assert!(
+        output.status.success(),
+        "string-path-imported record through an annotated parameter should run; \
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "annotated\nmade\ncount: 7\n"
+    );
+}
+
 /// Revision-2 regression: a FILE-IMPORTED actor whose receive body exercises
 /// checker-owned `SpanKey`-keyed facts that are consumed during HIR body
 /// lowering — a closure literal (`closure_capture_facts` / `closure_escape_facts`)

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -2428,12 +2428,63 @@ pub fn lower_program_with_mono_cap(
             };
             decl.is_opaque.then(|| decl.name.clone())
         }));
-    ctx.root_visible_source_type_short_names
-        .extend(program.items.iter().filter_map(|(item, _)| match item {
-            Item::TypeDecl(decl) => Some(decl.name.clone()),
-            Item::Record(decl) => Some(decl.name.clone()),
-            _ => None,
-        }));
+    // Root-authored declarations only: items spliced into `program.items` by
+    // `flatten_file_import_items` keep their defining file's module identity
+    // (`file_import_module_idx`), so they must not claim the root bare
+    // namespace here. Their layouts key by `qualified_name()`; leaving the
+    // spliced short name in this set made a root annotation resolve bare and
+    // miss the qualified MIR field-order/value-class entries. The
+    // bare-spelling route for these declarations is
+    // `file_import_root_type_aliases` below.
+    ctx.root_visible_source_type_short_names.extend(
+        program
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(item_idx, _)| !file_import_module_idx.contains_key(item_idx))
+            .filter_map(|(_, (item, _))| match item {
+                Item::TypeDecl(decl) => Some(decl.name.clone()),
+                Item::Record(decl) => Some(decl.name.clone()),
+                _ => None,
+            }),
+    );
+    // Flat-file imports share the root bare namespace (the checker enforces
+    // uniqueness there), but their declaration identity is the defining
+    // module's qualified name. Publish the bare→qualified projection so an
+    // annotation written at root (`fn f(w: WorkflowState)`) resolves to the
+    // same identity the layout registries key by.
+    for (item_idx, (item, _)) in program.items.iter().enumerate() {
+        let Some(module_idx) = file_import_module_idx.get(&item_idx) else {
+            continue;
+        };
+        let Some(module_full_path) = span_indices.module_name(*module_idx) else {
+            continue;
+        };
+        match item {
+            Item::TypeDecl(decl) => {
+                ctx.file_import_root_type_aliases.insert(
+                    decl.name.clone(),
+                    format!("{module_full_path}.{}", decl.name),
+                );
+            }
+            Item::Record(decl) => {
+                ctx.file_import_root_type_aliases.insert(
+                    decl.name.clone(),
+                    format!("{module_full_path}.{}", decl.name),
+                );
+            }
+            Item::Machine(decl) => {
+                ctx.file_import_root_type_aliases.insert(
+                    decl.name.clone(),
+                    format!("{module_full_path}.{}", decl.name),
+                );
+                let event = machine_event_surface_type(&decl.name);
+                ctx.file_import_root_type_aliases
+                    .insert(event.clone(), format!("{module_full_path}.{event}"));
+            }
+            _ => {}
+        }
+    }
     if let Some(module_graph) = &program.module_graph {
         for module_id in &module_graph.topo_order {
             if *module_id == module_graph.root {
@@ -2894,6 +2945,56 @@ pub fn lower_program_with_mono_cap(
         program,
         &type_check_output.root_value_bindings,
     ));
+
+    // Selective/glob imports bind a pub const's bare (or aliased) name at
+    // root, but the pre-pass above registers imported consts only under the
+    // qualified `{module}.{CONST}` key. Alias the importer-visible binding to
+    // the same entry so a bare `MAX_RETRIES` resolves to the identical
+    // `ItemId`/descriptor a dotted `reasons.MAX_RETRIES` reaches. Root-owned
+    // consts registered by the root pre-pass keep precedence (`or_insert`),
+    // mirroring `root_imported_fn_rewrites` for functions.
+    for (item, _) in &program.items {
+        let Item::Import(decl) = item else {
+            continue;
+        };
+        if decl.path.is_empty() {
+            continue;
+        }
+        let Some(spec) = &decl.spec else {
+            continue;
+        };
+        let Some(resolved_items) = &decl.resolved_items else {
+            continue;
+        };
+        let module_full_path = decl.path.join(".");
+        for (resolved_item, _) in resolved_items {
+            let Item::Const(const_decl) = resolved_item else {
+                continue;
+            };
+            if !const_decl.visibility.is_pub() {
+                continue;
+            }
+            let binding = match spec {
+                ImportSpec::Glob => Some(const_decl.name.clone()),
+                ImportSpec::Names(names) => names
+                    .iter()
+                    .find(|imported| imported.name == const_decl.name)
+                    .map(|imported| {
+                        imported
+                            .alias
+                            .clone()
+                            .unwrap_or_else(|| const_decl.name.clone())
+                    }),
+            };
+            let Some(binding) = binding else {
+                continue;
+            };
+            let qualified = format!("{module_full_path}.{}", const_decl.name);
+            if let Some(entry) = ctx.const_registry.get(&qualified).cloned() {
+                ctx.const_registry.entry(binding).or_insert(entry);
+            }
+        }
+    }
 
     // Pre-pass: collect record/type-decl shapes so `Expr::StructInit`
     // lowering in the source-order pass can answer "is this a generic
@@ -7210,6 +7311,13 @@ struct LowerCtx {
     /// considered before the compiler-only `Task`, `Unit`, and
     /// `CancellationToken` fallbacks, including for generic source types.
     root_visible_source_type_short_names: HashSet<String>,
+    /// Bare→qualified identity projection for declarations reaching root
+    /// through a flat file import (`import "x.hew";`). The spliced items share
+    /// the root bare namespace at the source surface, but their declaration
+    /// identity — and every layout registry key derived from it — is the
+    /// defining file's `{module}.{name}`. Root annotations resolve through
+    /// this table so binding types and layout keys agree.
+    file_import_root_type_aliases: HashMap<String, String>,
     /// Exact `{module_owner}.{type}` identities declared by non-root modules.
     /// This lets the three compiler-special spellings retain their source
     /// identity inside a declaring module and through named imports without
@@ -7802,6 +7910,7 @@ impl LowerCtx {
             non_opaque_type_short_names: HashSet::new(),
             root_opaque_type_short_names: HashSet::new(),
             root_visible_source_type_short_names: HashSet::new(),
+            file_import_root_type_aliases: HashMap::new(),
             source_type_identities: HashSet::new(),
             canonical_std_source_type_identities: HashSet::new(),
             checker_type_identities: tc_output.type_defs.keys().cloned().collect(),
@@ -22306,6 +22415,17 @@ impl LowerCtx {
             }
         }
 
+        // A flat file import's declaration is spelled bare at root but its
+        // identity is the defining file's `{module}.{name}` — the key every
+        // layout registry uses. Project the bare annotation to that identity
+        // before the global record-registry fallback can freeze the bare
+        // spelling into a binding type MIR cannot look up.
+        if !name.contains('.') && self.current_module_name.is_none() {
+            if let Some(canonical) = self.file_import_root_type_aliases.get(name).cloned() {
+                return self.resolve_named_type_ref(&canonical, args);
+            }
+        }
+
         // A global record registry is layout metadata, not lexical authority.
         // In particular, source-owned lifecycle payloads must reach this point
         // through the checker-published import binding above; their bare
@@ -22402,6 +22522,15 @@ impl LowerCtx {
             .get(&(self.current_module_name.clone(), name.to_string()))
         {
             return Some(self.resolve_named_type_ref(canonical, args));
+        }
+
+        // A flat-file-imported declaration sharing a compiler-special leaf
+        // (`Unit`, `Task`, `CancellationToken`) keeps source authority under
+        // its qualified identity, same as the root-authored branch below.
+        if self.current_module_name.is_none() {
+            if let Some(canonical) = self.file_import_root_type_aliases.get(name).cloned() {
+                return Some(self.resolve_named_type_ref(&canonical, args));
+            }
         }
 
         if self.current_module_name.is_none()

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -4736,9 +4736,12 @@ impl Builder {
                         let _ = self.lower_value(object);
                         self.diagnostics.push(MirDiagnostic {
                             kind: MirDiagnosticKind::NotYetImplemented {
+                                // `construct` carries only the construct; the
+                                // CLI diagnostic frame wraps it in the
+                                // "MIR lowering for … is not implemented yet"
+                                // sentence.
                                 construct: format!(
-                                    "MIR lowering for field access on unregistered record type \
-                                     `{type_name}` is not implemented yet"
+                                    "field access on unregistered record type `{type_name}`"
                                 ),
                                 site: expr.site,
                             },

--- a/hew-parser/src/parser/core.rs
+++ b/hew-parser/src/parser/core.rs
@@ -647,23 +647,47 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Type-declaration keywords admitted as import path segments. Module
+    /// files are named after what they declare (`actor.hew`, `machine.hew`),
+    /// so these words must be spellable in an import path even though they
+    /// are reserved everywhere else. Import path position is unambiguous:
+    /// segments only appear directly after `import` or `::`, where no
+    /// declaration keyword carries its keyword meaning. Qualifier position
+    /// (`machine.Machine` as a type annotation) stays reserved — selective
+    /// import (`import a::machine::{Machine};`) is the supported spelling.
+    pub(crate) fn import_path_segment_keyword(tok: &Token<'_>) -> Option<&'static str> {
+        match tok {
+            Token::Actor => Some("actor"),
+            Token::Machine => Some("machine"),
+            Token::Record => Some("record"),
+            Token::Enum => Some("enum"),
+            Token::Supervisor => Some("supervisor"),
+            Token::Type => Some("type"),
+            Token::Trait => Some("trait"),
+            _ => None,
+        }
+    }
+
     pub(crate) fn is_import_path_segment_token(tok: &Token<'_>) -> bool {
-        matches!(tok, Token::Identifier(_) | Token::Actor)
+        matches!(tok, Token::Identifier(_))
+            || Self::import_path_segment_keyword(tok).is_some()
             || Self::contextual_keyword_name(tok).is_some()
     }
 
     pub(crate) fn expect_import_path_segment(&mut self) -> Option<String> {
         match self.peek() {
-            Some(Token::Actor) => {
-                self.advance();
-                Some("actor".to_string())
+            Some(tok) => {
+                if let Some(name) = Self::import_path_segment_keyword(tok) {
+                    self.advance();
+                    Some(name.to_string())
+                } else if let Some(name) = Self::contextual_keyword_name(tok) {
+                    self.advance();
+                    Some(name.to_string())
+                } else {
+                    self.expect_ident()
+                }
             }
-            Some(tok) if Self::contextual_keyword_name(tok).is_some() => {
-                let name = Self::contextual_keyword_name(tok).expect("checked above");
-                self.advance();
-                Some(name.to_string())
-            }
-            _ => self.expect_ident(),
+            None => self.expect_ident(),
         }
     }
 

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -1835,6 +1835,62 @@ fn parse_import_actor_path_segment() {
 }
 
 #[test]
+fn parse_import_machine_path_segment() {
+    let source = "import src::workflow::machine::{Machine};";
+    let result = parse(source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    if let Item::Import(imp) = &result.program.items[0].0 {
+        assert_eq!(imp.path, vec!["src", "workflow", "machine"]);
+        let Some(ImportSpec::Names(names)) = &imp.spec else {
+            panic!("expected selective import spec");
+        };
+        assert_eq!(names[0].name, "Machine");
+    } else {
+        panic!("expected import");
+    }
+}
+
+#[test]
+fn parse_import_type_decl_keyword_path_segments() {
+    // Every type-declaration keyword is a plausible module file name and
+    // must parse as an import path segment.
+    for kw in [
+        "actor",
+        "machine",
+        "record",
+        "enum",
+        "supervisor",
+        "type",
+        "trait",
+    ] {
+        let source = format!("import src::{kw}::helpers;");
+        let result = parse(&source);
+        assert!(
+            result.errors.is_empty(),
+            "segment `{kw}` should parse, errors: {:?}",
+            result.errors
+        );
+        if let Item::Import(imp) = &result.program.items[0].0 {
+            assert_eq!(imp.path, vec!["src", kw, "helpers"]);
+        } else {
+            panic!("expected import for segment `{kw}`");
+        }
+    }
+}
+
+#[test]
+fn machine_qualifier_in_type_position_rejected() {
+    // The import-path carve-out does not extend to qualifier position:
+    // `machine.Machine` as a type annotation stays reserved.
+    let source = "fn f(m: machine.Machine) {}";
+    let result = parse(source);
+    assert!(
+        !result.errors.is_empty(),
+        "expected parse error for `machine` qualifier in type position"
+    );
+}
+
+#[test]
 fn parse_trait_declaration() {
     let source = "trait Printable { fn print(self); }";
     let result = parse(source);

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -7701,9 +7701,24 @@ impl Checker {
             }
 
             // Static method calls on type names: e.g. Point.from_json(json)
-            // Look up "TypeName.method" in fn_sigs (registered by wire types etc.)
-            let static_key = format!("{name}.{method}");
-            if let Some(sig) = self.fn_sigs.get(&static_key).cloned() {
+            // Look up "TypeName.method" in fn_sigs (registered by wire types
+            // etc.). The surface spelling resolves to its canonical
+            // declaration identity first (A316): the wire codec surface
+            // registers under `{module}.{Name}.{method}` only, so the bare
+            // binding an import published (or an `as`-alias) must consult the
+            // canonical key of ITS owner. The surface key remains the lookup
+            // for root-canonical (bare) declarations and any non-wire dotted
+            // signature registered under its own spelling.
+            let canonical_static_owner = self
+                .canonical_nominal_name(name)
+                .unwrap_or_else(|| name.clone());
+            let static_key = format!("{canonical_static_owner}.{method}");
+            let static_sig = self.fn_sigs.get(&static_key).cloned().or_else(|| {
+                (canonical_static_owner != *name)
+                    .then(|| self.fn_sigs.get(&format!("{name}.{method}")).cloned())
+                    .flatten()
+            });
+            if let Some(sig) = static_sig {
                 self.check_arity(args, sig.params.len(), &format!("`{static_key}`"), span);
                 for (i, arg) in args.iter().enumerate() {
                     if let Some(param_ty) = sig.params.get(i) {
@@ -7741,7 +7756,9 @@ impl Checker {
                 // here without this arm, so the call would lower to
                 // `MethodCallNoRewrite`. Record a dedicated codec rewrite so
                 // HIR/codegen drive the matching thunk with the correct ABI.
-                if self.wire_struct_types.contains(name) || self.wire_enum_types.contains(name) {
+                if self.wire_struct_types.contains(&canonical_static_owner)
+                    || self.wire_enum_types.contains(&canonical_static_owner)
+                {
                     let text_dir = match method {
                         "decode" => Some(WireCodecDirection::Decode),
                         "from_json" => Some(WireCodecDirection::FromJson),
@@ -9590,26 +9607,35 @@ impl Checker {
                         // fall through to `MethodCallNoRewrite`. Record a dedicated
                         // codec rewrite so HIR/codegen drive the matching thunk
                         // with the correct ABI.
-                        let wire_serialize_dir = if self.wire_struct_types.contains(name)
-                            || self.wire_enum_types.contains(name)
-                        {
-                            match method {
-                                "encode" => Some(WireCodecDirection::Encode),
-                                "to_json" => Some(WireCodecDirection::ToJson),
-                                "to_yaml" => Some(WireCodecDirection::ToYaml),
-                                _ => None,
-                            }
-                        } else {
-                            None
-                        };
+                        let wire_serialize_dir =
+                            if self.wire_struct_types.contains(&canonical_receiver_name)
+                                || self.wire_enum_types.contains(&canonical_receiver_name)
+                            {
+                                match method {
+                                    "encode" => Some(WireCodecDirection::Encode),
+                                    "to_json" => Some(WireCodecDirection::ToJson),
+                                    "to_yaml" => Some(WireCodecDirection::ToYaml),
+                                    _ => None,
+                                }
+                            } else {
+                                None
+                            };
                         if let Some(direction) = wire_serialize_dir {
                             // `value_ty` is the receiver wire type (the value being
                             // serialized) regardless of the textual return type,
                             // so codegen keys the thunk by the same type the binary
-                            // path uses.
-                            if let Ok(value_ty) =
-                                ResolvedTy::from_ty(&self.subst.resolve(&resolved))
-                            {
+                            // path uses. Carry the CANONICAL nominal: the wire
+                            // layout table is keyed by the declaration identity
+                            // only, and codegen's tag probe falls back to
+                            // positional keys on a miss — a bare spelling here
+                            // would silently change the encoded schema.
+                            let mut value_source = self.subst.resolve(&resolved);
+                            if let Ty::Named { name: nominal, .. } = &mut value_source {
+                                if *nominal != canonical_receiver_name {
+                                    nominal.clone_from(&canonical_receiver_name);
+                                }
+                            }
+                            if let Ok(value_ty) = ResolvedTy::from_ty(&value_source) {
                                 self.record_method_call_rewrite(
                                     span,
                                     MethodCallRewrite::WireCodec {

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -3701,9 +3701,19 @@ impl Checker {
         wire: &WireMetadata,
         variant_order: &[String],
     ) {
+        // The declaration identity, following `register_record_decl`'s
+        // `declaration_name` pattern: inside a module the wire surface is
+        // keyed by `{module}.{Name}` — the identity every imported receiver
+        // and the codegen wire-layout lookup carry — with the bare key
+        // retained for the defining module's own body surface.
+        let qualified_identity = self
+            .current_module_identity()
+            .map(|module| format!("{module}.{type_name}"));
         let self_ty = Ty::Named {
             builtin: None,
-            name: type_name.to_string(),
+            name: qualified_identity
+                .clone()
+                .unwrap_or_else(|| type_name.to_string()),
             args: vec![],
         };
         let bytes_ty = Ty::Bytes;
@@ -3740,9 +3750,19 @@ impl Checker {
         // tag-keyed map, enums as the "map-of-one" shape.
         if is_wire_struct {
             self.wire_struct_types.insert(type_name.to_string());
+            if let Some(qualified) = &qualified_identity {
+                self.wire_struct_types.insert(qualified.clone());
+            }
         }
         if is_serial_wire_enum {
             self.wire_enum_types.insert(type_name.to_string());
+            if let Some(qualified) = &qualified_identity {
+                self.wire_enum_types.insert(qualified.clone());
+            }
+        }
+        if let Some(qualified) = &qualified_identity {
+            self.wire_layouts
+                .insert(qualified.clone(), layout_entry.clone());
         }
         self.wire_layouts
             .insert(type_name.to_string(), layout_entry);
@@ -3761,16 +3781,24 @@ impl Checker {
             vec![]
         };
 
-        if let Some(type_def) = self.type_defs.get_mut(type_name) {
-            for (method_name, params, return_type) in instance_methods {
-                type_def.methods.insert(
-                    method_name.to_string(),
-                    FnSig {
-                        params,
-                        return_type,
-                        ..FnSig::default()
-                    },
-                );
+        // Instance methods land on the bare declaration def AND on the
+        // qualified alias def when one already exists. Pre-registration mints
+        // the qualified skeleton before this runs, and
+        // `register_full_type_alias` refuses to overwrite an existing
+        // canonical entry — so without the direct mirror an imported
+        // receiver (`e.to_json()` on `src.env.Env`) found no method.
+        for def_key in std::iter::once(type_name).chain(qualified_identity.as_deref()) {
+            if let Some(type_def) = self.type_defs.get_mut(def_key) {
+                for (method_name, params, return_type) in &instance_methods {
+                    type_def.methods.insert(
+                        (*method_name).to_string(),
+                        FnSig {
+                            params: params.clone(),
+                            return_type: return_type.clone(),
+                            ..FnSig::default()
+                        },
+                    );
+                }
             }
         }
 
@@ -3791,15 +3819,21 @@ impl Checker {
         };
 
         for (method_name, params, return_type) in static_methods {
-            let qualified_name = format!("{type_name}.{method_name}");
-            self.fn_sigs.insert(
-                qualified_name,
-                FnSig {
-                    params,
-                    return_type,
-                    ..FnSig::default()
-                },
-            );
+            let sig = FnSig {
+                params,
+                return_type,
+                ..FnSig::default()
+            };
+            // Static codec entry points resolve through the receiver's
+            // resolved nominal: `Env.from_json` inside the defining module,
+            // `src.env.Env.from_json` wherever the qualified identity is the
+            // spelling the checker resolved. Register both keys.
+            if let Some(qualified) = &qualified_identity {
+                self.fn_sigs
+                    .insert(format!("{qualified}.{method_name}"), sig.clone());
+            }
+            self.fn_sigs
+                .insert(format!("{type_name}.{method_name}"), sig);
         }
     }
 

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -3701,19 +3701,21 @@ impl Checker {
         wire: &WireMetadata,
         variant_order: &[String],
     ) {
-        // The declaration identity, following `register_record_decl`'s
-        // `declaration_name` pattern: inside a module the wire surface is
-        // keyed by `{module}.{Name}` — the identity every imported receiver
-        // and the codegen wire-layout lookup carry — with the bare key
-        // retained for the defining module's own body surface.
-        let qualified_identity = self
-            .current_module_identity()
-            .map(|module| format!("{module}.{type_name}"));
+        // ONE canonical wire identity (A316). A module declaration's wire
+        // surface is keyed by `{module}.{Name}` — the identity every resolved
+        // receiver and the codegen wire-layout lookup carry; a root
+        // declaration's bare name IS its canonical identity. Surface
+        // spellings resolve TO this key at lookup time
+        // (`canonical_nominal_name`); no bare mirror entries exist, so two
+        // same-leaf wire types from different modules never collide on a
+        // shared last-write-wins key.
+        let canonical_identity = self.current_module_identity().map_or_else(
+            || type_name.to_string(),
+            |module| format!("{module}.{type_name}"),
+        );
         let self_ty = Ty::Named {
             builtin: None,
-            name: qualified_identity
-                .clone()
-                .unwrap_or_else(|| type_name.to_string()),
+            name: canonical_identity.clone(),
             args: vec![],
         };
         let bytes_ty = Ty::Bytes;
@@ -3749,23 +3751,13 @@ impl Checker {
         // re-deriving wire-ness. Both ride the CBOR body codec: structs as a
         // tag-keyed map, enums as the "map-of-one" shape.
         if is_wire_struct {
-            self.wire_struct_types.insert(type_name.to_string());
-            if let Some(qualified) = &qualified_identity {
-                self.wire_struct_types.insert(qualified.clone());
-            }
+            self.wire_struct_types.insert(canonical_identity.clone());
         }
         if is_serial_wire_enum {
-            self.wire_enum_types.insert(type_name.to_string());
-            if let Some(qualified) = &qualified_identity {
-                self.wire_enum_types.insert(qualified.clone());
-            }
-        }
-        if let Some(qualified) = &qualified_identity {
-            self.wire_layouts
-                .insert(qualified.clone(), layout_entry.clone());
+            self.wire_enum_types.insert(canonical_identity.clone());
         }
         self.wire_layouts
-            .insert(type_name.to_string(), layout_entry);
+            .insert(canonical_identity.clone(), layout_entry);
 
         // Wire structs and wire enums carry the same method surface: the binary
         // CBOR codec (`encode`/`decode`) plus the text-format helpers. The body
@@ -3781,25 +3773,28 @@ impl Checker {
             vec![]
         };
 
-        // Instance methods land on the bare declaration def AND on the
-        // qualified alias def when one already exists. Pre-registration mints
-        // the qualified skeleton before this runs, and
-        // `register_full_type_alias` refuses to overwrite an existing
-        // canonical entry — so without the direct mirror an imported
-        // receiver (`e.to_json()` on `src.env.Env`) found no method.
-        for def_key in std::iter::once(type_name).chain(qualified_identity.as_deref()) {
-            if let Some(type_def) = self.type_defs.get_mut(def_key) {
-                for (method_name, params, return_type) in &instance_methods {
-                    type_def.methods.insert(
-                        (*method_name).to_string(),
-                        FnSig {
-                            params: params.clone(),
-                            return_type: return_type.clone(),
-                            ..FnSig::default()
-                        },
-                    );
-                }
+        // Instance methods land on the DECLARATION record (the bare
+        // `type_defs` entry this module's registration just wrote), then the
+        // canonical qualified alias is refreshed FROM it — the
+        // `commit_reresolved_type_def` pattern. Pre-registration mints the
+        // qualified skeleton before this runs and `register_full_type_alias`
+        // refuses to overwrite it, so the refresh (owning-module overwrite)
+        // is what carries the codec methods onto the canonical def; there is
+        // no independent second mutation that could diverge from it.
+        if let Some(type_def) = self.type_defs.get_mut(type_name) {
+            for (method_name, params, return_type) in &instance_methods {
+                type_def.methods.insert(
+                    (*method_name).to_string(),
+                    FnSig {
+                        params: params.clone(),
+                        return_type: return_type.clone(),
+                        ..FnSig::default()
+                    },
+                );
             }
+        }
+        if let Some(module_owner) = self.current_module_identity().map(str::to_string) {
+            self.register_qualified_type_alias(&module_owner, type_name);
         }
 
         // `decode` returns bare `Self` (binary CBOR is trap-on-failure); the
@@ -3819,21 +3814,18 @@ impl Checker {
         };
 
         for (method_name, params, return_type) in static_methods {
-            let sig = FnSig {
-                params,
-                return_type,
-                ..FnSig::default()
-            };
-            // Static codec entry points resolve through the receiver's
-            // resolved nominal: `Env.from_json` inside the defining module,
-            // `src.env.Env.from_json` wherever the qualified identity is the
-            // spelling the checker resolved. Register both keys.
-            if let Some(qualified) = &qualified_identity {
-                self.fn_sigs
-                    .insert(format!("{qualified}.{method_name}"), sig.clone());
-            }
-            self.fn_sigs
-                .insert(format!("{type_name}.{method_name}"), sig);
+            // Static codec entry points register under the canonical identity
+            // ONLY. The call-site arm canonicalizes the receiver's surface
+            // spelling (`Env.from_json` inside the defining module, an
+            // importer's binding, an `as`-alias) to this key before lookup.
+            self.fn_sigs.insert(
+                format!("{canonical_identity}.{method_name}"),
+                FnSig {
+                    params,
+                    return_type,
+                    ..FnSig::default()
+                },
+            );
         }
     }
 

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -11704,6 +11704,23 @@ impl Checker {
                         let event_identity = format!("{module_full_path}.{event_name}");
                         self.record_published_bare_type(&machine_binding, &machine_identity);
                         self.record_published_bare_type(&event_binding, &event_identity);
+                        // HIR resolves annotations itself, and a machine's
+                        // value-class/layout facts key by the qualified
+                        // identity. Publish the binding→identity fact for
+                        // every named/glob import (not only renames): without
+                        // it, `fn f(m: Machine)` on a selectively-imported
+                        // machine froze a bare binding type MIR could not
+                        // classify (`owned call-carrier parameter` NYI +
+                        // `E_MIR: unknown type`), while the checker's own
+                        // expression facts already carried the dotted owner.
+                        self.import_type_name_aliases.insert(
+                            (self.current_module.clone(), machine_binding.clone()),
+                            machine_identity.clone(),
+                        );
+                        self.import_type_name_aliases.insert(
+                            (self.current_module.clone(), event_binding.clone()),
+                            event_identity.clone(),
+                        );
                         self.unqualified_to_module.insert(
                             (self.current_module.clone(), machine_binding),
                             module_full_path.to_string(),

--- a/tests/hew/imported_wire_codec_test.hew
+++ b/tests/hew/imported_wire_codec_test.hew
@@ -1,0 +1,60 @@
+//! Cross-module `#[wire]` codec regression coverage.
+//!
+//! A `#[wire]` type in a module carries its codec surface on the
+//! module-qualified identity: instance methods (`to_json`, `to_yaml`,
+//! `encode`), static entry points (`from_json`, `from_yaml`, `decode`), the
+//! wire-struct/enum sets, and the wire layout table. Registration keyed only
+//! the bare declaration name, so an imported receiver failed with
+//! "no method `to_json`" and the checker fix alone would have moved the
+//! failure to the codegen CBOR layout lookup — both surfaces are pinned here.
+
+import tests::hew::imported_wire_support::wire_defs::{Env, Signal, env_to_json};
+
+import std::testing;
+
+#[test]
+fn imported_wire_struct_json_round_trip() {
+    let e = Env { name: "svc", port: 8080 };
+    let j = e.to_json();
+    testing.assert_eq_str(j, "{\"name\":\"svc\",\"port\":8080}");
+    match Env.from_json(j) {
+        Ok(back) => {
+            testing.assert_eq_str(back.name, "svc");
+            testing.assert_eq(back.port, 8080);
+        },
+        Err(msg) => panic(f"from_json failed: {msg}"),
+    }
+}
+
+#[test]
+fn imported_wire_struct_binary_and_yaml_round_trips() {
+    let e = Env { name: "bin", port: 9 };
+    let back = Env.decode(e.encode());
+    testing.assert_eq_str(back.name, "bin");
+    testing.assert_eq(back.port, 9);
+    match Env.from_yaml(back.to_yaml()) {
+        Ok(again) => testing.assert_eq(again.port, 9),
+        Err(msg) => panic(f"from_yaml failed: {msg}"),
+    }
+}
+
+#[test]
+fn defining_module_helper_serializes_when_module_is_imported() {
+    let e = Env { name: "helper", port: 1 };
+    testing.assert_eq_str(env_to_json(e), "{\"name\":\"helper\",\"port\":1}");
+}
+
+#[test]
+fn imported_wire_enum_json_round_trip() {
+    let s = Signal::Busy(4);
+    match Signal.from_json(s.to_json()) {
+        Ok(back) => {
+            let tag = match back {
+                Signal::Busy(n) => n,
+                Signal::Ready => -1,
+            };
+            testing.assert_eq(tag, 4);
+        },
+        Err(msg) => panic(f"enum from_json failed: {msg}"),
+    }
+}

--- a/tests/hew/imported_wire_identity_collision_test.hew
+++ b/tests/hew/imported_wire_identity_collision_test.hew
@@ -1,0 +1,53 @@
+//! Two same-leaf `#[wire]` types from different modules coexist: one
+//! canonical wire keyspace, keyed by the module-qualified identity, with each
+//! surface spelling (a published bare binding, an `as`-alias) resolving to
+//! ITS import's canonical entry. `env_a.Env` and `env_b.Env` carry disjoint
+//! schemas — a shared bare layout/signature key would reject one of them or
+//! silently serialize it through the other's schema.
+
+import tests::hew::imported_wire_support::env_a::{Env, label_a};
+import tests::hew::imported_wire_support::env_b::{Env as BEnv, label_b};
+
+import std::testing;
+
+#[test]
+fn same_leaf_wire_types_round_trip_independently() {
+    let a = Env { name: "svc", port: 8080 };
+    let b = BEnv { label: "edge", port: 9 };
+    testing.assert_eq_str(a.to_json(), "{\"name\":\"svc\",\"port\":8080}");
+    testing.assert_eq_str(b.to_json(), "{\"label\":\"edge\",\"port\":9}");
+    match Env.from_json(a.to_json()) {
+        Ok(back) => {
+            testing.assert_eq_str(back.name, "svc");
+            testing.assert_eq(back.port, 8080);
+        },
+        Err(msg) => panic(f"env_a from_json failed: {msg}"),
+    }
+    match BEnv.from_json(b.to_json()) {
+        Ok(back) => {
+            testing.assert_eq_str(back.label, "edge");
+            testing.assert_eq(back.port, 9);
+        },
+        Err(msg) => panic(f"env_b from_json failed: {msg}"),
+    }
+}
+
+#[test]
+fn same_leaf_wire_types_binary_round_trip_independently() {
+    let a = Env { name: "bin", port: 1 };
+    let b = BEnv { label: "bin", port: 2 };
+    let a_back = Env.decode(a.encode());
+    testing.assert_eq_str(a_back.name, "bin");
+    testing.assert_eq(a_back.port, 1);
+    let b_back = BEnv.decode(b.encode());
+    testing.assert_eq_str(b_back.label, "bin");
+    testing.assert_eq(b_back.port, 2);
+}
+
+#[test]
+fn cross_use_resolves_per_import() {
+    let a = Env { name: "x", port: 3 };
+    let b = BEnv { label: "y", port: 4 };
+    testing.assert_eq_str(label_a(a), "a:x:3");
+    testing.assert_eq_str(label_b(b), "b:y:4");
+}

--- a/tests/hew/imported_wire_support/env_a.hew
+++ b/tests/hew/imported_wire_support/env_a.hew
@@ -1,0 +1,14 @@
+//! Same-leaf wire collision fixture, module A. `Env` here and `Env` in
+//! `env_b` are DISTINCT wire types with divergent schemas; each must keep its
+//! own canonical layout entry (one keyspace, module-qualified — no shared
+//! bare key to last-write-wins over).
+
+#[wire]
+pub type Env {
+    name: string @1,
+    port: i64 @2,
+}
+
+pub fn label_a(e: Env) -> string {
+    f"a:{e.name}:{e.port}"
+}

--- a/tests/hew/imported_wire_support/env_b.hew
+++ b/tests/hew/imported_wire_support/env_b.hew
@@ -1,0 +1,14 @@
+//! Same-leaf wire collision fixture, module B. Schema deliberately disjoint
+//! from `env_a.Env` — different field set AND different wire tags — so any
+//! keyspace collapse between the two is observable in both the text and
+//! binary codecs.
+
+#[wire]
+pub type Env {
+    label: string @7,
+    port: i64 @9,
+}
+
+pub fn label_b(e: Env) -> string {
+    f"b:{e.label}:{e.port}"
+}

--- a/tests/hew/imported_wire_support/wire_defs.hew
+++ b/tests/hew/imported_wire_support/wire_defs.hew
@@ -1,0 +1,19 @@
+//! Support module for the cross-module `#[wire]` codec tests. The wire
+//! surface must be reachable through the module-qualified type identity,
+//! not only the bare declaration name this file spells.
+
+#[wire]
+pub type Env {
+    name: string @1,
+    port: i64 @2,
+}
+
+#[wire]
+pub enum Signal {
+    Ready;
+    Busy(i64);
+}
+
+pub fn env_to_json(e: Env) -> string {
+    e.to_json()
+}

--- a/tests/hew/selective_import_machine_annotation_test.hew
+++ b/tests/hew/selective_import_machine_annotation_test.hew
@@ -1,0 +1,38 @@
+//! Selectively-imported machine identity regression coverage.
+//!
+//! `import mod::{Machine}` publishes a bare binding whose declaration
+//! identity is the defining module's qualified name. The bare annotation on
+//! a free-function parameter was the failing site: the checker's expression
+//! facts carried the dotted owner while the HIR binding froze the bare
+//! spelling, so MIR failed with the owned-call-carrier NYI and an unknown
+//! type at the boundary. Inferred locals and module-qualified annotations
+//! were the working controls.
+
+import tests::hew::imported_machine_support::machine_defs::{PayloadLifecycle, make, bounce};
+
+import std::testing;
+
+fn carry(value: PayloadLifecycle) -> PayloadLifecycle {
+    value
+}
+
+fn label_of(value: PayloadLifecycle) -> string {
+    match value {
+        PayloadLifecycle::Loaded { label } => label,
+        PayloadLifecycle::Empty => "empty",
+    }
+}
+
+#[test]
+fn selectively_imported_machine_crosses_bare_annotated_parameter() {
+    let made = make("bare-annotation".to_upper());
+    let carried = carry(made);
+    testing.assert_eq_str(label_of(carried), "BARE-ANNOTATION");
+}
+
+#[test]
+fn selectively_imported_machine_transitions_through_bare_spelling() {
+    var value = PayloadLifecycle::Empty;
+    value = bounce(value);
+    testing.assert_eq_str(label_of(value), "empty");
+}


### PR DESCRIPTION
## Summary

Five imported-identity registration gaps, all in the territory #2930 opened (checker/HIR/MIR keying declarations by their module-qualified identity):

- **Cross-module `#[wire]` codec**: a `#[wire]` type in a module now serializes everywhere it is visible. The wire surface (instance `to_json`/`to_yaml`/`encode`, static `from_json`/`from_yaml`/`decode`, the wire-struct/enum sets, and the wire layout table) registers under the module-qualified identity, so imported receivers, the defining module's own helpers called from an importer, and the binary CBOR path all resolve. Previously: `no method 'to_json'` at the checker, with the codegen layout lookup as the next failure behind it.
- **Selectively-imported machine bare annotation**: `import mod::{Machine}; fn f(m: Machine)` compiles and runs. Named/glob machine imports publish the machine and its Event companion as type-name aliases, so the bare annotation projects to the qualified identity the layout and value-class registries key by. Inferred locals and module-qualified annotations were already correct post-#2930.
- **String-path import identity**: a record imported via `import "file.hew"` works through an annotated parameter — the historically failing site — not just construction and inferred locals. Spliced flat-file items no longer claim the root bare namespace; root annotations project through a bare→qualified alias table matching the MIR layout keys. The doubled `MIR lowering for MIR lowering for … is not implemented yet is not implemented yet` framing in that diagnostic is also fixed (the construct no longer embeds the frame sentence).
- **Selectively-imported `pub const`**: `import mod::{MAX_RETRIES}` binds bare like a `pub fn` from the same module, aliasing the importer-visible binding to the qualified const-registry entry. Previously `E_HIR: identifier has no binding in resolved HIR`.
- **`machine` as an import path segment**: `import src::workflow::machine::{Machine};` parses. The `actor` carve-out generalizes to one segment-keyword table covering the type-declaration keywords (`machine`, `record`, `enum`, `supervisor`, `type`, `trait`). Qualifier position stays reserved: `machine.Machine` as a type annotation is still rejected.

## Verification

- `cargo test -p hew-parser`: pass, including the new segment-keyword tests and the qualifier-position negative
- `cargo test -p hew-types -p hew-hir -p hew-mir -p hew-codegen-rs`: pass
- `cargo test -p hew-cli --test run_e2e`: new string-path record and selective-const e2e tests pass
- `hew test tests/hew/`: new `imported_wire_codec_test.hew` (JSON/YAML/CBOR round-trips, defining-module helper, wire enum) and `selective_import_machine_annotation_test.hew` pass
- `make test-hew-ratchet`: PASSED (0 expected, 0 actual failures)
- `make lint`: green (clippy `-D warnings`, rustfmt, structural-authority audit, hew-fmt-check)
- Vertical-slice same-module wire fixtures spot-checked (`wire_json_struct_roundtrip`, `wire_cbor_vec_owned_enum`) — exit codes unchanged

## Out of scope

- The unused-import lint still false-positives on a selective import used only in expression position (e.g. a const-only import); that is the expression/pattern-position lint-credit gap, tracked separately.
- Selective import currently bypasses machine visibility (a non-pub machine is importable), and a string-path machine import mints a duplicate machine-mono key — both separable follow-ups in the same family.
- Retiring the checker's bare short-name compatibility keys belongs to the broader qualified-name sweep.