### PR TITLE
fix(pkg): make hew publish fail closed instead of silently falling back to a local copy

### DIFF
--- a/hew-cli/tests/pkg_publish_fail_closed_e2e.rs
+++ b/hew-cli/tests/pkg_publish_fail_closed_e2e.rs
@@ -234,6 +234,45 @@ fn publish_without_credentials_exits_one_and_writes_no_local_copy() {
     );
 }
 
+// ── 1b. corrupt credentials.toml — parse error, not "not logged in" ────────
+
+#[test]
+fn publish_corrupt_credentials_file_exits_one_with_parse_diagnostic() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+    let hew_dir = home.path().join(".hew");
+    fs::create_dir_all(&hew_dir).expect("create .hew dir");
+    fs::write(
+        hew_dir.join("credentials.toml"),
+        "this is not valid toml {{{",
+    )
+    .expect("write corrupt credentials.toml");
+
+    let output = run_publish(project.path(), home.path(), &[]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("invalid credentials file"),
+        "stderr missing parse-error diagnostic:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("not logged in"),
+        "a corrupt credentials file must not be misreported as not-logged-in:\n{stderr}"
+    );
+    assert!(
+        !local_package_dir(home.path()).exists(),
+        "no local copy should be written when credentials.toml is corrupt"
+    );
+}
+
 // ── 2. named registry, no token for it (Arm C: has_token hardcoded true) ───
 
 #[test]
@@ -256,6 +295,51 @@ fn publish_named_registry_without_token_exits_one() {
     assert!(
         !local_package_dir(home.path()).exists(),
         "no local copy should be written when the named registry has no token"
+    );
+}
+
+// ── 2b. --registry names a registry absent from config.toml ────────────────
+//
+// Credential resolution runs before `make_client` (test 1's comment above),
+// so a typo'd `--registry` name must still surface `make_client`'s precise
+// unknown-registry diagnostic rather than being misreported as "not logged
+// in" — no stored token is ever found for a registry name that doesn't
+// exist, so a naive `Err(_) => not-logged-in` classification would shadow
+// this diagnostic entirely.
+
+#[test]
+fn publish_unknown_registry_name_exits_one_with_precise_diagnostic() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+    // No config.toml at all, and no credentials.toml — the unknown-registry
+    // check must fire before any credential lookup.
+
+    let output = run_publish(project.path(), home.path(), &["--registry", "typoreg"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("hew: unknown registry 'typoreg'"),
+        "stderr missing precise unknown-registry diagnostic:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("[registries.typoreg]"),
+        "stderr missing config-hint for the unknown registry:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("not logged in"),
+        "unknown-registry diagnostic must not be shadowed by the not-logged-in message:\n{stderr}"
+    );
+    assert!(
+        !local_package_dir(home.path()).exists(),
+        "no local copy should be written when the named registry is unknown"
     );
 }
 

