### PR TITLE
fix(types): model scope tails as subsuming values

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -8280,7 +8280,13 @@ impl Checker {
             }
             Expr::Scope { body } | Expr::ScopeDeadline { body, .. } => {
                 body.trailing_expr.as_deref().map(|tail| {
-                    ProducedValueDependency::Identity(SpanKey::in_module(
+                    // A scope expression is always Unit at the outer surface,
+                    // but its tail expression may produce any type and still be
+                    // evaluated for side effects. Model that as a subsuming
+                    // publication rather than an identity edge so the checker
+                    // does not require the scope node and its tail to have the
+                    // same type.
+                    ProducedValueDependency::Subsumes(SpanKey::in_module(
                         &tail.1,
                         self.current_module_idx,
                     ))

--- a/hew-types/src/check/tests/output.rs
+++ b/hew-types/src/check/tests/output.rs
@@ -447,6 +447,31 @@ fn tail_ok_publication_preserves_the_source_payload_type() {
     );
 }
 
+#[test]
+fn scope_body_with_spawned_call_and_trailing_value_checks_cleanly() {
+    let output = check_source(
+        r"
+        actor Worker {
+            receive fn run() {}
+        }
+
+        fn main() {
+            scope {
+                let worker = spawn Worker();
+                worker.run();
+                0
+            };
+        }
+        ",
+    );
+
+    assert!(
+        output.errors.is_empty(),
+        "scope body with a spawned worker and trailing value must typecheck cleanly; got: {:#?}",
+        output.errors
+    );
+}
+
 fn ownership_graph_key(start: usize, module_idx: u32) -> SpanKey {
     SpanKey {
         start,


### PR DESCRIPTION
## Summary

- model `scope` and `scope after(...)` tails as subsumed values rather than identity edges
- allow a scope's trailing expression to differ from the outer scope's `Unit` type
- cover the reported `spawn` + actor call + trailing value form with a regression test

## Root cause

The produced-value graph treated the scope node and its tail as type-identical. A scope expression is always `Unit`, while its tail is evaluated for side effects and may have another type, so the validator rejected valid code as an internal graph error.

## Verification

- `cargo test -p hew-types scope_body_with_spawned_call_and_trailing_value_checks_cleanly -- --nocapture`
- `cargo test -p hew-types native_scope_no_platform_error -- --nocapture`
- `cargo test -p hew-types`
- `cargo fmt --all --check`
- reported reproducer via `cargo run -p hew-cli -- check`: `OK`

Closes #2898.
