### PR TITLE
test(wasi): await native periodic timer tick

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1534,6 +1534,12 @@ Periodic handlers preserve the actor's single-threaded state model: a tick never
 runs concurrently with another receive handler on the same actor. It is just a
 separate mailbox dispatch armed by the runtime timer.
 
+When the runtime shuts down, periodic-timer admission closes first. A periodic
+tick becomes live work only when the timer ticker claims it for callback
+delivery. Shutdown waits for callbacks already claimed, then cancels every
+pending periodic entry, including an entry that is already due but has not yet
+been claimed. Such an entry is not delivered during shutdown.
+
 ### Cancellable long-running work in actor handlers
 
 A receive handler runs to completion before the actor observes the next message.

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -205,6 +205,12 @@ actor HealthChecker {
 - The timer starts when the actor is spawned and repeats until the actor stops
 - Periodic handlers run within the actor's message loop, preserving single-threaded semantics
 
+At runtime shutdown, periodic-timer admission closes. A periodic tick becomes
+live work only when it is claimed for callback delivery. Shutdown waits for
+callbacks already claimed and cancels all pending entries, including entries
+that are due but not yet claimed; those entries are not delivered during
+shutdown.
+
 **Implementation:** The runtime uses a global timer wheel to schedule periodic self-sends. Each tick fires a zero-payload message to the actor's dispatch function at the handler's message index.
 
 ### 2.1.3 Lambda Actors

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -715,6 +715,32 @@ fn main() {
 }
 "#;
 
+// The native probe must synchronize with the first delivery instead of using a
+// wall-clock sleep: under scheduler pressure, main can wake and begin shutdown
+// before the periodic ticker thread runs, cancelling the still-pending first tick.
+const NATIVE_PERIODIC_HANDSHAKE_SOURCE: &str = r#"import std::channel::channel;
+
+actor Pulse {
+    let ready: channel.Sender<i64>;
+    var count: i64 = 0;
+
+    #[every(20ms)]
+    receive fn tick() {
+        count += 1;
+        println(f"tick {count}");
+        ready.send(count);
+    }
+}
+
+fn main() {
+    let (ready_tx, ready_rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(1);
+    let _p = spawn Pulse(ready: ready_tx, count: 0);
+    println("spawned");
+    let _ = ready_rx.recv();
+    println("done");
+}
+"#;
+
 #[test]
 fn wasm_actor_periodic_timer_fires_but_never_reaches_quiescence() {
     require_wasi_runner();
@@ -763,17 +789,17 @@ fn wasm_actor_periodic_timer_fires_but_never_reaches_quiescence() {
     );
 }
 
-// The native half: the same periodic-timer program terminates on its own.
-// Pinning this is what makes the wasm probe above a *parity* statement rather
-// than an isolated observation — it is the side that behaves, and the contrast
-// is the thing under test.
+// The native half uses the same periodic handler and interval, plus a channel
+// handshake that makes first delivery a precondition for main returning. Native
+// blocking receive is unavailable on WASM, so the WASM half keeps its cooperative
+// sleep probe while this half avoids racing wall-clock sleep against shutdown.
 #[test]
 fn native_actor_periodic_timer_reaches_quiescence() {
     support::require_codegen();
 
     let dir = support::tempdir();
     let source = dir.path().join("cooperative_periodic_native.hew");
-    fs::write(&source, COOPERATIVE_PERIODIC_SOURCE)
+    fs::write(&source, NATIVE_PERIODIC_HANDSHAKE_SOURCE)
         .expect("write cooperative periodic native source");
 
     let output = support::run_bounded_hew_run(&source, dir.path());

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -344,6 +344,11 @@ pub(crate) fn cancel_all_timers_for_actor(actor: *mut HewActor) {
 
 /// Close periodic-timer admission and cancel every timer already registered.
 ///
+/// A periodic tick becomes live work only when the ticker claims it for
+/// callback delivery. Shutdown closes admission, waits for callbacks already
+/// claimed, and cancels every pending entry, including entries that are due but
+/// not yet claimed.
+///
 /// Shutdown calls this before observing scheduler quiescence. The admission
 /// lock orders a concurrent schedule against the registry drain: a schedule
 /// either publishes its wheel entry and registry reference before the close
@@ -1358,6 +1363,64 @@ mod tests {
         unsafe { hew_actor_cancel_periodic(restarted) };
         // SAFETY: final serialized cleanup for this test.
         unsafe { hew_periodic_shutdown() };
+    }
+
+    #[test]
+    fn shutdown_cancels_due_but_unclaimed_periodic_entry() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Start from a fresh global wheel and leave the ticker parked on a far
+        // deadline. The test advances only the wheel cursor, so the entry can
+        // be made due without letting the ticker claim it.
+        // SAFETY: this test serializes ownership of the process-wide timer state.
+        unsafe { hew_periodic_shutdown() };
+        reset_periodic_admission();
+
+        let mut actor = create_test_actor(50_403);
+        let actor_ptr = &raw mut actor;
+        // SAFETY: actor_ptr remains live through the serialized shutdown.
+        let handle = unsafe { hew_actor_schedule_periodic(actor_ptr, 7, 60_000) };
+        assert!(!handle.is_null());
+
+        let ctx = ACTOR_TIMERS.access(|lock| {
+            Arc::clone(
+                lock.as_ref()
+                    .and_then(|map| map.get(&(actor_ptr as usize)))
+                    .and_then(|timers| timers.first())
+                    .expect("scheduled timer must be registered"),
+            )
+        });
+        let wheel = ctx.wheel;
+        let first_fire = ctx.next_fire_ms.load(Ordering::SeqCst);
+        // SAFETY: `wheel` is the live wheel owned by the periodic context.
+        let cursor = unsafe { timer_wheel_cursor_ms(wheel) };
+        assert!(first_fire > cursor);
+
+        // Let the ticker settle into its far-deadline park before making the
+        // entry due. No insertion notification occurs for this cursor change.
+        std::thread::sleep(Duration::from_millis(20));
+        // SAFETY: the ticker is parked and the test owns the wheel cursor.
+        unsafe {
+            crate::timer_wheel::timer_wheel_advance_cursor_for_test(
+                wheel,
+                first_fire.saturating_sub(cursor).saturating_add(1),
+            );
+        }
+        // SAFETY: `wheel` remains live until the serialized shutdown below.
+        assert_eq!(unsafe { hew_timer_wheel_next_deadline_ms(wheel) }, 0);
+        assert_eq!(ctx.next_fire_ms.load(Ordering::SeqCst), first_fire);
+
+        // The due entry is still pending and unclaimed. Shutdown must cancel
+        // it rather than silently delivering the callback.
+        // SAFETY: this test owns the process-wide timer state.
+        unsafe { hew_periodic_shutdown() };
+
+        assert_eq!(ctx.next_fire_ms.load(Ordering::SeqCst), first_fire);
+        assert!(ctx.cancelled.load(Ordering::SeqCst));
+        assert_eq!(timer_count_for_actor(actor_ptr), 0);
+        assert_eq!(Arc::strong_count(&ctx), 1, "pending wheel reference leaked");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace the native periodic-timer probe wall-clock delay with a channel handshake from the first delivered tick.
- Keep the WASM cooperative-timer fixture unchanged because blocking channel receive is not supported there.
- Prevent loaded runners from starting shutdown before the native ticker thread delivers its first due callback.

## Verification

- Focused native probe: 200/200 while 15 CPU burners saturated the host.
- `cargo test -p hew-cli wasi`
- `make test-hew-ratchet`
- `cargo clippy -p hew-cli --test wasi_run_e2e -- -D warnings`

## Out of scope

Runtime timer scheduling semantics are unchanged; the reproduced failure was the probe racing main-thread wakeup against first-tick delivery.