--- a/hew-cli/tests/pkg_publish_fail_closed_e2e.rs
+++ b/hew-cli/tests/pkg_publish_fail_closed_e2e.rs
@@ -1,0 +1,429 @@
+//! Exit-code contract for `hew publish`'s fail-closed behaviour.
+//!
+//! `hew publish`'s whole purpose is a remote side effect. Before this test
+//! existed, missing credentials, an unreachable registry, and a remote
+//! publish failure all exited 0 after silently writing the package into the
+//! local registry — "Published" printed regardless of whether anything
+//! reached a registry. These tests assert the corrected contract: the
+//! remote leg either completes (exit 0) or the command exits nonzero with no
+//! local copy ever written implicitly. `hew publish --local` is the explicit,
+//! opt-in local workflow (test 6); everything else here proves the remote
+//! path never falls back to it.
+//!
+//! Every test relocates `$HOME` (and `$USERPROFILE`, for Windows parity) per
+//! `Command`, never via `std::env::set_var` — see LESSONS
+//! `global-test-isolation`. Every child is spawned through
+//! `support::run_bounded_command` — see LESSONS `exec-test-must-bound-the-child`.
+//!
+//! Production-registry safety: no test here ever writes a `[registry]`
+//! (default-registry) token into `credentials.toml`. Every test that
+//! supplies a token uses a **named** registry pinned to `127.0.0.1`, so a bug
+//! here can never address `https://registry.hewpkg.com`.
+mod support;
+
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::Duration;
+
+const PKG_NAME: &str = "repro_pkg";
+const PKG_VERSION: &str = "0.1.0";
+
+/// Write a minimal publishable manifest plus one source file into `project`.
+///
+/// Exactly the five fields `manifest::validate_for_publish` requires
+/// (`name`, `version`, `description`, `license`, `authors`); `edition` is
+/// included even though `manifest::default_edition` covers its absence.
+/// Dependency-free, since path dependencies are also rejected by
+/// `validate_for_publish`.
+fn write_publishable_manifest(project: &Path) {
+    fs::write(
+        project.join("hew.toml"),
+        format!(
+            "[package]\n\
+             name = \"{PKG_NAME}\"\n\
+             version = \"{PKG_VERSION}\"\n\
+             description = \"repro\"\n\
+             license = \"MIT\"\n\
+             authors = [\"a\"]\n\
+             edition = \"2026\"\n"
+        ),
+    )
+    .expect("write hew.toml");
+    fs::write(project.join("main.hew"), "fn main() {}\n").expect("write main.hew");
+}
+
+/// Generate a signing keypair under `home/.hew/keys` via `hew key generate`.
+fn generate_signing_key(home: &Path) {
+    let mut cmd = support::hew_command();
+    cmd.arg("key")
+        .arg("generate")
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    let output = support::run_bounded_command(cmd, "hew key generate");
+    assert!(
+        output.status.success(),
+        "hew key generate failed\n{}",
+        support::describe_output(&output)
+    );
+}
+
+/// Write `home/.hew/config.toml` with a single named registry pointed at
+/// `api_url`.
+fn write_named_registry_config(home: &Path, registry_name: &str, api_url: &str) {
+    let hew_dir = home.join(".hew");
+    fs::create_dir_all(&hew_dir).expect("create .hew dir");
+    fs::write(
+        hew_dir.join("config.toml"),
+        format!(
+            "[registries.{registry_name}]\n\
+             index = \"http://127.0.0.1:9/index\"\n\
+             api = \"{api_url}\"\n"
+        ),
+    )
+    .expect("write config.toml");
+}
+
+/// Write `home/.hew/credentials.toml` with a token for the **named**
+/// registry only — never the default `[registry]` table, which would point
+/// a bug at the real `registry.hewpkg.com`.
+fn write_named_registry_token(home: &Path, registry_name: &str, token: &str) {
+    let hew_dir = home.join(".hew");
+    fs::create_dir_all(&hew_dir).expect("create .hew dir");
+    fs::write(
+        hew_dir.join("credentials.toml"),
+        format!("[registries.{registry_name}]\ntoken = \"{token}\"\ngithub_user = \"tester\"\n"),
+    )
+    .expect("write credentials.toml");
+}
+
+/// Path the local registry would use if (and only if) a local publish wrote it.
+fn local_package_dir(home: &Path) -> PathBuf {
+    home.join(".hew")
+        .join("packages")
+        .join(PKG_NAME)
+        .join(PKG_VERSION)
+}
+
+fn publish_command(project: &Path, home: &Path, args: &[&str]) -> Command {
+    let mut cmd = support::hew_command();
+    cmd.arg("publish")
+        .args(args)
+        .current_dir(project)
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    cmd
+}
+
+fn run_publish(project: &Path, home: &Path, args: &[&str]) -> Output {
+    support::run_bounded_command(publish_command(project, home, args), "hew publish")
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Read an HTTP request's headers and drain its `Content-Length` body so the
+/// client's write completes before the server responds — otherwise the
+/// client can fail on the write side instead of on the response status.
+fn drain_http_request(stream: &mut TcpStream) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("set read timeout");
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    while let Ok(n) = stream.read(&mut chunk) {
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        let Some(header_end) = find_double_crlf(&buf) else {
+            continue;
+        };
+        let header_text = String::from_utf8_lossy(&buf[..header_end]);
+        let content_length: usize = header_text
+            .lines()
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                key.trim()
+                    .eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        let body_so_far = buf.len() - (header_end + 4);
+        let mut remaining = content_length.saturating_sub(body_so_far);
+        while remaining > 0 {
+            let Ok(n) = stream.read(&mut chunk) else {
+                break;
+            };
+            if n == 0 {
+                break;
+            }
+            remaining = remaining.saturating_sub(n);
+        }
+        break;
+    }
+}
+
+fn find_double_crlf(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+/// Bind an ephemeral port, accept exactly one connection, drain its request,
+/// and reply with a canned `status_line`/`body` response, then stop.
+///
+/// Returns the bound port; the caller points a named registry's `api` at it.
+fn spawn_canned_response_server(status_line: &'static str, body: &'static str) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _addr)) = listener.accept() {
+            drain_http_request(&mut stream);
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    port
+}
+
+// ── 1. no credentials at all ────────────────────────────────────────────────
+
+#[test]
+fn publish_without_credentials_exits_one_and_writes_no_local_copy() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+    // No config.toml, no credentials.toml.
+
+    let output = run_publish(project.path(), home.path(), &[]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("run `hew login`"),
+        "stderr missing login hint:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--local"),
+        "stderr missing --local hint:\n{stderr}"
+    );
+    assert!(
+        !local_package_dir(home.path()).exists(),
+        "no local copy should be written when credentials are missing"
+    );
+}
+
+// ── 2. named registry, no token for it (Arm C: has_token hardcoded true) ───
+
+#[test]
+fn publish_named_registry_without_token_exits_one() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+    write_named_registry_config(home.path(), "testreg", "http://127.0.0.1:9/api/v1");
+    // No credentials.toml at all — not even for the default registry.
+
+    let output = run_publish(project.path(), home.path(), &["--registry", "testreg"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    assert!(
+        !local_package_dir(home.path()).exists(),
+        "no local copy should be written when the named registry has no token"
+    );
+}
+
+// ── 3. remote publish returns an error ──────────────────────────────────────
+
+#[test]
+fn publish_remote_error_exits_one_and_writes_no_local_copy() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+
+    let port =
+        spawn_canned_response_server("500 Internal Server Error", r#"{"error":"registry down"}"#);
+    write_named_registry_config(
+        home.path(),
+        "testreg",
+        &format!("http://127.0.0.1:{port}/api/v1"),
+    );
+    write_named_registry_token(home.path(), "testreg", "tok_fake");
+
+    let output = run_publish(project.path(), home.path(), &["--registry", "testreg"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        stderr.contains("hew publish: remote publish failed:"),
+        "stderr missing remote-failure prefix:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Falling back"),
+        "stderr must not mention a local fallback:\n{stderr}"
+    );
+    assert!(
+        !local_package_dir(home.path()).exists(),
+        "no local copy should be written when the remote publish fails"
+    );
+}
+
+// ── 4. registry unreachable (connection refused) ────────────────────────────
+
+#[test]
+fn publish_unreachable_registry_exits_one() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+
+    // Bind, record the port, then drop the listener so the port is refusing
+    // connections without a live server.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+
+    write_named_registry_config(
+        home.path(),
+        "testreg",
+        &format!("http://127.0.0.1:{port}/api/v1"),
+    );
+    write_named_registry_token(home.path(), "testreg", "tok_fake");
+
+    let output = run_publish(project.path(), home.path(), &["--registry", "testreg"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    assert!(
+        !local_package_dir(home.path()).exists(),
+        "no local copy should be written when the registry is unreachable"
+    );
+}
+
+// ── 5. remote publish succeeds (positive control) ───────────────────────────
+
+#[test]
+fn publish_remote_success_exits_zero_and_writes_no_local_copy() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+
+    let port = spawn_canned_response_server("201 Created", "{}");
+    write_named_registry_config(
+        home.path(),
+        "testreg",
+        &format!("http://127.0.0.1:{port}/api/v1"),
+    );
+    write_named_registry_token(home.path(), "testreg", "tok_fake");
+
+    let output = run_publish(project.path(), home.path(), &["--registry", "testreg"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit 0\n{}",
+        support::describe_output(&output)
+    );
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("to registry"),
+        "stdout missing remote-success message:\n{stdout}"
+    );
+    assert!(
+        !local_package_dir(home.path()).exists(),
+        "a successful remote publish must not also write a local copy"
+    );
+}
+
+// ── 6. --local: explicit local workflow ─────────────────────────────────────
+
+#[test]
+fn publish_local_flag_exits_zero_and_writes_local_copy() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+    // No credentials.toml, no config.toml — --local must need neither.
+
+    let output = run_publish(project.path(), home.path(), &["--local"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit 0\n{}",
+        support::describe_output(&output)
+    );
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("local registry only"),
+        "stdout missing local-only annotation:\n{stdout}"
+    );
+    assert!(
+        local_package_dir(home.path()).join("hew.toml").exists(),
+        "--local must write the package into the local registry"
+    );
+}
+
+// ── 7. --local --registry is a usage error ──────────────────────────────────
+
+#[test]
+fn publish_local_with_registry_flag_is_usage_error() {
+    let home = support::tempdir();
+    let project = support::tempdir();
+    generate_signing_key(home.path());
+    write_publishable_manifest(project.path());
+
+    let output = run_publish(
+        project.path(),
+        home.path(),
+        &["--local", "--registry", "testreg"],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected clap usage error (exit 2)\n{}",
+        support::describe_output(&output)
+    );
+    assert!(
+        !local_package_dir(home.path()).exists(),
+        "a usage error must not write a local copy"
+    );
+}

