### PR TITLE
docs(comments): remove history narration

### DIFF
--- a/hew-analysis/src/resolver.rs
+++ b/hew-analysis/src/resolver.rs
@@ -125,7 +125,7 @@ impl Resolution {
 ///
 /// Intra-file definitions produce fully-resolved variants. Identifiers that
 /// only resolve via an import statement produce [`Resolution::ImportedItem`]
-/// with the import span; the caller (LSP handler, for now) chases the import
+/// with the import span; the caller (LSP handler) chases the import
 /// across files. Unresolved identifiers return [`Resolution::Unknown`]
 /// carrying the identifier text, so the caller can still attempt any
 /// fallbacks it owns.

--- a/hew-cabi/src/map.rs
+++ b/hew-cabi/src/map.rs
@@ -235,24 +235,22 @@ pub struct HewMapValueLayout {
 }
 
 // ---------------------------------------------------------------------------
-// Static layout descriptor symbols (W4.001 Stage C0b)
+// Static layout descriptor symbols.
 // ---------------------------------------------------------------------------
 //
 // `hew-runtime/src/layout_intrinsics.rs` defines `#[no_mangle] pub static`
-// instances of `HewMapKeyLayout` / `HewMapValueLayout` for the C0a-scoped
+// instances of `HewMapKeyLayout` / `HewMapValueLayout` for the supported
 // types (`i32, i64, u32, u64, f32, f64, bool, char, string, bytes, unit`).
-// Re-declaring them here as `extern "C"` statics lets codegen-rs (Stage C
-// consumer) and parallel back-ends take the address of the descriptor
+// Re-declaring them here as `extern "C"` statics lets codegen-rs and other
+// back-ends take the address of the descriptor
 // through the cabi surface without depending on hew-runtime directly.
 //
-// **C0b boundary:** these are checker-visible artifacts only. The first
-// production reader is Stage C's `HashMapLoweringFact` materialiser. No
-// consumer in C0b references these symbols at compile time, so a missing
-// link would not surface until Stage C — the `resolved_call_kernel_symbols`
-// integration test in `hew-types/tests/` is the C0b-time linkage gate.
+// These are checker-visible artifacts and are linked by the
+// `resolved_call_kernel_symbols` integration test. Keep the declarations in
+// sync with the runtime definitions so missing symbols fail at link time.
 //
-// **Float K descriptors** ship with `hash_fn = None` / `eq_fn = None`;
-// belt-and-suspenders DI-003 fail-closed-by-absence per plan §4 Stage C0b.
+// Float descriptors ship with `hash_fn = None` / `eq_fn = None`; callers must
+// reject hashing or equality when those operations are unavailable.
 //
 // **WASM parity (#1820):** the layout-backed HashMap/HashSet path is supported
 // on wasm32-wasip1. These descriptors are pure data, and codegen may take their

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -397,7 +397,7 @@ pub struct CheckArgs {
     ///
     /// Shows whether each `actor.method(arg)` call crossed the mailbox
     /// boundary via a refcount-bumped alias (no copy) or a deep-copy
-    /// (the legacy path). Default off; opt-in for Phase α.
+    /// (the compatibility path). Default off; enable it explicitly.
     #[arg(long)]
     pub explain_cow: bool,
     /// Target triple.

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -2189,7 +2189,7 @@ mod tests {
 
     #[test]
     fn imported_generic_impl_bodies_publish_each_checker_owned_declaration() {
-        // `privslot` deliberately combines all three conditions that used to
+        // `privslot` deliberately combines all three conditions that
         // make a body lookup tempting to recover from a leaf spelling: its
         // module-private generic `Slot<T>` is nested in a public `Store<T>`,
         // and the consumer dispatches two inherent methods after the root body
@@ -4399,9 +4399,8 @@ extern "C" { fn hew_tcp_read(foo: Foo); }
 
     /// `std::misc::log` ships `pub const JSON: i64 = 1` and `pub const TEXT: i64 = 0`
     /// in its Hew source layer.  The stdlib registration path routes these through
-    /// `register_stdlib_hew_items`, which previously had no `Item::Const` arm and
-    /// silently dropped them so `log.JSON` / `log.TEXT` were unknown to the type
-    /// checker.
+    /// `register_stdlib_hew_items` registers these constants so `log.JSON` /
+    /// `log.TEXT` are available to the type checker.
     ///
     /// This test verifies the real stdlib const resolution works end-to-end: the
     /// source goes through import resolution (which populates `resolved_items` on
@@ -4440,8 +4439,8 @@ extern "C" { fn hew_tcp_read(foo: Foo); }
         );
     }
 
-    /// Importing `std::fs` and `std::path` together previously produced two
-    /// defects caused by `SpanKey` lacking a per-module discriminator:
+    /// Importing `std::fs` and `std::path` together uses a per-module
+    /// discriminator in `SpanKey`:
     ///
     /// * Defect A — `hew check`: `unsupported unary - for operand i64 -> string`
     ///   at `std/path.hew:227` (ordinary `return -1;`).  The negation was

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -505,8 +505,8 @@ const SYNTHETIC_INSTANT_NOW_ITEM: ItemId = ItemId(u32::MAX / 2 - 19);
 /// the same `u32::MAX / 2` band, just below `monitor`.
 ///
 /// The sibling checker builtin `duplex` (detached) is deliberately NOT seeded
-/// here: `duplex` has no runtime constructor (`hew_duplex_new` was removed in
-/// the M2 runtime refactor). Registering it would pass `verify_hir` but fail
+/// here: `duplex` has no runtime constructor (`hew_duplex_new`). Registering it
+/// would pass `verify_hir` but fail
 /// closed at the MIR boundary — pretend-support rather than a real lowering
 /// path. The runnable Stream/Sink constructor surface is `std::stream`'s
 /// `pipe`/`bytes_pipe` (real `fn` items).

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -1498,10 +1498,9 @@ fn load_navigation_target(path: &std::path::Path) -> Option<(String, Vec<usize>,
 /// no workspace root exists or when the symbol is a Rust-registered type-method
 /// builtin with no `.hew` source.
 ///
-/// SHIM: `O(#workspace_files)` per goto-def miss. Acceptable for now — goto-def
-/// misses are rare in practice and `collect_hew_files` already exists for
-/// rename. A proper solution would add a workspace-level symbol index populated
-/// at startup.
+/// SHIM: `O(#workspace_files)` per goto-def miss. Replace the file scan with a
+/// workspace-level symbol index populated at startup when navigation latency
+/// requires indexed lookup.
 pub(super) fn find_stdlib_definition(
     current_uri: &Url,
     imports: &[hew_parser::ast::ImportDecl],
@@ -1560,9 +1559,8 @@ pub(super) fn find_stdlib_definition(
 /// confirmed to have a definition somewhere in the workspace (checked by the
 /// caller).
 ///
-/// SHIM: `O(#files × #tokens)` per call. Acceptable for now — references is
-/// user-initiated and infrequent. A proper solution would maintain an inverted
-/// index at startup.
+/// SHIM: `O(#files × #tokens)` per call. Replace the scan with an inverted index
+/// populated at startup when reference-search latency requires indexed lookup.
 fn collect_workspace_references(
     current_uri: &Url,
     name: &str,

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -5180,7 +5180,7 @@ fn dedup_whole_value_handoff(
 /// the candidate view, to a fixpoint (each round strictly shrinks the view,
 /// and removing a candidate only removes escape notes, so admissions grow
 /// monotonically). The excluded binding itself ends unregistered — the same
-/// leak-not-double-free posture the legacy path had for that shape.
+/// leak-not-double-free safety posture for that shape.
 fn admit_with_flagged_fallback<C, F>(
     owned_locals_snapshot: &[(BindingId, String, ResolvedTy)],
     collection_drop_flags: &HashMap<BindingId, Place>,

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -1576,9 +1576,9 @@ struct Builder {
     /// `drops_for_exit` dataflow filter narrows the drop per control-flow
     /// path and codegen gates the surviving close on `flag == 0` — exactly
     /// once on a `MaybeConsumed` join. A user resource absent here (no flag
-    /// allocated) falls back to the legacy path-insensitive
+    /// allocated) falls back to the path-insensitive
     /// `mark_binding_moved` removal: fail-closed to no-double-close (it may
-    /// leak on a not-consumed branch, the pre-#1933 posture, but never
+    /// leak on a not-consumed branch, but never
     /// double-frees the non-idempotent close).
     pub(crate) affine_release_flags: HashMap<BindingId, Place>,
     /// #2301 (extends #53): runtime drop-flags for an owned
@@ -1630,7 +1630,7 @@ struct Builder {
     /// #2418: runtime drop-flags for an owned collection local (owned-element
     /// `Vec`, plain `Vec`, `HashMap`/`HashSet` handle) that the pre-pass saw
     /// genuinely consumed (`intent=Consume`, a move-out such as `let ys = xs`)
-    /// somewhere in the body. The legacy path-insensitive `mark_binding_moved`
+    /// somewhere in the body. The path-insensitive `mark_binding_moved`
     /// retraction at the consume site removed the binding from the scope-exit
     /// set entirely, so a binding moved out on only SOME control-flow paths
     /// (`MaybeConsumed` at the converging join) leaked on the not-moved path —

--- a/hew-mir/src/lower/pattern.rs
+++ b/hew-mir/src/lower/pattern.rs
@@ -3347,8 +3347,8 @@ impl Builder {
             //
             // Capture places: typed as I64 (opaque pointer). The runtime returns
             // a NUL-terminated C string as *mut u8 cast to i64 (zero = null).
-            // Slice 5 will introduce proper CString/StrPtr semantics; for now the
-            // i64 opaque representation is substrate-correct for null-check dispatch.
+            // The i64 opaque representation is substrate-correct for null-check
+            // dispatch until nullable pointer types are available.
             //
             // WHY I64 for a pointer: MIR has no nullable-pointer type today. I64
             // is the convention used by other handle places (lambda-actor handles

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -6432,7 +6432,7 @@ pub enum MirCheck {
     /// Rather than emit the double-free, the elaborator refuses. This is the
     /// catch-all gate for the combinatorial aggregate-extraction shapes (re-
     /// aggregation, nested aggregates, multi-hop extraction) whose precise
-    /// exact-once proof is deferred to v0.5.1: the invariant is "no owned handle
+    /// The exact-once proof is incomplete: the invariant is "no owned handle
     /// reaches codegen with more than one live free path; unprovable → refuse".
     ///
     /// `name` is the source binding's name; `handle_ty` is its rendered type for

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -588,11 +588,11 @@ pub enum UnaryOp {
     BitNot,
     /// Raw pointer dereference (`*expr`).
     ///
-    /// v0.5 endpoint: the parser recognizes this only far enough to
-    /// reject it deterministically in the type checker.  Outside
+    /// The parser recognizes this only far enough to reject it
+    /// deterministically in the type checker. Outside
     /// `unsafe { ... }` the diagnostic is `UnsafeOperationRequiresBlock`;
-    /// inside `unsafe { ... }` the operation is rejected as "not lowered
-    /// in v0.5" before HIR.  No HIR/MIR/codegen path is reached.
+    /// inside `unsafe { ... }` the operation is rejected as "not lowered"
+    /// before HIR. No HIR/MIR/codegen path is reached.
     RawDeref,
 }
 
@@ -867,8 +867,8 @@ pub struct FnDecl {
     /// dispatch authority used by HIR/MIR/codegen. The checker validates the key
     /// against the known intrinsic catalog at registration time.
     ///
-    /// WHY: the catalog previously conjured `CompilerIntrinsic` entries with no
-    /// Hew-side declaration. This field enables typed declarations that the checker
+    /// WHY: the intrinsic catalog has no Hew-side declaration for these entries.
+    /// This field enables typed declarations that the checker
     /// can validate, making the intrinsic surface opt-in and fail-closed.
     /// WHEN-OBSOLETE: when all catalog `CompilerIntrinsic` rows have been migrated
     /// to `#[intrinsic]` declarations (slices 4–7).

--- a/hew-parser/src/parser/actor_machine_supervisor.rs
+++ b/hew-parser/src/parser/actor_machine_supervisor.rs
@@ -1267,9 +1267,8 @@ impl Parser<'_> {
                         self.expect(&Token::RightParen)?;
                     }
 
-                    // Legacy bare restart keyword (e.g. `child n: T permanent`)
-                    // was removed in the flat-reliability-fields cutover. The
-                    // only restart spelling is the `restart: <policy>` clause.
+                    // A supervisor child accepts restart policy only through the
+                    // `restart: <policy>` clause.
                     if matches!(
                         self.peek(),
                         Some(Token::Permanent | Token::Transient | Token::Temporary)
@@ -1282,7 +1281,8 @@ impl Parser<'_> {
                         );
                         self.advance();
                     }
-                    // Legacy `with restart:` form was removed; only `restart:`.
+                    // `with restart:` is not a valid supervisor-child clause;
+                    // use `restart:` directly.
                     if matches!(self.peek(), Some(Token::Identifier(s)) if *s == "with") {
                         self.error_with_hint(
                             "the `with restart:` form was removed; \
@@ -1331,8 +1331,8 @@ impl Parser<'_> {
                                 };
                             }
                             // `shutdown: <duration> | brutal_kill | infinity` clause.
-                            // `infinity` is accepted-only in v0.5 (no per-child
-                            // deadline wheel yet) and is a contextual keyword.
+                            // `infinity` is accepted without a per-child deadline
+                            // wheel and is a contextual keyword.
                             Some(Token::Identifier(s)) if *s == "shutdown" => {
                                 self.advance();
                                 self.expect(&Token::Colon)?;

--- a/hew-parser/src/parser/expressions.rs
+++ b/hew-parser/src/parser/expressions.rs
@@ -702,8 +702,8 @@ impl Parser<'_> {
             }
             Token::Less => {
                 // Speculative parse to detect old generic lambda: <T>(x: T) => expr.
-                // This form was removed in v0.5; type-parameterized closures are not
-                // supported. Detect the form and emit a typed migration diagnostic.
+                // Type-parameterized closures are not supported. Detect the form
+                // and emit a typed diagnostic.
                 let saved_pos = self.save_pos();
                 self.advance(); // consume '<'
 
@@ -766,8 +766,8 @@ impl Parser<'_> {
                 let _allow_struct = self.set_no_struct_literal(false);
 
                 // Detect and reject old `(params) => body` parenthesized lambda syntax.
-                // This form was removed in v0.5; the current form is `|params| body`.
-                // Keep the detection here so we can surface a typed migration diagnostic
+                // The current closure form is `|params| body`. Keep the detection here
+                // so we can surface a typed diagnostic
                 // rather than a cryptic parse error when `=>` is encountered later.
                 let saved_pos = self.save_pos();
                 let is_old_paren_lambda = if self.try_parse_lambda_params().is_some() {
@@ -984,7 +984,7 @@ impl Parser<'_> {
                 self.advance();
 
                 // Check whether the user wrote the legacy `spawn (params) => body` form.
-                // This form was removed in favour of `actor |params| { body }`.
+                // The supported form is `actor |params| { body }`.
                 // Consume an optional `move` keyword only to detect legacy syntax; it is not
                 // used in the regular `spawn ActorName(...)` form.
                 let _is_move_legacy = self.eat(&Token::Move);

--- a/hew-parser/src/parser/items.rs
+++ b/hew-parser/src/parser/items.rs
@@ -1031,8 +1031,8 @@ impl Parser<'_> {
     ///
     /// The attribute is not consumed from the slice; callers that render
     /// attributes should filter `resource` / `linear` out themselves if they
-    /// want to suppress them in output.  For now the checker is the only
-    /// consumer, so we leave the slice untouched.
+    /// want to suppress them in output. The checker is the only consumer, so
+    /// we leave the slice untouched.
     ///
     /// Valid type-decl attributes: `resource`, `linear`, `wire`, `json`,
     /// `yaml`, `deprecated`, `opaque`.  Anything else triggers `E_UNKNOWN_TYPE_MARKER`.

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -1007,7 +1007,6 @@ fn parse_negative_i64_min_literal_pattern() {
 #[test]
 fn parse_pattern_contextual_keywords() {
     // All contextual keywords that can appear as identifiers in patterns.
-    // state/event/on/when/join were previously missing from the inline list.
     let keywords = [
         "after",
         "from",
@@ -1394,10 +1393,6 @@ fn parse_empty_actor_body() {
 
 #[test]
 fn parse_actor_lifecycle_hook_and_receive_attributes() {
-    // The `terminate { }` block surface was removed in favour of the
-    // annotation-based hook surface; cleanup logic is expressed as a
-    // plain `fn` annotated with `#[on(stop)]` (and `#[on(start)]` for
-    // startup logic).
     let source = r"actor Worker {
     #[on(stop)]
     fn shutdown() { stop(); }
@@ -2369,7 +2364,6 @@ fn parse_visibility_modifiers() {
 }
 #[test]
 fn parse_generic_lambda_removed_emits_typed_diagnostic() {
-    // Generic lambda `<T>(params) => body` was removed in v0.5.
     // The parser must emit a typed E_CLOSURE_PIPE_SYNTAX diagnostic,
     // not silently accept or produce a cryptic error.
     for source in [
@@ -2392,7 +2386,6 @@ fn parse_generic_lambda_removed_emits_typed_diagnostic() {
 
 #[test]
 fn parse_paren_lambda_removed_emits_typed_diagnostic() {
-    // Parenthesized `(params) => body` was removed in v0.5.
     // The parser must emit a typed E_CLOSURE_PIPE_SYNTAX diagnostic.
     for source in [
         "fn main() { let f = (x) => x; }",

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -5182,8 +5182,8 @@ pub unsafe extern "C" fn hew_node_api_register(
 
 /// `Node::register<T>(name, pid)` — Register a named actor by bare PID.
 ///
-/// Per registry R81 (2026-05-23), `LocalPid<T>` lowers to a bare `u64` PID
-/// at this ABI boundary rather than a `*mut HewActor` pointer. The caller
+/// `LocalPid<T>` lowers to a bare `u64` PID at this ABI boundary rather than a
+/// `*mut HewActor` pointer. The caller
 /// extracts the PID via `hew_actor_pid` before passing it here.
 ///
 /// Returns 0 on success, -1 on any of the fail-closed conditions:

--- a/hew-runtime/src/lambda_actor.rs
+++ b/hew-runtime/src/lambda_actor.rs
@@ -1451,8 +1451,8 @@ pub unsafe extern "C" fn hew_lambda_actor_release(actor: *mut HewLambdaActorHand
         // per the contract there is no peer, so this branch only fires
         // on a tight serial bug. The free below would then race with
         // whichever path runs second — both branches free, so we get
-        // a double-free instead of a leak. For now we accept that
-        // tight-serial-bug double-release surfaces as a double-free in
+        // a double-free instead of a leak. A tight serial double-release
+        // surfaces as a double-free in
         // tests, which is louder than a silent leak (the compiler's
         // drop-spine prevents this from ever firing in practice).
         return SendError::DoubleClose as i32;

--- a/hew-types/src/actor_protocol.rs
+++ b/hew-types/src/actor_protocol.rs
@@ -1,14 +1,8 @@
 //! Actor protocol descriptor — the stable, centralized authority for
 //! actor-handler message identifiers (`msg_id`s).
 //!
-//! Until Q87 ratification (2026-05-19, registry D-tag) every consumer derived
-//! a handler's `msg_id` from its source-order index inside the actor body
-//! (`for (i, h) in handlers.iter().enumerate() { msg_id = i }`). Reordering
-//! the handler declarations silently re-numbered every existing recipient —
-//! an ABI flip with no syntactic signal. The descriptor replaces that
-//! `enumerate` path with a deterministic hash over the fully-qualified
-//! handler name so source-order changes no longer leak into the wire
-//! protocol.
+//! A handler's `msg_id` is a deterministic hash over its fully-qualified name.
+//! Source-order changes therefore do not alter the wire protocol.
 //!
 //! ## Hash determinism contract
 //!

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -12423,9 +12423,9 @@ impl Checker {
     }
 
     /// Add a full-path declaration alias for a source module type while
-    /// retaining the historical short-key alias for lookup compatibility.
-    /// Canonical IDs and imported type resolution consume this entry; legacy
-    /// layout consumers can continue to use the short alias until Stage 5.
+    /// retaining the short-key alias required by compatibility lookups.
+    /// Canonical IDs and imported type resolution consume the full-path entry;
+    /// layout consumers use the short alias where the ABI requires it.
     fn register_full_type_alias(
         &mut self,
         module_full_path: &str,


### PR DESCRIPTION
Summary:
- rewrite comments to state present constraints and replacement conditions
- remove completed syntax and migration history from compiler/runtime source comments
- keep implementation and diagnostic behavior unchanged

Validation:
- cargo check --workspace
- make lint

Deferred obligations noted during review:
- navigation scans still need workspace/inverted indexes when latency requires them
- exact-once aggregate handle proof remains incomplete and fails closed
- nullable pointer types are still needed to replace opaque i64 capture places