### PR TITLE
ci: prefetch binaryen with retries so wasm-pack skips its download

### DIFF
--- a/.github/actions/setup-wasm-pack/action.yml
+++ b/.github/actions/setup-wasm-pack/action.yml
@@ -1,0 +1,36 @@
+name: Setup wasm-pack and Binaryen
+description: >
+  Install the pinned Linux x86_64 wasm-pack release and prefetch its pinned
+  Binaryen wasm-opt dependency with retry and checksum verification.
+
+runs:
+  using: composite
+  steps:
+    - name: Install wasm-pack v0.13.1
+      shell: bash
+      run: |
+        set -euo pipefail
+        WASM_PACK_VERSION=0.13.1
+        TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}" \
+          -o "${RUNNER_TEMP}/${TARBALL}"
+        tar -xzf "${RUNNER_TEMP}/${TARBALL}" -C "${RUNNER_TEMP}"
+        echo "${RUNNER_TEMP}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl" >> "${GITHUB_PATH}"
+        "${RUNNER_TEMP}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack" --version
+
+    # wasm-pack v0.13.1 otherwise downloads Binaryen 117 during its release
+    # build. Prefetch the exact immutable asset so that download is the only
+    # retried unit; compiler and test verdicts remain single-attempt.
+    - name: Install Binaryen version_117
+      shell: bash
+      run: |
+        set -euo pipefail
+        BINARYEN_VERSION=version_117
+        BINARYEN_SHA256=3dc677006555b355ea2da5e82602065a161d5e83eaefd3f759afa00b96e83212
+        RETRY_ATTEMPTS=5 RETRY_INITIAL_DELAY=10 \
+          "${GITHUB_ACTION_PATH}/../../scripts/retry-download.sh" \
+          "${GITHUB_ACTION_PATH}/../../scripts/download-verify-binaryen.sh" \
+          "${BINARYEN_VERSION}" "${BINARYEN_SHA256}" \
+          "${RUNNER_TEMP}"
+        echo "${RUNNER_TEMP}/binaryen-${BINARYEN_VERSION}/bin" >> "${GITHUB_PATH}"
+        "${RUNNER_TEMP}/binaryen-${BINARYEN_VERSION}/bin/wasm-opt" --version

--- a/.github/scripts/download-verify-binaryen.sh
+++ b/.github/scripts/download-verify-binaryen.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Download, checksum-verify, and extract the Binaryen release used by
+# wasm-pack v0.13.1 on Linux x86_64.
+#
+# The caller wraps this complete immutable-download unit in retry-download.sh,
+# so every attempt fetches fresh bytes and verifies them before extraction.
+#
+# Usage: download-verify-binaryen.sh <version> <expected_sha256> <install_root>
+set -euo pipefail
+
+version="$1"
+expected="$2"
+install_root="$3"
+asset="binaryen-${version}-x86_64-linux.tar.gz"
+tarball="${install_root}/${asset}"
+url="https://github.com/WebAssembly/binaryen/releases/download/${version}/${asset}"
+
+mkdir -p "${install_root}"
+echo "Downloading ${url}"
+curl -fL --retry 3 --retry-delay 5 --retry-all-errors -o "${tarball}" "${url}"
+
+echo "${expected}  ${tarball}" > "${tarball}.sha256"
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c "${tarball}.sha256"
+else
+  shasum -a 256 -c "${tarball}.sha256"
+fi
+
+tar -xzf "${tarball}" -C "${install_root}"
+rm -f "${tarball}" "${tarball}.sha256"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,10 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'Makefile'
+              - '.github/actions/setup-wasm-pack/**'
+              - '.github/scripts/download-verify-binaryen.sh'
+              - '.github/scripts/retry-download.sh'
+              - '.github/workflows/ci.yml'
             docs:
               - 'docs/**'
               - '*.md'
@@ -400,16 +404,8 @@ jobs:
         with:
           cache-shared-key: playground-wasm
 
-      - name: Install wasm-pack v0.13.1
-        run: |
-          set -euo pipefail
-          WASM_PACK_VERSION=0.13.1
-          TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}" \
-            -o "/tmp/${TARBALL}"
-          tar -xzf "/tmp/${TARBALL}" -C /tmp
-          echo "/tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl" >> "$GITHUB_PATH"
-          /tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack --version
+      - name: Install wasm-pack v0.13.1 and Binaryen 117
+        uses: ./.github/actions/setup-wasm-pack
 
       - name: Check sandbox fixtures are current
         # The committed sandbox fixtures are generated from in-tree sources; a
@@ -729,17 +725,9 @@ jobs:
           echo "$PWD/${WASMTIME_DIR}" >> "$GITHUB_PATH"
           "./${WASMTIME_DIR}/wasmtime" --version
 
-      - name: Install wasm-pack v0.13.1
+      - name: Install wasm-pack v0.13.1 and Binaryen 117
         if: env.RUN_CODE_PATH == 'true'
