### PR TITLE
fix(mir): scope resource match handoffs

### DIFF
--- a/hew-cli/tests/match_resource_result_handoff_leak_oracle.rs
+++ b/hew-cli/tests/match_resource_result_handoff_leak_oracle.rs
@@ -1,0 +1,182 @@
+//! Exact-value ownership oracle for resources selected out of call-result matches.
+//!
+//! Each resource representation runs the four active-payload shapes: consumed
+//! and unconsumed `Ok`, and consumed and unconsumed `Err`. Exact zero-leak
+//! measurements pin sibling payload cleanup; allocator scribbling pins the
+//! opposite failure mode, where both the arm-local owner and carrier release
+//! the same payload.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::Path;
+
+use support::leak_slope::{
+    compile_to_native, measure_leaks_exact, require_leaks_tool, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+const FRAMES: usize = 12;
+
+#[derive(Clone, Copy)]
+enum ResourceShape {
+    Opaque,
+    FieldBearingRecord,
+}
+
+impl ResourceShape {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Opaque => "opaque",
+            Self::FieldBearingRecord => "record",
+        }
+    }
+
+    fn declarations(self) -> &'static str {
+        match self {
+            Self::Opaque => {
+                "#[resource]\n\
+                 #[opaque]\n\
+                 type Handle {}\n\
+                 impl Handle {\n\
+                 \x20   fn probe(self) -> i64 { 7 }\n\
+                 \x20   fn close(self) { unsafe { hew_deque_free(self) }; }\n\
+                 }\n\
+                 extern \"C\" {\n\
+                 \x20   fn hew_deque_new() -> Handle;\n\
+                 \x20   fn hew_deque_free(consume handle: Handle);\n\
+                 }\n\
+                 fn fresh() -> Handle { unsafe { hew_deque_new() } }\n"
+            }
+            Self::FieldBearingRecord => {
+                "#[opaque]\n\
+                 type Raw {}\n\
+                 #[resource]\n\
+                 type Handle { raw: Raw; tag: i64; }\n\
+                 impl Handle {\n\
+                 \x20   fn probe(self) -> i64 { self.tag }\n\
+                 \x20   fn close(self) { unsafe { hew_deque_free(self.raw) }; }\n\
+                 }\n\
+                 extern \"C\" {\n\
+                 \x20   fn hew_deque_new() -> Raw;\n\
+                 \x20   fn hew_deque_free(consume handle: Raw);\n\
+                 }\n\
+                 fn fresh() -> Handle { Handle { raw: unsafe { hew_deque_new() }, tag: 7 } }\n"
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ActivePayload {
+    OkConsumed,
+    OkUnconsumed,
+    ErrConsumed,
+    ErrUnconsumed,
+}
+
+impl ActivePayload {
+    fn name(self) -> &'static str {
+        match self {
+            Self::OkConsumed => "ok_consumed",
+            Self::OkUnconsumed => "ok_unconsumed",
+            Self::ErrConsumed => "err_consumed",
+            Self::ErrUnconsumed => "err_unconsumed",
+        }
+    }
+
+    fn body(self) -> &'static str {
+        match self {
+            Self::OkConsumed => {
+                "let handle = match make(true) {\n\
+                 \x20   Ok(value) => value,\n\
+                 \x20   Err(_) => return 71,\n\
+                 };\n\
+                 handle.close();"
+            }
+            Self::OkUnconsumed => {
+                "match make(true) {\n\
+                 \x20   Ok(value) => { if value.probe() != 7 { return 76; } },\n\
+                 \x20   Err(_) => return 72,\n\
+                 };"
+            }
+            Self::ErrConsumed => {
+                "let message = match make(false) {\n\
+                 \x20   Ok(value) => { value.close(); return 73; },\n\
+                 \x20   Err(value) => value,\n\
+                 };\n\
+                 if message.len() == 0 { return 74; }"
+            }
+            Self::ErrUnconsumed => {
+                "match make(false) {\n\
+                 \x20   Ok(value) => { value.close(); return 75; },\n\
+                 \x20   Err(_) => {},\n\
+                 };"
+            }
+        }
+    }
+}
+
+fn source(shape: ResourceShape, active: ActivePayload) -> String {
+    format!(
+        "{}\n\
+         fn make(ok: bool) -> Result<Handle, string> {{\n\
+         \x20   if ok {{ Ok(fresh()) }} else {{ Err(\"handoff-error\".to_upper()) }}\n\
+         }}\n\
+         fn run_once() -> i64 {{\n\
+         \x20   {}\n\
+         \x20   0\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   for _ in 0..{FRAMES} {{\n\
+         \x20       let status = run_once();\n\
+         \x20       if status != 0 {{ return status; }}\n\
+         \x20   }}\n\
+         \x20   0\n\
+         }}\n",
+        shape.declarations(),
+        active.body()
+    )
+}
+
+fn assert_exact_zero_leaks(bin: &Path, case: &str) {
+    require_leaks_tool();
+    assert_eq!(
+        measure_leaks_exact(bin),
+        (0, 0),
+        "{case} must report exactly zero leaked allocations and bytes"
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "exact leak oracle and deterministic poisoned allocator require macOS"
+)]
+#[test]
+fn resource_result_match_handoffs_drop_every_payload_exactly_once() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("match-resource-result-handoff-")
+        .tempdir()
+        .expect("tempdir");
+
+    for shape in [ResourceShape::Opaque, ResourceShape::FieldBearingRecord] {
+        for active in [
+            ActivePayload::OkConsumed,
+            ActivePayload::OkUnconsumed,
+            ActivePayload::ErrConsumed,
+            ActivePayload::ErrUnconsumed,
+        ] {
+            let case = format!("{}_{}", shape.name(), active.name());
+            let bin = compile_to_native(&source(shape, active), dir.path(), &case);
+            let output = run_under_malloc_scribble(&bin);
+            assert!(
+                output.status.success(),
+                "{case} must not double-free or read freed storage under allocator scribbling:\n{}",
+                describe_output(&output)
+            );
+            assert_exact_zero_leaks(&bin, &case);
+        }
+    }
+}

