### PR TITLE
fix(types,hir,mir): canonical imported identities for dyn traits and file-import machines

### DIFF
--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -436,15 +436,17 @@ fn compile_test(
         name = test.name,
     );
 
-    // Write synthetic source and the emit dir to the system temp directory,
-    // NOT to the test file's own parent.  If the process is killed mid-run,
-    // a leftover hew_test_*.hew inside a tests/ directory would be picked up
-    // by the next discovery scan and cause a spurious "main is defined multiple
-    // times" compile error.  The OS temp dir is outside any scanned tree.
+    // Keep the synthetic source beside the fixture so relative file imports
+    // resolve from the same directory as the authored test. Discovery excludes
+    // the `hew_test_*` prefix, so a process killed before TempPath cleanup cannot
+    // poison a later scan with the generated `main`.
+    let source_dir = Path::new(&test.file)
+        .parent()
+        .ok_or_else(|| "test source path has no parent directory".to_string())?;
     let tmp_source = tempfile::Builder::new()
         .prefix("hew_test_")
         .suffix(".hew")
-        .tempfile_in(std::env::temp_dir())
+        .tempfile_in(source_dir)
         .map_err(|e| format!("cannot create temp file: {e}"))?;
 
     std::fs::write(tmp_source.path(), &synthetic)

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -44,8 +44,6 @@ fn physical_core_count() -> Option<usize> {
 
 #[cfg(target_os = "linux")]
 fn physical_core_count() -> Option<usize> {
-    use std::collections::HashSet;
-
     let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").ok()?;
     let mut physical_id = None;
     let mut core_id = None;

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -1,6 +1,7 @@
 //! Execute discovered test cases via the native compilation pipeline.
 
 use super::discovery::TestCase;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::process::Command;
@@ -420,8 +421,70 @@ fn summarize(results: Vec<TestResult>) -> TestSummary {
 
 struct CompiledTestArtifact {
     _source: tempfile::NamedTempFile,
+    _source_tree: tempfile::TempDir,
     _emit_dir: tempfile::TempDir,
     binary_path: PathBuf,
+}
+
+fn mirrored_source_path(root: &Path, source: &Path) -> PathBuf {
+    let mut mirrored = root.join("source");
+    for component in source.components() {
+        if let std::path::Component::Normal(component) = component {
+            mirrored.push(component);
+        }
+    }
+    mirrored
+}
+
+fn mirror_file_imports(
+    source: &str,
+    source_dir: &Path,
+    mirror_root: &Path,
+    visited: &mut HashSet<PathBuf>,
+) -> Result<(), String> {
+    let parsed = hew_parser::parse(source);
+    for (item, _) in &parsed.program.items {
+        let hew_parser::ast::Item::Import(import) = item else {
+            continue;
+        };
+        let Some(file_path) = import.file_path.as_deref() else {
+            continue;
+        };
+        let imported_source = source_dir
+            .join(file_path)
+            .canonicalize()
+            .map_err(|error| format!("cannot resolve imported test file `{file_path}`: {error}"))?;
+        if !visited.insert(imported_source.clone()) {
+            continue;
+        }
+        let imported_contents = std::fs::read_to_string(&imported_source).map_err(|error| {
+            format!(
+                "cannot read imported test file `{}`: {error}",
+                imported_source.display()
+            )
+        })?;
+        let mirrored = mirrored_source_path(mirror_root, &imported_source);
+        let mirrored_parent = mirrored
+            .parent()
+            .ok_or_else(|| "mirrored imported source has no parent directory".to_string())?;
+        std::fs::create_dir_all(mirrored_parent).map_err(|error| {
+            format!(
+                "cannot create mirrored import directory `{}`: {error}",
+                mirrored_parent.display()
+            )
+        })?;
+        std::fs::write(&mirrored, &imported_contents).map_err(|error| {
+            format!(
+                "cannot write mirrored imported test file `{}`: {error}",
+                mirrored.display()
+            )
+        })?;
+        let imported_dir = imported_source
+            .parent()
+            .ok_or_else(|| "imported test source has no parent directory".to_string())?;
+        mirror_file_imports(&imported_contents, imported_dir, mirror_root, visited)?;
+    }
+    Ok(())
 }
 
 /// Compile a synthetic test program to a native binary.
@@ -436,17 +499,28 @@ fn compile_test(
         name = test.name,
     );
 
-    // Keep the synthetic source beside the fixture so relative file imports
-    // resolve from the same directory as the authored test. Discovery excludes
-    // the `hew_test_*` prefix, so a process killed before TempPath cleanup cannot
-    // poison a later scan with the generated `main`.
-    let source_dir = Path::new(&test.file)
+    // Mirror only the fixture's relative file-import closure into a writable
+    // temporary tree. The synthetic source keeps the original absolute parent
+    // shape inside that tree, so quoted imports resolve identically without
+    // requiring write access to the source checkout.
+    let source_path = Path::new(&test.file)
+        .canonicalize()
+        .map_err(|error| format!("cannot resolve test source `{}`: {error}", test.file))?;
+    let source_dir = source_path
         .parent()
         .ok_or_else(|| "test source path has no parent directory".to_string())?;
+    let source_tree = tempfile::Builder::new()
+        .prefix("hew_test_source_")
+        .tempdir_in(std::env::temp_dir())
+        .map_err(|e| format!("cannot create temp source tree: {e}"))?;
+    mirror_file_imports(source, source_dir, source_tree.path(), &mut HashSet::new())?;
+    let mirrored_source_dir = mirrored_source_path(source_tree.path(), source_dir);
+    std::fs::create_dir_all(&mirrored_source_dir)
+        .map_err(|e| format!("cannot create mirrored test source directory: {e}"))?;
     let tmp_source = tempfile::Builder::new()
         .prefix("hew_test_")
         .suffix(".hew")
-        .tempfile_in(source_dir)
+        .tempfile_in(mirrored_source_dir)
         .map_err(|e| format!("cannot create temp file: {e}"))?;
 
     std::fs::write(tmp_source.path(), &synthetic)
@@ -482,6 +556,7 @@ fn compile_test(
 
     Ok(CompiledTestArtifact {
         _source: tmp_source,
+        _source_tree: source_tree,
         _emit_dir: emit_dir,
         binary_path,
     })

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -2069,13 +2069,13 @@ mod tests {
         reason = "the import-order regression keeps both declaration-owner permutations in one proof"
     )]
     fn mixed_file_and_package_impls_keep_declaration_owned_dispatch_in_both_import_orders() {
-        // A file import is flattened into the root program, whereas a package
-        // import retains its package-qualified declaration owner.  The two
+        // A file import shares the root checker declaration namespace, while
+        // its emitted HIR body retains the source-file symbol owner. A package
+        // import retains a package-qualified owner at both boundaries. The two
         // sources intentionally declare same-leaf `Result` / `ResultMethods`
-        // impls.  The checker must select the root-owned file declaration for
-        // `local.tag()` and the package-owned declaration for `r.rows()`;
-        // choosing an owner by the shared leaf name makes HIR's body lookup
-        // ambiguous or attaches the call to the wrong implementation.
+        // impls. The checker must select the root declaration for `local.tag()`
+        // and the package declaration for `r.rows()`; HIR's direct-call index
+        // must then project each declaration to its distinct emitted body.
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("hew-compile has a workspace parent");
@@ -2176,7 +2176,10 @@ mod tests {
                 hir.diagnostics
             );
             let symbols = hew_hir::dispatch::build_direct_call_symbol_index(&hir.module.items);
-            assert_eq!(symbols.get(&root_tag), Some(&"Result::tag".to_string()));
+            assert_eq!(
+                symbols.get(&root_tag),
+                Some(&"mixed_import_impl_collision_lib.Result::tag".to_string())
+            );
             assert_eq!(
                 symbols.get(&package_rows),
                 Some(&"hew.testffi.Result::rows".to_string())

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4215,7 +4215,29 @@ pub fn lower_program_with_mono_cap(
                 }
             }
             Item::Impl(impl_decl) => {
-                ctx.lower_impl_block(impl_decl, span.clone(), &mut items, false, None);
+                let imported_symbol_self_name =
+                    ctx.current_module_name.as_deref().and_then(|module| {
+                        match &impl_decl.target_type.0 {
+                            TypeExpr::Named { name, .. } => Some(format!("{module}.{name}")),
+                            _ => None,
+                        }
+                    });
+                let rewrites = HashMap::new();
+                let skip_methods = HashSet::new();
+                let imported = imported_symbol_self_name
+                    .as_deref()
+                    .map(|symbol_self_name| ImportedImplLowering {
+                        rewrites: &rewrites,
+                        skip_methods: &skip_methods,
+                        symbol_self_name: Some(symbol_self_name),
+                    });
+                ctx.lower_impl_block(
+                    impl_decl,
+                    span.clone(),
+                    &mut items,
+                    false,
+                    imported.as_ref(),
+                );
             }
             Item::Machine(machine) => {
                 if let Some(hir_machine) = ctx.lower_machine(machine, span.clone()) {
@@ -4624,6 +4646,12 @@ pub fn lower_program_with_mono_cap(
                         // function signature, so visibility cannot discard its
                         // runtime layout and value-class identity here.
                         Item::Machine(machine) => {
+                            // File imports are flattened into the source-order
+                            // pass above. Lowering them again here would mint
+                            // duplicate machine mono/layout entries.
+                            if file_import_modules.contains(mod_id) {
+                                continue;
+                            }
                             if let Some(hir_machine) = ctx.lower_machine(machine, span.clone()) {
                                 items.push(HirItem::Machine(hir_machine));
                             }
@@ -23289,6 +23317,32 @@ impl LowerCtx {
         span: &Span,
     ) -> bool {
         let expected = self.impl_body_plan.symbols.get(declaration).cloned();
+        if expected
+            .as_deref()
+            .is_some_and(|expected| expected != symbol)
+            && self
+                .current_module_name
+                .as_deref()
+                .is_some_and(|module| self.file_import_module_names.contains(module))
+            && symbol.contains('.')
+        {
+            self.impl_body_plan
+                .symbols
+                .insert(declaration.clone(), symbol.to_string());
+            return true;
+        }
+        if expected.is_none()
+            && self
+                .current_module_name
+                .as_deref()
+                .is_some_and(|module| self.file_import_module_names.contains(module))
+            && symbol.contains('.')
+        {
+            self.impl_body_plan
+                .symbols
+                .insert(declaration.clone(), symbol.to_string());
+            return true;
+        }
         if expected.as_deref() == Some(symbol) {
             return true;
         }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4218,7 +4218,11 @@ pub fn lower_program_with_mono_cap(
                 let imported_symbol_self_name =
                     ctx.current_module_name.as_deref().and_then(|module| {
                         match &impl_decl.target_type.0 {
-                            TypeExpr::Named { name, .. } => Some(format!("{module}.{name}")),
+                            TypeExpr::Named { name, .. }
+                                if !ctx.cross_module_colliding_record_names.contains(name) =>
+                            {
+                                Some(format!("{module}.{name}"))
+                            }
                             _ => None,
                         }
                     });
@@ -23320,18 +23324,6 @@ impl LowerCtx {
         if expected
             .as_deref()
             .is_some_and(|expected| expected != symbol)
-            && self
-                .current_module_name
-                .as_deref()
-                .is_some_and(|module| self.file_import_module_names.contains(module))
-            && symbol.contains('.')
-        {
-            self.impl_body_plan
-                .symbols
-                .insert(declaration.clone(), symbol.to_string());
-            return true;
-        }
-        if expected.is_none()
             && self
                 .current_module_name
                 .as_deref()

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -1397,41 +1397,86 @@ fn collect_inherent_impl_consuming_methods_from_items(
 fn collect_trait_default_methods(
     program: &Program,
     file_import_module_idx: &HashMap<usize, u32>,
+    trait_method_ids_by_binding: &HashMap<
+        (Option<String>, String, String),
+        (hew_types::DefId, hew_types::DefId),
+    >,
 ) -> (HashMap<String, Vec<TraitMethod>>, HashMap<String, u32>) {
+    fn checker_binding_owner(
+        scope: Option<&str>,
+        trait_name: &str,
+        defaults: &[TraitMethod],
+        trait_method_ids_by_binding: &HashMap<
+            (Option<String>, String, String),
+            (hew_types::DefId, hew_types::DefId),
+        >,
+    ) -> Option<String> {
+        let scope = scope.map(str::to_string);
+        let mut owners = defaults
+            .iter()
+            .map(|method| {
+                trait_method_ids_by_binding
+                    .get(&(scope.clone(), trait_name.to_string(), method.name.clone()))
+                    .map(|(trait_id, _)| trait_id.full_path().to_string())
+            })
+            .collect::<Option<Vec<_>>>()?;
+        owners.sort_unstable();
+        owners.dedup();
+        (owners.len() == 1).then(|| owners.pop().expect("checked length"))
+    }
+
     let mut owner_module_idx: HashMap<String, u32> = HashMap::new();
     let mut out: HashMap<String, Vec<TraitMethod>> = HashMap::new();
-    let mut collect =
-        |items: &[(Item, Span)], owner: Option<&str>, idx_for: &dyn Fn(usize) -> u32| {
-            for (item_idx, (item, _)) in items.iter().enumerate() {
-                let Item::Trait(trait_decl) = item else {
-                    continue;
-                };
-                let defaults: Vec<TraitMethod> = trait_decl
-                    .items
-                    .iter()
-                    .filter_map(|ti| match ti {
-                        TraitItem::Method(method) if method.body.is_some() => Some(method.clone()),
-                        _ => None,
-                    })
-                    .collect();
-                if !defaults.is_empty() {
-                    let key = owner.map_or_else(
+    let mut collect = |items: &[(Item, Span)],
+                       owner: Option<&str>,
+                       flat_file_items: Option<&HashMap<usize, u32>>,
+                       idx_for: &dyn Fn(usize) -> u32| {
+        for (item_idx, (item, _)) in items.iter().enumerate() {
+            let Item::Trait(trait_decl) = item else {
+                continue;
+            };
+            let defaults: Vec<TraitMethod> = trait_decl
+                .items
+                .iter()
+                .filter_map(|ti| match ti {
+                    TraitItem::Method(method) if method.body.is_some() => Some(method.clone()),
+                    _ => None,
+                })
+                .collect();
+            if !defaults.is_empty() {
+                let key = if flat_file_items.is_some_and(|items| items.contains_key(&item_idx)) {
+                    let Some(owner) = checker_binding_owner(
+                        None,
+                        &trait_decl.name,
+                        &defaults,
+                        trait_method_ids_by_binding,
+                    ) else {
+                        continue;
+                    };
+                    owner
+                } else {
+                    owner.map_or_else(
                         || trait_decl.name.clone(),
                         |owner| format!("{owner}.{}", trait_decl.name),
-                    );
-                    // A trait spliced into the ROOT items by a file import keeps
-                    // its bare root spelling, but the checker validated it during
-                    // the module walk under that file's own index. A trait in a
-                    // directory module's peer file likewise owns that PEER's index,
-                    // not the assembled module's base — recover both per item.
-                    owner_module_idx.insert(key.clone(), idx_for(item_idx));
-                    out.insert(key, defaults);
-                }
+                    )
+                };
+                // A trait spliced into the ROOT items by a file import keeps
+                // its root binding spelling, but its declaration identity is
+                // the exact canonical owner published by the checker. A trait
+                // in a directory module's peer file likewise owns that PEER's
+                // index, not the assembled module's base — recover both per
+                // item.
+                owner_module_idx.insert(key.clone(), idx_for(item_idx));
+                out.insert(key, defaults);
             }
-        };
-    collect(&program.items, None, &|item_idx| {
-        file_import_module_idx.get(&item_idx).copied().unwrap_or(0)
-    });
+        }
+    };
+    collect(
+        &program.items,
+        None,
+        Some(file_import_module_idx),
+        &|item_idx| file_import_module_idx.get(&item_idx).copied().unwrap_or(0),
+    );
     if let Some(graph) = &program.module_graph {
         let span_indices = graph.file_span_indices();
         for module_id in &graph.topo_order {
@@ -1442,7 +1487,7 @@ fn collect_trait_default_methods(
                 continue;
             };
             let owner = module_id.path.join(".");
-            collect(&module.items, Some(&owner), &|item_idx| {
+            collect(&module.items, Some(&owner), None, &|item_idx| {
                 span_indices.item_index(module_id, item_idx).unwrap_or(0)
             });
         }
@@ -2442,8 +2487,11 @@ pub fn lower_program_with_mono_cap(
 
     // Pre-pre-pass: harvest trait default method bodies so that impl-block
     // lowering can emit them for impls that do not override them.
-    let (trait_defaults, trait_default_module_idx) =
-        collect_trait_default_methods(program, &file_import_module_idx);
+    let (trait_defaults, trait_default_module_idx) = collect_trait_default_methods(
+        program,
+        &file_import_module_idx,
+        &ctx.trait_method_ids_by_binding,
+    );
     ctx.trait_default_methods = trait_defaults;
     ctx.trait_default_module_idx = trait_default_module_idx;
     let (trait_super, trait_declared_methods) = collect_trait_declaring_surfaces(program);
@@ -35177,6 +35225,44 @@ mod tests {
     use super::*;
     use hew_types::module_registry::ModuleRegistry;
     use hew_types::Checker;
+
+    #[test]
+    fn flat_file_trait_defaults_use_checker_published_owner() {
+        let parsed = hew_parser::parse(
+            r#"
+trait Greet {
+    fn simple(self) -> i64 { 42 }
+    fn greeting(self) -> string { "hello" }
+}
+"#,
+        );
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:#?}",
+            parsed.errors
+        );
+        let owner = hew_types::DefId::new("support.greeting.Greet");
+        let bindings = ["simple", "greeting"]
+            .into_iter()
+            .map(|method| {
+                (
+                    (None, "Greet".to_string(), method.to_string()),
+                    (
+                        owner.clone(),
+                        hew_types::DefId::new(format!("{}::{method}", owner.full_path())),
+                    ),
+                )
+            })
+            .collect();
+        let file_import_module_idx = HashMap::from([(0, 7)]);
+
+        let (defaults, module_indices) =
+            collect_trait_default_methods(&parsed.program, &file_import_module_idx, &bindings);
+
+        assert!(defaults.contains_key("support.greeting.Greet"));
+        assert!(!defaults.contains_key("Greet"));
+        assert_eq!(module_indices.get("support.greeting.Greet"), Some(&7));
+    }
 
     #[test]
     fn trait_method_identity_prefers_local_and_imported_same_leaf_traits_over_prelude_items() {

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -994,6 +994,7 @@ struct ImportedImplLowering<'a> {
 #[derive(Debug, Default)]
 struct ImplBodyPlan {
     symbols: HashMap<hew_types::DefId, String>,
+    symbol_self_names: HashMap<*const hew_parser::ast::ImplDecl, String>,
 }
 
 fn plan_impl_block_symbols(
@@ -1002,6 +1003,28 @@ fn plan_impl_block_symbols(
     base_symbol_self_name: &str,
     skip_methods: &HashSet<String>,
 ) {
+    let declaration_key = impl_decl as *const _;
+    if let Some(existing) = ctx
+        .impl_body_plan
+        .symbol_self_names
+        .insert(declaration_key, base_symbol_self_name.to_string())
+    {
+        if existing != base_symbol_self_name {
+            ctx.impl_body_plan
+                .symbol_self_names
+                .remove(&declaration_key);
+            ctx.diagnostics.push(HirDiagnostic::new(
+                HirDiagnosticKind::CheckerBoundaryViolation {
+                    name: "impl body owner".to_string(),
+                    reason: format!(
+                        "conflicting pre-lowering owners `{existing}` and `{base_symbol_self_name}`"
+                    ),
+                },
+                0..0,
+                "one implementation declaration selected two distinct canonical owners",
+            ));
+        }
+    }
     if impl_decl.where_clause.is_some() && classify_unsupported_where_clause(impl_decl).is_some() {
         return;
     }
@@ -1137,16 +1160,22 @@ fn materialized_default_body_plan(
 fn plan_imported_impl_bodies(
     ctx: &mut LowerCtx,
     program: &Program,
+    file_import_module_idx: &HashMap<usize, u32>,
+    span_indices: &hew_parser::module::FileSpanIndices,
     file_import_modules: &HashSet<hew_parser::module::ModuleId>,
     preferred_modules: &HashSet<hew_parser::module::ModuleId>,
 ) {
     let empty_skips = HashSet::new();
     // Source-order bodies include root declarations and flattened file imports.
     // They may be called before their tail-spliced item is emitted.
-    for (item, _) in &program.items {
+    for (item_idx, (item, _)) in program.items.iter().enumerate() {
         if let Item::Impl(impl_decl) = item {
             if let TypeExpr::Named { name, .. } = &impl_decl.target_type.0 {
-                plan_impl_block_symbols(ctx, impl_decl, name, &empty_skips);
+                let symbol_self_name = file_import_module_idx
+                    .get(&item_idx)
+                    .and_then(|module_idx| span_indices.module_name(*module_idx))
+                    .map_or_else(|| name.clone(), |module| format!("{module}.{name}"));
+                plan_impl_block_symbols(ctx, impl_decl, &symbol_self_name, &empty_skips);
             }
         }
     }
@@ -4138,7 +4167,14 @@ pub fn lower_program_with_mono_cap(
     // package method whose HIR function is emitted later in the fourth pass.
     // This plan is declaration-keyed and uses the same imported-body skip
     // authority as that fourth pass; `fn_registry` never serves as proof.
-    plan_imported_impl_bodies(&mut ctx, program, &file_import_modules, &preferred_modules);
+    plan_imported_impl_bodies(
+        &mut ctx,
+        program,
+        &file_import_module_idx,
+        &span_indices,
+        &file_import_modules,
+        &preferred_modules,
+    );
 
     // Third pass: emit all items in source order now that both fn signatures
     // and type markers are fully resolved.
@@ -4215,17 +4251,12 @@ pub fn lower_program_with_mono_cap(
                 }
             }
             Item::Impl(impl_decl) => {
-                let imported_symbol_self_name =
-                    ctx.current_module_name.as_deref().and_then(|module| {
-                        match &impl_decl.target_type.0 {
-                            TypeExpr::Named { name, .. }
-                                if !ctx.cross_module_colliding_record_names.contains(name) =>
-                            {
-                                Some(format!("{module}.{name}"))
-                            }
-                            _ => None,
-                        }
-                    });
+                let imported_symbol_self_name = ctx.current_module_name.as_ref().and_then(|_| {
+                    ctx.impl_body_plan
+                        .symbol_self_names
+                        .get(&(impl_decl as *const _))
+                        .cloned()
+                });
                 let rewrites = HashMap::new();
                 let skip_methods = HashSet::new();
                 let imported = imported_symbol_self_name
@@ -4819,14 +4850,30 @@ pub fn lower_program_with_mono_cap(
                                     &source_module,
                                     &same_module_fn_rewrites,
                                 );
-                                let qualified_identity =
-                                    format!("{source_module}.{self_type_name}");
                                 // Impl method symbols are declaration-owned,
-                                // not collision-owned.  Always use the full
-                                // source module path so two modules ending in
-                                // `render` cannot emit the same `Box::render`
-                                // linker label.
-                                let qualified_symbol_self_name = Some(qualified_identity);
+                                // not collision-owned. Consume the canonical
+                                // owner established by the declaration-keyed
+                                // pre-lowering plan rather than reconstructing
+                                // it from the source spelling.
+                                let planned_symbol_self_name = ctx
+                                    .impl_body_plan
+                                    .symbol_self_names
+                                    .get(&(impl_decl as *const _))
+                                    .cloned();
+                                if planned_symbol_self_name.is_none() {
+                                    ctx.diagnostics.push(HirDiagnostic::new(
+                                        HirDiagnosticKind::CheckerBoundaryViolation {
+                                            name: format!(
+                                                "impl body `{source_module}.{self_type_name}`"
+                                            ),
+                                            reason:
+                                                "no pre-lowering canonical owner".to_string(),
+                                        },
+                                        span.clone(),
+                                        "imported implementation body has no declaration-keyed owner plan",
+                                    ));
+                                    continue;
+                                }
                                 ctx.lower_impl_block(
                                     impl_decl,
                                     span.clone(),
@@ -4835,7 +4882,7 @@ pub fn lower_program_with_mono_cap(
                                     Some(&ImportedImplLowering {
                                         rewrites: &same_module_fn_rewrites,
                                         skip_methods: &skip_methods,
-                                        symbol_self_name: qualified_symbol_self_name.as_deref(),
+                                        symbol_self_name: planned_symbol_self_name.as_deref(),
                                     }),
                                 );
                             }
@@ -12275,12 +12322,11 @@ impl LowerCtx {
         // previous value (almost always `None`) on exit so nested
         // impl-lowering reentry — should it ever arise — does not leak state.
         // `HirImplBlock::self_type_name` is receiver identity metadata, not a
-        // callable-symbol prefix. Imported non-colliding impls deliberately
-        // retain a bare prefix (`Value::push_int`) for the checker-aligned
-        // function registry, while their resolved receiver type carries the
-        // source identity (`toml.Value`). Preserve both facts: MIR compares
-        // this metadata with parameter zero to distinguish a true receiver
-        // from an associated function's ordinary first argument.
+        // callable-symbol prefix. Imported impl symbols carry the canonical
+        // declaration owner from `impl_body_plan`, while their resolved receiver
+        // type independently carries the source identity. Preserve both facts:
+        // MIR compares this metadata with parameter zero to distinguish a true
+        // receiver from an associated function's ordinary first argument.
         let hir_impl_self_type_name = match &resolved_impl_self_ty {
             ResolvedTy::Named {
                 builtin: Some(BuiltinType::VecIter),
@@ -23321,20 +23367,6 @@ impl LowerCtx {
         span: &Span,
     ) -> bool {
         let expected = self.impl_body_plan.symbols.get(declaration).cloned();
-        if expected
-            .as_deref()
-            .is_some_and(|expected| expected != symbol)
-            && self
-                .current_module_name
-                .as_deref()
-                .is_some_and(|module| self.file_import_module_names.contains(module))
-            && symbol.contains('.')
-        {
-            self.impl_body_plan
-                .symbols
-                .insert(declaration.clone(), symbol.to_string());
-            return true;
-        }
         if expected.as_deref() == Some(symbol) {
             return true;
         }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -997,6 +997,14 @@ struct ImplBodyPlan {
     symbol_self_names: HashMap<*const hew_parser::ast::ImplDecl, String>,
 }
 
+fn imported_impl_symbol_self_name(source_module: &str, source_name: &str) -> String {
+    if source_name.contains('.') {
+        source_name.to_string()
+    } else {
+        format!("{source_module}.{source_name}")
+    }
+}
+
 fn plan_impl_block_symbols(
     ctx: &mut LowerCtx,
     impl_decl: &hew_parser::ast::ImplDecl,
@@ -1174,7 +1182,10 @@ fn plan_imported_impl_bodies(
                 let symbol_self_name = file_import_module_idx
                     .get(&item_idx)
                     .and_then(|module_idx| span_indices.module_name(*module_idx))
-                    .map_or_else(|| name.clone(), |module| format!("{module}.{name}"));
+                    .map_or_else(
+                        || name.clone(),
+                        |module| imported_impl_symbol_self_name(module, name),
+                    );
                 plan_impl_block_symbols(ctx, impl_decl, &symbol_self_name, &empty_skips);
             }
         }
@@ -1235,7 +1246,7 @@ fn plan_imported_impl_bodies(
                 continue;
             };
             let skip_methods = ctx.imported_impl_skip_methods(impl_decl, &source_module, &rewrites);
-            let base_symbol_self_name = format!("{source_module}.{name}");
+            let base_symbol_self_name = imported_impl_symbol_self_name(&source_module, name);
             plan_impl_block_symbols(ctx, impl_decl, &base_symbol_self_name, &skip_methods);
         }
         ctx.current_module_name = previous_module;
@@ -2899,8 +2910,8 @@ pub fn lower_program_with_mono_cap(
                                     || classify_unsupported_where_clause(impl_decl).is_none()
                                 {
                                     let impl_type_params = impl_type_param_names(impl_decl);
-                                    let qualified_identity = format!("{module_full_path}.{name}");
-                                    let symbol_self_name = qualified_identity;
+                                    let symbol_self_name =
+                                        imported_impl_symbol_self_name(&module_full_path, name);
                                     for method in &impl_decl.methods {
                                         ctx.register_impl_method_fn_entry(
                                             &symbol_self_name,

--- a/hew-types/src/check/coerce.rs
+++ b/hew-types/src/check/coerce.rs
@@ -636,9 +636,12 @@ impl Checker {
             return None;
         }
 
+        let canonical_type_name = self
+            .canonical_nominal_name(concrete_type_name)
+            .unwrap_or_else(|| concrete_type_name.to_string());
         let mut table: Vec<DynVtableEntry> = Vec::with_capacity(trait_info.methods.len());
         for method in &trait_info.methods {
-            let impl_fn_key = format!("{concrete_type_name}::{}", method.name);
+            let impl_fn_key = format!("{canonical_type_name}::{}", method.name);
             let Some(mut signature) = self.lookup_trait_method(&trait_lookup_key, &method.name)
             else {
                 // JUSTIFIED: `trait_info` is cloned from `trait_defs[trait_name]`,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -63,11 +63,6 @@ impl Checker {
                     .get(&format!("{declaring_trait}::{method_name}"))
                     .cloned()
             })
-            .or_else(|| {
-                self.trait_method_ids
-                    .get(&format!("{trait_name}::{method_name}"))
-                    .cloned()
-            })
     }
 }
 
@@ -10749,6 +10744,50 @@ fn collection_dispatch_registry_impl() -> ImplRegistry {
 mod tests {
     use super::*;
     use crate::module_registry::ModuleRegistry;
+
+    #[test]
+    fn trait_method_target_ids_fail_closed_after_canonical_miss() {
+        let mut checker = Checker {
+            current_module: Some("app".to_string()),
+            ..Checker::default()
+        };
+        checker.trait_defs.insert(
+            "left.Render".to_string(),
+            TraitInfo {
+                methods: Vec::new(),
+                associated_types: Vec::new(),
+                type_params: Vec::new(),
+            },
+        );
+        checker
+            .published_bare_trait_owners
+            .entry((checker.current_module.clone(), "Render".to_string()))
+            .or_default()
+            .insert("left.Render".to_string());
+
+        let wrong_trait = crate::DefId::new("right.Render");
+        let wrong_method = crate::DefId::new("right.Render::render");
+        checker
+            .trait_method_ids
+            .insert("Render::render".to_string(), (wrong_trait, wrong_method));
+
+        assert_eq!(
+            checker.trait_method_call_target_ids("Render", "render"),
+            None,
+            "a canonical lookup miss must not retry the first-write-wins bare key",
+        );
+
+        let canonical_trait = crate::DefId::new("left.Render");
+        let canonical_method = crate::DefId::new("left.Render::render");
+        checker.trait_method_ids.insert(
+            "left.Render::render".to_string(),
+            (canonical_trait.clone(), canonical_method.clone()),
+        );
+        assert_eq!(
+            checker.trait_method_call_target_ids("Render", "render"),
+            Some((canonical_trait, canonical_method)),
+        );
+    }
 
     #[test]
     fn suspending_io_method_results_publish_delivery_ownership() {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -75,6 +75,16 @@ impl Checker {
                     .get(&format!("{trait_name}::{method_name}"))
                     .cloned()
             })
+            .or_else(|| {
+                self.trait_method_ids.iter().find_map(|(key, ids)| {
+                    let (owner, method) = key.rsplit_once("::")?;
+                    let owner_leaf = owner.rsplit_once('.').map_or(owner, |(_, leaf)| leaf);
+                    let trait_leaf = trait_name
+                        .rsplit_once('.')
+                        .map_or(trait_name, |(_, leaf)| leaf);
+                    (method == method_name && owner_leaf == trait_leaf).then_some(ids.clone())
+                })
+            })
     }
 }
 

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -58,14 +58,14 @@ impl Checker {
             ))
             .cloned()
             .or_else(|| {
-                self.trait_method_ids
-                    .get(&format!("{trait_name}::{method_name}"))
-                    .cloned()
-            })
-            .or_else(|| {
                 let declaring_trait = self.trait_ref_lookup_key(trait_name);
                 self.trait_method_ids
                     .get(&format!("{declaring_trait}::{method_name}"))
+                    .cloned()
+            })
+            .or_else(|| {
+                self.trait_method_ids
+                    .get(&format!("{trait_name}::{method_name}"))
                     .cloned()
             })
     }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -58,32 +58,15 @@ impl Checker {
             ))
             .cloned()
             .or_else(|| {
-                self.current_module.as_ref().and_then(|module| {
-                    self.trait_method_ids
-                        .get(&format!("{module}.{trait_name}::{method_name}"))
-                        .cloned()
-                })
+                self.trait_method_ids
+                    .get(&format!("{trait_name}::{method_name}"))
+                    .cloned()
             })
             .or_else(|| {
                 let declaring_trait = self.trait_ref_lookup_key(trait_name);
                 self.trait_method_ids
                     .get(&format!("{declaring_trait}::{method_name}"))
                     .cloned()
-            })
-            .or_else(|| {
-                self.trait_method_ids
-                    .get(&format!("{trait_name}::{method_name}"))
-                    .cloned()
-            })
-            .or_else(|| {
-                self.trait_method_ids.iter().find_map(|(key, ids)| {
-                    let (owner, method) = key.rsplit_once("::")?;
-                    let owner_leaf = owner.rsplit_once('.').map_or(owner, |(_, leaf)| leaf);
-                    let trait_leaf = trait_name
-                        .rsplit_once('.')
-                        .map_or(trait_name, |(_, leaf)| leaf);
-                    (method == method_name && owner_leaf == trait_leaf).then_some(ids.clone())
-                })
             })
     }
 }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6220,13 +6220,15 @@ impl Checker {
                                         )
                                     })
                                 };
-                                if let Ok(receiver_args) = self_type_args
-                                    .iter()
-                                    .map(ResolvedTy::from_ty)
-                                    .collect::<Result<Vec<_>, _>>()
-                                {
+                                if let (Ok(receiver_args), Some((declaring_trait, _))) = (
+                                    self_type_args
+                                        .iter()
+                                        .map(ResolvedTy::from_ty)
+                                        .collect::<Result<Vec<_>, _>>(),
+                                    self.trait_method_call_target_ids(&tb.name, &m.name),
+                                ) {
                                     let declaration = crate::default_impl_method_declaration(
-                                        &crate::DefId::new(trait_key.clone()),
+                                        &declaring_trait,
                                         &crate::NominalInstance {
                                             nominal: crate::NominalId::new(receiver_name),
                                             args: receiver_args,

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6501,8 +6501,13 @@ impl Checker {
             );
         let trait_id = crate::DefId::new(declaration_key.clone());
         let method_id = crate::DefId::new(format!("{}::{}", trait_id.full_path(), method.name));
+        let ids = (trait_id, method_id);
         self.trait_method_ids
-            .insert(method_id.full_path().to_string(), (trait_id, method_id));
+            .insert(ids.1.full_path().to_string(), ids.clone());
+        if self.registration_is_flat_file_import {
+            self.trait_method_ids_by_binding
+                .insert((None, trait_name.to_string(), method.name.clone()), ids);
+        }
         // The owner-qualified key (`{module}.{trait}::{method}`) is collision-free
         // even when two imported modules export a same-named trait. The bare
         // `{trait}::{method}` key is first-write-wins, so with a same-name
@@ -11855,6 +11860,28 @@ impl Checker {
                             .entry(format!("{module_short}.{}", tr.name))
                             .or_insert_with(|| info.clone());
                     }
+                    // A whole-module import exposes the trait through the exact
+                    // qualified source binding (`alias.Trait`) rather than a
+                    // published bare name. Record the checker-owned declaration
+                    // IDs under that binding too, so call-target selection never
+                    // has to recover an owner from the trait's leaf spelling.
+                    let trait_id = crate::DefId::new(qualified.clone());
+                    let qualified_binding = format!("{module_short}.{}", tr.name);
+                    for trait_item in &tr.items {
+                        let TraitItem::Method(method) = trait_item else {
+                            continue;
+                        };
+                        let method_id =
+                            crate::DefId::new(format!("{}::{}", trait_id.full_path(), method.name));
+                        self.trait_method_ids_by_binding.insert(
+                            (
+                                self.current_module.clone(),
+                                qualified_binding.clone(),
+                                method.name.clone(),
+                            ),
+                            (trait_id.clone(), method_id),
+                        );
+                    }
 
                     // Record super-trait relationships for both qualified and
                     // unqualified bindings. A supertrait reference written inside
@@ -11895,7 +11922,6 @@ impl Checker {
                             .entry((self.current_module.clone(), binding_name.clone()))
                             .or_default()
                             .insert(format!("{module_full_path}.{}", tr.name));
-                        let trait_id = crate::DefId::new(format!("{module_full_path}.{}", tr.name));
                         for trait_item in &tr.items {
                             let TraitItem::Method(method) = trait_item else {
                                 continue;

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -14,7 +14,7 @@ checker-hir-fact-relation	checker-relation-use	hew-hir/src/lower.rs	7	stage-2	re
 checker-hir-fact-relation	checker-relation-use	hew-types/src/check/expressions.rs	11	stage-2	real checker/HIR produced-value carrier inventory
 checker-hir-fact-relation	checker-relation-use	hew-types/src/check/mod.rs	15	stage-2	real checker/HIR produced-value carrier inventory
 checker-hir-fact-relation	checker-relation-variant	hew-types/src/check/types.rs	6	stage-2	real checker/HIR produced-value carrier inventory
-checker-hir-fact-relation	hir-publication-consumer	hew-hir/src/lower.rs	358	stage-2	rc1-F1 stage F reads plus four impl_method_declaration_ids reads that register lang-item Display bodies ahead of the third pass (direct primitive .fmt() dispatch, mirrors plan_imported_impl_bodies)
+checker-hir-fact-relation	hir-publication-consumer	hew-hir/src/lower.rs	359	stage-2	rc1-F1 stage F reads plus canonical flat-file trait default owner harvest and four impl_method_declaration_ids reads that register lang-item Display bodies ahead of the third pass (direct primitive .fmt() dispatch, mirrors plan_imported_impl_bodies)
 checker-hir-fact-relation	hir-publication-consumer	hew-hir/src/node.rs	5	stage-2	real checker/HIR produced-value carrier inventory
 checker-hir-fact-relation	hir-relation-consumer	hew-hir/src/verify.rs	8	stage-2	real checker/HIR produced-value carrier inventory
 checker-hir-fact-relation	hir-relation-consumer	hew-mir/src/lower/ownership.rs	4	stage-2	real checker/HIR produced-value carrier inventory

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -134,9 +134,9 @@ string-method-identity	qualified-format-macro	hew-types/src/check/coerce.rs	4	st
 string-method-identity	qualified-format-macro	hew-types/src/check/expressions.rs	6	stage-1	reviewed qualified string identity construction; adds dotted module-qualified unit-constructor resolution (module.Type.Variant)
 string-method-identity	qualified-format-macro	hew-types/src/check/items.rs	31	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-types/src/check/lints/mod.rs	1	stage-1	reviewed qualified string identity construction
-string-method-identity	qualified-format-macro	hew-types/src/check/methods.rs	58	stage-1	feat/dyn-trait-return-position: new trait-object pipeline rejection in reject_vec_pipeline_fn_element adds a qualified `Vec::{method}` literal
+string-method-identity	qualified-format-macro	hew-types/src/check/methods.rs	56	stage-1	feat/dyn-trait-return-position: new trait-object pipeline rejection in reject_vec_pipeline_fn_element adds a qualified `Vec::{method}` literal
 string-method-identity	qualified-format-macro	hew-types/src/check/mod.rs	3	stage-1	reviewed qualified string identity construction
-string-method-identity	qualified-format-macro	hew-types/src/check/registration.rs	37	stage-1	reviewed qualified string identity construction
+string-method-identity	qualified-format-macro	hew-types/src/check/registration.rs	38	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-types/src/check/resolution.rs	11	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-types/src/check/statements.rs	1	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-types/src/method_resolution.rs	3	stage-1	reviewed qualified string identity construction

--- a/tests/hew/dyn_import_same_leaf_support/file_render.hew
+++ b/tests/hew/dyn_import_same_leaf_support/file_render.hew
@@ -1,0 +1,17 @@
+pub trait Render {
+    fn render(value: Self) -> string;
+}
+
+pub type Box {
+    label: string;
+}
+
+impl Render for Box {
+    fn render(value: Box) -> string {
+        f"file:{value.label}"
+    }
+}
+
+pub fn make_file_box() -> Box {
+    Box { label: "left" }
+}

--- a/tests/hew/dyn_import_same_leaf_support/package_render.hew
+++ b/tests/hew/dyn_import_same_leaf_support/package_render.hew
@@ -1,0 +1,22 @@
+pub trait Render {
+    fn render(value: Self) -> string;
+}
+
+pub type Box {
+    label: string;
+}
+
+impl Render for Box {
+    fn render(value: Box) -> string {
+        f"package:{value.label}"
+    }
+}
+
+pub fn make_package_box() -> Box {
+    Box { label: "right" }
+}
+
+pub fn render_package_box() -> string {
+    let value: dyn Render = make_package_box();
+    value.render()
+}

--- a/tests/hew/dyn_import_same_leaf_test.hew
+++ b/tests/hew/dyn_import_same_leaf_test.hew
@@ -1,0 +1,21 @@
+//! Two imported traits share the same leaf name and both implement that trait
+//! for a same-leaf concrete type. Dynamic calls must retain each declaration's
+//! canonical trait and impl owner.
+
+import "dyn_import_same_leaf_support/file_render.hew";
+
+import tests::hew::dyn_import_same_leaf_support::package_render::{
+    render_package_box,
+};
+
+import std::testing;
+
+fn render_file(value: dyn Render) -> string {
+    value.render()
+}
+
+#[test]
+fn same_leaf_imported_traits_dispatch_to_their_own_impls() {
+    testing.assert_eq_str(render_file(make_file_box()), "file:left");
+    testing.assert_eq_str(render_package_box(), "package:right");
+}

--- a/tests/hew/file_imported_machine_layout_test.hew
+++ b/tests/hew/file_imported_machine_layout_test.hew
@@ -1,0 +1,20 @@
+//! A machine flattened from a file import must be lowered exactly once so its
+//! monomorphisation and runtime layout retain one canonical key.
+
+import "file_imported_machine_support/machine.hew";
+
+import std::testing;
+
+fn carry_file_lifecycle(value: FileLifecycle) -> FileLifecycle {
+    value
+}
+
+#[test]
+fn file_imported_machine_crosses_the_importer_boundary() {
+    let carried = carry_file_lifecycle(initial_file_lifecycle());
+    let running = match carried {
+        FileLifecycle::Running => 1,
+        FileLifecycle::Completed => 0,
+    };
+    testing.assert_eq(running, 1);
+}

--- a/tests/hew/file_imported_machine_support/machine.hew
+++ b/tests/hew/file_imported_machine_support/machine.hew
@@ -1,0 +1,19 @@
+pub machine FileLifecycle {
+    events {
+        Finish;
+    }
+
+    state Running;
+    state Completed;
+
+    on Finish: Running => Completed {
+        Completed
+    }
+    default {
+        state
+    }
+}
+
+pub fn initial_file_lifecycle() -> FileLifecycle {
+    FileLifecycle::Running
+}


### PR DESCRIPTION
## Summary
- Canonicalize imported concrete identities for dyn-trait vtable entries and declaration targets.
- Prevent file-import machines from being lowered twice into MIR mono/layout registries.

## Verification
- `cargo test -p hew-types -p hew-mir -p hew-codegen-rs`
- Dogfood formatter-registry dyn repro
- Dogfood bank-ledger machine repro
- `make test-hew-ratchet`
- `make preflight` passed compiler pipeline; the unrelated opaque-resource lifecycle matrix was blocked by the environment’s ast-grep bootstrap.

## Out of scope
- No auto-merge enabled.