### PR TITLE
fix: close port-review friction smalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,45 @@ jobs:
         if: env.RUN_CODE_PATH != 'true'
         run: echo "No code changes detected; there are no compiled Hew shards to aggregate."
 
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        if: always() && env.RUN_CODE_PATH == 'true'
+
+      - name: Download compiled Hew bundle
+        if: >-
+          always() && env.RUN_CODE_PATH == 'true' &&
+          needs.compiled-hew-linux.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: compiled-hew-linux-${{ github.sha }}
+          path: ${{ runner.temp }}/compiled-hew-download
+
+      - name: Verify compiled Hew bundle
+        if: >-
+          always() && env.RUN_CODE_PATH == 'true' &&
+          needs.compiled-hew-linux.result == 'success'
+        run: >-
+          python3 scripts/compiled-hew-artifact.py unpack
+          --input "${{ runner.temp }}/compiled-hew-download/compiled-hew-linux.tar.gz"
+          --destination "${{ runner.temp }}/compiled-hew-artifact"
+          --expected-revision "$GITHUB_SHA"
+
+      - name: Download every shard report
+        if: always() && env.RUN_CODE_PATH == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: compiled-hew-shard-*-${{ github.sha }}
+          path: ${{ runner.temp }}/compiled-hew-reports
+          merge-multiple: true
+
+      - name: Report compiled Hew shard failures
+        if: always() && env.RUN_CODE_PATH == 'true'
+        run: >-
+          python3 scripts/compiled-hew-shards.py report
+          --reports-dir "${{ runner.temp }}/compiled-hew-reports"
+          --shard-count 4
+
       - name: Require every shard to complete
+        if: always()
         env:
           CHANGE_RESULT: ${{ needs.changes.result }}
           BUILD_RESULT: ${{ needs.compiled-hew-linux.result }}
@@ -565,32 +603,6 @@ jobs:
           test "$CHANGE_RESULT" = success
           test "$BUILD_RESULT" = success
           test "$SHARD_RESULT" = success
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        if: env.RUN_CODE_PATH == 'true'
-
-      - name: Download compiled Hew bundle
-        if: env.RUN_CODE_PATH == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: compiled-hew-linux-${{ github.sha }}
-          path: ${{ runner.temp }}/compiled-hew-download
-
-      - name: Verify compiled Hew bundle
-        if: env.RUN_CODE_PATH == 'true'
-        run: >-
-          python3 scripts/compiled-hew-artifact.py unpack
-          --input "${{ runner.temp }}/compiled-hew-download/compiled-hew-linux.tar.gz"
-          --destination "${{ runner.temp }}/compiled-hew-artifact"
-          --expected-revision "$GITHUB_SHA"
-
-      - name: Download every shard report
-        if: env.RUN_CODE_PATH == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          pattern: compiled-hew-shard-*-${{ github.sha }}
-          path: ${{ runner.temp }}/compiled-hew-reports
-          merge-multiple: true
 
       - name: List the independent full suite inventory
         if: env.RUN_CODE_PATH == 'true'

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -897,6 +897,22 @@ fn hew_lib_candidates(
                 .iter()
                 .map(|profile| target_dir.join(triple).join(profile).join(name)),
         );
+        // A native (non-cross-compiled) build has no `<triple>` segment: Cargo
+        // writes straight to `<target-dir>/<profile>/<archive>`. The
+        // hardcoded `../../target/<profile>` fallbacks below only match a
+        // target dir literally named `target`; a custom `CARGO_TARGET_DIR`
+        // (e.g. an isolated ratchet target) never resolves through them, so
+        // a release-built driver cannot find a debug-only sibling archive.
+        // Push the flat per-profile path — in the same `cargo_profiles`
+        // order used above, so `release-lib` still shadows a stale `release`
+        // or `debug` sibling — right after the triple-qualified candidates.
+        if target_matches_host {
+            candidates.extend(
+                cargo_profiles
+                    .iter()
+                    .map(|profile| target_dir.join(profile).join(name)),
+            );
+        }
     }
 
     candidates.extend([
@@ -995,8 +1011,13 @@ pub(crate) fn find_hew_lib(
         }
     }
 
+    let searched = candidates
+        .iter()
+        .map(|c| c.display().to_string())
+        .collect::<Vec<_>>()
+        .join("\n  ");
     Err(format!(
-        "Error: cannot find {name}. Build with: make stdlib"
+        "Error: cannot find {name}. Build with: make stdlib\nSearched:\n  {searched}"
     ))
 }
 
@@ -2181,17 +2202,18 @@ mod tests {
             };
 
             // Host-fallback block: release-lib before the plain release archive.
