### PR TITLE
fix(mir): lower closure Borrow captures as retained shares, not owned moves

### DIFF
--- a/hew-cli/tests/closure_capture_owned_leak_oracle.rs
+++ b/hew-cli/tests/closure_capture_owned_leak_oracle.rs
@@ -370,20 +370,28 @@ fn borrow_capture_read_after_loop_source(frames: usize) -> String {
     )
 }
 
+/// Two escaping closures share one source string. Returning an outer closure
+/// forces both inner closure envs onto the heap; each inner env takes one
+/// retained share, while the direct `label.len()` keeps the source binding
+/// live after both captures. This reaches the retained-env exclusion in the
+/// generic hand-off inference: without it, that walk adds a second retain for
+/// each env field and the leak slope grows by two shares per iteration.
 fn borrow_capture_two_shares_loop_source(frames: usize) -> String {
     let label_len = "row-payload-seed".len();
     let expected_total = frames * 3 * label_len + frames * frames.saturating_sub(1);
     format!(
-        "fn two_shares(n: i64) -> i64 {{\n\
+        "fn make_two_shares(n: i64) -> fn() -> i64 {{\n\
          \x20   let label = \"row-payload-seed\".to_upper();\n\
          \x20   let a = || label.len() + n;\n\
          \x20   let b = || label.len() + n;\n\
-         \x20   a() + b() + label.len()\n\
+         \x20   let after = label.len();\n\
+         \x20   || a() + b() + after\n\
          }}\n\
          fn run_loop(frames: i64) -> i64 {{\n\
          \x20   var total: i64 = 0;\n\
          \x20   for i in 0..frames {{\n\
-         \x20       total = total + two_shares(i);\n\
+         \x20       let f = make_two_shares(i);\n\
+         \x20       total = total + f();\n\
          \x20   }}\n\
          \x20   total\n\
          }}\n\
@@ -395,10 +403,13 @@ fn borrow_capture_two_shares_loop_source(frames: usize) -> String {
     )
 }
 
-/// Record source read after a field-projecting capture, closure invoked
-/// directly (no std combinator): isolates the retained-share capture ownership
-/// from the pre-existing closure-pair-argument leak the `iter::any` pin below
-/// tracks.
+/// Record source read after a field-projecting capture, with an outer returned
+/// closure forcing the field-projecting inner closure env onto the heap. The
+/// source read after the inner capture makes the generic hand-off inference
+/// want another aggregate retain; excluding the retained env field keeps the
+/// env at exactly one recursive leaf retain. The direct invocation of the
+/// returned closure avoids the pre-existing closure-pair-argument leak the
+/// `iter::any` pin below tracks.
 fn borrow_capture_record_read_after_loop_source(frames: usize) -> String {
     let item_len = "row-item".len();
     let expected_total = frames * (1 + item_len) + frames * frames.saturating_sub(1) / 2;
@@ -407,18 +418,22 @@ fn borrow_capture_record_read_after_loop_source(frames: usize) -> String {
          \x20   item: string;\n\
          \x20   run_id: string;\n\
          }}\n\
-         fn probe() -> i64 {{\n\
+         fn make_probe(n: i64) -> fn() -> i64 {{\n\
          \x20   let claim = Claim {{ item: \"row-item\".to_upper(), run_id: \"row-run\".to_upper() }};\n\
          \x20   let matches_run = |t: string| t == claim.run_id;\n\
-         \x20   var score: i64 = 0;\n\
-         \x20   if matches_run(\"ROW-RUN\") {{ score = score + 1; }}\n\
-         \x20   if matches_run(\"nope\") {{ score = score + 100; }}\n\
-         \x20   score + claim.item.len()\n\
+         \x20   let item_len = claim.item.len();\n\
+         \x20   || {{\n\
+         \x20       var score: i64 = 0;\n\
+         \x20       if matches_run(\"ROW-RUN\") {{ score = score + 1; }}\n\
+         \x20       if matches_run(\"nope\") {{ score = score + 100; }}\n\
+         \x20       score + item_len + n\n\
+         \x20   }}\n\
          }}\n\
          fn run_loop(frames: i64) -> i64 {{\n\
          \x20   var total: i64 = 0;\n\
          \x20   for i in 0..frames {{\n\
-         \x20       total = total + probe() + i;\n\
+         \x20       let f = make_probe(i);\n\
+         \x20       total = total + f();\n\
          \x20   }}\n\
          \x20   total\n\
          }}\n\
@@ -530,16 +545,18 @@ fn assert_no_double_free(shape_name: &str, source: &str) {
 
     assert!(
         output.status.success(),
-        "{shape_name}: escaping closure capture must free the owned value exactly once -- a \
-         crash here indicates a double-free: the caller binding freed the same handle the env \
-         now owns. The env must be the sole owner (the caller's scope-exit drop is suppressed by \
-         the aliased-local scan); a non-zero exit is a scribbled-read miscompute or the fixture's \
-         own total check;\n{}",
+        "{shape_name}: escaping closure capture must balance every owning share exactly once -- \
+         a crash indicates a double-free between the source binding and an env share, while a \
+         non-zero exit is a scribbled-read miscompute or the fixture's own total check;\n{}",
         describe_output(&output)
     );
 }
 
-fn assert_compile_fails(shape_name: &str, source: &str, expected: &str) {
+fn assert_compile_fails_after_retained_capture(
+    shape_name: &str,
+    source: &str,
+    expected_record_binding: &str,
+) {
     require_codegen();
 
     let dir = tempfile::Builder::new()
@@ -570,9 +587,16 @@ fn assert_compile_fails(shape_name: &str, source: &str, expected: &str) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    let expected = format!("binding `{expected_record_binding}` is used after it was consumed");
     assert!(
-        combined.contains(expected),
-        "{shape_name}: compile failed but did not mention `{expected}`:\n{combined}"
+        combined.contains(&expected),
+        "{shape_name}: compile failed before reaching the intended record-store seam; expected \
+         `{expected}`:\n{combined}"
+    );
+    assert!(
+        !combined.contains("binding `label` is used after it was consumed"),
+        "{shape_name}: the read-only capture still consumed `label`, so this is the pre-fix \
+         capture failure rather than the intended record-store rejection:\n{combined}"
     );
 }
 
@@ -803,9 +827,9 @@ fn borrow_capture_read_after_freed_exactly_once_under_malloc_scribble() {
     );
 }
 
-/// Slope oracle: two closures sharing one source string, plus a direct read of
-/// the source — three co-owners (two retained env shares + the original), three
-/// releases, flat slope.
+/// Slope oracle: two escaping closures sharing one source string, plus a direct
+/// read of the source — three co-owners (two retained heap-env shares + the
+/// original), three releases, flat slope.
 #[cfg_attr(
     not(target_os = "macos"),
     ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
@@ -830,9 +854,10 @@ fn borrow_capture_two_shares_freed_exactly_once_under_malloc_scribble() {
     );
 }
 
-/// Slope oracle: record source read after a field-projecting capture (direct
-/// invocation) — the env's retained record share and the source's own drop
-/// each release once; flat slope.
+/// Slope oracle: record source read after a field-projecting capture that an
+/// outer returned closure forces to escape. Directly invoking the returned
+/// closure avoids the std-combinator carrier seam. The inner env's retained
+/// record share and the source's own drop each release once; flat slope.
 #[cfg_attr(
     not(target_os = "macos"),
     ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
@@ -879,24 +904,26 @@ fn borrow_capture_record_iter_any_freed_exactly_once_under_malloc_scribble() {
 /// takes a retained share), but storing a CAPTURING closure pair into a record
 /// field still fails closed — `UseAfterConsume` fires on `a`/`b` at the
 /// `RecordInit` (the closure-pair-into-record transfer has no ownership
-/// protocol yet). This pin holds the fail-closed line at that seam.
+/// protocol yet). Requiring that record-store diagnostic while rejecting an
+/// earlier `label` diagnostic distinguishes this from the pre-fix failure.
 #[test]
 fn shared_source_two_escaping_closures_fail_closed() {
-    assert_compile_fails(
+    assert_compile_fails_after_retained_capture(
         "shared_source_two_closures",
         &shared_source_two_closures_source(),
-        "UseAfterConsume",
+        "a",
     );
 }
 
 /// Same seam as above: the capture itself (closure + original both live) is now
 /// a legal retained share, but the record store of the capturing closure pair
-/// `f` still fails closed at the `RecordInit`.
+/// `f` still fails closed at the `RecordInit`. The pin also rejects the pre-fix
+/// `label`-consume diagnostic, so an early capture failure cannot satisfy it.
 #[test]
 fn shared_source_closure_plus_original_store_fail_closed() {
-    assert_compile_fails(
+    assert_compile_fails_after_retained_capture(
         "shared_source_original_store",
         &shared_source_closure_plus_original_store_source(),
-        "UseAfterConsume",
+        "f",
     );
 }

--- a/hew-cli/tests/closure_capture_owned_leak_oracle.rs
+++ b/hew-cli/tests/closure_capture_owned_leak_oracle.rs
@@ -15,6 +15,12 @@
 //! field through the per-field drop authority before freeing the box, so the
 //! captured value is freed exactly once as the env's sole owner.
 //!
+//! A checker-`Borrow` capture (read-only body use, no `move`) whose source
+//! stays live takes a RETAINED SHARE instead: the env field is
+//! `OwnsClonedOrRetained`, an explicit retain mints the env's co-owner, and
+//! the source binding keeps its own scope-exit drop — two owners, each
+//! released exactly once (D3, amends #2933's closure-surface claim).
+//!
 //! The failure modes this oracle catches:
 //!   * a LEAK (the env frees the box but not the captured handle) — a positive
 //!     per-iteration leak slope;
@@ -332,6 +338,145 @@ fn nested_closure_parameter_control_loop_source(frames: usize) -> String {
     )
 }
 
+/// Read-only (`Borrow`) capture with the SOURCE STILL LIVE after the capture —
+/// the retained-share contract: each escaping env takes an
+/// `OwnsClonedOrRetained` field backed by an explicit retain, the source
+/// binding keeps its own scope-exit owner, and both release exactly once.
+/// Shapes: read-after-capture (string), two closures sharing one source plus a
+/// direct read, and a record source read after a field-projecting capture.
+fn borrow_capture_read_after_loop_source(frames: usize) -> String {
+    let label_len = "row-payload-seed".len();
+    let expected_total = frames * 2 * label_len + frames * frames.saturating_sub(1) / 2;
+    format!(
+        "fn make_reader(n: i64) -> fn() -> i64 {{\n\
+         \x20   let label = \"row-payload-seed\".to_upper();\n\
+         \x20   let f = || label.len() + n;\n\
+         \x20   let after = label.len();\n\
+         \x20   || f() + after\n\
+         }}\n\
+         fn run_loop(frames: i64) -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..frames {{\n\
+         \x20       let r = make_reader(i);\n\
+         \x20       total = total + r();\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let total = run_loop({frames});\n\
+         \x20   if total != {expected_total} {{ return 90; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+fn borrow_capture_two_shares_loop_source(frames: usize) -> String {
+    let label_len = "row-payload-seed".len();
+    let expected_total = frames * 3 * label_len + frames * frames.saturating_sub(1);
+    format!(
+        "fn two_shares(n: i64) -> i64 {{\n\
+         \x20   let label = \"row-payload-seed\".to_upper();\n\
+         \x20   let a = || label.len() + n;\n\
+         \x20   let b = || label.len() + n;\n\
+         \x20   a() + b() + label.len()\n\
+         }}\n\
+         fn run_loop(frames: i64) -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..frames {{\n\
+         \x20       total = total + two_shares(i);\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let total = run_loop({frames});\n\
+         \x20   if total != {expected_total} {{ return 89; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Record source read after a field-projecting capture, closure invoked
+/// directly (no std combinator): isolates the retained-share capture ownership
+/// from the pre-existing closure-pair-argument leak the `iter::any` pin below
+/// tracks.
+fn borrow_capture_record_read_after_loop_source(frames: usize) -> String {
+    let item_len = "row-item".len();
+    let expected_total = frames * (1 + item_len) + frames * frames.saturating_sub(1) / 2;
+    format!(
+        "type Claim {{\n\
+         \x20   item: string;\n\
+         \x20   run_id: string;\n\
+         }}\n\
+         fn probe() -> i64 {{\n\
+         \x20   let claim = Claim {{ item: \"row-item\".to_upper(), run_id: \"row-run\".to_upper() }};\n\
+         \x20   let matches_run = |t: string| t == claim.run_id;\n\
+         \x20   var score: i64 = 0;\n\
+         \x20   if matches_run(\"ROW-RUN\") {{ score = score + 1; }}\n\
+         \x20   if matches_run(\"nope\") {{ score = score + 100; }}\n\
+         \x20   score + claim.item.len()\n\
+         }}\n\
+         fn run_loop(frames: i64) -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..frames {{\n\
+         \x20       total = total + probe() + i;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let total = run_loop({frames});\n\
+         \x20   if total != {expected_total} {{ return 87; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// The elegance-probe shape that falsified #2933's "closures solid" claim: a
+/// record binding field-projected inside an `iter::any` predicate closure, with
+/// the record still used AFTERWARDS. Pre-fix this was rejected outright
+/// (`E_MIR_CHECK UseAfterConsume` — the Borrow capture lowered as `OwnsMoved`),
+/// which forced index loops in every filter+side-output pattern.
+///
+/// This shape has NO leak-slope oracle: the closure-pair temp passed into the
+/// generic `iter::any` leaks its env on main independently of capture
+/// ownership (differentially confirmed: main-era and post-fix binaries leak
+/// the same ~4 nodes/iteration; a capture-free predicate still leaks
+/// ~1/iteration) — a separate std/iter call-carrier seam. The
+/// direct-invocation slope oracle above owns the capture-ownership leak
+/// question; this pin owns compile + correctness + no-double-free.
+fn borrow_capture_record_iter_any_loop_source(frames: usize) -> String {
+    let expected_total = frames * 2 + frames * frames.saturating_sub(1) / 2;
+    format!(
+        "import std::iter;\n\
+         pub type Claim {{\n\
+         \x20   item: string;\n\
+         \x20   run_id: string;\n\
+         }}\n\
+         fn probe() -> i64 {{\n\
+         \x20   let claim = Claim {{ item: \"row-item\".to_upper(), run_id: \"row-run\".to_upper() }};\n\
+         \x20   let runs = Vec::new();\n\
+         \x20   runs.push(\"ROW-RUN\");\n\
+         \x20   let hit = iter::any(runs.into_iter(), |terminal: string| terminal == claim.run_id);\n\
+         \x20   let out = Vec::new();\n\
+         \x20   out.push(claim.item);\n\
+         \x20   var score: i64 = 0;\n\
+         \x20   if hit {{ score = score + 1; }}\n\
+         \x20   score + out.len()\n\
+         }}\n\
+         fn run_loop(frames: i64) -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..frames {{\n\
+         \x20       total = total + probe() + i;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let total = run_loop({frames});\n\
+         \x20   if total != {expected_total} {{ return 88; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
 fn shared_source_two_closures_source() -> String {
     "type PairFns {\n\
      \x20   a: fn() -> i64;\n\
@@ -363,20 +508,6 @@ fn shared_source_closure_plus_original_store_source() -> String {
      fn main() -> i64 {\n\
      \x20   let p = make_pair(1);\n\
      \x20   p.f() + p.label.len()\n\
-     }\n"
-    .to_string()
-}
-
-fn shared_source_read_after_capture_source() -> String {
-    "fn make_reader(n: i64) -> fn() -> i64 {\n\
-     \x20   let label: string = \"row-payload-seed\".to_upper();\n\
-     \x20   let f = || label.len() + n;\n\
-     \x20   let after = label.len();\n\
-     \x20   || f() + after\n\
-     }\n\
-     fn main() -> i64 {\n\
-     \x20   let f = make_reader(1);\n\
-     \x20   f()\n\
      }\n"
     .to_string()
 }
@@ -638,9 +769,117 @@ fn parameter_record_capture_both_fields_freed_exactly_once_under_malloc_scribble
     );
 }
 
-/// Shared-source oracle (#2433 shape 2): two escaping closures must not both
-/// own the same heap handle. Until a clone/retain path exists, this fails closed
-/// at compile time instead of reaching the poisoned allocator double-free.
+// -- retained-share captures (D3 / #2933 amendment) --------------------------
+
+/// Slope oracle: read-after-capture (string). The checker-`Borrow` capture
+/// takes a RETAINED SHARE (`OwnsClonedOrRetained` + explicit retain) instead of
+/// consuming the source — pre-fix this shape failed closed with
+/// `UseAfterConsume`. The env free thunk and the source's own scope-exit drop
+/// each release one share; the slope stays flat.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn borrow_capture_read_after_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "borrow_capture_read_after",
+        borrow_capture_read_after_loop_source,
+    );
+}
+
+/// No-double-free pin: read-after-capture (string) across 200 iterations under
+/// the poisoned allocator — the retained env share and the live source binding
+/// are independent owners; a second release of EITHER aborts.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn borrow_capture_read_after_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "borrow_capture_read_after_df",
+        &borrow_capture_read_after_loop_source(200),
+    );
+}
+
+/// Slope oracle: two closures sharing one source string, plus a direct read of
+/// the source — three co-owners (two retained env shares + the original), three
+/// releases, flat slope.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn borrow_capture_two_shares_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "borrow_capture_two_shares",
+        borrow_capture_two_shares_loop_source,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn borrow_capture_two_shares_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "borrow_capture_two_shares_df",
+        &borrow_capture_two_shares_loop_source(200),
+    );
+}
+
+/// Slope oracle: record source read after a field-projecting capture (direct
+/// invocation) — the env's retained record share and the source's own drop
+/// each release once; flat slope.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn borrow_capture_record_read_after_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "borrow_capture_record_read_after",
+        borrow_capture_record_read_after_loop_source,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn borrow_capture_record_read_after_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "borrow_capture_record_read_after_df",
+        &borrow_capture_record_read_after_loop_source(200),
+    );
+}
+
+/// Elegance-probe regression (D3, amends #2933): compile + correctness +
+/// no-double-free for the `iter::any` shape. See the fixture doc for why this
+/// shape carries no slope oracle (pre-existing std/iter closure-pair-argument
+/// leak, independent of capture ownership).
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn borrow_capture_record_iter_any_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "borrow_capture_record_iter_any_df",
+        &borrow_capture_record_iter_any_loop_source(200),
+    );
+}
+
+// -- remaining fail-closed seams ---------------------------------------------
+
+/// The `label` sharing between two escaping closures is now legal (each env
+/// takes a retained share), but storing a CAPTURING closure pair into a record
+/// field still fails closed — `UseAfterConsume` fires on `a`/`b` at the
+/// `RecordInit` (the closure-pair-into-record transfer has no ownership
+/// protocol yet). This pin holds the fail-closed line at that seam.
 #[test]
 fn shared_source_two_escaping_closures_fail_closed() {
     assert_compile_fails(
@@ -650,20 +889,14 @@ fn shared_source_two_escaping_closures_fail_closed() {
     );
 }
 
+/// Same seam as above: the capture itself (closure + original both live) is now
+/// a legal retained share, but the record store of the capturing closure pair
+/// `f` still fails closed at the `RecordInit`.
 #[test]
 fn shared_source_closure_plus_original_store_fail_closed() {
     assert_compile_fails(
         "shared_source_original_store",
         &shared_source_closure_plus_original_store_source(),
-        "UseAfterConsume",
-    );
-}
-
-#[test]
-fn shared_source_read_after_capture_fail_closed() {
-    assert_compile_fails(
-        "shared_source_read_after_capture",
-        &shared_source_read_after_capture_source(),
         "UseAfterConsume",
     );
 }

--- a/hew-mir/src/lower/closure_gen.rs
+++ b/hew-mir/src/lower/closure_gen.rs
@@ -240,11 +240,29 @@ impl Builder {
     /// the ledger turns exactly that case into `BorrowsOnly`: the env aliases the
     /// value and releases nothing — the leak-not-double-free direction, and the
     /// same answer the binder itself gave.
+    ///
+    /// A checker-inferred `Borrow` capture (read-only body use, no `move`
+    /// keyword) does NOT consume the source: the env owns a RETAINED SHARE
+    /// (`OwnsClonedOrRetained`) and the source binding keeps its own owner.
+    /// The string ownership prover mints the balancing `+1`
+    /// (`string_share_sink_places` lists these env fields as share sinks;
+    /// aggregate sources get `StringRetainCondition::AggregateBorrowedIngress`),
+    /// and the env free thunk releases the env's share — two independent
+    /// owners, each released exactly once. The share is admitted only for
+    /// shapes the recursive string retain fully co-owns
+    /// (`string_or_bitcopy_tree`): a shape with bytes/collection/resource
+    /// leaves keeps the consuming `OwnsMoved` capture — the fail-closed
+    /// direction (compile-time `UseAfterConsume` on a later source use), never
+    /// a partially-retained env that would double-free the unretained leaves.
+    /// That fallback retires when a whole-value retain/clone authority exists
+    /// for those leaf classes (copy-on-write north star); extend the predicate, not this
+    /// match.
     fn closure_env_capture_ownership(
         &self,
         strategy: crate::closure_env::AllocationStrategy,
         ty: &ResolvedTy,
         source_binding: Option<BindingId>,
+        mode: hew_types::ClosureCaptureMode,
     ) -> ClosureEnvFieldOwnership {
         match strategy {
             crate::closure_env::AllocationStrategy::Stack
@@ -269,6 +287,15 @@ impl Builder {
                     .is_some_and(|binding| self.proven_foreign_bindings.contains(&binding));
                 if nothing_to_own || proven_foreign {
                     ClosureEnvFieldOwnership::BorrowsOnly
+                } else if mode == hew_types::ClosureCaptureMode::Borrow
+                    && super::composite_own::string_or_bitcopy_tree(
+                        &ty,
+                        &self.record_field_orders,
+                        &self.enum_layouts,
+                        &mut HashSet::new(),
+                    )
+                {
+                    ClosureEnvFieldOwnership::OwnsClonedOrRetained
                 } else {
                     ClosureEnvFieldOwnership::OwnsMoved
                 }
@@ -407,7 +434,12 @@ impl Builder {
                 continue;
             };
             let field_ty = self.subst_ty(&capture.ty);
-            let ownership = self.closure_env_capture_ownership(strategy, &field_ty, source_binding);
+            let ownership = self.closure_env_capture_ownership(
+                strategy,
+                &field_ty,
+                source_binding,
+                capture.mode,
+            );
             if ownership == ClosureEnvFieldOwnership::OwnsMoved {
                 if let Some(binding) = source_binding {
                     self.statements.push(MirStatement::Use {

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -36,6 +36,7 @@ use super::{
     PayloadBinderRoot, Place, ResolvedTy, RootScan, ScopeId, ScopeInfoEntry, StringRetainCondition,
     SuspendKind, Terminator, FOR_ITER_CURSOR_NAME_PREFIX,
 };
+pub(crate) use aggregate_borrowed_ingress_clone::string_or_bitcopy_tree;
 use aggregate_borrowed_ingress_clone::{
     aggregate_borrowed_ingress_retain_clones_value, aggregate_borrowed_ingress_sink_clones_source,
 };

--- a/hew-mir/src/lower/composite_own/aggregate_borrowed_ingress_clone.rs
+++ b/hew-mir/src/lower/composite_own/aggregate_borrowed_ingress_clone.rs
@@ -121,7 +121,17 @@ pub(super) fn aggregate_borrowed_ingress_sink_clones_source(
         }))
 }
 
-fn string_or_bitcopy_tree(
+/// Whether every owning leaf of `ty` is a `string` (or the shape is pure
+/// bit-copy) — the exact class `StringRetainCondition::AggregateBorrowedIngress`
+/// can turn into an independent co-owner with one recursive retain. Shapes with
+/// bytes, collections, indirect enums, resources, or opaque handles return
+/// `false`: the aggregate string retain does not clone those leaves.
+///
+/// Shared with the closure-capture ownership classifier
+/// (`closure_env_capture_ownership`): a `Borrow` capture may become a retained
+/// share (`OwnsClonedOrRetained`) only for shapes this predicate admits, so the
+/// classifier and the retain-derivation proof stay one authority.
+pub(crate) fn string_or_bitcopy_tree(
     ty: &ResolvedTy,
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
     enum_layouts: &[crate::model::EnumLayout],

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -1846,6 +1846,37 @@ pub(super) fn derive_cow_sole_owner(
             }
 
             if let Instr::ClosureEnvInit { fields, .. } = instr {
+                // A retained-share capture (`OwnsClonedOrRetained`) makes the
+                // heap env a genuine CO-OWNER: the env free thunk releases the
+                // field unconditionally while the source binding keeps its own
+                // scope-exit owner, so the mint here is UNCONDITIONAL — there
+                // is no hand-off arm for this ownership class (used-after
+                // inference decides retain-vs-transfer for `OwnsMoved`
+                // ingress; a retained field's release is fixed at the thunk,
+                // so skipping the mint when the source looks dead
+                // double-frees at the source's still-present scope-exit
+                // drop). This loop is the single retain authority for these
+                // fields; the generic share-sink walk below skips them.
+                for field in fields.iter().filter(|field| {
+                    field.ownership == ClosureEnvFieldOwnership::OwnsClonedOrRetained
+                }) {
+                    let condition = if string_place_is_typed(field.src, locals) {
+                        StringRetainCondition::Always
+                    } else {
+                        // Aggregate source: recursive leaf retain. The
+                        // capture classifier admits only
+                        // `string_or_bitcopy_tree` shapes, the exact class
+                        // this condition fully co-owns.
+                        StringRetainCondition::AggregateBorrowedIngress
+                    };
+                    aggregate_ingress_share_sites.push(StringRetainSite {
+                        block: block.id,
+                        instr_index,
+                        value: field.src,
+                        condition,
+                        required_bindings: Vec::new(),
+                    });
+                }
                 for field in fields
                     .iter()
                     .filter(|field| field.ownership == ClosureEnvFieldOwnership::OwnsMoved)
@@ -1887,10 +1918,27 @@ pub(super) fn derive_cow_sole_owner(
             } else {
                 string_share_sink_places(instr)
             };
+            // Retained-share env fields already received their unconditional
+            // mint in the `ClosureEnvInit` loop above; running them through
+            // the used-after inference here would add a second retain (leak)
+            // or classify a dead-looking source as a hand-off (double-free).
+            let retained_env_field_srcs: HashSet<Place> = match instr {
+                Instr::ClosureEnvInit { fields, .. } => fields
+                    .iter()
+                    .filter(|field| {
+                        field.ownership == ClosureEnvFieldOwnership::OwnsClonedOrRetained
+                    })
+                    .map(|field| field.src)
+                    .collect(),
+                _ => HashSet::new(),
+            };
             if !share_places.is_empty() {
                 let mut candidate_groups: HashMap<u32, Vec<Place>> = HashMap::new();
                 let mut external_groups: HashMap<u32, (bool, Vec<Place>)> = HashMap::new();
                 for place in share_places {
+                    if retained_env_field_srcs.contains(&place) {
+                        continue;
+                    }
                     let Some(local) = base_local(place) else {
                         continue;
                     };

--- a/hew-mir/tests/lowering_expr/closure_env_ownership.rs
+++ b/hew-mir/tests/lowering_expr/closure_env_ownership.rs
@@ -100,8 +100,13 @@ fn run_loop(frames: i64) -> i64 {
     );
 }
 
+/// A checker-`Borrow` (read-only) heap capture of a `string` is a RETAINED
+/// SHARE: the env field manifest records `OwnsClonedOrRetained`, an
+/// unconditional `StringRetain` mints the env's co-owner before the env init,
+/// and the source binding is NOT consumed (its own scope-exit owner survives).
+/// The env free thunk releases the env's share — two owners, two releases.
 #[test]
-fn single_source_heap_capture_manifest_owns_moved_source() {
+fn single_source_heap_borrow_capture_manifest_is_retained_share() {
     let pl = pipeline_with_tc(
         r#"
 fn make_label(n: i64) -> fn() -> i64 {
@@ -116,28 +121,64 @@ fn make_label(n: i64) -> fn() -> i64 {
         pl.diagnostics
     );
     let make_label = raw_fn(&pl, "make_label");
-    let env_fields: Vec<_> = make_label
+    let instructions: Vec<_> = make_label
         .blocks
         .iter()
         .flat_map(|block| block.instructions.iter())
-        .filter_map(|instr| match instr {
-            Instr::ClosureEnvInit { fields, .. } => Some(fields),
+        .collect();
+    let (env_init_index, retained_src, retained_binding) = instructions
+        .iter()
+        .enumerate()
+        .find_map(|(index, instr)| match instr {
+            Instr::ClosureEnvInit { fields, .. } => fields
+                .iter()
+                .find(|field| {
+                    field.allocation == ClosureEnvAllocation::Heap
+                        && field.ownership == ClosureEnvFieldOwnership::OwnsClonedOrRetained
+                })
+                .and_then(|field| {
+                    field
+                        .source_binding
+                        .map(|binding| (index, field.src, binding))
+                }),
             _ => None,
         })
-        .flat_map(|fields| fields.iter())
-        .collect();
+        .expect("heap Borrow string capture must carry a retained-share manifest");
+    let retain_index = instructions
+        .iter()
+        .position(
+            |instr| matches!(instr, Instr::StringRetain { value, .. } if *value == retained_src),
+        )
+        .expect("the env co-owner must be minted with a StringRetain");
     assert!(
-        env_fields.iter().any(|field| {
-            field.allocation == ClosureEnvAllocation::Heap
-                && field.ownership == ClosureEnvFieldOwnership::OwnsMoved
-                && field.source_binding.is_some()
-        }),
-        "heap string capture must own a moved source binding: {env_fields:?}"
+        retain_index < env_init_index,
+        "the retain must precede the env init that byte-copies the handle"
+    );
+    assert!(
+        !make_label
+            .blocks
+            .iter()
+            .flat_map(|block| block.statements.iter())
+            .any(|stmt| matches!(
+                stmt,
+                hew_mir::MirStatement::Use {
+                    binding,
+                    intent: hew_hir::IntentKind::Consume,
+                    ..
+                } if *binding == retained_binding
+            )),
+        "a retained-share capture must not consume the source binding"
     );
 }
 
+/// A read-only (`Borrow`) capture of an owned call-carrier record parameter is
+/// a RETAINED SHARE: the env field manifest records `OwnsClonedOrRetained`, an
+/// `AggregateBorrowedIngress` string retain mints the env's co-owner over the
+/// record's string leaves before the env init, and the parameter is NOT
+/// moved-and-neutralized — its own terminal carrier drop survives as the
+/// second, independent release.
 #[test]
-fn owned_carrier_parameter_capture_transfers_before_terminal_drop() {
+fn owned_carrier_parameter_borrow_capture_retains_and_keeps_terminal_drop() {
     let pl = pipeline_with_tc(
         r#"
 type Holder {
@@ -179,48 +220,41 @@ fn run_once() -> i64 {
                 .iter()
                 .find(|field| {
                     field.source_is_parameter
-                        && field.ownership == ClosureEnvFieldOwnership::OwnsMoved
+                        && field.ownership == ClosureEnvFieldOwnership::OwnsClonedOrRetained
                 })
                 .map(|field| (index, field.src)),
             _ => None,
         })
-        .expect("owned parameter capture manifest");
+        .expect("retained-share parameter capture manifest");
 
     let parameter = Place::Local(0);
-    assert_ne!(
-        env_source, parameter,
-        "the heap env must receive the transferred owner, not alias the parameter slot"
-    );
-    let move_index = instructions
+    let retain_index = instructions
         .iter()
         .position(|instr| {
-            matches!(instr, Instr::Move { dest, src } if *dest == env_source && *src == parameter)
+            matches!(
+                instr,
+                Instr::StringRetain {
+                    value,
+                    condition: hew_mir::StringRetainCondition::AggregateBorrowedIngress,
+                } if *value == env_source
+            )
         })
-        .expect("carrier parameter move into the env source");
-    let neutralize_indices: Vec<_> = instructions
-        .iter()
-        .enumerate()
-        .filter_map(|(index, instr)| {
-            matches!(instr, Instr::NeutralizePayloadSlot { place, .. } if *place == parameter)
-                .then_some(index)
-        })
-        .collect();
-    assert_eq!(
-        neutralize_indices.len(),
-        1,
-        "the captured carrier parameter must be neutralized exactly once"
-    );
-    let terminal_drop_index = instructions
-        .iter()
-        .position(
-            |instr| matches!(instr, Instr::ValueSnapshotDrop { value, .. } if *value == parameter),
-        )
-        .expect("terminal owned-carrier parameter drop");
+        .expect("the env co-owner must be minted with an aggregate string retain");
     assert!(
-        move_index < neutralize_indices[0]
-            && neutralize_indices[0] < env_init_index
-            && env_init_index < terminal_drop_index,
-        "the owner must move and neutralize before env initialization, while the terminal drop remains"
+        retain_index < env_init_index,
+        "the aggregate retain must precede the env init that byte-copies the record"
+    );
+    assert!(
+        !instructions.iter().any(|instr| {
+            matches!(instr, Instr::NeutralizePayloadSlot { place, .. } if *place == parameter)
+        }),
+        "a retained-share capture must not neutralize the parameter slot"
+    );
+    assert!(
+        instructions.iter().any(|instr| {
+            matches!(instr, Instr::ValueSnapshotDrop { value, .. } if *value == parameter)
+        }),
+        "the parameter's terminal owned-carrier drop must survive as the second release"
     );
 }
 
@@ -300,6 +334,11 @@ fn run_loop(frames: i64) -> i64 {
     );
 }
 
+/// The `label` sharing between the two closures is now legal (each env takes a
+/// retained share), but storing a CAPTURING closure pair into a record field
+/// still fails closed (`UseAfterConsume` on `a`/`b` at the `RecordInit`) — the
+/// closure-pair-into-record transfer has no ownership protocol yet. This pin
+/// holds the fail-closed line at that seam.
 #[test]
 fn shared_source_heap_capture_fails_closed_before_codegen() {
     let pl = pipeline_with_tc(

--- a/hew-mir/tests/lowering_expr/owner_mint_warrant_seams.rs
+++ b/hew-mir/tests/lowering_expr/owner_mint_warrant_seams.rs
@@ -52,6 +52,15 @@ fn own_moved_env_fields(p: &IrPipeline) -> usize {
         .count()
 }
 
+/// Retained-share closure-env capture fields (`own_cloned_or_retained`): the
+/// env destructor releases the env's OWN share while the source binding keeps
+/// its scope-exit owner — the checker-`Borrow` capture manifest.
+fn retained_share_env_fields(p: &IrPipeline) -> usize {
+    hew_mir::dump_mir(p, DumpStage::Raw)
+        .matches("own=own_cloned_or_retained")
+        .count()
+}
+
 fn record_in_place_drops(p: &IrPipeline, fn_name: &str) -> usize {
     p.elaborated_mir
         .iter()
@@ -149,16 +158,30 @@ fn a_heap_env_capture_of_a_proven_foreign_binding_takes_no_ownership() {
 
 /// The counterfactual, and it is the whole reason the assertion above cannot be
 /// satisfied by deleting the mint: the identically shaped DOMESTIC capture
-/// still moves into the env and the env destructor is still its release
-/// authority. Exact count: **1**.
+/// still makes the env destructor a release authority. Since the checker
+/// classifies this read-only capture as `Borrow`, the env now owns a RETAINED
+/// SHARE (`own_cloned_or_retained`) rather than consuming the source: the env
+/// destructor releases the env's share and the source binding keeps its own
+/// scope-exit owner. Exact counts: **1** retained env field, **0** moved, and
+/// the source's `RecordInPlace` scope-exit releases survive in `main`.
 #[test]
 fn a_heap_env_capture_of_a_domestic_binding_still_owns_it() {
     let p = in_loop(&format!("{RUN}{DOMESTIC_MK}"), CAPTURE_BODY);
     assert_eq!(
-        own_moved_env_fields(&p),
+        retained_share_env_fields(&p),
         1,
-        "the withhold is provenance-directed: a domestic capture keeps its \
-         ownership transfer into the closure env"
+        "the withhold is provenance-directed: a domestic read-only capture \
+         mints a retained share into the closure env"
+    );
+    assert_eq!(
+        own_moved_env_fields(&p),
+        0,
+        "a Borrow-mode capture of a retainable shape must not consume the source"
+    );
+    assert!(
+        record_in_place_drops(&p, "main") > 0,
+        "the source binding keeps its own scope-exit release alongside the \
+         env's retained share"
     );
 }
 


### PR DESCRIPTION
## Summary

A closure that captures a heap value read-only no longer consumes the source binding. Borrow-mode captures of string and bit-copy shapes now lower as co-owned retained shares, so the original stays usable after the closure literal. Vec, bytes, resource, and handle captures deliberately keep the fail-closed consuming behaviour. The used-after hand-off inference now excludes retained fields, closing a double-free on the dead-source path found during implementation.

This amends the closures finding in #2933.

## Verification

- Closure capture ownership oracle (`closure_capture_owned_leak_oracle`): 24/24 pass — leak-slope checks and the malloc-scribble matrix, including multi-closure sharing of one source
- `cargo test -p hew-mir`: all targets pass, 0 failures (1709 tests)
- Ratchet: green
- Regression pins verified in both directions: failing on the pre-fix compiler, passing on this branch
- Preflight: ready-to-push

## Out of scope

- Actor/suspension capture regression tests (tracked)
- Pre-existing iter-closure-pair env leak (tracked)