--- a/hew-pkg/README.md
+++ b/hew-pkg/README.md
@@ -52,8 +52,9 @@ hew install
 
 ### Registry
 
-- `hew publish [--registry <NAME>]` — Publish package to the registry
+- `hew publish [--registry <NAME>]` — Publish package to a remote registry (requires `hew login`; fails if the remote publish fails)
   - `--registry`, `-r` — Use a named registry from config
+  - `--local` — Install into the local package registry only; never contacts a remote registry
 - `hew list` — List installed packages
 - `hew search <QUERY> [--category <CATEGORY>] [--page <N>] [--per-page <N>] [--registry <NAME>]` — Search for packages
   - `--registry`, `-r` — Use a named registry from config

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -326,6 +326,24 @@ fn make_client(registry_name: Option<&str>) -> client::RegistryClient {
     }
 }
 
+/// Resolve the API token required for a remote publish.
+///
+/// Injecting `cred_path` keeps this unit-testable without `$HOME` mutation.
+///
+/// # Errors
+///
+/// Returns [`credentials::CredentialError::NotLoggedIn`] when no token is
+/// stored for the target registry (default or named).
+fn resolve_publish_token(
+    cred_path: &Path,
+    registry_name: Option<&str>,
+) -> Result<String, credentials::CredentialError> {
+    match registry_name {
+        Some(name) => credentials::get_named_token(cred_path, name),
+        None => credentials::get_token(cred_path),
+    }
+}
+
 fn load_config_or_exit() -> config::PkgConfig {
     config::load_config().unwrap_or_else(|error| {
         eprintln!("hew: {error}");
@@ -939,6 +957,26 @@ fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>, local
         }
     };
 
+    // Resolve the remote token up front, before packing, so a logged-out
+    // publish never packs a tarball it cannot use. `--local` never reads
+    // credentials at all.
+    let token = if local {
+        None
+    } else {
+        let cred_path = credentials::credentials_path();
+        Some(
+            resolve_publish_token(&cred_path, registry_name).unwrap_or_else(|_| {
+                eprintln!(
+                    "hew publish: not logged in; run `hew login` to publish to a remote registry"
+                );
+                eprintln!(
+                    "Use `hew publish --local` to install this package into the local registry only."
+                );
+                std::process::exit(1);
+            }),
+        )
+    };
+
     // Pack tarball.
     let exclude = m.package.exclude.as_deref().unwrap_or_default();
     let include = m.package.include.as_deref().unwrap_or_default();
@@ -997,84 +1035,60 @@ fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>, local
         return;
     }
 
