### PR TITLE
stdlib: add concrete two-stage pipeline admission proof

### DIFF
--- a/hew-cli/tests/pipeline_stdlib_ownership_oracle.rs
+++ b/hew-cli/tests/pipeline_stdlib_ownership_oracle.rs
@@ -1,0 +1,252 @@
+//! Ownership gates for the concrete `std::pipeline` S1 chain.
+//!
+//! Every source uses `pipeline.PipelineItemI64`, whose `label: string` crosses
+//! the source, stage, and sink mailboxes. The stage also constructs a new label,
+//! exercising the transform input-to-output ownership edge.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance_exact_lines, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+fn source_with_frames(template: &str, frames: usize) -> String {
+    template.replace("__FRAMES__", &frames.to_string())
+}
+
+fn expected_lines(frames: usize) -> usize {
+    frames
+}
+
+fn normal_source(frames: usize) -> String {
+    source_with_frames(
+        r#"import std::pipeline;
+
+fn main() -> i64 {
+    let source = pipeline.run(pipeline.from(__FRAMES__));
+    var i: i64 = 0;
+    while i < __FRAMES__ {
+        let item: pipeline.PipelineItemI64 = PipelineItemI64 {
+            value: i,
+            label: f"normal-owned-{i}",
+            crash_stage: false,
+        };
+        match await source.push(item) {
+            Ok(admitted) => { if !admitted { return 2; } },
+            Err(_) => { return 3; },
+        }
+        println("normal");
+        i = i + 1;
+    }
+    match await source.shutdown(__FRAMES__) {
+        Ok(drained) => if drained { 0 } else { 4 },
+        Err(_) => 5,
+    }
+}
+"#,
+        frames,
+    )
+}
+
+fn cancellation_source(frames: usize) -> String {
+    source_with_frames(
+        r#"import std::pipeline;
+
+fn item(value: i64, label: string) -> pipeline.PipelineItemI64 {
+    PipelineItemI64 { value: value, label: label, crash_stage: false }
+}
+
+fn main() -> i64 {
+    let source = pipeline.run(pipeline.from(0));
+    let control = match await source.control_handle() {
+        Ok(value) => value,
+        Err(_) => { return 10; },
+    };
+    match await source.push(item(-2, "cancel-seed-one")) {
+        Ok(admitted) => { if !admitted { return 11; } },
+        Err(_) => { return 12; },
+    }
+    match await source.push(item(-1, "cancel-seed-two")) {
+        Ok(admitted) => { if !admitted { return 13; } },
+        Err(_) => { return 14; },
+    }
+
+    var i: i64 = 0;
+    while i < __FRAMES__ {
+        let outcome = select {
+            reply from source.push(item(i, f"cancel-owned-{i}")) => if reply { 1 } else { -1 },
+            after 1ms => 0,
+        };
+        if outcome != 0 {
+            return 15;
+        }
+        control.release();
+        var posts: i64 = 0;
+        while posts < i + 3 {
+            match await control.post_sends() {
+                Ok(value) => { posts = value; },
+                Err(_) => { return 16; },
+            }
+            if posts < i + 3 {
+                sleep(1ms);
+            }
+        }
+        println("cancelled");
+        i = i + 1;
+    }
+
+    control.release();
+    control.release();
+    match await source.shutdown(__FRAMES__ + 2) {
+        Ok(drained) => if drained { 0 } else { 17 },
+        Err(_) => 18,
+    }
+}
+"#,
+        frames,
+    )
+}
+
+fn crash_source(frames: usize) -> String {
+    source_with_frames(
+        r#"import std::pipeline;
+
+fn main() -> i64 {
+    var i: i64 = 0;
+    while i < __FRAMES__ {
+        let source = pipeline.run(pipeline.from(1));
+        let item: pipeline.PipelineItemI64 = PipelineItemI64 {
+            value: i,
+            label: f"crash-owned-{i}",
+            crash_stage: true,
+        };
+        match await source.push(item) {
+            Ok(admitted) => { if admitted { return 20; } },
+            Err(_) => { return 21; },
+        }
+        match await source.count() {
+            Ok(count) => { if count != 0 { return 22; } },
+            Err(_) => { return 23; },
+        }
+        println("crashed");
+        i = i + 1;
+    }
+    0
+}
+"#,
+        frames,
+    )
+}
+
+fn shutdown_drain_source(frames: usize) -> String {
+    source_with_frames(
+        r#"import std::pipeline;
+
+fn main() -> i64 {
+    let source = pipeline.run(pipeline.from(__FRAMES__));
+    var i: i64 = 0;
+    while i < __FRAMES__ {
+        let item: pipeline.PipelineItemI64 = PipelineItemI64 {
+            value: i,
+            label: f"drain-owned-{i}",
+            crash_stage: false,
+        };
+        match await source.push(item) {
+            Ok(admitted) => { if !admitted { return 30; } },
+            Err(_) => { return 31; },
+        }
+        println("queued");
+        i = i + 1;
+    }
+    match await source.shutdown(__FRAMES__) {
+        Ok(drained) => if drained { 0 } else { 32 },
+        Err(_) => 33,
+    }
+}
+"#,
+        frames,
+    )
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator"
+)]
+#[test]
+fn pipeline_owned_payload_normal_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance_exact_lines(
+        "pipeline_owned_normal",
+        normal_source,
+        expected_lines,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator"
+)]
+#[test]
+fn pipeline_owned_payload_cancellation_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance_exact_lines(
+        "pipeline_owned_cancellation",
+        cancellation_source,
+        expected_lines,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator"
+)]
+#[test]
+fn pipeline_owned_payload_crash_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance_exact_lines(
+        "pipeline_owned_crash",
+        crash_source,
+        expected_lines,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator"
+)]
+#[test]
+fn pipeline_owned_payload_shutdown_drain_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance_exact_lines(
+        "pipeline_owned_shutdown_drain",
+        shutdown_drain_source,
+        expected_lines,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "poisoned allocator gate needs the Darwin malloc diagnostics"
+)]
+#[test]
+fn pipeline_owned_payload_lifecycle_edges_do_not_double_free() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("pipeline-owned-double-free-")
+        .tempdir()
+        .expect("tempdir");
+
+    for (name, source) in [
+        ("normal", normal_source(20)),
+        ("cancellation", cancellation_source(20)),
+        ("crash", crash_source(20)),
+        ("shutdown_drain", shutdown_drain_source(20)),
+    ] {
+        let bin = compile_to_native(&source, dir.path(), name);
+        let output = run_under_malloc_scribble(&bin);
+        assert!(
+            output.status.success(),
+            "pipeline {name} ownership edge aborted under the poisoned allocator:\n{}",
+            describe_output(&output)
+        );
+    }
+}

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -4746,4 +4746,66 @@ extern "C" { fn hew_tcp_read(foo: Foo); }
             foreign.diagnostics
         );
     }
+
+    #[test]
+    fn imported_stdlib_function_can_spawn_and_wire_private_module_actors() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("hew-compile lives below repository root");
+        let dir = tempfile::tempdir().expect("create temp project");
+        let input = write_source(
+            dir.path(),
+            "main.hew",
+            "import std::pipeline;\n\
+             fn main() {\n\
+                 let chain = pipeline.run(pipeline.from(1));\n\
+                 let item: pipeline.PipelineItemI64 = PipelineItemI64 {\n\
+                     value: 21, label: \"probe\", crash_stage: false\n\
+                 };\n\
+                 match await chain.push(item) { Ok(_) => {}, Err(_) => {} }\n\
+             }\n",
+        );
+        let state = run_file_frontend_to_typecheck(
+            &input,
+            &FrontendOptions {
+                project_dir: Some(repo_root.to_path_buf()),
+                ..FrontendOptions::default()
+            },
+        )
+        .unwrap_or_else(|failure| panic!("frontend failed: {failure:#?}"));
+        let typecheck = state
+            .typecheck_result
+            .tco
+            .as_ref()
+            .expect("fixture must typecheck");
+        let hir = hew_hir::lower_program(
+            &state.program,
+            typecheck,
+            &hew_hir::ResolutionCtx,
+            hew_hir::TargetArch::host(),
+        );
+        assert!(
+            hir.diagnostics.is_empty(),
+            "imported pipeline bodies must lower: {:#?}",
+            hir.diagnostics
+        );
+        let mir = hew_mir::lower_hir_module(&hir.module);
+        assert!(
+            mir.diagnostics.is_empty(),
+            "imported pipeline actor layouts and calls must lower: {:#?}",
+            mir.diagnostics
+        );
+        for actor in [
+            "std.pipeline.AdmissionControlI64",
+            "std.pipeline.SinkI64",
+            "std.pipeline.StageI64",
+            "std.pipeline.SourceI64",
+        ] {
+            assert!(
+                mir.actor_layouts.iter().any(|layout| layout.name == actor),
+                "missing imported actor layout `{actor}`: {:#?}",
+                mir.actor_layouts
+            );
+        }
+    }
 }

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -4748,7 +4748,7 @@ extern "C" { fn hew_tcp_read(foo: Foo); }
     }
 
     #[test]
