### PR TITLE
ci(release): mint a GitHub App token for the playground dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@
 #   APPLE_API_KEY_ID            — App Store Connect API key ID
 #   APPLE_API_ISSUER_ID         — App Store Connect API issuer ID
 #
-# Required secret for the required playground dispatch:
-#   PLAYGROUND_DISPATCH_TOKEN — purpose-scoped token with the minimum permission
-#     needed to dispatch hew-lang/playground's build.yml workflow
+# Required variable and secret for the required playground dispatch:
+#   vars.PLAYGROUND_APP_ID — GitHub App ID for the playground dispatch App
+#   secrets.PLAYGROUND_APP_PRIVATE_KEY — Private key for the playground dispatch App
 #
 # Homebrew tap updates use a separate optional credential and are skipped for
 # prereleases:
@@ -1565,18 +1565,36 @@ jobs:
           fi
           echo "hew_sha=${HEW_SHA}" >> "${GITHUB_OUTPUT}"
 
+      - name: Validate playground GitHub App configuration
+        shell: bash
+        env:
+          PLAYGROUND_APP_ID: ${{ vars.PLAYGROUND_APP_ID }}
+          PLAYGROUND_APP_PRIVATE_KEY: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${PLAYGROUND_APP_ID}" || -z "${PLAYGROUND_APP_PRIVATE_KEY}" ]]; then
+            echo "::error::Playground dispatch requires vars.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY; configure both before running a release"
+            exit 1
+          fi
+
+      - name: Mint playground GitHub App token
+        id: playground-app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
+        with:
+          app-id: ${{ vars.PLAYGROUND_APP_ID }}
+          private-key: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}
+          owner: hew-lang
+          repositories: playground
+
       - name: Trigger playground image rebuild
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.PLAYGROUND_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.playground-app-token.outputs.token }}
           HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}
         run: |
           set -euo pipefail
 
-          if [ -z "${GH_TOKEN}" ]; then
-            echo "::error::PLAYGROUND_DISPATCH_TOKEN secret is required for the playground dispatch"
-            exit 1
-          fi
           if ! [[ "${HEW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::release commit identity is not an exact lowercase 40-character commit SHA"
             exit 1

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -309,6 +309,7 @@ def test_npm_publication_is_pinned_to_a_version_matching_release_tag() -> None:
 
 
 def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
+    text = workflow()
     job = playground_job()
     assert "      - name: Resolve release commit identity\n" in job
     assert (
@@ -316,11 +317,45 @@ def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
     ) in job
     assert "did not resolve to an exact lowercase" in job
     assert "HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}" in job
-    assert "PLAYGROUND_DISPATCH_TOKEN" in job
+    assert "PLAYGROUND_DISPATCH_TOKEN" not in text
     assert "HOMEBREW_TAP_TOKEN" not in job
-    assert 'if [ -z "${GH_TOKEN}" ]; then' in job
-    assert "PLAYGROUND_DISPATCH_TOKEN secret is required" in job
-    assert "exit 1" in job
+    assert "#   vars.PLAYGROUND_APP_ID" in text
+    assert "#   secrets.PLAYGROUND_APP_PRIVATE_KEY" in text
+
+    validate = job.index("      - name: Validate playground GitHub App configuration\n")
+    mint = job.index("      - name: Mint playground GitHub App token\n")
+    trigger = job.index("      - name: Trigger playground image rebuild\n")
+    assert validate < mint < trigger
+    validation_step = job[validate:mint]
+    token_step = job[mint:trigger]
+    trigger_step = job[trigger:]
+
+    assert "PLAYGROUND_APP_ID: ${{ vars.PLAYGROUND_APP_ID }}" in validation_step
+    assert (
+        "PLAYGROUND_APP_PRIVATE_KEY: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}"
+        in validation_step
+    )
+    assert (
+        "requires vars.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY"
+        in validation_step
+    )
+    assert "exit 1" in validation_step
+    assert "if:" not in validation_step
+    assert "continue-on-error:" not in validation_step
+
+    assert "id: playground-app-token" in token_step
+    assert re.search(
+        r"uses: actions/create-github-app-token@[0-9a-f]{40}  # v2\.2\.2$",
+        token_step,
+        re.MULTILINE,
+    )
+    assert "app-id: ${{ vars.PLAYGROUND_APP_ID }}" in token_step
+    assert "private-key: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}" in token_step
+    assert "owner: hew-lang" in token_step
+    assert "repositories: playground" in token_step
+    assert "if:" not in token_step
+    assert "continue-on-error:" not in token_step
+    assert "GH_TOKEN: ${{ steps.playground-app-token.outputs.token }}" in trigger_step
     assert "gh repo view hew-lang/playground" in job
     assert "gh api repos/hew-lang/playground --jq '.default_branch'" in job
     assert "gh workflow view build.yml" in job


### PR DESCRIPTION
## Summary

The playground image-rebuild trigger used a static personal access token, which failed with a 403 during the rc1 release and requires manual rotation. The release job now mints a short-lived installation token per run via a GitHub App scoped to the playground repository. Until the App is provisioned, the job fails with an actionable message naming the required `PLAYGROUND_APP_ID` variable and `PLAYGROUND_APP_PRIVATE_KEY` secret.

## Verification

- Release workflow contract suites: 91 pass
- actionlint: clean

## Out of scope

- The one-time GitHub App creation and installation (owner-side provisioning).