--- a/hew-cli/tests/stdlib_corpus_release_count_differential.rs
+++ b/hew-cli/tests/stdlib_corpus_release_count_differential.rs
@@ -105,27 +105,22 @@ const ACCOUNTED_BELOW_BASELINE: &[(&str, &str, usize, &str)] = &[
     (
         "examples/benchmarks/http_server.hew",
         "main",
-        5,
-        "the current main has exactly five releases: the Server close on serve_forever's cancel-before-handoff edge, plus reason/detail on both the normal and cancel exits from the listen-error print (1 + 2 + 2). The request loop and its owned path temporaries now live in serve_forever, so the pre-refactor baseline of 10 describes an obsolete main topology",
+        8,
+        "the current main has exactly eight releases: the Server close and the three restored resource match-handoff releases, plus reason/detail on both normal and cancel exits from the listen-error print. The request loop and its owned path temporaries remain in serve_forever, so the pre-refactor baseline of 10 still describes an obsolete main topology",
     ),
     (
         "examples/benchmarks/http_server_expert.hew",
         "main",
-        9,
-        "the current main has exactly nine releases: addr on return, panic, serve_forever cancel, and listen-error-print cancel; the Server close on serve_forever's cancel-before-handoff edge; and reason/detail on both exits from the error print (4 + 1 + 4). The request loop and its owned path temporaries now live in serve_forever, so the pre-refactor baseline of 14 describes an obsolete main topology",
+        12,
+        "the current main has exactly twelve releases: addr on return, panic, serve_forever cancel, and listen-error-print cancel; the Server close and three restored resource match-handoff releases; and reason/detail on both exits from the error print. The request loop and its owned path temporaries remain in serve_forever, so the pre-refactor baseline of 14 still describes an obsolete main topology",
     ),
-    // The non-benchmark examples share the same current 21-entry topology.
+    // The non-benchmark examples share the same current 24-entry topology.
     // The Server close remains on cancel-before-handoff; the remaining entries
     // cover the three persistent strings and the two error strings on every
-    // live exit where each value is still owned.
-    ("examples/http_server.hew", "main", 21, "the current main has exactly 21 releases: port/root on both os.args cancel edges (4); port/root/addr on return, panic, serve_forever cancel, and listen-error-print cancel (12); the Server close on serve_forever's cancel-before-handoff edge (1); and reason/detail on both exits from the error print (4). This complete live-owner topology, not a removed Server close, accounts for the shortfall from the obsolete 25-entry baseline"),
-    ("examples/static_server.hew", "main", 21, "the current main has the same exact 21-entry topology as examples/http_server.hew::main: four os.args-edge string releases, twelve port/root/addr releases across four live exits, one Server close on cancel-before-handoff, and four reason/detail releases. The 25-entry baseline predates this consolidated serve_forever control flow"),
-    (
-        "examples/http_json_demo.hew",
-        "main",
-        14,
-        "main explicitly consumes the three owned JSON Value handles with Value::free, so their implicit resource plans are retracted; the 14 remaining entries are exactly the Option<string> shell and url string paired on seven return, panic, and cancel exits (7 * 2). The former 19-entry count included five plans that no longer belong to live implicit owners",
-    ),
+    // live exit where each value is still owned, plus the three restored
+    // resource match-handoff releases.
+    ("examples/http_server.hew", "main", 24, "the current main has exactly 24 releases: port/root on both os.args cancel edges; port/root/addr on return, panic, serve_forever cancel, and listen-error-print cancel; the Server close and three restored resource match-handoff releases; and reason/detail on both exits from the error print. This live-owner topology remains one below the obsolete 25-entry baseline"),
+    ("examples/static_server.hew", "main", 24, "the current main has the same exact 24-entry topology as examples/http_server.hew::main: four os.args-edge string releases, twelve port/root/addr releases across four live exits, the Server close and three restored resource match-handoff releases, and four reason/detail releases. The 25-entry baseline predates this consolidated serve_forever control flow"),
     // `Child` is now a resource record around an opaque runtime handle. These
     // methods contain no Hew heap value: resource teardown is the `Child.close`
     // action itself, outside the cow-heap drop count measured here.

--- a/hew-cli/tests/value_tree_resource_leak_oracle.rs
+++ b/hew-cli/tests/value_tree_resource_leak_oracle.rs
@@ -57,6 +57,48 @@ fn source(family: &str, frames: usize) -> String {
     )
 }
 
+fn try_parse_match_source(family: &str, frames: usize, valid: bool) -> String {
+    let (document, arms) = match (family, valid) {
+        ("json", true) => (
+            r#"{\"n\":7}"#,
+            "Ok(parsed) => { let child = parsed.get_field(\"n\"); let n = child.get_int(); child.close(); parsed.close(); n }, Err(_) => return 1",
+        ),
+        ("toml", true) => (
+            "n = 7",
+            "Ok(parsed) => { let child = parsed.get_field(\"n\"); let n = child.get_int(); child.close(); parsed.close(); n }, Err(_) => return 1",
+        ),
+        ("yaml", true) => (
+            "n: 7",
+            "Ok(parsed) => { let child = parsed.get_field(\"n\"); let n = child.get_int(); child.close(); parsed.close(); n }, Err(_) => return 1",
+        ),
+        ("json", false) => (
+            "{",
+            "Ok(parsed) => { parsed.close(); return 1; }, Err(_) => 7",
+        ),
+        ("toml", false) => (
+            "=",
+            "Ok(parsed) => { parsed.close(); return 1; }, Err(_) => 7",
+        ),
+        ("yaml", false) => (
+            "[",
+            "Ok(parsed) => { parsed.close(); return 1; }, Err(_) => 7",
+        ),
+        _ => panic!("unknown value-tree family {family}"),
+    };
+    format!(
+        "import std::encoding::{family};\n\
+         fn main() -> i32 {{\n\
+         \x20   for _ in 0..{frames} {{\n\
+         \x20       let n = match {family}.try_parse(\"{document}\") {{\n\
+         \x20           {arms}\n\
+         \x20       }};\n\
+         \x20       println(n);\n\
+         \x20   }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
 #[cfg_attr(
     not(target_os = "macos"),
     ignore = "exact leak oracle needs macOS leaks(1); absent capability must be a counted skip"
@@ -117,5 +159,72 @@ fn high_value_trees_do_not_double_free_or_read_poison() {
             HIGH_FRAMES,
             "{family} poisoned-allocator probe must execute every frame"
         );
+    }
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "exact leak oracle needs macOS leaks(1); absent capability must be a counted skip"
+)]
+#[test]
+fn try_parse_match_results_are_exactly_leak_clean() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("value-tree-try-parse-leaks-")
+        .tempdir()
+        .expect("tempdir");
+    for (case, valid) in [("success", true), ("handled_error", false)] {
+        for family in ["json", "toml", "yaml"] {
+            for frames in [LOW_FRAMES, HIGH_FRAMES] {
+                let bin = compile_to_native(
+                    &try_parse_match_source(family, frames, valid),
+                    dir.path(),
+                    &format!("{family}_try_parse_{case}_{frames}"),
+                );
+                assert_eq!(
+                    run_probe_witness(&bin, &[]),
+                    frames,
+                    "{family} {case} must execute every requested match-result frame"
+                );
+                assert_eq!(
+                    measure_leaks_exact(&bin),
+                    (0, 0),
+                    "{family} {case} must release every owner after {frames} frames"
+                );
+            }
+        }
+    }
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the deterministic poisoned-allocator contract is macOS-only"
+)]
+#[test]
+fn try_parse_match_results_do_not_double_free_or_read_poison() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("value-tree-try-parse-scribble-")
+        .tempdir()
+        .expect("tempdir");
+    for (case, valid) in [("success", true), ("handled_error", false)] {
+        for family in ["json", "toml", "yaml"] {
+            let bin = compile_to_native(
+                &try_parse_match_source(family, HIGH_FRAMES, valid),
+                dir.path(),
+                &format!("{family}_try_parse_{case}_scribble"),
+            );
+            let output = run_under_malloc_scribble(&bin);
+            assert!(
+                output.status.success(),
+                "{family} {case} owners must survive until their one release:\n{}",
+                describe_output(&output)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout).lines().count(),
+                HIGH_FRAMES,
+                "{family} {case} probe must execute every frame"
+            );
+        }
     }
 }

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -1232,6 +1232,14 @@ pub(super) fn derive_enum_composite_drop_allowed(
             )
         })
     };
