### PR TITLE
Migrate fixtures to dotted syntax

### DIFF
--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -24,18 +24,11 @@
 // Output contract (the harness asserts on these, with teeth):
 //   - "PASS <scenario> <detail>"  on success
 //   - "FAIL <scenario> <detail>"  on any mismatch; main returns non-zero
-import std::os;
+import std.os;
 
-import std::fs;
+import std.fs;
 
-import std::link_monitor::{
-    DownNotification,
-    DownReason,
-    DownTarget,
-    MonitorError,
-    MonitorRef,
-    PartitionPolicy,
-};
+import std.link_monitor.{DownNotification, DownReason, DownTarget, MonitorError, MonitorRef, PartitionPolicy,};
 
 // Self-stop FFI: the cross-node clean-exit scenario drives the remote actor to
 // the Stopped terminal state from within its own handler. `stop(self)` is not a
@@ -112,38 +105,38 @@ actor KeyValue {
     let store: HashMap<string, string>;
     receive fn handle(req: KvReq) -> KvResp {
         match req {
-            KvReq::Put(kv) => {
+            KvReq.Put(kv) => {
                 store.insert(kv.key, kv.val);
-                KvResp::Ack
+                KvResp.Ack
             },
-            KvReq::GetKey(k) => {
+            KvReq.GetKey(k) => {
                 match store.get(k) {
-                    Some(v) => KvResp::Value(v),
-                    None => KvResp::Value(""),
+                    .Some(v) => KvResp.Value(v),
+                    .None => KvResp.Value(""),
                 }
             },
             // Clean exit: the actor stops itself, transitioning to the Stopped
             // terminal state, which the cross-node monitor reports as a DOWN
             // carrying the clean-exit reason.
-            KvReq::StopSelf => {
+            KvReq.StopSelf => {
                 unsafe {
                     hew_actor_self_stop()
                 };
-                KvResp::Ack
+                KvResp.Ack
             },
             // Crash: a deliberate panic transitions the actor to the Crashed
             // terminal state, reported as a DOWN carrying the crash reason.
-            KvReq::CrashSelf => {
+            KvReq.CrashSelf => {
                 panic("crash requested by cross-node monitor scenario");
-                KvResp::Ack
+                KvResp.Ack
             },
             // Deterministic pend for scenario_partition_ask phase A: hold the
             // reply well past the client's ask deadline (3 s) so the armed
             // partition probe is the only path that can resolve the pending ask
             // early. The harness SIGKILLs this process before the sleep ends.
-            KvReq::Stall => {
+            KvReq.Stall => {
                 sleep(10s);
-                KvResp::Ack
+                KvResp.Ack
             },
         }
     }
@@ -164,8 +157,8 @@ actor WireProbe {
     let calls: i64;
     receive fn handle(cmd: WireCmd) -> WireResult {
         match cmd {
-            WireCmd::Ping => WireResult { tag: 0, sum: 0 },
-            WireCmd::Move(p) => WireResult { tag: 1, sum: p.x + p.y },
+            WireCmd.Ping => WireResult { tag: 0, sum: 0 },
+            WireCmd.Move(p) => WireResult { tag: 1, sum: p.x + p.y },
         }
     }
 }
@@ -191,12 +184,12 @@ enum IdentityResp {
 
 actor IdentityProbe {
     receive fn handle(_req: IdentityReq) -> IdentityResp {
-        let self_pid: Result<RemotePid<IdentityProbe>, LookupError> = Node::lookup("identity");
+        let self_pid: Result<RemotePid<IdentityProbe>, LookupError> = Node.lookup("identity");
         let identity = match self_pid {
-            Result::Ok(pid) => DistIdentity { node_id: to_string(pid.node_id()), slot: pid.slot(), incarnation: pid.incarnation() },
-            Result::Err(_) => DistIdentity { node_id: "", slot: 0, incarnation: 0 },
+            Result.Ok(pid) => DistIdentity { node_id: to_string(pid.node_id()), slot: pid.slot(), incarnation: pid.incarnation() },
+            Result.Err(_) => DistIdentity { node_id: "", slot: 0, incarnation: 0 },
         };
-        IdentityResp::Value(identity)
+        IdentityResp.Value(identity)
     }
 }
 
@@ -316,13 +309,13 @@ actor Linker {
     // can poll its terminal state.
     receive fn link_go(peer: RemotePid<KeyValue>) -> i64 {
         let status = if policy_sel == 0 {
-            link_remote(peer, PartitionPolicy::CrashLinked)
+            link_remote(peer, PartitionPolicy.CrashLinked)
         } else {
-            link_remote(peer, PartitionPolicy::MonitorLost)
+            link_remote(peer, PartitionPolicy.MonitorLost)
         };
         let ok = match status {
-            Result::Ok(_) => true,
-            Result::Err(_) => false,
+            Result.Ok(_) => true,
+            Result.Err(_) => false,
         };
         // Return this actor's process-local runtime id on success, 0 on failure.
         if ok {
@@ -349,22 +342,22 @@ actor MonitorProbe {
     receive fn arm(peer: RemotePid<KeyValue>, drive: i64) -> i64 {
         active_monitor = monitor(peer);
         expected_monitor_id = match active_monitor {
-            Result::Ok(monitor_ref) => monitor_ref.id().value,
-            Result::Err(_) => 0,
+            Result.Ok(monitor_ref) => monitor_ref.id().value,
+            Result.Err(_) => 0,
         };
         if expected_monitor_id == 0 {
             return 1;
         }
         if drive == 0 {
-            match peer.send(KvReq::StopSelf) {
-                Result::Ok(_) => 0,
-                Result::Err(_) => 2,
+            match peer.send(KvReq.StopSelf) {
+                Result.Ok(_) => 0,
+                Result.Err(_) => 2,
             }
         } else {
             if drive == 1 {
-                match peer.send(KvReq::CrashSelf) {
-                    Result::Ok(_) => 0,
-                    Result::Err(_) => 3,
+                match peer.send(KvReq.CrashSelf) {
+                    Result.Ok(_) => 0,
+                    Result.Err(_) => 3,
                 }
             } else {
                 0
@@ -698,17 +691,17 @@ actor MonitorProbe {
             return;
         }
         match note.target {
-            DownTarget::Remote(_) => {},
-            DownTarget::Local(_) => {
+            DownTarget.Remote(_) => {},
+            DownTarget.Local(_) => {
                 down_reason = -97;
                 return;
             },
         }
         down_reason = match note.reason {
-            DownReason::Exited => 6,
-            DownReason::Crashed(_) => 5,
-            DownReason::MonitorLost => -1,
-            DownReason::LocalShutdown => -3,
+            DownReason.Exited => 6,
+            DownReason.Crashed(_) => 5,
+            DownReason.MonitorLost => -1,
+            DownReason.LocalShutdown => -3,
         };
     }
 }
@@ -716,7 +709,6 @@ actor MonitorProbe {
 actor SetupRaceStopper {
     let monitor_target: LocalPid<KeyValue>;
     let link_target: LocalPid<KeyValue>;
-
     receive fn run() {
         var monitor_stopped = false;
         var link_stopped = false;
@@ -725,11 +717,11 @@ actor SetupRaceStopper {
                 hew_dist_setup_race_kind()
             };
             if kind == 1 && !monitor_stopped {
-                let _ = await monitor_target.handle(KvReq::StopSelf);
+                let _ = await monitor_target.handle(KvReq.StopSelf);
                 monitor_stopped = true;
             }
             if kind == 2 && !link_stopped {
-                let _ = await link_target.handle(KvReq::StopSelf);
+                let _ = await link_target.handle(KvReq.StopSelf);
                 link_stopped = true;
             }
             if monitor_stopped && link_stopped {
@@ -745,23 +737,21 @@ actor LinkSetupRaceProbe {
     var expected_monitor_id: u64 = 0;
     var down_count: i64 = 0;
     var down_reason: i64 = 100;
-
     receive fn arm(peer: RemotePid<KeyValue>) -> i64 {
         let linker = spawn Linker(policy_sel: 0);
         active_monitor = monitor(linker);
         expected_monitor_id = match active_monitor {
-            Result::Ok(monitor_ref) => monitor_ref.id().value,
-            Result::Err(_) => 0,
+            Result.Ok(monitor_ref) => monitor_ref.id().value,
+            Result.Err(_) => 0,
         };
         if expected_monitor_id == 0 {
             return 0;
         }
         match await linker.link_go(peer) {
-            Result::Ok(linker_id) => linker_id,
-            Result::Err(_) => 0,
+            Result.Ok(linker_id) => linker_id,
+            Result.Err(_) => 0,
         }
     }
-
     receive fn status() -> i64 {
         if down_count == 0 {
             100
@@ -773,7 +763,6 @@ actor LinkSetupRaceProbe {
             }
         }
     }
-
     #[on(down)]
     fn on_down(note: DownNotification) {
         down_count = down_count + 1;
@@ -782,17 +771,17 @@ actor LinkSetupRaceProbe {
             return;
         }
         match note.target {
-            DownTarget::Local(_) => {},
-            DownTarget::Remote(_) => {
+            DownTarget.Local(_) => {},
+            DownTarget.Remote(_) => {
                 down_reason = -97;
                 return;
             },
         }
         down_reason = match note.reason {
-            DownReason::Crashed(_) => 5,
-            DownReason::Exited => 6,
-            DownReason::MonitorLost => -1,
-            DownReason::LocalShutdown => -3,
+            DownReason.Crashed(_) => 5,
+            DownReason.Exited => 6,
+            DownReason.MonitorLost => -1,
+            DownReason.LocalShutdown => -3,
         };
     }
 }
@@ -803,9 +792,9 @@ actor MonitorSetupProbe {
         loop {
             let setup: Result<MonitorRef, MonitorError> = monitor(peer);
             match setup {
-                Result::Err(MonitorError::Partition) => return 0,
-                Result::Err(_) => return 2,
-                Result::Ok(monitor_ref) => {
+                Result.Err(MonitorError.Partition) => return 0,
+                Result.Err(_) => return 2,
+                Result.Ok(monitor_ref) => {
                     monitor_ref.close();
                     attempts = attempts + 1;
                     if attempts >= 100 {
@@ -822,8 +811,8 @@ actor MonitorCloseProbe {
     receive fn register_and_close(peer: RemotePid<KeyValue>) -> i64 {
         let setup: Result<MonitorRef, MonitorError> = monitor(peer);
         match setup {
-            Result::Err(_) => 1,
-            Result::Ok(monitor_ref) => {
+            Result.Err(_) => 1,
+            Result.Ok(monitor_ref) => {
                 println("READY_CLIENT_WATCHER cross_node_monitor_close_reclaim");
                 sleep(800ms);
                 monitor_ref.close();
@@ -836,15 +825,14 @@ actor MonitorCloseProbe {
 
 actor MonitorLeakProbe {
     var down_count: i64 = 0;
-
     receive fn run(peer: RemotePid<KeyValue>, iterations: i64) -> i64 {
         var completed: i64 = 0;
         var previous_id: u64 = 0;
         while completed < iterations {
             let setup: Result<MonitorRef, MonitorError> = monitor(peer);
             match setup {
-                Result::Err(_) => return -1,
-                Result::Ok(monitor_ref) => {
+                Result.Err(_) => return -1,
+                Result.Ok(monitor_ref) => {
                     let monitor_id = monitor_ref.id().value;
                     if monitor_id == 0 || monitor_id <= previous_id {
                         return -2;
@@ -867,7 +855,6 @@ actor MonitorLeakProbe {
         }
         completed
     }
-
     #[on(down)]
     fn on_down(_note: DownNotification) {
         down_count = down_count + 1;
@@ -898,8 +885,8 @@ fn wait_for_file(path: string) -> string {
 }
 
 fn stage_peer_credentials(kx: string, my_role: string, peer_role: string, peer_route_slot: u16) {
-    Node::load_keys(f"{kx}/{my_role}.key");
-    let me = Node::identity_key();
+    Node.load_keys(f"{kx}/{my_role}.key");
+    let me = Node.identity_key();
     publish_atomic(kx, f"{my_role}.pub", me);
     let peer_key = wait_for_file(f"{kx}/{peer_role}.pub");
     let configured_peer_key = if os.env("HEW_DIST_BAD_PEER_PIN") == "1" {
@@ -907,7 +894,7 @@ fn stage_peer_credentials(kx: string, my_role: string, peer_role: string, peer_r
     } else {
         peer_key
     };
-    Node::allow_peer(peer_route_slot, configured_peer_key);
+    Node.allow_peer(peer_route_slot, configured_peer_key);
 }
 
 fn signal_server_listening(kx: string) {
@@ -927,12 +914,12 @@ fn lookup_with_retry(name: string) -> Result<RemotePid<KeyValue>, LookupError> {
     };
     var attempts: i64 = 0;
     loop {
-        let found: Result<RemotePid<KeyValue>, LookupError> = Node::lookup(name);
+        let found: Result<RemotePid<KeyValue>, LookupError> = Node.lookup(name);
         match found {
-            Result::Ok(pid) => {
+            Result.Ok(pid) => {
                 return Ok(pid);
             },
-            Result::Err(e) => {
+            Result.Err(e) => {
                 attempts = attempts + 1;
                 if attempts >= max_attempts {
                     return Err(e);
@@ -946,12 +933,12 @@ fn lookup_with_retry(name: string) -> Result<RemotePid<KeyValue>, LookupError> {
 fn lookup_wire_with_retry(name: string) -> Result<RemotePid<WireProbe>, LookupError> {
     var attempts: i64 = 0;
     loop {
-        let found: Result<RemotePid<WireProbe>, LookupError> = Node::lookup(name);
+        let found: Result<RemotePid<WireProbe>, LookupError> = Node.lookup(name);
         match found {
-            Result::Ok(pid) => {
+            Result.Ok(pid) => {
                 return Ok(pid);
             },
-            Result::Err(e) => {
+            Result.Err(e) => {
                 attempts = attempts + 1;
                 if attempts >= 50 {
                     return Err(e);
@@ -965,12 +952,12 @@ fn lookup_wire_with_retry(name: string) -> Result<RemotePid<WireProbe>, LookupEr
 fn lookup_identity_with_retry(name: string) -> Result<RemotePid<IdentityProbe>, LookupError> {
     var attempts: i64 = 0;
     loop {
-        let found: Result<RemotePid<IdentityProbe>, LookupError> = Node::lookup(name);
+        let found: Result<RemotePid<IdentityProbe>, LookupError> = Node.lookup(name);
         match found {
-            Result::Ok(pid) => {
+            Result.Ok(pid) => {
                 return Ok(pid);
             },
-            Result::Err(e) => {
+            Result.Err(e) => {
                 attempts = attempts + 1;
                 if attempts >= 50 {
                     return Err(e);
@@ -984,27 +971,24 @@ fn lookup_identity_with_retry(name: string) -> Result<RemotePid<IdentityProbe>, 
 fn run_server(port: string, scenario: string) {
     let addr = f"127.0.0.1:{port}";
     let kx = os.env("HEW_DIST_KX_DIR");
-    Node::set_transport("tcp");
+    Node.set_transport("tcp");
     stage_peer_credentials(kx, "server", "client", 2);
-    Node::start(addr);
-    let s: HashMap<string, string> = HashMap::new();
+    Node.start(addr);
+    let s: HashMap<string, string> = HashMap.new();
     let kv = spawn KeyValue(store: s);
-    Node::register("kv", kv);
+    Node.register("kv", kv);
     let wp = spawn WireProbe(calls: 0);
-    Node::register("wire", wp);
+    Node.register("wire", wp);
     let identity = spawn IdentityProbe;
-    Node::register("identity", identity);
+    Node.register("identity", identity);
     if scenario == "remote_setup_exit_race" {
-        let monitor_store: HashMap<string, string> = HashMap::new();
+        let monitor_store: HashMap<string, string> = HashMap.new();
         let monitor_target = spawn KeyValue(store: monitor_store);
-        Node::register("monitor-race", monitor_target);
-        let link_store: HashMap<string, string> = HashMap::new();
+        Node.register("monitor-race", monitor_target);
+        let link_store: HashMap<string, string> = HashMap.new();
         let link_target = spawn KeyValue(store: link_store);
-        Node::register("link-race", link_target);
-        let stopper = spawn SetupRaceStopper(
-            monitor_target: monitor_target,
-            link_target: link_target
-        );
+        Node.register("link-race", link_target);
+        let stopper = spawn SetupRaceStopper(monitor_target: monitor_target, link_target: link_target);
         stopper.run();
     }
     signal_server_listening(kx);
@@ -1027,9 +1011,9 @@ fn run_server(port: string, scenario: string) {
                 let _ = unsafe {
                     hew_node_api_unregister("kv")
                 };
-                let s2: HashMap<string, string> = HashMap::new();
+                let s2: HashMap<string, string> = HashMap.new();
                 let kv2 = spawn KeyValue(store: s2);
-                Node::register("kv", kv2);
+                Node.register("kv", kv2);
                 println("SERVER_REPOINTED repoint_preserves_ref");
                 sleep(2m);
             } else {
@@ -1037,36 +1021,36 @@ fn run_server(port: string, scenario: string) {
             }
         }
     }
-    Node::shutdown();
+    Node.shutdown();
 }
 
 fn scenario_remote_ask(kv: RemotePid<KeyValue>) -> i64 {
-    let send1 = kv.send(KvReq::Put(KvPut { key: "hello", val: "world" }));
+    let send1 = kv.send(KvReq.Put(KvPut { key: "hello", val: "world" }));
     match send1 {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL remote_ask put-hello-send-error");
             return 2;
         },
-        Result::Ok(_) => {},
+        Result.Ok(_) => {},
     }
-    let send2 = kv.send(KvReq::Put(KvPut { key: "count", val: "42" }));
+    let send2 = kv.send(KvReq.Put(KvPut { key: "count", val: "42" }));
     match send2 {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL remote_ask put-count-send-error");
             return 3;
         },
-        Result::Ok(_) => {},
+        Result.Ok(_) => {},
     }
     sleep(200ms);
-    let ask1 = kv.ask(KvReq::GetKey("hello"), 5000);
+    let ask1 = kv.ask(KvReq.GetKey("hello"), 5000);
     match ask1 {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL remote_ask get-hello-ask-error");
             return 4;
         },
-        Result::Ok(resp) => {
+        Result.Ok(resp) => {
             match resp {
-                KvResp::Value(v) => {
+                KvResp.Value(v) => {
                     if v == "world" {
                         println("PASS remote_ask get-hello=world");
                     } else {
@@ -1074,22 +1058,22 @@ fn scenario_remote_ask(kv: RemotePid<KeyValue>) -> i64 {
                         return 5;
                     }
                 },
-                KvResp::Ack => {
+                KvResp.Ack => {
                     println("FAIL remote_ask get-hello-got-ack");
                     return 5;
                 },
             }
         },
     }
-    let ask2 = kv.ask(KvReq::GetKey("count"), 5000);
+    let ask2 = kv.ask(KvReq.GetKey("count"), 5000);
     match ask2 {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL remote_ask get-count-ask-error");
             return 6;
         },
-        Result::Ok(resp) => {
+        Result.Ok(resp) => {
             match resp {
-                KvResp::Value(v) => {
+                KvResp.Value(v) => {
                     if v == "42" {
                         println("PASS remote_ask get-count=42");
                     } else {
@@ -1097,7 +1081,7 @@ fn scenario_remote_ask(kv: RemotePid<KeyValue>) -> i64 {
                         return 7;
                     }
                 },
-                KvResp::Ack => {
+                KvResp.Ack => {
                     println("FAIL remote_ask get-count-got-ack");
                     return 7;
                 },
@@ -1108,13 +1092,13 @@ fn scenario_remote_ask(kv: RemotePid<KeyValue>) -> i64 {
 }
 
 fn scenario_wire_cbor(wp: RemotePid<WireProbe>) -> i64 {
-    let ask_move = wp.ask(WireCmd::Move(WirePoint { x: 3, y: 4 }), 5000);
+    let ask_move = wp.ask(WireCmd.Move(WirePoint { x: 3, y: 4 }), 5000);
     match ask_move {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL wire_cbor move-ask-error");
             return 2;
         },
-        Result::Ok(res) => {
+        Result.Ok(res) => {
             if res.tag == 1 {
                 println(f"PASS wire_cbor move-tag={res.tag}");
             } else {
@@ -1129,13 +1113,13 @@ fn scenario_wire_cbor(wp: RemotePid<WireProbe>) -> i64 {
             }
         },
     }
-    let ask_ping = wp.ask(WireCmd::Ping, 5000);
+    let ask_ping = wp.ask(WireCmd.Ping, 5000);
     match ask_ping {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL wire_cbor ping-ask-error");
             return 5;
         },
-        Result::Ok(res) => {
+        Result.Ok(res) => {
             if res.tag == 0 {
                 println(f"PASS wire_cbor ping-tag={res.tag}");
             } else {
@@ -1154,9 +1138,9 @@ fn scenario_wire_cbor(wp: RemotePid<WireProbe>) -> i64 {
 }
 
 fn scenario_identity_location(identity: RemotePid<IdentityProbe>) -> i64 {
-    let local_node = match Node::id() {
-        Some(id) => id,
-        None => {
+    let local_node = match Node.id() {
+        .Some(id) => id,
+        .None => {
             println("FAIL identity_location local-node-id-missing");
             return 2;
         },
@@ -1172,15 +1156,15 @@ fn scenario_identity_location(identity: RemotePid<IdentityProbe>) -> i64 {
         println("FAIL identity_location slot-zero");
         return 4;
     }
-    let inspected = identity.ask(IdentityReq::Inspect, 5000);
+    let inspected = identity.ask(IdentityReq.Inspect, 5000);
     match inspected {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL identity_location inspect-ask-error");
             return 7;
         },
-        Result::Ok(resp) => {
+        Result.Ok(resp) => {
             match resp {
-                IdentityResp::Value(actual) => {
+                IdentityResp.Value(actual) => {
                     if actual.node_id != to_string(remote_node) {
                         println("FAIL identity_location node-mismatch");
                         return 8;
@@ -1236,16 +1220,11 @@ fn scenario_identity_display(identity: RemotePid<IdentityProbe>, scenario: strin
 }
 
 fn monitor_hook_scenario(kv: RemotePid<KeyValue>, scenario: string, drive: i64, expected: i64, ready_drop: bool) -> i64 {
-    let probe = spawn MonitorProbe(
-        active_monitor: Err(MonitorError::InvalidTarget),
-        expected_monitor_id: 0,
-        down_count: 0,
-        down_reason: 100
-    );
+    let probe = spawn MonitorProbe(active_monitor: Err(MonitorError.InvalidTarget), expected_monitor_id: 0, down_count: 0, down_reason: 100);
     let armed = await probe.arm(kv, drive);
     let arm_status = match armed {
-        Result::Ok(status) => status,
-        Result::Err(_) => {
+        Result.Ok(status) => status,
+        Result.Err(_) => {
             println(f"FAIL {scenario} arm-ask-error");
             return 2;
         },
@@ -1256,8 +1235,8 @@ fn monitor_hook_scenario(kv: RemotePid<KeyValue>, scenario: string, drive: i64, 
     }
     let id_result = await probe.monitor_id();
     let monitor_id = match id_result {
-        Result::Ok(value) => value,
-        Result::Err(_) => {
+        Result.Ok(value) => value,
+        Result.Err(_) => {
             println(f"FAIL {scenario} monitor-id-ask-error");
             return 9;
         },
@@ -1273,8 +1252,8 @@ fn monitor_hook_scenario(kv: RemotePid<KeyValue>, scenario: string, drive: i64, 
     loop {
         let status = await probe.status();
         let observed = match status {
-            Result::Ok(value) => value,
-            Result::Err(_) => {
+            Result.Ok(value) => value,
+            Result.Err(_) => {
                 println(f"FAIL {scenario} status-ask-error");
                 return 4;
             },
@@ -1297,13 +1276,13 @@ fn monitor_hook_scenario(kv: RemotePid<KeyValue>, scenario: string, drive: i64, 
     sleep(1200ms);
     let duplicate_check = await probe.status();
     match duplicate_check {
-        Result::Ok(value) => {
+        Result.Ok(value) => {
             if value != expected {
                 println(f"FAIL {scenario} duplicate-status={value}");
                 return 7;
             }
         },
-        Result::Err(_) => {
+        Result.Err(_) => {
             println(f"FAIL {scenario} duplicate-check-error");
             return 8;
         },
@@ -1329,7 +1308,7 @@ fn scenario_remote_monitor_setup_after_drop(kv: RemotePid<KeyValue>) -> i64 {
     let probe = spawn MonitorSetupProbe;
     println("READY_DROP remote_monitor_setup_after_drop");
     match await probe.wait_for_partition(kv) {
-        Result::Ok(status) => {
+        Result.Ok(status) => {
             if status == 0 {
                 println("PASS remote_monitor_setup_after_drop error=Partition");
                 0
@@ -1343,38 +1322,23 @@ fn scenario_remote_monitor_setup_after_drop(kv: RemotePid<KeyValue>) -> i64 {
                 }
             }
         },
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL remote_monitor_setup_after_drop probe-error");
             4
         },
     }
 }
 
-fn scenario_remote_setup_exit_race(
-    monitor_target: RemotePid<KeyValue>,
-    link_target: RemotePid<KeyValue>
-) -> i64 {
-    let monitor_status = monitor_hook_scenario(
-        monitor_target,
-        "remote_setup_exit_race_monitor",
-        2,
-        -1,
-        false
-    );
+fn scenario_remote_setup_exit_race(monitor_target: RemotePid<KeyValue>, link_target: RemotePid<KeyValue>) -> i64 {
+    let monitor_status = monitor_hook_scenario(monitor_target, "remote_setup_exit_race_monitor", 2, -1, false);
     if monitor_status != 0 {
         return monitor_status;
     }
-
-    let probe = spawn LinkSetupRaceProbe(
-        active_monitor: Err(MonitorError::InvalidTarget),
-        expected_monitor_id: 0,
-        down_count: 0,
-        down_reason: 100
-    );
+    let probe = spawn LinkSetupRaceProbe(active_monitor: Err(MonitorError.InvalidTarget), expected_monitor_id: 0, down_count: 0, down_reason: 100);
     let armed = await probe.arm(link_target);
     let linker_id = match armed {
-        Result::Ok(value) => value,
-        Result::Err(_) => {
+        Result.Ok(value) => value,
+        Result.Err(_) => {
             println("FAIL remote_setup_exit_race link-arm-error");
             return 20;
         },
@@ -1387,8 +1351,8 @@ fn scenario_remote_setup_exit_race(
     loop {
         let status = await probe.status();
         let observed = match status {
-            Result::Ok(value) => value,
-            Result::Err(_) => {
+            Result.Ok(value) => value,
+            Result.Err(_) => {
                 println("FAIL remote_setup_exit_race link-status-error");
                 return 22;
             },
@@ -1410,13 +1374,13 @@ fn scenario_remote_setup_exit_race(
     println("PASS remote_setup_exit_race link-down=5");
     sleep(1200ms);
     match await probe.status() {
-        Result::Ok(value) => {
+        Result.Ok(value) => {
             if value != 5 {
                 println(f"FAIL remote_setup_exit_race link-duplicate={value}");
                 return 25;
             }
         },
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL remote_setup_exit_race link-duplicate-check-error");
             return 26;
         },
@@ -1429,7 +1393,6 @@ fn scenario_partition_ask(kv: RemotePid<KeyValue>) -> i64 {
     let injector = spawn PartitionInjector;
     injector.arm();
     let fast_fail_ceiling_ms: i64 = 900;
-
     // Phase A — the armed probe must PROVE it fired. The route is still live
     // (READY_DROP has not been printed, so the harness has not killed the
     // server) and KvReq::Stall holds the server-side reply past this ask's
@@ -1438,17 +1401,17 @@ fn scenario_partition_ask(kv: RemotePid<KeyValue>) -> i64 {
     // reply arrives, no socket drops, no route is torn down. A broken or
     // no-op probe surfaces here as a deadline timeout -> FAIL, instead of
     // hiding behind the kill's routing-failure / socket-drop outcomes.
-    let probe_started = instant::now();
-    let probe = kv.ask(KvReq::Stall, 3000);
+    let probe_started = instant.now();
+    let probe = kv.ask(KvReq.Stall, 3000);
     let probe_elapsed = probe_started.elapsed().millis();
     match probe {
-        Result::Ok(_) => {
+        Result.Ok(_) => {
             println("FAIL partition_ask probe-replied");
             return 4;
         },
-        Result::Err(e) => {
+        Result.Err(e) => {
             match e {
-                AskError::Partition => {
+                AskError.Partition => {
                     if probe_elapsed >= fast_fail_ceiling_ms {
                         println(f"FAIL partition_ask probe-slow ms={probe_elapsed}");
                         return 5;
@@ -1462,7 +1425,6 @@ fn scenario_partition_ask(kv: RemotePid<KeyValue>) -> i64 {
             }
         },
     }
-
     // Phase B — the real-teardown no-hang gate: kill the server, then the ask
     // must fail closed with ANY typed cause without hanging. Re-arm the
     // injector (phase A consumed its first arm) so the typed verdict again
@@ -1472,11 +1434,11 @@ fn scenario_partition_ask(kv: RemotePid<KeyValue>) -> i64 {
     let ask_timeout_ms: u64 = 1000;
     var attempts: i64 = 0;
     loop {
-        let started = instant::now();
-        let probe = kv.ask(KvReq::GetKey("hello"), ask_timeout_ms);
+        let started = instant.now();
+        let probe = kv.ask(KvReq.GetKey("hello"), ask_timeout_ms);
         let elapsed_ms = started.elapsed().millis();
         match probe {
-            Result::Ok(_) => {
+            Result.Ok(_) => {
                 attempts = attempts + 1;
                 if attempts >= 20 {
                     println("FAIL partition_ask never-partitioned");
@@ -1484,9 +1446,9 @@ fn scenario_partition_ask(kv: RemotePid<KeyValue>) -> i64 {
                 }
                 sleep(200ms);
             },
-            Result::Err(e) => {
+            Result.Err(e) => {
                 let timed_out = match e {
-                    AskError::Timeout => true,
+                    AskError.Timeout => true,
                     _ => elapsed_ms >= fast_fail_ceiling_ms,
                 };
                 if timed_out {
@@ -1498,12 +1460,12 @@ fn scenario_partition_ask(kv: RemotePid<KeyValue>) -> i64 {
                     sleep(200ms);
                 } else {
                     match e {
-                        AskError::Partition => println(f"PASS partition_ask reason=partition ms={elapsed_ms}"),
-                        AskError::ConnectionDropped => println(f"PASS partition_ask reason=conn-dropped ms={elapsed_ms}"),
-                        AskError::RoutingFailed => println(f"PASS partition_ask reason=routing-failed ms={elapsed_ms}"),
-                        AskError::NodeNotRunning => println(f"PASS partition_ask reason=node-not-running ms={elapsed_ms}"),
-                        AskError::SendFailed => println(f"PASS partition_ask reason=send-failed ms={elapsed_ms}"),
-                        AskError::StaleRef => println(f"PASS partition_ask reason=stale-ref ms={elapsed_ms}"),
+                        AskError.Partition => println(f"PASS partition_ask reason=partition ms={elapsed_ms}"),
+                        AskError.ConnectionDropped => println(f"PASS partition_ask reason=conn-dropped ms={elapsed_ms}"),
+                        AskError.RoutingFailed => println(f"PASS partition_ask reason=routing-failed ms={elapsed_ms}"),
+                        AskError.NodeNotRunning => println(f"PASS partition_ask reason=node-not-running ms={elapsed_ms}"),
+                        AskError.SendFailed => println(f"PASS partition_ask reason=send-failed ms={elapsed_ms}"),
+                        AskError.StaleRef => println(f"PASS partition_ask reason=stale-ref ms={elapsed_ms}"),
                         _ => println(f"PASS partition_ask reason=fail-closed ms={elapsed_ms}"),
                     }
                     return 0;
@@ -1514,19 +1476,19 @@ fn scenario_partition_ask(kv: RemotePid<KeyValue>) -> i64 {
 }
 
 fn scenario_repoint_preserves_ref(kv: RemotePid<KeyValue>) -> i64 {
-    let seeded = kv.ask(KvReq::Put(KvPut { key: "owner", val: "original" }), 5000);
+    let seeded = kv.ask(KvReq.Put(KvPut { key: "owner", val: "original" }), 5000);
     match seeded {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL repoint_preserves_ref seed-error");
             return 2;
         },
-        Result::Ok(_) => {},
+        Result.Ok(_) => {},
     }
     var attempts: i64 = 0;
     loop {
-        let current: Result<RemotePid<KeyValue>, LookupError> = Node::lookup("kv");
+        let current: Result<RemotePid<KeyValue>, LookupError> = Node.lookup("kv");
         match current {
-            Result::Err(_) => {
+            Result.Err(_) => {
                 attempts = attempts + 1;
                 if attempts >= 60 {
                     println("FAIL repoint_preserves_ref lookup-error");
@@ -1534,7 +1496,7 @@ fn scenario_repoint_preserves_ref(kv: RemotePid<KeyValue>) -> i64 {
                 }
                 sleep(100ms);
             },
-            Result::Ok(replacement) => {
+            Result.Ok(replacement) => {
                 if replacement == kv {
                     attempts = attempts + 1;
                     if attempts >= 60 {
@@ -1543,34 +1505,34 @@ fn scenario_repoint_preserves_ref(kv: RemotePid<KeyValue>) -> i64 {
                     }
                     sleep(100ms);
                 } else {
-                    let old_value = kv.ask(KvReq::GetKey("owner"), 5000);
+                    let old_value = kv.ask(KvReq.GetKey("owner"), 5000);
                     match old_value {
-                        Result::Err(_) => {
+                        Result.Err(_) => {
                             println("FAIL repoint_preserves_ref captured-ref-error");
                             return 5;
                         },
-                        Result::Ok(KvResp::Ack) => {
+                        Result.Ok(KvResp.Ack) => {
                             println("FAIL repoint_preserves_ref captured-ref-ack");
                             return 6;
                         },
-                        Result::Ok(KvResp::Value(v)) => {
+                        Result.Ok(KvResp.Value(v)) => {
                             if v != "original" {
                                 println("FAIL repoint_preserves_ref captured-ref-wrong-actor");
                                 return 7;
                             }
                         },
                     }
-                    let new_value = replacement.ask(KvReq::GetKey("owner"), 5000);
+                    let new_value = replacement.ask(KvReq.GetKey("owner"), 5000);
                     match new_value {
-                        Result::Err(_) => {
+                        Result.Err(_) => {
                             println("FAIL repoint_preserves_ref replacement-error");
                             return 8;
                         },
-                        Result::Ok(KvResp::Ack) => {
+                        Result.Ok(KvResp.Ack) => {
                             println("FAIL repoint_preserves_ref replacement-ack");
                             return 9;
                         },
-                        Result::Ok(KvResp::Value(v)) => {
+                        Result.Ok(KvResp.Value(v)) => {
                             if v != "" {
                                 println("FAIL repoint_preserves_ref replacement-not-fresh");
                                 return 10;
@@ -1634,18 +1596,13 @@ fn scenario_server_watcher_node_death(_kv_serial: i64) {
 }
 
 fn scenario_client_watcher_node_death(kv: RemotePid<KeyValue>) -> i64 {
-    let probe = spawn MonitorProbe(
-        active_monitor: Err(MonitorError::InvalidTarget),
-        expected_monitor_id: 0,
-        down_count: 0,
-        down_reason: 100
-    );
+    let probe = spawn MonitorProbe(active_monitor: Err(MonitorError.InvalidTarget), expected_monitor_id: 0, down_count: 0, down_reason: 100);
     match await probe.arm(kv, 2) {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL monitor_watcher_node_death arm-ask-error");
             2
         },
-        Result::Ok(status) => {
+        Result.Ok(status) => {
             if status != 0 {
                 println(f"FAIL monitor_watcher_node_death arm-status={status}");
                 return 3;
@@ -1661,8 +1618,8 @@ fn link_cascade_common(kv: RemotePid<KeyValue>, scenario: string, drive: string)
     let linker = spawn Linker(policy_sel: 0);
     let linker_id = await linker.link_go(kv);
     let lid = match linker_id {
-        Result::Ok(id) => id,
-        Result::Err(_) => {
+        Result.Ok(id) => id,
+        Result.Err(_) => {
             println(f"FAIL {scenario} link-ask-error");
             return 2;
         },
@@ -1673,35 +1630,35 @@ fn link_cascade_common(kv: RemotePid<KeyValue>, scenario: string, drive: string)
     }
     let live = await linker.ping();
     match live {
-        Result::Ok(value) => {
+        Result.Ok(value) => {
             if value != 7 {
                 println(f"FAIL {scenario} linker-pre-cascade-wrong value={value}");
                 return 7;
             }
         },
-        Result::Err(_) => {
+        Result.Err(_) => {
             println(f"FAIL {scenario} linker-died-during-setup");
             return 7;
         },
     }
     if drive == "stop" {
-        let t = kv.send(KvReq::StopSelf);
+        let t = kv.send(KvReq.StopSelf);
         match t {
-            Result::Err(_) => {
+            Result.Err(_) => {
                 println(f"FAIL {scenario} stop-send-error");
                 return 4;
             },
-            Result::Ok(_) => {},
+            Result.Ok(_) => {},
         }
     } else {
         if drive == "crash" {
-            let t = kv.send(KvReq::CrashSelf);
+            let t = kv.send(KvReq.CrashSelf);
             match t {
-                Result::Err(_) => {
+                Result.Err(_) => {
                     println(f"FAIL {scenario} crash-send-error");
                     return 4;
                 },
-                Result::Ok(_) => {},
+                Result.Ok(_) => {},
             }
         }
     }
@@ -1746,8 +1703,8 @@ fn scenario_link_remote_non_crashlinked(kv: RemotePid<KeyValue>) -> i64 {
     let linker = spawn Linker(policy_sel: 1);
     let linker_id = await linker.link_go(kv);
     let lid = match linker_id {
-        Result::Ok(id) => id,
-        Result::Err(_) => {
+        Result.Ok(id) => id,
+        Result.Err(_) => {
             println("FAIL link_remote_non_crashlinked link-ask-error");
             return 2;
         },
@@ -1756,13 +1713,13 @@ fn scenario_link_remote_non_crashlinked(kv: RemotePid<KeyValue>) -> i64 {
         println("FAIL link_remote_non_crashlinked link-register-failed");
         return 3;
     }
-    let t = kv.send(KvReq::StopSelf);
+    let t = kv.send(KvReq.StopSelf);
     match t {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL link_remote_non_crashlinked stop-send-error");
             return 4;
         },
-        Result::Ok(_) => {},
+        Result.Ok(_) => {},
     }
     sleep(1500ms);
     let st = unsafe {
@@ -1774,11 +1731,11 @@ fn scenario_link_remote_non_crashlinked(kv: RemotePid<KeyValue>) -> i64 {
     }
     let ping = await linker.ping();
     match ping {
-        Result::Ok(_) => {
+        Result.Ok(_) => {
             println("PASS link_remote_non_crashlinked linker-survived");
             0
         },
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL link_remote_non_crashlinked linker-unreachable");
             6
         },
@@ -1842,11 +1799,11 @@ fn scenario_server_monitor_close_reclaim() {
 fn scenario_client_monitor_close_reclaim(kv: RemotePid<KeyValue>) -> i64 {
     let probe = spawn MonitorCloseProbe;
     match await probe.register_and_close(kv) {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("FAIL cross_node_monitor_close_reclaim probe-error");
             2
         },
-        Result::Ok(status) => {
+        Result.Ok(status) => {
             if status != 0 {
                 println("FAIL cross_node_monitor_close_reclaim setup-error");
                 return 1;
@@ -1917,11 +1874,11 @@ fn scenario_server_monitor_leak(kx: string, scenario: string, expected: i64) {
 fn scenario_client_monitor_leak(kv: RemotePid<KeyValue>, kx: string, scenario: string, iterations: i64) -> i64 {
     let probe = spawn MonitorLeakProbe(down_count: 0);
     match await probe.run(kv, iterations) {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println(f"FAIL {scenario} probe-ask-error");
             2
         },
-        Result::Ok(completed) => {
+        Result.Ok(completed) => {
             if completed != iterations {
                 println(f"FAIL {scenario} completed={completed}");
                 return 3;
@@ -2006,11 +1963,11 @@ fn scenario_quarantine_rejoin() -> i64 {
 
 fn scenario_handshake_reject() -> i64 {
     match lookup_with_retry("kv") {
-        Result::Err(_) => {
+        Result.Err(_) => {
             println("PASS handshake_reject unroutable");
             0
         },
-        Result::Ok(_) => {
+        Result.Ok(_) => {
             println("FAIL handshake_reject unauthorized-peer-routable");
             2
         },
@@ -2022,43 +1979,42 @@ fn scenario_stale_incarnation_restart(old: RemotePid<KeyValue>, kx: string, port
     let old_incarnation = old.incarnation();
     println(f"READY_STALE_CAPTURED node={old_node} incarnation={old_incarnation}");
     let _ = wait_for_file(f"{kx}/server.restarted");
-    Node::connect(f"1@127.0.0.1:{port}");
-
+    Node.connect(f"1@127.0.0.1:{port}");
     var attempts: i64 = 0;
     loop {
-        let candidate: Result<RemotePid<KeyValue>, LookupError> = Node::lookup("kv");
+        let candidate: Result<RemotePid<KeyValue>, LookupError> = Node.lookup("kv");
         match candidate {
-            Result::Ok(fresh) => {
+            Result.Ok(fresh) => {
                 let fresh_incarnation = fresh.incarnation();
                 if fresh.node_id() == old_node && fresh_incarnation > old_incarnation {
-                    match fresh.ask(KvReq::GetKey("restart-proof"), 5000) {
-                        Result::Err(_) => {
+                    match fresh.ask(KvReq.GetKey("restart-proof"), 5000) {
+                        Result.Err(_) => {
                             println("FAIL stale_incarnation_restart fresh-pid-unusable");
                             return 4;
                         },
-                        Result::Ok(KvResp::Ack) => {
+                        Result.Ok(KvResp.Ack) => {
                             println("FAIL stale_incarnation_restart fresh-pid-wrong-reply");
                             return 5;
                         },
-                        Result::Ok(KvResp::Value(_)) => {},
+                        Result.Ok(KvResp.Value(_)) => {},
                     }
-                    match old.ask(KvReq::GetKey("restart-proof"), 5000) {
-                        Result::Err(AskError::StaleRef) => {
+                    match old.ask(KvReq.GetKey("restart-proof"), 5000) {
+                        Result.Err(AskError.StaleRef) => {
                             println(f"PASS stale_incarnation_restart old={old_incarnation} new={fresh_incarnation} error=StaleRef");
                             return 0;
                         },
-                        Result::Err(_) => {
+                        Result.Err(_) => {
                             println("FAIL stale_incarnation_restart old-pid-wrong-error");
                             return 6;
                         },
-                        Result::Ok(_) => {
+                        Result.Ok(_) => {
                             println("FAIL stale_incarnation_restart old-pid-succeeded");
                             return 7;
                         },
                     }
                 }
             },
-            Result::Err(_) => {},
+            Result.Err(_) => {},
         }
         attempts = attempts + 1;
         if attempts >= 200 {
@@ -2071,12 +2027,12 @@ fn scenario_stale_incarnation_restart(old: RemotePid<KeyValue>, kx: string, port
 
 fn run_client(port: string, scenario: string) -> i64 {
     let kx = os.env("HEW_DIST_KX_DIR");
-    Node::set_transport("tcp");
+    Node.set_transport("tcp");
     stage_peer_credentials(kx, "client", "server", 1);
-    Node::start("127.0.0.1:0");
+    Node.start("127.0.0.1:0");
     wait_for_server_listening(kx);
     let remote_addr = f"1@127.0.0.1:{port}";
-    Node::connect(remote_addr);
+    Node.connect(remote_addr);
     let status = if scenario == "handshake_reject" {
         scenario_handshake_reject()
     } else if scenario == "quarantine_rejoin" {
@@ -2084,11 +2040,11 @@ fn run_client(port: string, scenario: string) -> i64 {
     } else if scenario == "identity_location" || scenario == "identity_display_low" || scenario == "identity_display_high" {
         let found_identity = lookup_identity_with_retry("identity");
         match found_identity {
-            Result::Err(_) => {
+            Result.Err(_) => {
                 println(f"FAIL {scenario} lookup-unresolved");
                 1
             },
-            Result::Ok(identity) => {
+            Result.Ok(identity) => {
                 if scenario == "identity_location" {
                     scenario_identity_location(identity)
                 } else {
@@ -2103,29 +2059,29 @@ fn run_client(port: string, scenario: string) -> i64 {
     } else if scenario == "wire_cbor" {
         let found_wire = lookup_wire_with_retry("wire");
         match found_wire {
-            Result::Err(_) => {
+            Result.Err(_) => {
                 println(f"FAIL {scenario} lookup-unresolved");
                 1
             },
-            Result::Ok(wp) => {
+            Result.Ok(wp) => {
                 scenario_wire_cbor(wp)
             },
         }
     } else if scenario == "remote_setup_exit_race" {
         let monitor_found = lookup_with_retry("monitor-race");
         match monitor_found {
-            Result::Err(_) => {
+            Result.Err(_) => {
                 println("FAIL remote_setup_exit_race monitor-lookup-unresolved");
                 1
             },
-            Result::Ok(monitor_target) => {
+            Result.Ok(monitor_target) => {
                 let link_found = lookup_with_retry("link-race");
                 match link_found {
-                    Result::Err(_) => {
+                    Result.Err(_) => {
                         println("FAIL remote_setup_exit_race link-lookup-unresolved");
                         1
                     },
-                    Result::Ok(link_target) => {
+                    Result.Ok(link_target) => {
                         scenario_remote_setup_exit_race(monitor_target, link_target)
                     },
                 }
@@ -2134,11 +2090,11 @@ fn run_client(port: string, scenario: string) -> i64 {
     } else {
         let found = lookup_with_retry("kv");
         match found {
-            Result::Err(_) => {
+            Result.Err(_) => {
                 println(f"FAIL {scenario} lookup-unresolved");
                 1
             },
-            Result::Ok(kv) => {
+            Result.Ok(kv) => {
                 if scenario == "stale_incarnation_restart" {
                     scenario_stale_incarnation_restart(kv, kx, port)
                 } else if scenario == "remote_ask" {
@@ -2206,7 +2162,7 @@ fn run_client(port: string, scenario: string) -> i64 {
             },
         }
     };
-    Node::shutdown();
+    Node.shutdown();
     status
 }
 

--- a/hew-cli/tests/fixtures/explain_cow_actor_sends.hew
+++ b/hew-cli/tests/fixtures/explain_cow_actor_sends.hew
@@ -7,13 +7,11 @@
 // The golden test verifies that both sites appear in --explain-cow output
 // with MIR-authored ownership modes.
 actor Printer {
-    receive fn print_message(msg: string) {
-    }
+    receive fn print_message(msg: string) {}
 }
 
 actor Counter {
-    receive fn increment(amount: i64) {
-    }
+    receive fn increment(amount: i64) {}
 }
 
 fn main() {

--- a/hew-cli/tests/fixtures/generic_ctor_return_type_mono.hew
+++ b/hew-cli/tests/fixtures/generic_ctor_return_type_mono.hew
@@ -17,7 +17,7 @@ type Stack<T> {
 
 impl<T> Stack<T> {
     fn new() -> Stack<T> {
-        Stack { items: Vec::new() }
+        Stack { items: Vec.new() }
     }
     fn push(self, x: T) {
         self.items.push(x);
@@ -28,17 +28,17 @@ impl<T> Stack<T> {
 }
 
 fn new_stack<T>() -> Stack<T> {
-    Stack { items: Vec::new() }
+    Stack { items: Vec.new() }
 }
 
 // Return-position inference: `T` comes from the enclosing fn's return type.
 fn make_strings() -> Stack<string> {
-    Stack::new()
+    Stack.new()
 }
 
 fn main() {
     // assoc-fn ctor, `T` (= i64) from the `let` annotation
-    let a: Stack<i64> = Stack::new();
+    let a: Stack<i64> = Stack.new();
     a.push(1);
     a.push(2);
     println(a.len());
@@ -57,8 +57,8 @@ fn main() {
 
     // nested: Stack<Stack<i64>> — both the outer and inner ctor are
     // return-type-polymorphic
-    let outer: Stack<Stack<i64>> = Stack::new();
-    let inner: Stack<i64> = Stack::new();
+    let outer: Stack<Stack<i64>> = Stack.new();
+    let inner: Stack<i64> = Stack.new();
     inner.push(10);
     outer.push(inner);
     println(outer.len());
@@ -67,7 +67,7 @@ fn main() {
     // type parameter is pinned at the call site, not by the expected type. This
     // surface already lowered before the F7 fix; pinning it here guards the
     // whole constructor family against regression.
-    let t = Stack::<i64>::new();
+    let t = Stack<i64>.new();
     t.push(100);
     t.push(200);
     t.push(300);

--- a/hew-cli/tests/fixtures/generic_enum_mono.hew
+++ b/hew-cli/tests/fixtures/generic_enum_mono.hew
@@ -8,19 +8,19 @@ enum Holder<T> {
 }
 
 fn wrap<T>(x: T) -> Holder<T> {
-    Holder::Present(x)
+    Holder.Present(x)
 }
 
 fn unwrap_or<T>(h: Holder<T>, fallback: T) -> T {
     match h {
-        Holder::Present(v) => v,
-        Holder::Absent => fallback,
+        Holder.Present(v) => v,
+        Holder.Absent => fallback,
     }
 }
 
 fn main() {
     let present = wrap(99);
     println(unwrap_or(present, 0));
-    let absent: Holder<i64> = Holder::Absent;
+    let absent: Holder<i64> = Holder.Absent;
     println(unwrap_or(absent, 42));
 }

--- a/hew-cli/tests/fixtures/generic_enum_record_scope_drop.hew
+++ b/hew-cli/tests/fixtures/generic_enum_record_scope_drop.hew
@@ -1,4 +1,4 @@
-import std::string;
+import std.string;
 
 enum Choice<T> {
     Present(T);
@@ -11,23 +11,17 @@ record EnumHolder<T> {
 }
 
 fn replace_many(frames: i64) -> i64 {
-    var enums = EnumHolder {
-        item: Choice::Present(string.repeat("initial", 8)),
-        count: 0,
-    };
+    var enums = EnumHolder { item: Choice.Present(string.repeat("initial", 8)), count: 0 };
     var i = 0;
     while i < frames {
-        enums.item = Choice::Present(string.repeat("replacement", 8));
+        enums.item = Choice.Present(string.repeat("replacement", 8));
         i = i + 1;
     }
     enums.count
 }
 
 fn untouched() -> i64 {
-    let enums = EnumHolder {
-        item: Choice::Present(string.repeat("untouched", 8)),
-        count: 0,
-    };
+    let enums = EnumHolder { item: Choice.Present(string.repeat("untouched", 8)), count: 0 };
     enums.count
 }
 

--- a/hew-cli/tests/fixtures/generic_impl_method_mono.hew
+++ b/hew-cli/tests/fixtures/generic_impl_method_mono.hew
@@ -15,7 +15,11 @@ impl<T> Pair<T> {
         self.left
     }
     fn pick(self, take_left: bool) -> T {
-        if take_left { self.left } else { self.right }
+        if take_left {
+            self.left
+        } else {
+            self.right
+        }
     }
 }
 
@@ -23,7 +27,6 @@ fn main() {
     let nums = Pair { left: 7, right: 8 };
     println(nums.first());
     println(nums.pick(false));
-
     let flags = Pair { left: true, right: false };
     println(flags.pick(true));
 }

--- a/hew-cli/tests/fixtures/pattern_guard_payload.hew
+++ b/hew-cli/tests/fixtures/pattern_guard_payload.hew
@@ -11,19 +11,19 @@ enum MyOpt {
 
 fn describe(v: MyOpt) -> string {
     match v {
-        MyOpt::Some(n) if n > 0 => "positive",
-        MyOpt::Some(_) => "non-positive",
-        MyOpt::None => "absent",
+        MyOpt.Some(n) if n > 0 => "positive",
+        MyOpt.Some(_) => "non-positive",
+        MyOpt.None => "absent",
     }
 }
 
 fn main() {
-    print(describe(MyOpt::Some(5)));
+    print(describe(MyOpt.Some(5)));
     print("\n");
-    print(describe(MyOpt::Some(0)));
+    print(describe(MyOpt.Some(0)));
     print("\n");
-    print(describe(MyOpt::Some(-3)));
+    print(describe(MyOpt.Some(-3)));
     print("\n");
-    print(describe(MyOpt::None));
+    print(describe(MyOpt.None));
     print("\n");
 }

--- a/hew-cli/tests/fixtures/pattern_literal_payload.hew
+++ b/hew-cli/tests/fixtures/pattern_literal_payload.hew
@@ -8,17 +8,17 @@ enum MyOpt {
 
 fn describe(v: MyOpt) -> string {
     match v {
-        MyOpt::Some(0) => "zero",
-        MyOpt::Some(n) => "nonzero",
-        MyOpt::None => "nothing",
+        MyOpt.Some(0) => "zero",
+        MyOpt.Some(n) => "nonzero",
+        MyOpt.None => "nothing",
     }
 }
 
 fn main() {
-    print(describe(MyOpt::Some(0)));
+    print(describe(MyOpt.Some(0)));
     print("\n");
-    print(describe(MyOpt::Some(5)));
+    print(describe(MyOpt.Some(5)));
     print("\n");
-    print(describe(MyOpt::None));
+    print(describe(MyOpt.None));
     print("\n");
 }

--- a/hew-cli/tests/fixtures/pattern_payload_or.hew
+++ b/hew-cli/tests/fixtures/pattern_payload_or.hew
@@ -17,10 +17,10 @@ fn describe(e: ParseError) -> string {
 }
 
 fn main() {
-    print(describe(ParseError::UnclosedBlock("block-msg")));
+    print(describe(ParseError.UnclosedBlock("block-msg")));
     print("\n");
-    print(describe(ParseError::UnknownDirective("dir-msg")));
+    print(describe(ParseError.UnknownDirective("dir-msg")));
     print("\n");
-    print(describe(ParseError::Empty));
+    print(describe(ParseError.Empty));
     print("\n");
 }

--- a/hew-cli/tests/fixtures/pattern_payload_or_wildcard.hew
+++ b/hew-cli/tests/fixtures/pattern_payload_or_wildcard.hew
@@ -17,10 +17,10 @@ fn kind(e: Event) -> string {
 }
 
 fn main() {
-    print(kind(Event::Click(1)));
+    print(kind(Event.Click(1)));
     print("\n");
-    print(kind(Event::Scroll(2)));
+    print(kind(Event.Scroll(2)));
     print("\n");
-    print(kind(Event::Idle));
+    print(kind(Event.Idle));
     print("\n");
 }

--- a/repros/03_hashmap_string_vec_value.hew
+++ b/repros/03_hashmap_string_vec_value.hew
@@ -5,10 +5,9 @@ fn main() {
     xs.push(2);
     m.insert("a", clone xs);
     xs.push(99);
-
     match m.get("a") {
-        Some(v) => println(f"got={v.len()}:{v.get(0)}:{v.get(1)}"),
-        None => println("got=missing"),
+        .Some(v) => println(f"got={v.len()}:{v.get(0)}:{v.get(1)}"),
+        .None => println("got=missing"),
     }
     let has = m.contains_key("a");
     let removed = m.remove("a");

--- a/repros/20_generic_task_spawn.hew
+++ b/repros/20_generic_task_spawn.hew
@@ -5,7 +5,6 @@
 // through the monomorphized callee symbol (fn$$T) via the TaskEntry adapter.
 //
 // Exit 0 on success. Non-zero on any assertion failure.
-
 fn compute<T>() -> i64 {
     return 42;
 }
@@ -21,8 +20,8 @@ actor Runner {
     // Asserts the exact computed value from both tasks.
     receive fn run_value() -> i64 {
         scope {
-            fork t1 = compute::<i64>();
-            fork t2 = compute::<string>();
+            fork t1 = compute<i64>();
+            fork t2 = compute<string>();
             let v1 = await t1;
             let v2 = await t2;
             total = v1 + v2;
@@ -33,8 +32,12 @@ actor Runner {
     // ForkBlock no-arg unit at two type args.
     receive fn run_unit() -> i64 {
         scope {
-            fork { unit_worker::<i64>(); }
-            fork { unit_worker::<string>(); }
+            fork {
+                unit_worker<i64>();
+            };
+            fork {
+                unit_worker<string>();
+            };
         };
         return 7;
     }
@@ -42,8 +45,12 @@ actor Runner {
     // ForkBlock arg-bearing unit at two type args.
     receive fn run_args() -> i64 {
         scope {
-            fork { side_work::<i64>(20, 22); }
-            fork { side_work::<string>(10, 32); }
+            fork {
+                side_work<i64>(20, 22);
+            };
+            fork {
+                side_work<string>(10, 32);
+            };
         };
         return 55;
     }
@@ -51,25 +58,21 @@ actor Runner {
 
 fn main() -> i64 {
     let r = spawn Runner(total: 0);
-
     // Value task: compute$$i64 + compute$$string both return 42 → sum 84
     let v = match await r.run_value() {
-        Ok(n) => n,
-        Err(_) => -1,
+        .Ok(n) => n,
+        .Err(_) => -1,
     };
-
     // Unit fork: no values, just join-all correctness → sentinel 7
     let u = match await r.run_unit() {
-        Ok(n) => n,
-        Err(_) => -1,
+        .Ok(n) => n,
+        .Err(_) => -1,
     };
-
     // Arg fork: shim packs args into env, callee runs → sentinel 55
     let a = match await r.run_args() {
-        Ok(n) => n,
-        Err(_) => -1,
+        .Ok(n) => n,
+        .Err(_) => -1,
     };
-
     // Total should be 84 + 7 + 55 = 146.
     // Return 0 for success, non-zero for any mismatch.
     v + u + a - 146

--- a/repros/p0a_hashmap_owned_record_value.hew
+++ b/repros/p0a_hashmap_owned_record_value.hew
@@ -4,17 +4,14 @@ type Payload {
 }
 
 fn main() {
-    let m: HashMap<string, Payload> = HashMap::new();
+    let m: HashMap<string, Payload> = HashMap.new();
     let n: i64 = 77;
-    let payload = Payload {
-        label: f"record-value-{n}-heap-owned",
-        count: n,
-    };
+    let payload = Payload { label: f"record-value-{n}-heap-owned", count: n };
     m.insert("record", payload);
     let got: Option<Payload> = m.get("record");
     m.remove("record");
     match got {
-        Some(p) => println(f"{p.label}:{p.count}"),
-        None => println("missing"),
+        .Some(p) => println(f"{p.label}:{p.count}"),
+        .None => println("missing"),
     }
 }

--- a/repros/p0a_hashmap_string_vec_value.hew
+++ b/repros/p0a_hashmap_string_vec_value.hew
@@ -9,7 +9,7 @@ fn main() {
     let got: Option<Vec<i64>> = m.get("vec");
     m.remove("vec");
     match got {
-        Some(v) => println(f"got={v.len()}:{v.get(0)}:{v.get(1)}:{v.get(2)} src={xs.len()}"),
-        None => println("missing"),
+        .Some(v) => println(f"got={v.len()}:{v.get(0)}:{v.get(1)}:{v.get(2)} src={xs.len()}"),
+        .None => println("missing"),
     }
 }

--- a/repros/p0a_heap_remove_uaf.hew
+++ b/repros/p0a_heap_remove_uaf.hew
@@ -1,12 +1,12 @@
 fn main() {
-    let m: HashMap<string, string> = HashMap::new();
+    let m: HashMap<string, string> = HashMap.new();
     let n: i64 = 123456;
     let heap: string = f"prefix-{n}-suffix-padding-to-force-heap-alloc-zzzzzzzzzzzz";
     m.insert("k", heap);
     let got: Option<string> = m.get("k");
     m.remove("k");
     match got {
-        Some(s) => println(s),
-        None => println("none"),
+        .Some(s) => println(s),
+        .None => println("none"),
     }
 }

--- a/repros/p0c_all_methods.hew
+++ b/repros/p0c_all_methods.hew
@@ -15,19 +15,19 @@ fn result_unwrap_or<T, E>(res: Result<T, E>, fallback: T) -> T {
 }
 
 fn main() {
-    let a = option_unwrap(Some(5));
-    let b = Some(1).is_some();
-    let c: Option<i64> = None;
+    let a = option_unwrap(Option.Some(5));
+    let b = Option.Some(1).is_some();
+    let c: Option<i64> = Option.None;
     let d = c.is_none();
-    let e: Option<i64> = None;
+    let e: Option<i64> = Option.None;
     let f = option_unwrap_or(e, 9);
-    let g: Result<i64, string> = Ok(11);
+    let g: Result<i64, string> = Result.Ok(11);
     let h = result_unwrap(g);
-    let i: Result<i64, string> = Err("no");
+    let i: Result<i64, string> = Result.Err("no");
     let j = i.is_err();
-    let k: Result<i64, string> = Ok(13);
+    let k: Result<i64, string> = Result.Ok(13);
     let l = k.is_ok();
-    let m: Result<i64, string> = Err("fallback");
+    let m: Result<i64, string> = Result.Err("fallback");
     let n = result_unwrap_or(m, 17);
     println(f"{a} / {b} / {d} / {f} / {h} / {j} / {l} / {n}");
 }

--- a/repros/p0c_method_value_failclosed.hew
+++ b/repros/p0c_method_value_failclosed.hew
@@ -4,5 +4,5 @@ fn apply(f: fn(Option<i64>) -> i64, opt: Option<i64>) -> i64 {
 
 fn main() {
     let f: fn(Option<i64>) -> i64 = Option.unwrap;
-    println(apply(f, Some(5)));
+    println(apply(f, Option.Some(5)));
 }

--- a/repros/p0c_path_variants.hew
+++ b/repros/p0c_path_variants.hew
@@ -1,15 +1,15 @@
 import p0c_helpers;
 
 fn main() {
-    let concrete = Some(21).unwrap();
+    let concrete = Option.Some(21).unwrap();
     let option_through_closure = |value: Option<i64>| value.unwrap_or(22);
-    let abstract_opt = option_through_closure(None);
-    let imported_opt = p0c_helpers.imported_option(Some(23));
-    let method_path_opt = Some(24).unwrap_or(0);
-    let res: Result<i64, string> = Ok(25);
+    let abstract_opt = option_through_closure(Option.None);
+    let imported_opt = p0c_helpers.imported_option(Option.Some(23));
+    let method_path_opt = Option.Some(24).unwrap_or(0);
+    let res: Result<i64, string> = Result.Ok(25);
     let result_through_closure = |value: Result<i64, string>| value.unwrap_or(0);
     let abstract_res = result_through_closure(res);
-    let imported_res: Result<i64, string> = Err("missing");
+    let imported_res: Result<i64, string> = Result.Err("missing");
     let imported_fallback = p0c_helpers.imported_result(imported_res, 26);
     println(f"{concrete} / {abstract_opt} / {imported_opt} / {method_path_opt} / {abstract_res} / {imported_fallback}");
 }

--- a/tools/downstream/syntax-fixtures/syntax_test.hew
+++ b/tools/downstream/syntax-fixtures/syntax_test.hew
@@ -12,10 +12,10 @@
 /* This is a block comment */
 
 // === Imports ===
-// std::io is available, and Vec/HashMap are built-in types rather than
-// std::collections imports.
-// import std::io;
-// import std::net::*;
+// std.io is available, and Vec/HashMap are built-in types rather than
+// std.collections imports.
+// import std.io;
+// import std.net.*;
 
 // === Constants ===
 /// This is a doc comment
@@ -107,10 +107,10 @@ fn factorial(n: i32) -> i32 {
 // === Pattern Matching ===
 fn describe(c: Colour) -> i32 {
     match c {
-        Colour::Red => 1,
-        Colour::Green => 2,
-        Colour::Blue => 3,
-        Colour::Custom(r, g, b) => r + g + b,
+        Colour.Red => 1,
+        Colour.Green => 2,
+        Colour.Blue => 3,
+        Colour.Custom(r, g, b) => r + g + b,
         _ => 0,
     }
 }


### PR DESCRIPTION
Summary:
- Migrate repros, downstream syntax fixtures, and CLI fixtures to dotted paths and variants.
- Preserve intentionally non-type-checking fixtures with hand-applied syntax migrations.

Validation:
- make hew-fmt-check: passed
- Scoped formatter checks: passed
- cargo test -p hew-cli: 340 unit tests passed; the integration run hit an existing leak-oracle failure and stalled in conditional_handler_bytes_transfer_balances_both_paths.