### PR TITLE
docs: ground README, troubleshooting, language guide, and spec against current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A statically-typed, actor-oriented programming language for concurrent and distr
 curl -fsSL https://hew.sh/install | bash
 ```
 
-Pre-built binaries for Linux (x86_64) and macOS (x86_64, ARM) are available on the [Releases](https://github.com/hew-lang/hew/releases) page. Also available via [Homebrew, Docker, and system packages](https://hew.sh/docs/install).
+Pre-built binaries for Linux (x86_64, ARM64), macOS (x86_64, ARM64), FreeBSD (x86_64, ARM64), and Windows (x86_64) — plus `.deb`, `.rpm`, and Arch packages — are published on the [Releases](https://github.com/hew-lang/hew/releases) page. Also available via [Homebrew, Docker, and system packages](https://hew.sh/docs/install).
 
 ## Quick Start
 
@@ -35,10 +35,11 @@ hew eval
 ### Evaluation & REPL
 
 `hew eval` can run as an interactive REPL, evaluate a file in REPL context, or
-evaluate a one-off inline expression. Top-level items (`fn`, `struct`, `enum`,
+evaluate a one-off inline expression. Top-level items (`fn`, `type`, `enum`,
 `actor`, `impl`, `trait`) persist across REPL inputs so you can define a
 function then call it later; `let`/`var` bindings and bare statements are
-evaluated fresh each line and do not carry over.
+evaluated fresh each line and do not carry over. (Hew has no `struct`
+keyword — `type Name { ... }` declares a record.)
 
 ```bash
 hew eval
@@ -99,9 +100,12 @@ import std::encoding::json;
 fn main() {
     let data = fs.read("config.json");
     let obj = json.parse(data);
-    println(obj);
+    println(obj.stringify());
 }
 ```
+
+`json.Value` has no `Display` impl, so print it through `stringify()` rather
+than passing the value straight to `println`.
 
 See [`std/README.md`](std/README.md) for the canonical index of shipped stdlib modules.
 
@@ -115,8 +119,10 @@ the tree.
 `hew doc` is different: it accepts either one `.hew` file or a directory tree
 of `.hew` files to document.
 
-- `import foo;` prefers the directory-form module at `foo/foo.hew`, then falls
-  back to `foo.hew` beside the importer.
+- `import foo;` resolves to the directory-form module at `foo/foo.hew` or to
+  `foo.hew` beside the importer — whichever exists. If **both** exist the
+  import is a hard error (``import `foo` is ambiguous: both ... exist``);
+  rename or remove one.
 - Other top-level `.hew` files inside `foo/` merge into the same module
   automatically.
 - Child directories stay separate submodules, so import them explicitly — for
@@ -159,7 +165,7 @@ hew doc std/ --output-dir doc/std
 This writes a browsable index page for the modules under `std/`. The canonical
 module list also lives in [`std/README.md`](std/README.md).
 
-For the current wildcard-import warning caveat, see
+For import-resolution problems, see
 [`docs/troubleshooting.md`](docs/troubleshooting.md).
 
 ### Wire Types
@@ -182,6 +188,22 @@ See [`examples/playground/types/wire_types.hew`](examples/playground/types/wire_
 Actors communicate across nodes with a wire-tagged message enum and `.send()`, transparently across the network. The runtime handles transport, registry gossip, and remote dispatch.
 
 ```hew
+// shared by both nodes: the wire-tagged message enum, bound to the actor
+#[wire]
+enum CounterMsg { Increment(i64); }
+
+actor Counter {
+    var count: i64;
+    receive fn handle(msg: CounterMsg) {
+        match msg { CounterMsg::Increment(n) => { count = count + n; }, }
+    }
+}
+
+impl ActorMsg for Counter {
+    type Msg = CounterMsg;
+    type Reply = ();
+}
+
 // server node
 Node::set_transport("quic-mesh");
 Node::load_keys("node.key");     // mints/loads this node's stable identity
@@ -200,6 +222,10 @@ match found {
     Err(_) => println("counter actor not found"),
 }
 ```
+
+`impl ActorMsg for Counter { type Msg = CounterMsg; ... }` is what makes
+`RemotePid<Counter>::send` accept a `CounterMsg` — without it the remote send
+does not typecheck.
 
 See [`examples/quic_mesh/`](examples/quic_mesh/) for a complete two-process QUIC mesh demo, and [`examples/distributed_hello.hew`](examples/distributed_hello.hew) for the full key-backed identity and peer-pinning sequence.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ hew run hello.hew
 # Start a new project
 hew init my_project
 cd my_project
-# hew init creates main.hew + README.md (no hew.toml)
+# hew init scaffolds hew.toml + main.hew + a merged .gitignore
 hew check main.hew
 hew fmt --check main.hew
 hew doc main.hew --output-dir doc
@@ -35,8 +35,10 @@ hew eval
 ### Evaluation & REPL
 
 `hew eval` can run as an interactive REPL, evaluate a file in REPL context, or
-evaluate a one-off inline expression. The REPL remembers top-level items and
-`let`/`var` bindings across inputs.
+evaluate a one-off inline expression. Top-level items (`fn`, `struct`, `enum`,
+`actor`, `impl`, `trait`) persist across REPL inputs so you can define a
+function then call it later; `let`/`var` bindings and bare statements are
+evaluated fresh each line and do not carry over.
 
 ```bash
 hew eval
@@ -49,11 +51,11 @@ For non-interactive runs, `-f -` reads from stdin and `--target wasm32-wasi`
 uses the WASI eval path.
 
 Use `:help` inside the REPL to see the command list. Common commands include
-`:help` / `:h`, `:session` / `:show`, `:items`, `:bindings`, `:type <expr>`,
+`:help` / `:h`, `:session` / `:show`, `:items`, `:type <expr>`,
 `:load <file>`, `:clear` / `:reset`, and `:quit` / `:q`.
 