-    // Try remote publish first if we have credentials.
-    let cred_path = credentials::credentials_path();
-    let has_token = if registry_name.is_some() {
-        // Named registries get their token via make_client
-        true
-    } else {
-        credentials::get_token(&cred_path).is_ok()
-    };
-    if has_token {
-        let api_client = {
-            let mut c = make_client(registry_name);
-            if registry_name.is_none() {
-                if let Ok(token) = credentials::get_token(&cred_path) {
-                    c = c.with_token(token);
-                }
-            }
-            c
-        };
-        let request = client::PublishRequest {
-            metadata: client::PublishMetadata {
-                name: m.package.name.clone(),
-                vers: m.package.version.clone(),
-                description: m.package.description.clone().unwrap_or_default(),
-                license: m.package.license.clone().unwrap_or_default(),
-                authors: m.package.authors.clone().unwrap_or_default(),
-                deps: deps.clone(),
-                features: m.features.clone(),
-                edition: Some(m.package.edition.clone()),
-                hew: m.package.hew.clone(),
-                keywords: m.package.keywords.clone(),
-                categories: m.package.categories.clone(),
-                homepage: m.package.homepage.clone(),
-                repository: m.package.repository.clone(),
-                documentation: m.package.documentation.clone(),
-            },
-            checksum: pack_result.checksum.clone(),
-            signature: signature.clone(),
-            key_fingerprint: fingerprint.clone(),
-        };
-
-        match api_client.publish(
-            &m.package.name,
-            &m.package.version,
-            &pack_result.data,
-            &request,
-        ) {
-            Ok(()) => {
-                println!(
-                    "Published {}@{} to registry",
-                    m.package.name, m.package.version
-                );
-                println!("Checksum: {}", pack_result.checksum);
-                println!("Signature: {signature}");
-                return;
-            }
-            Err(e) => {
-                eprintln!("hew publish: remote publish failed: {e}");
-                eprintln!("Falling back to local publish.");
+    // `local` is false here, so `token` was resolved above (or the process
+    // already exited). Remote publish either completes or the command exits
+    // nonzero — there is no local-copy fallback.
+    let api_client = {
+        let mut c = make_client(registry_name);
+        if registry_name.is_none() {
+            if let Some(token) = token {
+                c = c.with_token(token);
             }
         }
-    }
+        c
+    };
+    let request = client::PublishRequest {
+        metadata: client::PublishMetadata {
+            name: m.package.name.clone(),
+            vers: m.package.version.clone(),
+            description: m.package.description.clone().unwrap_or_default(),
+            license: m.package.license.clone().unwrap_or_default(),
+            authors: m.package.authors.clone().unwrap_or_default(),
+            deps: deps.clone(),
+            features: m.features.clone(),
+            edition: Some(m.package.edition.clone()),
+            hew: m.package.hew.clone(),
+            keywords: m.package.keywords.clone(),
+            categories: m.package.categories.clone(),
+            homepage: m.package.homepage.clone(),
+            repository: m.package.repository.clone(),
+            documentation: m.package.documentation.clone(),
+        },
+        checksum: pack_result.checksum.clone(),
+        signature: signature.clone(),
+        key_fingerprint: fingerprint.clone(),
+    };
 
-    // Fall back to local publish.
-    let dest = registry.package_dir(&m.package.name, &m.package.version);
-    if let Err(e) = copy_dir(&cwd, &dest) {
-        eprintln!("hew publish: {e}");
-        std::process::exit(1);
+    match api_client.publish(
+        &m.package.name,
+        &m.package.version,
+        &pack_result.data,
+        &request,
+    ) {
+        Ok(()) => {
+            println!(
+                "Published {}@{} to registry",
+                m.package.name, m.package.version
+            );
+            println!("Checksum: {}", pack_result.checksum);
+            println!("Signature: {signature}");
+        }
+        Err(e) => {
+            eprintln!("hew publish: remote publish failed: {e}");
+            eprintln!("Nothing was published; no local copy was written.");
+            std::process::exit(1);
+        }
     }
-
-    println!(
-        "Published {}@{} to {}",
-        m.package.name,
-        m.package.version,
-        dest.display()
-    );
-    println!("Checksum: {}", pack_result.checksum);
-    println!("Signature: {signature}");
-    println!("Key: {fingerprint}");
 }
 
 fn cmd_list(registry: &registry::Registry) {
@@ -2271,6 +2285,65 @@ mod tests {
 
         assert!(dest.join("hew.toml").exists());
         assert!(dest.join("main.hew").exists());
+    }
+
+    #[test]
+    fn resolve_publish_token_default_registry_missing_is_not_logged_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_path = dir.path().join("credentials.toml");
+        let result = resolve_publish_token(&cred_path, None);
+        assert!(matches!(
+            result,
+            Err(credentials::CredentialError::NotLoggedIn)
+        ));
+    }
+
+    #[test]
+    fn resolve_publish_token_named_registry_requires_named_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_path = dir.path().join("credentials.toml");
+        credentials::save_credentials(
+            &cred_path,
+            &credentials::CredentialsFile {
+                registry: Some(credentials::Credentials {
+                    token: "tok_default".to_string(),
+                    github_user: None,
+                }),
+                registries: None,
+            },
+        )
+        .unwrap();
+
+        let result = resolve_publish_token(&cred_path, Some("testreg"));
+        assert!(matches!(
+            result,
+            Err(credentials::CredentialError::NotLoggedIn)
+        ));
+    }
+
+    #[test]
+    fn resolve_publish_token_named_registry_returns_named_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_path = dir.path().join("credentials.toml");
+        let mut registries = std::collections::BTreeMap::new();
+        registries.insert(
+            "testreg".to_string(),
+            credentials::Credentials {
+                token: "tok_testreg".to_string(),
+                github_user: None,
+            },
+        );
+        credentials::save_credentials(
+            &cred_path,
+            &credentials::CredentialsFile {
+                registry: None,
+                registries: Some(registries),
+            },
+        )
+        .unwrap();
+
+        let token = resolve_publish_token(&cred_path, Some("testreg")).unwrap();
+        assert_eq!(token, "tok_testreg");
     }
 
     // ── search tests ────────────────────────────────────────────────────

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -305,16 +305,26 @@ pub fn run_init(dir: &Path, template: manifest::ManifestTemplate) {
     cmd_init(dir, template, &cfg);
 }
 
