### PR TITLE
build: route escape-prone cross-crate gates in the preflight dispatcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ The installer is worktree-safe and targets the shared git common dir, so linked 
 
 The pre-push hook runs `cargo fmt --all -- --check` — it is intentionally fast. Its job is to catch unformatted code before it reaches review; it is not a substitute for CI.
 
-For substantive changes, run `make ci-preflight` yourself before opening a PR. CI runs `make ci-preflight` (or its dispatcher) on every PR regardless, so formatting errors, clippy violations, and test failures will be caught there. The pre-push hook just keeps the signal fast and local.
+For substantive changes, run `make preflight` yourself before opening a PR. It is the standard diff-routed, fail-fast gate for local iteration; reserve `make ci-preflight` for integration and release moments. CI runs the dispatcher on every PR regardless, so formatting errors, clippy violations, and test failures will be caught there. The pre-push hook just keeps the signal fast and local.
 
 If `cargo fmt --check` fails: run `cargo fmt --all` and re-push. There is no environment-based exemption and no `--no-verify` bypass.
 
@@ -80,7 +80,7 @@ Use `test-runtime-unit` for no-network runtime iteration and `test-compiler-pipe
 
 `make test-runtime-unit` is the recommended target when iterating on `hew-runtime` logic that does not touch QUIC, TLS, or the profiler. It runs the full `hew-runtime` test suite (lib unit tests + all integration tests) with `--no-default-features`, cutting compile time roughly 3× (measured: ~32 s vs ~85 s per integration test binary on a warm build cache). The two profiler allocator tests in `transport.rs` are excluded under this target because they require active allocation counters to be meaningful; they still run under `cargo test -p hew-runtime` (default features).
 
-`make ci-preflight` dispatches a conservative local preflight from your current diff and is the recommended manual gate before opening a PR or tagging a release. Pass `ARGS="--dry-run"` to preview without running. CI runs this on every PR regardless.
+`make preflight` dispatches a conservative, diff-routed local preflight and fails fast; it is the standard manual gate before opening a PR. Reserve `make ci-preflight` for integration and release moments. Pass `ARGS="--dry-run"` to preview without running. CI runs the dispatcher on every PR regardless.
 
 ### E2E test workflow
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,10 @@
 #   make licenses-check            — verify THIRD-PARTY-LICENSES is current (used in CI)
 #   make check-gate-reachability   — verify every gate target/crate/exclusion is reached by CI,
 #                                    and every documented make target exists
-#   make ci-preflight              — dispatch a conservative local preflight from the current diff
+#   make preflight                 — STANDARD per-branch gate: dispatcher-routed checks for the
+#                                    current diff, fail-fast; hosted CI remains the backstop
+#   make ci-preflight              — run-all dispatcher preflight; for integration/release
+#                                    moments (merge trains, RC cuts), not routine branch gating
 #   make ci-preflight-smoke        — fast smoke tier: fmt + in-process tests (<5 min)
 #   make ci-preflight-strict       — run the local preflight superset that mirrors merge-queue gates
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
@@ -68,7 +71,7 @@
 #   make clean        — remove build/, target/
 # ============================================================================
 
-.PHONY: all build bootstrap install-hooks hew hew-native hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
+.PHONY: all build bootstrap install-hooks hew hew-native hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
 .PHONY: test macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix test-o2-differential o2-differential-selftest test-stdlib-ratchet test-stdlib-execution-proofs test-ux-examples test-surface-examples test-example-expectations-selftest test-release-binary test-release-lib-link test-release-workflow-contract check-sanitizer-gate asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-structural-authority-audit test-ast-grep-contract test-structural-lint-bootstrap runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo lint-wasm-todo-self-test leak-scan hew-fmt-check check-gate-reachability test-check-gate-reachability sandbox-parity-coverage-check test-sandbox-parity-coverage-check doc-ratchet-selftest freebsd-workflow-contract-check verify-sys-lane-closure test-sys-lane-closure hew-fmt-property
 .PHONY: clean install uninstall verify-ffi test-verify-ffi test-python310-toml-compat
 .PHONY: assemble assemble-release pre-release publish-docs
@@ -371,7 +374,24 @@ playground-wasi-check:
 	cargo test -p hew-cli --test wasi_run_e2e curated_playground_examples_run_under_wasi -- --exact
 	cargo test -p hew-cli --test wasi_run_e2e supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi -- --exact
 
-# Conservative diff-based local preflight dispatcher.
+# Standard per-branch gate: the dispatcher classifies the current diff and
+# runs the narrowest sufficient checks for its file classes, stopping at the
+# first failure for quick iteration.  This is THE routine gate before pushing a
+# branch — hosted CI is the backstop for cross-cutting fallout the routing cannot
+# foresee.  Escape classes observed while gating by hand-picked per-crate tests
+# (structural ratchets outside the cargo dependency graph, cross-crate exec
+# fallout from resolver changes, ll-oracle golden drift from emission reorders)
+# are routed by the dispatcher itself, so use this target rather than an ad-hoc
+# test selection.
+# Usage: make preflight            (classify + run, fail-fast)
+#        make preflight ARGS="--dry-run"   (print the routing only)
+preflight:
+	scripts/ci-preflight-dispatcher.sh --fail-fast $(ARGS)
+
+# Conservative diff-based local preflight dispatcher, run-all failure policy.
+# Reserve for integration/release moments (merge trains, RC cuts, post-squash
+# re-verification) where the complete failure report is worth the wall clock;
+# routine branch gating uses make preflight above.
 # Usage: make ci-preflight ARGS="--dry-run" or ARGS="--base origin/main"
 ci-preflight:
 	scripts/ci-preflight-dispatcher.sh $(ARGS)

--- a/README.md
+++ b/README.md
@@ -287,20 +287,20 @@ brew install llvm
 ```bash
 make          # Build everything (debug)
 make release  # Build everything (optimized)