-        run: |
-          set -euo pipefail
-          WASM_PACK_VERSION=0.13.1
-          TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}" \
-            -o "/tmp/${TARBALL}"
-          tar -xzf "/tmp/${TARBALL}" -C /tmp
-          echo "/tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl" >> "$GITHUB_PATH"
-          /tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack --version
+        uses: ./.github/actions/setup-wasm-pack
 
       - name: Setup Node.js for selected browser checks
         if: env.RUN_CODE_PATH == 'true'

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -70,15 +70,8 @@ jobs:
           key: publish-npm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: publish-npm-${{ runner.os }}-
 
-      - name: Install wasm-pack v0.13.1
-        run: |
-          set -euo pipefail
-          WASM_PACK_VERSION=0.13.1
-          TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}" \
-            -o "/tmp/${TARBALL}"
-          tar -xzf "/tmp/${TARBALL}" -C /tmp
-          echo "/tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl" >> "$GITHUB_PATH"
+      - name: Install wasm-pack v0.13.1 and Binaryen 117
+        uses: ./.github/actions/setup-wasm-pack
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -225,20 +225,13 @@ jobs:
         run: make mqtt-broker-e2e
 
       # Browser-analysis WASM gate — Linux x86_64 only.
-      # Installs wasm-pack + wasm32-unknown-unknown and runs the full playground
+      # Installs wasm-pack + Binaryen + wasm32-unknown-unknown and runs the full
+      # playground
       # check: manifest freshness, full hew-wasm test suite (lib + fixture-coverage
       # integration), and the wasm-pack release build.  Scoped to x86_64 to avoid
       # multiplying wasm-pack installs across aarch64/macOS/Windows lanes.
-      - name: Install wasm-pack v0.13.1 (browser-analysis gate)
-        run: |
-          set -euo pipefail
-          WASM_PACK_VERSION=0.13.1
-          TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}" \
-            -o "/tmp/${TARBALL}"
-          tar -xzf "/tmp/${TARBALL}" -C /tmp
-          echo "/tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl" >> "$GITHUB_PATH"
-          /tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack --version
+      - name: Install wasm-pack v0.13.1 and Binaryen 117 (browser-analysis gate)
+        uses: ./.github/actions/setup-wasm-pack
 
       - name: Add wasm32-unknown-unknown target
         run: rustup target add wasm32-unknown-unknown

--- a/scripts/tests/test_playground_path_filter_oracle.py
+++ b/scripts/tests/test_playground_path_filter_oracle.py
@@ -126,6 +126,18 @@ MUST_TRIGGER: list[tuple[str, str]] = [
     ("Cargo.toml", "root Cargo.toml must trigger playground"),
     ("Cargo.lock", "Cargo.lock must trigger playground"),
     ("Makefile", "Makefile must trigger playground"),
+    (
+        ".github/actions/setup-wasm-pack/action.yml",
+        "wasm-pack setup changes must trigger playground",
+    ),
+    (
+        ".github/scripts/download-verify-binaryen.sh",
+        "Binaryen download changes must trigger playground",
+    ),
+    (
+        ".github/scripts/retry-download.sh",
+        "download retry changes must trigger playground",
+    ),
     (".github/workflows/ci.yml", "ci.yml self-change must trigger playground"),
 ]
 
@@ -251,6 +263,19 @@ def test_hew_wasm_triggers_playground() -> None:
     assert path_matches_any("hew-wasm/src/lib.rs", patterns), (
         "hew-wasm/** must be in the playground path filter"
     )
+
+
+def test_wasm_toolchain_changes_trigger_playground() -> None:
+    patterns = _get_patterns()
+    for path in (
+        ".github/actions/setup-wasm-pack/action.yml",
+        ".github/scripts/download-verify-binaryen.sh",
+        ".github/scripts/retry-download.sh",
+        ".github/workflows/ci.yml",
+    ):
+        assert path_matches_any(path, patterns), (
+            f"{path} must trigger the playground build"
+        )
 
 
 def test_docs_only_does_not_trigger_playground() -> None:

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -39,11 +39,14 @@ RELEASE_BINARY_SMOKE = ROOT / "scripts" / "test-release-binary.sh"
 PACKAGE_BUILDER = ROOT / "installers" / "build-packages.sh"
 WINDOWS_LLVM_PREBUILD = ROOT / ".github" / "workflows" / "prebuild-llvm.yml"
 SETUP_LLVM_ACTION = ROOT / ".github" / "actions" / "setup-llvm" / "action.yml"
+SETUP_WASM_PACK_ACTION = ROOT / ".github" / "actions" / "setup-wasm-pack" / "action.yml"
+DOWNLOAD_VERIFY_BINARYEN = ROOT / ".github" / "scripts" / "download-verify-binaryen.sh"
 WINDOWS_BUILD_GUIDE = ROOT / "docs" / "cross-platform-build-guide.md"
 WINDOWS_LLVM_TOOLCHAIN_REPO = "hew-lang/llvm-toolchain"
 WINDOWS_LLVM_TOOLCHAIN_VERSION = "22.1.0-windows-msvc-v1"
 WINDOWS_LLVM_TOOLCHAIN_TAG = f"llvm-{WINDOWS_LLVM_TOOLCHAIN_VERSION}"
 WINDOWS_LLVM_TOOLCHAIN_ASSET = f"hew-llvm-{WINDOWS_LLVM_TOOLCHAIN_VERSION}.tar.gz"