+            // The flat `/repo/target/release-lib/{name}` candidate is the
+            // earliest release-lib occurrence (pushed once by the
+            // matching-profile block and again, redundantly, by the D10
+            // flat-per-profile block) — always earlier than any
+            // `.../release/{name}` occurrence.
             assert!(
-                position(format!("../../target/release-lib/{name}"))
+                position(format!("/repo/target/release-lib/{name}"))
                     < position(format!("/repo/target/release/{name}"))
             );
             assert!(
-                position(format!("../../target/release-lib/{name}"))
+                position(format!("/repo/target/release-lib/{name}"))
                     < position(format!("../../target/release/{name}"))
-            );
-            assert!(
-                position(format!("../release-lib/{name}"))
-                    < position(format!("/repo/target/release/{name}"))
             );
 
             // Cross-target block: <triple>/release-lib before <triple>/release.
@@ -2247,6 +2269,50 @@ mod tests {
             .expect("flat host archive");
 
         assert!(cross_debug_index < host_debug_index);
+    }
+
+    #[test]
+    fn hew_lib_candidates_find_a_debug_archive_under_a_custom_target_dir() {
+        // D10: a release-built driver under a `CARGO_TARGET_DIR` that is not
+        // literally named `target` (e.g. an isolated ratchet target root)
+        // could not find a debug-only sibling archive. The hardcoded
+        // `../../target/<profile>` fallbacks only match a dir literally
+        // named `target`; the flat host-profile candidate derived from
+        // `exe_dir.parent()` must cover a custom root too.
+        let exe_dir = std::path::Path::new("/scratch/isolated-target/release");
+        let triple = "aarch64-apple-darwin";
+        let candidates = hew_lib_candidates(exe_dir, "libhew.a", triple, true);
+        let flat_debug = std::path::PathBuf::from("/scratch/isolated-target/debug/libhew.a");
+        let flat_debug_index = candidates
+            .iter()
+            .position(|path| path == &flat_debug)
+            .expect("flat debug archive under the custom target dir must be a candidate");
+        let flat_release_lib =
+            std::path::PathBuf::from("/scratch/isolated-target/release-lib/libhew.a");
+        let flat_release_lib_index = candidates
+            .iter()
+            .position(|path| path == &flat_release_lib)
+            .expect("flat release-lib archive under the custom target dir must be a candidate");
+        // Profile order (release-lib, release, debug) is preserved so a
+        // release-lib sibling still shadows a debug one when both exist.
+        assert!(
+            flat_release_lib_index < flat_debug_index,
+            "release-lib must be probed before debug under a custom target dir"
+        );
+    }
+
+    #[test]
+    fn find_hew_lib_error_lists_searched_candidates() {
+        let result = find_hew_lib("nonexistent_lib_xyz.a", "aarch64-apple-darwin", true);
+        let err = result.expect_err("a nonexistent archive name must fail");
+        assert!(
+            err.contains("Searched:"),
+            "error must list the searched candidate paths: {err}"
+        );
+        assert!(
+            err.contains("nonexistent_lib_xyz.a"),
+            "searched paths must name the archive being looked up: {err}"
+        );
     }
 
     #[test]

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -1593,6 +1593,14 @@ impl Checker {
             if !func_name.contains("::") {
                 self.warn_bare_variant_expr(&func_name, &format!("{type_name}.{func_name}"), span);
             }
+            // A selectively-imported enum/struct type used only as a variant
+            // constructor (`Status::Ok(m)`) never reached the unused-import
+            // credit below `check_struct_init` covers for record literals —
+            // this call-form constructor is its own resolution path. Credit
+            // the lexical binding the same way, via the resolved owner.
+            if let Some((owner, _)) = type_name.rsplit_once('.') {
+                self.mark_module_owner_bindings_used(owner);
+            }
             let type_param_count = type_params.len();
             if type_param_count == 0 {
                 if let Some(type_args_provided) = type_args {

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -78,7 +78,7 @@ impl Checker {
             }
         }
 
-        let mut findings: Vec<(Span, String, Option<String>)> = Vec::new();
+        let mut findings: Vec<(Span, String, Option<String>, bool)> = Vec::new();
         for (fn_name, (def_span, stored_module)) in &self.fn_def_spans {
             // Only ROOT free functions are warned (module functions keep
             // their historical exemption); the finding renders the bare
@@ -92,20 +92,44 @@ impl Checker {
             if reachable.contains(fn_name) {
                 continue;
             }
-            findings.push((def_span.clone(), leaf.to_string(), stored_module.clone()));
+            let is_pub = self
+                .fn_visibility
+                .get(fn_name)
+                .is_some_and(|vis| vis.is_pub());
+            findings.push((
+                def_span.clone(),
+                leaf.to_string(),
+                stored_module.clone(),
+                is_pub,
+            ));
         }
         // Route through the lint registry so `dead_code` is configurable
         // (`-A/-W/-D`) and suppressible (`// hew:allow(dead_code)`). The
         // collect-then-emit split releases the `&self.fn_def_spans` borrow
         // before the `&mut self` emit calls. Default level is `Warn`, so the
         // warning still appears exactly as before unless reconfigured.
-        for (def_span, fn_name, stored_module) in findings {
+        for (def_span, fn_name, stored_module, is_pub) in findings {
+            // An unreferenced `pub fn` is dead only from THIS compilation
+            // unit's point of view — it is public API another crate/module
+            // may call. `_`-prefixing it would rename the public surface
+            // (a breaking change) just to silence the lint. Point at the
+            // suppression mechanisms instead; the lint itself still fires
+            // (program-shaped packages should warn on truly dead pub code
+            // until a package/library manifest distinguishes the two).
+            let help = if is_pub {
+                "if this is intentional, suppress with `-A dead_code` or \
+                 `// hew:allow(dead_code)` — a pub fn's leading underscore \
+                 would rename its public API"
+                    .to_string()
+            } else {
+                format!("if this is intentional, prefix with underscore: `_{fn_name}`")
+            };
             self.emit_main_pass_lint(
                 LintId::DeadCode,
                 &def_span,
                 stored_module.as_deref(),
                 format!("function `{fn_name}` is never called"),
-                format!("if this is intentional, prefix with underscore: `_{fn_name}`"),
+                help,
             );
         }
     }

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -8016,12 +8016,19 @@ impl Checker {
             .published_bare_type_qualified(name)
             .or_else(|| self.flat_file_import_type_owner(name));
         if let Some(qualified) = qualified_owned.as_deref() {
-            if let Some((module, _)) = qualified.split_once('.') {
-                self.used_modules.borrow_mut().insert(ImportKey::in_file(
-                    self.current_module.clone(),
-                    self.current_module_idx,
-                    module.to_string(),
-                ));
+            // `qualified` is the full owner-qualified source identity
+            // (`owner.TypeName`), and `owner` itself may be a dotted module
+            // path (`src.plain`). Splitting on the FIRST dot mistook the
+            // owner's leading path segment for the lexical import binding —
+            // `import_spans` keys a selective import by the MODULE's short
+            // name (`plain`), not its first path segment (`src`), so that
+            // mis-derived key never matched and `Plain { … }` warned
+            // "unused import" even though it constructed the imported type.
+            // `mark_module_owner_bindings_used` resolves the owner back to
+            // the correct lexical binding via `module_import_bindings`,
+            // mirroring the working annotation-position credit above.
+            if let Some((owner, _)) = qualified.rsplit_once('.') {
+                self.mark_module_owner_bindings_used(owner);
             }
         }
         let name = qualified_owned.as_deref().unwrap_or(name);

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -2821,7 +2821,7 @@ fn warn_named_import_type_unused() {
 // resolution (a record literal, an enum-variant constructor call) still
 // warned "unused import" — the checker's `import_spans` unused-import
 // table keys each import by the MODULE's short name (`fixture` for
-// `import src::fixture::{Widget}`), but the two credit sites below spliced
+// `import src.fixture.{Widget}`), but the two credit sites below spliced
 // the resolved owner-qualified identity apart on the FIRST `.` rather than
 // the LAST, so a multi-segment module path (`src.fixture`) mapped to the
 // wrong lexical key (`src` instead of `fixture`) and the credit never
@@ -2852,7 +2852,7 @@ const D8_FIXTURE_SOURCE: &str = "pub type Widget { label: string; }\n\
 
 #[test]
 fn no_warn_selective_import_used_only_as_record_literal() {
-    let root = "import src::fixture::{Widget};\n\
+    let root = "import src.fixture.{Widget};\n\
                 fn main() { let w = Widget { label: \"hi\" }; println(w.label); }";
     let output = check_resolved_selective_import(D8_FIXTURE_SOURCE, root);
     assert!(output.errors.is_empty(), "errors: {:?}", output.errors);
@@ -2869,9 +2869,9 @@ fn no_warn_selective_import_used_only_as_record_literal() {
 
 #[test]
 fn no_warn_selective_import_used_only_as_enum_variant_constructor() {
-    let root = "import src::fixture::{Status};\n\
-                fn main() { let s = Status::Ok(\"done\"); match s { \
-                Status::Ok(m) => println(m), Status::Err(m) => println(m), } }";
+    let root = "import src.fixture.{Status};\n\
+                fn main() { let s = Status.Ok(\"done\"); match s { \
+                Status.Ok(m) => println(m), Status.Err(m) => println(m), } }";
     let output = check_resolved_selective_import(D8_FIXTURE_SOURCE, root);
     assert!(output.errors.is_empty(), "errors: {:?}", output.errors);
     assert!(
@@ -2889,7 +2889,7 @@ fn no_warn_selective_import_used_only_as_enum_variant_constructor() {
 fn warn_selective_import_genuinely_unused() {
     // Negative control: an import present but never referenced anywhere
     // (no annotation, no construction, no pattern) must still warn.
-    let root = "import src::fixture::{Widget};\nfn main() { println(1); }";
+    let root = "import src.fixture.{Widget};\nfn main() { println(1); }";
     let output = check_resolved_selective_import(D8_FIXTURE_SOURCE, root);
     assert!(output.errors.is_empty(), "errors: {:?}", output.errors);
     assert!(

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -2593,6 +2593,64 @@ fn warn_dead_code_unused_function() {
 }
 
 #[test]
+fn dead_code_pub_fn_suggests_allow_not_underscore() {
+    // D11: `pub fn` is public API — a leading underscore would rename it,
+    // a breaking surface change just to silence an advisory lint. The
+    // suggestion must point at the suppression mechanisms instead.
+    let source = "pub fn reason_unused(x: i64) -> i64 { x + 1 } fn main() { println(1); }";
+    let result = hew_parser::parse(source);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    let finding = output
+        .warnings
+        .iter()
+        .find(|w| {
+            w.kind == TypeErrorKind::Lint(LintId::DeadCode) && w.message.contains("reason_unused")
+        })
+        .unwrap_or_else(|| panic!("expected dead code warning: {:?}", output.warnings));
+    assert!(
+        finding
+            .suggestions
+            .iter()
+            .any(|s| s.contains("-A dead_code") || s.contains("hew:allow(dead_code)")),
+        "a pub fn's dead-code suggestion must point at lint suppression: {finding:?}"
+    );
+    assert!(
+        !finding
+            .suggestions
+            .iter()
+            .any(|s| s.contains("_reason_unused")),
+        "a pub fn's dead-code suggestion must not propose an underscore rename \
+         (that renames the public API): {finding:?}"
+    );
+}
+
+#[test]
+fn dead_code_private_fn_still_suggests_underscore() {
+    // The complement: a private (non-pub) unused function is a local
+    // rename-to-suppress decision the author controls, so the existing
+    // underscore-prefix suggestion is unchanged.
+    let source = "fn unused_helper(x: i64) -> i64 { x + 1 } fn main() { println(1); }";
+    let result = hew_parser::parse(source);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    let finding = output
+        .warnings
+        .iter()
+        .find(|w| {
+            w.kind == TypeErrorKind::Lint(LintId::DeadCode) && w.message.contains("unused_helper")
+        })
+        .unwrap_or_else(|| panic!("expected dead code warning: {:?}", output.warnings));
+    assert!(
+        finding
+            .suggestions
+            .iter()
+            .any(|s| s.contains("_unused_helper")),
+        "a private fn keeps the underscore-prefix suggestion: {finding:?}"
+    );
+}
+
+#[test]
 fn no_warn_dead_code_main() {
     let source = "fn main() { println(1); }";
     let result = hew_parser::parse(source);

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -2757,6 +2757,93 @@ fn warn_named_import_type_unused() {
     );
 }
 
+// ── Selective-import load-bearing use false positive (D8) ─────────────
+//
+// A selectively-imported type used only through expression-position
+// resolution (a record literal, an enum-variant constructor call) still
+// warned "unused import" — the checker's `import_spans` unused-import
+// table keys each import by the MODULE's short name (`fixture` for
+// `import src::fixture::{Widget}`), but the two credit sites below spliced
+// the resolved owner-qualified identity apart on the FIRST `.` rather than
+// the LAST, so a multi-segment module path (`src.fixture`) mapped to the
+// wrong lexical key (`src` instead of `fixture`) and the credit never
+// landed. Annotation-position resolution already threaded the correct
+// `mark_module_owner_bindings_used` call (post-#2930) and never had this bug.
+
+fn check_resolved_selective_import(child_source: &str, root_source: &str) -> TypeCheckOutput {
+    let child = hew_parser::parse(child_source);
+    assert!(child.errors.is_empty(), "child parse: {:?}", child.errors);
+    let mut root = hew_parser::parse(root_source);
+    assert!(root.errors.is_empty(), "root parse: {:?}", root.errors);
+    let import = root
+        .program
+        .items
+        .iter_mut()
+        .find_map(|(item, _)| match item {
+            Item::Import(import) => Some(import),
+            _ => None,
+        })
+        .expect("fixture import");
+    import.resolved_items = Some(child.program.items);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    checker.check_program(&root.program)
+}
+
+const D8_FIXTURE_SOURCE: &str = "pub type Widget { label: string; }\n\
+                                  pub enum Status { Ok(string); Err(string); }\n";
+
+#[test]
+fn no_warn_selective_import_used_only_as_record_literal() {
+    let root = "import src::fixture::{Widget};\n\
+                fn main() { let w = Widget { label: \"hi\" }; println(w.label); }";
+    let output = check_resolved_selective_import(D8_FIXTURE_SOURCE, root);
+    assert!(output.errors.is_empty(), "errors: {:?}", output.errors);
+    assert!(
+        !output
+            .warnings
+            .iter()
+            .any(|w| w.kind == TypeErrorKind::UnusedImport),
+        "a selectively-imported type constructed as a record literal must not \
+         warn unused: {:?}",
+        output.warnings
+    );
+}
+
+#[test]
+fn no_warn_selective_import_used_only_as_enum_variant_constructor() {
+    let root = "import src::fixture::{Status};\n\
+                fn main() { let s = Status::Ok(\"done\"); match s { \
+                Status::Ok(m) => println(m), Status::Err(m) => println(m), } }";
+    let output = check_resolved_selective_import(D8_FIXTURE_SOURCE, root);
+    assert!(output.errors.is_empty(), "errors: {:?}", output.errors);
+    assert!(
+        !output
+            .warnings
+            .iter()
+            .any(|w| w.kind == TypeErrorKind::UnusedImport),
+        "a selectively-imported enum constructed via its variant constructor \
+         call must not warn unused: {:?}",
+        output.warnings
+    );
+}
+
+#[test]
+fn warn_selective_import_genuinely_unused() {
+    // Negative control: an import present but never referenced anywhere
+    // (no annotation, no construction, no pattern) must still warn.
+    let root = "import src::fixture::{Widget};\nfn main() { println(1); }";
+    let output = check_resolved_selective_import(D8_FIXTURE_SOURCE, root);
+    assert!(output.errors.is_empty(), "errors: {:?}", output.errors);
+    assert!(
+        output
+            .warnings
+            .iter()
+            .any(|w| w.kind == TypeErrorKind::UnusedImport && w.message.contains("fixture")),
+        "a genuinely unused selective import must still warn: {:?}",
+        output.warnings
+    );
+}
+
 #[test]
 fn stdlib_import_registers_trait_impls_for_generic_bounds() {
     let root_source = r"

--- a/scripts/compiled-hew-shards.py
+++ b/scripts/compiled-hew-shards.py
@@ -63,7 +63,13 @@ def normalized_identity(classname: str, name: str) -> str:
 
 def parse_junit(path: Path) -> dict[str, str]:
     try:
-        root = ET.fromstring(path.read_text(encoding="utf-8"))
+        try:
+            root = ET.fromstring(path.read_text(encoding="utf-8"))
+        except ET.ParseError as error:
+            die(
+                f"malformed JUnit report for shard {shard} {label.upper()}: "
+                f"{path}: {error}"
+            )
     except FileNotFoundError:
         die(f"JUnit report is missing: {path}")
     except ET.ParseError as error:
@@ -107,6 +113,47 @@ def parse_junit(path: Path) -> dict[str, str]:
             f"counted={(len(outcomes), failures, skipped)}"
         )
     return outcomes
+
+
+def report_failures(reports_dir: Path, shard_count: int) -> None:
+    """Print every JUnit failure before an aggregate gate exits."""
+    if shard_count < 1:
+        die("shard count must be at least one")
+
+    for shard in range(1, shard_count + 1):
+        for label in ("o0", "o2"):
+            path = reports_dir / f"hew-{label}-shard-{shard}.xml"
+            if not path.is_file():
+                print(
+                    f"COMPILED_HEW_REPORT_MISSING shard={shard} suite={label.upper()} "
+                    f"path={path}",
+                    file=sys.stderr,
+                )
+                continue
+
+            root = ET.fromstring(path.read_text(encoding="utf-8"))
+            for testcase in root.iter("testcase"):
+                failure = testcase.find("failure")
+                if failure is None:
+                    continue
+                identity = normalized_identity(
+                    testcase.get("classname", ""), testcase.get("name", "")
+                )
+                diagnostic_parts = [
+                    part.strip()
+                    for part in (failure.get("message"), failure.text)
+                    if part and part.strip()
+                ]
+                system_out = testcase.findtext("system-out", default="").strip()
+                if system_out:
+                    diagnostic_parts.append(f"output:\n{system_out}")
+                diagnostic = (
+                    "\n".join(diagnostic_parts) or "JUnit failure without a diagnostic"
+                )
+                print(
+                    f"COMPILED_HEW_FAILURE shard={shard} suite={label.upper()} "
+                    f"test={identity}\nassertion:\n{diagnostic}"
+                )
 
 
 def run_command(
@@ -304,6 +351,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         type=Path,
         default=REPO_ROOT / "scripts" / "hew-suite-expected-failures.txt",
     )
+    report_parser = subcommands.add_parser("report")
+    report_parser.add_argument("--reports-dir", type=Path, required=True)
+    report_parser.add_argument("--shard-count", type=int, required=True)
     return parser.parse_args(argv)
 
 
@@ -311,7 +361,7 @@ def main(argv: list[str]) -> int:
     args = parse_args(argv)
     if args.action == "run":
         run_shard(args.compiler.resolve(), args.partition, args.output_dir)
-    else:
+    elif args.action == "aggregate":
         aggregate(
             args.mode,
             args.reports_dir,
@@ -319,6 +369,8 @@ def main(argv: list[str]) -> int:
             args.shard_count,
             args.expected_failures,
         )
+    else:
+        report_failures(args.reports_dir, args.shard_count)
     return 0
 
 

--- a/scripts/compiled-hew-shards.py
+++ b/scripts/compiled-hew-shards.py
@@ -63,13 +63,7 @@ def normalized_identity(classname: str, name: str) -> str:
 
 def parse_junit(path: Path) -> dict[str, str]:
     try:
-        try:
-            root = ET.fromstring(path.read_text(encoding="utf-8"))
-        except ET.ParseError as error:
-            die(
-                f"malformed JUnit report for shard {shard} {label.upper()}: "
-                f"{path}: {error}"
-            )
+        root = ET.fromstring(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         die(f"JUnit report is missing: {path}")
     except ET.ParseError as error:

--- a/scripts/compiled-hew-shards.py
+++ b/scripts/compiled-hew-shards.py
@@ -125,7 +125,20 @@ def report_failures(reports_dir: Path, shard_count: int) -> None:
                 )
                 continue
 
-            root = ET.fromstring(path.read_text(encoding="utf-8"))
+            try:
+                root = ET.fromstring(path.read_text(encoding="utf-8"))
+            except ET.ParseError as error:
+                # This is the diagnostic pass that runs before the aggregate
+                # gate fails the job. Dying here would hide every other
+                # shard's assertions behind one truncated report, so name the
+                # unreadable report and keep going; the aggregate gate still
+                # fails the job on the same malformed input.
+                print(
+                    f"COMPILED_HEW_REPORT_UNREADABLE shard={shard} "
+                    f"suite={label.upper()} path={path}: {error}",
+                    file=sys.stderr,
+                )
+                continue
             for testcase in root.iter("testcase"):
                 failure = testcase.find("failure")
                 if failure is None:

--- a/scripts/tests/test_compiled_hew_shards.py
+++ b/scripts/tests/test_compiled_hew_shards.py
@@ -163,6 +163,16 @@ class CompiledHewShardTests(unittest.TestCase):
         self.assertIn("forced diagnostic text", result.stdout)
         self.assertIn("forced fixture output", result.stdout)
 
+    def test_report_survives_a_malformed_shard_report(self) -> None:
+        values = self.full[0::SHARDS]
+        (self.reports / "hew-o0-shard-1.xml").write_text(
+            "<testsuite><testcase", encoding="utf-8"
+        )
+        write_junit(self.reports / "hew-o2-shard-2.xml", values, failed={values[0]})
+        result = self.report()
+        self.assertIn("COMPILED_HEW_REPORT_UNREADABLE shard=1", result.stderr)
+        self.assertIn("COMPILED_HEW_FAILURE shard=2 suite=O2", result.stdout)
+
 
 class CompiledHewWorkflowContractTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/scripts/tests/test_compiled_hew_shards.py
+++ b/scripts/tests/test_compiled_hew_shards.py
@@ -45,7 +45,10 @@ def write_junit(
         classname, name = value.rsplit("::", 1)
         testcase = ET.SubElement(suite, "testcase", classname=classname, name=name)
         if value in failed:
-            ET.SubElement(testcase, "failure", message="forced")
+            failure = ET.SubElement(testcase, "failure", message="forced assertion")
+            failure.text = "forced diagnostic text"
+            system_out = ET.SubElement(testcase, "system-out")
+            system_out.text = "forced fixture output"
     ET.ElementTree(root).write(path, encoding="unicode", xml_declaration=True)
 
 
@@ -96,6 +99,25 @@ class CompiledHewShardTests(unittest.TestCase):
         self.assertEqual(result.returncode, expect, result.stdout + result.stderr)
         return result
 
+    def report(self) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "report",
+                "--reports-dir",
+                str(self.reports),
+                "--shard-count",
+                str(SHARDS),
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result
+
     def test_complete_disjoint_union_passes_both_gates(self) -> None:
         self.assertIn("ratchet passed", self.aggregate("ratchet").stdout)
         self.assertIn("differential passed", self.aggregate("differential").stdout)
@@ -130,6 +152,16 @@ class CompiledHewShardTests(unittest.TestCase):
         write_junit(self.reports / "hew-o0-shard-1.xml", values, failed={values[0]})
         result = self.aggregate("ratchet", expect=1)
         self.assertIn("failure set differs", result.stderr)
+
+    def test_report_names_the_failed_shard_test_and_diagnostic(self) -> None:
+        values = self.full[0::SHARDS]
+        write_junit(self.reports / "hew-o0-shard-1.xml", values, failed={values[0]})
+        result = self.report()
+        self.assertIn("COMPILED_HEW_FAILURE shard=1 suite=O0", result.stdout)
+        self.assertIn(f"test={values[0]}", result.stdout)
+        self.assertIn("forced assertion", result.stdout)
+        self.assertIn("forced diagnostic text", result.stdout)
+        self.assertIn("forced fixture output", result.stdout)
 
 
 class CompiledHewWorkflowContractTests(unittest.TestCase):
@@ -174,6 +206,14 @@ class CompiledHewWorkflowContractTests(unittest.TestCase):
         self.assertIn("make test-hew-ratchet", self.workflow)
         self.assertIn("make test-o2-differential", self.workflow)
         self.assertEqual(self.workflow.count("HEW_SHARD_COUNT=4"), 2)
+
+    def test_failure_reporter_runs_before_the_aggregate_gates(self) -> None:
+        report = self.workflow.index("Report compiled Hew shard failures")
+        gate = self.workflow.index("Require every shard to complete")
+        ratchet = self.workflow.index("Assert shard union and Hew ratchet")
+        self.assertLess(report, gate)
+        self.assertLess(gate, ratchet)
+        self.assertIn("scripts/compiled-hew-shards.py report", self.workflow)
 
     def test_established_required_check_requires_both_parallel_branches(self) -> None:
         required = self.workflow.split("  linux-required:\n", 1)[1].split(

--- a/std/path.hew
+++ b/std/path.hew
@@ -303,7 +303,7 @@ pub fn normalize(p: string) -> string {
     }
     let rooted = p.starts_with("/");
     let parts = p.split("/");
-    let stack: Vec<string> = Vec::new();
+    let stack: Vec<string> = Vec.new();
     for i in 0 .. parts.len() {
         let seg = parts[i];
         if seg == "" || seg == "." {

--- a/std/path.hew
+++ b/std/path.hew
@@ -19,7 +19,7 @@
 //! }
 //! ```
 
-import std::string;
+import std.string;
 
 /// The result of a glob expansion.
 ///
@@ -290,7 +290,7 @@ pub fn absolute(p: string) -> string {
 /// # Examples
 ///
 /// ```
-/// import std::path;
+/// import std.path;
 ///
 /// path.normalize("/var/www/../../etc/passwd")  // "/etc/passwd"
 /// path.normalize("a/./b/../c")                 // "a/c"

--- a/std/path.hew
+++ b/std/path.hew
@@ -19,6 +19,8 @@
 //! }
 //! ```
 
+import std::string;
+
 /// The result of a glob expansion.
 ///
 /// Created by `path.glob(pattern)`. Glob results close automatically at scope
@@ -263,19 +265,70 @@ pub fn is_dir(p: string) -> bool {
     }
 }
 
-/// Return the absolute form of a path by joining `p` onto the current
-/// working directory when `p` is relative.
+/// Return the absolute form of a path.
 ///
-/// This does NOT resolve `..` or `.` segments — `absolute("../../etc/passwd")`
-/// returns `<cwd>/../../etc/passwd`, not a cleaned path. There is currently
-/// no `normalize`/`canonicalize` in this module; do not use `absolute()`
-/// alone for containment checks (e.g. "is this path still inside my sandbox
-/// root?") — a `..`-bearing or symlinked input can walk outside any prefix
-/// you check against.
+/// This is a lexical join against the current working directory: it does
+/// NOT resolve `..` or symlinks. `absolute("../../etc/passwd")` returns
+/// `<cwd>/../../etc/passwd`, not a collapsed or containment-checked path.
+/// Pass the result through `normalize` for a lexically clean path, or use
+/// a real symlink-aware `canonicalize` (not yet in std) before treating a
+/// path as safe to open — `normalize` alone does not guard against `..`
+/// escaping through a symlinked directory.
 pub fn absolute(p: string) -> string {
     unsafe {
         hew_path_absolute(p)
     }
+}
+
+/// Lexically clean a path: collapse repeated separators, drop `.` segments,
+/// and resolve `..` segments against the preceding component. Follows Go's
+/// `filepath.Clean` semantics. Does not touch the filesystem — it has no
+/// symlink awareness, so a cleaned path can still escape a directory the
+/// caller intended to stay inside if any component is a symlink. Returns
+/// `"."` for an empty path.
+///
+/// # Examples
+///
+/// ```
+/// import std::path;
+///
+/// path.normalize("/var/www/../../etc/passwd")  // "/etc/passwd"
+/// path.normalize("a/./b/../c")                 // "a/c"
+/// path.normalize("../../etc/passwd")           // "../../etc/passwd"
+/// path.normalize("")                           // "."
+/// ```
+pub fn normalize(p: string) -> string {
+    if p == "" {
+        return ".";
+    }
+    let rooted = p.starts_with("/");
+    let parts = p.split("/");
+    let stack: Vec<string> = Vec::new();
+    for i in 0 .. parts.len() {
+        let seg = parts[i];
+        if seg == "" || seg == "." {
+            continue;
+        }
+        if seg == ".." {
+            if stack.len() > 0 && stack[stack.len() - 1] != ".." {
+                stack.pop();
+            } else if !rooted {
+                stack.push(seg);
+            }
+            // Rooted with an empty (or all-"..") stack: `..` above root
+            // collapses to root, matching filepath.Clean.
+            continue;
+        }
+        stack.push(seg);
+    }
+    let joined = string.join(stack, "/");
+    if rooted {
+        return "/" + joined;
+    }
+    if joined == "" {
+        return ".";
+    }
+    joined
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/tests/hew/path_test.hew
+++ b/tests/hew/path_test.hew
@@ -99,6 +99,60 @@ fn test_extension_uses_basename_for_full_path() {
     testing.assert_eq_str(path.extension("/home/user/file.txt"), "txt");
 }
 
+// ── normalize ───────────────────────────────────────────────────────────
+#[test]
+fn test_normalize_collapses_dotdot_against_preceding_component() {
+    testing.assert_eq_str(path.normalize("/var/www/../../etc/passwd"), "/etc/passwd");
+}
+
+#[test]
+fn test_normalize_collapses_dot_and_dotdot_in_relative_path() {
+    testing.assert_eq_str(path.normalize("a/./b/../c"), "a/c");
+}
+
+#[test]
+fn test_normalize_preserves_leading_dotdot_on_relative_path() {
+    // A relative path with no earlier component to cancel against keeps the
+    // leading `..` — there is nothing lexical to resolve it to.
+    testing.assert_eq_str(path.normalize("../../etc/passwd"), "../../etc/passwd");
+}
+
+#[test]
+fn test_normalize_empty_path_returns_dot() {
+    testing.assert_eq_str(path.normalize(""), ".");
+}
+
+#[test]
+fn test_normalize_root_stays_root() {
+    testing.assert_eq_str(path.normalize("/"), "/");
+}
+
+#[test]
+fn test_normalize_strips_trailing_slash() {
+    testing.assert_eq_str(path.normalize("/a/b/"), "/a/b");
+}
+
+#[test]
+fn test_normalize_dotdot_above_root_collapses_to_root() {
+    // `..` above the root has nowhere to go; filepath.Clean semantics
+    // collapse it back to root rather than erroring or escaping.
+    testing.assert_eq_str(path.normalize("/../a"), "/a");
+}
+
+#[test]
+fn test_normalize_collapses_repeated_separators() {
+    testing.assert_eq_str(path.normalize("/home//user"), "/home/user");
+}
+
+#[test]
+fn test_normalize_absolute_with_escape_shape_stays_lexically_clean() {
+    // The porters' reported shape: absolute() alone leaves `..` unresolved
+    // (`<cwd>/../../etc/passwd`); normalize(absolute(p)) is the documented
+    // safe pattern for lexical cleanup.
+    let escaped = path.combine("/srv/app/data", "../../etc/passwd");
+    testing.assert_eq_str(path.normalize(escaped), "/srv/etc/passwd");
+}
+
 // ── heap-string regression tests ────────────────────────────────────────
 //
 // The tests below construct their string inputs via concatenation so the

--- a/tests/hew/path_test.hew
+++ b/tests/hew/path_test.hew
@@ -1,4 +1,4 @@
-//! Tests for the std::path pure helper functions.
+//! Tests for the std.path pure helper functions.
 
 import std.fs;
 


### PR DESCRIPTION
## Summary

Small fixes surfaced by reviewing a real port of an external project onto Hew:

- `path.normalize()`: new pure-Hew lexical path cleaner (Go `filepath.Clean` semantics); doc-warns `path.absolute()` does not resolve `..` segments.
- Credit selective imports (`import mod::{Thing};`) as used when the imported name appears via record/variant construction, not just annotation position — fixes a false-positive unused-import warning.
- `hew build --release`/link driver: find the debug `libhew.a` archive under a custom `CARGO_TARGET_DIR`, not just the literal `target/` path.
- Dead-code lint: for a `pub` function, suggest suppression (`-A dead_code` / `// hew:allow(dead_code)`) instead of a `_`-prefix rename, since renaming a public symbol is not the fix a caller wants.
- Bump the structural-authority lint TSV counts to match the above changes.

## Deferred

One finding from the same source is not in this PR: a false-positive leak advisory (`E_MIR_CHECK ObligationUnderReleased`) that `std::iter::any`/`filter`/`collect` combinators emit at every use site from their own monomorphized bodies, even though the runtime already discharges correctly. It needs its own change in the MIR drop-plan/obligation-balance modelling and carries a distinct, real leak finding worth fixing alongside it — tracked separately, not folded into this PR.

## Verification

- `make lint`: pass (exit 0)
- `make test-hew-ratchet`: pass, 0 expected failures, 0 actual failures

## Out of scope

- The false-positive leak advisory noted above (deferred).
- Everything else that came out of the same review — separate PRs.