-    fn imported_stdlib_function_can_spawn_and_wire_private_module_actors() {
+    fn imported_stdlib_function_can_spawn_and_wire_public_module_actors() {
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("hew-compile lives below repository root");

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4498,6 +4498,23 @@ pub fn lower_program_with_mono_cap(
                         )
                     })
                     .collect();
+                let same_module_actor_rewrites: HashMap<String, String> = module
+                    .items
+                    .iter()
+                    .filter_map(|(it, _)| {
+                        if let Item::Actor(actor) = it {
+                            Some((
+                                actor.name.clone(),
+                                format!("{source_module}.{}", actor.name),
+                            ))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                let prev_actor_rewrites = ctx
+                    .imported_actor_rewrites
+                    .replace(same_module_actor_rewrites);
                 // Populate bare-name const scope for this module's own consts.
                 // Functions inside the module reference module-level consts by
                 // bare name (e.g. `STATUS_OK`), but the global `const_registry`
@@ -4832,11 +4849,13 @@ pub fn lower_program_with_mono_cap(
                                 items.push(HirItem::Const(lowered));
                             }
                         }
-                        // Emit `HirItem::Actor` entries for imported pub actors
+                        // Emit `HirItem::Actor` entries for imported actors
                         // so MIR's actor-layout pass (which walks `module.items`)
-                        // builds a layout keyed by the actor's bare name. Without
-                        // it, `spawn module.Actor(...)` and the subsequent
-                        // `receive fn` calls fail closed at MIR with
+                        // builds every layout reachable from an imported body.
+                        // Private actors are runtime implementation details, but
+                        // a public module function or public actor may spawn or
+                        // message them. Without their layouts, those bodies fail
+                        // closed at MIR with
                         // `spawn of unknown actor` / `actor call on unknown actor`,
                         // even though HIR/types resolved the cross-module
                         // reference. Mirrors the `Item::Machine` arm above. The
@@ -4844,7 +4863,7 @@ pub fn lower_program_with_mono_cap(
                         // active (see `lower_imported_actor`) so bare same-module
                         // calls resolve to their qualified symbols, exactly like
                         // the imported free-fn path.
-                        Item::Actor(actor) if actor.visibility.is_pub() => {
+                        Item::Actor(actor) => {
                             // Skip actors of FILE-import modules: their items
                             // were spliced into `program.items` and already
                             // emitted (under the flat/root identity) by the
@@ -4913,10 +4932,9 @@ pub fn lower_program_with_mono_cap(
                                 }
                             }
                         }
-                        // Item::Record, Item::Supervisor and non-pub Item::Actor
-                        // from imported modules are intentionally not emitted in
-                        // this slice; their cross-module lowering semantics are
-                        // tracked as separate follow-ups.
+                        // Item::Record and Item::Supervisor from imported modules
+                        // are intentionally not emitted in this slice; their
+                        // cross-module lowering semantics are tracked separately.
                         //
                         // Non-pub Function/TypeDecl/Actor fall here (not
                         // visible to importers). If a new Item variant is
@@ -4926,12 +4944,12 @@ pub fn lower_program_with_mono_cap(
                         | Item::TypeDecl(_)
                         | Item::TypeAlias(_)
                         | Item::Record(_)
-                        | Item::Actor(_)
                         | Item::Supervisor(_) => {}
                     }
                 }
                 // Restore the const scope after lowering this module's bodies.
                 ctx.imported_module_consts = prev_module_consts;
+                ctx.imported_actor_rewrites = prev_actor_rewrites;
                 ctx.folded_integer_consts = previous_folded_integer_consts;
                 ctx.tag_diagnostics_since(diag_start, &source_module);
                 record_source_modules_for_items(
@@ -6678,6 +6696,10 @@ struct LowerCtx {
     /// the qualified, native-symbol-safe `fn_registry` keys emitted for that
     /// imported module.
     imported_fn_rewrites: Option<HashMap<String, String>>,
+    /// Same-module actor identity rewrites active while lowering imported
+    /// module bodies. Keys are source-visible bare actor names; values are the
+    /// fully-qualified actor-layout identities used by MIR.
+    imported_actor_rewrites: Option<HashMap<String, String>>,
     /// Bare-name → `ConstEntry` map active while lowering an imported module's
     /// function bodies.  A module may reference its own module-level consts
     /// by bare name (e.g. `STATUS_OK` inside `tls.hew`), but only the
@@ -7825,6 +7847,7 @@ impl LowerCtx {
             fn_registry: HashMap::new(),
             extern_fn_names: HashSet::new(),
             imported_fn_rewrites: None,
+            imported_actor_rewrites: None,
             imported_module_consts: None,
             type_classes,
             opaque_resource_candidates: tc_output.opaque_resource_candidates.clone(),
@@ -12580,6 +12603,7 @@ impl LowerCtx {
         // bare identity — its layout stays bare too, so qualifying here would
         // instead CREATE a mismatch.
         for handler in &mut lowered.receive_handlers {
+            handler.return_ty = self.qualify_current_module_record_ty(handler.return_ty.clone());
             handler.return_ty =
                 self.qualify_colliding_module_record_ty(&handler.return_ty, module_full_path);
         }
@@ -12596,6 +12620,21 @@ impl LowerCtx {
         actor_identity
             .rsplit_once('.')
             .map(|(module, _actor)| module)
+    }
+
+    fn qualify_imported_actor_method_id(&self, method_id: String) -> String {
+        let Some((actor, method)) = method_id.rsplit_once("::") else {
+            return method_id;
+        };
+        if actor.contains('.') {
+            return method_id;
+        }
+        self.imported_actor_rewrites
+            .as_ref()
+            .and_then(|rewrites| rewrites.get(actor))
+            .map_or(method_id.clone(), |qualified| {
+                format!("{qualified}::{method}")
+            })
     }
 
     /// Qualify a bare user-record type reference to `{module_short}.{name}` when
@@ -14164,6 +14203,36 @@ impl LowerCtx {
     ) -> ResolvedTy {
         if let ResolvedTy::Named {
             name,
+            mut args,
+            builtin: Some(BuiltinType::LocalPid),
+            is_opaque,
+        } = ty
+        {
+            if let [ResolvedTy::Named {
+                name: actor_name,
+                args: actor_args,
+                builtin: None,
+                ..
+            }] = args.as_mut_slice()
+            {
+                if actor_args.is_empty() && !actor_name.contains('.') {
+                    if let Some(module) = decl_module {
+                        let qualified = format!("{module}.{actor_name}");
+                        if self.actor_type_names.contains(&qualified) {
+                            actor_name.clone_from(&qualified);
+                        }
+                    }
+                }
+            }
+            return ResolvedTy::Named {
+                name,
+                args,
+                builtin: Some(BuiltinType::LocalPid),
+                is_opaque,
+            };
+        }
+        if let ResolvedTy::Named {
+            name,
             args,
             builtin,
             ..
@@ -14323,7 +14392,7 @@ impl LowerCtx {
                 field.span.clone(),
             );
         }
-        let params = params.iter().map(|p| self.bind_param(p)).collect();
+        let params = params.iter().map(|p| self.bind_actor_param(p)).collect();
         let body = self.with_current_return_type(expected_ty.clone(), |ctx| {
             ctx.lower_block(body, expected_ty)
         });
@@ -14363,7 +14432,7 @@ impl LowerCtx {
             );
             state_field_bindings.insert(binding.id);
         }
-        let params = params.iter().map(|p| self.bind_param(p)).collect();
+        let params = params.iter().map(|p| self.bind_actor_param(p)).collect();
 
         // Snapshot the enclosing scope (state fields + params, just bound
         // above) BEFORE lowering the body, mirroring `lower_generator_fn_body`
@@ -20399,6 +20468,13 @@ impl LowerCtx {
         if let Some(inner) = Self::local_pid_actor_identity(&ty) {
             inner.clone_into(&mut actor_name);
         }
+        if let Some(qualified) = self
+            .imported_actor_rewrites
+            .as_ref()
+            .and_then(|rewrites| rewrites.get(&actor_name))
+        {
+            actor_name.clone_from(qualified);
+        }
         (
             HirExprKind::Spawn {
                 actor_name,
@@ -22784,10 +22860,24 @@ impl LowerCtx {
         else {
             return ty;
         };
-        let args = args
+        let mut args: Vec<ResolvedTy> = args
             .into_iter()
             .map(|arg| self.qualify_current_module_record_ty(arg))
             .collect();
+        if builtin == Some(BuiltinType::LocalPid) {
+            if let [ResolvedTy::Named {
+                name: actor_name, ..
+            }] = args.as_mut_slice()
+            {
+                if let Some(qualified) = self
+                    .imported_actor_rewrites
+                    .as_ref()
+                    .and_then(|rewrites| rewrites.get(actor_name))
+                {
+                    actor_name.clone_from(qualified);
+                }
+            }
+        }
         let current_module_is_file_import = self
             .current_module_name
             .as_deref()
@@ -26240,46 +26330,54 @@ impl LowerCtx {
                 })
                 .collect();
             return match dispatch {
-                ActorMethodKind::Fire(method_id) => (
-                    HirExprKind::ActorSend {
-                        receiver: Box::new(lowered_receiver),
-                        method_id,
-                        args: lowered_args,
-                    },
-                    ResolvedTy::Unit,
-                ),
-                ActorMethodKind::Ask(method_id, reply_ty) => match ResolvedTy::from_ty(&reply_ty) {
-                    Ok(reply_ty) => {
-                        // Owner-qualify the ask-reply record identity to the
-                        // ASKED actor's declaring module when it collides, so
-                        // this reply type and the actor-handler layout return
-                        // type (qualified in `lower_imported_actor` under the
-                        // same collision gate) both resolve to the SAME
-                        // qualified identity the MIR record layout is keyed by.
-                        // `method_id` is `{module}.{Actor}::{method}` for an
-                        // imported actor; a bare/root actor has no leading module
-                        // segment and is left unqualified (#2208).
-                        let reply_ty = Self::actor_module_short_of_method_id(&method_id)
-                            .map_or_else(
-                                || reply_ty.clone(),
-                                |module_short| {
-                                    self.qualify_colliding_module_record_ty(&reply_ty, module_short)
+                ActorMethodKind::Fire(method_id) => {
+                    let method_id = self.qualify_imported_actor_method_id(method_id);
+                    (
+                        HirExprKind::ActorSend {
+                            receiver: Box::new(lowered_receiver),
+                            method_id,
+                            args: lowered_args,
+                        },
+                        ResolvedTy::Unit,
+                    )
+                }
+                ActorMethodKind::Ask(method_id, reply_ty) => {
+                    let method_id = self.qualify_imported_actor_method_id(method_id);
+                    match ResolvedTy::from_ty(&reply_ty) {
+                        Ok(reply_ty) => {
+                            // Owner-qualify the ask-reply record identity to the
+                            // ASKED actor's declaring module when it collides, so
+                            // this reply type and the actor-handler layout return
+                            // type (qualified in `lower_imported_actor` under the
+                            // same collision gate) both resolve to the SAME
+                            // qualified identity the MIR record layout is keyed by.
+                            // `method_id` is `{module}.{Actor}::{method}` for an
+                            // imported actor; a bare/root actor has no leading module
+                            // segment and is left unqualified (#2208).
+                            let reply_ty = Self::actor_module_short_of_method_id(&method_id)
+                                .map_or_else(
+                                    || reply_ty.clone(),
+                                    |module_short| {
+                                        self.qualify_colliding_module_record_ty(
+                                            &reply_ty,
+                                            module_short,
+                                        )
+                                    },
+                                );
+                            (
+                                HirExprKind::ActorAsk {
+                                    receiver: Box::new(lowered_receiver),
+                                    method_id,
+                                    args: lowered_args,
+                                    reply_ty: reply_ty.clone(),
+                                    source_anchor: None,
+                                    deadline_ns: None,
                                 },
-                            );
-                        (
-                            HirExprKind::ActorAsk {
-                                receiver: Box::new(lowered_receiver),
-                                method_id,
-                                args: lowered_args,
-                                reply_ty: reply_ty.clone(),
-                                source_anchor: None,
-                                deadline_ns: None,
-                            },
-                            reply_ty,
-                        )
-                    }
-                    Err(err) => {
-                        self.diagnostics.push(HirDiagnostic::new(
+                                reply_ty,
+                            )
+                        }
+                        Err(err) => {
+                            self.diagnostics.push(HirDiagnostic::new(
                             HirDiagnosticKind::CheckerBoundaryViolation {
                                 name: format!("actor method `.{method}`"),
                                 reason: err.to_string(),
@@ -26287,15 +26385,17 @@ impl LowerCtx {
                             span.clone(),
                             "checker-authoritative actor_method_dispatch reply type failed boundary conversion",
                         ));
-                        (
-                            HirExprKind::Unsupported(format!(
-                                "actor method `.{method}` has poisoned dispatch reply type"
-                            )),
-                            ResolvedTy::Unit,
-                        )
+                            (
+                                HirExprKind::Unsupported(format!(
+                                    "actor method `.{method}` has poisoned dispatch reply type"
+                                )),
+                                ResolvedTy::Unit,
+                            )
+                        }
                     }
-                },
+                }
                 ActorMethodKind::StreamProducer(method_id, elem_ty) => {
+                    let method_id = self.qualify_imported_actor_method_id(method_id);
                     match ResolvedTy::from_ty(&elem_ty) {
                         Ok(elem_ty) => {
                             let stream_ty = ResolvedTy::named_builtin(
@@ -27454,6 +27554,14 @@ impl LowerCtx {
     /// every non-param binder) always leaves `false`.
     fn bind_param(&mut self, param: &Param) -> HirBinding {
         let ty = self.lower_type(&param.ty);
+        let mut binding = self.bind(param.name.clone(), ty, param.is_mutable, param.ty.1.clone());
+        binding.is_consume = param.is_consume;
+        binding
+    }
+
+    fn bind_actor_param(&mut self, param: &Param) -> HirBinding {
+        let ty = self.lower_type(&param.ty);
+        let ty = self.qualify_current_module_record_ty(ty);
         let mut binding = self.bind(param.name.clone(), ty, param.is_mutable, param.ty.1.clone());
         binding.is_consume = param.is_consume;
         binding

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4849,13 +4849,11 @@ pub fn lower_program_with_mono_cap(
                                 items.push(HirItem::Const(lowered));
                             }
                         }
-                        // Emit `HirItem::Actor` entries for imported actors
+                        // Emit `HirItem::Actor` entries for imported pub actors
                         // so MIR's actor-layout pass (which walks `module.items`)
-                        // builds every layout reachable from an imported body.
-                        // Private actors are runtime implementation details, but
-                        // a public module function or public actor may spawn or
-                        // message them. Without their layouts, those bodies fail
-                        // closed at MIR with
+                        // builds a layout keyed by the actor's bare name. Without
+                        // it, `spawn module.Actor(...)` and the subsequent
+                        // `receive fn` calls fail closed at MIR with
                         // `spawn of unknown actor` / `actor call on unknown actor`,
                         // even though HIR/types resolved the cross-module
                         // reference. Mirrors the `Item::Machine` arm above. The
@@ -4863,7 +4861,7 @@ pub fn lower_program_with_mono_cap(
                         // active (see `lower_imported_actor`) so bare same-module
                         // calls resolve to their qualified symbols, exactly like
                         // the imported free-fn path.
-                        Item::Actor(actor) => {
+                        Item::Actor(actor) if actor.visibility.is_pub() => {
                             // Skip actors of FILE-import modules: their items
                             // were spliced into `program.items` and already
                             // emitted (under the flat/root identity) by the
@@ -4932,9 +4930,10 @@ pub fn lower_program_with_mono_cap(
                                 }
                             }
                         }
-                        // Item::Record and Item::Supervisor from imported modules
-                        // are intentionally not emitted in this slice; their
-                        // cross-module lowering semantics are tracked separately.
+                        // Item::Record, Item::Supervisor and non-pub Item::Actor
+                        // from imported modules are intentionally not emitted in
+                        // this slice; their cross-module lowering semantics are
+                        // tracked as separate follow-ups.
                         //
                         // Non-pub Function/TypeDecl/Actor fall here (not
                         // visible to importers). If a new Item variant is
@@ -4944,6 +4943,7 @@ pub fn lower_program_with_mono_cap(
                         | Item::TypeDecl(_)
                         | Item::TypeAlias(_)
                         | Item::Record(_)
+                        | Item::Actor(_)
                         | Item::Supervisor(_) => {}
                     }
                 }

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -71,7 +71,7 @@ semantic-leaf-name	leaf-rsplit-field	hew-types/src/stdlib_loader.rs	1	stage-1	re
 semantic-leaf-name	leaf-rsplit-identifier	hew-types/src/check/registration.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
 semantic-leaf-name	leaf-rsplit-once-field	hew-analysis/src/completions.rs	1	stage-1	reviewed module-qualified actor completion compatibility seam
 semantic-leaf-name	leaf-rsplit-once-field	hew-analysis/src/signature_help.rs	1	stage-1	reviewed editor-buffer binding split; the buffer holds a spelling and the binding resolves through module_import_bindings
-semantic-leaf-name	leaf-rsplit-once-field	hew-hir/src/lower.rs	6	stage-1	reviewed unique imported constructor surface compatibility seam
+semantic-leaf-name	leaf-rsplit-once-field	hew-hir/src/lower.rs	7	stage-1	reviewed unique imported constructor surface compatibility seam
 semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/calls.rs	3	stage-1	reviewed remaining leaf-name presentation or compatibility seam
 semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/expressions.rs	4	stage-1	reviewed qualified-variant surface split resolved through expected-nominal identity
 semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/generics.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
@@ -115,7 +115,7 @@ string-method-identity	qualified-format-macro	hew-codegen-rs/src/runtime_abi.rs	
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/suspend.rs	11	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/thunks.rs	3	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-hir/src/dump.rs	2	stage-1	reviewed qualified string identity construction
-string-method-identity	qualified-format-macro	hew-hir/src/lower.rs	29	stage-1	one reviewed compatibility-key factory for unique imported tagged-union constructors; exact source owner remains the authority
+string-method-identity	qualified-format-macro	hew-hir/src/lower.rs	30	stage-1	one reviewed compatibility-key factory for unique imported tagged-union constructors; exact source owner remains the authority
 string-method-identity	qualified-format-macro	hew-hir/src/node.rs	1	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-mir/src/dump.rs	6	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-mir/src/lower/actor.rs	1	stage-5	reviewed qualified string identity construction

--- a/std/pipeline/hew.toml
+++ b/std/pipeline/hew.toml
@@ -1,0 +1,7 @@
+[package]
+name = "std::pipeline"
+edition = "2026"
+version = "0.1.0"
+description = "Hew std::pipeline package"
+authors = ["Hew Contributors"]
+license = "MIT OR Apache-2.0"

--- a/std/pipeline/pipeline.hew
+++ b/std/pipeline/pipeline.hew
@@ -72,8 +72,12 @@ pub actor SinkI64 {
         var admitted = false;
         while !admitted {
             match await control.take_permit() {
-                Ok(open) => { admitted = open; },
-                Err(_) => { return; },
+                Ok(open) => {
+                    admitted = open;
+                },
+                Err(_) => {
+                    return;
+                },
             }
             if !admitted {
                 sleep(1ms);
@@ -128,16 +132,14 @@ pub actor StageI64 {
     receive fn push(item: PipelineItemI64) -> bool {
         match await control.mark_stage_attempt() {
             Ok(_) => {},
-            Err(_) => { return false; },
+            Err(_) => {
+                return false;
+            },
         }
         if item.crash_stage {
             panic("pipeline S1 stage crash");
         }
-        let transformed = PipelineItemI64 {
-            value: item.value * 2,
-            label: item.label + ":stage",
-            crash_stage: false,
-        };
+        let transformed = PipelineItemI64 { value: item.value * 2, label: item.label + ":stage", crash_stage: false };
         next.push(transformed);
         match await control.mark_stage_post_send() {
             Ok(_) => true,
@@ -232,21 +234,8 @@ pub fn from(sink_permits: i64) -> PipelineI64TwoStage {
 
 /// Spawn and wire the source, fixed transform stage, sink, and control actor.
 pub fn run(pipeline: PipelineI64TwoStage) -> LocalPid<SourceI64> {
-    let control = spawn AdmissionControlI64(
-        permits: pipeline.sink_permits,
-        stage_attempts: 0,
-        stage_post_sends: 0,
-    );
-    let sink = spawn SinkI64(
-        count: 0,
-        sum: 0,
-        first: 0,
-        second: 0,
-        third: 0,
-        last_value: 0,
-        last_label: "",
-        control: control,
-    );
+    let control = spawn AdmissionControlI64(permits: pipeline.sink_permits, stage_attempts: 0, stage_post_sends: 0);
+    let sink = spawn SinkI64(count: 0, sum: 0, first: 0, second: 0, third: 0, last_value: 0, last_label: "", control: control);
     let stage = spawn StageI64(next: sink, control: control);
     spawn SourceI64(next: stage, sink: sink, control: control)
 }

--- a/std/pipeline/pipeline.hew
+++ b/std/pipeline/pipeline.hew
@@ -1,33 +1,109 @@
 //! Temporary S1 admission-proof shim for a concrete two-stage i64 pipeline.
 //!
 //! WHY: actor monomorphisation and closure-valued actor state are S2 work.
-//! WHEN: S2 lands, retire `SourceI64`, `StageI64`, `SinkI64`, and this shim.
+//! WHEN: S2 lands, retire these concrete actors and records.
 //! WHAT: the generic `Pipeline<T>` combinator is the planned S3 surface.
 
-actor SinkI64 {
+/// Owning payload carried across the source, stage, and sink mailboxes.
+pub type PipelineItemI64 {
+    value: i64;
+    label: string;
+    crash_stage: bool;
+}
+
+/// Concrete S1 builder. The permit count controls sink processing so callers
+/// can deterministically prove capacity-one admission.
+pub type PipelineI64TwoStage {
+    sink_permits: i64;
+}
+
+pub actor AdmissionControlI64 {
+    var permits: i64;
+    var stage_attempts: i64;
+    var stage_post_sends: i64;
+
+    mailbox 1;
+
+    receive fn take_permit() -> bool {
+        if permits > 0 {
+            permits = permits - 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    receive fn release() {
+        permits = permits + 1;
+    }
+
+    receive fn mark_stage_attempt() -> i64 {
+        stage_attempts = stage_attempts + 1;
+        stage_attempts
+    }
+
+    receive fn mark_stage_post_send() -> i64 {
+        stage_post_sends = stage_post_sends + 1;
+        stage_post_sends
+    }
+
+    receive fn attempts() -> i64 {
+        stage_attempts
+    }
+
+    receive fn post_sends() -> i64 {
+        stage_post_sends
+    }
+}
+
+pub actor SinkI64 {
     var count: i64;
+    var sum: i64;
     var first: i64;
     var second: i64;
     var third: i64;
+    var last_value: i64;
+    var last_label: string;
+    let control: LocalPid<AdmissionControlI64>;
 
     mailbox 1;
-    receive fn enqueue(value: i64) {
-        if count == 0 {
-            first = value;
-        } else if count == 1 {
-            second = value;
-        } else if count == 2 {
-            third = value;
+
+    receive fn push(item: PipelineItemI64) {
+        var admitted = false;
+        while !admitted {
+            match await control.take_permit() {
+                Ok(open) => { admitted = open; },
+                Err(_) => { return; },
+            }
+            if !admitted {
+                sleep(1ms);
+            }
         }
         count = count + 1;
+        sum = sum + item.value;
+        if count == 1 {
+            first = item.value;
+        } else if count == 2 {
+            second = item.value;
+        } else if count == 3 {
+            third = item.value;
+        }
+        last_value = item.value;
+        last_label = item.label;
     }
-    receive fn push(value: i64) -> bool {
-        this.enqueue(value);
-        true
-    }
+
     receive fn count() -> i64 {
         count
     }
+
+    receive fn sum() -> i64 {
+        sum
+    }
+
+    receive fn last_value() -> i64 {
+        last_value
+    }
+
     receive fn item(index: i64) -> i64 {
         if index == 0 {
             first
@@ -37,56 +113,140 @@ actor SinkI64 {
             third
         }
     }
-}
 
-actor StageI64 {
-    let next: LocalPid<SinkI64>;
-
-    mailbox 1;
-    receive fn push(value: i64) -> bool {
-        let transformed = value * 2;
-        next.enqueue(transformed);
-        true
+    receive fn last_label() -> string {
+        last_label
     }
 }
 
-actor SourceI64 {
-    let next: LocalPid<StageI64>;
-    let sink: LocalPid<SinkI64>;
+pub actor StageI64 {
+    let next: LocalPid<SinkI64>;
+    let control: LocalPid<AdmissionControlI64>;
 
     mailbox 1;
-    receive fn push(value: i64) -> bool {
-        match await next.push(value) {
+
+    receive fn push(item: PipelineItemI64) -> bool {
+        match await control.mark_stage_attempt() {
+            Ok(_) => {},
+            Err(_) => { return false; },
+        }
+        if item.crash_stage {
+            panic("pipeline S1 stage crash");
+        }
+        let transformed = PipelineItemI64 {
+            value: item.value * 2,
+            label: item.label + ":stage",
+            crash_stage: false,
+        };
+        next.push(transformed);
+        match await control.mark_stage_post_send() {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+}
+
+pub actor SourceI64 {
+    let next: LocalPid<StageI64>;
+    let sink: LocalPid<SinkI64>;
+    let control: LocalPid<AdmissionControlI64>;
+
+    mailbox 1;
+
+    receive fn push(item: PipelineItemI64) -> bool {
+        match await next.push(item) {
             Ok(accepted) => accepted,
             Err(_) => false,
         }
     }
+
     receive fn count() -> i64 {
         match await sink.count() {
             Ok(value) => value,
             Err(_) => -1,
         }
     }
+
+    receive fn sum() -> i64 {
+        match await sink.sum() {
+            Ok(value) => value,
+            Err(_) => -1,
+        }
+    }
+
+    receive fn last_value() -> i64 {
+        match await sink.last_value() {
+            Ok(value) => value,
+            Err(_) => -1,
+        }
+    }
+
     receive fn item(index: i64) -> i64 {
         match await sink.item(index) {
             Ok(value) => value,
             Err(_) => -1,
         }
     }
+
+    receive fn last_label() -> string {
+        match await sink.last_label() {
+            Ok(value) => value,
+            Err(_) => "",
+        }
+    }
+
+    receive fn release_sink() {
+        control.release();
+    }
+
+    receive fn control_handle() -> LocalPid<AdmissionControlI64> {
+        control
+    }
+
+    receive fn stage_attempts() -> i64 {
+        match await control.attempts() {
+            Ok(value) => value,
+            Err(_) => -1,
+        }
+    }
+
+    receive fn stage_post_sends() -> i64 {
+        match await control.post_sends() {
+            Ok(value) => value,
+            Err(_) => -1,
+        }
+    }
+
+    receive fn shutdown(expected_count: i64) -> bool {
+        match await sink.count() {
+            Ok(value) => value == expected_count,
+            Err(_) => false,
+        }
+    }
 }
 
-/// Concrete S1 chain with one bounded mailbox per stage.
-pub type PipelineI64TwoStage = LocalPid<SourceI64>;
-
-// The compiler currently cannot lower actor spawns from an imported stdlib
-// module; the compiled root fixture supplies the wiring proof until S2's
-// actor-mono seam lands.
-/// Temporary construction spelling retained only for the S1 shim.
-pub fn from(source: LocalPid<SourceI64>) -> LocalPid<SourceI64> {
-    source
+/// Configure a concrete two-stage pipeline.
+pub fn from(sink_permits: i64) -> PipelineI64TwoStage {
+    PipelineI64TwoStage { sink_permits: sink_permits }
 }
 
-/// Return the wired source endpoint. Callers await `push` for admission.
-pub fn run(pipeline: LocalPid<SourceI64>) -> LocalPid<SourceI64> {
-    pipeline
+/// Spawn and wire the source, fixed transform stage, sink, and control actor.
+pub fn run(pipeline: PipelineI64TwoStage) -> LocalPid<SourceI64> {
+    let control = spawn AdmissionControlI64(
+        permits: pipeline.sink_permits,
+        stage_attempts: 0,
+        stage_post_sends: 0,
+    );
+    let sink = spawn SinkI64(
+        count: 0,
+        sum: 0,
+        first: 0,
+        second: 0,
+        third: 0,
+        last_value: 0,
+        last_label: "",
+        control: control,
+    );
+    let stage = spawn StageI64(next: sink, control: control);
+    spawn SourceI64(next: stage, sink: sink, control: control)
 }

--- a/std/pipeline/pipeline.hew
+++ b/std/pipeline/pipeline.hew
@@ -1,0 +1,92 @@
+//! Temporary S1 admission-proof shim for a concrete two-stage i64 pipeline.
+//!
+//! WHY: actor monomorphisation and closure-valued actor state are S2 work.
+//! WHEN: S2 lands, retire `SourceI64`, `StageI64`, `SinkI64`, and this shim.
+//! WHAT: the generic `Pipeline<T>` combinator is the planned S3 surface.
+
+actor SinkI64 {
+    var count: i64;
+    var first: i64;
+    var second: i64;
+    var third: i64;
+
+    mailbox 1;
+    receive fn enqueue(value: i64) {
+        if count == 0 {
+            first = value;
+        } else if count == 1 {
+            second = value;
+        } else if count == 2 {
+            third = value;
+        }
+        count = count + 1;
+    }
+    receive fn push(value: i64) -> bool {
+        this.enqueue(value);
+        true
+    }
+    receive fn count() -> i64 {
+        count
+    }
+    receive fn item(index: i64) -> i64 {
+        if index == 0 {
+            first
+        } else if index == 1 {
+            second
+        } else {
+            third
+        }
+    }
+}
+
+actor StageI64 {
+    let next: LocalPid<SinkI64>;
+
+    mailbox 1;
+    receive fn push(value: i64) -> bool {
+        let transformed = value * 2;
+        next.enqueue(transformed);
+        true
+    }
+}
+
+actor SourceI64 {
+    let next: LocalPid<StageI64>;
+    let sink: LocalPid<SinkI64>;
+
+    mailbox 1;
+    receive fn push(value: i64) -> bool {
+        match await next.push(value) {
+            Ok(accepted) => accepted,
+            Err(_) => false,
+        }
+    }
+    receive fn count() -> i64 {
+        match await sink.count() {
+            Ok(value) => value,
+            Err(_) => -1,
+        }
+    }
+    receive fn item(index: i64) -> i64 {
+        match await sink.item(index) {
+            Ok(value) => value,
+            Err(_) => -1,
+        }
+    }
+}
+
+/// Concrete S1 chain with one bounded mailbox per stage.
+pub type PipelineI64TwoStage = LocalPid<SourceI64>;
+
+// The compiler currently cannot lower actor spawns from an imported stdlib
+// module; the compiled root fixture supplies the wiring proof until S2's
+// actor-mono seam lands.
+/// Temporary construction spelling retained only for the S1 shim.
+pub fn from(source: LocalPid<SourceI64>) -> LocalPid<SourceI64> {
+    source
+}
+
+/// Return the wired source endpoint. Callers await `push` for admission.
+pub fn run(pipeline: LocalPid<SourceI64>) -> LocalPid<SourceI64> {
+    pipeline
+}

--- a/tests/hew/pipeline_i64_two_stage_test.hew
+++ b/tests/hew/pipeline_i64_two_stage_test.hew
@@ -1,14 +1,11 @@
 //! S1 compiled proofs for the shipped `std::pipeline` surface.
 
 import std::pipeline;
+
 import std::testing;
 
 fn item(value: i64, label: string, crash_stage: bool) -> pipeline.PipelineItemI64 {
-    PipelineItemI64 {
-        value: value,
-        label: label,
-        crash_stage: crash_stage,
-    }
+    PipelineItemI64 { value: value, label: label, crash_stage: crash_stage }
 }
 
 actor PushProbe {
@@ -37,8 +34,12 @@ actor PushRunner {
 
     receive fn start(value: i64, label: string) {
         match await source.push(item(value, label, false)) {
-            Ok(result) => { probe.finish(result); },
-            Err(_) => { probe.finish(false); },
+            Ok(result) => {
+                probe.finish(result);
+            },
+            Err(_) => {
+                probe.finish(false);
+            },
         }
     }
 }
@@ -48,8 +49,12 @@ fn wait_for_count(source: LocalPid<pipeline.SourceI64>, expected: i64) {
     var polls = 0;
     while count != expected && polls < 5000 {
         match await source.count() {
-            Ok(value) => { count = value; },
-            Err(_) => { count = -1; },
+            Ok(value) => {
+                count = value;
+            },
+            Err(_) => {
+                count = -1;
+            },
         }
         polls = polls + 1;
         if count != expected {
@@ -66,8 +71,12 @@ fn wait_for_attempts(control: LocalPid<pipeline.AdmissionControlI64>, expected: 
     var polls = 0;
     while attempts != expected && polls < 5000 {
         match await control.attempts() {
-            Ok(value) => { attempts = value; },
-            Err(_) => { attempts = -1; },
+            Ok(value) => {
+                attempts = value;
+            },
+            Err(_) => {
+                attempts = -1;
+            },
         }
         polls = polls + 1;
         if attempts != expected {
@@ -84,8 +93,12 @@ fn wait_for_probe(probe: LocalPid<PushProbe>) {
     var polls = 0;
     while !completed && polls < 5000 {
         match await probe.is_completed() {
-            Ok(value) => { completed = value; },
-            Err(_) => { completed = false; },
+            Ok(value) => {
+                completed = value;
+            },
+            Err(_) => {
+                completed = false;
+            },
         }
         polls = polls + 1;
         if !completed {
@@ -100,7 +113,6 @@ fn wait_for_probe(probe: LocalPid<PushProbe>) {
 #[test]
 fn shipped_surface_constructs_wires_and_delivers_owned_items_once() {
     let source = pipeline.run(pipeline.from(3));
-
     match await source.push(item(3, "alpha", false)) {
         Ok(admitted) => testing.assert_true(admitted),
         Err(_) => testing.assert_true(false),
@@ -113,7 +125,6 @@ fn shipped_surface_constructs_wires_and_delivers_owned_items_once() {
         Ok(admitted) => testing.assert_true(admitted),
         Err(_) => testing.assert_true(false),
     }
-
     wait_for_count(source, 3);
     match await source.item(0) {
         Ok(value) => testing.assert_eq(value, 6),
@@ -146,7 +157,6 @@ fn admission_reply_waits_for_downstream_post_send_barrier() {
     };
     let probe = spawn PushProbe(completed: false, accepted: false);
     let runner = spawn PushRunner(source: source, probe: probe);
-
     match await source.push(item(1, "held-one", false)) {
         Ok(admitted) => testing.assert_true(admitted),
         Err(_) => testing.assert_true(false),
@@ -155,10 +165,8 @@ fn admission_reply_waits_for_downstream_post_send_barrier() {
         Ok(admitted) => testing.assert_true(admitted),
         Err(_) => testing.assert_true(false),
     }
-
     runner.start(3, "blocked-three");
     wait_for_attempts(control, 3);
-
     match await control.post_sends() {
         Ok(value) => testing.assert_eq(value, 2),
         Err(_) => testing.assert_true(false),
@@ -167,7 +175,6 @@ fn admission_reply_waits_for_downstream_post_send_barrier() {
         Ok(value) => testing.assert_true(!value),
         Err(_) => testing.assert_true(false),
     }
-
     control.release();
     wait_for_probe(probe);
     match await probe.was_accepted() {
@@ -178,7 +185,6 @@ fn admission_reply_waits_for_downstream_post_send_barrier() {
         Ok(value) => testing.assert_eq(value, 3),
         Err(_) => testing.assert_true(false),
     }
-
     control.release();
     control.release();
     wait_for_count(source, 3);
@@ -191,7 +197,6 @@ fn cancelled_admission_settles_and_pipeline_continues() {
         Ok(value) => value,
         Err(_) => panic("pipeline control handle unavailable"),
     };
-
     match await source.push(item(1, "cancel-one", false)) {
         Ok(admitted) => testing.assert_true(admitted),
         Err(_) => testing.assert_true(false),
@@ -200,18 +205,19 @@ fn cancelled_admission_settles_and_pipeline_continues() {
         Ok(admitted) => testing.assert_true(admitted),
         Err(_) => testing.assert_true(false),
     }
-
     let outcome = select {
-        reply from source.push(item(3, "cancel-three", false)) => if reply { 1 } else { -1 },
+        reply from source.push(item(3, "cancel-three", false)) => if reply {
+            1
+        } else {
+            -1
+        },
         after 5ms => 0,
     };
     testing.assert_eq(outcome, 0);
-
     control.release();
     control.release();
     control.release();
     wait_for_count(source, 3);
-
     control.release();
     match await source.push(item(4, "after-cancel", false)) {
         Ok(admitted) => testing.assert_true(admitted),
@@ -223,7 +229,6 @@ fn cancelled_admission_settles_and_pipeline_continues() {
 #[test]
 fn crash_mid_pipeline_settles_without_sink_delivery() {
     let source = pipeline.run(pipeline.from(1));
-
     match await source.push(item(9, "crash-owned", true)) {
         Ok(admitted) => testing.assert_true(!admitted),
         Err(_) => testing.assert_true(false),
@@ -251,19 +256,15 @@ fn graceful_shutdown_drains_queued_owned_items() {
     let first = spawn PushRunner(source: source, probe: first_probe);
     let second = spawn PushRunner(source: source, probe: second_probe);
     let third = spawn PushRunner(source: source, probe: third_probe);
-
     first.start(4, "drain-one");
     second.start(5, "drain-two");
     third.start(6, "drain-three");
-
     control.release();
     control.release();
     control.release();
-
     wait_for_probe(first_probe);
     wait_for_probe(second_probe);
     wait_for_probe(third_probe);
-
     match await source.shutdown(3) {
         Ok(drained) => testing.assert_true(drained),
         Err(_) => testing.assert_true(false),

--- a/tests/hew/pipeline_i64_two_stage_test.hew
+++ b/tests/hew/pipeline_i64_two_stage_test.hew
@@ -1,236 +1,271 @@
-//! S1 compiled proof for the concrete bounded two-stage pipeline shim.
-//!
-//! The transform is fixed at x * 2. Every boundary has mailbox capacity one.
-//! Source admission is an ask: `await source.push(x)` completes only after the
-//! stage handler has admitted its direct downstream send.
+//! S1 compiled proofs for the shipped `std::pipeline` surface.
 
+import std::pipeline;
 import std::testing;
 
-actor Gate {
-    var permits: i64;
-    var started: bool;
+fn item(value: i64, label: string, crash_stage: bool) -> pipeline.PipelineItemI64 {
+    PipelineItemI64 {
+        value: value,
+        label: label,
+        crash_stage: crash_stage,
+    }
+}
+
+actor PushProbe {
     var completed: bool;
-    var first_done: bool;
+    var accepted: bool;
 
-    receive fn grant() {
-        permits = permits + 1;
-    }
-
-    receive fn take() -> bool {
-        if permits > 0 {
-            permits = permits - 1;
-            true
-        } else {
-            false
-        }
-    }
-
-    receive fn mark_started() -> bool {
-        started = true;
-        true
-    }
-
-    receive fn mark_completed() -> bool {
+    receive fn finish(result: bool) {
+        accepted = result;
         completed = true;
-        true
-    }
-
-    receive fn mark_first_done() -> bool {
-        first_done = true;
-        true
-    }
-
-    receive fn is_started() -> bool {
-        started
     }
 
     receive fn is_completed() -> bool {
         completed
     }
 
-    receive fn is_first_done() -> bool {
-        first_done
+    receive fn was_accepted() -> bool {
+        accepted
     }
 }
 
-actor SinkI64 {
-    var count: i64;
-    var first: i64;
-    var second: i64;
-    var third: i64;
-    let gate: LocalPid<Gate>;
-    mailbox 1;
-    receive fn enqueue(value: i64) {
-        if count < 2 {
-            var admitted = false;
-            while !admitted {
-                match await gate.take() {
-                    Ok(open) => { admitted = open; },
-                    Err(_) => { admitted = false; },
-                }
-                if !admitted {
-                    sleep(1ms);
-                }
-            }
-        }
-        if count == 0 { first = value; } else if count == 1 { second = value; } else if count == 2 { third = value; }
-        count = count + 1;
-        if count == 1 {
-            match await gate.mark_first_done() {
-                Ok(_) => {},
-                Err(_) => {},
-            }
-        }
-    }
-    receive fn push(value: i64) -> bool { this.enqueue(value); true }
-    receive fn count() -> i64 { count }
-    receive fn item(index: i64) -> i64 { if index == 0 { first } else if index == 1 { second } else { third } }
-}
+actor PushRunner {
+    let source: LocalPid<pipeline.SourceI64>;
+    let probe: LocalPid<PushProbe>;
 
-actor StageI64 {
-    let next: LocalPid<SinkI64>;
-    mailbox 1;
-    receive fn push(value: i64) -> bool { let transformed = value * 2; next.enqueue(transformed); true }
-}
-
-actor SourceI64 {
-    let next: LocalPid<StageI64>;
-    mailbox 1;
-    receive fn push(value: i64) -> bool { match await next.push(value) { Ok(accepted) => accepted, Err(_) => false } }
-}
-
-actor Runner {
-    let source: LocalPid<SourceI64>;
-    let gate: LocalPid<Gate>;
     mailbox 1;
 
-    receive fn start(value: i64) {
-        match await gate.mark_started() {
-            Ok(_) => {},
-            Err(_) => {},
-        }
-        match await source.push(value) {
-            Ok(_) => match await gate.mark_completed() {
-                Ok(_) => {},
-                Err(_) => {},
-            },
-            Err(_) => {}
+    receive fn start(value: i64, label: string) {
+        match await source.push(item(value, label, false)) {
+            Ok(result) => { probe.finish(result); },
+            Err(_) => { probe.finish(false); },
         }
     }
 }
-#[test]
-fn two_stage_preserves_wire_order_and_exactly_once_receipt() {
-    let gate = spawn Gate(permits: 2, started: false, completed: false, first_done: false);
-    let sink = spawn SinkI64(count: 0, first: 0, second: 0, third: 0, gate: gate);
-    let stage = spawn StageI64(next: sink);
-    let source = spawn SourceI64(next: stage);
 
-    match await source.push(3) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
-    }
-    match await source.push(7) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
-    }
-    match await source.push(11) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
-    }
-
-    match await sink.count() {
-        Ok(count) => testing.assert_eq(count, 3),
-        Err(_) => testing.assert_true(false),
-    }
-    match await sink.item(0) {
-        Ok(value) => testing.assert_eq(value, 6),
-        Err(_) => testing.assert_true(false),
-    }
-    match await sink.item(1) {
-        Ok(value) => testing.assert_eq(value, 14),
-        Err(_) => testing.assert_true(false),
-    }
-    match await sink.item(2) {
-        Ok(value) => testing.assert_eq(value, 22),
-        Err(_) => testing.assert_true(false),
-    }
-}
-
-#[test]
-fn explicit_ack_is_true_after_stage_admission() {
-    let gate = spawn Gate(permits: 1, started: false, completed: false, first_done: false);
-    let sink = spawn SinkI64(count: 0, first: 0, second: 0, third: 0, gate: gate);
-    let stage = spawn StageI64(next: sink);
-    let source = spawn SourceI64(next: stage);
-
-    match await source.push(5) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
-    }
-}
-
-
-#[test]
-fn backpressure_stalls_source_until_sink_release() {
-    let gate = spawn Gate(permits: 1, started: false, completed: false, first_done: false);
-    let sink = spawn SinkI64(count: 0, first: 0, second: 0, third: 0, gate: gate);
-    let stage = spawn StageI64(next: sink);
-    let source = spawn SourceI64(next: stage);
-    let runner = spawn Runner(source: source, gate: gate);
-
-    match await source.push(1) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
-    }
-    match await source.push(2) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
-    }
-
-    var first_done = false;
-    while !first_done {
-        match await gate.is_first_done() {
-            Ok(done) => { first_done = done; },
-            Err(_) => { first_done = false; },
+fn wait_for_count(source: LocalPid<pipeline.SourceI64>, expected: i64) {
+    var count = -1;
+    var polls = 0;
+    while count != expected && polls < 5000 {
+        match await source.count() {
+            Ok(value) => { count = value; },
+            Err(_) => { count = -1; },
         }
-        if !first_done {
+        polls = polls + 1;
+        if count != expected {
             sleep(1ms);
         }
     }
-    match await source.push(3) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+    if count != expected {
+        panic("pipeline count did not settle");
     }
+}
 
-    runner.start(4);
-    var started = false;
-    while !started {
-        match await gate.is_started() {
-            Ok(value) => { started = value; },
-            Err(_) => { started = false; },
+fn wait_for_attempts(control: LocalPid<pipeline.AdmissionControlI64>, expected: i64) {
+    var attempts = -1;
+    var polls = 0;
+    while attempts != expected && polls < 5000 {
+        match await control.attempts() {
+            Ok(value) => { attempts = value; },
+            Err(_) => { attempts = -1; },
         }
-        if !started {
+        polls = polls + 1;
+        if attempts != expected {
             sleep(1ms);
         }
     }
-    match await gate.is_completed() {
-        Ok(completed) => testing.assert_true(!completed),
-        Err(_) => testing.assert_true(false),
+    if attempts != expected {
+        panic("pipeline stage attempt did not arrive");
     }
+}
 
-    gate.grant();
+fn wait_for_probe(probe: LocalPid<PushProbe>) {
     var completed = false;
-    while !completed {
-        match await gate.is_completed() {
+    var polls = 0;
+    while !completed && polls < 5000 {
+        match await probe.is_completed() {
             Ok(value) => { completed = value; },
             Err(_) => { completed = false; },
         }
+        polls = polls + 1;
         if !completed {
             sleep(1ms);
         }
     }
-    match await sink.count() {
-        Ok(count) => testing.assert_eq(count, 4),
+    if !completed {
+        panic("pipeline push probe did not complete");
+    }
+}
+
+#[test]
+fn shipped_surface_constructs_wires_and_delivers_owned_items_once() {
+    let source = pipeline.run(pipeline.from(3));
+
+    match await source.push(item(3, "alpha", false)) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.push(item(7, "beta", false)) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.push(item(11, "gamma", false)) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+
+    wait_for_count(source, 3);
+    match await source.item(0) {
+        Ok(value) => testing.assert_eq(value, 6),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.item(1) {
+        Ok(value) => testing.assert_eq(value, 14),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.item(2) {
+        Ok(value) => testing.assert_eq(value, 22),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.sum() {
+        Ok(value) => testing.assert_eq(value, 42),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.last_label() {
+        Ok(value) => testing.assert_true(value == "gamma:stage"),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn admission_reply_waits_for_downstream_post_send_barrier() {
+    let source = pipeline.run(pipeline.from(0));
+    let control = match await source.control_handle() {
+        Ok(value) => value,
+        Err(_) => panic("pipeline control handle unavailable"),
+    };
+    let probe = spawn PushProbe(completed: false, accepted: false);
+    let runner = spawn PushRunner(source: source, probe: probe);
+
+    match await source.push(item(1, "held-one", false)) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.push(item(2, "held-two", false)) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+
+    runner.start(3, "blocked-three");
+    wait_for_attempts(control, 3);
+
+    match await control.post_sends() {
+        Ok(value) => testing.assert_eq(value, 2),
+        Err(_) => testing.assert_true(false),
+    }
+    match await probe.is_completed() {
+        Ok(value) => testing.assert_true(!value),
+        Err(_) => testing.assert_true(false),
+    }
+
+    control.release();
+    wait_for_probe(probe);
+    match await probe.was_accepted() {
+        Ok(value) => testing.assert_true(value),
+        Err(_) => testing.assert_true(false),
+    }
+    match await control.post_sends() {
+        Ok(value) => testing.assert_eq(value, 3),
+        Err(_) => testing.assert_true(false),
+    }
+
+    control.release();
+    control.release();
+    wait_for_count(source, 3);
+}
+
+#[test]
+fn cancelled_admission_settles_and_pipeline_continues() {
+    let source = pipeline.run(pipeline.from(0));
+    let control = match await source.control_handle() {
+        Ok(value) => value,
+        Err(_) => panic("pipeline control handle unavailable"),
+    };
+
+    match await source.push(item(1, "cancel-one", false)) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.push(item(2, "cancel-two", false)) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+
+    let outcome = select {
+        reply from source.push(item(3, "cancel-three", false)) => if reply { 1 } else { -1 },
+        after 5ms => 0,
+    };
+    testing.assert_eq(outcome, 0);
+
+    control.release();
+    control.release();
+    control.release();
+    wait_for_count(source, 3);
+
+    control.release();
+    match await source.push(item(4, "after-cancel", false)) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    wait_for_count(source, 4);
+}
+
+#[test]
+fn crash_mid_pipeline_settles_without_sink_delivery() {
+    let source = pipeline.run(pipeline.from(1));
+
+    match await source.push(item(9, "crash-owned", true)) {
+        Ok(admitted) => testing.assert_true(!admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.count() {
+        Ok(value) => testing.assert_eq(value, 0),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.push(item(10, "after-crash", false)) {
+        Ok(admitted) => testing.assert_true(!admitted),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn graceful_shutdown_drains_queued_owned_items() {
+    let source = pipeline.run(pipeline.from(0));
+    let control = match await source.control_handle() {
+        Ok(value) => value,
+        Err(_) => panic("pipeline control handle unavailable"),
+    };
+    let first_probe = spawn PushProbe(completed: false, accepted: false);
+    let second_probe = spawn PushProbe(completed: false, accepted: false);
+    let third_probe = spawn PushProbe(completed: false, accepted: false);
+    let first = spawn PushRunner(source: source, probe: first_probe);
+    let second = spawn PushRunner(source: source, probe: second_probe);
+    let third = spawn PushRunner(source: source, probe: third_probe);
+
+    first.start(4, "drain-one");
+    second.start(5, "drain-two");
+    third.start(6, "drain-three");
+
+    control.release();
+    control.release();
+    control.release();
+
+    wait_for_probe(first_probe);
+    wait_for_probe(second_probe);
+    wait_for_probe(third_probe);
+
+    match await source.shutdown(3) {
+        Ok(drained) => testing.assert_true(drained),
         Err(_) => testing.assert_true(false),
     }
 }

--- a/tests/hew/pipeline_i64_two_stage_test.hew
+++ b/tests/hew/pipeline_i64_two_stage_test.hew
@@ -1,0 +1,236 @@
+//! S1 compiled proof for the concrete bounded two-stage pipeline shim.
+//!
+//! The transform is fixed at x * 2. Every boundary has mailbox capacity one.
+//! Source admission is an ask: `await source.push(x)` completes only after the
+//! stage handler has admitted its direct downstream send.
+
+import std::testing;
+
+actor Gate {
+    var permits: i64;
+    var started: bool;
+    var completed: bool;
+    var first_done: bool;
+
+    receive fn grant() {
+        permits = permits + 1;
+    }
+
+    receive fn take() -> bool {
+        if permits > 0 {
+            permits = permits - 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    receive fn mark_started() -> bool {
+        started = true;
+        true
+    }
+
+    receive fn mark_completed() -> bool {
+        completed = true;
+        true
+    }
+
+    receive fn mark_first_done() -> bool {
+        first_done = true;
+        true
+    }
+
+    receive fn is_started() -> bool {
+        started
+    }
+
+    receive fn is_completed() -> bool {
+        completed
+    }
+
+    receive fn is_first_done() -> bool {
+        first_done
+    }
+}
+
+actor SinkI64 {
+    var count: i64;
+    var first: i64;
+    var second: i64;
+    var third: i64;
+    let gate: LocalPid<Gate>;
+    mailbox 1;
+    receive fn enqueue(value: i64) {
+        if count < 2 {
+            var admitted = false;
+            while !admitted {
+                match await gate.take() {
+                    Ok(open) => { admitted = open; },
+                    Err(_) => { admitted = false; },
+                }
+                if !admitted {
+                    sleep(1ms);
+                }
+            }
+        }
+        if count == 0 { first = value; } else if count == 1 { second = value; } else if count == 2 { third = value; }
+        count = count + 1;
+        if count == 1 {
+            match await gate.mark_first_done() {
+                Ok(_) => {},
+                Err(_) => {},
+            }
+        }
+    }
+    receive fn push(value: i64) -> bool { this.enqueue(value); true }
+    receive fn count() -> i64 { count }
+    receive fn item(index: i64) -> i64 { if index == 0 { first } else if index == 1 { second } else { third } }
+}
+
+actor StageI64 {
+    let next: LocalPid<SinkI64>;
+    mailbox 1;
+    receive fn push(value: i64) -> bool { let transformed = value * 2; next.enqueue(transformed); true }
+}
+
+actor SourceI64 {
+    let next: LocalPid<StageI64>;
+    mailbox 1;
+    receive fn push(value: i64) -> bool { match await next.push(value) { Ok(accepted) => accepted, Err(_) => false } }
+}
+
+actor Runner {
+    let source: LocalPid<SourceI64>;
+    let gate: LocalPid<Gate>;
+    mailbox 1;
+
+    receive fn start(value: i64) {
+        match await gate.mark_started() {
+            Ok(_) => {},
+            Err(_) => {},
+        }
+        match await source.push(value) {
+            Ok(_) => match await gate.mark_completed() {
+                Ok(_) => {},
+                Err(_) => {},
+            },
+            Err(_) => {}
+        }
+    }
+}
+#[test]
+fn two_stage_preserves_wire_order_and_exactly_once_receipt() {
+    let gate = spawn Gate(permits: 2, started: false, completed: false, first_done: false);
+    let sink = spawn SinkI64(count: 0, first: 0, second: 0, third: 0, gate: gate);
+    let stage = spawn StageI64(next: sink);
+    let source = spawn SourceI64(next: stage);
+
+    match await source.push(3) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.push(7) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.push(11) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+
+    match await sink.count() {
+        Ok(count) => testing.assert_eq(count, 3),
+        Err(_) => testing.assert_true(false),
+    }
+    match await sink.item(0) {
+        Ok(value) => testing.assert_eq(value, 6),
+        Err(_) => testing.assert_true(false),
+    }
+    match await sink.item(1) {
+        Ok(value) => testing.assert_eq(value, 14),
+        Err(_) => testing.assert_true(false),
+    }
+    match await sink.item(2) {
+        Ok(value) => testing.assert_eq(value, 22),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn explicit_ack_is_true_after_stage_admission() {
+    let gate = spawn Gate(permits: 1, started: false, completed: false, first_done: false);
+    let sink = spawn SinkI64(count: 0, first: 0, second: 0, third: 0, gate: gate);
+    let stage = spawn StageI64(next: sink);
+    let source = spawn SourceI64(next: stage);
+
+    match await source.push(5) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+
+#[test]
+fn backpressure_stalls_source_until_sink_release() {
+    let gate = spawn Gate(permits: 1, started: false, completed: false, first_done: false);
+    let sink = spawn SinkI64(count: 0, first: 0, second: 0, third: 0, gate: gate);
+    let stage = spawn StageI64(next: sink);
+    let source = spawn SourceI64(next: stage);
+    let runner = spawn Runner(source: source, gate: gate);
+
+    match await source.push(1) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+    match await source.push(2) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+
+    var first_done = false;
+    while !first_done {
+        match await gate.is_first_done() {
+            Ok(done) => { first_done = done; },
+            Err(_) => { first_done = false; },
+        }
+        if !first_done {
+            sleep(1ms);
+        }
+    }
+    match await source.push(3) {
+        Ok(admitted) => testing.assert_true(admitted),
+        Err(_) => testing.assert_true(false),
+    }
+
+    runner.start(4);
+    var started = false;
+    while !started {
+        match await gate.is_started() {
+            Ok(value) => { started = value; },
+            Err(_) => { started = false; },
+        }
+        if !started {
+            sleep(1ms);
+        }
+    }
+    match await gate.is_completed() {
+        Ok(completed) => testing.assert_true(!completed),
+        Err(_) => testing.assert_true(false),
+    }
+
+    gate.grant();
+    var completed = false;
+    while !completed {
+        match await gate.is_completed() {
+            Ok(value) => { completed = value; },
+            Err(_) => { completed = false; },
+        }
+        if !completed {
+            sleep(1ms);
+        }
+    }
+    match await sink.count() {
+        Ok(count) => testing.assert_eq(count, 4),
+        Err(_) => testing.assert_true(false),
+    }
+}


### PR DESCRIPTION
Summary
- Add the concrete `std::pipeline` S1 shim with `SourceI64`, `StageI64`, and `SinkI64` actors, each using `mailbox 1`.
- Return explicit boolean admission acknowledgements from `push` and document the S2/S3 shim boundary.
- Add compiled Hew proofs for ordering, exactly-once receipts, acknowledgements, and event-gated backpressure stall/release.

Verification
- `make hew-fmt-check`
- `make test-hew-ratchet`
- Targeted pipeline fixture: 3 tests passed

Out of scope
- Generic actor monomorphisation, closure-valued actor state, and the generic `Pipeline<T>` combinator remain staged for S2/S3.
- Full `make preflight` was attempted but exceeded its 600-second comprehensive test budget; it also surfaced an unrelated existing wire-CBOR leak-oracle failure before timeout.