### PR TITLE
fix(hir): preserve opaque try payload representation through generic carriers

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -27809,7 +27809,17 @@ impl LowerCtx {
         name: &str,
     ) -> Option<ResolvedTy> {
         let checker_key = self.mk_key(span);
-        let checker_ty = self.expr_types.get(&checker_key).cloned()?;
+        let Some(checker_ty) = self.expr_types.get(&checker_key).cloned() else {
+            self.diagnostics.push(HirDiagnostic::new(
+                HirDiagnosticKind::CheckerBoundaryViolation {
+                    name: name.to_string(),
+                    reason: "missing expr_types entry".to_string(),
+                },
+                span.clone(),
+                "checker-authoritative expression type is required for `?` lowering",
+            ));
+            return None;
+        };
         match ResolvedTy::from_ty(&checker_ty) {
             // `Ty::Named` does not carry source-declaration opacity. Route
             // checker-authored expression types through the same identity
@@ -28393,9 +28403,9 @@ impl LowerCtx {
                 );
             }
             self.try_register_enum_instantiation_ty(&return_ty, span);
-            let result_ty = self
-                .checker_expr_resolved_ty(span, "`?` expression")
-                .unwrap_or_else(|| ok_ty.clone());
+            let Some(result_ty) = self.checker_expr_resolved_ty(span, "`?` expression") else {
+                return self.unsupported_postfix_try(span, "`?` checker payload type is missing");
+            };
             if &result_ty != ok_ty {
                 return self.unsupported_postfix_try(
                     span,
@@ -28413,9 +28423,9 @@ impl LowerCtx {
                 );
             }
             self.try_register_enum_instantiation_ty(&return_ty, span);
-            let result_ty = self
-                .checker_expr_resolved_ty(span, "`?` expression")
-                .unwrap_or_else(|| some_ty.clone());
+            let Some(result_ty) = self.checker_expr_resolved_ty(span, "`?` expression") else {
+                return self.unsupported_postfix_try(span, "`?` checker payload type is missing");
+            };
             if &result_ty != some_ty {
                 return self.unsupported_postfix_try(
                     span,
@@ -38121,6 +38131,51 @@ fn main() {}
         );
         let pass = function_named(&lowered, "pass");
         assert_result_try_match(first_let_value(pass));
+    }
+
+    #[test]
+    fn postfix_try_missing_checker_expr_type_is_diagnosed_and_unsupported() {
+        let source = r"
+            fn pass(r: Result<i64, i64>) -> Result<i64, i64> {
+                let x: i64 = r?;
+                Ok(x)
+            }
+        ";
+        let parsed = hew_parser::parse(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:#?}",
+            parsed.errors
+        );
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let mut tco = checker.check_program(&parsed.program);
+        assert!(tco.errors.is_empty(), "type errors: {:#?}", tco.errors);
+
+        let try_start = source.find("r?").expect("source must contain `r?`");
+        let try_span = try_start..try_start + 2;
+        assert!(
+            tco.expr_types
+                .remove(&SpanKey::in_module(&try_span, 0))
+                .is_some(),
+            "checker must publish the `?` expression type"
+        );
+
+        let lowered = lower_program(&parsed.program, &tco, &ResolutionCtx, TargetArch::host());
+        assert!(
+            lowered.diagnostics.iter().any(|diagnostic| matches!(
+                &diagnostic.kind,
+                HirDiagnosticKind::CheckerBoundaryViolation { name, reason }
+                    if name == "`?` expression" && reason == "missing expr_types entry"
+            )),
+            "missing checker type must be diagnosed: {:#?}",
+            lowered.diagnostics
+        );
+        let pass = function_named(&lowered, "pass");
+        assert!(
+            matches!(first_let_value(pass).kind, HirExprKind::Unsupported(_)),
+            "missing checker type must lower `?` as unsupported"
+        );
     }
 
     #[test]

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -27811,7 +27811,12 @@ impl LowerCtx {
         let checker_key = self.mk_key(span);
         let checker_ty = self.expr_types.get(&checker_key).cloned()?;
         match ResolvedTy::from_ty(&checker_ty) {
-            Ok(resolved) => Some(resolved),
+            // `Ty::Named` does not carry source-declaration opacity. Route
+            // checker-authored expression types through the same identity
+            // normalisation funnel as other checker→HIR boundaries so an
+            // opaque Result/Option payload remains pointer-shaped, including
+            // when nested inside another generic carrier.
+            Ok(resolved) => Some(self.qualify_current_module_record_ty(resolved)),
             Err(err) => {
                 self.diagnostics.push(HirDiagnostic::new(
                     HirDiagnosticKind::CheckerBoundaryViolation {
@@ -28391,6 +28396,14 @@ impl LowerCtx {
             let result_ty = self
                 .checker_expr_resolved_ty(span, "`?` expression")
                 .unwrap_or_else(|| ok_ty.clone());
+            if &result_ty != ok_ty {
+                return self.unsupported_postfix_try(
+                    span,
+                    format!(
+                        "`?` checker payload type `{result_ty}` disagrees with Result::Ok payload type `{ok_ty}`",
+                    ),
+                );
+            }
             self.lower_result_postfix_try(scrutinee, result_ty, err_ty.clone(), return_ty, span)
         } else if let Some(some_ty) = Self::resolved_option_inner(&scrutinee_ty) {
             if Self::resolved_option_inner(&return_ty).is_none() {
@@ -28403,6 +28416,14 @@ impl LowerCtx {
             let result_ty = self
                 .checker_expr_resolved_ty(span, "`?` expression")
                 .unwrap_or_else(|| some_ty.clone());
+            if &result_ty != some_ty {
+                return self.unsupported_postfix_try(
+                    span,
+                    format!(
+                        "`?` checker payload type `{result_ty}` disagrees with Option::Some payload type `{some_ty}`",
+                    ),
+                );
+            }
             self.lower_option_postfix_try(scrutinee, result_ty, return_ty, span)
         } else {
             self.unsupported_postfix_try(span, "`?` scrutinee that is not Result or Option")
@@ -38100,6 +38121,50 @@ fn main() {}
         );
         let pass = function_named(&lowered, "pass");
         assert_result_try_match(first_let_value(pass));
+    }
+
+    #[test]
+    fn postfix_try_preserves_opaque_payload_representation() {
+        let (_, _, lowered) = parse_typecheck_and_lower(
+            r"
+            #[opaque]
+            type Handle {}
+
+            fn pass(r: Result<Handle, string>) -> Result<Handle, string> {
+                let handle = r?;
+                Ok(handle)
+            }
+            ",
+        );
+        assert!(
+            lowered.diagnostics.is_empty(),
+            "unexpected HIR diagnostics: {:#?}",
+            lowered.diagnostics
+        );
+
+        let pass = function_named(&lowered, "pass");
+        let try_expr = first_let_value(pass);
+        assert_result_try_match(try_expr);
+        let HirExprKind::Match { arms, .. } = &try_expr.kind else {
+            unreachable!("assert_result_try_match already checked the expression shape");
+        };
+        for (surface, ty) in [
+            ("try expression", &try_expr.ty),
+            ("Ok payload binding", &arms[0].bindings[0].ty),
+            ("Ok payload body", &arms[0].body.ty),
+        ] {
+            assert!(
+                matches!(
+                    ty,
+                    ResolvedTy::Named {
+                        name,
+                        is_opaque: true,
+                        ..
+                    } if name == "Handle"
+                ),
+                "{surface} must preserve the opaque Handle discriminator; got {ty:#?}"
+            );
+        }
     }
 
     #[test]

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -115,7 +115,7 @@ string-method-identity	qualified-format-macro	hew-codegen-rs/src/runtime_abi.rs	
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/suspend.rs	11	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/thunks.rs	3	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-hir/src/dump.rs	2	stage-1	reviewed qualified string identity construction
-string-method-identity	qualified-format-macro	hew-hir/src/lower.rs	30	stage-1	one reviewed compatibility-key factory for unique imported tagged-union constructors; exact source owner remains the authority
+string-method-identity	qualified-format-macro	hew-hir/src/lower.rs	32	stage-1	reviewed compatibility-key factory for unique imported tagged-union constructors and `?` checker payload mismatch diagnostics; exact source owner remains the authority
 string-method-identity	qualified-format-macro	hew-hir/src/node.rs	1	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-mir/src/dump.rs	6	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-mir/src/lower/actor.rs	1	stage-5	reviewed qualified string identity construction

--- a/tests/vertical-slice/accept/result_try_payload_abi.hew
+++ b/tests/vertical-slice/accept/result_try_payload_abi.hew
@@ -1,0 +1,57 @@
+// Regression for F17: the `?` desugar must preserve the checker-selected
+// payload representation. An opaque JSON Value remains pointer-shaped instead
+// of becoming an inline `%std.encoding.json.Value = type {}` local.
+import std::encoding::json;
+
+type Box<T> {
+    value: T;
+}
+
+fn _small_source() -> Result<i64, string> {
+    Ok(7)
+}
+
+fn _small_chain() -> Result<i64, string> {
+    let value = _small_source()?;
+    Ok(value)
+}
+
+fn _boxed_source() -> Result<Box<string>, string> {
+    Ok(Box { value: "boxed" })
+}
+
+fn _boxed_chain() -> Result<Box<string>, string> {
+    let value = _boxed_source()?;
+    Ok(value)
+}
+
+fn _json_source(text: string) -> Result<json.Value, string> {
+    Ok(json.parse(text))
+}
+
+fn _json_chain(text: string) -> Result<json.Value, string> {
+    let value = _json_source(text)?;
+    Ok(value)
+}
+
+fn _option_source(text: string) -> Option<json.Value> {
+    Some(json.parse(text))
+}
+
+fn _option_chain(text: string) -> Option<json.Value> {
+    let value = _option_source(text)?;
+    Some(value)
+}
+
+fn _nested_source(text: string) -> Result<Result<json.Value, string>, string> {
+    Ok(_json_source(text))
+}
+
+fn _nested_chain(text: string) -> Result<json.Value, string> {
+    let inner = _nested_source(text)?;
+    let value = inner?;
+    Ok(value)
+}
+
+fn main() {
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4033,6 +4033,11 @@ run_accept_expect_stdout "result_ok_string_payload"
 # lift with ZERO HIR change (the W3.044 `?` desugar was already type-agnostic).
 run_accept_expect_stdout "try_op_heap_result"
 
+# F17 ABI regression: compile the same `?` chain across scalar, owned-record,
+# opaque-pointer, and nested-Result payloads. The opaque case previously failed
+# codegen-front with `Move type mismatch: src=ptr dest=%std.encoding.json.Value`.
+compile_accept "result_try_payload_abi"
+
 # Double-free guard: 50k iterations each construct, return, and drop a
 # heap-owning Result across both arms. A clean exit (no SIGABRT from the
 # free_cstring header-sentinel guard) is the behavioural proof the active


### PR DESCRIPTION
Summary — the checker's ? payload type lost opaque identity inside generic carriers, so codegen's Result payload ABI diverged from the checker's layout and correct user code failed with an internal LLVM pointer/struct mismatch; the payload type is now normalized with fail-closed consistency checks, and the repro is a compiled vertical-slice test proven to fail without the fix.