+    let local_has_user_close = |local: u32| -> bool {
+        local_tys.get(local as usize).is_some_and(|ty| {
+            matches!(
+                super::drop_plan::resource_drop_fn(ty, type_classes),
+                Some(crate::model::DropFnSpec::UserClose(_))
+            )
+        })
+    };
     let local_is_opaque_resource = |local: u32| -> bool {
         local_tys.get(local as usize).is_some_and(|ty| {
             matches!(
@@ -1243,6 +1251,14 @@ pub(super) fn derive_enum_composite_drop_allowed(
             ) && lifecycle_registry.opaque_resource_for_ty(ty).is_some()
         })
     };
+    let neutralized_payload_slots: HashSet<Place> = blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter_map(|instr| match instr {
+            Instr::NeutralizePayloadSlot { place, .. } => Some(*place),
+            _ => None,
+        })
+        .collect();
     // The candidate composite locals: base locals of heap-owning enum
     // composite bindings.
     let mut candidate_local_to_binding: HashMap<u32, BindingId> = HashMap::new();
@@ -1359,12 +1375,14 @@ pub(super) fn derive_enum_composite_drop_allowed(
     // the interior projection's aliased source (its `alias_of` root is the
     // candidate local) and carried along every onward hand-off below.
     let mut payload_binder_candidate_root: HashMap<u32, PayloadBinderRoot> = HashMap::new();
-    // A direct opaque-resource payload has its own lifecycle, while the enum's
-    // structural shell drop deliberately treats that slot as a no-op. Moving
-    // such a payload out must not suppress the shell drop needed by sibling
-    // variants. Track its forwarding chain so only the independent resource
-    // owner escapes; nested resource records keep the conservative exclusion.
-    let mut direct_opaque_resource_payloads: HashSet<u32> = HashSet::new();
+    // An opaque resource payload has an independent lifecycle. A field-bearing
+    // user-close payload gains the same status only when its carrier slot is
+    // neutralized by a proven consuming result handoff. Track those forwarding
+    // chains so the generic escape scan does not suppress sibling cleanup for
+    // the handoff, while an ordinary borrowed resource method keeps the legacy
+    // binder-owned close. The declared-release neutralize rule below still
+    // excludes the unsafe zeroed-record carrier itself.
+    let mut direct_independent_resource_payloads: HashSet<u32> = HashSet::new();
     for block in blocks {
         for instr in &block.instructions {
             if let Instr::Move { dest, src } = instr {
@@ -1379,8 +1397,11 @@ pub(super) fn derive_enum_composite_drop_allowed(
                                 // out — tracking it would over-exclude the
                                 // composite drop and leak.
                                 if local_is_heap_owning(dl) {
-                                    if local_is_opaque_resource(dl) {
-                                        direct_opaque_resource_payloads.insert(dl);
+                                    if local_is_opaque_resource(dl)
+                                        || (local_has_user_close(dl)
+                                            && neutralized_payload_slots.contains(src))
+                                    {
+                                        direct_independent_resource_payloads.insert(dl);
                                     }
                                     // The binder's real declaring scope
                                     // (`None` for a synthetic transient with no
@@ -1478,8 +1499,8 @@ pub(super) fn derive_enum_composite_drop_allowed(
                                 sl,
                                 dl,
                             );
-                            if direct_opaque_resource_payloads.contains(&sl) {
-                                direct_opaque_resource_payloads.insert(dl);
+                            if direct_independent_resource_payloads.contains(&sl) {
+                                direct_independent_resource_payloads.insert(dl);
                             }
                             changed = true;
                         }
@@ -1748,7 +1769,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
                         note_alias_escape(l, &mut excluded_roots);
                     }
                     if payload_binders.contains_key(&l)
-                        && !direct_opaque_resource_payloads.contains(&l)
+                        && !direct_independent_resource_payloads.contains(&l)
                     {
                         note_payload_escape(
                             &payload_binder_candidate_root,
@@ -1825,7 +1846,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
                             && dest_local.is_some_and(|dl| !local_is_heap_owning(dl));
                         if !benign_handoff
                             && !benign_bitcopy_extract
-                            && !direct_opaque_resource_payloads.contains(&sl)
+                            && !direct_independent_resource_payloads.contains(&sl)
                         {
                             note_payload_escape(
                                 &payload_binder_candidate_root,
@@ -1904,7 +1925,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
                             && !place_is_tag_read(p)
                             && !binder_read_is_borrow_safe_instr(instr, l)
                             && !vec_iter_cursor_ingress_of(instr, l)
-                            && !direct_opaque_resource_payloads.contains(&l)
+                            && !direct_independent_resource_payloads.contains(&l)
                         {
                             note_payload_escape(
                                 &payload_binder_candidate_root,
@@ -2024,7 +2045,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
                             module_generic_fn_names,
                             extern_contracts,
                         ));
-                    if !read_is_borrow && !direct_opaque_resource_payloads.contains(&l) {
+                    if !read_is_borrow && !direct_independent_resource_payloads.contains(&l) {
                         note_payload_escape(
                             &payload_binder_candidate_root,
                             l,

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -9,6 +9,7 @@ mod bytes_payload_handoff;
 mod foundation;
 mod opaque_resource_field_misuse;
 mod predicate_string_temp_drop;
+mod resource_payload_handoff;
 mod retained_string_aliases;
 mod shell_drop_safety;
 mod tuple_handle_projection;
@@ -45,34 +46,17 @@ use bytes_payload_handoff::provable_bytes_payload_handoff_sites;
 #[cfg(test)]
 use bytes_payload_handoff::BytesPayloadHandoff;
 use foundation::{
-    generator_env_snapshot_init_locals, initializes_generator_env_snapshot, scope_is_same_or_nested,
+    generator_env_snapshot_init_locals, initializes_generator_env_snapshot,
+    local_ty_carries_drop_obligation, scope_is_same_or_nested,
 };
 pub(super) use opaque_resource_field_misuse::detect_opaque_resource_field_misuse;
 use predicate_string_temp_drop::predicate_string_temp_drop_proof;
+use resource_payload_handoff::direct_independent_resource_payloads;
 use retained_string_aliases::{
     retained_string_field_load_aliases, uniquely_defined_retained_string_field_load_aliases,
 };
 pub(super) use shell_drop_safety::enum_payloads_are_shell_drop_safe;
 pub(super) use tuple_handle_projection::derive_owned_tuple_handle_projection_bindings;
-
-/// Obligation-axis projection shared by the per-local prover lambdas: a local
-/// carries an owner (and its escape must be tracked) when its type owns heap
-/// OR transitively contains a registered closeable `#[resource]` — the same
-/// admission axis the composite drops now use, so a resource payload binder is
-/// never mistaken for a harmless `BitCopy` escape (which would double-close).
-fn local_ty_carries_drop_obligation(
-    ty: &ResolvedTy,
-    record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
-    enum_layouts: &[crate::model::EnumLayout],
-    lifecycle_registry: &hew_hir::LifecycleRegistry,
-) -> bool {
-    crate::model::ty_carries_drop_obligation_mir(
-        ty,
-        record_field_orders,
-        enum_layouts,
-        lifecycle_registry,
-    )
-}
 
 /// #2212 — discharge the non-escaped owned sibling fields of a record whose
 /// composite drop the sole-owner prover excludes because ONE of its fields
@@ -1232,33 +1216,6 @@ pub(super) fn derive_enum_composite_drop_allowed(
             )
         })
     };
-    let local_has_user_close = |local: u32| -> bool {
-        local_tys.get(local as usize).is_some_and(|ty| {
-            matches!(
-                super::drop_plan::resource_drop_fn(ty, type_classes),
-                Some(crate::model::DropFnSpec::UserClose(_))
-            )
-        })
-    };
-    let local_is_opaque_resource = |local: u32| -> bool {
-        local_tys.get(local as usize).is_some_and(|ty| {
-            matches!(
-                ty,
-                ResolvedTy::Named {
-                    is_opaque: true,
-                    ..
-                }
-            ) && lifecycle_registry.opaque_resource_for_ty(ty).is_some()
-        })
-    };
-    let neutralized_payload_slots: HashSet<Place> = blocks
-        .iter()
-        .flat_map(|block| block.instructions.iter())
-        .filter_map(|instr| match instr {
-            Instr::NeutralizePayloadSlot { place, .. } => Some(*place),
-            _ => None,
-        })
-        .collect();
     // The candidate composite locals: base locals of heap-owning enum
     // composite bindings.
     let mut candidate_local_to_binding: HashMap<u32, BindingId> = HashMap::new();
@@ -1325,6 +1282,14 @@ pub(super) fn derive_enum_composite_drop_allowed(
     // reachable from two distinct roots is evicted, not oscillated (#1942).
     let alias_of =
         propagate_whole_value_alias_roots(blocks, candidate_local_to_binding.keys().copied());
+    let mut direct_independent_resource_payloads = direct_independent_resource_payloads(
+        blocks,
+        &alias_of,
+        local_tys,
+        type_classes,
+        lifecycle_registry,
+        &local_is_heap_owning,
+    );
 
     // Local→ScopeId helper for the propagation scope-equality check.
     // Built from the public `binding_locals` × `binding_scope` view: each
@@ -1375,14 +1340,6 @@ pub(super) fn derive_enum_composite_drop_allowed(
     // the interior projection's aliased source (its `alias_of` root is the
     // candidate local) and carried along every onward hand-off below.
     let mut payload_binder_candidate_root: HashMap<u32, PayloadBinderRoot> = HashMap::new();
-    // An opaque resource payload has an independent lifecycle. A field-bearing
-    // user-close payload gains the same status only when its carrier slot is
-    // neutralized by a proven consuming result handoff. Track those forwarding
-    // chains so the generic escape scan does not suppress sibling cleanup for
-    // the handoff, while an ordinary borrowed resource method keeps the legacy
-    // binder-owned close. The declared-release neutralize rule below still
-    // excludes the unsafe zeroed-record carrier itself.
-    let mut direct_independent_resource_payloads: HashSet<u32> = HashSet::new();
     for block in blocks {
         for instr in &block.instructions {
             if let Instr::Move { dest, src } = instr {
@@ -1397,12 +1354,6 @@ pub(super) fn derive_enum_composite_drop_allowed(
                                 // out — tracking it would over-exclude the
                                 // composite drop and leak.
                                 if local_is_heap_owning(dl) {
-                                    if local_is_opaque_resource(dl)
-                                        || (local_has_user_close(dl)
-                                            && neutralized_payload_slots.contains(src))
-                                    {
-                                        direct_independent_resource_payloads.insert(dl);
-                                    }
                                     // The binder's real declaring scope
                                     // (`None` for a synthetic transient with no
                                     // HIR scope — e.g. the nested-constructor

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -1232,6 +1232,17 @@ pub(super) fn derive_enum_composite_drop_allowed(
             )
         })
     };
+    let local_is_opaque_resource = |local: u32| -> bool {
+        local_tys.get(local as usize).is_some_and(|ty| {
+            matches!(
+                ty,
+                ResolvedTy::Named {
+                    is_opaque: true,
+                    ..
+                }
+            ) && lifecycle_registry.opaque_resource_for_ty(ty).is_some()
+        })
+    };
     // The candidate composite locals: base locals of heap-owning enum
     // composite bindings.
     let mut candidate_local_to_binding: HashMap<u32, BindingId> = HashMap::new();
@@ -1348,6 +1359,12 @@ pub(super) fn derive_enum_composite_drop_allowed(
     // the interior projection's aliased source (its `alias_of` root is the
     // candidate local) and carried along every onward hand-off below.
     let mut payload_binder_candidate_root: HashMap<u32, PayloadBinderRoot> = HashMap::new();
+    // A direct opaque-resource payload has its own lifecycle, while the enum's
+    // structural shell drop deliberately treats that slot as a no-op. Moving
+    // such a payload out must not suppress the shell drop needed by sibling
+    // variants. Track its forwarding chain so only the independent resource
+    // owner escapes; nested resource records keep the conservative exclusion.
+    let mut direct_opaque_resource_payloads: HashSet<u32> = HashSet::new();
     for block in blocks {
         for instr in &block.instructions {
             if let Instr::Move { dest, src } = instr {
@@ -1362,6 +1379,9 @@ pub(super) fn derive_enum_composite_drop_allowed(
                                 // out — tracking it would over-exclude the
                                 // composite drop and leak.
                                 if local_is_heap_owning(dl) {
+                                    if local_is_opaque_resource(dl) {
+                                        direct_opaque_resource_payloads.insert(dl);
+                                    }
                                     // The binder's real declaring scope
                                     // (`None` for a synthetic transient with no
                                     // HIR scope — e.g. the nested-constructor
@@ -1458,6 +1478,9 @@ pub(super) fn derive_enum_composite_drop_allowed(
                                 sl,
                                 dl,
                             );
+                            if direct_opaque_resource_payloads.contains(&sl) {
+                                direct_opaque_resource_payloads.insert(dl);
+                            }
                             changed = true;
                         }
                     }
@@ -1724,7 +1747,9 @@ pub(super) fn derive_enum_composite_drop_allowed(
                     if alias_of.contains_key(&l) {
                         note_alias_escape(l, &mut excluded_roots);
                     }
-                    if payload_binders.contains_key(&l) {
+                    if payload_binders.contains_key(&l)
+                        && !direct_opaque_resource_payloads.contains(&l)
+                    {
                         note_payload_escape(
                             &payload_binder_candidate_root,
                             l,
@@ -1798,7 +1823,10 @@ pub(super) fn derive_enum_composite_drop_allowed(
                         // `place_is_tag_read` discriminant exemption above.
                         let benign_bitcopy_extract = matches!(dest, Place::Local(_))
                             && dest_local.is_some_and(|dl| !local_is_heap_owning(dl));
-                        if !benign_handoff && !benign_bitcopy_extract {
+                        if !benign_handoff
+                            && !benign_bitcopy_extract
+                            && !direct_opaque_resource_payloads.contains(&sl)
+                        {
                             note_payload_escape(
                                 &payload_binder_candidate_root,
                                 sl,
@@ -1876,6 +1904,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
                             && !place_is_tag_read(p)
                             && !binder_read_is_borrow_safe_instr(instr, l)
                             && !vec_iter_cursor_ingress_of(instr, l)
+                            && !direct_opaque_resource_payloads.contains(&l)
                         {
                             note_payload_escape(
                                 &payload_binder_candidate_root,
@@ -1995,7 +2024,7 @@ pub(super) fn derive_enum_composite_drop_allowed(
                             module_generic_fn_names,
                             extern_contracts,
                         ));
-                    if !read_is_borrow {
+                    if !read_is_borrow && !direct_opaque_resource_payloads.contains(&l) {
                         note_payload_escape(
                             &payload_binder_candidate_root,
                             l,

--- a/hew-mir/src/lower/composite_own/foundation.rs
+++ b/hew-mir/src/lower/composite_own/foundation.rs
@@ -1,4 +1,25 @@
-use super::{base_local, BasicBlock, HashMap, HashSet, Instr, ScopeId, ScopeInfoEntry, Terminator};
+use super::{
+    base_local, BasicBlock, HashMap, HashSet, Instr, ResolvedTy, ScopeId, ScopeInfoEntry,
+    Terminator,
+};
+
+/// Obligation-axis projection shared by the per-local prover lambdas: a local
+/// carries an owner when its type owns heap or transitively contains a
+/// registered closeable resource, so a resource payload binder is never
+/// mistaken for a harmless bit-copy escape.
+pub(super) fn local_ty_carries_drop_obligation(
+    ty: &ResolvedTy,
+    record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
+    enum_layouts: &[crate::model::EnumLayout],
+    lifecycle_registry: &hew_hir::LifecycleRegistry,
+) -> bool {
+    crate::model::ty_carries_drop_obligation_mir(
+        ty,
+        record_field_orders,
+        enum_layouts,
+        lifecycle_registry,
+    )
+}
 
 pub(super) fn generator_env_snapshot_init_locals(blocks: &[BasicBlock]) -> HashSet<u32> {
     blocks

--- a/hew-mir/src/lower/composite_own/resource_payload_handoff.rs
+++ b/hew-mir/src/lower/composite_own/resource_payload_handoff.rs
@@ -1,0 +1,61 @@
+use super::{
+    base_local, place_is_interior_projection, BasicBlock, HashMap, HashSet, Instr, Place,
+    ResolvedTy,
+};
+
+/// Finds direct match payload binders whose resource lifecycle is independent
+/// from their enclosing enum shell. Opaque resources are independent by type;
+/// field-bearing user-close resources become independent only after a proven
+/// consuming handoff neutralizes their carrier slot.
+pub(super) fn direct_independent_resource_payloads(
+    blocks: &[BasicBlock],
+    alias_of: &HashMap<u32, u32>,
+    local_tys: &[ResolvedTy],
+    type_classes: &hew_hir::TypeClassTable,
+    lifecycle_registry: &hew_hir::LifecycleRegistry,
+    local_is_heap_owning: &dyn Fn(u32) -> bool,
+) -> HashSet<u32> {
+    let neutralized_payload_slots: HashSet<Place> = blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter_map(|instr| match instr {
+            Instr::NeutralizePayloadSlot { place, .. } => Some(*place),
+            _ => None,
+        })
+        .collect();
+    let mut payloads = HashSet::new();
+    for block in blocks {
+        for instr in &block.instructions {
+            let Instr::Move { dest, src } = instr else {
+                continue;
+            };
+            if !place_is_interior_projection(*src) {
+                continue;
+            }
+            let (Some(source), Some(dest)) = (base_local(*src), base_local(*dest)) else {
+                continue;
+            };
+            if !alias_of.contains_key(&source) || !local_is_heap_owning(dest) {
+                continue;
+            }
+            let Some(ty) = local_tys.get(dest as usize) else {
+                continue;
+            };
+            let opaque_resource = matches!(
+                ty,
+                ResolvedTy::Named {
+                    is_opaque: true,
+                    ..
+                }
+            ) && lifecycle_registry.opaque_resource_for_ty(ty).is_some();
+            let consumed_user_close = matches!(
+                super::super::drop_plan::resource_drop_fn(ty, type_classes),
+                Some(crate::model::DropFnSpec::UserClose(_))
+            ) && neutralized_payload_slots.contains(src);
+            if opaque_resource || consumed_user_close {
+                payloads.insert(dest);
+            }
+        }
+    }
+    payloads
+}

--- a/hew-mir/src/lower/facts.rs
+++ b/hew-mir/src/lower/facts.rs
@@ -13,7 +13,13 @@ use super::{
 
 impl Builder {
     pub(super) fn binding_ref_use_intent(&self, expr: &HirExpr) -> IntentKind {
-        if self.param_ownership.borrow_arg_sites.contains(&expr.site)
+        if self
+            .projected_resource_direct_move_sites
+            .last()
+            .is_some_and(|site| *site == expr.site)
+        {
+            IntentKind::Consume
+        } else if self.param_ownership.borrow_arg_sites.contains(&expr.site)
             || self.bytes_local_share_sites.contains(&expr.site)
             || self.string_local_share_sites.contains_key(&expr.site)
         {

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -897,6 +897,12 @@ struct Builder {
     /// though its value moves; this exact-site stack distinguishes that result
     /// transfer from unrelated cursor reads nested in a composite expression.
     pub(crate) vec_iter_direct_move_sites: Vec<hew_hir::SiteId>,
+    /// Direct projected user-resource binding sites currently crossing an
+    /// ownership boundary. Match-arm tails retain HIR `Read` intent even when
+    /// the selected value becomes the owning result of the match. This stack
+    /// lets binding lowering record that exact handoff as `Consume`, which
+    /// disarms the arm binder and neutralizes its source payload slot.
+    pub(crate) projected_resource_direct_move_sites: Vec<hew_hir::SiteId>,
     /// Ownership sidecar produced for each lowered `VecIter<T>` expression.
     /// Let/var and assignment destinations copy this bit after moving the value
     /// bytes, preserving both owning and borrowing topologies through composite

--- a/hew-mir/src/lower/move_value.rs
+++ b/hew-mir/src/lower/move_value.rs
@@ -457,6 +457,22 @@ impl Builder {
         }
     }
 
+    fn is_direct_projected_resource_move(&self, expr: &HirExpr, requested_transfer: bool) -> bool {
+        let HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(binding),
+            ..
+        } = &expr.kind
+        else {
+            return false;
+        };
+        requested_transfer
+            && self.projected_payload_provenance.contains_key(binding)
+            && matches!(
+                super::drop_plan::resource_drop_fn(&self.subst_ty(&expr.ty), &self.type_classes),
+                Some(crate::model::DropFnSpec::UserClose(_))
+            )
+    }
+
     fn lower_value_with_vec_iter_transfer(
         &mut self,
         expr: &HirExpr,
@@ -525,10 +541,18 @@ impl Builder {
         let direct_binding = vec_iter_move
             && effective_transfer
             && matches!(expr.kind, HirExprKind::BindingRef { .. });
+        let direct_projected_resource =
+            self.is_direct_projected_resource_move(expr, requested_transfer);
         if direct_binding {
             self.vec_iter_direct_move_sites.push(expr.site);
         }
+        if direct_projected_resource {
+            self.projected_resource_direct_move_sites.push(expr.site);
+        }
         let value = self.lower_value(expr);
+        if direct_projected_resource {
+            self.projected_resource_direct_move_sites.pop();
+        }
         if direct_binding {
             self.vec_iter_direct_move_sites.pop();
         }

--- a/hew-mir/src/lower/move_value.rs
+++ b/hew-mir/src/lower/move_value.rs
@@ -3,8 +3,8 @@ use super::{
     ty_is_indirect_enum, BasicBlock, BindingId, Builder, CaptureEnvOwnedLoad, Disposition,
     FieldLoadClass, HashMap, HashSet, HirBinding, HirExpr, HirExprKind, Instr, MirDiagnostic,
     MirDiagnosticKind, MirStatement, OwnedCarrierNeutralizeTarget, OwnedCarrierParam,
-    PendingOwnedCallArg, PendingOwnedCallSite, Place, ResolvedRef, ResolvedTy, SiteId,
-    SnapshotFieldKind, SuspendKind,
+    PendingOwnedCallArg, PendingOwnedCallSite, Place, ProjectedPayloadOrigin, ResolvedRef,
+    ResolvedTy, SiteId, SnapshotFieldKind, SuspendKind,
 };
 
 /// Whether a scope-exit tuple can safely have one of its projected ownership
@@ -430,7 +430,7 @@ impl Builder {
     /// create a second drop authority. Borrow and projection roots bypass this
     /// funnel and continue through `lower_value`.
     pub(crate) fn lower_value_for_move(&mut self, expr: &HirExpr) -> Option<Place> {
-        self.lower_value_with_vec_iter_transfer(expr, true)
+        self.lower_value_with_vec_iter_transfer(expr, true, false)
     }
 
     /// Lower a `VecIter<T>` value for a non-owning read context while retaining
@@ -438,7 +438,7 @@ impl Builder {
     /// and keep their source owner bit; fresh leaves are marked owned so a
     /// discarded result can release its temporary snapshot.
     pub(crate) fn lower_vec_iter_value_for_read(&mut self, expr: &HirExpr) -> Option<Place> {
-        self.lower_value_with_vec_iter_transfer(expr, false)
+        self.lower_value_with_vec_iter_transfer(expr, false, false)
     }
 
     /// Lower a composite arm or block tail under the ownership mode established
@@ -453,11 +453,16 @@ impl Builder {
         {
             self.lower_vec_iter_value_for_read(expr)
         } else {
-            self.lower_value_for_move(expr)
+            self.lower_value_with_vec_iter_transfer(expr, true, true)
         }
     }
 
-    fn is_direct_projected_resource_move(&self, expr: &HirExpr, requested_transfer: bool) -> bool {
+    fn is_direct_projected_resource_handoff(
+        &self,
+        expr: &HirExpr,
+        requested_transfer: bool,
+        composite_result_handoff: bool,
+    ) -> bool {
         let HirExprKind::BindingRef {
             resolved: ResolvedRef::Binding(binding),
             ..
@@ -466,7 +471,14 @@ impl Builder {
             return false;
         };
         requested_transfer
-            && self.projected_payload_provenance.contains_key(binding)
+            && composite_result_handoff
+            && expr.intent != hew_hir::IntentKind::Consume
+            && self
+                .projected_payload_provenance
+                .get(binding)
+                .is_some_and(|provenance| {
+                    !matches!(provenance.origin, ProjectedPayloadOrigin::Reject(_))
+                })
             && matches!(
                 super::drop_plan::resource_drop_fn(&self.subst_ty(&expr.ty), &self.type_classes),
                 Some(crate::model::DropFnSpec::UserClose(_))
@@ -477,6 +489,7 @@ impl Builder {
         &mut self,
         expr: &HirExpr,
         requested_transfer: bool,
+        composite_result_handoff: bool,
     ) -> Option<Place> {
         if requested_transfer {
             if let HirExprKind::BindingRef {
@@ -541,8 +554,11 @@ impl Builder {
         let direct_binding = vec_iter_move
             && effective_transfer
             && matches!(expr.kind, HirExprKind::BindingRef { .. });
-        let direct_projected_resource =
-            self.is_direct_projected_resource_move(expr, requested_transfer);
+        let direct_projected_resource = self.is_direct_projected_resource_handoff(
+            expr,
+            requested_transfer,
+            composite_result_handoff,
+        );
         if direct_binding {
             self.vec_iter_direct_move_sites.push(expr.site);
         }

--- a/hew-mir/src/lower/pattern.rs
+++ b/hew-mir/src/lower/pattern.rs
@@ -523,6 +523,24 @@ impl Builder {
             ResolvedTy::Tuple(_) | ResolvedTy::Array(_, _) => ReleaseSymbolVerdict::WiredInPlace(
                 crate::ownership::InPlaceReleaseKind::AggregateRecursive,
             ),
+            // A field-bearing resource record has a drop-only in-place thunk:
+            // it runs user close and then tears down its fields. It is affine
+            // and therefore intentionally lacks the clone-total admission used
+            // by ordinary composites, but a fresh arm-local owner needs only
+            // the drop half.
+            ResolvedTy::Named {
+                name,
+                args,
+                is_opaque: false,
+                ..
+            } if args.is_empty()
+                && self
+                    .lifecycle_registry
+                    .resource_record(&hew_types::DefId::new(name))
+                    .is_some() =>
+            {
+                ReleaseSymbolVerdict::WiredInPlace(crate::ownership::InPlaceReleaseKind::Record)
+            }
             // A registered heap-owning record/enum composite: release through
             // the synthesised in-place drop thunk. `owned_composite_release_kind`
             // (→ `elem_is_owned_abi_releasable`) is the SAME admission the
@@ -4484,6 +4502,33 @@ impl Builder {
             // `for await item in rx` / `match channel.recv(...) { ... }` /
             // `match stream.recv() { ... }`.
             let arm_is_recv_some = recv_next_scrutinee && arm_is_some;
+            let call_carrier_needs_skipped_payload_owner = call_scrutinee_owner.is_some()
+                && match &self.subst_ty(&scrutinee.ty) {
+                    ResolvedTy::Named { name, args, .. } => {
+                        crate::model::find_enum_layout(name, args, &self.enum_layouts).is_some_and(
+                            |layout| {
+                                layout.variants.iter().any(|variant| {
+                                    variant.field_tys.iter().any(|field_ty| {
+                                        matches!(
+                                            field_ty,
+                                            ResolvedTy::Named {
+                                                name,
+                                                args,
+                                                is_opaque: false,
+                                                ..
+                                            } if args.is_empty()
+                                                && self
+                                                    .lifecycle_registry
+                                                    .resource_record(&hew_types::DefId::new(name))
+                                                    .is_some()
+                                        )
+                                    })
+                                })
+                            },
+                        )
+                    }
+                    _ => false,
+                };
             let mut overwritten_bindings = Vec::with_capacity(arm.bindings.len());
             let mut call_carrier_match_result_candidates = Vec::new();
             // Fresh `Some(x)` bindings whose payload owns heap. VecIter clone
@@ -4560,7 +4605,8 @@ impl Builder {
                 // and shell releases for one owner.
                 if call_scrutinee_owner.is_some()
                     && keep_for_drop_elab
-                    && self.is_owned_aggregate_record_ty(&binding_ty)
+                    && (self.is_owned_aggregate_record_ty(&binding_ty)
+                        || call_carrier_needs_skipped_payload_owner)
                 {
                     if let Some(local) = base_local(dest) {
                         call_carrier_match_result_candidates.push((binding.binding, local));
@@ -4729,7 +4775,7 @@ impl Builder {
             // the selected field once and gets one exit drop, while an opaque
             // sibling or an unproven field remains untouched (leak, never a
             // guessed release).
-            if call_scrutinee_owner.is_none() {
+            if call_scrutinee_owner.is_none() || call_carrier_needs_skipped_payload_owner {
                 use crate::model::HeapOwnershipLayouts as _;
                 let bound_fields: HashSet<u32> = arm.bindings.iter().map(|b| b.field_idx).collect();
                 let predicate_fields: HashSet<u32> = arm
@@ -4781,19 +4827,32 @@ impl Builder {
                         "__hew_active_variant_payload",
                         arm.body.site,
                         local,
-                        field_ty,
+                        field_ty.clone(),
                         warrant,
                     );
+                    self.record_match_arm_binding_scope(binding, arm);
+                    self.set_owned_local_disposition(binding, Disposition::BodyEndReleased);
                     self.fresh_variant_payload_bindings.insert(binding);
                     self.fresh_variant_payload_binder_locals.insert(local);
-                    self.push_instr(Instr::Move {
-                        dest,
-                        src: Place::MachineVariant {
-                            local: scrutinee_local,
-                            variant_idx,
-                            field_idx,
-                        },
-                    });
+                    generator_yield_drop_bindings.push((binding, dest, field_ty, arm.body.site));
+                    let source = Place::MachineVariant {
+                        local: scrutinee_local,
+                        variant_idx,
+                        field_idx,
+                    };
+                    self.push_instr(Instr::Move { dest, src: source });
+                    // A whole call carrier normally drops its active payload.
+                    // The synthetic wildcard owner takes that payload instead,
+                    // so clear the carrier slot on this arm. This is essential
+                    // when a consuming field-bearing resource arm makes the
+                    // carrier's recursive drop unsafe: the sibling wildcard
+                    // still owns and releases its payload exactly once.
+                    if call_carrier_needs_skipped_payload_owner {
+                        self.push_move_out_neutralize(
+                            source,
+                            crate::model::NeutralizeAuthority::EphemeralTempConsume,
+                        );
+                    }
                 }
             }
 

--- a/hew-mir/tests/lowering_expr/match_call_scrutinee_drop.rs
+++ b/hew-mir/tests/lowering_expr/match_call_scrutinee_drop.rs
@@ -25,7 +25,7 @@
 //! let-bound scrutinee must not gain a SECOND owner over the same slot, and an
 //! escaping payload must keep the composite excluded (leak, never double-free).
 
-use hew_mir::{DropKind, ElabDrop, ExitPath, IrPipeline};
+use hew_mir::{DropKind, ElabDrop, ExitPath, Instr, IrPipeline};
 use hew_types::module_registry::ModuleRegistry;
 use hew_types::Checker;
 
@@ -300,6 +300,57 @@ fn main() -> i64 {
         1,
         "the call-carrier shell remains the complementary inactive-alternative cleanup, \
          but must not be counted as a second discharge of the moved-out string; got {ret:?}"
+    );
+}
+
+/// A non-idempotent resource selected as the value of a call-result match must
+/// transfer out of the arm binder. The payload slot is cleared at that exact
+/// handoff so an explicit close of the result cannot be followed by a second
+/// implicit close of the binder or its carrier.
+#[test]
+fn from_call_resource_match_result_neutralizes_the_payload_slot() {
+    let p = pipeline_with_tc(
+        r#"
+#[resource]
+#[opaque]
+type Handle {}
+
+impl Handle {
+    fn close(self) {}
+}
+
+fn make() -> Result<Handle, string> {
+    Err("unavailable".to_upper())
+}
+
+fn main() -> i64 {
+    let handle = match make() {
+        Ok(value) => value,
+        Err(_) => return 1,
+    };
+    handle.close();
+    0
+}
+"#,
+    );
+    assert!(
+        p.diagnostics.is_empty(),
+        "the match-result handoff must preserve exactly one resource owner: {:?}",
+        p.diagnostics
+    );
+    let main = p
+        .raw_mir
+        .iter()
+        .find(|function| function.name == "main")
+        .expect("raw fn main");
+    assert_eq!(
+        main.blocks
+            .iter()
+            .flat_map(|block| block.instructions.iter())
+            .filter(|instr| matches!(instr, Instr::NeutralizePayloadSlot { .. }))
+            .count(),
+        1,
+        "the selected resource payload must transfer out of its carrier once"
     );
 }
 

--- a/hew-mir/tests/lowering_expr/match_call_scrutinee_drop.rs
+++ b/hew-mir/tests/lowering_expr/match_call_scrutinee_drop.rs
@@ -312,8 +312,10 @@ fn from_call_resource_match_result_neutralizes_the_payload_slot() {
     let p = pipeline_with_tc(
         r#"
 #[resource]
+type Handle { raw: Raw; }
+
 #[opaque]
-type Handle {}
+type Raw {}
 
 impl Handle {
     fn close(self) {}
@@ -343,14 +345,23 @@ fn main() -> i64 {
         .iter()
         .find(|function| function.name == "main")
         .expect("raw fn main");
+    let neutralized_fields = main
+        .blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter_map(|instr| match instr {
+            Instr::NeutralizePayloadSlot {
+                place: hew_mir::Place::MachineVariant { field_idx, .. },
+                ..
+            } => Some(*field_idx),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
     assert_eq!(
-        main.blocks
-            .iter()
-            .flat_map(|block| block.instructions.iter())
-            .filter(|instr| matches!(instr, Instr::NeutralizePayloadSlot { .. }))
-            .count(),
-        1,
-        "the selected resource payload must transfer out of its carrier once"
+        neutralized_fields,
+        vec![0, 0],
+        "the selected resource and skipped error payloads must each transfer out of their \
+         carrier on their own arm"
     );
 }
 


### PR DESCRIPTION
## Summary

- I scope forced `UserClose` consumption to direct match-result handoffs.
- I preserve carrier cleanup for opaque resources and transfer sibling payload cleanup to arm-local owners when a field-bearing resource record makes the carrier drop unsafe.
- I add exact leak and poisoned-allocator coverage for opaque and field-bearing resources across consumed and unconsumed success and error paths.

## Root cause

I found three ownership decisions that disagreed for `Result<ResourceRecord, string>`: direct projected resources were marked consumed too broadly, the enum escape prover treated a neutralized record handoff as a generic payload escape, and call carriers skipped synthetic wildcard cleanup. Moving the resource record to the match result therefore suppressed the carrier drop without assigning the inactive `Err(string)` payload another cleanup authority.

## Verification

- F16 enum-resource and JSON/TOML/YAML repro matrix: 10 tests passed
- exact resource-result oracle: 8/8 cases reported 0 leaks and 0 leaked bytes; all allocator-scribble checks passed
- `make macos-leak-oracle`: 787 passed
- `make test-hew-ratchet`: 0 expected failures, 0 actual failures