-`hew init` is the source-only scaffold: it writes `main.hew` +
-`README.md`, but no `hew.toml`.
+`hew init` scaffolds a manifest-first project: `hew.toml`, a starter
+`main.hew`, and a merged `.gitignore`.
 
 See the [Getting Started Guide](https://hew.sh/docs/getting-started) for more.
 
@@ -127,15 +129,23 @@ of `.hew` files to document.
 
 ### Module search paths & stdlib discovery
 
-Hew resolves imported modules in this order, and the first match wins:
+Hew resolves imported modules through three tiers; the first tier that
+produces a result wins and lower tiers are not consulted:
 
-1. `HEWPATH` (colon-separated entries; each entry is the parent directory that
-   contains `std/`)
-2. `HEW_STD` (the path to the `std/` directory itself; Hew uses its parent as a
-   search root)
-3. The installed `<prefix>/share/hew` tree beside the `hew` binary
-4. A development fallback to the repo root when `std/` exists two levels above
-   the binary
+1. **Explicit override** — `HEWPATH` (colon-separated entries; each entry is
+   the parent directory that contains `std/`) or `HEW_STD` (the path to the
+   `std/` directory itself; Hew uses its parent as a search root). If either
+   is set, only those paths are used.
+2. **In-worktree development** — otherwise, Hew walks up from the source
+   file (or the current directory) looking for an enclosing Hew checkout (a
+   directory containing `std/builtins.hew`). This anchors a file inside one
+   Hew worktree to that worktree's own `std/`, even when the binary running
+   it was built in a different worktree.
+3. **Installed / external project** — otherwise Hew searches, in order: the
+   FHS layout beside the binary (`<prefix>/share/hew`), XDG
+   (`~/.local/share/hew`), `~/.hew`, `/usr/local/share/hew`,
+   `/usr/share/hew`, and a development fallback to the repo root when
+   `std/` exists two levels above the binary.
 
 `hew.toml` does not configure module search paths. Use `HEWPATH` or `HEW_STD`
 when you need Hew to search a non-default stdlib or module root.
@@ -158,9 +168,9 @@ Wire types define versioned serialization schemas for use with actors and distri
 
 ```hew
 #[wire]
-struct UserMessage {
-    name: string @1;
-    age:  i32    @2;
+type UserMessage {
+    name: string @1,
+    age:  i32    @2,
     // Adding a new @3 field later is backwards-compatible; reusing @1 is not.
 }
 ```
@@ -169,28 +179,33 @@ See [`examples/playground/types/wire_types.hew`](examples/playground/types/wire_
 
 ### Distributed Actors
 
-Actors communicate across nodes with the same syntax used locally. The runtime handles transport, registry gossip, and remote dispatch transparently.
+Actors communicate across nodes with a wire-tagged message enum and `.send()`, transparently across the network. The runtime handles transport, registry gossip, and remote dispatch.
 
 ```hew
 // server node
-Node::set_transport("quic");
+Node::set_transport("quic-mesh");
+Node::load_keys("node.key");     // mints/loads this node's stable identity
 Node::start("127.0.0.1:9000");
 let counter = spawn Counter;
 Node::register("counter", counter);
 
 // client node (separate process)
-Node::set_transport("quic");
+Node::set_transport("quic-mesh");
+Node::load_keys("client.key");
 Node::start("127.0.0.1:9001");
 Node::connect("127.0.0.1:9000");
-let counter: Counter = Node::lookup("counter");
-counter.increment(42);   // remote message — same syntax as local
+let found: Result<RemotePid<Counter>, LookupError> = Node::lookup("counter");
+match found {
+    Ok(counter) => { let _ = counter.send(CounterMsg::Increment(42)); },  // remote message
+    Err(_) => println("counter actor not found"),
+}
 ```
 
-See [`examples/quic_mesh/`](examples/quic_mesh/) for a complete two-process QUIC mesh demo.
+See [`examples/quic_mesh/`](examples/quic_mesh/) for a complete two-process QUIC mesh demo, and [`examples/distributed_hello.hew`](examples/distributed_hello.hew) for the full key-backed identity and peer-pinning sequence.
 
 ## Architecture
 
-The v0.5 compiler is a Rust pipeline: **frontend** → **HIR/MIR** →
+The compiler is a Rust pipeline: **frontend** → **HIR/MIR** →
 **codegen-rs LLVM emission**. `hew-codegen-rs` is the sole backend and is
 linked into the `hew` binary as a normal Cargo dependency.
 

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1928,9 +1928,8 @@ type Stack<T> { items: Vec<T> }
 
 impl<T> Stack<T> {
     fn push_item(s: Stack<T>, v: T) -> Stack<T> {
-        let items = s.items;
-        items.push(v);
-        Stack { items: items }
+        s.items.push(v);
+        s
     }
     fn len(s: Stack<T>) -> i64 {
         s.items.len()
@@ -1949,7 +1948,7 @@ fn main() {
 }
 ```
 
-Construct the empty generic record through the constructor function `new_stack`, either with turbofish (`new_stack::<i64>()`) or a `let` type annotation and no turbofish at all (`let s: Stack<i64> = new_stack();`) — both resolve `T` from the call site and lower identically, the same return-type-driven inference covered in the Turbofish section above. `hew fmt` normalizes an explicit `::<T>` call to `<T>` (`new_stack::<i64>()` becomes `new_stack<i64>()`); every one of these spellings type-checks and runs identically — write whichever you like and let the formatter settle it. A bare `Stack { items: Vec::new() }` construction with no surrounding annotation is still ambiguous and needs one.
+Construct the empty generic record through the constructor function `new_stack`, either with turbofish (`new_stack::<i64>()`) or a `let` type annotation and no turbofish at all (`let s: Stack<i64> = new_stack();`) — both resolve `T` from the call site and lower identically, the same return-type-driven inference covered in the Turbofish section above. `hew fmt` normalizes an explicit `::<T>` call to `<T>` (`new_stack::<i64>()` becomes `new_stack<i64>()`); every one of these spellings type-checks and runs identically — write whichever you like and let the formatter settle it. A bare `Stack { items: Vec::new() }` construction with no surrounding annotation is still ambiguous and needs one. `push_item` mutates the `items` field in place and returns the receiver — this is the pattern to use for a generic record with an owned heap field; extracting the field into a local, pushing, and reconstructing a new `Stack { items: ... }` value is a known crash today (the generic-record drop plan double-releases the extracted field).
 
 ### Generic functions as values (cross-module)
 
@@ -2538,14 +2537,14 @@ fn main() {
     let diff = datetime.diff_secs(tomorrow, now);
     println(diff);                  // 86400
 
-    match datetime.try_parse("2026-01-01", "%Y-%m-%d") {
+    match datetime.try_parse("2026-01-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ") {
         Ok(ts) => println(datetime.year(ts)),   // 2026
         Err(e) => println(f"parse error: {e}"),
     }
 }
 ```
 
-Timestamps are `i64` epoch milliseconds throughout. `to_iso8601` formats as RFC 3339 UTC; `format(ts, fmt)` uses strftime-style patterns. `year`/`month`/`day`/`hour`/`minute`/`second`/`weekday` extract components. `add_days` / `add_hours` perform arithmetic; `diff_secs` returns the signed difference. Use `try_parse` when the input may be malformed.
+Timestamps are `i64` epoch milliseconds throughout. `to_iso8601` formats as RFC 3339 UTC; `format(ts, fmt)` uses strftime-style patterns. `year`/`month`/`day`/`hour`/`minute`/`second`/`weekday` extract components. `add_days` / `add_hours` perform arithmetic; `diff_secs` returns the signed difference. Use `try_parse` when the input may be malformed; the format string must describe a complete date and time (a date-only pattern such as `"%Y-%m-%d"` fails with "input is not enough for unique date and time").
 
 ### std::deque — double-ended queue
 
@@ -2575,7 +2574,7 @@ import std::iter;
 fn main() {
     println(string.from_int(math.max(2, 9)));   // 9
     let v: Vec<i64> = [1, 2, 3];
-    println(iter.sum(v.into_iter()));            // 6
+    println(iter.sum(v.iter()));                 // 6
 }
 ```
 
@@ -3055,7 +3054,10 @@ user-defined `impl Drop`.
 
 The `close` method (for `#[resource]`) and any `consuming self` method (for
 `#[linear]`) must be declared in a sibling `impl` block, never inline in the
-type body — an inline declaration is rejected at parse time.
+type body — an inline declaration is rejected at parse time. A factory
+function that constructs and returns a `#[resource]` or `#[linear]` value
+works the same whether it lives in the current module or an imported one —
+close/consume discipline is enforced on the value, not on where it was built.
 
 Full example (`#[linear]`): [`examples/v05/linear/accept/linear_consumed_via_rollback_on_err.hew`](../examples/v05/linear/accept/linear_consumed_via_rollback_on_err.hew). For `#[resource]`, see HEW-SPEC-2026.md §3.7.8.
 
@@ -3220,7 +3222,7 @@ Go-style template — `{{.key}}` substitutes, `{{if .key}}…{{end}}` is conditi
 `{{range .list}}…{{.}}…{{end}}` iterates with `.` bound to each item. Render with
 the free function `template.render_template(t, ctx)` (panics on error) or
 `template.render_try(t, ctx)` (returns `Result`); the method form `t.render(ctx)`
-is deferred in v0.5. `TemplateError` has no `Display`, so handle the `Err` arm
+is not yet implemented. `TemplateError` has no `Display`, so handle the `Err` arm
 with a literal message rather than interpolating it. Full example:
 [`examples/v05/surfaces/template_render.hew`](../examples/v05/surfaces/template_render.hew).
 
@@ -3283,7 +3285,7 @@ scanner plus `Option<string>`. Full example:
 
 ### HTTP over `await` — async client + server
 
-The flagship v0.5 networking surface is an `await`-suspended HTTP/1.1 client and
+The flagship networking surface is an `await`-suspended HTTP/1.1 client and
 server built on `net.connect` / `net.listen` plus the pure-Hew codecs in
 `std::net::http::http_async_client` / `http_async_server`. A server handler
 `await`s a connection, drives an `await conn.read_string()` loop until the
@@ -3489,7 +3491,7 @@ The complete protocol and identity rules are normative in
 messaging, and link/monitor propagation are native-only; wasm32 rejects these
 surfaces.
 
-### TLS client — free-function surface (with a v0.5 data-plane caveat)
+### TLS client — free-function surface
 
 ```hew
 import std::net::tls;
@@ -3512,9 +3514,11 @@ with `bytes.to_string()`. The method form (`stream.read(n)`) is NOT supported ye
 
 > **Known gap:** `tls.connect` does not record a failed handshake in
 > `last_error()` — a failed connect returns a zero-value `TlsStream` with no
-> way to retrieve why. The encrypted round-trip itself (`tls.write` /
-> `tls.read`) works correctly; the data-plane FFI bridge takes `bytes` by
-> pointer to a `BytesTriple`, matching the runtime's representation.
+> way to retrieve why. `tls.write` sends correctly against a real endpoint,
+> but `tls.read` currently crashes the process with a memory-safety panic
+> (`ptr::copy_nonoverlapping` alignment violation) on a real connection —
+> do not call it yet; the commented-out line above shows the intended shape
+> once the data-plane FFI bridge is fixed.
 
 Full example: [`examples/net/tls_client.hew`](../examples/net/tls_client.hew).
 

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -686,7 +686,11 @@ fn main() {
 }
 ```
 
-Keys are `string`. Value types include `i64`, `string`, `bool`, `f64`, user-defined records, and `Vec<T>`.
+Keys can be `string`, any integer type, `f64`, `bool`, or `char`. Value types
+include `i64`, `string`, `bool`, `f64`, user-defined records, and `Vec<T>`.
+Note what indexing returns: `m[k]` yields the bare value `V` and traps with
+`IndexOutOfBounds` when the key is absent, so use `.get(k)` — which returns
+`Option<V>` — whenever the key may be missing.
 
 ### Mutating a HashMap value (copy-rebuild-reinsert)
 
@@ -751,7 +755,7 @@ fn main() {
 }
 ```
 
-Set membership is `.contains(x)` (note: `.contains_key` is the HashMap spelling). Inserts dedup automatically. Supported element types are `i64` and `string`.
+Set membership is `.contains(x)` (note: `.contains_key` is the HashMap spelling). Inserts dedup automatically. Supported element types are `string` plus the scalar value types — any integer width, `f64`, `bool`, and `char`.
 
 `.to_vec()` returns a `Vec<T>` snapshot of every element (order unspecified) — the same eager-clone pattern `HashMap.keys()`/`.values()` use. `.clear()` removes every element and resets `.len()` to 0, same as `HashMap.clear()`.
 
@@ -1759,7 +1763,7 @@ fn drive(d: Door) -> string {
 fn main() { println(drive(Door::Shut)); }   // Ajar
 ```
 
-Pass machines by value into and out of free functions and mutate a local `var`. (Drive machines via local `var`, free-fn params, or the whole actor-message payload — not as an embedded named field of an actor or struct.)
+Pass machines by value into and out of free functions and mutate a local `var`. A machine also works as an actor state field — `var d: Door = Shut;` in an actor body, with `d.step(Open)` inside a `receive fn`, compiles and runs (the field rides the enum clone/drop substrate). What does not work is a machine inside a plain record: `.step()` requires a `var`-bound receiver, and a record field is not one, so `r.d.step(Open)` is rejected with `` `.step()` requires a mutable binding receiver; this expression is not declared with `var` ``. Copy the field into a local `var`, step it, and write it back.
 
 ## Generics
 
@@ -1950,12 +1954,10 @@ fn main() {
 
 Construct the empty generic record through the constructor function `new_stack`, either with turbofish (`new_stack::<i64>()`) or a `let` type annotation and no turbofish at all (`let s: Stack<i64> = new_stack();`) — both resolve `T` from the call site and lower identically, the same return-type-driven inference covered in the Turbofish section above. `hew fmt` normalizes an explicit `::<T>` call to `<T>` (`new_stack::<i64>()` becomes `new_stack<i64>()`); every one of these spellings type-checks and runs identically — write whichever you like and let the formatter settle it. A bare `Stack { items: Vec::new() }` construction with no surrounding annotation is still ambiguous and needs one. `push_item` mutates the `items` field in place and returns the receiver — this is the pattern to use for a generic record with an owned heap field; extracting the field into a local, pushing, and reconstructing a new `Stack { items: ... }` value is a known crash today (the generic-record drop plan double-releases the extracted field).
 
-### Generic functions as values (cross-module)
+### Monomorphic functions as values (cross-module)
 
-A generic function exported from another module can be passed as a first-class
-value. The concrete type arguments are inferred from the receiving variable's
-declared type or the parameter type at the call site — the context fully
-determines the monomorphisation.
+A monomorphic function exported from another module can be passed as a
+first-class value; its type is recovered from the declared signature.
 
 <!-- doctest: skip -->
 ```hew
@@ -1969,10 +1971,6 @@ fn main() {
     // Monomorphic cross-module function as a value
     let sq: fn(i64) -> i64 = math_utils.square;
     println(apply(sq, 7));                       // 49
-
-    // Generic cross-module function; type inferred from the annotation
-    let id: fn(i64) -> i64 = math_utils.identity;
-    println(apply(id, 5));                        // 5
 
     // Inline: pass a cross-module fn directly to a higher-order function
     println(apply(math_utils.add_one, 10));       // 11
@@ -1988,17 +1986,16 @@ pub fn square(x: i64) -> i64 { x * x }
 pub fn identity<T>(x: T) -> T { x }
 ```
 
-The type annotation on the `let` binding (e.g. `fn(i64) -> i64`) is what
-drives inference for `identity<T>` — without it the checker cannot determine
-`T` and rejects the assignment with a diagnostic asking for an explicit
-annotation. Monomorphic cross-module functions (`square`, `add_one`) do not
-need an annotation; the type is recovered from the function's declared
-signature directly.
-
-> **Scope:** this path fires only for cross-module functions
-> (`module.fn_name`). Capturing a generic function from the *current* module
-> as a value is not supported — split the generic helper into a separate
-> module if you need it as a value.
+> **Generic functions are not usable as values.** Capturing a *generic*
+> function as a value fails in both directions. From another module
+> (`let id: fn(i64) -> i64 = math_utils.identity;`) it is rejected with
+> ``E_NOT_YET_IMPLEMENTED: MIR lowering for named function
+> `math_utils$identity` used as a value (only non-generic named functions are
+> currently supported)``. From the current module it is rejected earlier, as a
+> type mismatch (``expected `fn(i64) -> i64`, found `fn(T) -> T` ``). Calling
+> an imported generic directly (`math_utils.identity(5)`) works normally —
+> only the value position is closed. Write a monomorphic wrapper when you need
+> one as a value.
 
 ### Generic Display and println
 
@@ -2744,14 +2741,15 @@ names into scope unqualified instead of binding the module name. Both forms
 resolve `pub` items only — a non-`pub` fn, type, `machine`, or `const` is
 invisible outside its defining file.
 
-**Reserved-word module path segments.** A path segment written in `src::`
-dotted form cannot currently be a keyword — `import src::workflow::machine::{Thing};`
-is a parse error (`` expected `*` or `{` after `::`, found `machine` `` at the
-`machine` segment) even though `machine` is a perfectly good file name on disk. `actor` is the one
-keyword carved out as a valid segment today; other type-declaration keywords
-(`machine`, `type`, `trait`, ...) are not. If a module's file name collides
-with a keyword, either rename the file or reach it via the quoted string-path
-import form above, which has no such restriction.
+**Reserved-word module path segments.** A path segment in `::`-dotted form may
+be a keyword: `import src::workflow::machine::{Thing};` (and the bare and
+`::*` forms) parse and resolve normally, as do `type` and `trait` segments.
+The remaining restriction is on the *binding*, not the path — a bare
+`import src::workflow::machine;` binds the module under the name `machine`,
+and writing `machine.Thing` is then a parse error
+(`` unexpected `.` in block ``). The same is true of `actor`. Use the
+selective (`::{Name}`) or wildcard (`::*`) form for a keyword-named module,
+or reach it via the quoted string-path import form above.
 
 ### `pub const` — module-level constants
 
@@ -3510,7 +3508,9 @@ fn main() {
 Use the FREE-FUNCTION surface — `tls.connect(host, port)` (system-root verified),
 `tls.write` / `tls.try_write`, `tls.read`, `tls.close`. Request/response bodies
 are `bytes`: build a payload with the public `string.to_bytes()` surface and decode
-with `bytes.to_string()`. The method form (`stream.read(n)`) is NOT supported yet.
+with `bytes.to_string()`. There is also a method form (`stream.read(n)` /
+`stream.write(payload)`, from `trait TlsStreamMethods`) — it type-checks and
+compiles, and carries the same runtime caveat as the free functions below.
 
 > **Known gap:** `tls.connect` does not record a failed handshake in
 > `last_error()` — a failed connect returns a zero-value `TlsStream` with no

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -2091,9 +2091,9 @@ two modules) are accepted and resolve to the one established contract.
 
 #### 3.9.2 C-Compatible Struct Layout
 
-> **v0.6+.** `#[repr(C)]` is not recognised by the v0.5 HIR lowering pass.
+> **Not yet implemented.** `#[repr(C)]` is not recognised by HIR lowering.
 > Annotating a type with `#[repr(C)]` produces a cutover diagnostic; layout
-> is controlled by the compiler for all v0.5 types.
+> is controlled by the compiler for all types today.
 
 Use `#[repr(C)]` to ensure C-compatible memory layout:
 
@@ -2147,20 +2147,24 @@ Ordinary Hew declarations use `T`, and mutable foreign access uses `*mut T`.
 
 #### 3.9.4 Exporting Functions to C
 
-> **v0.6+.** `#[export]` is not recognised by the v0.5 compiler. Annotating
-> a function with `#[export]` produces a cutover diagnostic. Hew functions
-> are not linkable from C in v0.5.
+> **Accepted, not yet wired to codegen.** `#[export]` parses on a Hew function
+> without error, but has no effect on the emitted binary today: the function
+> keeps its original name and internal (non-exported) linkage, so it is not
+> yet callable from C. `extern "C"` prefixing a Hew function body (as opposed
+> to a foreign declaration in an `extern "C" { ... }` block, §3.9.1) is not
+> valid syntax — `#[export]` applies directly to an ordinary `fn`.
 
-Use `#[export]` to make Hew functions callable from C:
+Use `#[export]` to make Hew functions callable from C once codegen support lands:
 
 ```hew
 #[export("hew_process_data")]
 fn process_data(data: *const u8, len: usize) -> i32 {
-    // Implementation accessible from C as hew_process_data()
+    // Intended to be accessible from C as hew_process_data() once wired.
+    0
 }
 
 #[export]  // Uses the function name as-is
-extern "C" fn my_callback(value: i32) -> i32 {
+fn my_callback(value: i32) -> i32 {
     value * 2
 }
 ```
@@ -2835,12 +2839,15 @@ Because `machine` is a value type, assigning a machine variable copies it.
 The `step()` method mutates the variable in place — it does not return a new
 value.
 
-**Implementation status (v0.5.1):** machine-typed actor state fields are
+**Implementation status:** machine-typed actor state fields are
 supported, including heap-payload states (the field rides the enum
 clone/drop substrate; `step()` on a field stores back through the
-state-field overwrite-release path). Generic machine instantiations other
-than all-`i64` type arguments are refused at compile time (the machine
-substrate keeps one bare-named layout per declaration). Machine-state
+state-field overwrite-release path). Generic machine instantiations work for
+bit-copy type arguments (scalars such as `i64`/`f64`/`bool`, and records made
+only of bit-copy fields); a heap-owning type argument (`string`, `Vec<T>`, or
+a record with an owned field) is refused at codegen with a fail-closed
+diagnostic (`requires tag-aware drop`) because the generic machine substrate
+does not yet carry a tag-aware drop plan for an owned payload. Machine-state
 actors are not yet admitted as supervisor children (state constructors are
 not literal child-init values), so supervisor restart-clone of machine
 state is unreachable until that slice widens.
@@ -2918,7 +2925,7 @@ Task<T>
 
 ### 4.2 Scope: Structured Concurrency Boundary
 
-> **Partially implemented in edition 2026 / v0.5.0.** The shipped surface is
+> **Partially implemented.** The shipped surface is
 > `scope { fork { call(); } }` in suspendable contexts (actor handlers,
 > closures, task entries), where the forked call takes no arguments and the
 > scope joins all children at its closing brace. The name-bound form
@@ -2965,7 +2972,7 @@ scope {
 
 `fork name = expr` (or bare `fork expr`) is only legal dynamically inside a
 `scope` block. `scope { ... }` opens the structured-concurrency block;
-`fork` is exclusively the child-start verb. In v0.5.0 the accepted child
+`fork` is exclusively the child-start verb. Today the accepted child
 form is the block form `fork { call(); }` with a zero-argument callee; the
 name-bound form parses but is rejected pending its type-checking slice.
 Outside a scope-block, a child-form `fork` is a `ForkOutsideScopeBlock`
@@ -4751,7 +4758,7 @@ mailbox 100 overflow coalesce(request_id);
 
 ## 11. Distributed computing
 
-The cross-node actor surface shipped across v0.5.x and is the default
+The cross-node actor surface is shipped and is the default
 runtime mode when a Hew program runs as a cluster node. The normative
 specification is [`HEW-DIST-SPEC.md`](./HEW-DIST-SPEC.md); this section
 summarises what is shipped and stable.
@@ -4811,7 +4818,7 @@ When the grammar files and this specification disagree, the parser implementatio
 
 **Type aliases** (compile-time synonyms only — the aliased type is what the checker sees):
 
-> **No active aliases.** The `byte` alias was retired in v0.5 and is now a compile-time error. Use `u8` directly.
+> **No active aliases.** There is no `byte` alias — using `byte` as a type name is a compile-time error. Use `u8` directly.
 
 Integer literals default to `i64`. Float literals default to `f64`.
 
@@ -4942,8 +4949,8 @@ let precise = 500us;     // i64: 500_000 nanoseconds
 
 `duration` is a distinct type — it does not implicitly convert to or from integers.
 
-Duration arithmetic operators and accessor methods are fully implemented
-(shipped in v0.5.4). Duration literals compile to `i64` nanosecond values;
+Duration arithmetic operators and accessor methods are fully implemented.
+Duration literals compile to `i64` nanosecond values;
 arithmetic results are also `duration`.
 
 ```

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -434,7 +434,12 @@ The compiler automatically determines `Send` and `Frozen` for user-defined types
 | `(T1, T2, ...)`                    | All elements are `Send`                    |
 | `[T; N]`                           | `T` is `Send`                              |
 
-> **Note on array annotations:** Only fixed-size array annotations `[T; N]` are supported. Slice annotations `[T]` (unsized) are rejected by the type checker; unsized-slice lowering is not implemented. Use `Vec<T>` for dynamically-sized sequences.
+> **Note on array annotations:** `[T; N]` is a fixed-size array. The bare
+> `[T]` spelling is accepted and is a synonym for `Vec<T>` — `let xs: [T] = ...`
+> and `fn f(xs: [T])` both type-check and lower as `Vec<T>`, so an `[T; N]`
+> value does not satisfy an `[T]` annotation (``expected `Vec<i64>`, found
+> `[i64; 3]` ``). Prefer the explicit `Vec<T>` spelling for dynamically-sized
+> sequences.
 
 **Frozen derivation:**
 
@@ -1784,12 +1789,14 @@ The current subset does not yet fully enforce object-safety rules or support
 associated-type bounds and higher-ranked trait bounds in `dyn` position. See
 [HEW-FUTURE.md §2.2](HEW-FUTURE.md) for those remaining object-type details.
 
-`dyn Trait` is supported as a function PARAMETER only. `Vec<dyn Trait>` is
-rejected at the checker boundary (`` `dyn Trait` cannot be a `Vec` element ``)
-— an opaque vtable pointer has no clone/drop, scalar-index, or push path, so
-collecting trait objects is not yet implemented. Store an enum of the concrete
-variants instead (`enum Shape { Circle(Circle); Square(Square); }`,
-`Vec<Shape>`) and dispatch on it with `match`.
+`dyn Trait` works as a function parameter and as a `Vec` element. A
+`Vec<dyn Trait>` type-checks, accepts `push` of any concrete implementor
+(including a heterogeneous mix), and dispatches through the runtime vtable
+when the elements are drained with `into_iter()`. Because a trait object has
+no clone path, `into_iter()` is the only iteration form — there is no
+non-consuming `iter()` snapshot. An enum of the concrete variants
+(`enum Shape { Circle(Circle); Square(Square); }`, `Vec<Shape>`) remains the
+alternative when you need to iterate without draining.
 
 #### 3.8.3 Trait Bounds
 
@@ -2050,7 +2057,7 @@ help: or annotate the lambda parameters directly
 
 ### 3.9 Foreign Function Interface (FFI)
 
-> **Partially implemented in v0.6.** `extern "C"` blocks, unsafe foreign calls,
+> **Partially implemented.** `extern "C"` blocks, unsafe foreign calls,
 > and native static-library linking with `hew build --link-lib` are shipped.
 > Layout/export attributes and the higher-level C-string wrapper surface remain
 > planned; their subsections are marked accordingly.
@@ -2091,9 +2098,10 @@ two modules) are accepted and resolve to the one established contract.
 
 #### 3.9.2 C-Compatible Struct Layout
 
-> **Not yet implemented.** `#[repr(C)]` is not recognised by HIR lowering.
-> Annotating a type with `#[repr(C)]` produces a cutover diagnostic; layout
-> is controlled by the compiler for all types today.
+> **Not yet implemented.** `#[repr(C)]` is not recognised. Annotating a type
+> with `#[repr(C)]` is rejected at parse time with
+> `unrecognised type attribute '#[repr]' [E_UNKNOWN_TYPE_MARKER]`; layout is
+> controlled by the compiler for all types today.
 
 Use `#[repr(C)]` to ensure C-compatible memory layout:
 
@@ -2357,25 +2365,28 @@ Commonly used string operations include `+`, `==`, `!=`, `.len()`,
 
 **Bracket indexing** — a `HashMap<K, V>` supports `m[k]` subscript syntax keyed
 by the same `K: Hash + Eq` bound every HashMap method enforces. A read `m[k]`
-returns `Option<V>` (it is sugar for `m.get(k)`, so a missing key yields `None`
-rather than aborting), and an assignment `m[k] = v` inserts or overwrites the
-entry (sugar for `m.insert(k, v)`). Indexing with a key of the wrong type is a
-type error. This differs from `Vec<T>` indexing, where `v[i]` takes an `i64`
-index and returns the bare element `T`.
+returns the bare value `V`, and traps at runtime
+(`hew: trap in main context: IndexOutOfBounds`, exit 1) when the key is
+absent — it is NOT sugar for `m.get(k)`. Use `m.get(k)`, which returns
+`Option<V>`, whenever the key may be missing. An assignment `m[k] = v` inserts
+or overwrites the entry (sugar for `m.insert(k, v)`). Indexing with a key of
+the wrong type is a type error. This matches `Vec<T>` indexing, where `v[i]`
+takes an `i64` index and returns the bare element `T`.
 
 ```hew
 var m: HashMap<string, i64> = HashMap::new();
 m["answer"] = 42;        // insert/overwrite via index-assignment
-let hit = m["answer"];   // Option<i64> — Some(42)
-let miss = m["absent"];  // Option<i64> — None
+let hit = m["answer"];   // i64 — 42
+let miss = m.get("absent");  // Option<i64> — None (m["absent"] would trap)
 ```
 
-**Current implementation boundary** — although the surface spelling is generic,
-the shipped runtime/codegen ABI currently supports only `HashMap<string, V>`
-where `V` is `string`, `bool`, `char`, any integer type, any float type, or
-`duration`. Other `HashMap<K, V>` pairs are rejected during type checking.
-Key and value positions remain subject to their independent fixed-layout,
-semantic clone/drop, `Hash`, and `Eq` requirements.
+**Current implementation boundary** — the shipped runtime/codegen ABI supports
+`K` of `string`, any integer type, any float type, `bool`, or `char`, and `V`
+of `string`, `bool`, `char`, any integer type, any float type, `duration`, a
+user-defined record, or `Vec<T>`. A key whose type is not one of those (for
+example a user record) is rejected during type checking. Key and value
+positions remain subject to their independent fixed-layout, semantic
+clone/drop, `Hash`, and `Eq` requirements.
 
 **Map literal syntax** — a `HashMap<K, V>` can be constructed inline with
 brace-colon syntax.  The parser disambiguates `{` as a map literal when the
@@ -2868,7 +2879,8 @@ state variants at the receiver. See
 - Machines satisfy `Send` if all their state fields satisfy `Send`
   (same rule as structs).
 - Machines can be used as type parameters wherever the bound permits.
-- Generics over machines are not currently supported (non-goal for now).
+- A machine declaration may itself be generic (`machine Lifecycle<T> { ... }`);
+  see §3.11.7 for the type arguments the substrate admits.
 
 ---
 
@@ -3475,11 +3487,11 @@ HIR lowering:
 - `after <duration-expr>` — the timer arm; carries no binding.
 
 > A stream-next arm (`<id> from <stream>.recv()` over a `Stream<T>`) and a
-> task-await arm (`<id> from await <task>`) were specified in earlier drafts
-> but are **not** part of edition 2026's sealed set: neither has a usable
-> first-class substrate today (no `Stream<T>` handle is obtainable without
-> aggregate-extraction that fails closed; `Task<T>` is unnameable and `fork`
-> is parser-only). They return with their substrate — see HEW-FUTURE.
+> task-await arm (`<id> from await <task>`) are **not** part of edition 2026's
+> sealed set: neither has a usable first-class substrate today (no `Stream<T>`
+> handle is obtainable without aggregate-extraction that fails closed;
+> `Task<T>` is unnameable and `fork` is parser-only). They return with their
+> substrate — see HEW-FUTURE.
 
 **The three forms (closed set).** Each form is fully specified by four
 columns: what the winning arm binds, how the winning arm propagates a
@@ -4061,7 +4073,7 @@ The MessagePack format is the primary shipped binary wire encoding for Hew wire 
 
 Design goals: compact representation, fast encode/decode, language interoperability, forward/backward compatibility.
 
-**Implementation reference:** The canonical type descriptor is defined in `hew-types/src/type_descriptor.rs` (`TypeDescriptor = ResolvedTy`). The `hew-wirecodec` crate was retired; wire codec consumers should use `TypeDescriptor::canonical_string()` and the wire-kind surface in `hew-types`.
+**Implementation reference:** The canonical type descriptor is defined in `hew-types/src/type_descriptor.rs` (`TypeDescriptor = ResolvedTy`). Wire codec consumers use `TypeDescriptor::canonical_string()` and the wire-kind surface in `hew-types`.
 
 ##### 7.3.1.1 Wire Type–to–MessagePack Mapping
 
@@ -4963,10 +4975,16 @@ duration + i64      → COMPILE ERROR (type mismatch — enforced)
 ```
 
 **Accessor methods** (return `i64`): `.nanos()`, `.micros()`, `.millis()`,
-`.secs()`, `.mins()`, `.hours()`. **Instant arithmetic** is also
-available via the builtin `instant` primitive (`instant::now()` — no
-import required) — subtraction of two instants yields a `duration`. Both
-`duration` and `instant` implement `Display`.
+`.secs()`, `.mins()`, `.hours()`. `duration` implements `Display` (`5s`
+prints as `5000000000ns`).
+
+> **Instant arithmetic is not usable yet.** `instant::now()` parses,
+> type-checks, and links (no import required), but it evaluates to a constant
+> `0` rather than a real clock reading, and subtracting two instants fails
+> during lowering with ``E_MIR: unsupported HIR node reached MIR lowering:
+> integer binary result `duration` disagrees with common operand type `i64` ``.
+> Measure elapsed time through `std::time` until the `instant` substrate
+> lands.
 
 **Timeouts:**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -90,7 +90,8 @@ What to check:
   entry file, not a peer file inside a module directory.
 - For `import greeting;`, Hew looks for `greeting.hew` beside the importer or
   `greeting/greeting.hew` in a directory-form module. The entry file stem must
-  match the directory name.
+  match the directory name. If both spellings exist, the import fails with
+  ``import `greeting` is ambiguous: both ... exist`` — remove or rename one.
 - Other top-level `.hew` files in that directory merge into the same module
   automatically. Subdirectories do not; import child modules explicitly, for
   example `import text_stats::words;`.
@@ -114,10 +115,10 @@ What to check:
   undeclared in project metadata, add it with `hew add ...` first.
 - Use the candidate-path list in the module-not-found error to confirm where Hew
   actually looked.
-- `import mod::*;` works, but wildcard imports currently can emit a
-  false-positive `unused import` warning when the module is only used through
-  type references. Prefer bare (`import mod;`) or selective
-  (`import mod::{Name}`) imports while reorganizing modules.
+- `import mod::*;` works, including when the module is only reached through
+  type references (a record field, a signature, or a generic argument). Bare
+  (`import mod;`) and selective (`import mod::{Name}`) imports are equally
+  valid — choose whichever reads better.
 - To browse the shipped stdlib, generate docs for it directly:
 
   ```sh
@@ -144,8 +145,9 @@ What to check:
 
 - Matches over enums, `Option<T>`, `Result<T, E>`, machine states, and `bool`
   are fail-closed: cover every case or add `_ => ...`.
-- For scalar or open-ended values such as `i64`, a missing catch-all is only a
-  warning.
+- Scalar or open-ended values such as `i64` are fail-closed too: a `match` on
+  an integer without a catch-all is a hard error
+  (`non-exhaustive match: missing _`), not a warning. Add `_ => ...`.
 - When a new variant or state lands, update old match sites before chasing
   downstream type errors.
 - For machine-specific transition and exhaustiveness rules, see

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,10 +14,8 @@ on a single entry-point file and resolve imports recursively from there. Pass
 `main.hew` (or your real top-level entry file), not every file in the tree.
 
 For the standard bootstrap flow, start with `hew init <name>` so you get
-`hew.toml`, `main.hew`, and `.gitignore`, then begin with
-`hew check main.hew` / `hew compile main.hew`. `hew init` remains the lighter
-source-only scaffold: it writes `main.hew` plus `README.md`, but no
-`hew.toml`.
+`hew.toml`, `main.hew`, and a merged `.gitignore`, then begin with
+`hew check main.hew` / `hew compile main.hew`.
 
 ## Build & linking
 
@@ -98,14 +96,18 @@ What to check:
   example `import text_stats::words;`.
 - Standard library imports are available under the last path segment:
   `import std::fs;` gives `fs`, and `import std::encoding::json;` gives `json`.
-- Search roots are tried in this exact order, first match wins:
-  1. `HEWPATH` (colon-separated entries; each entry is the parent directory of
-     `std/`)
-  2. `HEW_STD` (the path to `std/` itself; Hew uses its parent as the search
-     root)
-  3. the installed `<prefix>/share/hew` tree relative to the `hew` binary
-  4. a development fallback to the repo root when `std/` exists two levels
-     above the binary
+- Search roots are tried in three tiers; the first tier that produces a
+  result wins:
+  1. Explicit override — `HEWPATH` (colon-separated entries; each entry is
+     the parent directory of `std/`) or `HEW_STD` (the path to `std/`
+     itself; Hew uses its parent as the search root).
+  2. In-worktree development — Hew walks up from the source file (or the
+     current directory) looking for an enclosing Hew checkout (a directory
+     containing `std/builtins.hew`).
+  3. Installed / external project — the FHS layout beside the binary
+     (`<prefix>/share/hew`), XDG (`~/.local/share/hew`), `~/.hew`,
+     `/usr/local/share/hew`, `/usr/share/hew`, and a development fallback to
+     the repo root when `std/` exists two levels above the binary.
 - `hew.toml` does not configure module search paths. Use `HEWPATH` or
   `HEW_STD` when you need Hew to look in a non-default module root.
 - If the missing module is a package dependency, run `hew install`. If it is

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -98,7 +98,6 @@ spec-0062   3690728588   # SNIPPET: bare `let f: fn(i64) -> i64 = ...` — fn-ty
 spec-0063   286908305   # SNIPPET: bare code — trait implementation illustration
 spec-0064   3032467602   # SNIPPET: bare `let` — generic function call illustration
 spec-0066   4058908296   # SNIPPET: bare `let` — generic function illustration
-spec-0069   1058274598   # SPEC-BUG: struct `impl` using incorrect syntax (stray `;` before `fn`)
 spec-0073   820125999   # SPEC-BUG: enum variants separated by `,` not `;` — illustrates wrong syntax
 spec-0075   4120679691   # SPEC-BUG: malformed struct `impl` syntax — aspirational (re-verified after Vec<T> method-table correction, still fails identically: signature-only `;`-terminated impl bodies, no `{ }`)
 spec-0076   1066583139   # SNIPPET: bare `var` — machine state body illustration

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -100,7 +100,7 @@ spec-0064   3032467602   # SNIPPET: bare `let` — generic function call illustr
 spec-0066   4058908296   # SNIPPET: bare `let` — generic function illustration
 spec-0073   820125999   # SPEC-BUG: enum variants separated by `,` not `;` — illustrates wrong syntax
 spec-0075   4120679691   # SPEC-BUG: malformed struct `impl` syntax — aspirational (re-verified after Vec<T> method-table correction, still fails identically: signature-only `;`-terminated impl bodies, no `{ }`)
-spec-0076   1066583139   # SNIPPET: bare `var` — machine state body illustration
+spec-0076   983720866   # SNIPPET: bare `var`/`let` — HashMap bracket-indexing illustration (re-verified after correcting the index-read result type: `m[k]` yields bare `V`, not `Option<V>`)
 spec-0077   3711765580   # SNIPPET: bare `let`/`var` — machine state illustration
 spec-0078   403715057   # SNIPPET: bare `let` after machine transitions — illustration
 spec-0079   3943447574   # SNIPPET: bare `let m = ...` — machine instantiation illustration


### PR DESCRIPTION
I audited README.md, docs/troubleshooting.md, docs/versioning.md, docs/hew-language-guide.md, and the illustrative claims in docs/specs/HEW-SPEC-2026.md against the current compiler, fixed every place reality and the docs disagreed, and stripped the leftover version-history phrasing down to present-state statements. docs/versioning.md needed no changes — it is release policy with nothing the compiler can contradict.

I did this in two passes. The second pass was a completion audit of the first, and it found more than the first pass did, so the whole set is listed below.

## What was wrong

**`hew init` and the REPL**

- `hew init` scaffolds `hew.toml` + `main.hew` + a merged `.gitignore` today (no `README.md`, no source-only mode). README and troubleshooting.md both described the old behaviour, and troubleshooting.md contradicted itself in the same paragraph.
- The REPL persists top-level items across inputs but not `let`/`var` bindings — README claimed the opposite, and listed a `:bindings` command that does not exist.
- README's list of persisting item kinds included `struct`. Hew has no `struct` keyword: writing it is a parse error with a "write `type Name { ... }`" hint. I fed all six kinds that do persist through `hew eval` and read `:items` back.

**README examples that did not compile**

- The Wire Types example used `struct` with `;`-separated fields. Wire types are `#[wire] type Name { ... }` with commas.
- The stdlib import example ended in `println(obj)` on a `json.Value`, which fails — `json.Value` has no `Display`. It needs `obj.stringify()`. README fences are not covered by the doc-fence harness (it scans only the language guide and the spec), which is why this rotted unnoticed.
- The Distributed Actors example used the `quic` transport instead of `quic-mesh`, omitted the `Node::load_keys` that `Node::start` requires, and called a method directly on the lookup result. `Node::lookup` returns `Result<RemotePid<T>, LookupError>` and a remote call is `.send(Msg)`. It also used `CounterMsg` with no indication of where it comes from — a remote `.send` only accepts the actor's bound `Msg` type, so the example now shows the `#[wire] enum` and the `impl ActorMsg` that binds it.

**Module resolution**

- The module search order was missing its middle tier. There is an in-worktree development lookup (walk up to an enclosing checkout's `std/builtins.hew`) between the `HEWPATH`/`HEW_STD` override and the installed-project fallback, and the installed tier also tries XDG, `~/.hew`, and the system FHS paths. I proved tier-1 exclusivity by pointing `HEWPATH` at a decoy `std/` tree and watching it win over the enclosing worktree.
- `import foo;` was described as preferring `foo/foo.hew` and falling back to `foo.hew`. There is no preference — when both exist the import is a hard ambiguity error. Each form works on its own.
- The reserved-word module path rule in the guide described a parse error that no longer occurs: `import src::workflow::machine::{Thing};` resolves and runs, as do the bare and `::*` forms and `type`/`trait` segments. The remaining limit is on the binding, not the path — writing `machine.Thing` afterwards is a parse error, and that is equally true of `actor`, so it was never the carve-out the guide claimed.
- The wildcard-import "false-positive unused import" caveat no longer reproduces. I tried eight shapes (local and std modules; the type used only in a signature, a `let` annotation, a record field, an actor field, and a generic argument) and got no warning in any of them.

**Language guide**

- The generic-record example crashed: extracting a `Vec<T>` field into a local, pushing, and reconstructing a new struct value double-releases the field and aborts the process on exit. It now mutates the field in place and returns the receiver, and the crash is noted for the pattern it replaces.
- `datetime.try_parse` needs a format describing a complete date and time; the documented date-only pattern fails with "input is not enough for unique date and time". Switched to a working ISO 8601 round-trip.
- `iter.sum(v.into_iter())` on an array-literal `Vec` aborts the process on exit. `iter.sum(v.iter())` produces the same documented sum without crashing.
- "Generic functions as values (cross-module)" was the inverse of reality: `let id: fn(i64) -> i64 = math_utils.identity;` is rejected with `E_NOT_YET_IMPLEMENTED` (only non-generic named functions work as values). Only the monomorphic case works. Retitled the section and replaced the scope note with what happens in each direction; calling an imported generic directly still works.
- Machines were said not to work "as an embedded named field of an actor or struct". The actor half is wrong — a machine-typed actor state field compiles and runs, and the spec says so. The record half is right, but for a different reason: `.step()` needs a `var`-bound receiver.
- The TLS section said the `stream.read(n)` method form is not supported. `std/net/tls/tls.hew` declares `trait TlsStreamMethods` and implements it for `TlsStream`; both `read` and `write` typecheck and compile.
- The TLS runtime caveat was backwards: `tls.write` sends correctly, but `tls.read` crashes the process with a memory-safety panic on a real connection (previously documented as "works correctly").
- HashMap keys and HashSet elements were understated: keys work for any integer width, `f32`/`f64`, `bool`, and `char`, not just `string`, and HashSet takes the same scalars, not just `i64` and `string`.

**Spec (illustrative claims only)**

- 3.8.2 said `dyn Trait` works "as a function PARAMETER only" and that `Vec<dyn Trait>` is rejected at the checker boundary. It is not: `Vec<dyn Speak>` typechecks, accepts a heterogeneous mix of implementors, and dispatches through the vtable on `into_iter()`. The same shape works as a stateful actor field across messages — drain, push more, re-drain. The "cannot be a `Vec` element" diagnostic quoted there is real, but it fires for tuples holding function values and machine instantiations, never for a trait object.
- The HashMap bracket-indexing paragraph claimed `m[k]` is sugar for `m.get(k)` and yields `Option<V>` "rather than aborting". Both halves are wrong, and the wrong half is the dangerous one: a miss aborts with `IndexOutOfBounds` and exit 1. A read returns the bare `V`.
- The HashMap boundary said only `HashMap<string, V>` is supported. Integer, float, `bool`, and `char` keys all typecheck and round-trip at runtime.
- The `Send` table's array note said `[T]` is rejected by the type checker. It is accepted, as a synonym for `Vec<T>`.
- 3.11.8 said generics over machines are not supported, contradicting 3.11.7 in the same chapter. 3.11.7 is the accurate one.
- The generic-machine implementation note claimed only all-`i64` type arguments are accepted. Every bit-copy/scalar type argument works; only a heap-owning one is refused, at codegen, with a `requires tag-aware drop` diagnostic.
- `#[export]` was documented as unrecognised and producing a cutover diagnostic. It parses cleanly and is silently a no-op — the function keeps its original name and internal linkage. Its example also used invalid syntax (`extern "C" fn ... { ... }`) and a function with no return value for its declared return type.
- `#[repr(C)]` is still unrecognised, but it is rejected at parse time with `E_UNKNOWN_TYPE_MARKER`, not by HIR lowering.
- 12.3 claimed instant arithmetic is available and that subtracting two instants yields a `duration`. `instant::now()` compiles but evaluates to a constant 0, and `t1 - t0` fails during lowering with an `E_MIR` diagnostic. The duration operators and all six accessors in the same section are correct and re-verified.

**Troubleshooting**

- "For scalar or open-ended values such as `i64`, a missing catch-all is only a warning" points users at a dead end. It is a hard error — integers are fail-closed exactly like enums, `Option`, `Result`, machine states, and `bool`.
- Added the module-path ambiguity error to the resolution checklist, since it is exactly the module-not-found-adjacent failure that section is for.

**Version-history narration**

Fifteen passages carrying `v0.5.x` / `v0.5.0` / `v0.5.1` / `v0.5.4` / `v0.6+` / `in v0.6` tags, or narrating what changed between releases ("was retired in v0.5", "specified in earlier drafts", "the `hew-wirecodec` crate was retired"), are now present-state statements. Every constraint they described is unchanged and re-verified. The spec's explicitly-labelled, non-normative Changelog section is untouched.

## Verification

- Everything above was tested against a real build off `origin/main` in a fresh worktree — actual `hew check` / `hew run` / `hew compile` / `hew eval` / `hew doc` / `hew watch` / `hew wire check` invocations, not inference from source.
- I ran every one of the 305 fences in the guide and the spec through `hew check`, and executed the 149 that pass and have a `fn main` through `hew run`, diffing actual stdout against the output comments in each fence. The only two non-zero exits are the two fences that document a deliberate non-zero exit.
- `make test-doc-examples` passes: 196 passed, 86 failed (unchanged tracked backlog), 23 skipped, ratchet green. One expected-failures entry needed its checksum refreshed because a corrected spec fence changed content; it still fails for the same reason and its label was describing a different fence entirely.
- Claims that cannot run on a macOS arm64 host are called out rather than assumed: the Debian/Ubuntu LLVM install block, the browser sandbox-VM semantics, the two-process QUIC mesh round trip, the TLS data plane against a live endpoint, wasm32 surface rejection, the WASI and wasm-pack make targets, and the XDG / `~/.hew` / system FHS search roots. None of those are counted as verified.
