### PR TITLE
Migrate stdlib to dotted surface

### DIFF
--- a/std/arena.hew
+++ b/std/arena.hew
@@ -88,8 +88,8 @@ pub fn new<T>() -> Arena<T> {
     if arena_id == 0 {
         panic("arena.new: arena identity space exhausted");
     }
-    let slots: Vec<Slot<T>> = Vec::new();
-    let free: Vec<i64> = Vec::new();
+    let slots: Vec<Slot<T>> = Vec.new();
+    let free: Vec<i64> = Vec.new();
     let generation_counter: Vec<i64> = [1];
     let clone_guard = ArenaCloneGuard { marker: 0 };
     Arena { clone_guard: clone_guard, arena_id: arena_id, generation_counter: generation_counter, slots: slots, free: free }

--- a/std/bench/bench.hew
+++ b/std/bench/bench.hew
@@ -15,7 +15,7 @@
 //! }
 //! ```
 
-import std::time::datetime;
+import std.time.datetime;
 
 // ── Types ─────────────────────────────────────────────────────────────
 /// A single benchmark result containing timing statistics.
@@ -37,7 +37,7 @@ pub type Suite {
 // ── Constructor ───────────────────────────────────────────────────────
 /// Create a new benchmark suite.
 pub fn suite(name: string) -> Suite {
-    let results: Vec<BenchResult> = Vec::new();
+    let results: Vec<BenchResult> = Vec.new();
     Suite { name: name, results: results }
 }
 

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -207,12 +207,12 @@ pub trait ActorMsg {
 pub trait Pid {
     type Msg;
 
-    fn send(pid: Self, msg: Self::Msg) -> Result<(), SendError>;
+    fn send(pid: Self, msg: Self.Msg) -> Result<(), SendError>;
 }
 
 impl<T: ActorMsg> LocalPid<T> {
     /// Send a message to this local actor.
-    fn send(pid: LocalPid<T>, msg: T::Msg) -> Result<(), SendError> {
+    fn send(pid: LocalPid<T>, msg: T.Msg) -> Result<(), SendError> {
         Ok(())
     }
 }
@@ -285,26 +285,26 @@ impl<T: ActorMsg> RemotePid<T> {
     /// and as a fail-closed fallback on targets without the codegen
     /// interception (notably WASM, where remote routing is not wired —
     /// WASM-TODO(distributed): add authenticated remote routing on wasm32).
-    fn send(pid: RemotePid<T>, msg: T::Msg) -> Result<(), SendError> {
-        Err(SendError::NodeRoutingNotWired)
+    fn send(pid: RemotePid<T>, msg: T.Msg) -> Result<(), SendError> {
+        Err(SendError.NodeRoutingNotWired)
     }
     /// Ask this remote actor for a reply, failing with `AskError` if the
     /// caller-supplied timeout elapses or routing/reply delivery fails.
-    fn ask(pid: RemotePid<T>, msg: T::Msg, timeout_ms: u64) -> Result<T::Reply, AskError> {
-        Err(AskError::NodeNotRunning)
+    fn ask(pid: RemotePid<T>, msg: T.Msg, timeout_ms: u64) -> Result<T.Reply, AskError> {
+        Err(AskError.NodeNotRunning)
     }
 }
 
 impl<T: ActorMsg> Pid for LocalPid<T> {
-    type Msg = T::Msg;
-    fn send(pid: LocalPid<T>, msg: Self::Msg) -> Result<(), SendError> {
+    type Msg = T.Msg;
+    fn send(pid: LocalPid<T>, msg: Self.Msg) -> Result<(), SendError> {
         pid.send(msg)
     }
 }
 
 impl<T: ActorMsg> Pid for RemotePid<T> {
-    type Msg = T::Msg;
-    fn send(pid: RemotePid<T>, msg: Self::Msg) -> Result<(), SendError> {
+    type Msg = T.Msg;
+    fn send(pid: RemotePid<T>, msg: Self.Msg) -> Result<(), SendError> {
         pid.send(msg)
     }
 }
@@ -338,7 +338,7 @@ pub trait Iterator {
     type Item;
 
     #[lang_item("iterator.next")]
-    fn next(var self) -> Option<Self::Item>;
+    fn next(var self) -> Option<Self.Item>;
 }
 
 // ---------------------------------------------------------------------------
@@ -359,9 +359,9 @@ pub trait Iterator {
 pub trait IntoIterator {
     type Item;
 
-    type IntoIter: Iterator<Item = Self::Item>;
+    type IntoIter: Iterator<Item = Self.Item>;
 
-    fn into_iter(self) -> Self::IntoIter;
+    fn into_iter(self) -> Self.IntoIter;
 }
 
 // ---------------------------------------------------------------------------
@@ -570,10 +570,10 @@ pub trait Index<Idx> {
     type Output;
 
     #[lang_item(index_get)]
-    fn get(self, index: Idx) -> Option<Self::Output>;
+    fn get(self, index: Idx) -> Option<Self.Output>;
 
     #[lang_item(index_at)]
-    fn at(self, index: Idx) -> Self::Output;
+    fn at(self, index: Idx) -> Self.Output;
 }
 
 impl<T> Index<i64> for Vec<T> {
@@ -769,7 +769,7 @@ impl duration {
 impl instant {
     #[extern_symbol(hew_instant_now)]
     fn now() -> instant {
-        instant::now()
+        instant.now()
     }
     #[extern_symbol(hew_instant_elapsed)]
     fn elapsed(i: instant) -> duration {

--- a/std/concurrency/lifecycle.hew
+++ b/std/concurrency/lifecycle.hew
@@ -54,23 +54,23 @@ pub machine Lifecycle<T> {
 
 #[test]
 fn lifecycle_i64_happy_path_state_names() {
-    var lifecycle: Lifecycle<i64> = Lifecycle.Created;
+    var lifecycle: Lifecycle<i64> = Lifecycle::Created;
     assert(lifecycle.state_name() == "Created");
-    lifecycle.step(Initialise);
+    lifecycle.step(.Initialise);
     assert(lifecycle.state_name() == "Initialising");
     lifecycle.step(LifecycleEvent.Started { handle: 42 });
     assert(lifecycle.state_name() == "Running");
-    lifecycle.step(Stop);
+    lifecycle.step(.Stop);
     assert(lifecycle.state_name() == "Stopping");
-    lifecycle.step(Stop);
+    lifecycle.step(.Stop);
     assert(lifecycle.state_name() == "Stopped");
 }
 
 #[test]
 fn lifecycle_string_faulted_path_state_names() {
-    var lifecycle: Lifecycle<string> = Lifecycle.Created;
+    var lifecycle: Lifecycle<string> = Lifecycle::Created;
     assert(lifecycle.state_name() == "Created");
-    lifecycle.step(Initialise);
+    lifecycle.step(.Initialise);
     assert(lifecycle.state_name() == "Initialising");
     lifecycle.step(LifecycleEvent.Crashed { error: Error.Code(7) });
     assert(lifecycle.state_name() == "Faulted");

--- a/std/concurrency/lifecycle.hew
+++ b/std/concurrency/lifecycle.hew
@@ -42,10 +42,10 @@ pub machine Lifecycle<T> {
         state
     }
     on Crashed: Initialising => Faulted {
-        Lifecycle::Faulted { error: event.error }
+        Lifecycle.Faulted { error: event.error }
     }
     on Crashed: Running => Faulted {
-        Lifecycle::Faulted { error: event.error }
+        Lifecycle.Faulted { error: event.error }
     }
     on Crashed: _ => _ {
         state
@@ -54,11 +54,11 @@ pub machine Lifecycle<T> {
 
 #[test]
 fn lifecycle_i64_happy_path_state_names() {
-    var lifecycle: Lifecycle<i64> = Lifecycle::Created;
+    var lifecycle: Lifecycle<i64> = Lifecycle.Created;
     assert(lifecycle.state_name() == "Created");
     lifecycle.step(Initialise);
     assert(lifecycle.state_name() == "Initialising");
-    lifecycle.step(LifecycleEvent::Started { handle: 42 });
+    lifecycle.step(LifecycleEvent.Started { handle: 42 });
     assert(lifecycle.state_name() == "Running");
     lifecycle.step(Stop);
     assert(lifecycle.state_name() == "Stopping");
@@ -68,10 +68,10 @@ fn lifecycle_i64_happy_path_state_names() {
 
 #[test]
 fn lifecycle_string_faulted_path_state_names() {
-    var lifecycle: Lifecycle<string> = Lifecycle::Created;
+    var lifecycle: Lifecycle<string> = Lifecycle.Created;
     assert(lifecycle.state_name() == "Created");
     lifecycle.step(Initialise);
     assert(lifecycle.state_name() == "Initialising");
-    lifecycle.step(LifecycleEvent::Crashed { error: Error::Code(7) });
+    lifecycle.step(LifecycleEvent.Crashed { error: Error.Code(7) });
     assert(lifecycle.state_name() == "Faulted");
 }

--- a/std/crypto/encrypt/encrypt.hew
+++ b/std/crypto/encrypt/encrypt.hew
@@ -86,9 +86,10 @@ pub fn last_seal_error() -> CryptoError {
 /// key is not a valid AES-256 key or the ciphertext cannot be produced; use
 /// `try_seal` to handle that instead.
 pub fn seal(key: bytes, plaintext: string) -> bytes {
-    match try_seal(key, plaintext) {
-        Ok(ciphertext) => ciphertext,
-        Err(err) => {
+    let result = try_seal(key, plaintext);
+    match result {
+        .Ok(ciphertext) => ciphertext,
+        .Err(err) => {
             panic(f"encrypt.seal failed: {error_message(err)}");
             "".to_bytes()
         },
@@ -132,8 +133,8 @@ pub fn try_open(key: bytes, ciphertext: bytes) -> Result<string, CryptoError> {
 /// structured error handling of attacker-controlled ciphertext.
 pub fn open(key: bytes, ciphertext: bytes) -> string {
     match try_open(key, ciphertext) {
-        Ok(plaintext) => plaintext,
-        Err(err) => {
+        .Ok(plaintext) => plaintext,
+        .Err(err) => {
             panic(f"encrypt.open failed: {error_message(err)}");
             ""
         },

--- a/std/crypto/encrypt/encrypt.hew
+++ b/std/crypto/encrypt/encrypt.hew
@@ -17,7 +17,7 @@
 //! }
 //! ```
 
-import std::encoding::base64;
+import std.encoding.base64;
 
 /// Structured errors returned by `try_open`.
 pub enum CryptoError {
@@ -39,27 +39,27 @@ pub enum CryptoError {
 
 fn crypto_error_from_i32(code: i32) -> CryptoError { // INTERNAL-ABI: C ABI error tag is i32 repr(C)
     match code {
-        0 => CryptoError::None,
-        1 => CryptoError::InvalidKey,
-        2 => CryptoError::ShortCiphertext,
-        3 => CryptoError::AuthFailed,
-        4 => CryptoError::InvalidUtf8,
-        5 => CryptoError::AllocationFailure,
-        6 => CryptoError::EntropyFailure,
-        _ => CryptoError::AuthFailed,
+        0 => CryptoError.None,
+        1 => CryptoError.InvalidKey,
+        2 => CryptoError.ShortCiphertext,
+        3 => CryptoError.AuthFailed,
+        4 => CryptoError.InvalidUtf8,
+        5 => CryptoError.AllocationFailure,
+        6 => CryptoError.EntropyFailure,
+        _ => CryptoError.AuthFailed,
     }
 }
 
 /// Return a human-readable message for a [`CryptoError`].
 pub fn error_message(err: CryptoError) -> string {
     match err {
-        CryptoError::None => "no error",
-        CryptoError::InvalidKey => "encrypt key must be 32 bytes",
-        CryptoError::ShortCiphertext => "encrypt ciphertext is too short",
-        CryptoError::AuthFailed => "encrypt authentication failed",
-        CryptoError::InvalidUtf8 => "encrypt plaintext was not valid UTF-8",
-        CryptoError::AllocationFailure => "encrypt native allocation failed",
-        CryptoError::EntropyFailure => "encrypt system entropy source failed",
+        CryptoError.None => "no error",
+        CryptoError.InvalidKey => "encrypt key must be 32 bytes",
+        CryptoError.ShortCiphertext => "encrypt ciphertext is too short",
+        CryptoError.AuthFailed => "encrypt authentication failed",
+        CryptoError.InvalidUtf8 => "encrypt plaintext was not valid UTF-8",
+        CryptoError.AllocationFailure => "encrypt native allocation failed",
+        CryptoError.EntropyFailure => "encrypt system entropy source failed",
     }
 }
 
@@ -107,7 +107,7 @@ pub fn try_seal(key: bytes, plaintext: string) -> Result<bytes, CryptoError> {
         hew_encrypt_try_seal_base64_hew(key, plaintext)
     };
     match last_seal_error() {
-        CryptoError::None => Ok(base64.decode(encoded)),
+        CryptoError.None => Ok(base64.decode(encoded)),
         err => Err(err),
     }
 }
@@ -121,7 +121,7 @@ pub fn try_open(key: bytes, ciphertext: bytes) -> Result<string, CryptoError> {
         hew_encrypt_try_open_hew(key, ciphertext)
     };
     match last_open_error() {
-        CryptoError::None => Ok(plaintext),
+        CryptoError.None => Ok(plaintext),
         err => Err(err),
     }
 }
@@ -168,15 +168,15 @@ extern "C" {
 // codes — can only live here as an inline test.
 #[test]
 fn crypto_error_from_i32_poisoned_codes_never_decode_to_none() {
-    assert(crypto_error_from_i32(99) != CryptoError::None);
-    assert(crypto_error_from_i32(99) == CryptoError::AuthFailed);
-    assert(crypto_error_from_i32(-1) != CryptoError::None);
-    assert(crypto_error_from_i32(-1) == CryptoError::AuthFailed);
-    assert(crypto_error_from_i32(7) != CryptoError::None);
-    assert(crypto_error_from_i32(7) == CryptoError::AuthFailed);
-    assert(crypto_error_from_i32(100) != CryptoError::None);
-    assert(crypto_error_from_i32(100) == CryptoError::AuthFailed);
+    assert(crypto_error_from_i32(99) != CryptoError.None);
+    assert(crypto_error_from_i32(99) == CryptoError.AuthFailed);
+    assert(crypto_error_from_i32(-1) != CryptoError.None);
+    assert(crypto_error_from_i32(-1) == CryptoError.AuthFailed);
+    assert(crypto_error_from_i32(7) != CryptoError.None);
+    assert(crypto_error_from_i32(7) == CryptoError.AuthFailed);
+    assert(crypto_error_from_i32(100) != CryptoError.None);
+    assert(crypto_error_from_i32(100) == CryptoError.AuthFailed);
 
     // A genuinely absent error (status 0) still means None (no error).
-    assert(crypto_error_from_i32(0) == CryptoError::None);
+    assert(crypto_error_from_i32(0) == CryptoError.None);
 }

--- a/std/crypto/jwt/jwt.hew
+++ b/std/crypto/jwt/jwt.hew
@@ -28,27 +28,27 @@ pub enum JwtError {
 
 fn jwt_error_from_i32(code: i32) -> JwtError { // INTERNAL-ABI: C ABI error tag is i32 repr(C)
     match code {
-        0 => JwtError::None,
-        1 => JwtError::AlgorithmUnsupported,
-        2 => JwtError::InvalidKey,
-        3 => JwtError::TokenMalformed,
-        4 => JwtError::SignatureInvalid,
-        5 => JwtError::ClaimsExpired,
-        6 => JwtError::AllocationFailure,
-        _ => JwtError::TokenMalformed,
+        0 => JwtError.None,
+        1 => JwtError.AlgorithmUnsupported,
+        2 => JwtError.InvalidKey,
+        3 => JwtError.TokenMalformed,
+        4 => JwtError.SignatureInvalid,
+        5 => JwtError.ClaimsExpired,
+        6 => JwtError.AllocationFailure,
+        _ => JwtError.TokenMalformed,
     }
 }
 
 /// Return a human-readable message for a [`JwtError`].
 pub fn error_message(err: JwtError) -> string {
     match err {
-        JwtError::None => "no error",
-        JwtError::AlgorithmUnsupported => "JWT algorithm is not supported",
-        JwtError::InvalidKey => "JWT key input is invalid",
-        JwtError::TokenMalformed => "JWT payload or token is malformed",
-        JwtError::SignatureInvalid => "JWT signature verification failed",
-        JwtError::ClaimsExpired => "JWT claims have expired",
-        JwtError::AllocationFailure => "JWT native allocation failed",
+        JwtError.None => "no error",
+        JwtError.AlgorithmUnsupported => "JWT algorithm is not supported",
+        JwtError.InvalidKey => "JWT key input is invalid",
+        JwtError.TokenMalformed => "JWT payload or token is malformed",
+        JwtError.SignatureInvalid => "JWT signature verification failed",
+        JwtError.ClaimsExpired => "JWT claims have expired",
+        JwtError.AllocationFailure => "JWT native allocation failed",
     }
 }
 
@@ -80,7 +80,7 @@ pub fn try_encode(payload: string, secret: string, algorithm: string) -> Result<
         hew_jwt_encode_hew(payload, secret, algo)
     };
     match last_error() {
-        JwtError::None => Ok(token),
+        JwtError.None => Ok(token),
         err => Err(err),
     }
 }
@@ -109,7 +109,7 @@ pub fn try_decode(token: string, secret: string, algorithm: string) -> Result<st
         hew_jwt_decode_hew(token, secret, algo)
     };
     match last_error() {
-        JwtError::None => Ok(payload),
+        JwtError.None => Ok(payload),
         err => Err(err),
     }
 }

--- a/std/encoding/base64/base64.hew
+++ b/std/encoding/base64/base64.hew
@@ -34,13 +34,13 @@ pub fn encode_url(data: bytes) -> string {
 /// Returns an empty `bytes` buffer if the input is not valid Base64.
 pub fn decode(s: string) -> bytes {
     let slen = s.len();
-    let out: bytes = bytes::new();
+    let out: bytes = bytes.new();
     if slen == 0 {
         return out;
     }
     let has_padding = s.slice(slen - 1, slen) == "=";
     if has_padding && slen % 4 != 0 {
-        return bytes::new();
+        return bytes.new();
     }
     // Strip trailing '=' padding
     var data_len = slen;
@@ -51,12 +51,12 @@ pub fn decode(s: string) -> bytes {
         data_len = data_len - 1;
     }
     // Collect 6-bit values
-    let vals: bytes = bytes::new();
+    let vals: bytes = bytes.new();
     for i in 0 .. data_len {
         let ch = s.slice(i, i + 1);
         let v = decode_char(ch);
         if v < 0 {
-            return bytes::new();
+            return bytes.new();
         }
         vals.push(v as u8);
     }
@@ -76,7 +76,7 @@ pub fn decode(s: string) -> bytes {
     // Handle remaining values (from stripped padding)
     let remaining = nvals - i;
     if remaining == 1 {
-        return bytes::new();
+        return bytes.new();
     }
     if remaining == 2 {
         let a = vals[i];
@@ -122,7 +122,7 @@ fn b64_char(idx: i32, url_safe: bool) -> i32 { // INTERNAL-ABI: byte-level 6-bit
 /// Encode binary data to a Base64 string using the standard or URL-safe alphabet.
 fn encode_impl(data: bytes, url_safe: bool) -> string {
     let dlen = data.len();
-    let out: bytes = bytes::new();
+    let out: bytes = bytes.new();
     var i = 0;
     // Process complete 3-byte groups
     while i + 3 <= dlen {

--- a/std/encoding/binary/binary.hew
+++ b/std/encoding/binary/binary.hew
@@ -43,7 +43,7 @@ fn lo_byte(v: i64) -> u8 { // INTERNAL-ABI: masks to low 8 bits; u8 matches byte
 ///
 /// Only the low 16 bits of `v` are written; the upper bits are ignored.
 pub fn put_u16_le(v: i64) -> bytes {
-    let b: bytes = bytes::new();
+    let b: bytes = bytes.new();
     b.push(lo_byte(v));
     b.push(lo_byte(v >> 8));
     b
@@ -53,7 +53,7 @@ pub fn put_u16_le(v: i64) -> bytes {
 ///
 /// Only the low 32 bits of `v` are written; the upper bits are ignored.
 pub fn put_u32_le(v: i64) -> bytes {
-    let b: bytes = bytes::new();
+    let b: bytes = bytes.new();
     b.push(lo_byte(v));
     b.push(lo_byte(v >> 8));
     b.push(lo_byte(v >> 16));
@@ -63,7 +63,7 @@ pub fn put_u32_le(v: i64) -> bytes {
 
 /// Encode a 64-bit value `v` as 8 little-endian bytes.
 pub fn put_u64_le(v: i64) -> bytes {
-    let b: bytes = bytes::new();
+    let b: bytes = bytes.new();
     b.push(lo_byte(v));
     b.push(lo_byte(v >> 8));
     b.push(lo_byte(v >> 16));
@@ -80,7 +80,7 @@ pub fn put_u64_le(v: i64) -> bytes {
 ///
 /// Only the low 16 bits of `v` are written; the upper bits are ignored.
 pub fn put_u16_be(v: i64) -> bytes {
-    let b: bytes = bytes::new();
+    let b: bytes = bytes.new();
     b.push(lo_byte(v >> 8));
     b.push(lo_byte(v));
     b
@@ -90,7 +90,7 @@ pub fn put_u16_be(v: i64) -> bytes {
 ///
 /// Only the low 32 bits of `v` are written; the upper bits are ignored.
 pub fn put_u32_be(v: i64) -> bytes {
-    let b: bytes = bytes::new();
+    let b: bytes = bytes.new();
     b.push(lo_byte(v >> 24));
     b.push(lo_byte(v >> 16));
     b.push(lo_byte(v >> 8));
@@ -100,7 +100,7 @@ pub fn put_u32_be(v: i64) -> bytes {
 
 /// Encode a 64-bit value `v` as 8 big-endian bytes.
 pub fn put_u64_be(v: i64) -> bytes {
-    let b: bytes = bytes::new();
+    let b: bytes = bytes.new();
     b.push(lo_byte(v >> 56));
     b.push(lo_byte(v >> 48));
     b.push(lo_byte(v >> 40));

--- a/std/encoding/csv/csv.hew
+++ b/std/encoding/csv/csv.hew
@@ -16,7 +16,7 @@
 //! }
 //! ```
 
-import std::fs;
+import std.fs;
 
 /// A parsed CSV table with headers and data rows.
 type Table {
@@ -127,7 +127,7 @@ pub fn parse(data: string) -> Table {
         Ok(tbl) => tbl,
         Err(reason) => {
             panic(reason);
-            Table { hdrs: Vec::new(), data: Vec::new() }
+            Table { hdrs: Vec.new(), data: Vec.new() }
         },
     }
 }
@@ -141,7 +141,7 @@ pub fn parse_no_headers(data: string) -> Table {
         Ok(tbl) => tbl,
         Err(reason) => {
             panic(reason);
-            Table { hdrs: Vec::new(), data: Vec::new() }
+            Table { hdrs: Vec.new(), data: Vec.new() }
         },
     }
 }
@@ -156,7 +156,7 @@ pub fn parse_file(path: string) -> Table {
         Ok(tbl) => tbl,
         Err(reason) => {
             panic(reason);
-            Table { hdrs: Vec::new(), data: Vec::new() }
+            Table { hdrs: Vec.new(), data: Vec.new() }
         },
     }
 }
@@ -176,14 +176,14 @@ pub fn parse_file(path: string) -> Table {
 /// consumed before advancing to the next field. Inside a quoted field
 /// (state 2), '\r\n' is preserved verbatim in the field value per RFC 4180 §2.6.
 fn parse_impl(data: string, has_headers: bool) -> Result<Table, string> {
-    let headers: Vec<string> = Vec::new();
-    let rows: Vec<Vec<string>> = Vec::new();
+    let headers: Vec<string> = Vec.new();
+    let rows: Vec<Vec<string>> = Vec.new();
     let ilen = data.len();
     if ilen == 0 {
         return Ok(Table { hdrs: headers, data: rows });
     }
     // Current row accumulator and field accumulator.
-    let cur_row: Vec<string> = Vec::new();
+    let cur_row: Vec<string> = Vec.new();
     var cur_field = "";
     // state: 0=Outside, 1=InUnquoted, 2=InQuoted, 3=AfterClosingQuote
     var state = 0;

--- a/std/encoding/hex/hex.hew
+++ b/std/encoding/hex/hex.hew
@@ -34,7 +34,7 @@ pub fn encode_upper(data: bytes) -> string {
 /// Returns an empty `bytes` buffer if the input is not valid hex.
 pub fn decode(s: string) -> bytes {
     let slen = s.len();
-    let out: bytes = bytes::new();
+    let out: bytes = bytes.new();
     if slen == 0 {
         return out;
     }
@@ -45,10 +45,10 @@ pub fn decode(s: string) -> bytes {
         let hi = hex_char_to_nibble(s.slice(i, i + 1));
         let lo = hex_char_to_nibble(s.slice(i + 1, i + 2));
         if hi < 0 {
-            return bytes::new();
+            return bytes.new();
         }
         if lo < 0 {
-            return bytes::new();
+            return bytes.new();
         }
         out.push((hi * 16 + lo) as u8);
     }
@@ -57,7 +57,7 @@ pub fn decode(s: string) -> bytes {
 
 /// Encode binary data to a hex string, optionally uppercase.
 fn encode_impl(data: bytes, upper: bool) -> string {
-    let out: bytes = bytes::new();
+    let out: bytes = bytes.new();
     for i in 0 .. data.len() {
         let b = data[i];
         let hi = b as i32 / 16;

--- a/std/encoding/json/json.hew
+++ b/std/encoding/json/json.hew
@@ -17,7 +17,7 @@
 //! }
 //! ```
 
-import std::encoding::wire::value_trait;
+import std.encoding.wire.value_trait;
 
 /// Structured error type for JSON parsing failures.
 ///
@@ -319,7 +319,7 @@ pub fn try_parse(s: string) -> Result<Value, ParseError> {
     if val.type_of() >= 0 {
         Ok(val)
     } else {
-        Err(ParseError::Invalid(parse_error_message()))
+        Err(ParseError.Invalid(parse_error_message()))
     }
 }
 

--- a/std/encoding/toml/toml.hew
+++ b/std/encoding/toml/toml.hew
@@ -19,7 +19,7 @@
 //! }
 //! ```
 
-import std::encoding::wire::value_trait;
+import std.encoding.wire.value_trait;
 
 /// Structured error type for TOML parsing failures.
 ///
@@ -299,7 +299,7 @@ pub fn try_parse(s: string) -> Result<Value, ParseError> {
     if val.type_of() >= 0 {
         Ok(val)
     } else {
-        Err(ParseError::Invalid(parse_error_message()))
+        Err(ParseError.Invalid(parse_error_message()))
     }
 }
 

--- a/std/encoding/yaml/yaml.hew
+++ b/std/encoding/yaml/yaml.hew
@@ -17,7 +17,7 @@
 //! }
 //! ```
 
-import std::encoding::wire::value_trait;
+import std.encoding.wire.value_trait;
 
 /// Structured error type for YAML parsing failures.
 ///
@@ -310,7 +310,7 @@ pub fn try_parse(s: string) -> Result<Value, ParseError> {
     if val.type_of() >= 0 {
         Ok(val)
     } else {
-        Err(ParseError::Invalid(parse_error_message()))
+        Err(ParseError.Invalid(parse_error_message()))
     }
 }
 

--- a/std/fmt/fmt.hew
+++ b/std/fmt/fmt.hew
@@ -16,7 +16,7 @@
 //! }
 //! ```
 
-import std::string;
+import std.string;
 
 // ── Number-to-string conversions ─────────────────────────────────────
 /// Convert an integer to its lowercase hexadecimal string representation.

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -77,22 +77,22 @@ pub enum IoError {
 pub fn io_error_from_errno(errno: i64) -> IoError {
     // ENOENT: Linux=2, macOS=2
     if errno == 2 {
-        IoError::NotFound(errno)
+        IoError.NotFound(errno)
     // EACCES: Linux=13, macOS=13
     } else if errno == 13 {
-        IoError::PermissionDenied(errno)
+        IoError.PermissionDenied(errno)
     // EEXIST: Linux=17, macOS=17; ERROR_ALREADY_EXISTS: Windows=183.
     // 183 is not a POSIX errno, so mapping it here is unambiguous.
     } else if errno == 17 || errno == 183 {
-        IoError::AlreadyExists(errno)
+        IoError.AlreadyExists(errno)
     // ETIMEDOUT: Linux=110, macOS=60
     } else if errno == 110 || errno == 60 {
-        IoError::TimedOut(errno)
+        IoError.TimedOut(errno)
     // ECANCELED: Linux=125, macOS=89
     } else if errno == 125 || errno == 89 {
-        IoError::Cancelled(errno)
+        IoError.Cancelled(errno)
     } else {
-        IoError::Other(errno)
+        IoError.Other(errno)
     }
 }
 
@@ -112,13 +112,13 @@ pub fn io_error_from_errno(errno: i64) -> IoError {
 /// this one authority rather than re-deriving it from the raw errno.
 pub fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
     if kind == 1 {
-        IoError::NotFound(errno)
+        IoError.NotFound(errno)
     } else if kind == 2 {
-        IoError::PermissionDenied(errno)
+        IoError.PermissionDenied(errno)
     } else if kind == 3 {
-        IoError::AlreadyExists(errno)
+        IoError.AlreadyExists(errno)
     } else if kind == 4 {
-        IoError::TimedOut(errno)
+        IoError.TimedOut(errno)
     } else {
         io_error_from_errno(errno)
     }
@@ -138,12 +138,12 @@ pub fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
 /// ```
 pub fn io_error_message(e: IoError) -> string {
     match e {
-        IoError::NotFound(code) => f"NotFound({code})",
-        IoError::PermissionDenied(code) => f"PermissionDenied({code})",
-        IoError::AlreadyExists(code) => f"AlreadyExists({code})",
-        IoError::TimedOut(code) => f"TimedOut({code})",
-        IoError::Cancelled(code) => f"Cancelled({code})",
-        IoError::Other(code) => f"Other({code})",
+        IoError.NotFound(code) => f"NotFound({code})",
+        IoError.PermissionDenied(code) => f"PermissionDenied({code})",
+        IoError.AlreadyExists(code) => f"AlreadyExists({code})",
+        IoError.TimedOut(code) => f"TimedOut({code})",
+        IoError.Cancelled(code) => f"Cancelled({code})",
+        IoError.Other(code) => f"Other({code})",
     }
 }
 
@@ -152,14 +152,14 @@ pub fn io_error_message(e: IoError) -> string {
 /// to map (e.g. `fs.io_error_from_errno` would need a platform-aware errno
 /// constant that the caller does not have).
 pub fn io_error_timed_out() -> IoError {
-    IoError::TimedOut(0)
+    IoError.TimedOut(0)
 }
 
 /// Construct an `IoError::Cancelled(0)` value without a platform-specific
 /// errno. Useful for in-process cancellation (e.g. blocking pool stopped)
 /// where there is no OS error to map.
 pub fn io_error_cancelled() -> IoError {
-    IoError::Cancelled(0)
+    IoError.Cancelled(0)
 }
 
 fn last_io_error() -> IoError {
@@ -170,7 +170,7 @@ fn last_io_error() -> IoError {
         let errno = hew_stream_last_errno() as i64;
         let _ = hew_stream_last_error();
         if errno == 0 && kind == 0 {
-            IoError::Other(5)
+            IoError.Other(5)
         } else {
             io_error_from_kind(kind, errno)
         }

--- a/std/io/closable.hew
+++ b/std/io/closable.hew
@@ -22,7 +22,7 @@
 //! automatically when it leaves scope. Any error from the implicit
 //! release is silently discarded.
 
-import std::fs;
+import std.fs;
 
 /// A type that can be explicitly closed before it leaves scope.
 ///

--- a/std/io/scanner.hew
+++ b/std/io/scanner.hew
@@ -68,9 +68,9 @@
 //! | `SplitLines` | Lines split on `\n`; `\r\n` stripped (default).   |
 //! | `SplitWords` | Fields split on any run of ASCII whitespace.       |
 
-import std::fs;
+import std.fs;
 
-import std::io;
+import std.io;
 
 // ── Split mode ────────────────────────────────────────────────────────
 /// How the scanner tokenises its source.
@@ -249,7 +249,7 @@ pub fn text(sc: Scanner) -> string {
 /// }
 /// ```
 pub fn lines(s: string) -> Vec<string> {
-    let result: Vec<string> = Vec::new();
+    let result: Vec<string> = Vec.new();
     if s.len() == 0 {
         return result;
     }
@@ -279,7 +279,7 @@ pub fn lines(s: string) -> Vec<string> {
 /// }
 /// ```
 pub fn words(s: string) -> Vec<string> {
-    let result: Vec<string> = Vec::new();
+    let result: Vec<string> = Vec.new();
     if s.len() == 0 {
         return result;
     }
@@ -313,7 +313,7 @@ pub fn words(s: string) -> Vec<string> {
 /// }
 /// ```
 pub fn collect(sc: Scanner) -> Vec<string> {
-    let result: Vec<string> = Vec::new();
+    let result: Vec<string> = Vec.new();
     if has_next(sc) {
         result.push(sc.current);
     }

--- a/std/iter.hew
+++ b/std/iter.hew
@@ -309,7 +309,7 @@ pub fn count<I, A>(it: I) -> i64 where I: Iterator<Item = A> {
 
 /// Collect every item produced by `it` into a `Vec<A>`.
 pub fn collect<I, A>(it: I) -> Vec<A> where I: Iterator<Item = A> {
-    let out: Vec<A> = Vec::new();
+    let out: Vec<A> = Vec.new();
     var iter = it;
     loop {
         match iter.next() {

--- a/std/link_monitor.hew
+++ b/std/link_monitor.hew
@@ -19,7 +19,7 @@
 // the `link()` builtin, like `SendError` for `.tell`), so it is NOT redeclared
 // here — that would collide with the always-loaded prelude on import. Programs
 // name `LinkError::AlreadyLinked` / `TargetDead` without importing this module.
-import std::failure::{CrashKind};
+import std.failure.{CrashKind};
 
 /// Error returned when a monitor delivery cannot be completed.
 pub enum MonitorError {
@@ -132,11 +132,11 @@ impl MonitorRef {
 /// never silently send an unmapped policy.
 pub fn set_partition_policy(policy: PartitionPolicy) -> bool {
     let tag = match policy {
-        PartitionPolicy::FailFast => 0,
-        PartitionPolicy::Deadline => 1,
-        PartitionPolicy::MonitorLost => 2,
-        PartitionPolicy::CrashLinked => 3,
-        PartitionPolicy::Quarantine => 4,
+        PartitionPolicy.FailFast => 0,
+        PartitionPolicy.Deadline => 1,
+        PartitionPolicy.MonitorLost => 2,
+        PartitionPolicy.CrashLinked => 3,
+        PartitionPolicy.Quarantine => 4,
     };
     unsafe {
         hew_set_partition_policy(tag)

--- a/std/metrics/metrics.hew
+++ b/std/metrics/metrics.hew
@@ -196,7 +196,7 @@ pub fn try_counter(name: string) -> Result<Counter, MetricsError> {
         hew_metric_counter_register(name)
     };
     if id < 0 {
-        Err(MetricsError::Rejected(name))
+        Err(MetricsError.Rejected(name))
     } else {
         Ok(Counter { id: id })
     }
@@ -223,7 +223,7 @@ pub fn try_gauge(name: string) -> Result<Gauge, MetricsError> {
         hew_metric_gauge_register(name)
     };
     if id < 0 {
-        Err(MetricsError::Rejected(name))
+        Err(MetricsError.Rejected(name))
     } else {
         Ok(Gauge { id: id })
     }
@@ -254,7 +254,7 @@ pub fn try_histogram(name: string) -> Result<Histogram, MetricsError> {
         hew_metric_histogram_register_simple(name)
     };
     if id < 0 {
-        Err(MetricsError::Rejected(name))
+        Err(MetricsError.Rejected(name))
     } else {
         Ok(Histogram { id: id })
     }

--- a/std/misc/log/log.hew
+++ b/std/misc/log/log.hew
@@ -60,7 +60,7 @@
 //! {"ts":1234567890.123,"level":"INFO","msg":"server starting","port":"8080"}
 //! ```
 
-import std::string;
+import std.string;
 
 // ── Level constants ───────────────────────────────────────────────────
 /// Error-level severity (highest priority).

--- a/std/net/dns/dns.hew
+++ b/std/net/dns/dns.hew
@@ -18,7 +18,7 @@
 //! }
 //! ```
 
-import std::net;
+import std.net;
 
 /// Resolve a hostname to all associated IP addresses.
 ///

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -25,7 +25,7 @@
 //! }
 //! ```
 
-import std::net;
+import std.net;
 
 /// An HTTP server bound to a TCP address.
 ///
@@ -377,7 +377,7 @@ pub fn listen(addr: string) -> Result<Server, net.NetError> {
         let detail = unsafe {
             hew_http_last_error()
         };
-        return Err(net.NetError::InvalidArgument(detail));
+        return Err(net.NetError.InvalidArgument(detail));
     }
     Err(net.net_error_from_errno(errno))
 }

--- a/std/net/http/http_async_client.hew
+++ b/std/net/http/http_async_client.hew
@@ -53,7 +53,7 @@
 //! }
 //! ```
 
-import std::string;
+import std.string;
 
 // ── Hardening limits (fail-closed DoS bounds) ─────────────────────────
 /// Maximum bytes accepted in the response head (status line + headers). A head

--- a/std/net/http/http_async_server.hew
+++ b/std/net/http/http_async_server.hew
@@ -62,7 +62,7 @@
 //! }
 //! ```
 
-import std::string;
+import std.string;
 
 // ── Hardening limits (fail-closed DoS / injection bounds) ─────────────
 /// Maximum bytes accepted in the request head (request line + headers). A head

--- a/std/net/http/http_client.hew
+++ b/std/net/http/http_client.hew
@@ -34,7 +34,7 @@
 //
 // WASM-TODO(http-client): outbound std::net::http client wrappers remain native-only until
 // a browser/WASM networking bridge exists.
-import std::net;
+import std.net;
 
 /// An opaque HTTP response handle.
 ///
@@ -121,12 +121,12 @@ impl Response {
 
 // ── Module-level helpers ──────────────────────────────────────────────
 fn empty_headers() -> Vec<(string, string)> {
-    let headers: Vec<(string, string)> = Vec::new();
+    let headers: Vec<(string, string)> = Vec.new();
     headers
 }
 
 fn content_type_headers(content_type: string) -> Vec<(string, string)> {
-    let headers: Vec<(string, string)> = Vec::new();
+    let headers: Vec<(string, string)> = Vec.new();
     headers.push(("Content-Type", content_type));
     headers
 }

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -48,9 +48,9 @@
 //! }
 //! ```
 
-import std::string;
+import std.string;
 
-import std::stream;
+import std.stream;
 
 // ── Network error type ────────────────────────────────────────────────
 /// Structured error type for network operations.
@@ -107,36 +107,36 @@ pub enum AttachError {
 pub fn net_error_from_errno(errno: i64) -> NetError {
     // ECONNREFUSED: Linux=111, macOS=61, Windows=10061
     if errno == 111 || errno == 61 || errno == 10061 {
-        NetError::ConnectionRefused(errno)
+        NetError.ConnectionRefused(errno)
     // EADDRINUSE: Linux=98, macOS=48, Windows=10048
     } else if errno == 98 || errno == 48 || errno == 10048 {
-        NetError::AddressInUse(errno)
+        NetError.AddressInUse(errno)
     // ETIMEDOUT: Linux=110, macOS=60, Windows=10060
     } else if errno == 110 || errno == 60 || errno == 10060 {
-        NetError::TimedOut(errno)
+        NetError.TimedOut(errno)
     // ECANCELED: Linux=125, macOS=89. Windows has no WSABASEERR-offset
     // ECANCELED; a cancelled/aborted overlapped net op surfaces as
     // ERROR_OPERATION_ABORTED (995) or WSAECANCELLED (10103) instead.
     } else if errno == 125 || errno == 89 || errno == 995 || errno == 10103 {
-        NetError::Cancelled(errno)
+        NetError.Cancelled(errno)
     // EADDRNOTAVAIL: Linux=99, macOS=49, Windows=10049
     } else if errno == 99 || errno == 49 || errno == 10049 {
-        NetError::AddressNotAvailable(errno)
+        NetError.AddressNotAvailable(errno)
     } else {
-        NetError::Other(errno)
+        NetError.Other(errno)
     }
 }
 
 /// Return a human-readable description of a `NetError`.
 pub fn net_error_message(e: NetError) -> string {
     match e {
-        NetError::ConnectionRefused(code) => f"ConnectionRefused({code})",
-        NetError::AddressInUse(code) => f"AddressInUse({code})",
-        NetError::AddressNotAvailable(code) => f"AddressNotAvailable({code})",
-        NetError::TimedOut(code) => f"TimedOut({code})",
-        NetError::Cancelled(code) => f"Cancelled({code})",
-        NetError::InvalidArgument(detail) => f"InvalidArgument({detail})",
-        NetError::Other(code) => f"Other({code})",
+        NetError.ConnectionRefused(code) => f"ConnectionRefused({code})",
+        NetError.AddressInUse(code) => f"AddressInUse({code})",
+        NetError.AddressNotAvailable(code) => f"AddressNotAvailable({code})",
+        NetError.TimedOut(code) => f"TimedOut({code})",
+        NetError.Cancelled(code) => f"Cancelled({code})",
+        NetError.InvalidArgument(detail) => f"InvalidArgument({detail})",
+        NetError.Other(code) => f"Other({code})",
     }
 }
 
@@ -158,10 +158,10 @@ pub fn abi_i32_max() -> i64 {
 /// `context` names the calling API so the rejection identifies its origin.
 pub fn try_duration_ms(context: string, ms: i64) -> Result<i64, NetError> {
     if ms < 0 {
-        return Err(NetError::InvalidArgument(f"{context}: invalid duration {ms} ms (must be >= 0)"));
+        return Err(NetError.InvalidArgument(f"{context}: invalid duration {ms} ms (must be >= 0)"));
     }
     if ms > abi_i32_max() {
-        return Err(NetError::InvalidArgument(f"{context}: invalid duration {ms} ms (must be <= {abi_i32_max()})"));
+        return Err(NetError.InvalidArgument(f"{context}: invalid duration {ms} ms (must be <= {abi_i32_max()})"));
     }
     Ok(ms)
 }
@@ -181,10 +181,10 @@ fn try_connection_timeout_ms(context: string, ms: i64) -> Result<i64, NetError> 
 /// Validate a byte count that the C ABI carries as an `i32`.
 pub fn try_size_arg(context: string, size: i64) -> Result<i64, NetError> {
     if size < 0 {
-        return Err(NetError::InvalidArgument(f"{context}: invalid size {size} (must be >= 0)"));
+        return Err(NetError.InvalidArgument(f"{context}: invalid size {size} (must be >= 0)"));
     }
     if size > abi_i32_max() {
-        return Err(NetError::InvalidArgument(f"{context}: invalid size {size} (must be <= {abi_i32_max()})"));
+        return Err(NetError.InvalidArgument(f"{context}: invalid size {size} (must be <= {abi_i32_max()})"));
     }
     Ok(size)
 }
@@ -192,7 +192,7 @@ pub fn try_size_arg(context: string, size: i64) -> Result<i64, NetError> {
 /// Validate a TCP/UDP port number.
 pub fn try_port_arg(context: string, port: i64) -> Result<i64, NetError> {
     if port < 0 || port > 65535 {
-        return Err(NetError::InvalidArgument(f"{context}: invalid port {port} (must be 0..=65535)"));
+        return Err(NetError.InvalidArgument(f"{context}: invalid port {port} (must be 0..=65535)"));
     }
     Ok(port)
 }
@@ -216,7 +216,7 @@ fn max_endpoint_len() -> i64 {
 }
 
 fn endpoint_reject(context: string, addr: string, reason: string) -> NetError {
-    NetError::InvalidArgument(f"{context}: invalid endpoint '{addr}' ({reason})")
+    NetError.InvalidArgument(f"{context}: invalid endpoint '{addr}' ({reason})")
 }
 
 fn try_endpoint_port(context: string, addr: string, text: string) -> Result<i64, NetError> {
@@ -306,14 +306,14 @@ fn try_parse_bracketed_endpoint(context: string, addr: string) -> Result<Endpoin
 /// errno. Useful for in-process deadline expiry where there is no OS error
 /// to map.
 pub fn net_error_timed_out() -> NetError {
-    NetError::TimedOut(0)
+    NetError.TimedOut(0)
 }
 
 /// Construct a `NetError::Cancelled(0)` value without a platform-specific
 /// errno. Useful for in-process cancellation where there is no OS error
 /// to map.
 pub fn net_error_cancelled() -> NetError {
-    NetError::Cancelled(0)
+    NetError.Cancelled(0)
 }
 
 // ── Write error type ──────────────────────────────────────────────────
@@ -361,27 +361,27 @@ pub enum WriteError {
 pub fn write_error_from_errno(errno: i64) -> WriteError {
     // EAGAIN / EWOULDBLOCK: Linux=11, macOS=35 (EWOULDBLOCK==EAGAIN on both).
     if errno == 11 || errno == 35 {
-        WriteError::BackpressureExceeded(errno)
+        WriteError.BackpressureExceeded(errno)
     // ETIMEDOUT: Linux=110, macOS=60. A write that times out with the send
     // buffer full is backpressure, not a connection failure. Windows surfaces
     // a blocked write past the deadline as WSAETIMEDOUT (10060), mapped here.
     } else if errno == 110 || errno == 60 || errno == 10060 {
-        WriteError::BackpressureExceeded(errno)
+        WriteError.BackpressureExceeded(errno)
     // ECONNRESET: Linux=104, macOS=54. EPIPE: Linux=32, macOS=32.
     // ENOTCONN: Linux=107, macOS=57.
     } else if errno == 104 || errno == 54 || errno == 32 || errno == 107 || errno == 57 {
-        WriteError::Disconnected(errno)
+        WriteError.Disconnected(errno)
     } else {
-        WriteError::Other(errno)
+        WriteError.Other(errno)
     }
 }
 
 /// Return a human-readable description of a `WriteError`.
 pub fn write_error_message(e: WriteError) -> string {
     match e {
-        WriteError::BackpressureExceeded(code) => f"BackpressureExceeded({code})",
-        WriteError::Disconnected(code) => f"Disconnected({code})",
-        WriteError::Other(code) => f"Other({code})",
+        WriteError.BackpressureExceeded(code) => f"BackpressureExceeded({code})",
+        WriteError.Disconnected(code) => f"Disconnected({code})",
+        WriteError.Other(code) => f"Other({code})",
     }
 }
 
@@ -690,7 +690,7 @@ impl Connection {
     /// `Err(AttachError::Refused)`. Every call site is rewritten to
     /// `hew_tcp_attach_local` by the checker/codegen.
     fn attach(consuming self, handler: LocalPid<ConnectionHandler>) -> Result<(), AttachError> {
-        Err(AttachError::Refused)
+        Err(AttachError.Refused)
     }
     /// Consume the connection and produce a `(Stream<bytes>, Sink<bytes>)` pair.
     fn into_stream_sink(consuming self) -> (Stream<bytes>, stream.Sink<bytes>) {
@@ -847,20 +847,20 @@ fn try_connect_timeout_ms(timeout_sec: i64, timeout_usec: i64) -> Result<i64, Ne
     let millis_per_second: i64 = 1000;
     let micros_per_millisecond: i64 = 1000;
     if timeout_sec < 0 {
-        return Err(NetError::InvalidArgument(f"net.connect_timeout: invalid timeout_sec {timeout_sec} (must be >= 0)"));
+        return Err(NetError.InvalidArgument(f"net.connect_timeout: invalid timeout_sec {timeout_sec} (must be >= 0)"));
     }
     if timeout_usec < 0 {
-        return Err(NetError::InvalidArgument(f"net.connect_timeout: invalid timeout_usec {timeout_usec} (must be >= 0)"));
+        return Err(NetError.InvalidArgument(f"net.connect_timeout: invalid timeout_usec {timeout_usec} (must be >= 0)"));
     }
     // Bound each term against the ABI ceiling before multiplying or adding, so
     // the accumulation itself can never wrap.
     if timeout_sec > abi_i32_max() / millis_per_second {
-        return Err(NetError::InvalidArgument(f"net.connect_timeout: invalid timeout_sec {timeout_sec} (deadline exceeds {abi_i32_max()} ms)"));
+        return Err(NetError.InvalidArgument(f"net.connect_timeout: invalid timeout_sec {timeout_sec} (deadline exceeds {abi_i32_max()} ms)"));
     }
     let seconds_ms = timeout_sec * millis_per_second;
     let micros_ms = timeout_usec / micros_per_millisecond;
     if micros_ms > abi_i32_max() - seconds_ms {
-        return Err(NetError::InvalidArgument(f"net.connect_timeout: invalid deadline (timeout_sec {timeout_sec} + timeout_usec {timeout_usec} exceeds {abi_i32_max()} ms)"));
+        return Err(NetError.InvalidArgument(f"net.connect_timeout: invalid deadline (timeout_sec {timeout_sec} + timeout_usec {timeout_usec} exceeds {abi_i32_max()} ms)"));
     }
     try_duration_ms("net.connect_timeout", seconds_ms + micros_ms)
 }

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -89,7 +89,7 @@
 //! }
 //! ```
 
-import std::net;
+import std.net;
 
 /// A QUIC endpoint bound to a local UDP address.
 ///

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -25,7 +25,7 @@
 //! }
 //! ```
 
-import std::net;
+import std.net;
 
 /// An established TLS connection to a remote host.
 ///
@@ -55,9 +55,9 @@ const TLS_STATUS_IO_ERROR: i32 = 3;
 
 fn tls_error_from_status(status: i32) -> net.NetError { // INTERNAL-ABI: TLS FFI bridge reports a small status enum; detail stays in last_error()
     if status == TLS_STATUS_RETRYABLE {
-        NetError::TimedOut(0)
+        NetError.TimedOut(0)
     } else {
-        NetError::Other(0)
+        NetError.Other(0)
     }
 }
 
@@ -260,7 +260,7 @@ extern "C" {
 // module-private and therefore only reachable from an inline test here.
 #[test]
 fn tls_error_from_status_retryable_maps_to_timed_out() {
-    assert(tls_error_from_status(TLS_STATUS_RETRYABLE) == NetError::TimedOut(0));
+    assert(tls_error_from_status(TLS_STATUS_RETRYABLE) == NetError.TimedOut(0));
 }
 
 #[test]
@@ -270,7 +270,7 @@ fn tls_error_from_status_success_never_reached_maps_like_other() {
     // function itself has no dedicated arm for it, so it falls into the
     // same `else` branch as TLS_ERROR/IO_ERROR. Pinned here so a stray
     // caller passing SUCCESS gets the current (non-crashing) behavior.
-    assert(tls_error_from_status(TLS_STATUS_SUCCESS) == NetError::Other(0));
+    assert(tls_error_from_status(TLS_STATUS_SUCCESS) == NetError.Other(0));
 }
 
 #[test]
@@ -283,7 +283,7 @@ fn tls_error_from_status_tls_error_and_io_error_currently_collapse() {
     // separate product decision, not something to do incidentally here.
     let tls_error = tls_error_from_status(TLS_STATUS_TLS_ERROR);
     let io_error = tls_error_from_status(TLS_STATUS_IO_ERROR);
-    assert(tls_error == NetError::Other(0));
-    assert(io_error == NetError::Other(0));
+    assert(tls_error == NetError.Other(0));
+    assert(io_error == NetError.Other(0));
     assert(tls_error == io_error);
 }

--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -19,7 +19,7 @@
 //! }
 //! ```
 
-import std::string;
+import std.string;
 
 /// A parsed URL.
 ///
@@ -208,7 +208,7 @@ fn decode_impl(s: string) -> string {
     if !valid_percent_utf8(data) {
         return "";
     }
-    let out: bytes = bytes::new();
+    let out: bytes = bytes.new();
     var i = 0;
     while i < data.len() {
         let b = data[i];
@@ -251,7 +251,7 @@ pub fn decode_query(params: string) -> Vec<(string, string)> {
 }
 
 fn decode_query_impl(params: string) -> Vec<(string, string)> {
-    let decoded: Vec<(string, string)> = Vec::new();
+    let decoded: Vec<(string, string)> = Vec.new();
     if string.is_empty(params) {
         return decoded;
     }
@@ -275,7 +275,7 @@ fn decode_form_component(s: string) -> string {
     if !valid_percent_utf8(data) {
         return "";
     }
-    let out: bytes = bytes::new();
+    let out: bytes = bytes.new();
     var i = 0;
     while i < data.len() {
         let b = data[i];
@@ -385,7 +385,7 @@ pub fn encode_query(params: string) -> string {
 }
 
 fn encode_query_impl(params: string) -> string {
-    let encoded: Vec<string> = Vec::new();
+    let encoded: Vec<string> = Vec.new();
     let lines = string.lines(params);
     for i in 0 .. lines.len() {
         let line = lines[i];

--- a/std/net/websocket/websocket.hew
+++ b/std/net/websocket/websocket.hew
@@ -45,7 +45,7 @@
 //! }
 //! ```
 
-import std::net;
+import std.net;
 
 fn checked_recv_deadline(deadline_ms: i64) -> Result<i64, net.NetError> {
     if deadline_ms <= 0 {
@@ -319,7 +319,7 @@ pub fn connect(url: string) -> Result<Conn, net.NetError> {
         let detail = unsafe {
             hew_ws_last_error()
         };
-        return Err(net.NetError::InvalidArgument(detail));
+        return Err(net.NetError.InvalidArgument(detail));
     }
     Err(net.net_error_from_errno(errno))
 }
@@ -354,7 +354,7 @@ pub fn listen(addr: string) -> Result<Server, net.NetError> {
         let detail = unsafe {
             hew_ws_last_error()
         };
-        return Err(net.NetError::InvalidArgument(detail));
+        return Err(net.NetError.InvalidArgument(detail));
     }
     Err(net.net_error_from_errno(errno))
 }

--- a/std/os.hew
+++ b/std/os.hew
@@ -68,13 +68,13 @@ pub enum EnvError {
 /// Environment names must be non-empty and cannot contain `=`.
 pub fn set_env(name: string, value: string) -> Result<i64, EnvError> {
     if name == "" || name.contains("=") {
-        return Err(EnvError::InvalidName(name));
+        return Err(EnvError.InvalidName(name));
     }
     unsafe {
         if hew_env_set(name, value) == 0 {
             Ok(0)
         } else {
-            Err(EnvError::InvalidName(name))
+            Err(EnvError.InvalidName(name))
         }
     }
 }
@@ -84,13 +84,13 @@ pub fn set_env(name: string, value: string) -> Result<i64, EnvError> {
 /// Environment names must be non-empty and cannot contain `=`.
 pub fn remove_env(name: string) -> Result<i64, EnvError> {
     if name == "" || name.contains("=") {
-        return Err(EnvError::InvalidName(name));
+        return Err(EnvError.InvalidName(name));
     }
     unsafe {
         if hew_env_remove(name) == 0 {
             Ok(0)
         } else {
-            Err(EnvError::InvalidName(name))
+            Err(EnvError.InvalidName(name))
         }
     }
 }

--- a/std/path.hew
+++ b/std/path.hew
@@ -44,8 +44,8 @@ pub enum PathError {
 /// Return the human-readable detail carried by a `PathError`.
 pub fn path_error_message(err: PathError) -> string {
     match err {
-        PathError::GlobFailed(message) => message,
-        PathError::IndexOutOfRange(message) => message,
+        PathError.GlobFailed(message) => message,
+        PathError.IndexOutOfRange(message) => message,
     }
 }
 
@@ -154,7 +154,7 @@ pub fn try_glob(pattern: string) -> Result<GlobResult, PathError> {
             // double-free it.
             let detail = hew_glob_error(handle);
             hew_glob_free(handle);
-            Err(PathError::GlobFailed(detail))
+            Err(PathError.GlobFailed(detail))
         }
     }
 }

--- a/std/prelude.hew
+++ b/std/prelude.hew
@@ -4,14 +4,14 @@
 //! snapshots the resulting bindings before user declarations and imports so
 //! later compatibility registries cannot silently replace them.
 
-import std::builtins::*;
+import std.builtins::{Display, Index, IntoIterator, Iterator, Option, Result};
 
-import std::failure::{CrashInfo, CrashAction, CrashNotification, CrashKind};
+import std.failure::{CrashInfo, CrashAction, CrashNotification, CrashKind};
 
-import std::io::closable::{Closable, CloseError};
+import std.io.closable::{Closable, CloseError};
 
-import std::link_monitor::{MonitorError, PartitionPolicy, MonitorId, DownTarget, DownReason, DownNotification, MonitorRef, set_partition_policy,};
+import std.link_monitor::{MonitorError, PartitionPolicy, MonitorId, DownTarget, DownReason, DownNotification, MonitorRef, set_partition_policy,};
 
-import std::math as math;
+import std.math as math;
 
-import std::random as random;
+import std.random as random;

--- a/std/process.hew
+++ b/std/process.hew
@@ -27,7 +27,7 @@
 //! }
 //! ```
 
-import std::string;
+import std.string;
 
 /// A handle to a completed command invocation inside the runtime.
 #[resource]
@@ -119,8 +119,8 @@ fn empty_output() -> CommandOutput {
 
 fn process_error_message(err: ProcessError) -> string {
     match err {
-        ProcessError::InvalidArguments(message) => message,
-        ProcessError::LaunchFailed(message) => message,
+        ProcessError.InvalidArguments(message) => message,
+        ProcessError.LaunchFailed(message) => message,
     }
 }
 
@@ -129,12 +129,12 @@ fn last_process_error(default_message: string) -> ProcessError {
         let message = hew_process_last_error();
         hew_clear_error();
         if message == "" {
-            ProcessError::LaunchFailed(default_message)
+            ProcessError.LaunchFailed(default_message)
         } else {
             // Public argument-shape validation happens before FFI. A runtime
             // execution failure is therefore always a launch failure; never
             // classify it by searching attacker-controlled command text.
-            ProcessError::LaunchFailed(message)
+            ProcessError.LaunchFailed(message)
         }
     }
 }
@@ -153,7 +153,7 @@ fn legacy_packed_args_note() -> string {
 
 fn split_legacy_packed_args(args: string) -> Vec<string> {
     let raw_parts = string.split(args, " ");
-    let filtered: Vec<string> = Vec::new();
+    let filtered: Vec<string> = Vec.new();
     for i in 0 .. raw_parts.len() {
         let part = raw_parts[i];
         if part != "" {
@@ -229,11 +229,11 @@ pub fn run_argv(command: string, args: Vec<string>) -> CommandOutput {
 /// `try_run_argv(command, Vec<string>)`.
 pub fn try_run_args(command: string, args: string, arg_count: i64) -> Result<CommandOutput, ProcessError> {
     if arg_count < 0 {
-        return Err(ProcessError::InvalidArguments(f"process.try_run_args: arg_count must be non-negative ({legacy_packed_args_note()})"));
+        return Err(ProcessError.InvalidArguments(f"process.try_run_args: arg_count must be non-negative ({legacy_packed_args_note()})"));
     }
     let argv = split_legacy_packed_args(args);
     if argv.len() != arg_count {
-        return Err(ProcessError::InvalidArguments(f"process.try_run_args: arg_count {arg_count} does not match parsed argument length {argv.len()} ({legacy_packed_args_note()})"));
+        return Err(ProcessError.InvalidArguments(f"process.try_run_args: arg_count {arg_count} does not match parsed argument length {argv.len()} ({legacy_packed_args_note()})"));
     }
     try_run_argv(command, argv)
 }

--- a/std/sort/sort.hew
+++ b/std/sort/sort.hew
@@ -21,7 +21,7 @@
 
 // ── Helpers ───────────────────────────────────────────────────────────
 fn copy_ints(v: Vec<i64>) -> Vec<i64> {
-    let out: Vec<i64> = Vec::new();
+    let out: Vec<i64> = Vec.new();
     for i in 0 .. v.len() {
         out.push(v[i]);
     }
@@ -33,7 +33,7 @@ fn copy_strings(v: Vec<string>) -> Vec<string> {
 }
 
 fn copy_floats(v: Vec<f64>) -> Vec<f64> {
-    let out: Vec<f64> = Vec::new();
+    let out: Vec<f64> = Vec.new();
     for i in 0 .. v.len() {
         out.push(v[i]);
     }

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -39,7 +39,7 @@
 //! }
 //! ```
 
-import std::fs;
+import std.fs;
 
 /// A readable stream handle, parameterised by element type.
 pub type Stream<T> {

--- a/std/string.hew
+++ b/std/string.hew
@@ -654,7 +654,7 @@ pub fn split(s: string, sep: string) -> Vec<string> {
 /// let trail = string.lines("foo\n");     // ["foo", ""]
 /// ```
 pub fn lines(s: string) -> Vec<string> {
-    let result: Vec<string> = Vec::new();
+    let result: Vec<string> = Vec.new();
     let slen = s.len();
     var start = 0;
     while start < slen {
@@ -760,11 +760,11 @@ impl string {
     }
     #[extern_symbol(hew_string_split)]
     fn split(s: string, sep: string) -> Vec<string> {
-        Vec::new()
+        Vec.new()
     }
     #[extern_symbol(hew_string_lines)]
     fn lines(s: string) -> Vec<string> {
-        Vec::new()
+        Vec.new()
     }
     /// Return `Some` of the byte index of the first occurrence of `needle`,
     /// or `None` when `needle` does not occur.
@@ -796,7 +796,7 @@ impl string {
     }
     #[extern_symbol(hew_string_chars)]
     fn chars(s: string) -> Vec<char> {
-        Vec::new()
+        Vec.new()
     }
     /// Return the number of Unicode codepoints (runes) in this string.
     ///
@@ -820,7 +820,7 @@ impl string {
     /// reaching for raw FFI. The inverse is `bytes.to_string()`.
     #[extern_symbol(hew_string_to_bytes)]
     fn to_bytes(s: string) -> bytes {
-        bytes::new()
+        bytes.new()
     }
 }
 

--- a/std/text/semver/semver.hew
+++ b/std/text/semver/semver.hew
@@ -17,7 +17,7 @@
 //! }
 //! ```
 
-import std::string;
+import std.string;
 
 /// A parsed semantic version.
 type Version {

--- a/std/text/unicode/unicode.hew
+++ b/std/text/unicode/unicode.hew
@@ -375,7 +375,7 @@ pub fn try_rune_len(cp: i64) -> Result<i64, string> {
 /// ```
 pub fn runes(s: string) -> Vec<i64> {
     let n = s.char_count_utf8();
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     for i in 0 .. n {
         // In-bounds loop over the codepoint count: always Some. The
         // unreachable None is skipped rather than pushed as a sentinel.

--- a/std/time/cron/cron.hew
+++ b/std/time/cron/cron.hew
@@ -50,19 +50,19 @@ fn cron_last_error_message() -> string {
 
 fn cron_error_message(err: CronError) -> string {
     match err {
-        CronError::NoNextOccurrence(message) => message,
-        CronError::InvalidInput(message) => message,
-        CronError::InvalidEpoch(message) => message,
+        CronError.NoNextOccurrence(message) => message,
+        CronError.InvalidInput(message) => message,
+        CronError.InvalidEpoch(message) => message,
     }
 }
 
 fn cron_error_from_result(result: CronNextResult) -> CronError {
     let message = cron_last_error_message();
     match result.status {
-        1 => CronError::NoNextOccurrence(message),
-        2 => CronError::InvalidInput(message),
-        3 => CronError::InvalidEpoch(message),
-        _ => CronError::InvalidInput(message),
+        1 => CronError.NoNextOccurrence(message),
+        2 => CronError.InvalidInput(message),
+        3 => CronError.InvalidEpoch(message),
+        _ => CronError.InvalidInput(message),
     }
 }
 
@@ -168,9 +168,9 @@ extern "C" {
 // (rather than only the one or two arms existing FFI-level tests reach).
 fn cron_error_tag(err: CronError) -> i64 {
     match err {
-        CronError::NoNextOccurrence(_) => 1,
-        CronError::InvalidInput(_) => 2,
-        CronError::InvalidEpoch(_) => 3,
+        CronError.NoNextOccurrence(_) => 1,
+        CronError.InvalidInput(_) => 2,
+        CronError.InvalidEpoch(_) => 3,
     }
 }
 


### PR DESCRIPTION
Migrates the stdlib Hew sources to the dotted surface and finalizes the prelude imports.

Validation:
- make test-stdlib-ratchet
- make test-stdlib-execution-proofs
- make hew-fmt-check

The prelude retains the tracked root-compile E_HIR dual-symbol failure.