### PR TITLE
ci(release): read the playground App ID from secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@
 #   APPLE_API_ISSUER_ID         — App Store Connect API issuer ID
 #
 # Required variable and secret for the required playground dispatch:
-#   vars.PLAYGROUND_APP_ID — GitHub App ID for the playground dispatch App
+#   secrets.PLAYGROUND_APP_ID — GitHub App ID for the playground dispatch App
 #   secrets.PLAYGROUND_APP_PRIVATE_KEY — Private key for the playground dispatch App
 #
 # Homebrew tap updates use a separate optional credential and are skipped for
@@ -1568,13 +1568,13 @@ jobs:
       - name: Validate playground GitHub App configuration
         shell: bash
         env:
-          PLAYGROUND_APP_ID: ${{ vars.PLAYGROUND_APP_ID }}
+          PLAYGROUND_APP_ID: ${{ secrets.PLAYGROUND_APP_ID }}
           PLAYGROUND_APP_PRIVATE_KEY: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
 
           if [[ -z "${PLAYGROUND_APP_ID}" || -z "${PLAYGROUND_APP_PRIVATE_KEY}" ]]; then
-            echo "::error::Playground dispatch requires vars.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY; configure both before running a release"
+            echo "::error::Playground dispatch requires secrets.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY; configure both before running a release"
             exit 1
           fi
 
@@ -1582,7 +1582,7 @@ jobs:
         id: playground-app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
         with:
-          app-id: ${{ vars.PLAYGROUND_APP_ID }}
+          app-id: ${{ secrets.PLAYGROUND_APP_ID }}
           private-key: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}
           owner: hew-lang
           repositories: playground

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -320,7 +320,7 @@ def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
     assert "HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}" in job
     assert "PLAYGROUND_DISPATCH_TOKEN" not in text
     assert "HOMEBREW_TAP_TOKEN" not in job
-    assert "#   vars.PLAYGROUND_APP_ID" in text
+    assert "#   secrets.PLAYGROUND_APP_ID" in text
     assert "#   secrets.PLAYGROUND_APP_PRIVATE_KEY" in text
 
     validate = job.index("      - name: Validate playground GitHub App configuration\n")
@@ -331,13 +331,13 @@ def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
     token_step = job[mint:trigger]
     trigger_step = job[trigger:]
 
-    assert "PLAYGROUND_APP_ID: ${{ vars.PLAYGROUND_APP_ID }}" in validation_step
+    assert "PLAYGROUND_APP_ID: ${{ secrets.PLAYGROUND_APP_ID }}" in validation_step
     assert (
         "PLAYGROUND_APP_PRIVATE_KEY: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}"
         in validation_step
     )
     assert (
-        "requires vars.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY"
+        "requires secrets.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY"
         in validation_step
     )
     assert "exit 1" in validation_step
@@ -350,7 +350,7 @@ def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
         token_step,
         re.MULTILINE,
     )
-    assert "app-id: ${{ vars.PLAYGROUND_APP_ID }}" in token_step
+    assert "app-id: ${{ secrets.PLAYGROUND_APP_ID }}" in token_step
     assert "private-key: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}" in token_step
     assert "owner: hew-lang" in token_step
     assert "repositories: playground" in token_step


### PR DESCRIPTION
## Summary

The playground App-token step expected the App ID as a repository variable, but it was provisioned as a secret alongside the private key. The step, its guard, the documentation comment, and the contract test now read `secrets.PLAYGROUND_APP_ID`.

## Verification

- Release workflow contract suites: 48+31+11+2 pass
- actionlint: clean
- Preflight: ready-to-push

## Out of scope

- No other workflow credentials or steps touched.