### PR TITLE
fix(types): project dotted associated types canonically

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -1997,7 +1997,9 @@ fn impl_type_param_names(decl: &hew_parser::ast::ImplDecl) -> Vec<String> {
         .unwrap_or_default()
 }
 
-fn check_builtin_receiver_impl_program(program: &Program) -> TypeCheckOutput {
+fn check_builtin_receiver_impl_program(
+    program: &Program,
+) -> Result<TypeCheckOutput, Box<HirDiagnostic>> {
     // The parsed embedded source uses private leaf spellings for its synthetic
     // cursor declarations. Type-check a projection whose impl targets carry
     // their exact compiler owner so declaration IDs and call facts cannot
@@ -2024,12 +2026,24 @@ fn check_builtin_receiver_impl_program(program: &Program) -> TypeCheckOutput {
     let mut checker =
         hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(Vec::new()));
     let output = checker.check_embedded_builtins(&checker_program);
-    debug_assert!(
-        output.errors.is_empty(),
-        "std/builtins.hew receiver impls failed to type-check: {:?}",
-        output.errors
-    );
-    output
+    if output.errors.is_empty() {
+        return Ok(output);
+    }
+
+    let reason = output
+        .errors
+        .iter()
+        .map(|error| error.message.as_str())
+        .collect::<Vec<_>>()
+        .join("; ");
+    Err(Box::new(HirDiagnostic::new(
+        HirDiagnosticKind::CheckerBoundaryViolation {
+            name: "std/builtins.hew receiver impls".to_string(),
+            reason,
+        },
+        0..0,
+        "compiler-injected receiver impls were not lowered",
+    )))
 }
 
 fn canonicalize_injected_cursor_type_expr(ty: &mut TypeExpr) {
@@ -2571,10 +2585,17 @@ pub fn lower_program_with_mono_cap(
         .map(hew_parser::module::ModuleGraph::file_span_indices)
         .unwrap_or_default();
     ctx.seed_stdlib_fn_registry();
-    let builtin_receiver_impl_program = builtin_receiver_impl_program();
-    let builtin_receiver_impl_output = builtin_receiver_impl_program
-        .as_ref()
-        .map(check_builtin_receiver_impl_program);
+    let (builtin_receiver_impl_program, builtin_receiver_impl_output) =
+        match builtin_receiver_impl_program() {
+            Some(program) => match check_builtin_receiver_impl_program(&program) {
+                Ok(output) => (Some(program), Some(output)),
+                Err(diagnostic) => {
+                    ctx.diagnostics.push(*diagnostic);
+                    (None, None)
+                }
+            },
+            None => (None, None),
+        };
 
     // Pre-pre-pass: harvest inherent-impl `close` method signatures from
     // the root program and imported modules so the type-decl pre-pass below
@@ -35631,6 +35652,39 @@ mod tests {
     use super::*;
     use hew_types::module_registry::ModuleRegistry;
     use hew_types::Checker;
+
+    #[test]
+    fn builtin_receiver_signature_mismatch_is_a_diagnostic_not_a_panic() {
+        let parsed = hew_parser::parse(
+            r"
+trait Sample {
+    fn value(self) -> i64;
+}
+
+type Broken {}
+
+impl Sample for Broken {
+    fn value(self) -> bool { true }
+}
+",
+        );
+        assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+
+        let diagnostic = *check_builtin_receiver_impl_program(&parsed.program)
+            .expect_err("the invalid injected impl must fail closed");
+        let HirDiagnosticKind::CheckerBoundaryViolation { name, reason } = diagnostic.kind else {
+            panic!("expected checker-boundary diagnostic, got {diagnostic:?}");
+        };
+        assert_eq!(name, "std/builtins.hew receiver impls");
+        assert!(
+            reason.contains("returns `bool`") && reason.contains("requires `i64`"),
+            "diagnostic must preserve the checker mismatch: {reason}"
+        );
+        assert_eq!(
+            diagnostic.note,
+            "compiler-injected receiver impls were not lowered"
+        );
+    }
 
     #[test]
     fn trait_method_identity_prefers_local_and_imported_same_leaf_traits_over_prelude_items() {

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -7804,20 +7804,18 @@ impl Checker {
     /// * `Ty::Named { name: "Self", args: [] }` → `impl_self`
     /// * `Ty::Named { name: <trait type param>, args: [] }` → the impl-supplied
     ///   type arg from `trait_param_map`
-    /// * `Ty::AssocType { base: Self, trait_name == trait_name, assoc_name }`
-    ///   → the impl's `type <assoc_name> = X` binding when present
+    /// * `Ty::AssocType { base: Self, .. }` → a concrete projection carrier
+    ///   over `impl_self`, then resolves it through `project_assoc_types`
     ///
     /// Used by [`Self::check_impl_method_against_trait`] to project the trait
     /// method's declared signature into the concrete shape the impl method
     /// must match. Returns the input unchanged for any subterm the
-    /// substitution cannot resolve (so comparison errs on the side of
-    /// accepting rather than firing on partial information).
+    /// substitution cannot resolve, so the later structural comparison remains
+    /// fail-closed instead of guessing from presentation spellings.
     fn substitute_trait_sig_for_impl(
         &self,
         ty: &Ty,
         impl_self: &Ty,
-        impl_target_name: &str,
-        trait_name: &str,
         trait_param_map: &HashMap<String, Ty>,
     ) -> Ty {
         match ty {
@@ -7833,38 +7831,15 @@ impl Checker {
                 trait_name: tn,
                 assoc_name,
             } => {
-                let base_is_self = matches!(&**base, Ty::Named { name, args, .. } if name == "Self" && args.is_empty());
-                if base_is_self && tn.as_ref() == trait_name {
-                    let key = (
-                        impl_target_name.to_string(),
-                        trait_name.to_string(),
-                        assoc_name.as_ref().to_string(),
-                    );
-                    if let Some(resolved) = self.impl_assoc_type_bindings.get(&key) {
-                        return resolved.clone();
-                    }
-                }
-                let new_base = self.substitute_trait_sig_for_impl(
-                    base,
-                    impl_self,
-                    impl_target_name,
-                    trait_name,
-                    trait_param_map,
-                );
-                Ty::AssocType {
+                let new_base = self.substitute_trait_sig_for_impl(base, impl_self, trait_param_map);
+                self.project_assoc_types(&Ty::AssocType {
                     base: Box::new(new_base),
                     trait_name: tn.clone(),
                     assoc_name: assoc_name.clone(),
-                }
+                })
             }
             _ => ty.map_children_pub(&|child| {
-                self.substitute_trait_sig_for_impl(
-                    child,
-                    impl_self,
-                    impl_target_name,
-                    trait_name,
-                    trait_param_map,
-                )
+                self.substitute_trait_sig_for_impl(child, impl_self, trait_param_map)
             }),
         }
     }
@@ -8752,12 +8727,6 @@ impl Checker {
             },
         );
 
-        // The DECLARING trait's canonical key drives `Self::Assoc` projection
-        // and associated-type-binding lookup. For an inline supermethod this is
-        // the exact supertrait owner that declared the associated type, not the
-        // sub-trait spelling written in the impl.
-        let declaring_trait_name = declaring_key.clone();
-
         // Build trait-type-param substitution map.
         let mut trait_param_map: HashMap<String, Ty> = HashMap::new();
         if let Some(args) = trait_bound.type_args.as_ref() {
@@ -8823,13 +8792,7 @@ impl Checker {
             .params
             .iter()
             .map(|p| {
-                let projected = self.substitute_trait_sig_for_impl(
-                    p,
-                    &impl_self,
-                    &impl_self_name,
-                    &declaring_trait_name,
-                    &trait_param_map,
-                );
+                let projected = self.substitute_trait_sig_for_impl(p, &impl_self, &trait_param_map);
                 Self::rename_method_type_params(
                     &projected,
                     trait_method.type_params.as_ref(),
@@ -8841,8 +8804,6 @@ impl Checker {
             let projected = self.substitute_trait_sig_for_impl(
                 &trait_sig.return_type,
                 &impl_self,
-                &impl_self_name,
-                &declaring_trait_name,
                 &trait_param_map,
             );
             Self::rename_method_type_params(

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -2159,12 +2159,12 @@ impl Checker {
 
     /// Walk a `Ty` and collapse `Ty::AssocType { base, trait_name, assoc_name }`
     /// carriers whose `base` resolves to either an in-scope type parameter
-    /// with a where-clause associated-type binding or a concrete
-    /// `Ty::Named { name, .. }` for which an impl is registered. Carriers whose
-    /// base is still abstract and unconstrained (a generic type param without
-    /// a matching associated-type binding, an unresolved inference variable,
-    /// another `Ty::AssocType`, etc.) pass through unchanged so they can be
-    /// diagnosed or collapsed later when more substitutions arrive.
+    /// with a where-clause associated-type binding or a concrete impl target
+    /// for which an impl is registered. Carriers whose base is still abstract
+    /// and unconstrained (a generic type param without a matching associated-
+    /// type binding, an unresolved inference variable, another
+    /// `Ty::AssocType`, etc.) pass through unchanged so they can be diagnosed
+    /// or collapsed later when more substitutions arrive.
     ///
     /// Lookup goes through `impl_assoc_type_bindings`, populated at impl-
     /// registration. When no binding exists for `(base_type, trait, assoc)`,
@@ -2201,11 +2201,20 @@ impl Checker {
                             assoc_name: assoc_name.clone(),
                         };
                     }
-                    // Associated-type projection is executable conformance
-                    // authority. Both registration and the resolved base carry
-                    // the full nominal owner, so a miss must remain a miss.
-                    let nominal_identity = Self::canonical_primitive_or_builtin_key(&resolved_base)
-                        .or_else(|| {
+                }
+
+                // Associated-type projection is executable conformance
+                // authority. Registration keys primitive targets by their flat
+                // `Ty` variant and named targets by their constructor identity;
+                // projection must accept both classes. Generic arguments remain
+                // instance data used only to substitute the selected binding.
+                let named_base = match &resolved_base {
+                    Ty::Named { name, args, .. } => Some((name, args)),
+                    _ => None,
+                };
+                let nominal_identity = Self::canonical_primitive_or_builtin_key(&resolved_base)
+                    .or_else(|| {
+                        named_base.and_then(|(name, args)| {
                             self.resolved_builtin_type(name).and_then(|builtin| {
                                 Self::canonical_primitive_or_builtin_key(&Ty::builtin_named(
                                     builtin,
@@ -2213,10 +2222,14 @@ impl Checker {
                                 ))
                             })
                         })
-                        .unwrap_or_else(|| {
+                    })
+                    .or_else(|| {
+                        named_base.map(|(name, _)| {
                             self.canonical_nominal_name(name)
                                 .unwrap_or_else(|| name.clone())
-                        });
+                        })
+                    });
+                if let Some(nominal_identity) = nominal_identity {
                     let key = (
                         nominal_identity.clone(),
                         trait_key.clone(),
@@ -2254,6 +2267,7 @@ impl Checker {
                         // available) zipped with `args`. The fallback when
                         // `type_params` is absent is to return the binding
                         // unchanged — sound when the impl is non-generic.
+                        let args = named_base.map_or(&[][..], |(_, args)| args.as_slice());
                         let bound = if let Some(td) = self.type_defs.get(&nominal_identity) {
                             let map: HashMap<String, Ty> = td
                                 .type_params
@@ -2262,7 +2276,9 @@ impl Checker {
                                 .map(|(p, a)| (p.clone(), a.clone()))
                                 .collect();
                             binding.substitute_named_params_parallel(&map)
-                        } else if let Some(type_params) = builtin_generic_type_params(name) {
+                        } else if let Some(type_params) =
+                            named_base.and_then(|(name, _)| builtin_generic_type_params(name))
+                        {
                             let map: HashMap<String, Ty> = type_params
                                 .iter()
                                 .zip(args.iter())

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -2206,8 +2206,12 @@ impl Checker {
                     // the full nominal owner, so a miss must remain a miss.
                     let nominal_identity = Self::canonical_primitive_or_builtin_key(&resolved_base)
                         .or_else(|| {
-                            self.resolved_builtin_type(name)
-                                .map(|builtin| builtin.canonical_name().to_string())
+                            self.resolved_builtin_type(name).and_then(|builtin| {
+                                Self::canonical_primitive_or_builtin_key(&Ty::builtin_named(
+                                    builtin,
+                                    args.clone(),
+                                ))
+                            })
                         })
                         .unwrap_or_else(|| {
                             self.canonical_nominal_name(name)
@@ -2858,7 +2862,10 @@ impl Checker {
                         return Ty::normalize_named(self_type_name.clone(), self_type_args.clone());
                     }
                 }
-                if let Some(alias_name) = name.strip_prefix("Self::") {
+                if let Some(alias_name) = name
+                    .strip_prefix("Self.")
+                    .or_else(|| name.strip_prefix("Self::"))
+                {
                     // Resolving a trait method's declared signature: the
                     // `Self::Bar` projection must materialise as a deferred
                     // `Ty::AssocType` carrier so downstream call sites (where
@@ -2929,7 +2936,20 @@ impl Checker {
                 // bounds), missing-assoc (no bound declares `Bar`), and
                 // ambiguous (more than one bound declares `Bar`) are all
                 // typed errors here. No silent pass-through.
-                if !name.starts_with("Self::") {
+                if !name.starts_with("Self::") && !name.starts_with("Self.") {
+                    // Dotted paths are also the module-qualified nominal
+                    // surface. Treat a direct `T.Item` as an associated-type
+                    // projection only when `T` is a type parameter in scope;
+                    // otherwise leave it for nominal resolution below.
+                    if let Some((base_name, assoc_name)) = name.split_once('.') {
+                        if !assoc_name.contains('.') {
+                            if let Some(ty) =
+                                self.try_resolve_assoc_projection(base_name, assoc_name, &te.1)
+                            {
+                                return ty;
+                            }
+                        }
+                    }
                     if let Some((base_name, assoc_name)) = name.split_once("::") {
                         // Reject multi-segment projections (`T::Iter::Bar`)
                         // explicitly — deferred per the precursor plan.

--- a/hew-types/tests/trait/trait_impl_signature_equivalence.rs
+++ b/hew-types/tests/trait/trait_impl_signature_equivalence.rs
@@ -29,7 +29,7 @@ const ITER_TRAIT_PRELUDE: &str = r"
 pub trait Iterator {
     type Item;
 
-    fn next(self) -> Option<Self::Item>;
+    fn next(self) -> Option<Self.Item>;
 }
 ";
 
@@ -62,6 +62,60 @@ impl Iterator for Counter {{
     assert!(
         output.errors.is_empty(),
         "correct signature must not emit TraitImplSignatureMismatch; got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn impl_projects_direct_dotted_associated_return_type() {
+    let src = r"
+pub trait Source {
+    type Item;
+    fn item(self) -> Self.Item;
+}
+
+pub type Counter {
+    n: i64;
+}
+
+impl Source for Counter {
+    type Item = i64;
+    fn item(counter: Counter) -> i64 {
+        counter.n
+    }
+}
+";
+    let output = typecheck_isolated(src);
+    assert!(
+        output.errors.is_empty(),
+        "direct `Self.Item` must project through the impl binding; got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn impl_projects_dotted_generic_binding_in_associated_parameter() {
+    let src = r"
+pub trait Message {
+    type Body;
+}
+
+pub trait Sender {
+    type Body;
+    fn send(self, body: Self.Body);
+}
+
+pub type LocalSender<T> {}
+
+impl<T: Message> Sender for LocalSender<T> {
+    type Body = T.Body;
+    fn send(sender: LocalSender<T>, body: Self.Body) {}
+}
+";
+    let output = typecheck_isolated(src);
+    assert!(
+        output.errors.is_empty(),
+        "dotted generic and Self projections must share canonical carriers; got: {:#?}",
         output.errors
     );
 }

--- a/hew-types/tests/trait/trait_impl_signature_equivalence.rs
+++ b/hew-types/tests/trait/trait_impl_signature_equivalence.rs
@@ -94,6 +94,118 @@ impl Source for Counter {
 }
 
 #[test]
+fn primitive_impl_targets_project_dotted_associated_types() {
+    let src = r"
+pub trait Container {
+    type Item;
+    fn item(self) -> Self.Item;
+}
+
+impl Container for i64 {
+    type Item = i64;
+    fn item(value: i64) -> i64 { value }
+}
+
+impl Container for bool {
+    type Item = bool;
+    fn item(value: bool) -> bool { value }
+}
+
+impl Container for string {
+    type Item = string;
+    fn item(value: string) -> string { value }
+}
+";
+    let output = typecheck_isolated(src);
+    assert!(
+        output.errors.is_empty(),
+        "flat primitive impl targets must project through their constructor binding; got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn impl_projects_associated_type_inside_tuple() {
+    let src = r"
+pub trait Pairing {
+    type Item;
+    fn pair(self) -> (Self.Item, bool);
+}
+
+pub type Counter {
+    n: i64;
+}
+
+impl Pairing for Counter {
+    type Item = i64;
+    fn pair(counter: Counter) -> (i64, bool) {
+        (counter.n, true)
+    }
+}
+";
+    let output = typecheck_isolated(src);
+    assert!(
+        output.errors.is_empty(),
+        "tuple children must retain associated-type projection; got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn generic_applied_impl_projects_deeper_generic_composition() {
+    let src = r"
+pub trait Container {
+    type Item;
+    fn items(self) -> Vec<Option<Self.Item>>;
+}
+
+pub type Boxed<T> {
+    value: T;
+}
+
+impl<T> Container for Boxed<T> {
+    type Item = T;
+    fn items(value: Boxed<T>) -> Vec<Option<T>> {
+        [Some(value.value)]
+    }
+}
+";
+    let output = typecheck_isolated(src);
+    assert!(
+        output.errors.is_empty(),
+        "a generic-applied impl target must project through Vec<Option<Self.Item>>; got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn nested_generic_associated_type_mismatch_is_rejected() {
+    let src = r"
+pub trait Container {
+    type Item;
+    fn item(self) -> Option<Self.Item>;
+}
+
+pub type Counter {
+    n: i64;
+}
+
+impl Container for Counter {
+    type Item = i64;
+    fn item(counter: Counter) -> Option<string> {
+        None
+    }
+}
+";
+    let output = typecheck_isolated(src);
+    assert!(
+        has_trait_impl_sig_mismatch(&output, "return type"),
+        "Option<string> must not match required Option<Self.Item> when Item = i64; got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn impl_projects_dotted_generic_binding_in_associated_parameter() {
     let src = r"
 pub trait Message {

--- a/tests/vertical-slice/accept/q004_trait_impl_sig_match.hew
+++ b/tests/vertical-slice/accept/q004_trait_impl_sig_match.hew
@@ -8,7 +8,7 @@
 
 pub trait Container {
     type Item;
-    fn unwrap(self) -> Option<Self::Item>;
+    fn unwrap(self) -> Option<Self.Item>;
 }
 
 pub type Holder {


### PR DESCRIPTION
## Summary

- Resolve dotted `Self.Item` and generic `T.Item` as canonical associated-type projections.
- Substitute the impl receiver before projecting trait signatures through the checker’s canonical machinery.
- Turn invalid compiler-injected receiver impls into fatal HIR diagnostics instead of assertion aborts.
- Cover direct, nested, generic-binding, compiled-fixture, and fail-closed diagnostic cases.

## Tests

- `cargo test -p hew-types -p hew-hir`
- `make test-hew-ratchet`
- `make test-vertical-slice`
- Supplementary stdlib re-gate with this build: all Iterator, IntoIterator, Index, and Pid associated-projection signature errors cleared. Two unrelated warning-only checks remain (bare variant pattern and orphan impl warning).