### PR TITLE
fix(cli): resolve test imports from the project root

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1038,32 +1038,6 @@ fn compile_build_binary_with_hew_lib(
     }
 }
 
-pub(crate) fn compile_test_binary_with_paths(
-    input: &Path,
-    output_path: &Path,
-    paths: &NativeBuildPaths,
-    extra_libs: &[String],
-) -> Result<(), ()> {
-    let target = target::TargetSpec::from_requested(None).map_err(|error| {
-        eprintln!("Error: cannot determine the host target: {error}");
-    })?;
-    let options = compile::CompileOptions {
-        project_dir: Some(paths.project_dir.clone()),
-        module_search_paths: Some(paths.module_search_paths.clone()),
-        ..compile::CompileOptions::default()
-    };
-    compile_build_binary_with_hew_lib(
-        input,
-        output_path,
-        &target,
-        false,
-        hew_codegen_rs::OptLevel::O0,
-        extra_libs,
-        &options,
-        Some(&paths.hew_lib),
-    )
-}
-
 /// Emit a single relocatable object for `hew build --emit-obj`, skipping the
 /// link step entirely. Writes `<cwd>/<stem><.o|.obj>` and exits 0 — even for
 /// foreign-OS targets that cannot be linked on this host (the whole point of

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -679,6 +679,15 @@ fn link_native_object_with_hew_lib(
     bin_path: &Path,
     hew_lib: Option<&Path>,
 ) -> Result<(), ()> {
+    link_native_object_with_hew_lib_and_extra(obj, bin_path, hew_lib, &[])
+}
+
+fn link_native_object_with_hew_lib_and_extra(
+    obj: &Path,
+    bin_path: &Path,
+    hew_lib: Option<&Path>,
+    extra_libs: &[String],
+) -> Result<(), ()> {
     let target = target::TargetSpec::from_requested(None).map_err(|e| {
         eprintln!("Error: cannot determine host target: {e}");
     })?;
@@ -688,7 +697,7 @@ fn link_native_object_with_hew_lib(
     let bin_str = bin_path.to_str().ok_or_else(|| {
         eprintln!("Error: output path is not valid UTF-8");
     })?;
-    crate::link::link_executable_with_hew_lib(obj_str, bin_str, &target, &[], false, hew_lib)
+    crate::link::link_executable_with_hew_lib(obj_str, bin_str, &target, extra_libs, false, hew_lib)
         .map_err(|e| {
             crate::diagnostic::emit_plain_diagnostic_line(&e);
         })
@@ -722,11 +731,6 @@ pub(crate) struct NativeBuildPaths {
     pub(crate) hew_lib: PathBuf,
 }
 
-#[allow(
-    clippy::too_many_lines,
-    reason = "cohesive frontend->MIR->emit->link pipeline already at the line boundary; \
-              threading opt_level tipped it over — splitting it would obscure the linear flow"
-)]
 pub(crate) fn compile_native_from_program(
     program: hew_parser::ast::Program,
     source: &str,
@@ -734,10 +738,36 @@ pub(crate) fn compile_native_from_program(
     output_path: &Path,
     options: &compile::CompileOptions,
 ) -> Result<(), ()> {
+    compile_native_from_program_with_paths(
+        program,
+        source,
+        source_label,
+        output_path,
+        options,
+        None,
+        &[],
+    )
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "cohesive frontend->MIR->emit->link pipeline already at the line boundary; \
+              splitting it would obscure the linear flow"
+)]
+pub(crate) fn compile_native_from_program_with_paths(
+    program: hew_parser::ast::Program,
+    source: &str,
+    source_label: &str,
+    output_path: &Path,
+    options: &compile::CompileOptions,
+    paths: Option<&NativeBuildPaths>,
+    extra_libs: &[String],
+) -> Result<(), ()> {
     let target = target::TargetSpec::from_requested(options.target.as_deref()).map_err(|e| {
         eprintln!("Error: {e}");
     })?;
-    let frontend_options = compile::frontend_options(&target, options);
+    let mut frontend_options = compile::frontend_options(&target, options);
+    frontend_options.module_search_paths = paths.map(|paths| paths.module_search_paths.clone());
     let state = hew_compile::run_program_frontend_to_typecheck(
         program,
         source,
@@ -830,7 +860,12 @@ pub(crate) fn compile_native_from_program(
             let obj = artefacts.native_obj_path.as_deref().ok_or_else(|| {
                 eprintln!("E_NOT_YET_IMPLEMENTED: native codegen did not produce an object");
             })?;
-            link_native_object(obj, output_path)
+            link_native_object_with_hew_lib_and_extra(
+                obj,
+                output_path,
+                paths.map(|paths| paths.hew_lib.as_path()),
+                extra_libs,
+            )
         }
         CompileEmitTarget::Wasm => {
             let obj = artefacts.wasm_obj_path.as_deref().ok_or_else(|| {

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -418,8 +418,6 @@ fn summarize(results: Vec<TestResult>) -> TestSummary {
 }
 
 struct CompiledTestArtifact {
-    _source: tempfile::NamedTempFile,
-    _source_tree: tempfile::TempDir,
     _emit_dir: tempfile::TempDir,
     binary_path: PathBuf,
 }
@@ -497,50 +495,33 @@ fn compile_test(
         name = test.name,
     );
 
-    // Mirror only the fixture's relative file-import closure into a writable
-    // temporary tree. The synthetic source keeps the original absolute parent
-    // shape inside that tree, so quoted imports resolve identically without
-    // requiring write access to the source checkout.
-    let source_path = Path::new(&test.file)
-        .canonicalize()
-        .map_err(|error| format!("cannot resolve test source `{}`: {error}", test.file))?;
-    let source_dir = source_path
-        .parent()
-        .ok_or_else(|| "test source path has no parent directory".to_string())?;
-    let source_tree = tempfile::Builder::new()
-        .prefix("hew_test_source_")
-        .tempdir_in(std::env::temp_dir())
-        .map_err(|e| format!("cannot create temp source tree: {e}"))?;
-    mirror_file_imports(source, source_dir, source_tree.path(), &mut HashSet::new())?;
-    let mirrored_source_dir = mirrored_source_path(source_tree.path(), source_dir);
-    std::fs::create_dir_all(&mirrored_source_dir)
-        .map_err(|e| format!("cannot create mirrored test source directory: {e}"))?;
-    let tmp_source = tempfile::Builder::new()
-        .prefix("hew_test_")
-        .suffix(".hew")
-        .tempfile_in(mirrored_source_dir)
-        .map_err(|e| format!("cannot create temp file: {e}"))?;
-
-    std::fs::write(tmp_source.path(), &synthetic)
-        .map_err(|e| format!("cannot write temp file: {e}"))?;
+    let parsed = hew_parser::parse(&synthetic);
 
     let emit_dir = tempfile::Builder::new()
         .prefix("hew_test_emit_")
         .tempdir_in(std::env::temp_dir())
         .map_err(|e| format!("cannot create temp emit dir: {e}"))?;
 
-    let binary_name = tmp_source
-        .path()
+    let source_path = Path::new(&test.file);
+    let binary_name = source_path
         .file_stem()
-        .ok_or_else(|| "temp source path has no file stem".to_string())?;
+        .ok_or_else(|| "test source path has no file stem".to_string())?;
     let binary_path = emit_dir.path().join(binary_name);
     let extra_libs = ffi_lib.into_iter().map(str::to_owned).collect::<Vec<_>>();
 
     crate::diagnostic::start_diagnostic_capture();
-    let compile_result = crate::compile_test_binary_with_paths(
-        tmp_source.path(),
+    // Compile the synthetic program in memory while retaining the real test
+    // path for file-relative imports and the invocation root for package imports.
+    let compile_result = crate::compile_native_from_program_with_paths(
+        parsed.program,
+        &synthetic,
+        &test.file,
         &binary_path,
-        &compile_paths.paths,
+        &crate::compile::CompileOptions {
+            project_dir: Some(compile_paths.paths.project_dir.clone()),
+            ..crate::compile::CompileOptions::default()
+        },
+        Some(&compile_paths.paths),
         &extra_libs,
     );
     let diagnostics = crate::diagnostic::finish_diagnostic_capture();
@@ -553,8 +534,6 @@ fn compile_test(
     }
 
     Ok(CompiledTestArtifact {
-        _source: tmp_source,
-        _source_tree: source_tree,
         _emit_dir: emit_dir,
         binary_path,
     })

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -1,6 +1,7 @@
 //! Execute discovered test cases via the native compilation pipeline.
 
 use super::discovery::TestCase;
+#[cfg(target_os = "linux")]
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 #[cfg(test)]
@@ -420,67 +421,6 @@ fn summarize(results: Vec<TestResult>) -> TestSummary {
 struct CompiledTestArtifact {
     _emit_dir: tempfile::TempDir,
     binary_path: PathBuf,
-}
-
-fn mirrored_source_path(root: &Path, source: &Path) -> PathBuf {
-    let mut mirrored = root.join("source");
-    for component in source.components() {
-        if let std::path::Component::Normal(component) = component {
-            mirrored.push(component);
-        }
-    }
-    mirrored
-}
-
-fn mirror_file_imports(
-    source: &str,
-    source_dir: &Path,
-    mirror_root: &Path,
-    visited: &mut HashSet<PathBuf>,
-) -> Result<(), String> {
-    let parsed = hew_parser::parse(source);
-    for (item, _) in &parsed.program.items {
-        let hew_parser::ast::Item::Import(import) = item else {
-            continue;
-        };
-        let Some(file_path) = import.file_path.as_deref() else {
-            continue;
-        };
-        let imported_source = source_dir
-            .join(file_path)
-            .canonicalize()
-            .map_err(|error| format!("cannot resolve imported test file `{file_path}`: {error}"))?;
-        if !visited.insert(imported_source.clone()) {
-            continue;
-        }
-        let imported_contents = std::fs::read_to_string(&imported_source).map_err(|error| {
-            format!(
-                "cannot read imported test file `{}`: {error}",
-                imported_source.display()
-            )
-        })?;
-        let mirrored = mirrored_source_path(mirror_root, &imported_source);
-        let mirrored_parent = mirrored
-            .parent()
-            .ok_or_else(|| "mirrored imported source has no parent directory".to_string())?;
-        std::fs::create_dir_all(mirrored_parent).map_err(|error| {
-            format!(
-                "cannot create mirrored import directory `{}`: {error}",
-                mirrored_parent.display()
-            )
-        })?;
-        std::fs::write(&mirrored, &imported_contents).map_err(|error| {
-            format!(
-                "cannot write mirrored imported test file `{}`: {error}",
-                mirrored.display()
-            )
-        })?;
-        let imported_dir = imported_source
-            .parent()
-            .ok_or_else(|| "imported test source has no parent directory".to_string())?;
-        mirror_file_imports(&imported_contents, imported_dir, mirror_root, visited)?;
-    }
-    Ok(())
 }
 
 /// Compile a synthetic test program to a native binary.

--- a/hew-cli/tests/test_project_root_fixture/hew.toml
+++ b/hew-cli/tests/test_project_root_fixture/hew.toml
@@ -1,0 +1,3 @@
+[package]
+name = "test_project_root"
+edition = "2026"

--- a/hew-cli/tests/test_project_root_fixture/hew.toml
+++ b/hew-cli/tests/test_project_root_fixture/hew.toml
@@ -1,3 +1,4 @@
 [package]
 name = "test_project_root"
+version = "0.1.0"
 edition = "2026"

--- a/hew-cli/tests/test_project_root_fixture/src/answer.hew
+++ b/hew-cli/tests/test_project_root_fixture/src/answer.hew
@@ -1,0 +1,3 @@
+pub fn answer() -> i64 {
+    42
+}

--- a/hew-cli/tests/test_project_root_fixture/src/answer.hew
+++ b/hew-cli/tests/test_project_root_fixture/src/answer.hew
@@ -1,3 +1,3 @@
-pub fn answer() -> i64 {
+pub fn value() -> i64 {
     42
 }

--- a/hew-cli/tests/test_project_root_fixture/tests/project_root_test.hew
+++ b/hew-cli/tests/test_project_root_fixture/tests/project_root_test.hew
@@ -1,0 +1,6 @@
+import test_project_root.answer.{answer};
+
+#[test]
+fn imports_source_module() {
+    assert(answer() == 42);
+}

--- a/hew-cli/tests/test_project_root_fixture/tests/project_root_test.hew
+++ b/hew-cli/tests/test_project_root_fixture/tests/project_root_test.hew
@@ -1,6 +1,6 @@
-import test_project_root.answer.{answer};
+import test_project_root.answer.{value};
 
 #[test]
 fn imports_source_module() {
-    assert(answer() == 42);
+    assert(value() == 42);
 }

--- a/hew-cli/tests/test_runner_e2e.rs
+++ b/hew-cli/tests/test_runner_e2e.rs
@@ -123,6 +123,21 @@ fn project_test_imports_source_module_from_project_root() {
 }
 
 #[test]
+fn project_test_fixture_check_uses_enclosing_manifest_for_source_imports() {
+    require_codegen();
+
+    let project = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/test_project_root_fixture");
+    let output = run_hew_in(&project, &["check", "tests/project_root_test.hew"]);
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn relative_string_import_resolves_from_test_file() {
     require_codegen();
 

--- a/hew-cli/tests/test_runner_e2e.rs
+++ b/hew-cli/tests/test_runner_e2e.rs
@@ -105,6 +105,48 @@ fn passing_suite_exits_zero() {
 }
 
 #[test]
+fn project_test_imports_source_module_from_project_root() {
+    require_codegen();
+
+    let project = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/test_project_root_fixture");
+    let output = run_hew_in(&project, &["test", ".", "--no-color"]);
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test imports_source_module ... ok"));
+    assert!(stdout.contains("1 passed; 0 failed; 0 ignored"));
+}
+
+#[test]
+fn relative_string_import_resolves_from_test_file() {
+    require_codegen();
+
+    let output = run_suite(
+        &[
+            ("support.hew", "pub fn expected() -> i64 { 42 }\n"),
+            (
+                "relative_test.hew",
+                "import \"support.hew\";\n\n#[test]\nfn imports_relative_file() {\n    assert(expected() == 42);\n}\n",
+            ),
+        ],
+        &["--no-color"],
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("test imports_relative_file ... ok"));
+}
+
+#[test]
 fn failing_suite_exits_non_zero() {
     require_codegen();
 

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -307,14 +307,16 @@ fn load_project_context(
 ) -> Result<ProjectContext, FrontendFailure> {
     let source = std::fs::read_to_string(input)
         .map_err(|e| FrontendFailure::message_only(format!("Error: cannot read {input}: {e}")))?;
+    let input_dir = Path::new(input).parent().unwrap_or(Path::new("."));
     let project_dir = options
         .and_then(|options| options.project_dir.clone())
-        .unwrap_or_else(|| {
-            Path::new(input)
-                .parent()
-                .unwrap_or(Path::new("."))
-                .to_path_buf()
-        });
+        .or_else(|| {
+            input_dir
+                .ancestors()
+                .find(|dir| dir.join("hew.toml").is_file())
+                .map(Path::to_path_buf)
+        })
+        .unwrap_or_else(|| input_dir.to_path_buf());
     let (manifest_deps, package_name) = load_manifest_metadata(&project_dir)?;
     Ok(ProjectContext {
         source,


### PR DESCRIPTION
## Summary

`hew test` compiled each harness from a staged copy in a temporary directory, so the compiler inferred that directory as the project root and no cross-file import resolved inside any test. Harnesses now compile in memory against the original test path with the project root threaded through, making test-time import resolution identical to `hew run`. A multi-file fixture and a string-path regression pin the behaviour.

## Verification

- `cargo test -p hew-cli --test test_runner_e2e`: 30 passed, 0 failed
- `cargo test -p hew-cli --bin hew test_runner`: 27 passed, 0 failed
- Full CLI preflight: pass
- Compiled ratchet: 0 new failures
- Preflight: ready-to-push

## Out of scope

- Test-runner discovery rules and layout conventions are unchanged; only where harnesses compile from is different.
- Package-level import surface for `*_test.hew` peers is handled separately and untouched here.