+BINARYEN_SHA256 = "3dc677006555b355ea2da5e82602065a161d5e83eaefd3f759afa00b96e83212"
 
 
 def workflow() -> str:
@@ -1020,6 +1023,74 @@ def workflow_job(text: str, name: str) -> str:
     return text[start:end]
 
 
+def assert_binaryen_downloader_contract(downloader: str) -> None:
+    assert (
+        "github.com/WebAssembly/binaryen/releases/download/${version}/${asset}"
+        in downloader
+    )
+    assert "--retry-all-errors" in downloader
+    assert 'sha256sum -c "${tarball}.sha256"' in downloader
+    assert 'tar -xzf "${tarball}" -C "${install_root}"' in downloader
+
+
+def assert_wasm_pack_action_contract(action: str) -> None:
+    assert "WASM_PACK_VERSION=0.13.1" in action
+    assert "RETRY_ATTEMPTS=5 RETRY_INITIAL_DELAY=10" in action
+    assert "scripts/retry-download.sh" in action
+    assert "scripts/download-verify-binaryen.sh" in action
+    assert "BINARYEN_VERSION=version_117" in action
+    assert f"BINARYEN_SHA256={BINARYEN_SHA256}" in action
+    assert '"${BINARYEN_VERSION}" "${BINARYEN_SHA256}"' in action
+    assert (
+        'echo "${RUNNER_TEMP}/binaryen-${BINARYEN_VERSION}/bin"'
+        ' >> "${GITHUB_PATH}"' in action
+    )
+    assert (
+        '"${RUNNER_TEMP}/binaryen-${BINARYEN_VERSION}/bin/wasm-opt" --version' in action
+    )
+
+
+def test_wasm_pack_consumers_prefetch_checksum_pinned_binaryen() -> None:
+    action = SETUP_WASM_PACK_ACTION.read_text()
+    downloader = DOWNLOAD_VERIFY_BINARYEN.read_text()
+    action_use = "uses: ./.github/actions/setup-wasm-pack"
+
+    assert_wasm_pack_action_contract(action)
+    assert_binaryen_downloader_contract(downloader)
+
+    consumers = (
+        (
+            workflow_job(CI_WORKFLOW.read_text(), "playground-wasm-build"),
+            "make playground-check",
+        ),
+        (
+            workflow_job(CI_WORKFLOW.read_text(), "build-and-test"),
+            "scripts/ci-preflight-dispatcher.sh",
+        ),
+        (
+            workflow_job(RELEASE_GATE.read_text(), "gate-linux"),
+            "make playground-check",
+        ),
+        (
+            workflow_job(NPM_PUBLISH_WORKFLOW.read_text(), "publish"),
+            "node scripts/build-npm-packages.mjs",
+        ),
+    )
+    for job, build_command in consumers:
+        assert job.count(action_use) == 1
+        assert job.index(action_use) < job.index(build_command)
+
+
+def test_binaryen_prefetch_pin_mutations_are_rejected() -> None:
+    action = SETUP_WASM_PACK_ACTION.read_text()
+    mutated = action.replace(BINARYEN_SHA256, "0" * 64)
+    try:
+        assert_wasm_pack_action_contract(mutated)
+    except AssertionError:
+        return
+    raise AssertionError("Binaryen checksum mutation escaped the contract")
+
+
 def assert_windows_job_initialises_msvc_before_native_linking(job: str) -> None:
     """Require precisely one MSVC environment import before LLVM/Cargo use."""
     setup_msvc = "uses: ./.github/actions/setup-msvc"
@@ -1688,6 +1759,8 @@ _TESTS = [
     test_sanitizer_gate_is_behavioral_and_release_scoped,
     test_release_record_is_durable_and_tag_ready,
     test_contract_oracle_runs_in_required_ci,
+    test_wasm_pack_consumers_prefetch_checksum_pinned_binaryen,
+    test_binaryen_prefetch_pin_mutations_are_rejected,
     test_windows_test_workflows_initialise_msvc_before_lld_link,
     test_windows_test_workflow_msvc_ordering_mutations_are_rejected,
     test_windows_llvm_prebuild_workflow_is_not_owned_by_this_repository,


### PR DESCRIPTION
## Summary

The playground WASM jobs downloaded binaryen through wasm-pack's own installer, which has no retry and failed two PRs on transient network errors. A shared setup step now prefetches binaryen 117 under the established retry-with-checksum wrapper and puts `wasm-opt` on PATH, so wasm-pack skips its own download. This covers all four workflow consumers (CI playground jobs, npm package publish, and the release gate).

## Verification

- Release workflow contract suite: 47/47 passing
- Playground path-filter oracle: 24/24 passing
- Combined contract pytest run after rebasing onto main: 89 passed
- actionlint + shellcheck on all changed workflow and script files: clean
- Preflight: ready-to-push

## Out of scope

- Retry behaviour for other tool downloads in CI — only the binaryen fetch changed.
- The retry-with-checksum wrapper itself is unchanged; this adds a consumer.