+/// Look up a named registry in config, exiting with the standard
+/// unknown-registry diagnostic if `name` is not configured.
+///
+/// Shared by [`make_client`] and the publish token-resolution path so a
+/// typo'd `--registry NAME` always gets this precise message rather than
+/// being misreported by whatever check happens to run first.
+fn resolve_named_registry_or_exit(name: &str) -> config::RemoteRegistry {
+    let cfg = load_config_or_exit();
+    config::get_named_registry(&cfg, name).unwrap_or_else(|| {
+        eprintln!("hew: unknown registry '{name}'");
+        eprintln!("Configure it in ~/.hew/config.toml under [registries.{name}]");
+        std::process::exit(1);
+    })
+}
+
 /// Build a [`RegistryClient`] for the given named registry (or default).
 fn make_client(registry_name: Option<&str>) -> client::RegistryClient {
     match registry_name {
         Some(name) => {
-            let cfg = load_config_or_exit();
-            let remote = config::get_named_registry(&cfg, name).unwrap_or_else(|| {
-                eprintln!("hew: unknown registry '{name}'");
-                eprintln!("Configure it in ~/.hew/config.toml under [registries.{name}]");
-                std::process::exit(1);
-            });
+            let remote = resolve_named_registry_or_exit(name);
             let mut c = client::RegistryClient::with_url(remote.api);
             let cred_path = credentials::credentials_path();
             if let Ok(token) = credentials::get_named_token(&cred_path, name) {
@@ -333,7 +343,9 @@ fn make_client(registry_name: Option<&str>) -> client::RegistryClient {
 /// # Errors
 ///
 /// Returns [`credentials::CredentialError::NotLoggedIn`] when no token is
-/// stored for the target registry (default or named).
+/// stored for the target registry (default or named), or
+/// [`credentials::CredentialError::Parse`]/[`credentials::CredentialError::Io`]
+/// when the credentials file exists but cannot be read.
 fn resolve_publish_token(
     cred_path: &Path,
     registry_name: Option<&str>,
@@ -963,15 +975,30 @@ fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>, local
     let token = if local {
         None
     } else {
+        // Validate a named registry before touching credentials at all, so
+        // a typo'd `--registry NAME` gets `make_client`'s precise
+        // unknown-registry diagnostic instead of being misreported as
+        // "not logged in" (no stored token is ever found for a registry
+        // name that doesn't exist).
+        if let Some(name) = registry_name {
+            resolve_named_registry_or_exit(name);
+        }
         let cred_path = credentials::credentials_path();
         Some(
-            resolve_publish_token(&cred_path, registry_name).unwrap_or_else(|_| {
-                eprintln!(
-                    "hew publish: not logged in; run `hew login` to publish to a remote registry"
-                );
-                eprintln!(
-                    "Use `hew publish --local` to install this package into the local registry only."
-                );
+            resolve_publish_token(&cred_path, registry_name).unwrap_or_else(|err| {
+                match err {
+                    credentials::CredentialError::NotLoggedIn => {
+                        eprintln!(
+                            "hew publish: not logged in; run `hew login` to publish to a remote registry"
+                        );
+                        eprintln!(
+                            "Use `hew publish --local` to install this package into the local registry only."
+                        );
+                    }
+                    credentials::CredentialError::Parse(_) | credentials::CredentialError::Io(_) => {
+                        eprintln!("hew publish: {err}");
+                    }
+                }
                 std::process::exit(1);
             }),
         )
@@ -2344,6 +2371,29 @@ mod tests {
 
         let token = resolve_publish_token(&cred_path, Some("testreg")).unwrap();
         assert_eq!(token, "tok_testreg");
+    }
+
+    /// A corrupt `credentials.toml` must surface as `CredentialError::Parse`,
+    /// not be collapsed into `NotLoggedIn` — the two point a user at
+    /// different remedies (`hew login` cannot fix a parse error, since
+    /// `hew login` also reads through this same file).
+    #[test]
+    fn resolve_publish_token_corrupt_credentials_file_is_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_path = dir.path().join("credentials.toml");
+        std::fs::write(&cred_path, "this is not valid toml {{{").unwrap();
+
+        let result = resolve_publish_token(&cred_path, None);
+        assert!(
+            matches!(result, Err(credentials::CredentialError::Parse(_))),
+            "expected Parse error, got {result:?}"
+        );
+
+        let result = resolve_publish_token(&cred_path, Some("testreg"));
+        assert!(
+            matches!(result, Err(credentials::CredentialError::Parse(_))),
+            "expected Parse error, got {result:?}"
+        );
     }
 
     // ── search tests ────────────────────────────────────────────────────

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -45,6 +45,10 @@ pub enum PkgCommand {
         /// Use a named registry from config
         #[arg(long, short = 'r')]
         registry: Option<String>,
+        /// Install into the local package registry only; never contacts a
+        /// remote registry
+        #[arg(long, conflicts_with = "registry")]
+        local: bool,
     },
     /// List packages in the local registry
     List,
@@ -212,7 +216,10 @@ pub fn dispatch(cmd: &PkgCommand) {
             locked,
             registry: reg,
         } => cmd_install(*locked, &registry, reg.as_deref()),
-        PkgCommand::Publish { registry: reg } => cmd_publish(&registry, reg.as_deref()),
+        PkgCommand::Publish {
+            registry: reg,
+            local,
+        } => cmd_publish(&registry, reg.as_deref(), *local),
         PkgCommand::List => cmd_list(&registry),
         PkgCommand::Search {
             query,
@@ -874,7 +881,7 @@ fn verify_registry_signature(
     clippy::too_many_lines,
     reason = "CLI command handler requires many steps"
 )]
-fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>) {
+fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>, local: bool) {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let manifest_path = cwd.join("hew.toml");
     if !manifest_path.exists() {
@@ -971,6 +978,24 @@ fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>) {
             }
         })
         .collect();
+
+    if local {
+        let dest = registry.package_dir(&m.package.name, &m.package.version);
+        if let Err(e) = copy_dir(&cwd, &dest) {
+            eprintln!("hew publish: {e}");
+            std::process::exit(1);
+        }
+        println!(
+            "Published {}@{} to {} (local registry only — not published to a remote registry)",
+            m.package.name,
+            m.package.version,
+            dest.display()
+        );
+        println!("Checksum: {}", pack_result.checksum);
+        println!("Signature: {signature}");
+        println!("Key: {fingerprint}");
+        return;
+    }
 
     // Try remote publish first if we have credentials.
     let cred_path = credentials::credentials_path();

--- a/tests/package-install/run.sh
+++ b/tests/package-install/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# End-to-end package-manager consumer proof: local publish setup -> user-facing
-# `hew install` -> lock/materialization -> compiler check/run.
+# End-to-end package-manager consumer proof: explicit local publish setup ->
+# user-facing `hew install` -> lock/materialization -> compiler check/run.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -170,7 +170,7 @@ run_in "${TMP}" keygen "${HEW}" key generate
 
 adder_pkg="${TMP}/pkgs/adder-0.1.0"
 write_package "${adder_pkg}" "acme::adder" "0.1.0" "42"
-run_in "${adder_pkg}" publish-adder "${HEW}" publish
+run_in "${adder_pkg}" publish-adder "${HEW}" publish --local
 
 consumer="${TMP}/consumer"
 write_consumer "${consumer}" "acme::adder" "0.1.0"
@@ -223,8 +223,8 @@ versioned_v1="${TMP}/pkgs/versioned-0.1.0"
 versioned_v2="${TMP}/pkgs/versioned-0.2.0"
 write_package "${versioned_v1}" "acme::versioned" "0.1.0" "101"
 write_package "${versioned_v2}" "acme::versioned" "0.2.0" "202"
-run_in "${versioned_v1}" publish-versioned-v1 "${HEW}" publish
-run_in "${versioned_v2}" publish-versioned-v2 "${HEW}" publish
+run_in "${versioned_v1}" publish-versioned-v1 "${HEW}" publish --local
+run_in "${versioned_v2}" publish-versioned-v2 "${HEW}" publish --local
 
 versioned_consumer="${TMP}/versioned-consumer"
 write_consumer "${versioned_consumer}" "acme::versioned" "0.1.0"


### PR DESCRIPTION
## Summary

`hew publish` no longer silently falls back to writing a local copy when a remote publish is impossible or fails — no credentials, an unrecognized `--registry` name, a connection failure, or any non-2xx response now all end the command with a nonzero exit and no local copy written, instead of the previous silent-success (`Published`, exit 0) behavior. Diagnostics are precise per cause: missing credentials say "not logged in" (with a `hew publish --local` hint), a corrupt credentials file or a typo'd registry name each get their own message instead of collapsing into the login message. A new explicit `--local` flag installs into the local package registry only and never contacts a remote registry or reads credentials; it conflicts with `--registry`.

**Breaking change:** `hew publish` used to write into the local registry whenever the remote publish path could not complete, printing "Published" regardless. That implicit fallback is removed. Anyone relying on `hew publish` to seed the local registry (CI, local dev loops, package-install tests) must switch to `hew publish --local`.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p hew-pkg -p hew-cli --tests -- -D warnings`: clean
- `cargo test -p hew-pkg`: 237 + 26 + 2 pass, 0 fail (includes 3 new unit tests)
- `cargo test -p hew-cli --test pkg_publish_fail_closed_e2e`: 7/7 pass
- `flake-stress.sh 3` on the above test binaries under 32 concurrent CPU hogs: 3/3 pass
- `make test-package-install`: 5/5 pass (migrated to `hew publish --local`)
- `make test-pkg-import`: all fixtures pass (unchanged)
- Preflight: ready-to-push

## Out of scope

- No `CHANGELOG.md` `## [Unreleased]` section exists at this point in history, so this breaking change is documented in `hew-pkg/README.md` and here rather than duplicated there.
- No other `hew` subcommands were touched — this is scoped to `hew publish`'s remote/local decision path.
