### PR TITLE
fix(cli): link package FFI libraries in hew test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 # This prevents CRLF issues when comparing test output on Windows
 *.expected text eol=lf
 *.hew text eol=lf
+/hew-cli/tests/fixtures/test_ffi_package/Cargo.toml text eol=lf
+/hew-cli/tests/fixtures/test_ffi_package/hew.toml text eol=lf
+/hew-cli/tests/fixtures/test_ffi_package/src/*.rs text eol=lf
 *.md text eol=lf
 # MIR goldens (checked-in `--dump-mir` baselines, e.g.
 # tests/mir-baselines/**/*.mir) preserve the compiler's byte-exact dump,

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -35,6 +35,8 @@ pub struct CompileOptions {
     /// Anchor an in-memory compile to a specific project directory so that
     /// manifest-aware import resolution matches `compile_file` behaviour.
     pub project_dir: Option<PathBuf>,
+    /// Exact standard-library and global-module roots for synthetic sources.
+    pub module_search_paths: Option<Vec<PathBuf>>,
     /// Compile a synthetic `hew eval` REPL fragment rather than a finished
     /// program, suppressing the whole-program completeness lints. See
     /// [`hew_compile::FrontendOptions::repl_fragment`]. Only the eval paths
@@ -54,7 +56,7 @@ pub(crate) fn frontend_options(target: &TargetSpec, options: &CompileOptions) ->
         enable_wasm_target: target.is_wasm(),
         pkg_path: options.pkg_path.clone(),
         project_dir: options.project_dir.clone(),
-        module_search_paths: None,
+        module_search_paths: options.module_search_paths.clone(),
         repl_fragment: options.repl_fragment,
         lint_levels: options.lint_levels.clone(),
     }
@@ -73,7 +75,7 @@ pub(crate) fn frontend_options_for_check(options: &CompileOptions) -> FrontendOp
         enable_wasm_target: false,
         pkg_path: options.pkg_path.clone(),
         project_dir: options.project_dir.clone(),
-        module_search_paths: None,
+        module_search_paths: options.module_search_paths.clone(),
         repl_fragment: options.repl_fragment,
         lint_levels: options.lint_levels.clone(),
     }

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -2,6 +2,7 @@
 //! the final binary from the object file emitted by Hew's Rust codegen-rs
 //! backend and the combined Hew library (`libhew.a`).
 
