### PR TITLE
fix(ci): provision the wasm32 target in playground build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust-build
         with:
+          targets: wasm32-unknown-unknown
           cache-shared-key: playground-wasm
 
       - name: Install wasm-pack v0.13.1 and Binaryen 117
@@ -704,6 +705,7 @@ jobs:
       - uses: ./.github/actions/setup-rust-build
         if: env.RUN_CODE_PATH == 'true'
         with:
+          targets: wasm32-unknown-unknown
           tools: nextest
           cache-shared-key: build-test-linux
 

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -1081,6 +1081,14 @@ def test_wasm_pack_consumers_prefetch_checksum_pinned_binaryen() -> None:
         assert job.index(action_use) < job.index(build_command)
 
 
+def test_ci_wasm_consumers_provision_unknown_target() -> None:
+    ci = CI_WORKFLOW.read_text()
+    for job_name in ("playground-wasm-build", "build-and-test"):
+        job = workflow_job(ci, job_name)
+        assert "uses: ./.github/actions/setup-rust-build" in job
+        assert "targets: wasm32-unknown-unknown" in job
+
+
 def test_binaryen_prefetch_pin_mutations_are_rejected() -> None:
     action = SETUP_WASM_PACK_ACTION.read_text()
     mutated = action.replace(BINARYEN_SHA256, "0" * 64)


### PR DESCRIPTION
## Summary

The playground WASM jobs install their toolchain through `setup-rust-build`, which passes an explicit `toolchain: stable` to `dtolnay/rust-toolchain` — bypassing `rust-toolchain.toml`'s pinned target list. As a result `wasm32-unknown-unknown` and its bundled `rust-lld` were never provisioned, and `wasm-pack` failed with "spawn rust-lld" errors. The two affected jobs (`playground-wasm-build` and the `build-and-test` code path) now request the target explicitly via the action's `targets:` input, and a workflow contract test asserts both jobs keep provisioning it.

## Verification

- Workflow contract tests (`scripts/tests/test_release_workflow_contract.py`, incl. the new `test_ci_wasm_consumers_provision_unknown_target`): passing
- actionlint on `.github/workflows/ci.yml`: clean
- Preflight: ready-to-push

## Out of scope

- `setup-rust-build`'s explicit `toolchain: stable` pin (the underlying bypass of `rust-toolchain.toml`) is left as-is; this change provisions the missing target at the two consuming jobs rather than reworking the composite action's toolchain resolution.
- wasm-pack/Binaryen installation and caching are unchanged.