-make ci-preflight  # Dispatch a conservative local preflight from your current diff
+make preflight     # Diff-routed, fail-fast pre-PR gate
 make test     # Run Rust + native codegen tests
 make lint     # cargo clippy
 ```
 
 See the [Makefile](Makefile) header for all targets.
 
-Use `make ci-preflight ARGS="--dry-run"` to inspect the selected commands before
-running them. By default the dispatcher runs every selected command, collects
-any failures, and reports the full timing summary at the end so one local run
-shows the whole preflight picture. Pass `make ci-preflight ARGS="--fail-fast"`
-if you want it to stop after the first failed command instead. The first slice
-stays conservative: known docs/parser/types/CLI diffs get narrower checks, and
-everything else falls back to broader local preflight commands.
+Use `make preflight ARGS="--dry-run"` to inspect the selected commands before
+running them. The standard pre-PR gate is diff-routed and fails fast after the
+first failed command. Reserve `make ci-preflight` for integration and release
+moments, when the run-all failure policy and full timing summary are useful.
+The first slice stays conservative: known docs/parser/types/CLI diffs get
+narrower checks, and everything else falls back to broader local preflight
+commands.
 
 ### Browser / Playground Validation
 

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -447,7 +447,7 @@ is_ll_oracle_path() {
     # change can drift it (e.g. an epilogue reorder), and nothing else in the
     # narrow lanes diffs those goldens — only make ll-diff does (~45s).
     case "$1" in
-        hew-codegen-rs/*|hew-mir/*|tests/ll-oracle/*)
+        hew-hir/*|hew-mir/*|hew-codegen-rs/*|tests/ll-oracle/*)
             return 0
             ;;
     esac

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -104,6 +104,10 @@ command_timeout_floor() {
         "make checked-mir-verify") echo 45 ;;
         "make checked-mir-run") echo 420 ;;
         "make ll-diff") echo 45 ;;
+        # Cold-tree headroom for the capability authority ratchet: the crate
+        # itself builds in seconds (serde/toml only) but a cold cargo tree
+        # still pays the shared-dependency compile before the test runs.
+        "cargo nextest run --profile ci -p hew-capability-gen") echo 300 ;;
         "make hew-check-all") echo 300 ;;
         "make hew-fmt-property") echo 600 ;;
         "make test-leak-oracle-selftest") echo 60 ;;
@@ -421,6 +425,35 @@ is_trap_fixtures_path() {
     return 1
 }
 
+is_capability_authority_path() {
+    # hew-capability-gen's authority ratchet (tests/authority.rs) pins checker
+    # coverage over the capability surface STRUCTURALLY — the crate has no
+    # cargo dependency on hew-mir or hew-types, so the reverse-dependency
+    # closure that feeds AFFECTED_PACKAGE_ARGS can never select it.  A
+    # hew-mir / hew-types change can therefore break the ratchet while every
+    # closure-routed test stays green (escape class: structural ratchets that
+    # live outside the cargo dependency graph).
+    case "$1" in
+        hew-mir/*|hew-types/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+is_ll_oracle_path() {
+    # The ll-oracle golden corpus (tests/ll-oracle/corpus/golden) pins the
+    # emitted per-function LLVM IR.  Any MIR-lowering or codegen emission
+    # change can drift it (e.g. an epilogue reorder), and nothing else in the
+    # narrow lanes diffs those goldens — only make ll-diff does (~45s).
+    case "$1" in
+        hew-codegen-rs/*|hew-mir/*|tests/ll-oracle/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
 is_scripts_config_path() {
     case "$1" in
         .gitignore|scripts/*|.github/*)
@@ -549,6 +582,8 @@ needs_sandbox_fixture_check=0
 needs_sandbox_parity=0
 needs_trap_fixtures=0
 needs_runtime_compiled_suite=0
+needs_capability_authority=0
+needs_ll_diff=0
 
 for path in "${CHANGED_FILES[@]}"; do
     crate_dir="${path%%/*}"
@@ -601,6 +636,15 @@ for path in "${CHANGED_FILES[@]}"; do
     # lane body without changing the lane selector itself.
     if is_trap_fixtures_path "$path"; then
         needs_trap_fixtures=1
+    fi
+
+    # Parallel side-channels in the same pattern: these flags append catching
+    # gates after the lane body without changing the lane selector.
+    if is_capability_authority_path "$path"; then
+        needs_capability_authority=1
+    fi
+    if is_ll_oracle_path "$path"; then
+        needs_ll_diff=1
     fi
 
     if is_sandbox_parity_path "$path"; then
@@ -998,6 +1042,29 @@ if (( needs_trap_fixtures == 1 )) && [[ "$LANE" != "fallback" && "$LANE" != "com
     # not already include fuzz-oracle.  Append it so the trap signal-code ratchet
     # runs before push regardless of the primary lane selected.
     add_command "make fuzz-oracle"
+fi
+
+if (( needs_capability_authority == 1 )) && [[ "$LANE" != "fallback" ]]; then
+    # hew-mir / hew-types changed: run the capability authority ratchet
+    # (hew-capability-gen/tests/authority.rs), which pins checker coverage
+    # structurally and sits OUTSIDE the reverse-dep closure — no closure-routed
+    # nextest run ever selects it (see is_capability_authority_path).  Cheap:
+    # the crate depends only on serde/serde_json/toml.  The hew-cli
+    # ownership/affine suites (e.g. affine_resource_carrier_boundaries) do NOT
+    # need an explicit entry here: hew-cli is a reverse dependency of both
+    # crates, so the lane's closure nextest run already carries them — pinned
+    # by test_mir_types_diff_routes_cross_crate_catching_gates.
+    # Skip when LANE is fallback: make test covers the whole workspace.
+    add_command "cargo nextest run --profile ci -p hew-capability-gen"
+fi
+
+if (( needs_ll_diff == 1 )) && [[ "$LANE" != "fallback" ]]; then
+    # MIR lowering / codegen emission changed: diff the ll-oracle golden corpus
+    # so an emission drift (an epilogue reorder, a changed intrinsic sequence)
+    # surfaces locally with the regen instruction instead of costing a hosted
+    # CI cycle.  Intentional drifts regenerate via make ll-golden in the same
+    # commit.  Skip when LANE is fallback: it already includes make ll-diff.
+    add_command "make ll-diff"
 fi
 
 # Orchestration-token leak scan — run on every push for every lane.

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -525,6 +525,111 @@ def test_types_lane_includes_checked_mir_run() -> None:
     )
 
 
+def test_mir_types_diff_routes_capability_authority_ratchet() -> None:
+    """hew-mir / hew-types diffs run the hew-capability-gen authority ratchet.
+
+    hew-capability-gen/tests/authority.rs pins checker coverage over the
+    capability surface STRUCTURALLY; the crate has no cargo dependency on
+    hew-mir or hew-types, so the reverse-dep closure never selects it.  A
+    hew-mir/hew-types branch broke structural_coverage_ratchet_is_pinned with
+    every closure-routed test green — this ratchet locks the explicit gate in.
+    """
+    result = run_dispatcher("hew-mir/src/lower.rs", "hew-types/src/check/resolution.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: compiler-pipeline" in result.stdout, result.stdout
+    assert (
+        "  - cargo nextest run --profile ci -p hew-capability-gen" in result.stdout
+    ), (
+        f"Expected the capability authority ratchet in the routing.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+def test_mir_types_diff_routes_cross_crate_catching_gates() -> None:
+    """The closure nextest run for hew-mir / hew-types diffs carries hew-cli
+    and hew-codegen-rs.
+
+    Two observed escape classes depend on this closure: a hew-mir/hew-types
+    change broke hew-cli/tests/affine_resource_carrier_boundaries.rs, and a
+    hew-types resolver change split stdlib nominal identity, caught only by
+    the hew-codegen-rs exec suites (sink_owned_element_exec).  Both catching
+    suites ride AFFECTED_PACKAGE_ARGS' reverse-dep closure; this ratchet pins
+    that the closure actually selects them, so a closure-computation change
+    cannot silently drop the coverage.
+    """
+    result = run_dispatcher("hew-mir/src/lower.rs", "hew-types/src/check/resolution.rs")
+    assert result.returncode == 0, result.stderr
+    nextest_lines = [
+        line
+        for line in result.stdout.splitlines()
+        if "cargo nextest run --profile ci" in line
+        and "-p hew-capability-gen" not in line
+    ]
+    assert nextest_lines, (
+        f"Expected a closure nextest command.\nstdout:\n{result.stdout}"
+    )
+    for package in ("-p hew-cli", "-p hew-codegen-rs"):
+        assert any(package in line for line in nextest_lines), (
+            f"Expected {package} in the closure nextest run.\nstdout:\n{result.stdout}"
+        )
+
+
+def test_types_resolver_diff_routes_codegen_exec_closure() -> None:
+    """A lone hew-types resolver diff still routes the codegen exec suites.
+
+    The nominal-identity escape came from a resolver change whose fallout was
+    only visible when hew-codegen-rs exec tests compiled and ran stdlib-using
+    programs.  The types lane's closure nextest must therefore carry
+    -p hew-codegen-rs (and the exec binaries with it) for resolver-file diffs.
+    """
+    result = run_dispatcher("hew-types/src/check/resolution.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: types" in result.stdout, result.stdout
+    assert "-p hew-codegen-rs" in result.stdout, (
+        f"Expected -p hew-codegen-rs in the types lane closure.\n"
+        f"stdout:\n{result.stdout}"
+    )
+    assert (
+        "  - cargo nextest run --profile ci -p hew-capability-gen" in result.stdout
+    ), (
+        f"Expected the capability authority ratchet for a hew-types diff.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+def test_codegen_emission_diff_routes_ll_oracle_golden_diff() -> None:
+    """hew-codegen-rs / hew-mir diffs run the ll-oracle golden diff.
+
+    A codegen epilogue reorder invalidated the ll-oracle goldens with the
+    whole compiler-pipeline lane green: nothing in the lane diffed the
+    committed per-function IR corpus.  make ll-diff (~45s) closes that class
+    for emission-reaching diffs; intentional drifts regenerate via ll-golden
+    in the same commit.
+    """
+    for path in ("hew-codegen-rs/src/llvm.rs", "hew-mir/src/lower.rs"):
+        result = run_dispatcher(path)
+        assert result.returncode == 0, result.stderr
+        assert "Selected profile: compiler-pipeline" in result.stdout, result.stdout
+        assert "  - make ll-diff" in result.stdout, (
+            f"Expected 'make ll-diff' for {path}.\nstdout:\n{result.stdout}"
+        )
+
+
+def test_fallback_lane_does_not_duplicate_side_channel_gates() -> None:
+    """The fallback lane already carries ll-diff and the full workspace run;
+    the side-channel flags must not append duplicates on top of it."""
+    result = run_dispatcher("hew-codegen-rs/src/llvm.rs", "tools/some-tool.py")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: comprehensive" in result.stdout, result.stdout
+    assert result.stdout.count("  - make ll-diff") == 1, result.stdout
+    assert (
+        "cargo nextest run --profile ci -p hew-capability-gen" not in result.stdout
+    ), (
+        f"make test already covers hew-capability-gen in the fallback lane.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
 def test_make_test_compiler_pipeline_recipe_keeps_consumer_corpus_packages() -> None:
     """The compiler-pipeline and types lanes delegate hew-cli consumer-corpus
     coverage to make test-compiler-pipeline: its nextest invocation must keep

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -598,7 +598,7 @@ def test_types_resolver_diff_routes_codegen_exec_closure() -> None:
 
 
 def test_codegen_emission_diff_routes_ll_oracle_golden_diff() -> None:
-    """hew-codegen-rs / hew-mir diffs run the ll-oracle golden diff.
+    """hew-hir / hew-codegen-rs / hew-mir diffs run the ll-oracle golden diff.
 
     A codegen epilogue reorder invalidated the ll-oracle goldens with the
     whole compiler-pipeline lane green: nothing in the lane diffed the
@@ -606,7 +606,11 @@ def test_codegen_emission_diff_routes_ll_oracle_golden_diff() -> None:
     for emission-reaching diffs; intentional drifts regenerate via ll-golden
     in the same commit.
     """
-    for path in ("hew-codegen-rs/src/llvm.rs", "hew-mir/src/lower.rs"):
+    for path in (
+        "hew-hir/src/lib.rs",
+        "hew-codegen-rs/src/llvm.rs",
+        "hew-mir/src/lower.rs",
+    ):
         result = run_dispatcher(path)
         assert result.returncode == 0, result.stderr
         assert "Selected profile: compiler-pipeline" in result.stdout, result.stdout


### PR DESCRIPTION
## Summary

Three regression classes recently escaped narrow local gating and were only caught by hosted CI or a full-workspace re-gate:

1. **Structural ratchets outside the cargo dependency graph** — a hew-mir/hew-types change broke `hew-capability-gen/tests/authority.rs` (`structural_coverage_ratchet_is_pinned`). The crate has no cargo dependency on hew-mir or hew-types, so the dispatcher's reverse-dep closure can never select it.
2. **Cross-crate exec fallout from resolver changes** — a hew-types resolver change split stdlib nominal identity, visible only when the hew-codegen-rs exec suites compiled and ran stdlib programs.
3. **ll-oracle golden drift from emission reorders** — a codegen epilogue reorder invalidated the ll-oracle goldens; nothing in the compiler-pipeline profile ran `make ll-diff`.

Dispatcher changes (`scripts/ci-preflight-dispatcher.sh`):
- hew-mir/hew-types diffs append `cargo nextest run --profile ci -p hew-capability-gen` (seconds; the crate depends only on serde/toml), closing class 1.
- hew-mir/hew-codegen-rs/tests/ll-oracle diffs append `make ll-diff` (~45s), closing class 3.
- Class 2 was already routed: the closure nextest run carries `-p hew-codegen-rs` (and `-p hew-cli` with the affine/ownership suites) for these diffs. New dispatcher tests pin that closure coverage so a routing change cannot silently drop it.

Makefile changes:
- New `make preflight` target: the standard per-branch gate — dispatcher-routed checks for the current diff, fail-fast, hosted CI as backstop.
- `make ci-preflight` (run-all) documented as the integration/release-moment profile.

## Verification

- `python3 -m pytest scripts/tests/test_ci_preflight_dispatcher.py` — 59 passed (5 new cases covering the three escape classes and fallback dedup).
- `bash scripts/tests/test_ci_preflight_timeout.sh` — 13 passed.
- `make check-gate-reachability` — green (all documented targets resolve; no unwired gate targets).
- `make test-check-gate-reachability` — 55 passed.
- `make leak-scan`, `shellcheck scripts/ci-preflight-dispatcher.sh` — clean.
- `make test-release-workflow-contract`, `make freebsd-workflow-contract-check`, `make doc-ratchet-selftest`, `make o2-differential-selftest` — all green.
- Dry-run routing for each escape's file set shows the catching gate selected (capability-gen nextest for hew-mir+hew-types; `-p hew-codegen-rs` closure for the resolver file; `make ll-diff` for hew-codegen-rs/src/llvm.rs).
- `make preflight ARGS="--base HEAD"` on a clean tree: no-op in 0.4s; `ARGS="--dry-run"` prints routing without executing.

## Out of scope

- Trimming the closure nextest run's breadth for mixed hew-mir+hew-types diffs (it expands to 11 crates; separate cost/value question).
- Routing `tests/ll-oracle/*` fixture edits onto a narrow lane (they continue to fall back to the comprehensive profile, which already includes ll-diff).