### PR TITLE
fix(ci): resolve npm-publish machinery from the workflow ref

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -53,6 +53,12 @@ jobs:
           ref: ${{ inputs.release_tag }}
           fetch-depth: 0
 
+      - name: Checkout release machinery
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: release-machinery
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master 2026-03-27
         with:
@@ -71,7 +77,7 @@ jobs:
           restore-keys: publish-npm-${{ runner.os }}-
 
       - name: Install wasm-pack v0.13.1 and Binaryen 117
-        uses: ./.github/actions/setup-wasm-pack
+        uses: ./release-machinery/.github/actions/setup-wasm-pack
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -120,8 +126,9 @@ jobs:
           echo "Publishing ${RELEASE_TAG} on npm dist-tag ${NPM_DIST_TAG}"
 
       - name: Build all npm packages
-        run: node scripts/build-npm-packages.mjs
+        run: node release-machinery/scripts/build-npm-packages.mjs
         env:
+          HEW_SOURCE_ROOT: ${{ github.workspace }}
           # Release profile in CI — wasm-opt enabled per Cargo.toml metadata.
           NPM_WASM_PROFILE: release
 

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -9,6 +9,7 @@
  *
  * Environment:
  *   NPM_WASM_PROFILE=dev   — use debug wasm-pack profile (fast local builds)
+ *   HEW_SOURCE_ROOT=<path>  — build a checkout other than the script's checkout
  *
  * Usage:
  *   node scripts/build-npm-packages.mjs
@@ -19,7 +20,8 @@ import { mkdirSync, readFileSync, writeFileSync, cpSync, rmSync } from "node:fs"
 import { resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
+const SCRIPT_REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
+const REPO_ROOT = resolve(process.env.HEW_SOURCE_ROOT ?? SCRIPT_REPO_ROOT);
 const GITHUB_PACKAGES_REGISTRY = "https://npm.pkg.github.com";
 
 // Honour NPM_WASM_PROFILE=dev for fast local builds.

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -41,6 +41,7 @@ WINDOWS_LLVM_PREBUILD = ROOT / ".github" / "workflows" / "prebuild-llvm.yml"
 SETUP_LLVM_ACTION = ROOT / ".github" / "actions" / "setup-llvm" / "action.yml"
 SETUP_WASM_PACK_ACTION = ROOT / ".github" / "actions" / "setup-wasm-pack" / "action.yml"
 DOWNLOAD_VERIFY_BINARYEN = ROOT / ".github" / "scripts" / "download-verify-binaryen.sh"
+NPM_PACKAGE_BUILDER = ROOT / "scripts" / "build-npm-packages.mjs"
 WINDOWS_BUILD_GUIDE = ROOT / "docs" / "cross-platform-build-guide.md"
 WINDOWS_LLVM_TOOLCHAIN_REPO = "hew-lang/llvm-toolchain"
 WINDOWS_LLVM_TOOLCHAIN_VERSION = "22.1.0-windows-msvc-v1"
@@ -651,6 +652,36 @@ def test_cross_release_machinery_resolves_from_workflow_ref() -> None:
     )
 
 
+def test_npm_publish_machinery_resolves_from_workflow_ref() -> None:
+    job = workflow_job(npm_publish_workflow(), "publish")
+    assert (
+        """      - name: Checkout release machinery
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: release-machinery
+"""
+        in job
+    )
+    assert "uses: ./release-machinery/.github/actions/setup-wasm-pack" in job
+    assert "node release-machinery/scripts/build-npm-packages.mjs" in job
+    assert "HEW_SOURCE_ROOT: ${{ github.workspace }}" in job
+
+    unscoped_machinery_references = [
+        line.strip()
+        for line in job.splitlines()
+        if re.search(r"(?<!release-machinery/)scripts/", line)
+        or re.search(r"uses:\s+\./(?!release-machinery/)", line)
+    ]
+    assert not unscoped_machinery_references, (
+        "npm publish machinery must resolve from the workflow ref: "
+        f"{unscoped_machinery_references}"
+    )
+
+    builder = NPM_PACKAGE_BUILDER.read_text()
+    assert "process.env.HEW_SOURCE_ROOT ?? SCRIPT_REPO_ROOT" in builder
+
+
 def test_cross_release_libraries_are_target_keyed_and_natively_proved() -> None:
     release = workflow()
     cross_start = release.index("  build-cross-release-libs:\n")
@@ -1053,30 +1084,32 @@ def assert_wasm_pack_action_contract(action: str) -> None:
 def test_wasm_pack_consumers_prefetch_checksum_pinned_binaryen() -> None:
     action = SETUP_WASM_PACK_ACTION.read_text()
     downloader = DOWNLOAD_VERIFY_BINARYEN.read_text()
-    action_use = "uses: ./.github/actions/setup-wasm-pack"
-
     assert_wasm_pack_action_contract(action)
     assert_binaryen_downloader_contract(downloader)
 
     consumers = (
         (
             workflow_job(CI_WORKFLOW.read_text(), "playground-wasm-build"),
+            "uses: ./.github/actions/setup-wasm-pack",
             "make playground-check",
         ),
         (
             workflow_job(CI_WORKFLOW.read_text(), "build-and-test"),
+            "uses: ./.github/actions/setup-wasm-pack",
             "scripts/ci-preflight-dispatcher.sh",
         ),
         (
             workflow_job(RELEASE_GATE.read_text(), "gate-linux"),
+            "uses: ./.github/actions/setup-wasm-pack",
             "make playground-check",
         ),
         (
             workflow_job(NPM_PUBLISH_WORKFLOW.read_text(), "publish"),
-            "node scripts/build-npm-packages.mjs",
+            "uses: ./release-machinery/.github/actions/setup-wasm-pack",
+            "node release-machinery/scripts/build-npm-packages.mjs",
         ),
     )
-    for job, build_command in consumers:
+    for job, action_use, build_command in consumers:
         assert job.count(action_use) == 1
         assert job.index(action_use) < job.index(build_command)
 
@@ -1760,6 +1793,7 @@ _TESTS = [
     test_prerelease_validator_proves_external_staticlib_linking,
     test_every_release_lane_executes_the_library_consumer_proof,
     test_cross_release_machinery_resolves_from_workflow_ref,
+    test_npm_publish_machinery_resolves_from_workflow_ref,
     test_cross_release_libraries_are_target_keyed_and_natively_proved,
     test_freebsd_release_lanes_provision_bash_and_package_with_posix_sh,
     test_freebsd_x86_64_release_uses_repository_pinned_rust,


### PR DESCRIPTION
## Summary

Dispatching `publish-npm-packages` against a tag older than the workflow failed because the shared wasm-pack setup action and the package build script resolved from the tag checkout. Both now resolve from the workflow's own commit (`github.sha` machinery checkout), while the tagged source tree remains the build input via `HEW_SOURCE_ROOT`. A workflow-specific contract test rejects tag-resolved machinery in this workflow.

## Verification

- Release contract suites: green (92/92)
- actionlint: clean
- JS syntax check on `scripts/build-npm-packages.mjs`: clean
- Preflight: ready-to-push

## Out of scope

- Other release workflows already use the machinery-from-workflow-ref pattern; no changes needed there.