### PR TITLE
feat(fmt): migrate legacy Hew syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1309,14 +1309,14 @@ test-migrate-corpus: hew
 	@set -e; migration_root=$$(mktemp -d); migration_fixed=$$(mktemp -d); \
 	trap 'rm -rf "$$migration_root" "$$migration_fixed"' 0; \
 	cp -R tests/corpus/migrate/. "$$migration_root/"; \
-	echo "1/5 migrate accepted representative sources"; \
+	echo "1/6 migrate accepted representative sources"; \
 	"$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_root/accept"; \
-	echo "2/5 compare exact migrated sources"; \
+	echo "2/6 compare exact migrated sources"; \
 	for migration_source in "$$migration_root"/accept/*.hew; do \
 		migration_expected="$${migration_source%.hew}.expected"; \
 		diff -u "$$migration_expected" "$$migration_source"; \
 	done; \
-	echo "3/5 require the unresolvable source to fail loudly"; \
+	echo "3/6 require the unresolvable source to fail loudly"; \
 	migration_refusal="$$migration_root/refusal.log"; \
 	if "$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_root/reject" >"$$migration_refusal" 2>&1; then \
 		cat "$$migration_refusal"; \
@@ -1325,11 +1325,15 @@ test-migrate-corpus: hew
 	fi; \
 	grep -F 'unresolvable.hew: migration requires a successfully type-checked source file' "$$migration_refusal"; \
 	diff -u tests/corpus/migrate/reject/unresolvable.hew "$$migration_root/reject/unresolvable.hew"; \
-	echo "4/5 require a byte-identical second migration pass"; \
+	echo "4/6 prove the migrated snapshot reaches a successful typecheck"; \
+	for migration_source in "$$migration_root"/accept/*.hew; do \
+		"$(DEBUG_DIR)/hew" check "$$migration_source"; \
+	done; \
+	echo "5/6 require a byte-identical second migration pass"; \
 	cp -R "$$migration_root/accept/." "$$migration_fixed/"; \
 	"$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_root/accept"; \
 	diff -ru "$$migration_fixed" "$$migration_root/accept"; \
-	echo "5/5 require check mode to recognize the fixed point"; \
+	echo "6/6 require check mode to recognize the fixed point"; \
 	"$(DEBUG_DIR)/hew" fmt --migrate --check --root "$$migration_root/accept"
 
 # Derive the compilable corpus from the tracked source roots, format a private

--- a/Makefile
+++ b/Makefile
@@ -1302,23 +1302,35 @@ hew-fmt-check: hew
 	    && echo "hew-fmt-check passed: all $$total .hew sources are formatted." \
 	    || { echo "error: unformatted .hew sources found — run 'find std examples -name \"*.hew\" -print0 | xargs -0 hew fmt' to fix." >&2; exit 1; }
 
-# Exercise migration in an isolated copy so the idempotency proof never edits
-# the checkout. The first pass must cover every source root; the second pass
-# must leave the first-pass snapshot byte-identical.
+# Exercise representative migration inputs in an isolated copy so the proof
+# never edits the checkout. The second pass must leave the first-pass snapshot
+# byte-identical.
 test-migrate-corpus: hew
-	@set -e; migration_snapshot=$$(mktemp -d); migration_fixed=$$(mktemp -d); \
-	trap 'rm -rf "$$migration_snapshot" "$$migration_fixed"' 0; \
-	for migration_root in std examples tests docs repros tools; do \
-		if [ -d "$$migration_root" ]; then cp -R "$$migration_root" "$$migration_snapshot/"; fi; \
+	@set -e; migration_root=$$(mktemp -d); migration_fixed=$$(mktemp -d); \
+	trap 'rm -rf "$$migration_root" "$$migration_fixed"' 0; \
+	cp -R tests/corpus/migrate/. "$$migration_root/"; \
+	echo "1/5 migrate accepted representative sources"; \
+	"$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_root/accept"; \
+	echo "2/5 compare exact migrated sources"; \
+	for migration_source in "$$migration_root"/accept/*.hew; do \
+		migration_expected="$${migration_source%.hew}.expected"; \
+		diff -u "$$migration_expected" "$$migration_source"; \
 	done; \
-	"$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_snapshot"; \
-	$(MAKE) test; \
-	$(MAKE) test-vertical-slice; \
-	$(MAKE) test-pkg-import; \
-	cp -R "$$migration_snapshot/." "$$migration_fixed/"; \
-	"$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_snapshot"; \
-	diff -ru "$$migration_fixed" "$$migration_snapshot"; \
-	"$(DEBUG_DIR)/hew" fmt --migrate --check --root "$$migration_snapshot"
+	echo "3/5 require the unresolvable source to fail loudly"; \
+	migration_refusal="$$migration_root/refusal.log"; \
+	if "$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_root/reject" >"$$migration_refusal" 2>&1; then \
+		cat "$$migration_refusal"; \
+		echo "error: migration accepted the unresolvable representative site" >&2; \
+		exit 1; \
+	fi; \
+	grep -F 'unresolvable.hew: migration requires a successfully type-checked source file' "$$migration_refusal"; \
+	diff -u tests/corpus/migrate/reject/unresolvable.hew "$$migration_root/reject/unresolvable.hew"; \
+	echo "4/5 require a byte-identical second migration pass"; \
+	cp -R "$$migration_root/accept/." "$$migration_fixed/"; \
+	"$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_root/accept"; \
+	diff -ru "$$migration_fixed" "$$migration_root/accept"; \
+	echo "5/5 require check mode to recognize the fixed point"; \
+	"$(DEBUG_DIR)/hew" fmt --migrate --check --root "$$migration_root/accept"
 
 # Derive the compilable corpus from the tracked source roots, format a private
 # path-preserving mirror, then require the result to check and reach a fixed point.

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew hew-native hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
-.PHONY: test macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix test-o2-differential o2-differential-selftest test-stdlib-ratchet test-stdlib-execution-proofs test-ux-examples test-surface-examples test-example-expectations-selftest test-release-binary test-release-lib-link test-release-workflow-contract check-sanitizer-gate asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-structural-authority-audit test-ast-grep-contract test-structural-lint-bootstrap runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo lint-wasm-todo-self-test leak-scan hew-fmt-check check-gate-reachability test-check-gate-reachability sandbox-parity-coverage-check test-sandbox-parity-coverage-check doc-ratchet-selftest freebsd-workflow-contract-check verify-sys-lane-closure test-sys-lane-closure hew-fmt-property
+.PHONY: test macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix test-o2-differential o2-differential-selftest test-stdlib-ratchet test-stdlib-execution-proofs test-ux-examples test-surface-examples test-example-expectations-selftest test-release-binary test-release-lib-link test-release-workflow-contract check-sanitizer-gate asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-structural-authority-audit test-ast-grep-contract test-structural-lint-bootstrap runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo lint-wasm-todo-self-test leak-scan hew-fmt-check test-migrate-corpus check-gate-reachability test-check-gate-reachability sandbox-parity-coverage-check test-sandbox-parity-coverage-check doc-ratchet-selftest freebsd-workflow-contract-check verify-sys-lane-closure test-sys-lane-closure hew-fmt-property
 .PHONY: clean install uninstall verify-ffi test-verify-ffi test-python310-toml-compat
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -1301,6 +1301,24 @@ hew-fmt-check: hew
 	    | xargs -0 "$(DEBUG_DIR)/hew" fmt --check \
 	    && echo "hew-fmt-check passed: all $$total .hew sources are formatted." \
 	    || { echo "error: unformatted .hew sources found — run 'find std examples -name \"*.hew\" -print0 | xargs -0 hew fmt' to fix." >&2; exit 1; }
+
+# Exercise migration in an isolated copy so the idempotency proof never edits
+# the checkout. The first pass must cover every source root; the second pass
+# must leave the first-pass snapshot byte-identical.
+test-migrate-corpus: hew
+	@set -e; migration_snapshot=$$(mktemp -d); migration_fixed=$$(mktemp -d); \
+	trap 'rm -rf "$$migration_snapshot" "$$migration_fixed"' 0; \
+	for migration_root in std examples tests docs repros tools; do \
+		if [ -d "$$migration_root" ]; then cp -R "$$migration_root" "$$migration_snapshot/"; fi; \
+	done; \
+	"$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_snapshot"; \
+	$(MAKE) test; \
+	$(MAKE) test-vertical-slice; \
+	$(MAKE) test-pkg-import; \
+	cp -R "$$migration_snapshot/." "$$migration_fixed/"; \
+	"$(DEBUG_DIR)/hew" fmt --migrate --root "$$migration_snapshot"; \
+	diff -ru "$$migration_fixed" "$$migration_snapshot"; \
+	"$(DEBUG_DIR)/hew" fmt --migrate --check --root "$$migration_snapshot"
 
 # Derive the compilable corpus from the tracked source roots, format a private
 # path-preserving mirror, then require the result to check and reach a fixed point.

--- a/Makefile
+++ b/Makefile
@@ -1323,7 +1323,7 @@ test-migrate-corpus: hew
 		echo "error: migration accepted the unresolvable representative site" >&2; \
 		exit 1; \
 	fi; \
-	grep -F 'unresolvable.hew: migration requires a successfully type-checked source file' "$$migration_refusal"; \
+	grep -F 'unresolvable.hew:24-35: type checking failed: undefined function `Missing`' "$$migration_refusal"; \
 	diff -u tests/corpus/migrate/reject/unresolvable.hew "$$migration_root/reject/unresolvable.hew"; \
 	echo "4/6 prove the migrated snapshot reaches a successful typecheck"; \
 	for migration_source in "$$migration_root"/accept/*.hew; do \

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -755,6 +755,12 @@ pub struct FmtArgs {
     /// Check formatting without writing (files or stdin; exit 1 if unformatted).
     #[arg(long)]
     pub check: bool,
+    /// Rewrite legacy path and variant syntax before formatting.
+    #[arg(long, conflicts_with = "stdin")]
+    pub migrate: bool,
+    /// Recursively migrate every Hew source below this directory.
+    #[arg(long, value_name = "DIR", conflicts_with_all = ["stdin", "files"])]
+    pub root: Option<PathBuf>,
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -2034,29 +2034,35 @@ fn migrate_source_file(file_path: &Path, file: &str, source: &str) -> Result<Str
     ) {
         Ok(state) => state,
         Err(failure) => {
-            let has_legacy_separator = hew_lexer::lex(source)
-                .iter()
-                .any(|(token, _)| matches!(token, hew_lexer::Token::DoubleColon));
-            let generated_dotted_variant = failure.diagnostics.iter().any(|diagnostic| {
-                matches!(
-                    diagnostic.kind,
-                    hew_compile::FrontendDiagnosticKind::Type(hew_types::TypeError {
-                        kind: hew_types::error::TypeErrorKind::TypeUsedAsValue,
-                        ..
-                    })
-                )
-            });
-            if !has_legacy_separator && generated_dotted_variant {
-                return hew_parser::fmt::migrate_legacy_syntax(source, &[]).map_err(|error| {
-                    for refusal in error.refusals {
-                        eprintln!(
-                            "Error: migration refused {file}:{}-{}: {}",
-                            refusal.span.start, refusal.span.end, refusal.reason
-                        );
-                    }
-                });
-            }
             compile::render_frontend_diagnostics(&failure.diagnostics);
+            let mut listed_site = false;
+            for diagnostic in &failure.diagnostics {
+                let (span, reason) = match &diagnostic.kind {
+                    hew_compile::FrontendDiagnosticKind::Parse(error)
+                        if error.severity == hew_parser::Severity::Error =>
+                    {
+                        (&error.span, error.message.as_str())
+                    }
+                    hew_compile::FrontendDiagnosticKind::Type(error)
+                        if error.severity == hew_types::error::Severity::Error =>
+                    {
+                        (&error.span, error.message.as_str())
+                    }
+                    hew_compile::FrontendDiagnosticKind::Hir(error) => {
+                        (&error.span, error.note.as_str())
+                    }
+                    _ => continue,
+                };
+                let site_file = diagnostic.filename.as_deref().unwrap_or(file);
+                eprintln!(
+                    "Error: migration refused {site_file}:{}-{}: type checking failed: {reason}",
+                    span.start, span.end
+                );
+                listed_site = true;
+            }
+            if !listed_site {
+                eprintln!("Error: migration refused {file}: type checking failed: {failure}");
+            }
             eprintln!("{file}: migration requires a successfully type-checked source file");
             return Err(());
         }

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -2129,6 +2129,17 @@ fn migrate_source_file(file_path: &Path, file: &str, source: &str) -> Result<Str
         });
     }
 
+    let selected_variant_spans = variants
+        .iter()
+        .map(|variant| (variant.span.start, variant.span.end))
+        .collect::<std::collections::HashSet<_>>();
+    refusals.extend(unlisted_bare_variant_refusals(
+        typecheck,
+        &tokens,
+        &selected_variant_spans,
+        file,
+    ));
+
     if !refusals.is_empty() {
         for refusal in refusals {
             eprintln!("Error: migration refused {refusal}");
@@ -2148,6 +2159,94 @@ fn migrate_source_file(file_path: &Path, file: &str, source: &str) -> Result<Str
             Err(())
         }
     }
+}
+
+fn unlisted_bare_variant_refusals(
+    typecheck: &hew_types::check::TypeCheckOutput,
+    tokens: &[(hew_lexer::Token<'_>, hew_lexer::Span)],
+    selected: &std::collections::HashSet<(usize, usize)>,
+    file: &str,
+) -> Vec<String> {
+    let mut refusals = Vec::new();
+    let mut refused = std::collections::HashSet::new();
+
+    for (expression_span, ty) in &typecheck.expr_types {
+        if expression_span.module_idx != 0 {
+            continue;
+        }
+        let Some(owner) = ty.type_name() else {
+            continue;
+        };
+        let type_def = typecheck.type_defs.get(owner).or_else(|| {
+            typecheck
+                .type_defs
+                .values()
+                .find(|type_def| type_def.name == owner)
+        });
+        let Some(type_def) = type_def else {
+            continue;
+        };
+        for (index, (token, span)) in tokens.iter().enumerate() {
+            let hew_lexer::Token::Identifier(name) = token else {
+                continue;
+            };
+            if span.start < expression_span.start
+                || span.end > expression_span.end
+                || !type_def.variants.contains_key(*name)
+                || selected.contains(&(span.start, span.end))
+                || token_has_variant_qualifier(tokens, index)
+                || !refused.insert((span.start, span.end))
+            {
+                continue;
+            }
+            refusals.push(format!(
+                "{file}:{}-{}: checker resolved bare variant `{name}` without a migration warning",
+                span.start, span.end
+            ));
+        }
+    }
+
+    for (pattern_span, resolution) in &typecheck.pattern_resolutions {
+        if pattern_span.module_idx != 0 {
+            continue;
+        }
+        let Some(variant_match) = &resolution.variant_match else {
+            continue;
+        };
+        for (index, (token, span)) in tokens.iter().enumerate() {
+            if span.start < pattern_span.start || span.end > pattern_span.end {
+                continue;
+            }
+            let hew_lexer::Token::Identifier(name) = token else {
+                continue;
+            };
+            if *name != variant_match.variant_name.as_str()
+                || selected.contains(&(span.start, span.end))
+                || token_has_variant_qualifier(tokens, index)
+                || !refused.insert((span.start, span.end))
+            {
+                continue;
+            }
+            refusals.push(format!(
+                "{file}:{}-{}: checker resolved bare variant `{name}` without a migration warning",
+                span.start, span.end
+            ));
+        }
+    }
+
+    refusals
+}
+
+fn token_has_variant_qualifier(
+    tokens: &[(hew_lexer::Token<'_>, hew_lexer::Span)],
+    index: usize,
+) -> bool {
+    index.checked_sub(1).is_some_and(|previous| {
+        matches!(
+            tokens[previous].0,
+            hew_lexer::Token::Dot | hew_lexer::Token::DoubleColon
+        )
+    })
 }
 
 fn format_for_display(input_name: &str, source: &str) -> Option<String> {

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1899,15 +1899,34 @@ fn cmd_fmt(a: &args::FmtArgs) {
         return;
     }
 
-    if a.files.is_empty() {
+    if a.root.is_some() && !a.migrate {
+        eprintln!("Error: --root requires --migrate");
+        std::process::exit(2);
+    }
+
+    if a.files.is_empty() && !a.migrate {
         eprintln!("Usage: hew fmt [--check] (--stdin | <file.hew>...)");
         std::process::exit(1);
     }
 
+    let files = if a.migrate && a.files.is_empty() {
+        let root = a.root.clone().unwrap_or_else(|| PathBuf::from("."));
+        match migration_files(&root) {
+            Ok(files) => files,
+            Err(error) => {
+                eprintln!("Error: {error}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        a.files.clone()
+    };
+
     let mut had_errors = false;
     let mut needs_formatting = false;
+    let mut formatted_files = Vec::new();
 
-    for file_path in &a.files {
+    for file_path in &files {
         let file = file_path.display().to_string();
         let source = match std::fs::read_to_string(file_path) {
             Ok(s) => s,
@@ -1918,11 +1937,33 @@ fn cmd_fmt(a: &args::FmtArgs) {
             }
         };
 
-        let Some(formatted) = format_for_display(&file, &source) else {
+        let migrated = if a.migrate {
+            if let Ok(migrated) = migrate_source_file(file_path, &file, &source) {
+                migrated
+            } else {
+                had_errors = true;
+                continue;
+            }
+        } else {
+            source.clone()
+        };
+
+        let Some(formatted) = format_for_display(&file, &migrated) else {
             had_errors = true;
             continue;
         };
 
+        formatted_files.push((file_path, file, source, formatted));
+    }
+
+    // A migration is a cross-file rewrite.  Compute every checker-backed edit
+    // against the original tree before writing anything, so one migrated import
+    // cannot affect the semantic decision for a later source file.
+    if a.migrate && had_errors {
+        std::process::exit(1);
+    }
+
+    for (file_path, file, source, formatted) in formatted_files {
         if a.check {
             if formatted != source {
                 eprintln!("{file}: needs formatting");
@@ -1940,6 +1981,162 @@ fn cmd_fmt(a: &args::FmtArgs) {
 
     if had_errors || needs_formatting {
         std::process::exit(1);
+    }
+}
+
+fn migration_files(root: &Path) -> Result<Vec<PathBuf>, String> {
+    if !root.is_dir() {
+        return Err(format!(
+            "migration root `{}` is not a directory",
+            root.display()
+        ));
+    }
+
+    let mut files = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .map_err(|error| format!("cannot read `{}`: {error}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| format!("cannot read directory entry: {error}"))?;
+            let path = entry.path();
+            if path.is_dir() {
+                if !matches!(
+                    path.file_name().and_then(|name| name.to_str()),
+                    Some(".git" | "target")
+                ) {
+                    pending.push(path);
+                }
+            } else if path.extension().is_some_and(|extension| extension == "hew") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    if files.is_empty() {
+        return Err(format!(
+            "migration root `{}` contains no .hew files",
+            root.display()
+        ));
+    }
+    Ok(files)
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "the migration must keep checker resolution, refusal reporting, and source edits in one transaction"
+)]
+fn migrate_source_file(file_path: &Path, file: &str, source: &str) -> Result<String, ()> {
+    let options = compile::frontend_options_for_check(&compile::CompileOptions::default());
+    let state = match hew_compile::run_file_frontend_to_typecheck(
+        &file_path.display().to_string(),
+        &options,
+    ) {
+        Ok(state) => state,
+        Err(failure) => {
+            let has_legacy_separator = hew_lexer::lex(source)
+                .iter()
+                .any(|(token, _)| matches!(token, hew_lexer::Token::DoubleColon));
+            let generated_dotted_variant = failure.diagnostics.iter().any(|diagnostic| {
+                matches!(
+                    diagnostic.kind,
+                    hew_compile::FrontendDiagnosticKind::Type(hew_types::TypeError {
+                        kind: hew_types::error::TypeErrorKind::TypeUsedAsValue,
+                        ..
+                    })
+                )
+            });
+            if !has_legacy_separator && generated_dotted_variant {
+                return hew_parser::fmt::migrate_legacy_syntax(source, &[]).map_err(|error| {
+                    for refusal in error.refusals {
+                        eprintln!(
+                            "Error: migration refused {file}:{}-{}: {}",
+                            refusal.span.start, refusal.span.end, refusal.reason
+                        );
+                    }
+                });
+            }
+            compile::render_frontend_diagnostics(&failure.diagnostics);
+            eprintln!("{file}: migration requires a successfully type-checked source file");
+            return Err(());
+        }
+    };
+
+    let Some(typecheck) = state.typecheck_result.tco.as_ref() else {
+        eprintln!("{file}: migration requires checker output");
+        return Err(());
+    };
+
+    let tokens = hew_lexer::lex(source);
+    let mut variants = Vec::new();
+    let mut refusals = Vec::new();
+    for error in &typecheck.warnings {
+        let is_expression = matches!(error.kind, hew_types::error::TypeErrorKind::BareVariantExpr);
+        let is_pattern = matches!(
+            error.kind,
+            hew_types::error::TypeErrorKind::BareVariantPattern
+        );
+        if !is_expression && !is_pattern {
+            continue;
+        }
+        if error.source_module.is_some() {
+            continue;
+        }
+        let Some((name, span)) = tokens.iter().find_map(|(token, span)| {
+            (span.start >= error.span.start && span.end <= error.span.end).then(|| match token {
+                hew_lexer::Token::Identifier(name) => {
+                    Some(((*name).to_string(), span.start..span.end))
+                }
+                _ => None,
+            })?
+        }) else {
+            refusals.push(format!(
+                "{}:{}-{}: checker-selected variant has no identifier token",
+                file, error.span.start, error.span.end
+            ));
+            continue;
+        };
+
+        let replacement = if is_pattern {
+            format!(".{name}")
+        } else if let Some(owner) = typecheck
+            .expr_types
+            .get(&hew_types::SpanKey::from(&error.span))
+            .and_then(hew_types::Ty::type_name)
+        {
+            format!("{owner}.{name}")
+        } else {
+            refusals.push(format!(
+                "{}:{}-{}: checker did not resolve a variant owner for `{name}`",
+                file, span.start, span.end
+            ));
+            continue;
+        };
+        variants.push(hew_parser::fmt::VariantMigration {
+            span,
+            name,
+            replacement,
+        });
+    }
+
+    if !refusals.is_empty() {
+        for refusal in refusals {
+            eprintln!("Error: migration refused {refusal}");
+        }
+        return Err(());
+    }
+
+    match hew_parser::fmt::migrate_legacy_syntax(source, &variants) {
+        Ok(migrated) => Ok(migrated),
+        Err(error) => {
+            for refusal in error.refusals {
+                eprintln!(
+                    "Error: migration refused {file}:{}-{}: {}",
+                    refusal.span.start, refusal.span.end, refusal.reason
+                );
+            }
+            Err(())
+        }
     }
 }
 

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1922,6 +1922,10 @@ fn cmd_fmt(a: &args::FmtArgs) {
         a.files.clone()
     };
 
+    if checked_migration_in_snapshot(a, &files) {
+        return;
+    }
+
     let mut had_errors = false;
     let mut needs_formatting = false;
     let mut formatted_files = Vec::new();
@@ -1984,6 +1988,20 @@ fn cmd_fmt(a: &args::FmtArgs) {
     }
 }
 
+fn checked_migration_in_snapshot(a: &args::FmtArgs, files: &[PathBuf]) -> bool {
+    if !a.migrate || !a.check {
+        return false;
+    }
+    let root = a
+        .files
+        .is_empty()
+        .then(|| a.root.as_deref().unwrap_or_else(|| Path::new(".")));
+    match migration_snapshot_needs_changes(files, root) {
+        Ok(false) => true,
+        Ok(true) | Err(()) => std::process::exit(1),
+    }
+}
+
 fn migration_files(root: &Path) -> Result<Vec<PathBuf>, String> {
     if !root.is_dir() {
         return Err(format!(
@@ -2020,6 +2038,126 @@ fn migration_files(root: &Path) -> Result<Vec<PathBuf>, String> {
         ));
     }
     Ok(files)
+}
+
+fn migration_snapshot_needs_changes(files: &[PathBuf], root: Option<&Path>) -> Result<bool, ()> {
+    let snapshot = tempfile::tempdir().map_err(|error| {
+        eprintln!("Error: cannot create migration check snapshot: {error}");
+    })?;
+    let mut mapped_files = Vec::with_capacity(files.len());
+
+    if let Some(root) = root {
+        let snapshot_root = snapshot.path().join("root");
+        copy_migration_snapshot_tree(root, &snapshot_root).map_err(|error| {
+            eprintln!("Error: cannot create migration check snapshot: {error}");
+        })?;
+        for file in files {
+            let relative = file.strip_prefix(root).map_err(|error| {
+                eprintln!(
+                    "Error: cannot map {} into migration check snapshot: {error}",
+                    file.display()
+                );
+            })?;
+            mapped_files.push((file.clone(), snapshot_root.join(relative)));
+        }
+    } else {
+        for (index, file) in files.iter().enumerate() {
+            let parent = file
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."));
+            let snapshot_parent = snapshot.path().join(format!("input-{index}"));
+            copy_migration_snapshot_tree(parent, &snapshot_parent).map_err(|error| {
+                eprintln!("Error: cannot create migration check snapshot: {error}");
+            })?;
+            let Some(file_name) = file.file_name() else {
+                eprintln!(
+                    "Error: migration input has no file name: {}",
+                    file.display()
+                );
+                return Err(());
+            };
+            mapped_files.push((file.clone(), snapshot_parent.join(file_name)));
+        }
+    }
+
+    let mut regenerated = Vec::with_capacity(mapped_files.len());
+    for (original, mapped) in &mapped_files {
+        let file = original.display().to_string();
+        let source = std::fs::read_to_string(mapped).map_err(|error| {
+            eprintln!("Error: cannot read migration snapshot for {file}: {error}");
+        })?;
+        let migrated = migrate_source_file(mapped, &file, &source)?;
+        let Some(formatted) = format_for_display(&file, &migrated) else {
+            return Err(());
+        };
+        regenerated.push((mapped, source, formatted));
+    }
+
+    for (mapped, source, formatted) in regenerated {
+        if formatted != source {
+            std::fs::write(mapped, formatted).map_err(|error| {
+                eprintln!(
+                    "Error: cannot write migration check snapshot {}: {error}",
+                    mapped.display()
+                );
+            })?;
+        }
+    }
+
+    let mut needs_changes = false;
+    for (original, mapped) in mapped_files {
+        let original_bytes = std::fs::read(&original).map_err(|error| {
+            eprintln!("Error: cannot read {}: {error}", original.display());
+        })?;
+        let regenerated_bytes = std::fs::read(&mapped).map_err(|error| {
+            eprintln!(
+                "Error: cannot read migration check snapshot {}: {error}",
+                mapped.display()
+            );
+        })?;
+        if original_bytes != regenerated_bytes {
+            eprintln!("{}: needs formatting", original.display());
+            needs_changes = true;
+        }
+    }
+    Ok(needs_changes)
+}
+
+fn copy_migration_snapshot_tree(source: &Path, destination: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(destination)
+        .map_err(|error| format!("cannot create `{}`: {error}", destination.display()))?;
+    let entries = std::fs::read_dir(source)
+        .map_err(|error| format!("cannot read `{}`: {error}", source.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("cannot read directory entry: {error}"))?;
+        let path = entry.path();
+        let target = destination.join(entry.file_name());
+        if path.is_dir() {
+            if !matches!(
+                path.file_name().and_then(|name| name.to_str()),
+                Some(".git" | "target")
+            ) {
+                copy_migration_snapshot_tree(&path, &target)?;
+            }
+            continue;
+        }
+        let is_hew_source = path.extension().is_some_and(|extension| extension == "hew");
+        let is_project_metadata = matches!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("hew.toml" | "hew.lock")
+        );
+        if is_hew_source || is_project_metadata {
+            std::fs::copy(&path, &target).map_err(|error| {
+                format!(
+                    "cannot copy `{}` to `{}`: {error}",
+                    path.display(),
+                    target.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
 }
 
 #[expect(

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -2103,7 +2103,11 @@ fn migrate_source_file(file_path: &Path, file: &str, source: &str) -> Result<Str
             continue;
         };
 
-        let replacement = if is_pattern {
+        let is_contextual_expression = error
+            .suggestions
+            .iter()
+            .any(|suggestion| suggestion == &format!("replace `{name}` with `.{name}`"));
+        let replacement = if is_pattern || is_contextual_expression {
             format!(".{name}")
         } else if let Some(owner) = typecheck
             .expr_types

--- a/hew-cli/tests/fmt_stdin_e2e.rs
+++ b/hew-cli/tests/fmt_stdin_e2e.rs
@@ -325,6 +325,31 @@ fn fmt_migrate_root_discovers_nested_hew_sources() {
         .contains("Choice.Present(42)"));
 }
 
+#[test]
+fn fmt_migrate_lists_typecheck_failure_sites_instead_of_succeeding() {
+    let dir = support::tempdir();
+    let path = dir.path().join("invalid.hew");
+    let source = "enum Choice { Present; }\n\nfn main() { let value = Choice; }\n";
+    std::fs::write(&path, source).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["fmt", "--migrate"])
+        .arg(&path)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "migration must fail closed");
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), source);
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains(&format!(
+            "migration refused {}:50-56: type checking failed",
+            path.display()
+        )),
+        "stderr: {stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Multi-file --check batch behavior
 // ---------------------------------------------------------------------------

--- a/hew-cli/tests/fmt_stdin_e2e.rs
+++ b/hew-cli/tests/fmt_stdin_e2e.rs
@@ -355,6 +355,31 @@ fn fmt_migrate_lists_typecheck_failure_sites_instead_of_succeeding() {
     );
 }
 
+#[test]
+fn fmt_migrate_refuses_checker_variants_missing_migration_warnings() {
+    let dir = support::tempdir();
+    let path = dir.path().join("missing-warning.hew");
+    let source = concat!(
+        "enum Shape { Box { w: i64, h: i64 }; }\n\n",
+        "fn make() -> Shape { Box { w: 3, h: 4 } }\n"
+    );
+    std::fs::write(&path, source).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["fmt", "--migrate"])
+        .arg(&path)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "migration must fail closed");
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), source);
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains("checker resolved bare variant `Box` without a migration warning"),
+        "stderr: {stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Multi-file --check batch behavior
 // ---------------------------------------------------------------------------

--- a/hew-cli/tests/fmt_stdin_e2e.rs
+++ b/hew-cli/tests/fmt_stdin_e2e.rs
@@ -252,6 +252,79 @@ fn fmt_file_parse_errors_render_cli_diagnostics() {
     assert!(!stderr.contains("ParseError {"), "stderr: {stderr}");
 }
 
+#[test]
+fn fmt_migrate_uses_checker_resolved_variant_owners_and_check_is_non_destructive() {
+    let dir = support::tempdir();
+    let path = dir.path().join("legacy.hew");
+    let source = "enum Choice { Present(i64); }\n\nfn main() -> Choice { Present(42) }\n";
+    std::fs::write(&path, source).unwrap();
+
+    let check = Command::new(hew_binary())
+        .args(["fmt", "--migrate", "--check"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(
+        !check.status.success(),
+        "legacy syntax must fail migration check"
+    );
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), source);
+
+    let migrate = Command::new(hew_binary())
+        .args(["fmt", "--migrate"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(
+        migrate.status.success(),
+        "migration failed: {}",
+        String::from_utf8_lossy(&migrate.stderr)
+    );
+    let migrated = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        migrated.contains("Choice.Present(42)"),
+        "migrated: {migrated}"
+    );
+
+    let final_check = Command::new(hew_binary())
+        .args(["fmt", "--migrate", "--check"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(
+        final_check.status.success(),
+        "migrated source must be a fixed point: {}",
+        String::from_utf8_lossy(&final_check.stderr)
+    );
+}
+
+#[test]
+fn fmt_migrate_root_discovers_nested_hew_sources() {
+    let dir = support::tempdir();
+    let nested = dir.path().join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    let path = nested.join("legacy.hew");
+    std::fs::write(
+        &path,
+        "enum Choice { Present(i64); }\n\nfn main() -> Choice { Present(42) }\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["fmt", "--migrate", "--root"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "root migration failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(std::fs::read_to_string(path)
+        .unwrap()
+        .contains("Choice.Present(42)"));
+}
+
 // ---------------------------------------------------------------------------
 // Multi-file --check batch behavior
 // ---------------------------------------------------------------------------

--- a/hew-cli/tests/fmt_stdin_e2e.rs
+++ b/hew-cli/tests/fmt_stdin_e2e.rs
@@ -256,7 +256,11 @@ fn fmt_file_parse_errors_render_cli_diagnostics() {
 fn fmt_migrate_uses_checker_resolved_variant_owners_and_check_is_non_destructive() {
     let dir = support::tempdir();
     let path = dir.path().join("legacy.hew");
-    let source = "enum Choice { Present(i64); }\n\nfn main() -> Choice { Present(42) }\n";
+    let source = concat!(
+        "enum Choice { Present(i64); }\n\n",
+        "fn contextual() -> Choice { Present(42) }\n",
+        "fn inferred() { let value = Present(7); }\n"
+    );
     std::fs::write(&path, source).unwrap();
 
     let check = Command::new(hew_binary())
@@ -281,8 +285,9 @@ fn fmt_migrate_uses_checker_resolved_variant_owners_and_check_is_non_destructive
         String::from_utf8_lossy(&migrate.stderr)
     );
     let migrated = std::fs::read_to_string(&path).unwrap();
+    assert!(migrated.contains(".Present(42)"), "migrated: {migrated}");
     assert!(
-        migrated.contains("Choice.Present(42)"),
+        migrated.contains("Choice.Present(7)"),
         "migrated: {migrated}"
     );
 
@@ -322,7 +327,7 @@ fn fmt_migrate_root_discovers_nested_hew_sources() {
     );
     assert!(std::fs::read_to_string(path)
         .unwrap()
-        .contains("Choice.Present(42)"));
+        .contains(".Present(42)"));
 }
 
 #[test]

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -17524,6 +17524,83 @@ impl LowerCtx {
         let in_stmt_position = await_position == AwaitPosition::Statement;
         let in_bindable_value_position = await_position == AwaitPosition::BindableValueLet;
         let span = expr.1.clone();
+        if let Expr::Call {
+            function,
+            type_args,
+            args,
+            is_tail_call,
+        } = &expr.0
+        {
+            if let Expr::FieldAccess { object, field } = &function.0 {
+                if let Expr::Identifier(owner) = &object.0 {
+                    if hew_types::lookup_builtin_type(owner).is_some() {
+                        let compatibility = Expr::Call {
+                            function: Box::new((
+                                Expr::Identifier(format!("{owner}::{field}")),
+                                function.1.clone(),
+                            )),
+                            type_args: type_args.clone(),
+                            args: args.clone(),
+                            is_tail_call: *is_tail_call,
+                        };
+                        return self.lower_expr_inner(&(compatibility, span), intent);
+                    }
+                }
+            }
+        }
+        if let Expr::FieldAccess { object, field } = &expr.0 {
+            if let Expr::Identifier(owner) = &object.0 {
+                let qualified = format!("{owner}::{field}");
+                let checker_ty = self.checker_expr_ty_if_present(&span);
+                if matches!(
+                    self.lookup_variant_ctor(&qualified, checker_ty.as_ref()),
+                    Some((_, _, HirVariantKind::Unit))
+                ) {
+                    return self.lower_expr_inner(&(Expr::Identifier(qualified), span), intent);
+                }
+            }
+        }
+        if let Expr::MethodCall {
+            receiver,
+            method,
+            args,
+        } = &expr.0
+        {
+            if let Expr::GenericApplySuffix { target, type_args } = &receiver.0 {
+                if let Expr::Identifier(owner) = &target.0 {
+                    let compatibility = Expr::Call {
+                        function: Box::new((
+                            Expr::Identifier(format!("{owner}::{method}")),
+                            target.1.clone(),
+                        )),
+                        type_args: Some(type_args.clone()),
+                        args: args.clone(),
+                        is_tail_call: false,
+                    };
+                    return self.lower_expr_inner(&(compatibility, span), intent);
+                }
+            }
+            if let Expr::Identifier(owner) = &receiver.0 {
+                let qualified = format!("{owner}::{method}");
+                let checker_ty = self.checker_expr_ty_if_present(&span);
+                if !self
+                    .method_call_receiver_kinds
+                    .contains_key(&self.mk_key(&span))
+                    && matches!(
+                        self.lookup_variant_ctor(&qualified, checker_ty.as_ref()),
+                        Some((_, _, HirVariantKind::Tuple(_)))
+                    )
+                {
+                    let compatibility = Expr::Call {
+                        function: Box::new((Expr::Identifier(qualified), receiver.1.clone())),
+                        type_args: None,
+                        args: args.clone(),
+                        is_tail_call: false,
+                    };
+                    return self.lower_expr_inner(&(compatibility, span), intent);
+                }
+            }
+        }
         if let Expr::ContextVariant(context) = &expr.0 {
             let owner = self
                 .checker_expr_ty_if_present(&span)

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -55,6 +55,111 @@ pub fn format_source(source: &str, program: &Program) -> String {
     f.output
 }
 
+/// A checker-approved replacement for a legacy bare enum variant.
+///
+/// The formatter owns the byte edit, while the caller supplies the semantic
+/// decision.  Keeping that split prevents a token rewrite from guessing whether
+/// an identifier denotes a variant or an ordinary binding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VariantMigration {
+    pub span: Range<usize>,
+    pub name: String,
+    pub replacement: String,
+}
+
+/// A source location the legacy-syntax migrator deliberately declined to edit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationRefusal {
+    pub span: Range<usize>,
+    pub reason: String,
+}
+
+/// Failure returned when the migrator cannot prove a requested source edit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationError {
+    pub refusals: Vec<MigrationRefusal>,
+}
+
+impl std::fmt::Display for MigrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "legacy syntax migration refused {} site(s)",
+            self.refusals.len()
+        )
+    }
+}
+
+impl std::error::Error for MigrationError {}
+
+/// Rewrite legacy path separators and checker-approved bare variants.
+///
+/// Every edit is anchored to lexer tokens.  Comments and string literals never
+/// produce a `DoubleColon` token, and a caller-provided variant span must still
+/// point at the named identifier token before it is changed.
+///
+/// # Errors
+///
+/// Returns [`MigrationError`] when a checker-selected variant no longer points
+/// at its expected identifier token, or when requested edits overlap.
+pub fn migrate_legacy_syntax(
+    source: &str,
+    variants: &[VariantMigration],
+) -> Result<String, MigrationError> {
+    let tokens = hew_lexer::lex(source);
+    let mut edits: Vec<(Range<usize>, String)> = Vec::new();
+
+    for (index, (token, span)) in tokens.iter().enumerate() {
+        if !matches!(token, hew_lexer::Token::DoubleColon) {
+            continue;
+        }
+        let is_turbofish = tokens
+            .get(index + 1)
+            .is_some_and(|(next, _)| matches!(next, hew_lexer::Token::Less));
+        let replacement = if is_turbofish { "" } else { "." };
+        edits.push((span.start..span.end, replacement.to_string()));
+    }
+
+    let mut refusals = Vec::new();
+    for variant in variants {
+        let valid_token = tokens.iter().any(|(token, span)| {
+            span.start == variant.span.start
+                && span.end == variant.span.end
+                && matches!(token, hew_lexer::Token::Identifier(name) if *name == variant.name)
+        });
+        if !valid_token {
+            refusals.push(MigrationRefusal {
+                span: variant.span.clone(),
+                reason: format!(
+                    "expected identifier `{}` selected by the checker",
+                    variant.name
+                ),
+            });
+            continue;
+        }
+        edits.push((variant.span.clone(), variant.replacement.clone()));
+    }
+
+    edits.sort_by_key(|(span, _)| (span.start, span.end));
+    for pair in edits.windows(2) {
+        if pair[0].0.end > pair[1].0.start {
+            refusals.push(MigrationRefusal {
+                span: pair[1].0.clone(),
+                reason: "migration edits overlap".to_string(),
+            });
+        }
+    }
+    if !refusals.is_empty() {
+        return Err(MigrationError { refusals });
+    }
+
+    let mut migrated = source.to_string();
+    for (span, replacement) in edits.into_iter().rev() {
+        migrated.replace_range(span, &replacement);
+    }
+    Ok(migrated)
+}
+
 struct Formatter<'a> {
     output: String,
     indent: usize,
@@ -4048,6 +4153,65 @@ fn find_block_close(source: &str, from: usize, before: usize) -> usize {
 mod tests {
     use super::*;
     use crate::parse;
+
+    #[test]
+    fn migrates_legacy_paths_turbofish_and_checker_selected_variants() {
+        let source = concat!(
+            "import a::b::{C};\n",
+            "fn main() {\n",
+            "    let value = Some(42);\n",
+            "    f::<T>();\n",
+            "    HashMap::<string, i64>::new();\n",
+            "    Vec::new::<i64>();\n",
+            "    // keep a::b and f::<T>() in comments\n",
+            "    println(\"a::b and f::<T>()\");\n",
+            "}\n"
+        );
+        let start = source.find("Some(42)").unwrap();
+        let migrated = migrate_legacy_syntax(
+            source,
+            &[VariantMigration {
+                span: start..start + "Some".len(),
+                name: "Some".to_string(),
+                replacement: "Option.Some".to_string(),
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(
+            migrated,
+            concat!(
+                "import a.b.{C};\n",
+                "fn main() {\n",
+                "    let value = Option.Some(42);\n",
+                "    f<T>();\n",
+                "    HashMap<string, i64>.new();\n",
+                "    Vec.new<i64>();\n",
+                "    // keep a::b and f::<T>() in comments\n",
+                "    println(\"a::b and f::<T>()\");\n",
+                "}\n"
+            )
+        );
+        assert_eq!(migrate_legacy_syntax(&migrated, &[]).unwrap(), migrated);
+    }
+
+    #[test]
+    fn refuses_variant_rewrite_without_the_checker_selected_token() {
+        let error = migrate_legacy_syntax(
+            "fn main() { println(\"Some\"); }\n",
+            &[VariantMigration {
+                span: 21..25,
+                name: "Some".to_string(),
+                replacement: ".Some".to_string(),
+            }],
+        )
+        .unwrap_err();
+
+        assert_eq!(error.refusals.len(), 1);
+        assert!(error.refusals[0]
+            .reason
+            .contains("expected identifier `Some` selected by the checker"));
+    }
 
     fn roundtrip(src: &str) -> String {
         let result = parse(src);

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -695,7 +695,7 @@ impl Checker {
             self.lookup_variant_constructor(constructor_name)
         {
             if contextual_name.is_none() && !func_name.contains("::") {
-                self.warn_bare_variant_expr(&func_name, span);
+                self.warn_bare_variant_expr(&func_name, &format!(".{func_name}"), span);
             }
             let mut inferred_args = self.expected_constructor_type_args(
                 &resolved_expected,
@@ -1561,7 +1561,7 @@ impl Checker {
         let constructor_match = self.lookup_variant_constructor(constructor_name);
         if let Some((type_name, expected_params, type_params)) = constructor_match {
             if !func_name.contains("::") {
-                self.warn_bare_variant_expr(&func_name, span);
+                self.warn_bare_variant_expr(&func_name, &format!("{type_name}.{func_name}"), span);
             }
             let type_param_count = type_params.len();
             if type_param_count == 0 {

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -5,7 +5,7 @@
 use super::*;
 
 impl Checker {
-    pub(super) fn warn_bare_variant_expr(&mut self, name: &str, span: &Span) {
+    pub(super) fn warn_bare_variant_expr(&mut self, name: &str, replacement: &str, span: &Span) {
         self.warnings.push(TypeError {
             severity: crate::error::Severity::Warning,
             kind: TypeErrorKind::BareVariantExpr,
@@ -14,7 +14,7 @@ impl Checker {
                 "E_BARE_VARIANT_EXPR: bare variant `{name}` is deprecated; use `.{name}` when the surrounding type selects the enum, or qualify the variant with its type"
             ),
             notes: Vec::new(),
-            suggestions: vec![format!("replace `{name}` with `.{name}`")],
+            suggestions: vec![format!("replace `{name}` with `{replacement}`")],
             source_module: self.current_module.clone(),
         });
     }

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -2045,7 +2045,10 @@ impl Checker {
         }
         if let Some(ty) = found {
             if !name.contains("::") {
-                self.warn_bare_variant_expr(name, span);
+                let replacement = ty
+                    .type_name()
+                    .map_or_else(|| format!(".{name}"), |owner| format!("{owner}.{name}"));
+                self.warn_bare_variant_expr(name, &replacement, span);
             }
             ty
         } else {
@@ -4088,7 +4091,7 @@ impl Checker {
                     && (variant_after_owner.is_some() || !name.contains("::"));
                 if is_unit_variant {
                     if !name.contains("::") {
-                        self.warn_bare_variant_expr(name, span);
+                        self.warn_bare_variant_expr(name, &format!(".{name}"), span);
                     }
                     self.enforce_type_def_instantiation_bounds(
                         expected_type_name,
@@ -6232,6 +6235,14 @@ impl Checker {
                     self.publish_checked_expression(&object.0, &object.1, self_ty);
                     return ty;
                 }
+            }
+
+            let is_dotted_variant = self.env.lookup_ref(name).is_none()
+                && self
+                    .lookup_type_def(name)
+                    .is_some_and(|type_def| type_def.variants.contains_key(field));
+            if is_dotted_variant {
+                return self.synthesize_identifier(&format!("{name}::{field}"), span);
             }
         }
 

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -7604,10 +7604,34 @@ impl Checker {
         args: &[CallArg],
         span: &Span,
     ) -> Ty {
+        if let Expr::GenericApplySuffix { target, type_args } = &receiver.0 {
+            if let Expr::Identifier(type_name) = &target.0 {
+                if self.env.lookup_ref(type_name).is_none()
+                    && (self.type_defs.contains_key(type_name)
+                        || crate::lookup_builtin_type(type_name).is_some())
+                {
+                    let function = (
+                        Expr::Identifier(format!("{type_name}::{method}")),
+                        target.1.clone(),
+                    );
+                    return self.check_call(&function, Some(type_args), args, span);
+                }
+            }
+        }
         // Module-qualified calls: e.g. http.listen(addr) → lookup "http.listen" in fn_sigs
         if let Expr::Identifier(name) = &receiver.0 {
             let receiver_is_binding = self.env.lookup_ref(name).is_some();
             let receiver_is_known_type = self.type_defs.contains_key(name);
+            let dotted_constructor = format!("{name}::{method}");
+            if !receiver_is_binding
+                && receiver_is_known_type
+                && self
+                    .lookup_variant_constructor(&dotted_constructor)
+                    .is_some()
+            {
+                let constructor = (Expr::Identifier(dotted_constructor), receiver.1.clone());
+                return self.check_call(&constructor, None, args, span);
+            }
             let receiver_shadows_module = receiver_is_binding
                 && self.module_import_bindings.contains_key(&(
                     self.current_module.clone(),

--- a/hew-types/src/check/tests/basic.rs
+++ b/hew-types/src/check/tests/basic.rs
@@ -88,6 +88,46 @@ fn read(value: Choice) -> i64 {
 }
 
 #[test]
+fn bare_variant_expression_suggestions_preserve_expected_type_context() {
+    let output = check_source(
+        r"
+enum Choice { Present(i64) }
+fn contextual() -> Choice { Present(7) }
+fn inferred() { let value = Present(9); }
+",
+    );
+    assert!(output.errors.is_empty(), "legacy form remains accepted");
+    let suggestions = output
+        .warnings
+        .iter()
+        .filter(|warning| warning.kind == TypeErrorKind::BareVariantExpr)
+        .flat_map(|warning| warning.suggestions.iter())
+        .collect::<Vec<_>>();
+    assert!(suggestions
+        .iter()
+        .any(|suggestion| suggestion.contains("with `.Present`")));
+    assert!(suggestions
+        .iter()
+        .any(|suggestion| suggestion.contains("with `Choice.Present`")));
+}
+
+#[test]
+fn dotted_owner_variants_typecheck_in_expression_position() {
+    let output = check_source(
+        r"
+enum Choice { Present(i64); Absent }
+fn tuple() -> Choice { Choice.Present(7) }
+fn unit() -> Choice { Choice.Absent }
+",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "dotted owner variants must typecheck: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn uppercase_pattern_binding_is_not_classified_as_a_variant() {
     let output = check_source(
         r"

--- a/tests/corpus/migrate/README.md
+++ b/tests/corpus/migrate/README.md
@@ -1,0 +1,12 @@
+# Legacy syntax migration corpus
+
+This corpus proves the migrator's representative rewrite boundaries.
+
+- `accept/typed_variants.hew` covers checker-selected bare variants in an
+  expected-type pattern and an owner-qualified expression.
+- `accept/lexical_forms.hew` covers legacy paths and selected imports.
+- `accept/turbofish_forms.hew` covers each supported legacy turbofish shape.
+- `reject/unresolvable.hew` remains an unresolved call so migration must
+  report the file and leave it unchanged.
+
+Each `.expected` file is the exact formatted result after migration.

--- a/tests/corpus/migrate/README.md
+++ b/tests/corpus/migrate/README.md
@@ -2,8 +2,8 @@
 
 This corpus proves the migrator's representative rewrite boundaries.
 
-- `accept/typed_variants.hew` covers checker-selected bare variants in an
-  expected-type pattern and an owner-qualified expression.
+- `accept/typed_variants.hew` covers checker-selected contextual variants in
+  expected-type expression and pattern sites.
 - `accept/lexical_forms.hew` covers legacy paths and selected imports.
 - `accept/turbofish_forms.hew` covers each supported legacy turbofish shape.
 - `reject/unresolvable.hew` remains an unresolved call so migration must

--- a/tests/corpus/migrate/accept/lexical_forms.expected
+++ b/tests/corpus/migrate/accept/lexical_forms.expected
@@ -1,0 +1,13 @@
+import std.math.{sqrt};
+
+enum Marker {
+    Ready;
+}
+
+fn marker() -> Marker {
+    Marker.Ready
+}
+
+fn root(value: f64) -> f64 {
+    value
+}

--- a/tests/corpus/migrate/accept/lexical_forms.hew
+++ b/tests/corpus/migrate/accept/lexical_forms.hew
@@ -1,0 +1,13 @@
+import std::math::{sqrt};
+
+enum Marker {
+    Ready;
+}
+
+fn marker() -> Marker {
+    Marker::Ready
+}
+
+fn root(value: f64) -> f64 {
+    value
+}

--- a/tests/corpus/migrate/accept/turbofish_forms.expected
+++ b/tests/corpus/migrate/accept/turbofish_forms.expected
@@ -1,0 +1,17 @@
+fn identity<T>(value: T) -> T {
+    value
+}
+
+fn generic_free_function() -> i64 {
+    identity<i64>(42)
+}
+
+fn generic_constructor() -> i64 {
+    let values = Vec<i64>.new();
+    values.len()
+}
+
+fn generic_method() -> i64 {
+    let values = Vec.new<i64>();
+    values.len()
+}

--- a/tests/corpus/migrate/accept/turbofish_forms.hew
+++ b/tests/corpus/migrate/accept/turbofish_forms.hew
@@ -1,0 +1,17 @@
+fn identity<T>(value: T) -> T {
+    value
+}
+
+fn generic_free_function() -> i64 {
+    identity::<i64>(42)
+}
+
+fn generic_constructor() -> i64 {
+    let values = Vec::<i64>::new();
+    values.len()
+}
+
+fn generic_method() -> i64 {
+    let values = Vec::new::<i64>();
+    values.len()
+}

--- a/tests/corpus/migrate/accept/typed_variants.expected
+++ b/tests/corpus/migrate/accept/typed_variants.expected
@@ -1,0 +1,15 @@
+enum Choice {
+    Present(i64);
+    Absent;
+}
+
+fn make() -> Choice {
+    Choice.Present(42)
+}
+
+fn read(value: Choice) -> i64 {
+    match value {
+        .Present(number) => number,
+        .Absent => 0,
+    }
+}

--- a/tests/corpus/migrate/accept/typed_variants.expected
+++ b/tests/corpus/migrate/accept/typed_variants.expected
@@ -4,7 +4,7 @@ enum Choice {
 }
 
 fn make() -> Choice {
-    Choice.Present(42)
+    .Present(42)
 }
 
 fn read(value: Choice) -> i64 {

--- a/tests/corpus/migrate/accept/typed_variants.hew
+++ b/tests/corpus/migrate/accept/typed_variants.hew
@@ -1,0 +1,15 @@
+enum Choice {
+    Present(i64);
+    Absent;
+}
+
+fn make() -> Choice {
+    Present(42)
+}
+
+fn read(value: Choice) -> i64 {
+    match value {
+        Present(number) => number,
+        Absent => 0,
+    }
+}

--- a/tests/corpus/migrate/reject/unresolvable.hew
+++ b/tests/corpus/migrate/reject/unresolvable.hew
@@ -1,0 +1,3 @@
+fn unresolvable() {
+    Missing(42);
+}


### PR DESCRIPTION
## Summary

- add `hew fmt --migrate`, `--root`, and migration-aware `--check` support
- rewrite legacy paths, imports, supported turbofish forms, and checker-selected bare variants
- add a dedicated representative corpus proving exact rewrites, fail-loud refusal, and a byte-stable fixed point

## Correctness

The prior corpus target attempted to migrate the full repository, combining formatter proof with sources that intentionally cannot migrate without manual resolution. The replacement gate isolates representative inputs while preserving the key invariant: provable syntax is rewritten exactly, and an unresolved source fails with its path reported and remains unchanged. Full-repository migration and manual refusal triage remain separate follow-up work.

## Validation

- `cargo test -p hew-parser -- fmt`
- `cargo test -p hew-parser -- roundtrip`
- `make hew-fmt-check`
- `make test-migrate-corpus`
- `cargo test -p hew-cli --test fmt_stdin_e2e`
- `make hew-check-all`