+use crate::diagnostic::emit_plain_diagnostic_line;
 use crate::target::TargetSpec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -389,7 +390,7 @@ pub(crate) fn link_executable_with_hew_lib(
     let stderr_text = String::from_utf8_lossy(&output.stderr);
 
     for line in linker_stderr_diagnostics(&stderr_text, output.status.success()) {
-        eprintln!("{line}");
+        emit_plain_diagnostic_line(&line);
     }
 
     if !output.status.success() {

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -265,20 +265,11 @@ fn lower_file_to_mir(
     input_path: &Path,
     requested_target: Option<&str>,
 ) -> Result<hew_mir::IrPipeline, ()> {
-    lower_file_to_mir_with_module_paths(input_path, requested_target, None)
-}
-
-fn lower_file_to_mir_with_module_paths(
-    input_path: &Path,
-    requested_target: Option<&str>,
-    module_search_paths: Option<&[PathBuf]>,
-) -> Result<hew_mir::IrPipeline, ()> {
     let input = input_path.display().to_string();
     let target = target::TargetSpec::from_requested(requested_target).map_err(|e| {
         eprintln!("Error: {e}");
     })?;
-    let mut fopts = compile::frontend_options(&target, &compile::CompileOptions::default());
-    fopts.module_search_paths = module_search_paths.map(<[PathBuf]>::to_vec);
+    let fopts = compile::frontend_options(&target, &compile::CompileOptions::default());
 
     let state = hew_compile::run_file_frontend_to_typecheck(&input, &fopts).map_err(|failure| {
         compile::render_frontend_diagnostics(&failure.diagnostics);
@@ -706,25 +697,7 @@ fn link_native_object_with_hew_lib(
 }
 
 pub(crate) fn compile_native_binary(input: &Path, bin_path: &Path) -> Result<(), ()> {
-    compile_native_binary_with_paths(input, bin_path, None)
-}
-
-#[derive(Debug)]
-pub(crate) struct NativeCompilePaths {
-    pub(crate) module_search_paths: Vec<PathBuf>,
-    pub(crate) hew_lib: PathBuf,
-}
-
-pub(crate) fn compile_native_binary_with_paths(
-    input: &Path,
-    bin_path: &Path,
-    paths: Option<&NativeCompilePaths>,
-) -> Result<(), ()> {
-    let pipeline = lower_file_to_mir_with_module_paths(
-        input,
-        None,
-        paths.map(|paths| paths.module_search_paths.as_slice()),
-    )?;
+    let pipeline = lower_file_to_mir(input, None)?;
     let emit_dir = bin_path.parent().unwrap_or_else(|| Path::new("."));
     let module_name = bin_path
         .file_stem()
@@ -741,7 +714,14 @@ pub(crate) fn compile_native_binary_with_paths(
     let obj = artefacts.native_obj_path.as_deref().ok_or_else(|| {
         eprintln!("E_NOT_YET_IMPLEMENTED: native codegen did not produce an object");
     })?;
-    link_native_object_with_hew_lib(obj, bin_path, paths.map(|paths| paths.hew_lib.as_path()))
+    link_native_object(obj, bin_path)
+}
+
+#[derive(Debug)]
+pub(crate) struct NativeBuildPaths {
+    pub(crate) project_dir: PathBuf,
+    pub(crate) module_search_paths: Vec<PathBuf>,
+    pub(crate) hew_lib: PathBuf,
 }
 
 #[allow(
@@ -899,12 +879,13 @@ fn resolve_build_output_path(
 /// `from_requested(None)`), this passes the resolved `&target` so the link plan,
 /// `linker_triple()`, and cross `libhew.a` resolution are correct for cross-arch
 /// and same-arch explicit-target builds.
-fn link_native_object_for_target(
+fn link_native_object_for_target_with_hew_lib(
     obj: &Path,
     bin_path: &Path,
     target: &target::TargetSpec,
     debug: bool,
     extra_libs: &[String],
+    hew_lib: Option<&Path>,
 ) -> Result<(), ()> {
     let obj_str = obj.to_str().ok_or_else(|| {
         eprintln!("Error: object path is not valid UTF-8");
@@ -912,9 +893,10 @@ fn link_native_object_for_target(
     let bin_str = bin_path.to_str().ok_or_else(|| {
         eprintln!("Error: output path is not valid UTF-8");
     })?;
-    crate::link::link_executable(obj_str, bin_str, target, extra_libs, debug).map_err(|e| {
-        eprintln!("{e}");
-    })
+    crate::link::link_executable_with_hew_lib(obj_str, bin_str, target, extra_libs, debug, hew_lib)
+        .map_err(|e| {
+            crate::diagnostic::emit_plain_diagnostic_line(&e);
+        })
 }
 
 /// Build a native (or wasm) binary for an explicit target, writing it to
@@ -931,6 +913,32 @@ fn compile_build_binary(
     opt_level: hew_codegen_rs::OptLevel,
     extra_libs: &[String],
     options: &compile::CompileOptions,
+) -> Result<(), ()> {
+    compile_build_binary_with_hew_lib(
+        input,
+        output_path,
+        target,
+        debug,
+        opt_level,
+        extra_libs,
+        options,
+        None,
+    )
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the test path adds one pre-resolved runtime archive to the shared build pipeline"
+)]
+fn compile_build_binary_with_hew_lib(
+    input: &Path,
+    output_path: &Path,
+    target: &target::TargetSpec,
+    debug: bool,
+    opt_level: hew_codegen_rs::OptLevel,
+    extra_libs: &[String],
+    options: &compile::CompileOptions,
+    hew_lib: Option<&Path>,
 ) -> Result<(), ()> {
     let (pipeline, native_pkg_dirs) = lower_file_to_mir_for_target(input, target, options)?;
     let emit_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
@@ -969,7 +977,14 @@ fn compile_build_binary(
                 eprintln!("Error: {e}");
             })?;
             let all_libs: Vec<String> = extra_libs.iter().cloned().chain(auto_libs).collect();
-            link_native_object_for_target(obj, output_path, target, debug, &all_libs)
+            link_native_object_for_target_with_hew_lib(
+                obj,
+                output_path,
+                target,
+                debug,
+                &all_libs,
+                hew_lib,
+            )
         }
         CompileEmitTarget::Wasm => {
             let wasm = artefacts.wasm_path.as_deref().ok_or_else(|| {
@@ -988,6 +1003,32 @@ fn compile_build_binary(
             Ok(())
         }
     }
+}
+
+pub(crate) fn compile_test_binary_with_paths(
+    input: &Path,
+    output_path: &Path,
+    paths: &NativeBuildPaths,
+    extra_libs: &[String],
+) -> Result<(), ()> {
+    let target = target::TargetSpec::from_requested(None).map_err(|error| {
+        eprintln!("Error: cannot determine the host target: {error}");
+    })?;
+    let options = compile::CompileOptions {
+        project_dir: Some(paths.project_dir.clone()),
+        module_search_paths: Some(paths.module_search_paths.clone()),
+        ..compile::CompileOptions::default()
+    };
+    compile_build_binary_with_hew_lib(
+        input,
+        output_path,
+        &target,
+        false,
+        hew_codegen_rs::OptLevel::O0,
+        extra_libs,
+        &options,
+        Some(&paths.hew_lib),
+    )
 }
 
 /// Emit a single relocatable object for `hew build --emit-obj`, skipping the

--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -191,12 +191,11 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
         return;
     }
 
-    // Detect and build FFI staticlib if this is an ecosystem package with
-    // a Cargo.toml (e.g. db/sqlite, image/magick).
     let cwd = root;
-    let ffi_lib = resolve_ffi_lib(&cwd);
+    let project_dir = find_project_dir(&cwd).unwrap_or_else(|| cwd.clone());
+    let ffi_lib = resolve_ffi_lib(&project_dir);
 
-    let compile_paths = resolve_compile_paths(&cwd);
+    let compile_paths = resolve_compile_paths(&project_dir);
 
     let summary = runner::run_tests(
         &all_tests,
@@ -216,6 +215,13 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
 
 fn requested_jobs(jobs: Option<std::num::NonZeroUsize>) -> usize {
     jobs.map_or_else(runner::default_jobs, std::num::NonZeroUsize::get)
+}
+
+fn find_project_dir(start_dir: &Path) -> Option<PathBuf> {
+    start_dir
+        .ancestors()
+        .find(|dir| dir.join("hew.toml").is_file())
+        .map(Path::to_path_buf)
 }
 
 fn resolve_ffi_lib(project_dir: &Path) -> Option<String> {
@@ -275,99 +281,27 @@ fn handle_discovered_file(file: &discovery::DiscoveredTestFile) -> bool {
     had_errors
 }
 
-/// Detect whether the current directory (or a close ancestor) is an FFI-backed
-/// ecosystem package — i.e. has both `hew.toml` and `Cargo.toml` — and if so,
-/// build the Rust staticlib with `cargo build --release` and return the path to
-/// the resulting `.a` file.
+/// Detect whether the current directory is inside an FFI-backed Hew package,
+/// build its declared native library, and return the artifact path.
 fn detect_and_build_ffi_lib(start_dir: &std::path::Path) -> Result<Option<String>, String> {
-    // Walk start_dir and up to 2 ancestors looking for a directory with both files.
-    let mut dir = start_dir.to_path_buf();
-    let mut found = false;
-    for _ in 0..3 {
-        if dir.join("hew.toml").exists() && dir.join("Cargo.toml").exists() {
-            found = true;
-            break;
-        }
-        if let Some(parent) = dir.parent() {
-            dir = parent.to_path_buf();
-        } else {
-            break;
-        }
-    }
-
-    if !found {
+    if !start_dir.join("hew.toml").is_file() {
         return Ok(None);
     }
-
-    // Parse Cargo.toml to get the crate name.
-    let cargo_toml_path = dir.join("Cargo.toml");
-    let cargo_toml_content = std::fs::read_to_string(&cargo_toml_path)
-        .map_err(|e| format!("cannot read {}: {e}", cargo_toml_path.display()))?;
-    let cargo_toml: toml::Value = toml::from_str(&cargo_toml_content)
-        .map_err(|e| format!("cannot parse {}: {e}", cargo_toml_path.display()))?;
-    let crate_name = cargo_toml
-        .get("package")
-        .and_then(|p| p.get("name"))
-        .and_then(toml::Value::as_str)
-        .ok_or_else(|| {
-            format!(
-                "cannot find [package].name in {}",
-                cargo_toml_path.display()
-            )
-        })?;
-
-    // Build the staticlib.
-    eprintln!("Building FFI library: {crate_name}");
-    let status = std::process::Command::new("cargo")
-        .args(["build", "--release"])
-        .current_dir(&dir)
-        .status()
-        .map_err(|e| format!("cannot run cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build --release failed".into());
-    }
-
-    // Find the workspace target directory.
-    let target_dir = find_cargo_target_dir(&dir);
-
-    // Crate names use underscores in library filenames.
-    let lib_name = crate_name.replace('-', "_");
-    let lib_path = target_dir.join("release").join(format!("lib{lib_name}.a"));
-
-    if !lib_path.exists() {
-        return Err(format!(
-            "expected staticlib not found: {}",
-            lib_path.display()
-        ));
-    }
-
-    let canonical = lib_path
+    let Some(artifact) = hew_pkg::native::build_native(start_dir)? else {
+        return Ok(None);
+    };
+    let canonical = artifact
+        .path
         .canonicalize()
-        .unwrap_or(lib_path)
+        .map_err(|error| {
+            format!(
+                "cannot canonicalize native artifact {}: {error}",
+                artifact.path.display()
+            )
+        })?
         .display()
         .to_string();
     Ok(Some(canonical))
-}
-
-/// Find the Cargo target directory for a package by walking up to find a
-/// workspace `Cargo.toml` (one containing `[workspace]`).
-fn find_cargo_target_dir(package_dir: &std::path::Path) -> std::path::PathBuf {
-    let mut dir = package_dir.to_path_buf();
-    while let Some(parent) = dir.parent() {
-        let candidate = parent.join("Cargo.toml");
-        if candidate.exists() {
-            if let Ok(content) = std::fs::read_to_string(&candidate) {
-                if let Ok(parsed) = toml::from_str::<toml::Value>(&content) {
-                    if parsed.get("workspace").is_some() {
-                        return parent.join("target");
-                    }
-                }
-            }
-        }
-        dir = parent.to_path_buf();
-    }
-    // Fallback: use the package's own target directory.
-    package_dir.join("target")
 }
 
 #[cfg(test)]

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -114,7 +114,7 @@ pub struct TestSummary {
 /// Filesystem inputs needed by the in-process native compiler.
 #[derive(Debug)]
 pub struct TestCompilePaths {
-    paths: crate::NativeCompilePaths,
+    paths: crate::NativeBuildPaths,
 }
 
 impl TestCompilePaths {
@@ -129,10 +129,18 @@ impl TestCompilePaths {
             target.normalized_triple(),
             target.can_run_on_host(),
         )?;
-        Self::from_explicit(module_search_paths, PathBuf::from(hew_lib))
+        Self::from_explicit(
+            project_dir.to_path_buf(),
+            module_search_paths,
+            PathBuf::from(hew_lib),
+        )
     }
 
-    fn from_explicit(module_search_paths: Vec<PathBuf>, hew_lib: PathBuf) -> Result<Self, String> {
+    fn from_explicit(
+        project_dir: PathBuf,
+        module_search_paths: Vec<PathBuf>,
+        hew_lib: PathBuf,
+    ) -> Result<Self, String> {
         let has_stdlib = module_search_paths
             .iter()
             .any(|root| root.join("std/builtins.hew").is_file());
@@ -158,7 +166,8 @@ impl TestCompilePaths {
             ));
         }
         Ok(Self {
-            paths: crate::NativeCompilePaths {
+            paths: crate::NativeBuildPaths {
+                project_dir,
                 module_search_paths,
                 hew_lib,
             },
@@ -422,10 +431,6 @@ fn compile_test(
     ffi_lib: Option<&str>,
     compile_paths: &TestCompilePaths,
 ) -> Result<CompiledTestArtifact, String> {
-    if ffi_lib.is_some() {
-        return Err("hew test FFI libraries are unavailable on the v0.5 compile path".to_string());
-    }
-
     let synthetic = format!(
         "{source}\n\nfn main() {{\n    {name}();\n}}\n",
         name = test.name,
@@ -455,12 +460,14 @@ fn compile_test(
         .file_stem()
         .ok_or_else(|| "temp source path has no file stem".to_string())?;
     let binary_path = emit_dir.path().join(binary_name);
+    let extra_libs = ffi_lib.into_iter().map(str::to_owned).collect::<Vec<_>>();
 
     crate::diagnostic::start_diagnostic_capture();
-    let compile_result = crate::compile_native_binary_with_paths(
+    let compile_result = crate::compile_test_binary_with_paths(
         tmp_source.path(),
         &binary_path,
-        Some(&compile_paths.paths),
+        &compile_paths.paths,
+        &extra_libs,
     );
     let diagnostics = crate::diagnostic::finish_diagnostic_capture();
     if compile_result.is_err() {
@@ -578,8 +585,6 @@ mod tests {
     use super::*;
     use std::sync::OnceLock;
 
-    /// Skip tests that require the linked native execution substrate while
-    /// `hew test` is still blocked by the v0.5 cutover guard.
     fn require_codegen() -> bool {
         ensure_test_toolchain()
     }
@@ -615,6 +620,7 @@ mod tests {
             let target = crate::target::TargetSpec::from_requested(None)
                 .expect("the test host target should resolve");
             TestCompilePaths::from_explicit(
+                workspace_root.clone(),
                 vec![workspace_root],
                 cargo_profile_dir.join(target.hew_lib_name()),
             )
@@ -628,8 +634,12 @@ mod tests {
         let archive = dir.path().join("libhew.a");
         std::fs::write(&archive, []).expect("create archive fixture");
 
-        let error = TestCompilePaths::from_explicit(vec![dir.path().to_path_buf()], archive)
-            .expect_err("a root without std/builtins.hew must fail");
+        let error = TestCompilePaths::from_explicit(
+            dir.path().to_path_buf(),
+            vec![dir.path().to_path_buf()],
+            archive,
+        )
+        .expect_err("a root without std/builtins.hew must fail");
 
         assert!(error.contains("standard library"), "error: {error}");
         assert!(error.contains("std/builtins.hew"), "error: {error}");
@@ -642,9 +652,12 @@ mod tests {
         std::fs::write(dir.path().join("std/builtins.hew"), []).expect("create builtins fixture");
         let archive = dir.path().join("missing-libhew.a");
 
-        let error =
-            TestCompilePaths::from_explicit(vec![dir.path().to_path_buf()], archive.clone())
-                .expect_err("a missing runtime archive must fail");
+        let error = TestCompilePaths::from_explicit(
+            dir.path().to_path_buf(),
+            vec![dir.path().to_path_buf()],
+            archive.clone(),
+        )
+        .expect_err("a missing runtime archive must fail");
 
         assert!(error.contains("runtime archive"), "error: {error}");
         assert!(
@@ -860,7 +873,8 @@ fn test_timeout() {
         ];
 
         let unused_paths = TestCompilePaths {
-            paths: crate::NativeCompilePaths {
+            paths: crate::NativeBuildPaths {
+                project_dir: PathBuf::new(),
                 module_search_paths: Vec::new(),
                 hew_lib: PathBuf::new(),
             },

--- a/hew-cli/tests/fixtures/test_ffi_package/Cargo.toml
+++ b/hew-cli/tests/fixtures/test_ffi_package/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "hew-test-ffi-package"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "hew_test_ffi_package"
+crate-type = ["staticlib"]
+
+[profile.release]
+panic = "abort"
+
+[profile.release-lib]
+inherits = "release"
+lto = "off"
+
+[workspace]

--- a/hew-cli/tests/fixtures/test_ffi_package/ffi_test.hew
+++ b/hew-cli/tests/fixtures/test_ffi_package/ffi_test.hew
@@ -1,0 +1,8 @@
+extern "C" {
+    fn hew_test_ffi_answer() -> i64;
+}
+
+#[test]
+fn native_ffi_is_linked() {
+    assert_eq(unsafe { hew_test_ffi_answer() }, 42);
+}

--- a/hew-cli/tests/fixtures/test_ffi_package/hew.toml
+++ b/hew-cli/tests/fixtures/test_ffi_package/hew.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test-ffi-package"
+version = "0.1.0"
+edition = "2026"
+
+[native]
+crate = "."
+lib = "hew_test_ffi_package"
+kind = "staticlib"

--- a/hew-cli/tests/fixtures/test_ffi_package/src/lib.rs
+++ b/hew-cli/tests/fixtures/test_ffi_package/src/lib.rs
@@ -1,0 +1,4 @@
+#[unsafe(no_mangle)]
+pub extern "C" fn hew_test_ffi_answer() -> i64 {
+    42
+}

--- a/hew-cli/tests/test_runner_e2e.rs
+++ b/hew-cli/tests/test_runner_e2e.rs
@@ -25,6 +25,63 @@ fn run_suite(files: &[(&str, &str)], extra_args: &[&str]) -> std::process::Outpu
 }
 
 #[test]
+fn package_native_ffi_is_built_and_linked() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    for (path, contents) in [
+        (
+            "hew.toml",
+            include_str!("fixtures/test_ffi_package/hew.toml"),
+        ),
+        (
+            "Cargo.toml",
+            include_str!("fixtures/test_ffi_package/Cargo.toml"),
+        ),
+        (
+            "src/lib.rs",
+            include_str!("fixtures/test_ffi_package/src/lib.rs"),
+        ),
+        (
+            "ffi_test.hew",
+            include_str!("fixtures/test_ffi_package/ffi_test.hew"),
+        ),
+    ] {
+        write_file(dir.path(), path, contents);
+    }
+
+    let output = Command::new(hew_binary())
+        .args(["test", "ffi_test.hew", "--no-color", "--jobs", "1"])
+        .env("CARGO_TARGET_DIR", dir.path().join("target"))
+        .current_dir(dir.path())
+        .output()
+        .expect("run package FFI test");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test native_ffi_is_linked ... ok"));
+    assert!(stdout.contains("1 passed; 0 failed; 0 ignored"));
+    assert!(dir.path().join("target/release-lib").is_dir());
+    let archive = if cfg!(target_os = "windows") {
+        dir.path()
+            .join("target/release-lib/hew_test_ffi_package.lib")
+    } else {
+        dir.path()
+            .join("target/release-lib/libhew_test_ffi_package.a")
+    };
+    assert!(
+        archive.is_file(),
+        "declared native library was not built at {}",
+        archive.display()
+    );
+}
+
+#[test]
 fn passing_suite_exits_zero() {
     require_codegen();
 

--- a/hew-pkg/src/native.rs
+++ b/hew-pkg/src/native.rs
@@ -15,7 +15,7 @@ use crate::manifest;
 pub struct NativeArtifact {
     /// The `[lib] name` (without the `lib` prefix or file extension).
     pub lib: String,
-    /// Absolute path to the built artifact (e.g. `.../release/lib<lib>.a`).
+    /// Absolute path to the built artifact (e.g. `.../release-lib/lib<lib>.a`).
     pub path: PathBuf,
 }
 
@@ -39,7 +39,8 @@ fn artifact_file_name(lib: &str, kind: &str) -> String {
 
 /// Build the `[native]` library declared in `<manifest_dir>/hew.toml`, if any.
 ///
-/// Runs `cargo build --release` for the crate and locates the produced library.
+/// Runs Cargo with the non-LTO `release-lib` profile used for consumer-facing
+/// static libraries and locates the produced artifact.
 /// Returns `Ok(None)` when the manifest has no `[native]` section.
 ///
 /// # Errors
@@ -67,9 +68,20 @@ pub fn build_native(manifest_dir: &Path) -> Result<Option<NativeArtifact>, Strin
     // the crate dir. The native staticlib must be built with the *same* rustc
     // as `libhew.a` so its embedded `libstd` is byte-identical and the linker
     // dedups `rust_eh_personality`; a mismatched toolchain re-introduces a
-    // duplicate-symbol link failure.
+    // duplicate-symbol link failure. Define `release-lib` on the Cargo
+    // command line so standalone packages inherit their own release settings
+    // while always disabling LTO for a consumer-linkable archive.
     let status = Command::new("cargo")
-        .args(["build", "--release", "--manifest-path"])
+        .args([
+            "build",
+            "--profile",
+            "release-lib",
+            "--config",
+            r#"profile.release-lib.inherits="release""#,
+            "--config",
+            "profile.release-lib.lto=false",
+            "--manifest-path",
+        ])
         .arg(&cargo_toml)
         .current_dir(&crate_dir)
         .status()
@@ -83,7 +95,7 @@ pub fn build_native(manifest_dir: &Path) -> Result<Option<NativeArtifact>, Strin
 
     let target_dir = cargo_target_dir(&cargo_toml)?;
     let file_name = artifact_file_name(&native.lib, &native.kind);
-    let artifact = target_dir.join("release").join(&file_name);
+    let artifact = target_dir.join("release-lib").join(&file_name);
     if !artifact.exists() {
         return Err(format!(
             "[native] crate built but artifact not found: {} (expected lib name `{}`, kind `{}`)",


### PR DESCRIPTION
## Summary

Synthetic `hew test` programs now compile through the v0.6 native build pipeline instead of the legacy v0.5 helper. Package-root manifest resolution, the pre-resolved `libhew` archive, and the package's built native library are all threaded into the final test-binary link, while real build and linker failures still fail closed.

Native package archives now use the consumer-linkable non-LTO `release-lib` profile. A minimal package fixture verifies that `hew test <file>.hew` builds one Rust FFI function and executes a Hew test that calls it.

## Verification

- `cargo test -p hew-cli`: passed
- `cargo test -p hew-cli --test test_runner_e2e package_native_ffi_is_built_and_linked -- --nocapture`: passed
- `cargo test -p hew-pkg`: passed
- `make test-pkg-import`: passed
- `make test-hew-ratchet`: passed
- `make preflight`: passed

## Out of scope

- The legacy compile/watch helper remains unchanged for commands that still intentionally use it.
- Native FFI remains a host-native feature; no WASM linking behavior changes.