### PR TITLE
docs(examples): migrate examples, docs, and spec grammars to the dotted surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ fn main() {
 To use modules beyond the builtins, add an `import` statement at the top of your file:
 
 ```hew
-import std::fs;
-import std::encoding::json;
+import std.fs;
+import std.encoding.json;
 
 fn main() {
     let data = fs.read("config.json");
@@ -173,16 +173,16 @@ Actors communicate across nodes with the same syntax used locally. The runtime h
 
 ```hew
 // server node
-Node::set_transport("quic");
-Node::start("127.0.0.1:9000");
+Node.set_transport("quic");
+Node.start("127.0.0.1:9000");
 let counter = spawn Counter;
-Node::register("counter", counter);
+Node.register("counter", counter);
 
 // client node (separate process)
-Node::set_transport("quic");
-Node::start("127.0.0.1:9001");
-Node::connect("127.0.0.1:9000");
-let counter: Counter = Node::lookup("counter");
+Node.set_transport("quic");
+Node.start("127.0.0.1:9001");
+Node.connect("127.0.0.1:9000");
+let counter: Counter = Node.lookup("counter");
 counter.increment(42);   // remote message — same syntax as local
 ```
 

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -175,7 +175,7 @@ fn main() {
     }
 
     let clamped: i32 = a.saturating_add(1);
-    println(clamped);          // 2147483647 (clamped to i32::MAX)
+    println(clamped);          // 2147483647 (clamped to i32.MAX)
 }
 ```
 
@@ -241,7 +241,7 @@ fn main() {
 ```hew
 fn main() {
     var total: i64 = 0;
-    let items: Vec<string> = Vec::new();
+    let items: Vec<string> = Vec.new();
     items.push("a");
     items.push("b");
     for s in items { total += s.len() as i64; }
@@ -350,7 +350,7 @@ fn main() {
 
 ```hew
 fn main() {
-    var v: Vec<i64> = Vec::new();
+    var v: Vec<i64> = Vec.new();
     v.push(10); v.push(20); v.push(30);
     var total = 0;
     for x in v { total += x; }
@@ -424,7 +424,7 @@ Use `if let Some(v) = opt` for a one-armed destructure; prefer `match` when you 
 
 ```hew
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10);
     v.push(20);
     v.push(30);
@@ -440,7 +440,7 @@ Annotate the binding type so the element type is inferred. `.len()` returns `i64
 ```hew
 type Point { x: i64; y: i64; }
 fn main() {
-    let v: Vec<Point> = Vec::new();
+    let v: Vec<Point> = Vec.new();
     v.push(Point { x: 1, y: 2 });
     v.push(Point { x: 3, y: 4 });
     let p = v[1];
@@ -450,7 +450,7 @@ fn main() {
 
 ```hew
 fn main() {
-    let names: Vec<string> = Vec::new();
+    let names: Vec<string> = Vec.new();
     names.push("ada");
     names.push("alan");
     let who = names[1];        // fresh owned string (a clone)
@@ -469,7 +469,7 @@ v.len()` already holds). A `Vec<string>` index returns a fresh owned `string`
 
 ```hew
 fn main() {
-    let v: Vec<string> = Vec::new();
+    let v: Vec<string> = Vec.new();
     v.push("a");
     v.push("b");
     match v.get(0) {
@@ -488,7 +488,7 @@ the trapping read). Use `.get(i)` whenever the index may be invalid.
 
 ```hew
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10); v.push(20); v.push(30); v.push(40);
     let s = v[1..3];
     println(s.len());    // 2
@@ -505,7 +505,7 @@ longer required for that.)
 
 ```hew
 fn main() {
-    let v: Vec<string> = Vec::new();
+    let v: Vec<string> = Vec.new();
     v.push("alpha");
     v.push("beta");
     for s in v {
@@ -522,14 +522,14 @@ Prefer for-in for read-only traversal of any element type, including
 ```hew
 enum Colour { Red; Green; Blue; }
 fn main() {
-    let v: Vec<Colour> = Vec::new();
-    v.push(Colour::Red);
-    v.push(Colour::Blue);
+    let v: Vec<Colour> = Vec.new();
+    v.push(Colour.Red);
+    v.push(Colour.Blue);
     let c = v[1];
     match c {
-        Colour::Red => println("red"),
-        Colour::Green => println("green"),
-        Colour::Blue => println("blue"),
+        Colour.Red => println("red"),
+        Colour.Green => println("green"),
+        Colour.Blue => println("blue"),
     }
 }
 ```
@@ -543,7 +543,7 @@ v.len()` before a `for i in 0 .. n` loop.
 
 ```hew
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(1);
     v.push(2);
     let last = v.pop();   // i64 — the removed element, returned directly
@@ -559,7 +559,7 @@ check `.len()` before `.pop()`), or use `.get(i)` for the non-trapping read.
 
 ```hew
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10); v.push(20); v.push(30);
     v.set(1, 99);
     println(v[0]);   // 10
@@ -574,12 +574,12 @@ fn main() {
 
 ```hew
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(1); v.push(2); v.push(3);
     println(v.contains(2));   // true
     println(v.contains(9));   // false
 
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(4); v2.push(5);
     v.append(v2);             // v is now [1, 2, 3, 4, 5]
     println(v.len());         // 5
@@ -595,12 +595,12 @@ fn main() {
 
 ```hew
 fn main() {
-    let matrix: Vec<Vec<i64>> = Vec::new();
+    let matrix: Vec<Vec<i64>> = Vec.new();
 
-    let row0: Vec<i64> = Vec::new();
+    let row0: Vec<i64> = Vec.new();
     row0.push(1); row0.push(2); row0.push(3);
 
-    let row1: Vec<i64> = Vec::new();
+    let row1: Vec<i64> = Vec.new();
     row1.push(4); row1.push(5); row1.push(6);
 
     matrix.push(row0);
@@ -620,7 +620,7 @@ fn main() {
 
 ```hew
 fn main() {
-    let m: HashMap<string, i64> = HashMap::new();
+    let m: HashMap<string, i64> = HashMap.new();
     m.insert("alice", 10);
     m.insert("bob", 20);
     println(m.len());   // 2
@@ -633,7 +633,7 @@ Use `let` (not `var`) — these have interior mutability so the binding is never
 
 ```hew
 fn main() {
-    let m: HashMap<string, i64> = HashMap::new();
+    let m: HashMap<string, i64> = HashMap.new();
     m.insert("alice", 10);
     match m.get("alice") {
         Some(v) => println(f"alice={v}"),
@@ -648,7 +648,7 @@ fn main() {
 
 ```hew
 fn main() {
-    let m: HashMap<string, i64> = HashMap::new();
+    let m: HashMap<string, i64> = HashMap.new();
     m.insert("alice", 1);
     m.insert("bob", 2);
     let has_alice = m.contains_key("alice");   // true
@@ -669,18 +669,18 @@ type User { name: string; score: i64; }
 
 fn main() {
     // Scalar values
-    let flags: HashMap<string, bool> = HashMap::new();
+    let flags: HashMap<string, bool> = HashMap.new();
     flags.insert("debug", true);
-    let ratios: HashMap<string, f64> = HashMap::new();
+    let ratios: HashMap<string, f64> = HashMap.new();
     ratios.insert("pi", 3.14);
 
     // User-defined records work as values
-    let users: HashMap<string, User> = HashMap::new();
+    let users: HashMap<string, User> = HashMap.new();
     users.insert("alice", User { name: "Alice", score: 100 });
 
     // Vec<T> also works as a value
-    let tags: HashMap<string, Vec<string>> = HashMap::new();
-    let v: Vec<string> = Vec::new();
+    let tags: HashMap<string, Vec<string>> = HashMap.new();
+    let v: Vec<string> = Vec.new();
     v.push("admin");
     tags.insert("alice", v);
 }
@@ -694,7 +694,7 @@ Keys are `string`. Value types include `i64`, `string`, `bool`, `f64`, user-defi
 
 ```hew
 fn main() {
-    let scores: HashMap<string, i64> = HashMap::new();
+    let scores: HashMap<string, i64> = HashMap.new();
     scores.insert("alice", 10);
     scores.insert("bob", 20);
 
@@ -717,7 +717,7 @@ fn main() {
 
 ```hew
 fn main() {
-    let m: HashMap<string, i64> = HashMap::new();
+    let m: HashMap<string, i64> = HashMap.new();
     m.insert("alice", 10);
     m.insert("bob", 20);
     m.insert("carol", 30);
@@ -740,7 +740,7 @@ fn main() {
 
 ```hew
 fn main() {
-    let s: HashSet<i64> = HashSet::new();
+    let s: HashSet<i64> = HashSet.new();
     s.insert(1);
     s.insert(2);
     s.insert(2);                 // dedups
@@ -792,7 +792,7 @@ fn main() -> i32 {
 ```
 
 ```hew
-import std::os;
+import std.os;
 
 // Pattern 2: check args, exit non-zero on error
 fn main() -> i32 {
@@ -826,7 +826,7 @@ Shell pipelines and `&&` chains read the exit code — write `main() -> i32` for
 ```hew
 fn fill(v: Vec<i64>) { v.push(1); v.push(2); v.push(3); }
 fn main() {
-    let xs: Vec<i64> = Vec::new();
+    let xs: Vec<i64> = Vec.new();
     fill(xs);
     println(xs.len());   // 3
 }
@@ -844,7 +844,7 @@ fn total(v: Vec<i64>) -> i64 {
     sum
 }
 fn main() {
-    let xs: Vec<i64> = Vec::new();
+    let xs: Vec<i64> = Vec.new();
     xs.push(10); xs.push(20);
     println(total(xs));
     println(total(xs));   // still valid; no move within a fn/actor
@@ -862,7 +862,7 @@ you need to keep using the original after such an insert, pass `clone x` (or
 
 ```hew
 fn main() {
-    let a: Vec<i64> = Vec::new();
+    let a: Vec<i64> = Vec.new();
     a.push(1); a.push(2);
     let b = a.clone();
     b.push(99);
@@ -877,7 +877,7 @@ Use `.clone()` only when you need a second independent copy — e.g. keeping the
 
 ```hew
 fn main() {
-    let a: Vec<i64> = Vec::new();
+    let a: Vec<i64> = Vec.new();
     a.push(1); a.push(2);
     let b = clone a;    // independent copy — same effect as `a.clone()`
     b.push(99);
@@ -936,8 +936,8 @@ fn main() {
     root.set(Node { label: "child", parent: Some(weak.clone()) });
 
     match weak.upgrade() {
-        Some(owner) => println(owner.strong_count()),
-        None => println("payload already released"),
+        .Some(owner) => println(owner.strong_count()),
+        .None => println("payload already released"),
     }
 }
 ```
@@ -1114,7 +1114,7 @@ fn eval(e: Expr) -> i64 {
     }
 }
 fn main() {
-    let e = Expr::Add(Expr::Lit(10), Expr::Lit(5));
+    let e = Expr.Add(Expr.Lit(10), Expr.Lit(5));
     println(eval(e));   // 15
 }
 ```
@@ -1376,7 +1376,7 @@ Put post-spawn initialization in `#[on(start)]` and teardown in `#[on(stop)]`. B
 ### #[on(crash)] hook
 
 ```hew
-import std::failure::{ CrashInfo, CrashAction };
+import std.failure.{ CrashInfo, CrashAction };
 
 actor Risky {
     var n: i64 = 0;
@@ -1472,7 +1472,7 @@ Returns immediately if `target` is already in the past. Combine with
 
 ```hew
 fn main() {
-    let t0 = instant::now();
+    let t0 = instant.now();
     let deadline = t0 + 50ms;
     // ... do some work ...
     sleep_until(deadline);    // waits only the remaining time
@@ -1587,7 +1587,7 @@ connection or data arrives, which is why `hew check` warns
 Inside a receive handler, use the suspending `await` form instead:
 
 ```hew
-import std::net;
+import std.net;
 
 actor Server {
     let addr: string;
@@ -1667,7 +1667,7 @@ machine Log {
     state Empty;
     state Filled { items: Vec<i64>; }
     on Append(item): Empty => Filled {
-        let v: Vec<i64> = Vec::new(); v.push(item); Filled { items: v }
+        let v: Vec<i64> = Vec.new(); v.push(item); Filled { items: v }
     }
     on Append(item): Filled => Filled reenter {
         let v = self.items; v.push(item); Filled { items: v }
@@ -1701,7 +1701,7 @@ machine Acc {
     on Add: Seed => Total { Total { sum: event.n } }
     on Add: Total => Total reenter { Total { sum: self.sum + event.n } }
 }
-fn make_add(n: i64) -> AccEvent { AccEvent::Add { n: n } }
+fn make_add(n: i64) -> AccEvent { AccEvent.Add { n: n } }
 fn main() {
     var a = Seed;
     a.step(make_add(5));
@@ -1756,7 +1756,7 @@ fn drive(d: Door) -> string {
     local.step(Open);
     local.state_name()
 }
-fn main() { println(drive(Door::Shut)); }   // Ajar
+fn main() { println(drive(.Shut)); }   // Ajar
 ```
 
 Pass machines by value into and out of free functions and mutate a local `var`. (Drive machines via local `var`, free-fn params, or the whole actor-message payload — not as an embedded named field of an actor or struct.)
@@ -1842,7 +1842,7 @@ A generic record instantiation may carry owned fields (`string`, `Vec<T>`, neste
 ```hew
 fn count<T>(items: Vec<T>) -> i64 { items.len() }
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10); v.push(20); v.push(30);
     println(count(v));   // 3
 }
@@ -1855,9 +1855,9 @@ Accept `Vec<T>` in a generic function and use `.len()`/`v[i]`.
 ```hew
 enum Shape { Circle(f64); Named(string); }
 fn main() {
-    let v: Vec<Shape> = Vec::new();
-    v.push(Shape::Circle(1.5));
-    v.push(Shape::Named("square"));
+    let v: Vec<Shape> = Vec.new();
+    v.push(Shape.Circle(1.5));
+    v.push(Shape.Named("square"));
     println(v.len());   // 2
 }
 ```
@@ -1869,7 +1869,7 @@ A monomorphic enum, even one carrying a string payload, is a valid Vec element. 
 ```hew
 type Point { x: i64; y: i64; }
 fn main() {
-    let v: Vec<Point> = Vec::new();
+    let v: Vec<Point> = Vec.new();
     v.push(Point { x: 1, y: 2 });
     v.push(Point { x: 3, y: 4 });
     let got = v[1];
@@ -1886,10 +1886,10 @@ When a generic function takes no arguments from which the type can be inferred, 
 
 ```hew
 fn make_vec<T>() -> Vec<T> {
-    Vec::new()
+    Vec.new()
 }
 fn main() {
-    let v = make_vec::<i64>();
+    let v = make_vec<i64>();
     v.push(10);
     v.push(20);
     println(v.len());   // 2
@@ -1901,7 +1901,7 @@ fn main() {
 ```hew
 type Stack<T> { items: Vec<T>; }
 
-fn new_empty<T>() -> Stack<T> { Stack { items: Vec::new() } }
+fn new_empty<T>() -> Stack<T> { Stack { items: Vec.new() } }
 
 fn make_i64_stack() -> Stack<i64> {
     new_empty()                    // return-position inference — no turbofish
@@ -1909,7 +1909,7 @@ fn make_i64_stack() -> Stack<i64> {
 
 fn main() {
     let s: Stack<i64> = new_empty();      // let-annotation inference — no turbofish
-    let s2 = new_empty::<i64>();          // turbofish — still supported, use when nothing else pins T
+    let s2 = new_empty<i64>();          // explicit type argument
     let s3 = make_i64_stack();
     println(s.items.len());
     println(s2.items.len());
@@ -1938,11 +1938,11 @@ impl<T> Stack<T> {
 }
 
 fn new_stack<T>() -> Stack<T> {
-    Stack { items: Vec::new() }
+    Stack { items: Vec.new() }
 }
 
 fn main() {
-    let s = new_stack::<i64>();
+    let s = new_stack<i64>();
     let s2 = s.push_item(1);
     let s3 = s2.push_item(2);
     println(s3.len());   // 2
@@ -2256,7 +2256,7 @@ fn main() {
 ### std::string module functions
 
 ```hew
-import std::string;
+import std.string;
 fn main() {
     println(string.from_int(42));            // 42
     let n = match string.to_int("42") {
@@ -2276,7 +2276,7 @@ Import `std::string` and call via the module name. `from_int`/`to_float` for con
 ### Concatenation, char round-trip, escapes
 
 ```hew
-import std::string;
+import std.string;
 fn main() {
     let g = "Hello" + ", " + "world";
     println(g);
@@ -2433,7 +2433,7 @@ Use `?` to short-circuit Err and propagate it; the enclosing fn must return a Re
 ### std::string helpers
 
 ```hew
-import std::string;
+import std.string;
 fn main() {
     println(string.from_int(42));            // 42
     println(string.to_int("100").unwrap_or(0));  // 100
@@ -2447,7 +2447,7 @@ Import `std::string` and call via the module name. Most case/slice/trim/find ope
 ### std::math helpers
 
 ```hew
-import std::math;
+import std.math;
 fn main() {
     println(math.sqrt(16.0));      // 4
     println(math.abs(-5.0));       // 5
@@ -2461,7 +2461,7 @@ fn main() {
 ### std::iter — lazy iterator combinators
 
 ```hew
-import std::iter;
+import std.iter;
 fn main() {
     let v: Vec<i64> = [1, 2, 3, 4, 5];
     println(iter.sum(iter.map(v.iter(), |x: i64| x * 2)));         // 30
@@ -2477,21 +2477,21 @@ When the receiver is a `Vec` field in actor state, `into_iter()` DRAINS the fiel
 ### std::sort — sorting vectors
 
 ```hew
-import std::sort;
+import std.sort;
 fn main() {
-    let nums: Vec<i64> = Vec::new();
+    let nums: Vec<i64> = Vec.new();
     nums.push(3); nums.push(1); nums.push(4); nums.push(1); nums.push(5);
     let sorted   = sort.sort_ints(nums);       // returns new Vec — original unchanged
     let reversed = sort.reverse_ints(sorted);
     println(sorted[0]);    // 1
     println(reversed[0]);  // 5
 
-    let words: Vec<string> = Vec::new();
+    let words: Vec<string> = Vec.new();
     words.push("banana"); words.push("apple"); words.push("cherry");
     let sw = sort.sort_strings(words);
     println(sw[0]);        // apple
 
-    let floats: Vec<f64> = Vec::new();
+    let floats: Vec<f64> = Vec.new();
     floats.push(3.14); floats.push(1.41); floats.push(2.72);
     let sf = sort.sort_floats(floats);
     println(sf[0]);        // 1.41
@@ -2503,14 +2503,14 @@ fn main() {
 ### std::random — pseudo-random number generation
 
 ```hew
-import std::random;
+import std.random;
 fn main() {
     random.seed(42);                   // deterministic sequence
     let r = random.random();           // f64 in [0.0, 1.0)
     let n = random.randint(1, 7);      // i64 in [1, 7)  — like a d6 roll
     let g = random.gauss(0.0, 1.0);   // Gaussian sample
 
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10); v.push(20); v.push(30);
     random.shuffle(v);                 // in-place Fisher-Yates shuffle
     println(v[0]);                     // non-deterministic (seeded above)
@@ -2522,7 +2522,7 @@ Backed by a CPython-compatible MT19937 Mersenne Twister — the same seed produc
 ### std::time::datetime — timestamps and date arithmetic
 
 ```hew
-import std::time::datetime;
+import std.time.datetime;
 fn main() {
     let now = datetime.now_ms();             // i64 epoch milliseconds
     println(datetime.to_iso8601(now));       // 2026-06-23T18:42:22Z
@@ -2550,7 +2550,7 @@ Timestamps are `i64` epoch milliseconds throughout. `to_iso8601` formats as RFC 
 ### std::deque — double-ended queue
 
 ```hew
-import std::deque;
+import std.deque;
 fn main() {
     let dq = deque.new();
     dq.push_back(1);
@@ -2569,9 +2569,9 @@ fn main() {
 ### Multiple stdlib imports coexisting
 
 ```hew
-import std::string;
-import std::math;
-import std::iter;
+import std.string;
+import std.math;
+import std.iter;
 fn main() {
     println(string.from_int(math.max(2, 9)));   // 9
     let v: Vec<i64> = [1, 2, 3];
@@ -2584,7 +2584,7 @@ fn main() {
 ### std::encoding::json — parsing and building JSON
 
 ```hew
-import std::encoding::json;
+import std.encoding.json;
 
 fn main() {
     // Parse a JSON string
@@ -2603,7 +2603,7 @@ fn main() {
 ```
 
 ```hew
-import std::encoding::json;
+import std.encoding.json;
 
 fn main() {
     // Build a JSON object
@@ -2629,7 +2629,7 @@ fn main() {
 | 6 | object |
 
 ```hew
-import std::encoding::json;
+import std.encoding.json;
 
 fn main() {
     let s = json.string_value("hello");
@@ -2641,7 +2641,7 @@ fn main() {
 **Fallible parsing with `try_parse`** returns `Result<Value, ParseError>`. Match on the module-qualified `ParseError::Invalid(msg)` pattern to recover the native parser's message, or match `Err(_)` to ignore it:
 
 ```hew
-import std::encoding::json;
+import std.encoding.json;
 
 fn main() {
     match json.try_parse("{\"ok\": true}") {
@@ -2649,11 +2649,11 @@ fn main() {
             println("parsed ok");
             v.free();
         },
-        Err(ParseError::Invalid(msg)) => println(f"parse failed: {msg}"),
+        Err(ParseError.Invalid(msg)) => println(f"parse failed: {msg}"),
     }
     match json.try_parse("not valid json {") {
         Ok(v) => { v.free(); },
-        Err(ParseError::Invalid(msg)) => println(f"bad json rejected: {msg}"),
+        Err(ParseError.Invalid(msg)) => println(f"bad json rejected: {msg}"),
     }
 }
 ```
@@ -2663,7 +2663,7 @@ fn main() {
 **Naming the `Value` type** — a plain `import std::encoding::json;` publishes the `json` module alias (`json.parse(...)`, `json.Value` as a qualified type) but does not put the bare `Value` name in scope. Use `Value` unqualified in a function signature (a parameter or return type) by importing it alongside the module in one combined import:
 
 ```hew
-import std::encoding::json::{self, Value};
+import std.encoding.json.{self, Value};
 ```
 
 `self` keeps the `json.parse(...)` / `json.object()` module-call style; `Value` lets you write `fn foo(v: Value) -> ...` instead of `fn foo(v: json.Value) -> ...`. Omitting the named import and using bare `Value` in a signature fails with `type Value is not in scope`.
@@ -2671,7 +2671,7 @@ import std::encoding::json::{self, Value};
 **Nested config with required fields** — `get_field` on a missing key returns a value whose `type_of()` is `-1` (distinct from `0`, the tag for an explicit JSON `null`). Use that to fail closed on a required field instead of silently reading garbage:
 
 ```hew
-import std::encoding::json::{self, Value};
+import std.encoding.json.{self, Value};
 
 fn require_string(config: Value, key: string) -> string {
     let field = config.get_field(key);
@@ -2733,7 +2733,7 @@ segment (`c` here) — call its public items as `c.function_name()` /
 `std::math`, and every other stdlib module:
 
 ```hew
-import std::string;
+import std.string;
 
 fn main() {
     println(string.from_int(42));
@@ -2837,13 +2837,13 @@ fn main() {
     println(a != c);   // true
 
     // Enum equality — unit variants
-    println(Color::Red == Color::Red);     // true
-    println(Color::Red == Color::Green);   // false
+    println(Color.Red == Color.Red);     // true
+    println(Color.Red == Color.Green);   // false
 
     // Enum equality — payload-bearing variants
-    println(Color::Custom(42) == Color::Custom(42));   // true
-    println(Color::Custom(42) == Color::Custom(99));   // false
-    println(Color::Custom(42) != Color::Red);           // true
+    println(Color.Custom(42) == Color.Custom(42));   // true
+    println(Color.Custom(42) == Color.Custom(99));   // false
+    println(Color.Custom(42) != Color.Red);           // true
 }
 ```
 
@@ -2859,30 +2859,30 @@ enum Tag { A; B(i64); }
 
 fn main() {
     // Primitive and string elements
-    let nums: Vec<i64> = Vec::new();
+    let nums: Vec<i64> = Vec.new();
     nums.push(10); nums.push(20); nums.push(30);
     println(nums.contains(20));   // true
     println(nums.contains(99));   // false
 
-    let words: Vec<string> = Vec::new();
+    let words: Vec<string> = Vec.new();
     words.push("hello"); words.push("world");
     println(words.contains("hello"));   // true
     println(words.contains("bye"));     // false
 
     // Record elements
-    let pts: Vec<Point> = Vec::new();
+    let pts: Vec<Point> = Vec.new();
     pts.push(Point { x: 1, y: 2 });
     pts.push(Point { x: 3, y: 4 });
     println(pts.contains(Point { x: 1, y: 2 }));   // true
     println(pts.contains(Point { x: 5, y: 6 }));   // false
 
     // Payload enum elements
-    let tags: Vec<Tag> = Vec::new();
-    tags.push(Tag::A);
-    tags.push(Tag::B(7));
-    println(tags.contains(Tag::A));      // true
-    println(tags.contains(Tag::B(7)));   // true
-    println(tags.contains(Tag::B(8)));   // false
+    let tags: Vec<Tag> = Vec.new();
+    tags.push(Tag.A);
+    tags.push(Tag.B(7));
+    println(tags.contains(Tag.A));      // true
+    println(tags.contains(Tag.B(7)));   // true
+    println(tags.contains(Tag.B(8)));   // false
 }
 ```
 
@@ -2937,7 +2937,7 @@ implies an equal hash and a float-bearing `record` is a sound `HashMap` key.
 record Coord { x: f64, y: f64 }
 
 fn main() {
-    let m: HashMap<Coord, i64> = HashMap::new();
+    let m: HashMap<Coord, i64> = HashMap.new();
     m.insert(Coord { x: 1.5, y: 2.5 }, 42);
     let v = m.get(Coord { x: 1.5, y: 2.5 });
     match v {
@@ -3028,7 +3028,7 @@ impl Conn {
 fn main() {
     let c: Conn = Conn { fd: 7 };
     println("work");
-    // c drops at scope exit here; Conn::close(c) runs automatically.
+    // c drops at scope exit here; Conn.close(c) runs automatically.
 }
 ```
 
@@ -3081,7 +3081,7 @@ copy for a new opaque type.
 ### Typed streams — `await sink.send(x)` / `await stream.recv()`
 
 ```hew
-import std::stream;
+import std.stream;
 
 actor Echo {
     let n: i64;
@@ -3124,7 +3124,7 @@ yet supported (`OwnedHandleAggregateExtractionUnsupported`). Full example:
 ### Channels — `channel.new`, `await rx.recv()`, and select arms
 
 ```hew
-import std::channel::channel;
+import std.channel.channel;
 
 actor Inbox {
     receive fn run(unused: i64) {
@@ -3165,7 +3165,7 @@ and [`examples/channel/select_recv.hew`](../examples/channel/select_recv.hew).
 ### Regex captures — `capture` / `find_all` / `find_all_submatch`
 
 ```hew
-import std::text::regex;
+import std.text.regex;
 
 fn main() {
     let re = regex.new("(?P<k>[a-z]+)=(?P<v>[0-9]+)");
@@ -3197,12 +3197,12 @@ exit; call `close()` to release it early. Full example:
 ### Templates — `parse` + `render_try`
 
 ```hew
-import std::text::template;
+import std.text.template;
 
 fn main() {
     let ctx = template.new_ctx();
     template.ctx_set_str(ctx, "name", "Hew");
-    let xs: Vec<string> = Vec::new();
+    let xs: Vec<string> = Vec.new();
     xs.push("a");
     xs.push("b");
     template.ctx_set_list(ctx, "xs", xs);
@@ -3227,7 +3227,7 @@ with a literal message rather than interpolating it. Full example:
 ### Unicode — rune helpers + classification predicates
 
 ```hew
-import std::text::unicode;
+import std.text.unicode;
 
 fn main() {
     let s = "Aé!";
@@ -3252,7 +3252,7 @@ codepoint with the predicates `is_upper` / `is_lower` / `is_digit` / `is_letter`
 ### Scanner — line and word tokenisation
 
 ```hew
-import std::io::scanner;
+import std.io.scanner;
 
 fn main() {
     var sc = scanner.from_string("alpha beta\ncolour");
@@ -3293,7 +3293,7 @@ serve and fetch on the same thread. The request/response codecs are pure and
 runnable in isolation:
 
 ```hew
-import std::net::http::http_async_client;
+import std.net.http.http_async_client;
 
 fn main() {
     let parts = http_async_client.split_address("http://127.0.0.1:8080/health");
@@ -3365,7 +3365,7 @@ impl ActorMsg for Echo {
 
 actor Client {
     receive fn go(unused: i64) {
-        let found: Result<RemotePid<Echo>, LookupError> = Node::lookup("echo");
+        let found: Result<RemotePid<Echo>, LookupError> = Node.lookup("echo");
         match found {
             Ok(peer) => {
                 let reply = peer.ask(7, 1000);
@@ -3422,13 +3422,13 @@ Call all identity and pinning operations before `Node::start`:
 
 <!-- doctest: skip -->
 ```hew
-Node::set_transport("quic-mesh");
-Node::load_keys("node.key");
-println(f"pin this credential on peers: {Node::identity_key()}");
+Node.set_transport("quic-mesh");
+Node.load_keys("node.key");
+println(f"pin this credential on peers: {Node.identity_key()}");
 
 // This process chooses local route slot 2 for the peer.
-Node::allow_peer(2, "3059301306072a8648ce3d020106082a8648ce3d030107");
-Node::start("0.0.0.0:9000");
+Node.allow_peer(2, "3059301306072a8648ce3d020106082a8648ce3d030107");
+Node.start("0.0.0.0:9000");
 ```
 
 On TCP, the pinned credential is the peer's 32-byte Noise public key. On
@@ -3439,7 +3439,7 @@ A client selects its local pin when connecting:
 
 <!-- doctest: skip -->
 ```hew
-Node::connect("2@127.0.0.1:9000");
+Node.connect("2@127.0.0.1:9000");
 ```
 
 The `2@` prefix is the client's route slot for that server. The authenticated
@@ -3466,16 +3466,16 @@ Remote monitors deliver one typed notification through `#[on(down)]`:
 
 <!-- doctest: skip -->
 ```hew
-import std::link_monitor::{DownNotification, DownReason};
+import std.link_monitor.{DownNotification, DownReason};
 
 actor Watcher {
     #[on(down)]
     fn on_down(note: DownNotification) {
         match note.reason {
-            DownReason::Exited => println("peer exited"),
-            DownReason::Crashed(_) => println("peer crashed"),
-            DownReason::MonitorLost => println("peer became unreachable"),
-            DownReason::LocalShutdown => println("local node shut down"),
+            DownReason.Exited => println("peer exited"),
+            DownReason.Crashed(_) => println("peer crashed"),
+            DownReason.MonitorLost => println("peer became unreachable"),
+            DownReason.LocalShutdown => println("local node shut down"),
         }
     }
 }
@@ -3492,7 +3492,7 @@ surfaces.
 ### TLS client — free-function surface (with a v0.5 data-plane caveat)
 
 ```hew
-import std::net::tls;
+import std.net.tls;
 
 fn main() {
     let stream = tls.connect("example.com", 443);
@@ -3521,13 +3521,13 @@ Full example: [`examples/net/tls_client.hew`](../examples/net/tls_client.hew).
 ### `process.run` vs `process.run_argv` — shell vs no-shell
 
 ```hew
-import std::process;
+import std.process;
 
 fn main() {
     let out = process.run("echo shell-form");
     println(out.trim());
 
-    let args: Vec<string> = Vec::new();
+    let args: Vec<string> = Vec.new();
     args.push("no-shell-form");
     let result = process.run_argv("echo", args);
     println(result.stdout.trim());

--- a/docs/migrations/v0.4.0.md
+++ b/docs/migrations/v0.4.0.md
@@ -152,8 +152,8 @@ fn process(input: String) -> bool {
 New pattern:
 
 ```hew
-import std::net::http;
-import std::text::regex;
+import std.net.http;
+import std.text.regex;
 
 fn main() {
     match http.listen(":8080") {
@@ -256,8 +256,8 @@ fn parse(s: String) {
 New pattern:
 
 ```hew
-import std::net::http;
-import std::encoding::json;
+import std.net.http;
+import std.encoding.json;
 
 actor Handler {
     receive fn handle(srv: http.Server) {
@@ -326,7 +326,7 @@ let decompressed = compress.gzip_decompress(data);
 New shape:
 
 ```hew
-import std::encoding::compress;
+import std.encoding.compress;
 
 let data = fs.read_bytes("archive.gz");
 let decompressed = compress.gzip_decompress(data, 64 * 1024 * 1024);
@@ -386,7 +386,7 @@ println(body);
 New shape:
 
 ```hew
-import std::net::http_client;
+import std.net.http_client;
 
 match http_client.get_string("https://example.com/api") {
     Some(body) => println(body),

--- a/docs/observe.md
+++ b/docs/observe.md
@@ -12,7 +12,7 @@ or telemetry — see the observable-honesty axiom in the
 There are three primary metric APIs in `std::observe`:
 
 ```hew
-import std::observe;
+import std.observe;
 
 observe.read("heap.live_bytes"); // i64
 observe.series();                 // string
@@ -34,7 +34,7 @@ Reads one scalar metric by its canonical dotted name and returns its current
 value as an `i64`.
 
 ```hew
-import std::observe;
+import std.observe;
 
 println(observe.read("heap.live_bytes"));
 println(observe.read("actors.turns_total"));
@@ -53,7 +53,7 @@ Returns the canonical metric names, one per line. It lists the 28 scalar names
 accepted by `observe.read` plus the two labelled actor-attribution series names.
 
 ```hew
-import std::observe;
+import std.observe;
 
 println(observe.series());
 ```
@@ -66,7 +66,7 @@ available.
 Returns Prometheus-style text for the current registry:
 
 ```hew
-import std::observe;
+import std.observe;
 
 println(observe.scrape());
 ```
@@ -90,7 +90,7 @@ actors_attributed_turns_by_handler_total{dispatch="0x...",msg_type="...",handler
 Save this as `observe_demo.hew`:
 
 ```hew
-import std::observe;
+import std.observe;
 
 actor Counter {
     var count: i64;

--- a/docs/specs/HEW-DIST-SPEC.md
+++ b/docs/specs/HEW-DIST-SPEC.md
@@ -243,24 +243,24 @@ An actor receives monitor termination through one typed hook:
 
 <!-- doctest: skip -->
 ```hew
-import std::link_monitor::{DownNotification, DownReason, DownTarget};
+import std.link_monitor.{DownNotification, DownReason, DownTarget};
 
 actor Watcher {
     #[on(down)]
     fn on_down(note: DownNotification) {
         match note.target {
-            DownTarget::Remote(location) => {
+            DownTarget.Remote(location) => {
                 println(f"remote actor down: {location}");
             },
-            DownTarget::Local(slot) => {
+            DownTarget.Local(slot) => {
                 println(f"local actor {slot} down");
             },
         }
         match note.reason {
-            DownReason::Exited => println("clean exit"),
-            DownReason::Crashed(_) => println("crash"),
-            DownReason::MonitorLost => println("partition"),
-            DownReason::LocalShutdown => println("local shutdown"),
+            DownReason.Exited => println("clean exit"),
+            DownReason.Crashed(_) => println("crash"),
+            DownReason.MonitorLost => println("partition"),
+            DownReason.LocalShutdown => println("local shutdown"),
         }
     }
 }
@@ -315,21 +315,21 @@ assigns the peer any free local route slot:
 
 <!-- doctest: skip -->
 ```hew
-Node::set_transport("tcp");
-Node::load_keys("server.key");
-println(f"pin this credential on peers: {Node::identity_key()}");
+Node.set_transport("tcp");
+Node.load_keys("server.key");
+println(f"pin this credential on peers: {Node.identity_key()}");
 
 // Slot 0 is reserved. Slot 1 is this process's local alias for this peer.
-Node::allow_peer(1, "8f4c...64-hex-digits-total");
-Node::start("0.0.0.0:9000");
+Node.allow_peer(1, "8f4c...64-hex-digits-total");
+Node.start("0.0.0.0:9000");
 ```
 
 A client that pinned the server at local route slot `1` connects with:
 
 <!-- doctest: skip -->
 ```hew
-Node::connect("1@127.0.0.1:9000");
-let found: Result<RemotePid<Counter>, LookupError> = Node::lookup("counter");
+Node.connect("1@127.0.0.1:9000");
+let found: Result<RemotePid<Counter>, LookupError> = Node.lookup("counter");
 ```
 
 The route-slot prefix selects the local credential pin. The authenticated key

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -456,7 +456,7 @@ The compiler automatically determines `Send` and `Frozen` for user-defined types
 `bytes` is a built-in compiler type with stdlib-registered methods: a mutable, heap-allocated byte buffer — semantically a `Vec<u8>` — but with a dedicated type name:
 
 ```hew
-let buf: bytes = bytes::new();
+let buf: bytes = bytes.new();
 buf.push(0x48);    // push a byte value (i64)
 buf.push(72);      // same as 'H' in ASCII
 let n = buf.len(); // i64
@@ -716,7 +716,7 @@ This is enforced at compile time: any captured value in a `spawn` expression mus
 
 ```hew
 actor Example {
-    var data: Vec<i64> = Vec::new();
+    var data: Vec<i64> = Vec.new();
 
     receive fn demo() {
         // Multiple mutable references - ALLOWED (single-threaded)
@@ -732,7 +732,7 @@ actor Example {
         y.push(4);        // ok - same actor, sequential execution
 
         // Returning references to local data - ALLOWED
-        let local = Vec::new();
+        let local = Vec.new();
         process(local);   // works because single-threaded
     }
 }
@@ -779,7 +779,7 @@ Hew uses a file-based module system inspired by Rust:
 
 ```hew
 // src/network/tcp.hew
-// This is module network::tcp
+// This is module network.tcp
 
 pub type Connection {
     address: string;       // public fields via pub keyword on type
@@ -798,10 +798,10 @@ fn helper() {  // private to this module
 **Import syntax:**
 
 ```hew
-import network::tcp;                    // Import module
-import network::tcp::Connection;        // Import specific symbol
-import network::tcp::{Connection, connect};  // Import multiple
-import network::tcp::*;                 // Import all public symbols (discouraged)
+import network.tcp;                    // Import module
+import network.tcp.Connection;        // Import specific symbol
+import network.tcp.{Connection, connect};  // Import multiple
+import network.tcp.*;                 // Import all public symbols (discouraged)
 ```
 
 **Module dot-syntax for standard library:**
@@ -809,10 +809,10 @@ import network::tcp::*;                 // Import all public symbols (discourage
 When importing a standard library module, the **last segment** of the module path becomes the local alias for the module. All access uses this short name, not the full path:
 
 ```hew
-import std::net::http;     // Available as "http", not "std::net::http"
-import std::fs;            // Available as "fs"
-import std::io;            // Available as "io"
-import std::text::regex;   // Available as "regex"
+import std.net.http;     // Available as "http", not "std.net.http"
+import std.fs;            // Available as "fs"
+import std.io;            // Available as "io"
+import std.text.regex;   // Available as "regex"
 
 // Call module functions with dot-syntax: module.function(args)
 match http.listen("127.0.0.1:0") { // Returns Result<Server, NetError>
@@ -1006,16 +1006,16 @@ Traits define shared behaviour that types can implement. Hew has built-in marker
 **Trait declaration:**
 
 ```hew
-trait Display {
+trait Renderable {
     fn fmt(val: Self) -> string;
 }
 
-trait Iterator {
+trait Sequence {
     type Item;
     fn next(iter: Self) -> Option<Self::Item>;
 }
 
-trait Clone {
+trait Duplicable {
     fn clone(val: Self) -> Self;
 }
 ```
@@ -1023,9 +1023,13 @@ trait Clone {
 **Trait implementation:**
 
 ```hew
+trait PointRenderer {
+    fn fmt(val: Self) -> string;
+}
+
 type Point { x: f64; y: f64 }
 
-impl Display for Point {
+impl PointRenderer for Point {
     fn fmt(p: Point) -> string {
         f"({p.x}, {p.y})"
     }
@@ -1057,11 +1061,13 @@ impl Display for Point {
 Hew uses **named receivers** instead of a `self` keyword. In trait declarations and `impl` blocks, the first parameter whose type matches the implementing type (or `Self` in traits) is the **receiver**. The receiver is what makes a function callable with dot-syntax:
 
 ```hew
-trait Display {
+type Point { x: f64; y: f64 }
+
+trait Formattable {
     fn fmt(val: Self) -> string;       // val is the receiver (type Self)
 }
 
-impl Display for Point {
+impl Formattable for Point {
     fn fmt(p: Point) -> string {       // p is the receiver (type Point)
         f"({p.x}, {p.y})"
     }
@@ -1074,7 +1080,7 @@ The compiler identifies the receiver by matching the parameter type against the 
 
 ```hew
 let p = Point { x: 1.0, y: 2.0 };
-p.fmt();    // desugars to Point::fmt(p) — p is consumed (by-value)
+p.fmt();    // desugars to Point.fmt(p) — p is consumed (by-value)
 // p is no longer valid here
 ```
 
@@ -1374,7 +1380,7 @@ indirect enum Expr {
 **Construction** works identically to regular enums:
 
 ```hew
-let e = Expr::Add(Expr::Lit(1), Expr::Neg(Expr::Lit(2)));
+let e = Expr.Add(Expr.Lit(1), Expr.Neg(Expr.Lit(2)));
 ```
 
 **Pattern matching** works identically to regular enums:
@@ -1537,7 +1543,7 @@ exists in stdlib — for file reading use `fs::try_read`):
 <!-- doctest: skip -->
 ```hew
 fn read_config(path: string) -> Result<Config, IoError> {
-    let f = File::open(path)?;
+    let f = File.open(path)?;
     let bytes = f.read_all()?;
     parse(bytes)
     // f drops at scope exit; the fd is closed automatically.
@@ -1549,7 +1555,7 @@ Early close, surfacing the I/O error to the caller (illustrative):
 <!-- doctest: skip -->
 ```hew
 fn read_and_process(path: string) -> Result<Summary, AppError> {
-    let f = File::open(path)?;
+    let f = File.open(path)?;
     let bytes = f.read_all()?;
     f.close()?;                 // close early; the error is visible.
     Ok(crunch(bytes))           // do CPU work after the fd is released.
@@ -1843,7 +1849,7 @@ Traits can declare associated types that implementors must specify:
 ```hew
 trait Iterator {
     type Item;
-    fn next(iter: Self) -> Option<Self::Item>;
+    fn next(iter: Self) -> Option<Self.Item>;
 }
 
 impl Iterator for RangeIter {
@@ -2275,11 +2281,11 @@ functions instead.
 The following traits are representative of the current trait style:
 
 ```hew
-trait Display {
+trait Printable {
     fn fmt(val: Self) -> string;
 }
 
-trait Drop {
+trait Releasable {
     fn drop(val: Self);
 }
 ```
@@ -2312,7 +2318,7 @@ pub enum IoError {
 }
 
 pub fn io_error_from_message(message: string) -> IoError {
-    IoError::Other(0)
+    IoError.Other(0)
 }
 ```
 
@@ -2360,7 +2366,7 @@ type error. This differs from `Vec<T>` indexing, where `v[i]` takes an `i64`
 index and returns the bare element `T`.
 
 ```hew
-var m: HashMap<string, i64> = HashMap::new();
+var m: HashMap<string, i64> = HashMap.new();
 m["answer"] = 42;        // insert/overwrite via index-assignment
 let hit = m["answer"];   // Option<i64> — Some(42)
 let miss = m["absent"];  // Option<i64> — None
@@ -2437,16 +2443,16 @@ The standard library exposes concrete modules rather than a large trait
 hierarchy. Representative APIs include:
 
 ```hew
-import std::deque;
-import std::fmt;
-import std::io;
-import std::iter;
-import std::math;
-import std::sort;
-import std::testing;
+import std.deque;
+import std.fmt;
+import std.io;
+import std.iter;
+import std.math;
+import std.sort;
+import std.testing;
 
-let ints: Vec<i64> = Vec::new();
-let set: HashSet<i64> = HashSet::new();
+let ints: Vec<i64> = Vec.new();
+let set: HashSet<i64> = HashSet.new();
 let dq = deque.new();
 
 println(math.abs(-5));
@@ -2794,9 +2800,9 @@ The compiler generates the following for every `machine Name { ... }`:
 accepted:
 
 ```hew
-var light = Light::Off;
+var light = Light.Off;
 light.step(Toggle);                // unqualified (preferred for brevity)
-light.step(LightEvent::Toggle);   // fully qualified (also valid)
+light.step(LightEvent.Toggle);   // fully qualified (also valid)
 ```
 
 **Pattern matching** — machine values can be destructured in `match`, `if let`,
@@ -2816,7 +2822,7 @@ Machines are values — they are commonly embedded as actor fields:
 
 ```hew
 actor ConnectionManager {
-    var tcp: TcpState = TcpState::Closed;
+    var tcp: TcpState = TcpState.Closed;
 
     receive fn handle(event: TcpStateEvent) {
         tcp.step(event);
@@ -3200,11 +3206,11 @@ When a scope-block is cancelled:
 
 ```hew
 receive fn download_files(urls: Vec<string>) -> Result<Vec<Data>, Error> {
-    var results: Vec<Data> = Vec::new();
+    var results: Vec<Data> = Vec.new();
     scope {
         for url in urls {
             scope {
-                let data = http::get(url)?;  // Safepoint — cancellation checked here
+                let data = http.get(url)?;  // Safepoint — cancellation checked here
                 results.push(process(data)); // If cancelled, stack unwinds; defer blocks run
             };
         }
@@ -3309,8 +3315,8 @@ handle type — reads and writes are free functions:
 <!-- doctest: skip -->
 ```hew
 fn read_config(path: string) -> Result<Config, string> {
-    let content = fs::try_read(path)?;
-    json::parse(content)
+    let content = fs.try_read(path)?;
+    json.parse(content)
 }
 ```
 
@@ -3318,8 +3324,8 @@ fn read_config(path: string) -> Result<Config, string> {
 
 ```hew
 // If the enclosing scope-block is cancelled while waiting for response,
-// http::get returns Err(Cancelled)
-let response = http::get(url)?;
+// http.get returns Err(Cancelled)
+let response = http.get(url)?;
 ```
 
 **Blocking operations:**
@@ -3359,7 +3365,7 @@ reachable from inside a child body.
 <!-- doctest: skip -->
 ```hew
 actor DataProcessor {
-    var cache: HashMap<string, Data> = HashMap::new();
+    var cache: HashMap<string, Data> = HashMap.new();
 
     receive fn prefetch(ids: Vec<string>) {
         scope {
@@ -3939,7 +3945,7 @@ Both handle types are `Send` (safe to pass to other actors), opaque (backed by a
 #### 6.5.1 Current `std::stream` surface
 
 ```hew
-import std::stream;
+import std.stream;
 
 // Canonical in-memory bounded bytes pipe
 let (bytes_sink, bytes_stream) = stream.bytes_pipe(16);
@@ -3992,7 +3998,7 @@ splits into a `(Stream<bytes>, Sink<bytes>)` pair via `.into_stream_sink()`:
 
 <!-- doctest: skip -->
 ```hew
-import std::net;
+import std.net;
 
 let conn = net.connect("127.0.0.1:8080")?;
 let (rx, tx) = conn.into_stream_sink();
@@ -4114,9 +4120,9 @@ emitted alongside the wire type codec path, unified on the CBOR body format.
 #[wire]
 enum Status { Pending; Active; Completed; }
 
-// Status::Pending   -> CBOR integer: 0
-// Status::Active    -> CBOR integer: 1
-// Status::Completed -> CBOR integer: 2
+// Status.Pending   -> CBOR integer: 0
+// Status.Active    -> CBOR integer: 1
+// Status.Completed -> CBOR integer: 2
 ```
 
 ##### 7.3.1.4 Optional Field Handling

--- a/docs/specs/Hew.g4
+++ b/docs/specs/Hew.g4
@@ -135,15 +135,15 @@ modulePath
 
 modulePathSeparator
     : '.'
-    | '::'                              // Temporary dual-accept scaffold
+    | '::'                              // Deprecated until the hard cutover
     ;
 
 importSelection
     : '.' '{' importBinding ( ',' importBinding )* ','? '}'
     ;
 
-// The existing parser temporarily accepts empty legacy `::{}` for corpus
-// continuity, while new `.{}` is rejected.
+// The existing parser accepts empty legacy `::{}` for corpus continuity;
+// dotted `.{}` selections are the primary surface.
 legacyImportSelection
     : '::' '{' ( importBinding ( ',' importBinding )* ','? )? '}'
     ;
@@ -787,7 +787,7 @@ genericApplyFollow
     ;
 
 legacyTurbofishSuffix
-    : '::' typeArgs                       // Temporary dual-accept scaffold
+    : '::' typeArgs                       // Deprecated until the hard cutover
     ;
 
 callSuffix
@@ -799,7 +799,7 @@ memberSuffix
     ;
 
 legacyMemberSuffix
-    : '::' ident                          // Temporary dual-accept scaffold
+    : '::' ident                          // Deprecated until the hard cutover
     ;
 
 tupleIndexSuffix
@@ -1034,7 +1034,7 @@ traitPath
 
 pathSeparator
     : '.'
-    | '::'                              // Temporary dual-accept scaffold
+    | '::'                              // Deprecated until the hard cutover
     ;
 
 qualifiedAssocBase

--- a/docs/specs/MACHINE-SPEC.md
+++ b/docs/specs/MACHINE-SPEC.md
@@ -233,15 +233,15 @@ Transitions produce a new state and may additionally emit named output events vi
 
 ```hew
 actor ConnectionManager {
-    var tcp: TcpState = TcpState::Closed;
+    var tcp: TcpState = TcpState.Closed;
 
     receive fn handle(event: TcpStateEvent) {
         tcp.step(event);
 
         // Side effects happen here, not in the machine body
         match tcp {
-            TcpState::Established { local_seq, remote_seq } => println("Connection established"),
-            TcpState::Closed => println("Connection closed"),
+            TcpState.Established { local_seq, remote_seq } => println("Connection established"),
+            TcpState.Closed => println("Connection closed"),
             _ => {}
         }
     }
@@ -253,7 +253,7 @@ _A dedicated `/ Output` arrow syntax is a declined non-goal — `emit` covers Me
 **Delivery semantics.** A unit `emit` pushes onto a thread-local emit queue tagged with the emitting machine's stable type id (a name-derived digest, not the instance). `step()`'s implicit queue wrapper keeps every pushed event queued — it never drains or discards. A machine method `m.take_emits(EventName) -> i64` removes every queued event matching (this machine's TYPE, `EventName`'s tag) and returns the count removed; unconsumed events — of other tags, or from other machine instances that share the same type — accumulate on the queue exactly like today's unbounded default mailbox. Delivery is per-thread, per-machine-TYPE: it is NOT per-instance and NOT per-actor. A machine stepped inside an actor's `receive fn` must call `take_emits` within that same handler activation — cross-activation delivery (routing an emit to a specific actor or scheduler slot) is deferred to the actor-scheduler integration slice and composes on top of this ABI without changing it.
 
 ```hew
-var s = Signal::Idle;
+var s = Signal.Idle;
 s.step(Start);            // transitions to Active, emits Ready {}
 s.take_emits(Ready);       // 1 — removes the queued Ready event
 s.take_emits(Ready);       // 0 — nothing left to remove
@@ -383,7 +383,7 @@ compile time (fail-closed).
 A `machine` declaration introduces a nominal type. The type name is the machine identifier.
 
 ```hew
-let state: TcpState = TcpState::Closed;
+let state: TcpState = TcpState.Closed;
 ```
 
 Machine types are:
@@ -473,9 +473,9 @@ For a machine named `M` with event type `MEvent`, the compiler generates:
 The primary API. Accepts an event, applies the matching transition, and mutates the machine in place. Does not return a value (like `Vec.push()`).
 
 ```hew
-var s = TcpState::Closed;
-s.step(TcpStateEvent::Connect);
-// s is now TcpState::Listen { backlog: 128 }
+var s = TcpState.Closed;
+s.step(TcpStateEvent.Connect);
+// s is now TcpState.Listen { backlog: 128 }
 ```
 
 _Implementation note: `step()` compiles to a nested switch on (tag, event_tag). The outer switch dispatches on the current state tag; the inner switch dispatches on the event tag. Each branch executes the corresponding transition body._
@@ -485,7 +485,7 @@ _Implementation note: `step()` compiles to a nested switch on (tag, event_tag). 
 Returns the name of the current state as a string, for debugging and logging.
 
 ```hew
-let s = TcpState::Established { local_seq: 42, remote_seq: 7 };
+let s = TcpState.Established { local_seq: 42, remote_seq: 7 };
 assert(s.state_name() == "Established");
 ```
 
@@ -523,9 +523,9 @@ match tcp_state {
 Each state is a constructor for the machine type, qualified by the machine name:
 
 ```hew
-let a = TcpState::Closed;
-let b = TcpState::Listen { backlog: 64 };
-let c = TcpState::Established { local_seq: 0, remote_seq: 0 };
+let a = TcpState.Closed;
+let b = TcpState.Listen { backlog: 64 };
+let c = TcpState.Established { local_seq: 0, remote_seq: 0 };
 ```
 
 Within the machine's own transition bodies, the machine name qualifier is optional:
@@ -539,7 +539,7 @@ on Connect: Closed => Listen {
 Outside the machine, the full qualifier is required:
 
 ```hew
-let s = TcpState::Listen { backlog: 128 };  // Required outside machine body
+let s = TcpState.Listen { backlog: 128 };  // Required outside machine body
 ```
 
 ### §7.5 Event constructors
@@ -547,7 +547,7 @@ let s = TcpState::Listen { backlog: 128 };  // Required outside machine body
 Events follow the same pattern:
 
 ```hew
-let e = TcpStateEvent::Data { payload: "hello" };
+let e = TcpStateEvent.Data { payload: "hello" };
 s1.step(e);
 ```
 
@@ -752,28 +752,28 @@ current MIR limitation, not yet fully lowered):
 
 ```hew
 actor ApiGateway {
-    var breaker: CircuitBreaker = CircuitBreaker::Closed { failures: 0 };
+    var breaker: CircuitBreaker = CircuitBreaker.Closed { failures: 0 };
 
     receive fn call(req: Request) -> Result<Response, string> {
         // Check circuit state
         match breaker {
-            CircuitBreaker::Open { expires_at } => {
+            CircuitBreaker.Open { expires_at } => {
                 return Err("circuit open");
             },
             _ => {}
         }
 
-        let result = http::send(req);
+        let result = http.send(req);
 
         // Update machine based on outcome
         match result {
             Ok(resp) => {
-                breaker.step(CircuitBreakerEvent::Success);
+                breaker.step(CircuitBreakerEvent.Success);
                 Ok(resp)
             },
             Err(e) => {
-                let now = time::now_ms();
-                breaker.step(CircuitBreakerEvent::Failure { timestamp: now });
+                let now = time.now_ms();
+                breaker.step(CircuitBreakerEvent.Failure { timestamp: now });
                 Err(e)
             },
         }
@@ -786,22 +786,22 @@ Testing (verified to compile and pass `hew check`):
 ```hew
 fn main() {
     // Test: circuit opens after 5 failures
-    var breaker = CircuitBreaker::Closed { failures: 0 };
+    var breaker = CircuitBreaker.Closed { failures: 0 };
     for i in 0..5 {
-        breaker.step(CircuitBreakerEvent::Failure { timestamp: i * 1000 });
+        breaker.step(CircuitBreakerEvent.Failure { timestamp: i * 1000 });
     }
     match breaker {
-        CircuitBreaker::Open { expires_at } => assert(expires_at > 0),
+        CircuitBreaker.Open { expires_at } => assert(expires_at > 0),
         _ => assert(false),
     }
 
     // Test: half-open recovers after 3 successes
-    var b2 = CircuitBreaker::HalfOpen { successes: 0 };
+    var b2 = CircuitBreaker.HalfOpen { successes: 0 };
     for i in 0..3 {
-        b2.step(CircuitBreakerEvent::Success);
+        b2.step(CircuitBreakerEvent.Success);
     }
     match b2 {
-        CircuitBreaker::Closed { failures } => assert(failures == 0),
+        CircuitBreaker.Closed { failures } => assert(failures == 0),
         _ => assert(false),
     }
 }

--- a/docs/specs/grammar.ebnf
+++ b/docs/specs/grammar.ebnf
@@ -59,9 +59,9 @@ AttrArg        = Ident ( "=" (StringLit | Ident) )?
                | StringLit ;
 
 (* Module system.
-   During the dot-path integration cutover, legacy `::` module separators,
-   `::{...}` selections, and `::*` globs remain accepted. New source uses
-   dotted module paths and `.{...}` selections. *)
+   Dotted module paths and `.{...}` selections are the primary surface.
+   Deprecated `::` separators, `::{...}` selections, and `::*` globs remain
+   accepted until the hard cutover. *)
 Import          = "import" ( StringLit | ModuleImport ) ";" ;
 ModuleImport    = ModulePath ( ModuleAlias
                              | ImportSelection
@@ -69,7 +69,7 @@ ModuleImport    = ModulePath ( ModuleAlias
                              | LegacyGlobImport )? ;
 ModuleAlias     = "as" Ident ;
 ModulePath      = Ident { ModulePathSeparator Ident } ;
-ModulePathSeparator = "." | "::" ;
+ModulePathSeparator = "." | "::" ;  (* `::` is deprecated until S7. *)
 ImportSelection = "." "{" ImportBinding { "," ImportBinding } [ "," ] "}" ;
 (* The existing parser temporarily accepts an empty legacy `::{}` for corpus
    continuity, but the new dotted selection requires at least one binding. *)
@@ -285,10 +285,10 @@ GenericApplyScanType = Ident { "." Ident }
                        [ "<" GenericApplyScanType
                          { "," GenericApplyScanType } ">" ] ;
 GenericApplyFollow = "(" | "." | "{" ;
-LegacyTurbofishSuffix = "::" TypeArgs ;  (* Temporary dual-accept scaffold. *)
+LegacyTurbofishSuffix = "::" TypeArgs ;  (* Deprecated until S7. *)
 CallSuffix     = "(" [ Args ] ")" ;
 MemberSuffix   = "." Ident ;
-LegacyMemberSuffix = "::" Ident ;        (* Temporary dual-accept scaffold. *)
+LegacyMemberSuffix = "::" Ident ;        (* Deprecated until S7. *)
 TupleIndexSuffix = "." IntLit ;           (* Existing depth-one tuple indexing *)
 RecordInitSuffix = "{" [ FieldInitList ] "}" ;
 (* RecordInitSuffix is legal only after a chain resolving to a record type or
@@ -385,7 +385,7 @@ PathRoot       = Ident | "Self" ;
 Path           = PathRoot { PathSeparator Ident } ;
 TypePath       = Path ;
 TraitPath      = Path ;
-PathSeparator  = "." | "::" ;  (* `::` is a temporary accepted separator. *)
+PathSeparator  = "." | "::" ;  (* `::` is deprecated until S7. *)
 QualifiedAssocBase = "<" Type "as" TraitPath ">" ;
 QualifiedAssocPath = QualifiedAssocBase "." Ident { "." Ident } ;
 NamedType      = TypePath TypeArgs?

--- a/docs/syntax-data.json
+++ b/docs/syntax-data.json
@@ -272,7 +272,11 @@
       ".",
       "::",
       "#["
-    ]
+    ],
+    "path_separators": {
+      "primary": ".",
+      "deprecated": ["::"]
+    }
   },
   "types": {
     "integer": [

--- a/docs/v05/ownership.md
+++ b/docs/v05/ownership.md
@@ -75,7 +75,7 @@ copy-on-write's lazy, on-demand fork. `clone x` (prefix form, the natural and
 primary spelling) and `x.clone()` (method form) are equivalent:
 
 ```hew
-let a: Vec<i64> = Vec::new();
+let a: Vec<i64> = Vec.new();
 a.push(1); a.push(2);
 let b = clone a;      // == a.clone() — independent copy, forked eagerly now
 b.push(99);

--- a/examples/actor/await_chain.hew
+++ b/examples/actor/await_chain.hew
@@ -20,8 +20,8 @@ actor Mid {
     receive fn step(n: i64) -> i64 {
         let r = await bottom.leaf(n);
         match r {
-            Ok(v) => v * 2,
-            Err(_) => -1,
+            .Ok(v) => v * 2,
+            .Err(_) => -1,
         }
     }
 }
@@ -31,8 +31,8 @@ actor Top {
     receive fn run(n: i64) -> i64 {
         let r = await mid.step(n);
         match r {
-            Ok(v) => v + 1,
-            Err(_) => -1,
+            .Ok(v) => v + 1,
+            .Err(_) => -1,
         }
     }
 }
@@ -43,7 +43,7 @@ fn main() {
     let t = spawn Top(mid: m);
     let r = await t.run(5);
     match r {
-        Ok(v) => println(f"result={v}"),
-        Err(_) => println("chain failed"),
+        .Ok(v) => println(f"result={v}"),
+        .Err(_) => println("chain failed"),
     }
 }

--- a/examples/actor/await_crash_after_sleep_resume.hew
+++ b/examples/actor/await_crash_after_sleep_resume.hew
@@ -31,8 +31,8 @@ fn main() {
     let reader = spawn Reader;
     let r = await reader.go(0);
     match r {
-        Ok(v) => println(f"reader-returned: {v}"),
-        Err(_) => println("reader-crash-fallback"),
+        .Ok(v) => println(f"reader-returned: {v}"),
+        .Err(_) => println("reader-crash-fallback"),
     }
     println("main-done");
 }

--- a/examples/actor/await_fanout.hew
+++ b/examples/actor/await_fanout.hew
@@ -21,8 +21,8 @@ actor Hub {
     receive fn relay(n: i64) -> i64 {
         let r = await worker.work(n);
         match r {
-            Ok(v) => v,
-            Err(_) => -1,
+            .Ok(v) => v,
+            .Err(_) => -1,
         }
     }
 }
@@ -34,10 +34,10 @@ fn main() {
     for i in 0 .. 5 {
         let r = await h.relay(i);
         match r {
-            Ok(v) => {
+            .Ok(v) => {
                 total = total + v;
             },
-            Err(_) => {},
+            .Err(_) => {},
         }
     }
     println(f"total={total}");

--- a/examples/actor/await_multi.hew
+++ b/examples/actor/await_multi.hew
@@ -24,11 +24,11 @@ actor Coordinator {
         let a = await worker.compute(n);
         let b = await worker.compute(n);
         match a {
-            Ok(va) => match b {
-                Ok(vb) => va + vb,
-                Err(_) => -1,
+            .Ok(va) => match b {
+                .Ok(vb) => va + vb,
+                .Err(_) => -1,
             },
-            Err(_) => -1,
+            .Err(_) => -1,
         }
     }
 
@@ -38,14 +38,14 @@ actor Coordinator {
         let b = await worker.compute(n);
         let c = await worker.compute(n);
         match a {
-            Ok(va) => match b {
-                Ok(vb) => match c {
-                    Ok(vc) => va + vb + vc,
-                    Err(_) => -1,
+            .Ok(va) => match b {
+                .Ok(vb) => match c {
+                    .Ok(vc) => va + vb + vc,
+                    .Err(_) => -1,
                 },
-                Err(_) => -1,
+                .Err(_) => -1,
             },
-            Err(_) => -1,
+            .Err(_) => -1,
         }
     }
 
@@ -55,10 +55,10 @@ actor Coordinator {
         for i in 0 .. rounds {
             let r = await worker.compute(n);
             match r {
-                Ok(v) => {
+                .Ok(v) => {
                     total = total + v;
                 },
-                Err(_) => {
+                .Err(_) => {
                     total = total - 1;
                 },
             }
@@ -72,17 +72,17 @@ fn main() {
     let c = spawn Coordinator(worker: w, rounds: 4);
     let r2 = await c.two(7);
     match r2 {
-        Ok(v) => println(f"two={v}"),
-        Err(_) => println("two failed"),
+        .Ok(v) => println(f"two={v}"),
+        .Err(_) => println("two failed"),
     }
     let r3 = await c.three(7);
     match r3 {
-        Ok(v) => println(f"three={v}"),
-        Err(_) => println("three failed"),
+        .Ok(v) => println(f"three={v}"),
+        .Err(_) => println("three failed"),
     }
     let rl = await c.loop_sum(7);
     match rl {
-        Ok(v) => println(f"loop={v}"),
-        Err(_) => println("loop failed"),
+        .Ok(v) => println(f"loop={v}"),
+        .Err(_) => println("loop failed"),
     }
 }

--- a/examples/actor/await_suspend_resume.hew
+++ b/examples/actor/await_suspend_resume.hew
@@ -18,8 +18,8 @@ actor Coordinator {
     receive fn run(n: i64) -> i64 {
         let r = await worker.compute(n);
         match r {
-            Ok(v) => v,
-            Err(_) => -1,
+            .Ok(v) => v,
+            .Err(_) => -1,
         }
     }
 }
@@ -29,7 +29,7 @@ fn main() {
     let c = spawn Coordinator(worker: w);
     let r = await c.run(7);
     match r {
-        Ok(v) => println(f"result={v}"),
-        Err(_) => println("ask failed"),
+        .Ok(v) => println(f"result={v}"),
+        .Err(_) => println("ask failed"),
     }
 }

--- a/examples/actor/await_then_fork.hew
+++ b/examples/actor/await_then_fork.hew
@@ -34,8 +34,8 @@ actor Coordinator {
         };
         match r {
             // `bias` is read after the await + fork — also from the live context.
-            Ok(v) => v + bias,
-            Err(_) => -1,
+            .Ok(v) => v + bias,
+            .Err(_) => -1,
         }
     }
 }
@@ -46,7 +46,7 @@ fn main() {
     let r = await c.run(7);
     match r {
         // compute(7) = 42; + bias(100) = 142
-        Ok(v) => println(f"result={v}"),
-        Err(_) => println("ask failed"),
+        .Ok(v) => println(f"result={v}"),
+        .Err(_) => println("ask failed"),
     }
 }

--- a/examples/actor/await_then_read_state.hew
+++ b/examples/actor/await_then_read_state.hew
@@ -19,8 +19,8 @@ actor Coordinator {
         let r = await worker.compute(n);
         match r {
             // `bias` is an actor-state field read AFTER the await resolves.
-            Ok(v) => v + bias,
-            Err(_) => -1,
+            .Ok(v) => v + bias,
+            .Err(_) => -1,
         }
     }
 }
@@ -31,7 +31,7 @@ fn main() {
     let r = await c.run(7);
     match r {
         // compute(7) = 42; + bias(100) = 142
-        Ok(v) => println(f"result={v}"),
-        Err(_) => println("ask failed"),
+        .Ok(v) => println(f"result={v}"),
+        .Err(_) => println("ask failed"),
     }
 }

--- a/examples/actor/scope_deadline_suspend.hew
+++ b/examples/actor/scope_deadline_suspend.hew
@@ -58,14 +58,14 @@ fn main() {
     // Deadline (20ms) beats the 500ms child: the recovery body runs.
     let t = await w.timeout_wins();
     match t {
-        Ok(v) => println(f"timeout={v}"),
-        Err(_) => println("timeout failed"),
+        .Ok(v) => println(f"timeout={v}"),
+        .Err(_) => println("timeout failed"),
     }
     // The 10ms child beats the 200ms deadline: the body is skipped.
     let g = spawn Worker(fired: 0);
     let s = await g.work_wins();
     match s {
-        Ok(v) => println(f"work={v}"),
-        Err(_) => println("work failed"),
+        .Ok(v) => println(f"work={v}"),
+        .Err(_) => println("work failed"),
     }
 }

--- a/examples/actor/select_suspend_deadline.hew
+++ b/examples/actor/select_suspend_deadline.hew
@@ -38,7 +38,7 @@ fn main() {
     // binds the deadline body's value (-7).
     let r = await c.race_deadline(5);
     match r {
-        Ok(v) => println(f"deadline={v}"),
-        Err(_) => println("race failed"),
+        .Ok(v) => println(f"deadline={v}"),
+        .Err(_) => println("race failed"),
     }
 }

--- a/examples/actor/select_suspend_race.hew
+++ b/examples/actor/select_suspend_race.hew
@@ -52,7 +52,7 @@ fn main() {
     // never fires.
     let r = await c.race_two(7);
     match r {
-        Ok(v) => println(f"winner={v}"),
-        Err(_) => println("race failed"),
+        .Ok(v) => println(f"winner={v}"),
+        .Err(_) => println("race failed"),
     }
 }

--- a/examples/actor_net_reader.hew
+++ b/examples/actor_net_reader.hew
@@ -1,7 +1,7 @@
 //! Status: runnable
 //! Description: Actor Net Reader example.
 
-import std::net::{Connection};
+import std.net.{Connection};
 
 actor ServerReader {
     let conn: Connection;

--- a/examples/algos/bellman_ford.hew
+++ b/examples/algos/bellman_ford.hew
@@ -12,9 +12,9 @@ fn main() {
     let num_nodes = 5;
     let INF: i32 = 999999;
     // Edge list: (from, to, weight)
-    let edge_from: Vec<i32> = Vec::new();
-    let edge_to: Vec<i32> = Vec::new();
-    let edge_weight: Vec<i32> = Vec::new();
+    let edge_from: Vec<i32> = Vec.new();
+    let edge_to: Vec<i32> = Vec.new();
+    let edge_weight: Vec<i32> = Vec.new();
     edge_from.push(0);
     edge_to.push(1);
     edge_weight.push(4);
@@ -34,7 +34,7 @@ fn main() {
     edge_to.push(4);
     edge_weight.push(3);
     let num_edges = edge_from.len();
-    let dist: Vec<i32> = Vec::new();
+    let dist: Vec<i32> = Vec.new();
     for i in 0 .. num_nodes {
         dist.push(INF);
     }
@@ -66,7 +66,7 @@ fn main() {
             }
         }
     }
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<i32> = Vec.new();
     expected.push(0);
     expected.push(3);
     expected.push(1);

--- a/examples/algos/bfs.hew
+++ b/examples/algos/bfs.hew
@@ -5,8 +5,8 @@
 fn main() {
     let num_nodes = 6;
     // Build adjacency list (undirected)
-    let adj_nodes: Vec<i32> = Vec::new();
-    let adj_offsets: Vec<i32> = Vec::new();
+    let adj_nodes: Vec<i32> = Vec.new();
+    let adj_offsets: Vec<i32> = Vec.new();
     // Node 0: neighbours 1, 2
     adj_offsets.push(0);
     adj_nodes.push(1);
@@ -35,12 +35,12 @@ fn main() {
     adj_offsets.push(12);
 
     // BFS
-    let dist: Vec<i32> = Vec::new();
+    let dist: Vec<i32> = Vec.new();
     for i in 0 .. num_nodes {
         dist.push(0 - 1);
     }
     dist.set(0, 0);
-    let queue: Vec<i32> = Vec::new();
+    let queue: Vec<i32> = Vec.new();
     queue.push(0);
     var front = 0;
     while front < queue.len() {
@@ -59,7 +59,7 @@ fn main() {
         }
     }
     // Expected distances: [0, 1, 1, 2, 2, 3]
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<i32> = Vec.new();
     expected.push(0);
     expected.push(1);
     expected.push(1);

--- a/examples/algos/binary_search.hew
+++ b/examples/algos/binary_search.hew
@@ -20,7 +20,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Test 1: find element in sorted array
-    let v1: Vec<i64> = Vec::new();
+    let v1: Vec<i64> = Vec.new();
     v1.push(2);
     v1.push(5);
     v1.push(8);
@@ -42,7 +42,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: find first element
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(2);
     v2.push(5);
     v2.push(8);
@@ -59,7 +59,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: find last element
-    let v3: Vec<i64> = Vec::new();
+    let v3: Vec<i64> = Vec.new();
     v3.push(2);
     v3.push(5);
     v3.push(8);
@@ -76,7 +76,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: element not found
-    let v4: Vec<i64> = Vec::new();
+    let v4: Vec<i64> = Vec.new();
     v4.push(2);
     v4.push(5);
     v4.push(8);
@@ -93,7 +93,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: empty array
-    let v5: Vec<i64> = Vec::new();
+    let v5: Vec<i64> = Vec.new();
     let r5 = binary_search(v5, 5);
     if r5 == 0 - 1 {
         println("Test 5 - empty array: PASS");
@@ -105,7 +105,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: single element found
-    let v6: Vec<i64> = Vec::new();
+    let v6: Vec<i64> = Vec.new();
     v6.push(42);
     let r6 = binary_search(v6, 42);
     if r6 == 0 {
@@ -118,7 +118,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: single element not found
-    let v7: Vec<i64> = Vec::new();
+    let v7: Vec<i64> = Vec.new();
     v7.push(42);
     let r7 = binary_search(v7, 99);
     if r7 == 0 - 1 {

--- a/examples/algos/bubble_sort.hew
+++ b/examples/algos/bubble_sort.hew
@@ -31,7 +31,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -68,16 +68,16 @@ fn main() {
 
     // Test 4: single element
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
 
     // Test 5: empty
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
     println(f"{passed}/{total} tests passed");
     if passed == total {

--- a/examples/algos/catalan_numbers.hew
+++ b/examples/algos/catalan_numbers.hew
@@ -1,6 +1,6 @@
 // Catalan numbers using dynamic programming
 fn catalan(n: i64) -> i64 {
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     dp.push(1); // C(0) = 1
     var i = 1;
     while i <= n {

--- a/examples/algos/climbing_stairs.hew
+++ b/examples/algos/climbing_stairs.hew
@@ -4,7 +4,7 @@ fn climb(n: i32) -> i32 {
     if n <= 1 {
         1
     } else {
-        let dp: Vec<i32> = Vec::new();
+        let dp: Vec<i32> = Vec.new();
         dp.push(1);
         dp.push(1);
         let n64: i64 = n as i64;

--- a/examples/algos/cocktail_sort.hew
+++ b/examples/algos/cocktail_sort.hew
@@ -57,7 +57,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -87,14 +87,14 @@ fn main() {
     total = total + 1;
     passed = passed + run_test("duplicates", make_vec_5(3, 1, 3, 1, 2), make_vec_5(1, 1, 2, 3, 3));
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
     println(f"{passed}/{total} tests passed");
     if passed == total {

--- a/examples/algos/coin_change.hew
+++ b/examples/algos/coin_change.hew
@@ -1,7 +1,7 @@
 // Minimum Coins to Make Change
 // Coins: [1, 5, 10, 25], Amount: 30 -> 2 (25 + 5)
 fn main() {
-    let coins: Vec<i32> = Vec::new();
+    let coins: Vec<i32> = Vec.new();
     coins.push(1);
     coins.push(5);
     coins.push(10);
@@ -9,7 +9,7 @@ fn main() {
     let num_coins = coins.len();
     let amount = 30;
     let INF = 999999;
-    let dp: Vec<i32> = Vec::new();
+    let dp: Vec<i32> = Vec.new();
     dp.push(0);
     for i in 1 .. amount + 1 {
         dp.push(INF);

--- a/examples/algos/counting_sort.hew
+++ b/examples/algos/counting_sort.hew
@@ -12,7 +12,7 @@ fn counting_sort(v: Vec<i64>) {
             i = i + 1;
         }
         // Build count array
-        let count: Vec<i64> = Vec::new();
+        let count: Vec<i64> = Vec.new();
         var c = 0;
         while c <= max_val {
             count.push(0);
@@ -54,7 +54,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -86,14 +86,14 @@ fn main() {
     total = total + 1;
     passed = passed + run_test("zeros", make_vec_5(0, 0, 0, 0, 0), make_vec_5(0, 0, 0, 0, 0));
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
     println(f"{passed}/{total} tests passed");
     if passed == total {

--- a/examples/algos/detect_cycle.hew
+++ b/examples/algos/detect_cycle.hew
@@ -5,8 +5,8 @@
 fn main() {
     // --- Test 1: graph with cycle ---
     // 3 nodes: 0->1, 1->2, 2->0
-    let adj1_nodes: Vec<i32> = Vec::new();
-    let adj1_offsets: Vec<i32> = Vec::new();
+    let adj1_nodes: Vec<i32> = Vec.new();
+    let adj1_offsets: Vec<i32> = Vec.new();
     adj1_offsets.push(0);
     adj1_nodes.push(1);
     adj1_offsets.push(1);
@@ -15,7 +15,7 @@ fn main() {
     adj1_nodes.push(0);
     adj1_offsets.push(3);
     let n1 = 3;
-    let colour1: Vec<i32> = Vec::new();
+    let colour1: Vec<i32> = Vec.new();
     for i in 0 .. n1 {
         colour1.push(0);
     }
@@ -24,7 +24,7 @@ fn main() {
     var has_cycle1 = 0;
     for start in 0 .. n1 {
         if colour1[start] == 0 {
-            let stack: Vec<i32> = Vec::new();
+            let stack: Vec<i32> = Vec.new();
             stack.push(start as i32 * 2);
             while stack.len() > 0 {
                 let entry: i64 = stack.pop() as i64;
@@ -65,8 +65,8 @@ fn main() {
     }
     // --- Test 2: DAG without cycle ---
     // 3 nodes: 0->1, 0->2, 1->2
-    let adj2_nodes: Vec<i32> = Vec::new();
-    let adj2_offsets: Vec<i32> = Vec::new();
+    let adj2_nodes: Vec<i32> = Vec.new();
+    let adj2_offsets: Vec<i32> = Vec.new();
     adj2_offsets.push(0);
     adj2_nodes.push(1);
     adj2_nodes.push(2);
@@ -75,14 +75,14 @@ fn main() {
     adj2_offsets.push(3);
     adj2_offsets.push(3);
     let n2 = 3;
-    let colour2: Vec<i32> = Vec::new();
+    let colour2: Vec<i32> = Vec.new();
     for i in 0 .. n2 {
         colour2.push(0);
     }
     var has_cycle2 = 0;
     for start in 0 .. n2 {
         if colour2[start] == 0 {
-            let stack: Vec<i32> = Vec::new();
+            let stack: Vec<i32> = Vec.new();
             stack.push(start as i32 * 2);
             while stack.len() > 0 {
                 let entry: i64 = stack.pop() as i64;

--- a/examples/algos/dfs.hew
+++ b/examples/algos/dfs.hew
@@ -5,8 +5,8 @@
 fn main() {
     let num_nodes = 6;
     // Build adjacency list (directed)
-    let adj_nodes: Vec<i32> = Vec::new();
-    let adj_offsets: Vec<i32> = Vec::new();
+    let adj_nodes: Vec<i32> = Vec.new();
+    let adj_offsets: Vec<i32> = Vec.new();
     // Node 0: -> 1, 2
     adj_offsets.push(0);
     adj_nodes.push(1);
@@ -28,12 +28,12 @@ fn main() {
     adj_offsets.push(6);
 
     // Iterative DFS using stack
-    let visited: Vec<i32> = Vec::new();
+    let visited: Vec<i32> = Vec.new();
     for i in 0 .. num_nodes {
         visited.push(0);
     }
-    let order: Vec<i32> = Vec::new();
-    let stack: Vec<i32> = Vec::new();
+    let order: Vec<i32> = Vec.new();
+    let stack: Vec<i32> = Vec.new();
     stack.push(0);
     while stack.len() > 0 {
         let u: i64 = stack.pop() as i64;

--- a/examples/algos/dijkstra.hew
+++ b/examples/algos/dijkstra.hew
@@ -6,9 +6,9 @@ fn main() {
     let num_nodes = 5;
     let INF = 999999;
     // Weighted adjacency list
-    let adj_nodes: Vec<i32> = Vec::new();
-    let adj_weights: Vec<i32> = Vec::new();
-    let adj_offsets: Vec<i32> = Vec::new();
+    let adj_nodes: Vec<i32> = Vec.new();
+    let adj_weights: Vec<i32> = Vec.new();
+    let adj_offsets: Vec<i32> = Vec.new();
     // Node 0: -> 1(4), 2(1)
     adj_offsets.push(0);
     adj_nodes.push(1);
@@ -34,8 +34,8 @@ fn main() {
     adj_offsets.push(6);
 
     // Dijkstra using simple O(V^2) approach
-    let dist: Vec<i32> = Vec::new();
-    let visited: Vec<i32> = Vec::new();
+    let dist: Vec<i32> = Vec.new();
+    let visited: Vec<i32> = Vec.new();
     for i in 0 .. num_nodes {
         dist.push(INF);
         visited.push(0);
@@ -72,7 +72,7 @@ fn main() {
         }
     }
     // Expected: [0, 3, 1, 4, 7]
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<i32> = Vec.new();
     expected.push(0);
     expected.push(3);
     expected.push(1);

--- a/examples/algos/dutch_flag.hew
+++ b/examples/algos/dutch_flag.hew
@@ -1,6 +1,6 @@
 // Dutch National Flag: 3-way partition (0s, 1s, 2s)
 fn main() {
-    let arr: Vec<i32> = Vec::new();
+    let arr: Vec<i32> = Vec.new();
     arr.push(2);
     arr.push(0);
     arr.push(1);
@@ -28,7 +28,7 @@ fn main() {
         }
     }
     // Expected: [0,0,1,1,2,2]
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<i32> = Vec.new();
     expected.push(0);
     expected.push(0);
     expected.push(1);

--- a/examples/algos/edit_distance.hew
+++ b/examples/algos/edit_distance.hew
@@ -19,7 +19,7 @@ fn main() {
     let n = s2.len();
     let rows = m + 1;
     let cols = n + 1;
-    let dp: Vec<i32> = Vec::new();
+    let dp: Vec<i32> = Vec.new();
     for i in 0 .. rows * cols {
         dp.push(0);
     }

--- a/examples/algos/exponential_search.hew
+++ b/examples/algos/exponential_search.hew
@@ -48,7 +48,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Test 1: find element
-    let v1: Vec<i64> = Vec::new();
+    let v1: Vec<i64> = Vec.new();
     v1.push(2);
     v1.push(4);
     v1.push(6);
@@ -70,7 +70,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: find first element
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(2);
     v2.push(4);
     v2.push(6);
@@ -87,7 +87,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: find last element
-    let v3: Vec<i64> = Vec::new();
+    let v3: Vec<i64> = Vec.new();
     v3.push(2);
     v3.push(4);
     v3.push(6);
@@ -104,7 +104,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: not found
-    let v4: Vec<i64> = Vec::new();
+    let v4: Vec<i64> = Vec.new();
     v4.push(2);
     v4.push(4);
     v4.push(6);
@@ -121,7 +121,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: empty array
-    let v5: Vec<i64> = Vec::new();
+    let v5: Vec<i64> = Vec.new();
     let r5 = exponential_search(v5, 5);
     if r5 == 0 - 1 {
         println("Test 5 - empty array: PASS");
@@ -133,7 +133,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: single element found
-    let v6: Vec<i64> = Vec::new();
+    let v6: Vec<i64> = Vec.new();
     v6.push(42);
     let r6 = exponential_search(v6, 42);
     if r6 == 0 {
@@ -146,7 +146,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: large array, find near end
-    let v7: Vec<i64> = Vec::new();
+    let v7: Vec<i64> = Vec.new();
     for i in 0 .. 100 {
         v7.push(i * 3);
     }

--- a/examples/algos/fibonacci_search.hew
+++ b/examples/algos/fibonacci_search.hew
@@ -54,7 +54,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Test 1: find element in sorted array
-    let v1: Vec<i64> = Vec::new();
+    let v1: Vec<i64> = Vec.new();
     v1.push(10);
     v1.push(22);
     v1.push(35);
@@ -77,7 +77,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: find first element
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(10);
     v2.push(20);
     v2.push(30);
@@ -94,7 +94,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: find last element
-    let v3: Vec<i64> = Vec::new();
+    let v3: Vec<i64> = Vec.new();
     v3.push(10);
     v3.push(20);
     v3.push(30);
@@ -111,7 +111,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: not found
-    let v4: Vec<i64> = Vec::new();
+    let v4: Vec<i64> = Vec.new();
     v4.push(10);
     v4.push(20);
     v4.push(30);
@@ -128,7 +128,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: empty array
-    let v5: Vec<i64> = Vec::new();
+    let v5: Vec<i64> = Vec.new();
     let r5 = fibonacci_search(v5, 5);
     if r5 == 0 - 1 {
         println("Test 5 - empty array: PASS");
@@ -140,7 +140,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: single element found
-    let v6: Vec<i64> = Vec::new();
+    let v6: Vec<i64> = Vec.new();
     v6.push(42);
     let r6 = fibonacci_search(v6, 42);
     if r6 == 0 {
@@ -153,7 +153,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: single element not found
-    let v7: Vec<i64> = Vec::new();
+    let v7: Vec<i64> = Vec.new();
     v7.push(42);
     let r7 = fibonacci_search(v7, 99);
     if r7 == 0 - 1 {
@@ -166,7 +166,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 8: two elements found second
-    let v8: Vec<i64> = Vec::new();
+    let v8: Vec<i64> = Vec.new();
     v8.push(5);
     v8.push(15);
     let r8 = fibonacci_search(v8, 15);

--- a/examples/algos/floyd_warshall.hew
+++ b/examples/algos/floyd_warshall.hew
@@ -10,7 +10,7 @@ fn main() {
     let n = 4;
     let INF = 999999;
     // Initialize distance matrix (flat n*n)
-    let dist: Vec<i32> = Vec::new();
+    let dist: Vec<i32> = Vec.new();
     for i in 0 .. n * n {
         dist.push(INF);
     }
@@ -38,7 +38,7 @@ fn main() {
         }
     }
     // Expected
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<i32> = Vec.new();
     expected.push(0);
     expected.push(3);
     expected.push(5);

--- a/examples/algos/heap_sort.hew
+++ b/examples/algos/heap_sort.hew
@@ -67,7 +67,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -97,19 +97,19 @@ fn main() {
     total = total + 1;
     passed = passed + run_test("duplicates", make_vec_5(3, 1, 3, 1, 2), make_vec_5(1, 1, 2, 3, 3));
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
 
     // Larger test
     total = total + 1;
-    let big: Vec<i64> = Vec::new();
+    let big: Vec<i64> = Vec.new();
     big.push(9);
     big.push(3);
     big.push(7);
@@ -120,7 +120,7 @@ fn main() {
     big.push(6);
     big.push(4);
     big.push(0);
-    let exp_big: Vec<i64> = Vec::new();
+    let exp_big: Vec<i64> = Vec.new();
     for x in 0 .. 10 {
         exp_big.push(x);
     }

--- a/examples/algos/insertion_sort.hew
+++ b/examples/algos/insertion_sort.hew
@@ -36,7 +36,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -66,14 +66,14 @@ fn main() {
     total = total + 1;
     passed = passed + run_test("duplicates", make_vec_5(3, 1, 3, 1, 2), make_vec_5(1, 1, 2, 3, 3));
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
     println(f"{passed}/{total} tests passed");
     if passed == total {

--- a/examples/algos/interpolation_search.hew
+++ b/examples/algos/interpolation_search.hew
@@ -45,7 +45,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Test 1: uniformly distributed data
-    let v1: Vec<i64> = Vec::new();
+    let v1: Vec<i64> = Vec.new();
     v1.push(10);
     v1.push(20);
     v1.push(30);
@@ -67,7 +67,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: find first element
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(10);
     v2.push(20);
     v2.push(30);
@@ -84,7 +84,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: find last element
-    let v3: Vec<i64> = Vec::new();
+    let v3: Vec<i64> = Vec.new();
     v3.push(10);
     v3.push(20);
     v3.push(30);
@@ -101,7 +101,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: not found
-    let v4: Vec<i64> = Vec::new();
+    let v4: Vec<i64> = Vec.new();
     v4.push(10);
     v4.push(20);
     v4.push(30);
@@ -118,7 +118,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: empty array
-    let v5: Vec<i64> = Vec::new();
+    let v5: Vec<i64> = Vec.new();
     let r5 = interpolation_search(v5, 5);
     if r5 == 0 - 1 {
         println("Test 5 - empty array: PASS");
@@ -130,7 +130,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: single element found
-    let v6: Vec<i64> = Vec::new();
+    let v6: Vec<i64> = Vec.new();
     v6.push(42);
     let r6 = interpolation_search(v6, 42);
     if r6 == 0 {
@@ -143,7 +143,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: target below range
-    let v7: Vec<i64> = Vec::new();
+    let v7: Vec<i64> = Vec.new();
     v7.push(10);
     v7.push(20);
     v7.push(30);
@@ -158,7 +158,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 8: target above range
-    let v8: Vec<i64> = Vec::new();
+    let v8: Vec<i64> = Vec.new();
     v8.push(10);
     v8.push(20);
     v8.push(30);

--- a/examples/algos/jump_search.hew
+++ b/examples/algos/jump_search.hew
@@ -42,7 +42,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Test 1: find element in sorted array
-    let v1: Vec<i64> = Vec::new();
+    let v1: Vec<i64> = Vec.new();
     v1.push(1);
     v1.push(3);
     v1.push(5);
@@ -63,7 +63,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: find first element
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(1);
     v2.push(3);
     v2.push(5);
@@ -80,7 +80,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: find last element
-    let v3: Vec<i64> = Vec::new();
+    let v3: Vec<i64> = Vec.new();
     v3.push(1);
     v3.push(3);
     v3.push(5);
@@ -97,7 +97,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: not found
-    let v4: Vec<i64> = Vec::new();
+    let v4: Vec<i64> = Vec.new();
     v4.push(1);
     v4.push(3);
     v4.push(5);
@@ -114,7 +114,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: empty array
-    let v5: Vec<i64> = Vec::new();
+    let v5: Vec<i64> = Vec.new();
     let r5 = jump_search(v5, 5);
     if r5 == 0 - 1 {
         println("Test 5 - empty array: PASS");
@@ -126,7 +126,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: single element found
-    let v6: Vec<i64> = Vec::new();
+    let v6: Vec<i64> = Vec.new();
     v6.push(42);
     let r6 = jump_search(v6, 42);
     if r6 == 0 {
@@ -139,7 +139,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: single element not found
-    let v7: Vec<i64> = Vec::new();
+    let v7: Vec<i64> = Vec.new();
     v7.push(42);
     let r7 = jump_search(v7, 99);
     if r7 == 0 - 1 {

--- a/examples/algos/knapsack.hew
+++ b/examples/algos/knapsack.hew
@@ -4,12 +4,12 @@
 fn main() {
     let n = 4;
     let capacity = 5;
-    let weights: Vec<i32> = Vec::new();
+    let weights: Vec<i32> = Vec.new();
     weights.push(2);
     weights.push(3);
     weights.push(4);
     weights.push(5);
-    let values: Vec<i32> = Vec::new();
+    let values: Vec<i32> = Vec.new();
     values.push(3);
     values.push(4);
     values.push(5);
@@ -18,7 +18,7 @@ fn main() {
     // dp is (n+1) x (capacity+1) flat array
     let rows = n + 1;
     let cols = capacity + 1;
-    let dp: Vec<i32> = Vec::new();
+    let dp: Vec<i32> = Vec.new();
     for i in 0 .. rows * cols {
         dp.push(0);
     }

--- a/examples/algos/kruskal_mst.hew
+++ b/examples/algos/kruskal_mst.hew
@@ -16,9 +16,9 @@ fn find(parent: Vec<i32>, x: i32) -> i32 {
 fn main() {
     let num_nodes = 6;
     // Edges sorted by weight (pre-sorted)
-    let edge_u: Vec<i32> = Vec::new();
-    let edge_v: Vec<i32> = Vec::new();
-    let edge_w: Vec<i32> = Vec::new();
+    let edge_u: Vec<i32> = Vec.new();
+    let edge_v: Vec<i32> = Vec.new();
+    let edge_w: Vec<i32> = Vec.new();
     edge_u.push(1);
     edge_v.push(2);
     edge_w.push(1);
@@ -48,8 +48,8 @@ fn main() {
     edge_w.push(8);
     let num_edges = edge_u.len();
     // Union-Find
-    let parent: Vec<i32> = Vec::new();
-    let rank: Vec<i32> = Vec::new();
+    let parent: Vec<i32> = Vec.new();
+    let rank: Vec<i32> = Vec.new();
     for i in 0 .. num_nodes {
         parent.push(i);
         rank.push(0);

--- a/examples/algos/lcs.hew
+++ b/examples/algos/lcs.hew
@@ -8,7 +8,7 @@ fn main() {
     // dp is (m+1) x (n+1) flat array
     let rows = m + 1;
     let cols = n + 1;
-    let dp: Vec<i32> = Vec::new();
+    let dp: Vec<i32> = Vec.new();
     for i in 0 .. rows * cols {
         dp.push(0);
     }

--- a/examples/algos/linear_search.hew
+++ b/examples/algos/linear_search.hew
@@ -14,7 +14,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Test 1: find element in middle
-    let v1: Vec<i64> = Vec::new();
+    let v1: Vec<i64> = Vec.new();
     v1.push(10);
     v1.push(20);
     v1.push(30);
@@ -31,7 +31,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: find first element
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(10);
     v2.push(20);
     v2.push(30);
@@ -46,7 +46,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: find last element
-    let v3: Vec<i64> = Vec::new();
+    let v3: Vec<i64> = Vec.new();
     v3.push(10);
     v3.push(20);
     v3.push(30);
@@ -61,7 +61,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: element not found
-    let v4: Vec<i64> = Vec::new();
+    let v4: Vec<i64> = Vec.new();
     v4.push(10);
     v4.push(20);
     v4.push(30);
@@ -76,7 +76,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: empty array
-    let v5: Vec<i64> = Vec::new();
+    let v5: Vec<i64> = Vec.new();
     let r5 = linear_search(v5, 5);
     if r5 == 0 - 1 {
         println("Test 5 - empty array: PASS");
@@ -88,7 +88,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: single element found
-    let v6: Vec<i64> = Vec::new();
+    let v6: Vec<i64> = Vec.new();
     v6.push(42);
     let r6 = linear_search(v6, 42);
     if r6 == 0 {
@@ -101,7 +101,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: single element not found
-    let v7: Vec<i64> = Vec::new();
+    let v7: Vec<i64> = Vec.new();
     v7.push(42);
     let r7 = linear_search(v7, 99);
     if r7 == 0 - 1 {

--- a/examples/algos/lis.hew
+++ b/examples/algos/lis.hew
@@ -1,7 +1,7 @@
 // Longest Increasing Subsequence (length)
 // Test: [10,9,2,5,3,7,101,18] -> 4
 fn main() {
-    let arr: Vec<i32> = Vec::new();
+    let arr: Vec<i32> = Vec.new();
     arr.push(10);
     arr.push(9);
     arr.push(2);
@@ -11,7 +11,7 @@ fn main() {
     arr.push(101);
     arr.push(18);
     let n = arr.len();
-    let dp: Vec<i32> = Vec::new();
+    let dp: Vec<i32> = Vec.new();
     for i in 0 .. n {
         dp.push(1);
     }

--- a/examples/algos/matrix_chain.hew
+++ b/examples/algos/matrix_chain.hew
@@ -2,7 +2,7 @@
 // Dimensions: [10, 30, 5, 60] -> minimum operations = 4500
 // Matrices: A1(10x30), A2(30x5), A3(5x60)
 fn main() {
-    let dims: Vec<i32> = Vec::new();
+    let dims: Vec<i32> = Vec.new();
     dims.push(10);
     dims.push(30);
     dims.push(5);
@@ -11,7 +11,7 @@ fn main() {
     let INF = 999999;
     // dp[i][j] = min cost to multiply matrices i..j (0-indexed)
     // Flat array: n x n
-    let dp: Vec<i32> = Vec::new();
+    let dp: Vec<i32> = Vec.new();
     for i in 0 .. n * n {
         dp.push(0);
     }

--- a/examples/algos/matrix_multiply.hew
+++ b/examples/algos/matrix_multiply.hew
@@ -1,7 +1,7 @@
 // 2x2 matrix multiply using flat Vec<i32> (row-major order)
 // C[i][j] = sum(A[i][k] * B[k][j]) for k in 0..n
 fn mat_mul(a: Vec<i32>, b: Vec<i32>, n: i32) -> Vec<i32> {
-    let c: Vec<i32> = Vec::new();
+    let c: Vec<i32> = Vec.new();
     let n64: i64 = n as i64;
     for i in 0 .. n64 {
         for j in 0 .. n64 {
@@ -18,12 +18,12 @@ fn mat_mul(a: Vec<i32>, b: Vec<i32>, n: i32) -> Vec<i32> {
 fn main() {
     // A = [[1,2],[3,4]], B = [[5,6],[7,8]]
     // C = [[1*5+2*7, 1*6+2*8], [3*5+4*7, 3*6+4*8]] = [[19,22],[43,50]]
-    let a: Vec<i32> = Vec::new();
+    let a: Vec<i32> = Vec.new();
     a.push(1);
     a.push(2);
     a.push(3);
     a.push(4);
-    let b: Vec<i32> = Vec::new();
+    let b: Vec<i32> = Vec.new();
     b.push(5);
     b.push(6);
     b.push(7);
@@ -51,12 +51,12 @@ fn main() {
         println(c[3]);
     }
     // Test 2: identity * A = A
-    let id: Vec<i32> = Vec::new();
+    let id: Vec<i32> = Vec.new();
     id.push(1);
     id.push(0);
     id.push(0);
     id.push(1);
-    let a2: Vec<i32> = Vec::new();
+    let a2: Vec<i32> = Vec.new();
     a2.push(3);
     a2.push(7);
     a2.push(2);

--- a/examples/algos/max_subarray.hew
+++ b/examples/algos/max_subarray.hew
@@ -1,6 +1,6 @@
 // Kadane's algorithm for maximum subarray sum
 fn main() {
-    let nums: Vec<i32> = Vec::new();
+    let nums: Vec<i32> = Vec.new();
     // [-2,1,-3,4,-1,2,1,-5,4] -> max sum = 6 (subarray [4,-1,2,1])
     nums.push(0 - 2);
     nums.push(1);
@@ -33,7 +33,7 @@ fn main() {
         println(max_sum);
     }
     // Test 2: all negative [-1,-2,-3] -> -1
-    let nums2: Vec<i32> = Vec::new();
+    let nums2: Vec<i32> = Vec.new();
     nums2.push(0 - 1);
     nums2.push(0 - 2);
     nums2.push(0 - 3);

--- a/examples/algos/merge_sort.hew
+++ b/examples/algos/merge_sort.hew
@@ -15,7 +15,7 @@ fn merge_sort(v: Vec<i64>) {
                     if end > n {
                         end = n;
                     }
-                    let aux: Vec<i64> = Vec::new();
+                    let aux: Vec<i64> = Vec.new();
                     var i = start;
                     var j = mid;
                     while i < mid {
@@ -62,7 +62,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -92,19 +92,19 @@ fn main() {
     total = total + 1;
     passed = passed + run_test("duplicates", make_vec_5(3, 1, 3, 1, 2), make_vec_5(1, 1, 2, 3, 3));
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
 
     // Test 6: larger input
     total = total + 1;
-    let big: Vec<i64> = Vec::new();
+    let big: Vec<i64> = Vec.new();
     big.push(9);
     big.push(3);
     big.push(7);
@@ -115,7 +115,7 @@ fn main() {
     big.push(6);
     big.push(4);
     big.push(0);
-    let exp_big: Vec<i64> = Vec::new();
+    let exp_big: Vec<i64> = Vec.new();
     for x in 0 .. 10 {
         exp_big.push(x);
     }

--- a/examples/algos/merge_sorted.hew
+++ b/examples/algos/merge_sorted.hew
@@ -1,14 +1,14 @@
 // Merge two sorted arrays into one sorted array
 fn main() {
-    let a: Vec<i32> = Vec::new();
+    let a: Vec<i32> = Vec.new();
     a.push(1);
     a.push(3);
     a.push(5);
-    let b: Vec<i32> = Vec::new();
+    let b: Vec<i32> = Vec.new();
     b.push(2);
     b.push(4);
     b.push(6);
-    let merged: Vec<i32> = Vec::new();
+    let merged: Vec<i32> = Vec.new();
     var i = 0;
     var j = 0;
     while i < a.len() {
@@ -43,12 +43,12 @@ fn main() {
         }
     }
     // Test 2: merge [1] + [2,3] -> [1,2,3]
-    let c: Vec<i32> = Vec::new();
+    let c: Vec<i32> = Vec.new();
     c.push(1);
-    let d: Vec<i32> = Vec::new();
+    let d: Vec<i32> = Vec.new();
     d.push(2);
     d.push(3);
-    let m2: Vec<i32> = Vec::new();
+    let m2: Vec<i32> = Vec.new();
     var ci = 0;
     var di = 0;
     while ci < c.len() {

--- a/examples/algos/quick_sort.hew
+++ b/examples/algos/quick_sort.hew
@@ -52,7 +52,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -82,14 +82,14 @@ fn main() {
     total = total + 1;
     passed = passed + run_test("duplicates", make_vec_5(3, 1, 3, 1, 2), make_vec_5(1, 1, 2, 3, 3));
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
     println(f"{passed}/{total} tests passed");
     if passed == total {

--- a/examples/algos/radix_sort.hew
+++ b/examples/algos/radix_sort.hew
@@ -14,11 +14,11 @@ fn radix_sort(v: Vec<i64>) {
         // Process each digit position
         var exp = 1;
         while max_val / exp > 0 {
-            let output: Vec<i64> = Vec::new();
+            let output: Vec<i64> = Vec.new();
             for i in 0 .. n {
                 output.push(0);
             }
-            let count: Vec<i64> = Vec::new();
+            let count: Vec<i64> = Vec.new();
             for i in 0 .. 10 {
                 count.push(0);
             }
@@ -68,7 +68,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -100,13 +100,13 @@ fn main() {
 
     // Multi-digit numbers
     total = total + 1;
-    let multi: Vec<i64> = Vec::new();
+    let multi: Vec<i64> = Vec.new();
     multi.push(170);
     multi.push(45);
     multi.push(75);
     multi.push(90);
     multi.push(802);
-    let exp_multi: Vec<i64> = Vec::new();
+    let exp_multi: Vec<i64> = Vec.new();
     exp_multi.push(45);
     exp_multi.push(75);
     exp_multi.push(90);
@@ -114,14 +114,14 @@ fn main() {
     exp_multi.push(802);
     passed = passed + run_test("multi_digit", multi, exp_multi);
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
     println(f"{passed}/{total} tests passed");
     if passed == total {

--- a/examples/algos/remove_duplicates.hew
+++ b/examples/algos/remove_duplicates.hew
@@ -1,6 +1,6 @@
 // Remove duplicates from sorted array in-place
 fn main() {
-    let arr: Vec<i32> = Vec::new();
+    let arr: Vec<i32> = Vec.new();
     arr.push(1);
     arr.push(1);
     arr.push(2);
@@ -36,7 +36,7 @@ fn main() {
         println("FAIL [2]");
     }
     // Test 2: [1,1,1] -> [1]
-    let arr2: Vec<i32> = Vec::new();
+    let arr2: Vec<i32> = Vec.new();
     arr2.push(1);
     arr2.push(1);
     arr2.push(1);

--- a/examples/algos/rod_cutting.hew
+++ b/examples/algos/rod_cutting.hew
@@ -2,7 +2,7 @@
 // Prices: [1,5,8,9,10,17,17,20] for lengths 1..8
 // Rod length: 8 -> max revenue = 22 (cut into 2+6 -> 5+17)
 fn main() {
-    let prices: Vec<i32> = Vec::new();
+    let prices: Vec<i32> = Vec.new();
     prices.push(1);
     prices.push(5);
     prices.push(8);
@@ -12,7 +12,7 @@ fn main() {
     prices.push(17);
     prices.push(20);
     let rod_len = 8;
-    let dp: Vec<i32> = Vec::new();
+    let dp: Vec<i32> = Vec.new();
     dp.push(0);
     for i in 1 .. rod_len + 1 {
         dp.push(0);

--- a/examples/algos/rotate_array.hew
+++ b/examples/algos/rotate_array.hew
@@ -14,7 +14,7 @@ fn reverse_range(arr: Vec<i32>, start: i32, end: i32) {
 }
 
 fn main() {
-    let arr: Vec<i32> = Vec::new();
+    let arr: Vec<i32> = Vec.new();
     arr.push(1);
     arr.push(2);
     arr.push(3);
@@ -28,7 +28,7 @@ fn main() {
     reverse_range(arr, k as i32, n as i32);
 
     // Expected: [4,5,1,2,3]
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<i32> = Vec.new();
     expected.push(4);
     expected.push(5);
     expected.push(1);

--- a/examples/algos/run_length_encode.hew
+++ b/examples/algos/run_length_encode.hew
@@ -1,5 +1,5 @@
 // Run-length encoding
-import std::string;
+import std.string;
 
 fn rle_encode(s: string) -> string {
     let n = s.len();

--- a/examples/algos/selection_sort.hew
+++ b/examples/algos/selection_sort.hew
@@ -37,7 +37,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -67,14 +67,14 @@ fn main() {
     total = total + 1;
     passed = passed + run_test("duplicates", make_vec_5(3, 1, 3, 1, 2), make_vec_5(1, 1, 2, 3, 3));
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
     println(f"{passed}/{total} tests passed");
     if passed == total {

--- a/examples/algos/sentinel_search.hew
+++ b/examples/algos/sentinel_search.hew
@@ -26,7 +26,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Test 1: find element in middle
-    let v1: Vec<i64> = Vec::new();
+    let v1: Vec<i64> = Vec.new();
     v1.push(10);
     v1.push(20);
     v1.push(30);
@@ -43,7 +43,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: find first element
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(10);
     v2.push(20);
     v2.push(30);
@@ -58,7 +58,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: find last element
-    let v3: Vec<i64> = Vec::new();
+    let v3: Vec<i64> = Vec.new();
     v3.push(10);
     v3.push(20);
     v3.push(30);
@@ -73,7 +73,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: not found
-    let v4: Vec<i64> = Vec::new();
+    let v4: Vec<i64> = Vec.new();
     v4.push(10);
     v4.push(20);
     v4.push(30);
@@ -88,7 +88,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: empty array
-    let v5: Vec<i64> = Vec::new();
+    let v5: Vec<i64> = Vec.new();
     let r5 = sentinel_search(v5, 5);
     if r5 == 0 - 1 {
         println("Test 5 - empty array: PASS");
@@ -100,7 +100,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: single element found
-    let v6: Vec<i64> = Vec::new();
+    let v6: Vec<i64> = Vec.new();
     v6.push(42);
     let r6 = sentinel_search(v6, 42);
     if r6 == 0 {
@@ -113,7 +113,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: single element not found
-    let v7: Vec<i64> = Vec::new();
+    let v7: Vec<i64> = Vec.new();
     v7.push(42);
     let r7 = sentinel_search(v7, 99);
     if r7 == 0 - 1 {

--- a/examples/algos/shell_sort.hew
+++ b/examples/algos/shell_sort.hew
@@ -42,7 +42,7 @@ fn vec_eq(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn make_vec_5(a: i64, b: i64, c: i64, d: i64, e: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(a);
     v.push(b);
     v.push(c);
@@ -72,19 +72,19 @@ fn main() {
     total = total + 1;
     passed = passed + run_test("duplicates", make_vec_5(3, 1, 3, 1, 2), make_vec_5(1, 1, 2, 3, 3));
     total = total + 1;
-    let single: Vec<i64> = Vec::new();
+    let single: Vec<i64> = Vec.new();
     single.push(42);
-    let exp_single: Vec<i64> = Vec::new();
+    let exp_single: Vec<i64> = Vec.new();
     exp_single.push(42);
     passed = passed + run_test("single", single, exp_single);
     total = total + 1;
-    let empty: Vec<i64> = Vec::new();
-    let exp_empty: Vec<i64> = Vec::new();
+    let empty: Vec<i64> = Vec.new();
+    let exp_empty: Vec<i64> = Vec.new();
     passed = passed + run_test("empty", empty, exp_empty);
 
     // Test with larger array
     total = total + 1;
-    let big: Vec<i64> = Vec::new();
+    let big: Vec<i64> = Vec.new();
     big.push(9);
     big.push(3);
     big.push(7);
@@ -95,7 +95,7 @@ fn main() {
     big.push(6);
     big.push(4);
     big.push(0);
-    let exp_big: Vec<i64> = Vec::new();
+    let exp_big: Vec<i64> = Vec.new();
     for x in 0 .. 10 {
         exp_big.push(x);
     }

--- a/examples/algos/sieve_primes.hew
+++ b/examples/algos/sieve_primes.hew
@@ -1,7 +1,7 @@
 // Sieve of Eratosthenes - find primes up to N using Vec<i64> with 0/1 flags
 fn sieve(n: i64) -> Vec<i64> {
     // is_prime[i] = 1 means i is prime, 0 means not
-    let is_prime: Vec<i64> = Vec::new();
+    let is_prime: Vec<i64> = Vec.new();
     var i = 0;
     while i <= n {
         if i < 2 {

--- a/examples/algos/spiral_matrix.hew
+++ b/examples/algos/spiral_matrix.hew
@@ -2,7 +2,7 @@
 fn main() {
     let n = 3;
     let total = n * n;
-    let mat: Vec<i64> = Vec::new();
+    let mat: Vec<i64> = Vec.new();
     for i in 0 .. total {
         mat.push(0);
     }
@@ -55,7 +55,7 @@ fn main() {
     // 1 2 3
     // 8 9 4
     // 7 6 5
-    let expected: Vec<i64> = Vec::new();
+    let expected: Vec<i64> = Vec.new();
     expected.push(1);
     expected.push(2);
     expected.push(3);

--- a/examples/algos/ternary_search.hew
+++ b/examples/algos/ternary_search.hew
@@ -30,7 +30,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Test 1: find element in sorted array
-    let v1: Vec<i64> = Vec::new();
+    let v1: Vec<i64> = Vec.new();
     v1.push(1);
     v1.push(4);
     v1.push(7);
@@ -51,7 +51,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: find first element
-    let v2: Vec<i64> = Vec::new();
+    let v2: Vec<i64> = Vec.new();
     v2.push(1);
     v2.push(4);
     v2.push(7);
@@ -68,7 +68,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: find last element
-    let v3: Vec<i64> = Vec::new();
+    let v3: Vec<i64> = Vec.new();
     v3.push(1);
     v3.push(4);
     v3.push(7);
@@ -85,7 +85,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: not found
-    let v4: Vec<i64> = Vec::new();
+    let v4: Vec<i64> = Vec.new();
     v4.push(1);
     v4.push(4);
     v4.push(7);
@@ -102,7 +102,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: empty array
-    let v5: Vec<i64> = Vec::new();
+    let v5: Vec<i64> = Vec.new();
     let r5 = ternary_search(v5, 5);
     if r5 == 0 - 1 {
         println("Test 5 - empty array: PASS");
@@ -114,7 +114,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: single element found
-    let v6: Vec<i64> = Vec::new();
+    let v6: Vec<i64> = Vec.new();
     v6.push(42);
     let r6 = ternary_search(v6, 42);
     if r6 == 0 {
@@ -127,7 +127,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: two elements, find second
-    let v7: Vec<i64> = Vec::new();
+    let v7: Vec<i64> = Vec.new();
     v7.push(5);
     v7.push(15);
     let r7 = ternary_search(v7, 15);

--- a/examples/algos/topological_sort.hew
+++ b/examples/algos/topological_sort.hew
@@ -5,8 +5,8 @@
 fn main() {
     let num_nodes = 6;
     // Build adjacency list (directed)
-    let adj_nodes: Vec<i32> = Vec::new();
-    let adj_offsets: Vec<i32> = Vec::new();
+    let adj_nodes: Vec<i32> = Vec.new();
+    let adj_offsets: Vec<i32> = Vec.new();
     // Node 0: -> 2, 3
     adj_offsets.push(0);
     adj_nodes.push(2);
@@ -29,7 +29,7 @@ fn main() {
     adj_offsets.push(7);
 
     // Compute in-degrees
-    let in_degree: Vec<i32> = Vec::new();
+    let in_degree: Vec<i32> = Vec.new();
     for i in 0 .. num_nodes {
         in_degree.push(0);
     }
@@ -44,13 +44,13 @@ fn main() {
         }
     }
     // Kahn's: start with in-degree 0 nodes
-    let queue: Vec<i32> = Vec::new();
+    let queue: Vec<i32> = Vec.new();
     for i in 0 .. num_nodes {
         if in_degree[i] == 0 {
             queue.push(i as i32);
         }
     }
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<i32> = Vec.new();
     var front = 0;
     while front < queue.len() {
         let u: i64 = queue[front] as i64;
@@ -78,7 +78,7 @@ fn main() {
         valid = 0;
     }
     // Build position map
-    let pos: Vec<i32> = Vec::new();
+    let pos: Vec<i32> = Vec.new();
     for i in 0 .. num_nodes {
         pos.push(0);
     }

--- a/examples/algos/two_sum.hew
+++ b/examples/algos/two_sum.hew
@@ -1,6 +1,6 @@
 // Two Sum: find two indices that sum to target (O(n^2) brute force)
 fn main() {
-    let nums: Vec<i32> = Vec::new();
+    let nums: Vec<i32> = Vec.new();
     nums.push(2);
     nums.push(7);
     nums.push(11);
@@ -30,7 +30,7 @@ fn main() {
         println(found_j);
     }
     // Test 2: [3,2,4] target=6 -> [1,2]
-    let nums2: Vec<i32> = Vec::new();
+    let nums2: Vec<i32> = Vec.new();
     nums2.push(3);
     nums2.push(2);
     nums2.push(4);

--- a/examples/async_comprehensive.hew
+++ b/examples/async_comprehensive.hew
@@ -21,8 +21,8 @@ fn main() {
     let calculator = spawn Calculator;
     let r = await calculator.simple_calculation(21);
     match r {
-        Ok(result) => println(result),
-        Err(_) => println(-1),
+        .Ok(result) => println(result),
+        .Err(_) => println(-1),
     }
     // Actor call-and-await with discarded return value.
     let messenger = spawn Messenger;

--- a/examples/async_demo.hew
+++ b/examples/async_demo.hew
@@ -20,7 +20,7 @@ fn main() {
     let calculator = spawn Calculator;
     let r = await calculator.compute(10);
     match r {
-        Ok(result) => println(result),
-        Err(_) => println(-1),
+        .Ok(result) => println(result),
+        .Err(_) => println(-1),
     }
 }

--- a/examples/benchmark_demo.hew
+++ b/examples/benchmark_demo.hew
@@ -2,8 +2,8 @@
 //! Description: Benchmark harness demo
 
 // Benchmark harness demo
-// Shows how to use std::bench to measure function performance.
-import std::bench;
+// Shows how to use std.bench to measure function performance.
+import std.bench;
 
 fn fibonacci(n: i32) -> i64 {
     if n <= 1 {

--- a/examples/benchmarks/hew/bench_bellman_ford.hew
+++ b/examples/benchmarks/hew/bench_bellman_ford.hew
@@ -1,6 +1,6 @@
 fn bellman_ford(edge_src: Vec<i64>, edge_dst: Vec<i64>, edge_wt: Vec<i64>, num_edges: i64, n: i64, start_node: i64) -> i64 {
     let INF = 999999;
-    let dist: Vec<i64> = Vec::new();
+    let dist: Vec<i64> = Vec.new();
     for i in 0 .. n {
         dist.push(INF);
     }
@@ -29,9 +29,9 @@ const ITERS: i64 = 20000;
 
 fn main() {
     let n = 50;
-    let edge_src: Vec<i64> = Vec::new();
-    let edge_dst: Vec<i64> = Vec::new();
-    let edge_wt: Vec<i64> = Vec::new();
+    let edge_src: Vec<i64> = Vec.new();
+    let edge_dst: Vec<i64> = Vec.new();
+    let edge_wt: Vec<i64> = Vec.new();
     for src in 0 .. n {
         for dst in 1 .. 4 {
             let neighbour = (src + dst) % n;

--- a/examples/benchmarks/hew/bench_bfs.hew
+++ b/examples/benchmarks/hew/bench_bfs.hew
@@ -19,8 +19,8 @@ fn build_graph(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, n: i64) -> i64 {
 }
 
 fn bfs(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, n: i64, start_node: i64) -> i64 {
-    let visited: Vec<i64> = Vec::new();
-    let queue: Vec<i64> = Vec::new();
+    let visited: Vec<i64> = Vec.new();
+    let queue: Vec<i64> = Vec.new();
     for i in 0 .. n {
         visited.push(0);
     }
@@ -49,8 +49,8 @@ const ITERS: i64 = 100000;
 
 fn main() {
     let n = 50;
-    let adj_nodes: Vec<i64> = Vec::new();
-    let adj_offsets: Vec<i64> = Vec::new();
+    let adj_nodes: Vec<i64> = Vec.new();
+    let adj_offsets: Vec<i64> = Vec.new();
     let _ = build_graph(adj_nodes, adj_offsets, n);
     var checksum = 0;
     for i in 0 .. ITERS {

--- a/examples/benchmarks/hew/bench_binary_search.hew
+++ b/examples/benchmarks/hew/bench_binary_search.hew
@@ -21,7 +21,7 @@ fn binary_search(v: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 1000000;
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. 10000 {
         v.push(i);
     }

--- a/examples/benchmarks/hew/bench_bubble_sort.hew
+++ b/examples/benchmarks/hew/bench_bubble_sort.hew
@@ -14,7 +14,7 @@ fn bubble_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_caesar_cipher.hew
+++ b/examples/benchmarks/hew/bench_caesar_cipher.hew
@@ -25,7 +25,7 @@ const ITERS: i64 = 200000;
 fn main() {
     let s = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv";
     let lower = "abcdefghijklmnopqrstuvwxyz";
-    let table: Vec<i64> = Vec::new();
+    let table: Vec<i64> = Vec.new();
     for k in 0 .. 26 {
         let shifted = (k + 13) % 26;
         table.push(shifted + 97);

--- a/examples/benchmarks/hew/bench_catalan.hew
+++ b/examples/benchmarks/hew/bench_catalan.hew
@@ -1,5 +1,5 @@
 fn catalan(n: i64) -> i64 {
-    let dp = Vec::new();
+    let dp = Vec.new();
     dp.push(1);
     dp.push(1);
     for i in 2 .. n + 1 {

--- a/examples/benchmarks/hew/bench_climbing_stairs.hew
+++ b/examples/benchmarks/hew/bench_climbing_stairs.hew
@@ -1,5 +1,5 @@
 fn climbing_stairs(n: i64) -> i64 {
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     for idx in 0 .. n + 1 {
         dp.push(0);
     }

--- a/examples/benchmarks/hew/bench_cocktail_sort.hew
+++ b/examples/benchmarks/hew/bench_cocktail_sort.hew
@@ -37,7 +37,7 @@ fn cocktail_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_coin_change.hew
+++ b/examples/benchmarks/hew/bench_coin_change.hew
@@ -1,7 +1,7 @@
 fn coin_change(coins: Vec<i64>, num_coins: i64, amount: i64) -> i64 {
     let INF = 999999;
     let sz = amount + 1;
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     for idx in 0 .. sz {
         dp.push(INF);
     }
@@ -23,7 +23,7 @@ fn coin_change(coins: Vec<i64>, num_coins: i64, amount: i64) -> i64 {
 const ITERS: i64 = 100000;
 
 fn main() {
-    let coins: Vec<i64> = Vec::new();
+    let coins: Vec<i64> = Vec.new();
     coins.push(1);
     coins.push(5);
     coins.push(10);

--- a/examples/benchmarks/hew/bench_counting_sort.hew
+++ b/examples/benchmarks/hew/bench_counting_sort.hew
@@ -9,7 +9,7 @@ fn counting_sort(v: Vec<i64>) -> Vec<i64> {
             max_val = v[i];
         }
     }
-    let count: Vec<i64> = Vec::new();
+    let count: Vec<i64> = Vec.new();
     for i in 0 .. max_val + 1 {
         count.push(0);
     }
@@ -30,7 +30,7 @@ fn counting_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_detect_cycle.hew
+++ b/examples/benchmarks/hew/bench_detect_cycle.hew
@@ -19,9 +19,9 @@ fn build_directed_graph(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, n: i64) -> i
 }
 
 fn detect_cycle(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, n: i64) -> i64 {
-    let colour: Vec<i64> = Vec::new();
-    let stack: Vec<i64> = Vec::new();
-    let stack_phase: Vec<i64> = Vec::new();
+    let colour: Vec<i64> = Vec.new();
+    let stack: Vec<i64> = Vec.new();
+    let stack_phase: Vec<i64> = Vec.new();
     for i in 0 .. n {
         colour.push(0);
     }
@@ -64,8 +64,8 @@ const ITERS: i64 = 200000;
 
 fn main() {
     let n = 50;
-    let adj_nodes: Vec<i64> = Vec::new();
-    let adj_offsets: Vec<i64> = Vec::new();
+    let adj_nodes: Vec<i64> = Vec.new();
+    let adj_offsets: Vec<i64> = Vec.new();
     let _ = build_directed_graph(adj_nodes, adj_offsets, n);
     var checksum = 0;
     for i in 0 .. ITERS {

--- a/examples/benchmarks/hew/bench_dfs.hew
+++ b/examples/benchmarks/hew/bench_dfs.hew
@@ -19,8 +19,8 @@ fn build_graph(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, n: i64) -> i64 {
 }
 
 fn dfs(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, n: i64, start_node: i64) -> i64 {
-    let visited: Vec<i64> = Vec::new();
-    let stack: Vec<i64> = Vec::new();
+    let visited: Vec<i64> = Vec.new();
+    let stack: Vec<i64> = Vec.new();
     for i in 0 .. n {
         visited.push(0);
     }
@@ -48,8 +48,8 @@ const ITERS: i64 = 100000;
 
 fn main() {
     let n = 50;
-    let adj_nodes: Vec<i64> = Vec::new();
-    let adj_offsets: Vec<i64> = Vec::new();
+    let adj_nodes: Vec<i64> = Vec.new();
+    let adj_offsets: Vec<i64> = Vec.new();
     let _ = build_graph(adj_nodes, adj_offsets, n);
     var checksum = 0;
     for i in 0 .. ITERS {

--- a/examples/benchmarks/hew/bench_dijkstra.hew
+++ b/examples/benchmarks/hew/bench_dijkstra.hew
@@ -24,8 +24,8 @@ fn build_weighted_graph(adj_nodes: Vec<i64>, adj_weights: Vec<i64>, adj_offsets:
 
 fn dijkstra(adj_nodes: Vec<i64>, adj_weights: Vec<i64>, adj_offsets: Vec<i64>, n: i64, start_node: i64) -> i64 {
     let INF = 999999;
-    let dist: Vec<i64> = Vec::new();
-    let used: Vec<i64> = Vec::new();
+    let dist: Vec<i64> = Vec.new();
+    let used: Vec<i64> = Vec.new();
     for i in 0 .. n {
         dist.push(INF);
         used.push(0);
@@ -69,9 +69,9 @@ const ITERS: i64 = 50000;
 
 fn main() {
     let n = 50;
-    let adj_nodes: Vec<i64> = Vec::new();
-    let adj_weights: Vec<i64> = Vec::new();
-    let adj_offsets: Vec<i64> = Vec::new();
+    let adj_nodes: Vec<i64> = Vec.new();
+    let adj_weights: Vec<i64> = Vec.new();
+    let adj_offsets: Vec<i64> = Vec.new();
     let _ = build_weighted_graph(adj_nodes, adj_weights, adj_offsets, n);
     var checksum = 0;
     for i in 0 .. ITERS {

--- a/examples/benchmarks/hew/bench_dutch_flag.hew
+++ b/examples/benchmarks/hew/bench_dutch_flag.hew
@@ -30,7 +30,7 @@ const ITERS: i64 = 100000;
 fn main() {
     var checksum = 0;
     for i in 0 .. ITERS {
-        let arr: Vec<i64> = Vec::new();
+        let arr: Vec<i64> = Vec.new();
         for k in 0 .. 1000 {
             arr.push(k % 3);
         }

--- a/examples/benchmarks/hew/bench_edit_distance.hew
+++ b/examples/benchmarks/hew/bench_edit_distance.hew
@@ -1,7 +1,7 @@
 fn edit_distance(a: Vec<i64>, b: Vec<i64>, m: i64, n: i64) -> i64 {
     let cols = n + 1;
     let total = (m + 1) * cols;
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     for idx in 0 .. total {
         dp.push(0);
     }
@@ -38,8 +38,8 @@ const ITERS: i64 = 50000;
 fn main() {
     let m = 50;
     let n = 50;
-    let a: Vec<i64> = Vec::new();
-    let b: Vec<i64> = Vec::new();
+    let a: Vec<i64> = Vec.new();
+    let b: Vec<i64> = Vec.new();
     for k in 0 .. m {
         a.push(k % 11);
     }

--- a/examples/benchmarks/hew/bench_exponential_search.hew
+++ b/examples/benchmarks/hew/bench_exponential_search.hew
@@ -41,7 +41,7 @@ fn exponential_search(v: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 1000000;
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. 10000 {
         v.push(i);
     }

--- a/examples/benchmarks/hew/bench_fibonacci_search.hew
+++ b/examples/benchmarks/hew/bench_fibonacci_search.hew
@@ -48,7 +48,7 @@ fn fibonacci_search(v: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 1000000;
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. 10000 {
         v.push(i);
     }

--- a/examples/benchmarks/hew/bench_floyd_warshall.hew
+++ b/examples/benchmarks/hew/bench_floyd_warshall.hew
@@ -1,7 +1,7 @@
 fn floyd_warshall(n: i64, edge_src: Vec<i64>, edge_dst: Vec<i64>, edge_wt: Vec<i64>, num_edges: i64) -> i64 {
     let INF = 999999;
     let total = n * n;
-    let dist: Vec<i64> = Vec::new();
+    let dist: Vec<i64> = Vec.new();
     for idx in 0 .. total {
         dist.push(INF);
     }
@@ -42,9 +42,9 @@ const ITERS: i64 = 5000;
 
 fn main() {
     let n = 30;
-    let edge_src: Vec<i64> = Vec::new();
-    let edge_dst: Vec<i64> = Vec::new();
-    let edge_wt: Vec<i64> = Vec::new();
+    let edge_src: Vec<i64> = Vec.new();
+    let edge_dst: Vec<i64> = Vec.new();
+    let edge_wt: Vec<i64> = Vec.new();
     for src in 0 .. n {
         var dst = 1;
         while dst <= 3 {

--- a/examples/benchmarks/hew/bench_heap_sort.hew
+++ b/examples/benchmarks/hew/bench_heap_sort.hew
@@ -39,7 +39,7 @@ fn heap_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_insertion_sort.hew
+++ b/examples/benchmarks/hew/bench_insertion_sort.hew
@@ -19,7 +19,7 @@ fn insertion_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_interpolation_search.hew
+++ b/examples/benchmarks/hew/bench_interpolation_search.hew
@@ -35,7 +35,7 @@ fn interpolation_search(v: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 1000000;
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. 10000 {
         v.push(i);
     }

--- a/examples/benchmarks/hew/bench_jump_search.hew
+++ b/examples/benchmarks/hew/bench_jump_search.hew
@@ -62,7 +62,7 @@ fn jump_search(v: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 1000000;
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. 10000 {
         v.push(i);
     }

--- a/examples/benchmarks/hew/bench_knapsack.hew
+++ b/examples/benchmarks/hew/bench_knapsack.hew
@@ -1,7 +1,7 @@
 fn knapsack(weights: Vec<i64>, values: Vec<i64>, n: i64, cap: i64) -> i64 {
     let cols = cap + 1;
     let total = (n + 1) * cols;
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     for idx in 0 .. total {
         dp.push(0);
     }
@@ -33,8 +33,8 @@ const ITERS: i64 = 50000;
 fn main() {
     let n = 20;
     let cap = 100;
-    let weights: Vec<i64> = Vec::new();
-    let values: Vec<i64> = Vec::new();
+    let weights: Vec<i64> = Vec.new();
+    let values: Vec<i64> = Vec.new();
     for k in 0 .. n {
         weights.push(k % 10 + 1);
         values.push(k % 15 + 3);

--- a/examples/benchmarks/hew/bench_kruskal.hew
+++ b/examples/benchmarks/hew/bench_kruskal.hew
@@ -32,8 +32,8 @@ fn union(parent: Vec<i64>, rank: Vec<i64>, a: i64, b: i64) -> i64 {
 }
 
 fn kruskal(edge_src: Vec<i64>, edge_dst: Vec<i64>, edge_wt: Vec<i64>, sorted_idx: Vec<i64>, num_edges: i64, n: i64) -> i64 {
-    let parent: Vec<i64> = Vec::new();
-    let rank: Vec<i64> = Vec::new();
+    let parent: Vec<i64> = Vec.new();
+    let rank: Vec<i64> = Vec.new();
     for i in 0 .. n {
         parent.push(i);
         rank.push(0);
@@ -84,9 +84,9 @@ const ITERS: i64 = 100000;
 
 fn main() {
     let n = 50;
-    let edge_src: Vec<i64> = Vec::new();
-    let edge_dst: Vec<i64> = Vec::new();
-    let edge_wt: Vec<i64> = Vec::new();
+    let edge_src: Vec<i64> = Vec.new();
+    let edge_dst: Vec<i64> = Vec.new();
+    let edge_wt: Vec<i64> = Vec.new();
     for src in 0 .. n {
         var dst = 1;
         while dst <= 3 {
@@ -99,7 +99,7 @@ fn main() {
         }
     }
     let num_edges = edge_src.len();
-    let sorted_idx: Vec<i64> = Vec::new();
+    let sorted_idx: Vec<i64> = Vec.new();
     let _ = sort_edges_by_weight(edge_wt, sorted_idx, num_edges);
     var checksum = 0;
     for i in 0 .. ITERS {

--- a/examples/benchmarks/hew/bench_lcs.hew
+++ b/examples/benchmarks/hew/bench_lcs.hew
@@ -1,7 +1,7 @@
 fn lcs(a: Vec<i64>, b: Vec<i64>, m: i64, n: i64) -> i64 {
     let cols = n + 1;
     let total = (m + 1) * cols;
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     for idx in 0 .. total {
         dp.push(0);
     }
@@ -32,8 +32,8 @@ const ITERS: i64 = 50000;
 fn main() {
     let m = 50;
     let n = 50;
-    let a: Vec<i64> = Vec::new();
-    let b: Vec<i64> = Vec::new();
+    let a: Vec<i64> = Vec.new();
+    let b: Vec<i64> = Vec.new();
     for k in 0 .. m {
         a.push(k % 7);
     }

--- a/examples/benchmarks/hew/bench_linear_search.hew
+++ b/examples/benchmarks/hew/bench_linear_search.hew
@@ -12,7 +12,7 @@ fn linear_search(v: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 100000;
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. 10000 {
         v.push(i);
     }

--- a/examples/benchmarks/hew/bench_lis.hew
+++ b/examples/benchmarks/hew/bench_lis.hew
@@ -1,5 +1,5 @@
 fn lis(arr: Vec<i64>, n: i64) -> i64 {
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     for idx in 0 .. n {
         dp.push(1);
     }
@@ -26,7 +26,7 @@ const ITERS: i64 = 5000;
 
 fn main() {
     let n = 500;
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     for k in 0 .. n {
         arr.push((k * 37 + 13) % 100);
     }

--- a/examples/benchmarks/hew/bench_matrix_chain.hew
+++ b/examples/benchmarks/hew/bench_matrix_chain.hew
@@ -1,7 +1,7 @@
 fn matrix_chain(dims: Vec<i64>, n: i64) -> i64 {
     let INF = 999999;
     let total = n * n;
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     for idx in 0 .. total {
         dp.push(0);
     }
@@ -30,7 +30,7 @@ fn main() {
     let num_matrices = 10;
     let n = num_matrices;
     let num_dims = num_matrices + 1;
-    let dims: Vec<i64> = Vec::new();
+    let dims: Vec<i64> = Vec.new();
     for k in 0 .. num_dims {
         dims.push(k % 7 * 5 + 10);
     }

--- a/examples/benchmarks/hew/bench_matrix_multiply.hew
+++ b/examples/benchmarks/hew/bench_matrix_multiply.hew
@@ -1,5 +1,5 @@
 fn matrix_multiply(a: Vec<i64>, b: Vec<i64>, n: i64) -> i64 {
-    let c: Vec<i64> = Vec::new();
+    let c: Vec<i64> = Vec.new();
     let total = n * n;
     for idx in 0 .. total {
         c.push(0);
@@ -21,8 +21,8 @@ const ITERS: i64 = 10000;
 fn main() {
     let n = 20;
     let total = n * n;
-    let a: Vec<i64> = Vec::new();
-    let b: Vec<i64> = Vec::new();
+    let a: Vec<i64> = Vec.new();
+    let b: Vec<i64> = Vec.new();
     for k in 0 .. total {
         a.push(k % 7 + 1);
         b.push(k % 5 + 1);

--- a/examples/benchmarks/hew/bench_max_subarray.hew
+++ b/examples/benchmarks/hew/bench_max_subarray.hew
@@ -19,7 +19,7 @@ fn max_subarray(arr: Vec<i64>) -> i64 {
 const ITERS: i64 = 500000;
 
 fn main() {
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     for k in 0 .. 1000 {
         let rem = k % 3;
         if rem == 0 {

--- a/examples/benchmarks/hew/bench_merge_sort.hew
+++ b/examples/benchmarks/hew/bench_merge_sort.hew
@@ -1,6 +1,6 @@
 fn merge(v: Vec<i64>, left: i64, mid: i64, right: i64) {
-    let left_arr: Vec<i64> = Vec::new();
-    let right_arr: Vec<i64> = Vec::new();
+    let left_arr: Vec<i64> = Vec.new();
+    let right_arr: Vec<i64> = Vec.new();
     var i = left;
     while i <= mid {
         left_arr.push(v[i]);
@@ -56,7 +56,7 @@ fn merge_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_merge_sorted.hew
+++ b/examples/benchmarks/hew/bench_merge_sorted.hew
@@ -1,7 +1,7 @@
 fn merge_sorted(a: Vec<i64>, b: Vec<i64>) -> i64 {
     let na = a.len();
     let nb = b.len();
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     var i = 0;
     var j = 0;
     while i < na {
@@ -30,8 +30,8 @@ const ITERS: i64 = 100000;
 fn main() {
     var checksum = 0;
     for i in 0 .. ITERS {
-        let a: Vec<i64> = Vec::new();
-        let b: Vec<i64> = Vec::new();
+        let a: Vec<i64> = Vec.new();
+        let b: Vec<i64> = Vec.new();
         for k in 0 .. 500 {
             a.push(k * 2);
             b.push(k * 2 + 1);

--- a/examples/benchmarks/hew/bench_pascal.hew
+++ b/examples/benchmarks/hew/bench_pascal.hew
@@ -1,5 +1,5 @@
 fn pascal(n: i64) -> i64 {
-    let row = Vec::new();
+    let row = Vec.new();
     row.push(1);
     for i in 0 .. n {
         row.push(0);

--- a/examples/benchmarks/hew/bench_quick_sort.hew
+++ b/examples/benchmarks/hew/bench_quick_sort.hew
@@ -34,7 +34,7 @@ fn quick_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_radix_sort.hew
+++ b/examples/benchmarks/hew/bench_radix_sort.hew
@@ -13,8 +13,8 @@ fn get_max(v: Vec<i64>) -> i64 {
 
 fn count_sort_by_exp(v: Vec<i64>, exp: i64) {
     let n = v.len();
-    let output: Vec<i64> = Vec::new();
-    let count: Vec<i64> = Vec::new();
+    let output: Vec<i64> = Vec.new();
+    let count: Vec<i64> = Vec.new();
     var i = 0;
     while i < 10 {
         count.push(0);
@@ -66,7 +66,7 @@ fn radix_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_remove_dupes.hew
+++ b/examples/benchmarks/hew/bench_remove_dupes.hew
@@ -20,7 +20,7 @@ const ITERS: i64 = 200000;
 fn main() {
     var checksum = 0;
     for i in 0 .. ITERS {
-        let arr: Vec<i64> = Vec::new();
+        let arr: Vec<i64> = Vec.new();
         for k in 0 .. 1000 {
             arr.push(k / 3);
         }

--- a/examples/benchmarks/hew/bench_rod_cutting.hew
+++ b/examples/benchmarks/hew/bench_rod_cutting.hew
@@ -1,5 +1,5 @@
 fn rod_cutting(prices: Vec<i64>, n: i64) -> i64 {
-    let dp: Vec<i64> = Vec::new();
+    let dp: Vec<i64> = Vec.new();
     var idx = 0;
     while idx <= n {
         dp.push(0);
@@ -24,7 +24,7 @@ const ITERS: i64 = 100000;
 
 fn main() {
     let n = 50;
-    let prices: Vec<i64> = Vec::new();
+    let prices: Vec<i64> = Vec.new();
     for k in 0 .. n {
         prices.push(k % 10 + 1 + k / 5);
     }

--- a/examples/benchmarks/hew/bench_rotate_array.hew
+++ b/examples/benchmarks/hew/bench_rotate_array.hew
@@ -24,7 +24,7 @@ const ITERS: i64 = 100000;
 fn main() {
     var checksum = 0;
     for i in 0 .. ITERS {
-        let arr: Vec<i64> = Vec::new();
+        let arr: Vec<i64> = Vec.new();
         for k in 0 .. 1000 {
             arr.push(k);
         }

--- a/examples/benchmarks/hew/bench_selection_sort.hew
+++ b/examples/benchmarks/hew/bench_selection_sort.hew
@@ -17,7 +17,7 @@ fn selection_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_sentinel_search.hew
+++ b/examples/benchmarks/hew/bench_sentinel_search.hew
@@ -24,7 +24,7 @@ fn sentinel_search(v: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 100000;
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. 10000 {
         v.push(i);
     }

--- a/examples/benchmarks/hew/bench_shell_sort.hew
+++ b/examples/benchmarks/hew/bench_shell_sort.hew
@@ -23,7 +23,7 @@ fn shell_sort(v: Vec<i64>) -> Vec<i64> {
 }
 
 fn make_test_array() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     var i = 100;
     while i > 0 {
         v.push(i);

--- a/examples/benchmarks/hew/bench_sieve.hew
+++ b/examples/benchmarks/hew/bench_sieve.hew
@@ -1,5 +1,5 @@
 fn sieve(n: i64) -> i64 {
-    let flags = Vec::new();
+    let flags = Vec.new();
     var i = 0;
     while i <= n {
         flags.push(1);

--- a/examples/benchmarks/hew/bench_spiral_matrix.hew
+++ b/examples/benchmarks/hew/bench_spiral_matrix.hew
@@ -1,6 +1,6 @@
 fn spiral_matrix(n: i64) -> i64 {
     let total = n * n;
-    let mat: Vec<i64> = Vec::new();
+    let mat: Vec<i64> = Vec.new();
     for idx in 0 .. total {
         mat.push(0);
     }

--- a/examples/benchmarks/hew/bench_string_reverse.hew
+++ b/examples/benchmarks/hew/bench_string_reverse.hew
@@ -1,6 +1,6 @@
 fn reverse_string(s: string) -> i64 {
     let n = s.len();
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     for i in 0 .. n {
         let j = n - 1 - i;
         result.push(j);

--- a/examples/benchmarks/hew/bench_ternary_search.hew
+++ b/examples/benchmarks/hew/bench_ternary_search.hew
@@ -32,7 +32,7 @@ fn ternary_search(v: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 1000000;
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. 10000 {
         v.push(i);
     }

--- a/examples/benchmarks/hew/bench_topological_sort.hew
+++ b/examples/benchmarks/hew/bench_topological_sort.hew
@@ -44,8 +44,8 @@ fn build_dag(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, in_degree: Vec<i64>, n:
 }
 
 fn topological_sort(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, in_deg_orig: Vec<i64>, n: i64) -> i64 {
-    let in_deg: Vec<i64> = Vec::new();
-    let queue: Vec<i64> = Vec::new();
+    let in_deg: Vec<i64> = Vec.new();
+    let queue: Vec<i64> = Vec.new();
     var i = 0;
     while i < n {
         in_deg.push(in_deg_orig[i]);
@@ -83,9 +83,9 @@ const ITERS: i64 = 100000;
 
 fn main() {
     let n = 50;
-    let adj_nodes: Vec<i64> = Vec::new();
-    let adj_offsets: Vec<i64> = Vec::new();
-    let in_degree: Vec<i64> = Vec::new();
+    let adj_nodes: Vec<i64> = Vec.new();
+    let adj_offsets: Vec<i64> = Vec.new();
+    let in_degree: Vec<i64> = Vec.new();
     let _ = build_dag(adj_nodes, adj_offsets, in_degree, n);
     var checksum = 0;
     for i in 0 .. ITERS {

--- a/examples/benchmarks/hew/bench_two_sum.hew
+++ b/examples/benchmarks/hew/bench_two_sum.hew
@@ -15,7 +15,7 @@ fn two_sum(arr: Vec<i64>, target: i64) -> i64 {
 const ITERS: i64 = 10000;
 
 fn main() {
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     for k in 0 .. 1000 {
         arr.push(k);
     }

--- a/examples/benchmarks/http_server.hew
+++ b/examples/benchmarks/http_server.hew
@@ -1,6 +1,6 @@
-import std::net::http::{Server};
+import std.net.http.{Server};
 
-import std::net;
+import std.net;
 
 fn serve_forever(server: Server) {
     loop {
@@ -23,10 +23,10 @@ fn serve_forever(server: Server) {
 fn main() {
     println("Listening on 0.0.0.0:18080");
     match http.listen("0.0.0.0:18080") {
-        Ok(server) => {
+        .Ok(server) => {
             serve_forever(server);
         },
-        Err(err) => {
+        .Err(err) => {
             let reason = net.net_error_message(err);
             let detail = http.listen_error();
             println(f"cannot listen on 0.0.0.0:18080: {reason} - {detail}");

--- a/examples/benchmarks/http_server_expert.hew
+++ b/examples/benchmarks/http_server_expert.hew
@@ -1,6 +1,6 @@
-import std::net::http::{Server};
+import std.net.http.{Server};
 
-import std::net;
+import std.net;
 
 fn serve_forever(server: Server) {
     loop {
@@ -48,10 +48,10 @@ fn main() {
     let addr = "0.0.0.0:18080";
     println("Listening on " + addr);
     match http.listen(addr) {
-        Ok(server) => {
+        .Ok(server) => {
             serve_forever(server);
         },
-        Err(err) => {
+        .Err(err) => {
             let reason = net.net_error_message(err);
             let detail = http.listen_error();
             println(f"cannot listen on {addr}: {reason} - {detail}");

--- a/examples/channel/await_recv_actor.hew
+++ b/examples/channel/await_recv_actor.hew
@@ -1,7 +1,7 @@
 //! Worker-free `await rx.recv()` over a std/channel `Receiver<T>` (NEW-4).
 //!
 //! An actor receive handler `await`s `rx.recv()`: from an execution-context caller the
-//! recv flips to `Terminator.SuspendingChannelRecv` and SUSPENDS the worker
+//! recv flips to `Terminator::SuspendingChannelRecv` and SUSPENDS the worker
 //! when empty, resuming on a sender deposit / close. Here the value is already
 //! queued (immediate-ready bind), then a second recv on the closed channel
 //! binds `None`. Run under `HEW_WORKERS=1`: a blocking recv would strand the

--- a/examples/channel/await_recv_actor.hew
+++ b/examples/channel/await_recv_actor.hew
@@ -1,13 +1,13 @@
 //! Worker-free `await rx.recv()` over a std/channel `Receiver<T>` (NEW-4).
 //!
 //! An actor receive handler `await`s `rx.recv()`: from an execution-context caller the
-//! recv flips to `Terminator::SuspendingChannelRecv` and SUSPENDS the worker
+//! recv flips to `Terminator.SuspendingChannelRecv` and SUSPENDS the worker
 //! when empty, resuming on a sender deposit / close. Here the value is already
 //! queued (immediate-ready bind), then a second recv on the closed channel
 //! binds `None`. Run under `HEW_WORKERS=1`: a blocking recv would strand the
 //! lone worker; the suspend ramp does not.
 
-import std::channel::channel;
+import std.channel.channel;
 
 actor Worker {
     receive fn run() {
@@ -15,12 +15,12 @@ actor Worker {
         tx.send("ping");
         tx.close();
         match await rx.recv() {
-            Some(v) => println(v),
-            None => println("closed"),
+            .Some(v) => println(v),
+            .None => println("closed"),
         }
         match await rx.recv() {
-            Some(v) => println(v),
-            None => println("closed"),
+            .Some(v) => println(v),
+            .None => println("closed"),
         }
         rx.close();
     }

--- a/examples/channel/select_recv.hew
+++ b/examples/channel/select_recv.hew
@@ -4,7 +4,7 @@
 //! the loser arm's poll is cancelled at the dispatch site, and the after-timer
 //! never fires. A correct run prints the winning channel's value.
 
-import std::channel::channel;
+import std.channel.channel;
 
 actor Worker {
     receive fn run() {
@@ -14,14 +14,14 @@ actor Worker {
         select {
             a from rxa.recv() => {
                 match a {
-                    Some(s) => println(f"a:{s}"),
-                    None => println("a:none"),
+                    .Some(s) => println(f"a:{s}"),
+                    .None => println("a:none"),
                 }
             },
             b from rxb.recv() => {
                 match b {
-                    Some(n) => println(f"b:{n}"),
-                    None => println("b:none"),
+                    .Some(n) => println(f"b:{n}"),
+                    .None => println("b:none"),
                 }
             },
             after 1s => println("timeout"),

--- a/examples/chat_client.hew
+++ b/examples/chat_client.hew
@@ -6,11 +6,11 @@
 //! directions: `pump` awaits inbound frames, `say` writes outbound lines.
 //! `main` owns the terminal and forwards typed lines as messages.
 
-import std::net::{Connection};
+import std.net.{Connection};
 
-import std::io;
+import std.io;
 
-import std::os;
+import std.os;
 
 extern "C" {
     fn hew_bytes_to_string(data: bytes) -> string;
@@ -41,8 +41,8 @@ actor ChatLink {
     /// Outbound write. Only this actor touches the connection.
     receive fn say(line: string) {
         match conn.write_string(line) {
-            Ok(_) => {},
-            Err(_) => println("[client] send failed"),
+            .Ok(_) => {},
+            .Err(_) => println("[client] send failed"),
         }
     }
 }
@@ -62,8 +62,8 @@ fn main() {
     let connect_timeout_usec: i64 = 0;
     let conn = net.connect_timeout(addr, connect_timeout_sec, connect_timeout_usec);
     match conn.set_read_timeout(-1) {
-        Ok(_) => {},
-        Err(_) => {
+        .Ok(_) => {},
+        .Err(_) => {
             let err = f"[client] failed to set read timeout on connection to {addr}";
             panic(err);
         },

--- a/examples/chat_server.hew
+++ b/examples/chat_server.hew
@@ -12,9 +12,9 @@
 // TCP I/O is confined to ClientHandler; ChatRoom never touches sockets directly.
 // The ChatRoom broadcasts by calling h.deliver(msg) on each handler actor —
 // pure actor-to-actor communication with no raw socket I/O leaking out.
-import std::net::{Connection};
+import std.net.{Connection};
 
-import std::os;
+import std.os;
 
 actor ChatRoom {
     var handlers: Vec<LocalPid<ClientHandler>>;
@@ -25,8 +25,8 @@ actor ChatRoom {
         println(f"{name} joined the chat");
     }
     receive fn unregister(name: string) {
-        var new_handlers: Vec<LocalPid<ClientHandler>> = Vec::new();
-        var new_names: Vec<string> = Vec::new();
+        var new_handlers: Vec<LocalPid<ClientHandler>> = Vec.new();
+        var new_names: Vec<string> = Vec.new();
         for i in 0 .. names.len() {
             if names[i] != name {
                 new_handlers.push(handlers[i]);
@@ -88,8 +88,8 @@ fn main() {
     let listener = net.listen(addr);
     println("=== Hew TCP Chat Server ===");
     println(f"Listening on {addr}");
-    let handlers: Vec<LocalPid<ClientHandler>> = Vec::new();
-    let names: Vec<string> = Vec::new();
+    let handlers: Vec<LocalPid<ClientHandler>> = Vec.new();
+    let names: Vec<string> = Vec.new();
     let room = spawn ChatRoom(handlers: handlers, names: names);
     var next_id: i32 = 1;
     var accepting = 1;

--- a/examples/chat_service.hew
+++ b/examples/chat_service.hew
@@ -8,7 +8,7 @@
 //   Client node: connects, looks up "room", sends messages
 //
 // The actor code is identical whether local or distributed.
-// Node::start/shutdown/register/lookup typecheck today. Node::connect is
+// Node.start/shutdown/register/lookup typecheck today. Node.connect is
 // runtime-only for now (not a typechecker builtin yet).
 actor ChatRoom {
     let users: Vec<string>;
@@ -39,17 +39,17 @@ actor ChatRoom {
 
 fn main() {
     // ── Server side ──────────────────────────────────────────
-    // Node::start("0.0.0.0:9000");
-    let empty_users: Vec<string> = Vec::new();
-    let empty_msgs: Vec<string> = Vec::new();
+    // Node.start("0.0.0.0:9000");
+    let empty_users: Vec<string> = Vec.new();
+    let empty_msgs: Vec<string> = Vec.new();
     let room = spawn ChatRoom(users: empty_users, messages: empty_msgs);
-    // Node::register("room", room);
+    // Node.register("room", room);
 
     // ── Client side (same process for now) ───────────────────
     // In a distributed setup:
-    //   Node::start("0.0.0.0:9001");
-    //   Node::connect("127.0.0.1:9000");  // runtime API, not a typechecker builtin yet
-    //   let room = Node::lookup("room");
+    //   Node.start("0.0.0.0:9001");
+    //   Node.connect("127.0.0.1:9000");  // runtime API, not a typechecker builtin yet
+    //   let room = Node.lookup("room");
 
     // These calls are location-transparent — identical syntax
     // whether room is local or on a remote node:
@@ -60,6 +60,6 @@ fn main() {
     room.say("alice", "how is the weather?");
     room.exit_room("bob");
     let _ = await room.history();
-    // Node::shutdown();
+    // Node.shutdown();
     println("[main] chat demo complete");
 }

--- a/examples/cli_argparse.hew
+++ b/examples/cli_argparse.hew
@@ -8,7 +8,7 @@
 //   cli_argparse --verbose --output=result.txt --port=8080 file1.txt file2.txt
 //   cli_argparse --help
 //   cli_argparse -v -h
-import std::os;
+import std.os;
 
 fn print_help() {
     println("Usage: cli_argparse [OPTIONS] [FILES...]");
@@ -56,10 +56,10 @@ fn main() {
         print_help();
         return;
     }
-    let flags: Vec<string> = Vec::new();
-    let opt_keys: Vec<string> = Vec::new();
-    let opt_vals: Vec<string> = Vec::new();
-    let positional: Vec<string> = Vec::new();
+    let flags: Vec<string> = Vec.new();
+    let opt_keys: Vec<string> = Vec.new();
+    let opt_vals: Vec<string> = Vec.new();
+    let positional: Vec<string> = Vec.new();
     var show_help = 0;
     // Parse arguments (skip argv[0] which is the program name)
     for i in 1 .. argc {
@@ -67,7 +67,7 @@ fn main() {
         if arg.starts_with("--") {
             // Long option: check for "=" to distinguish flag from key=value
             let eq_pos = arg.find("=");
-            if let Some(pos) = eq_pos {
+            if let .Some(pos) = eq_pos {
                 // Key-value option: --key=value
                 let key = arg.slice(2, pos);
                 let val = arg.slice(pos + 1, arg.len());

--- a/examples/collections/run_vec_record_contains.hew
+++ b/examples/collections/run_vec_record_contains.hew
@@ -1,11 +1,11 @@
-// Regression guard for `Vec<Record>::contains` on equality-eligible Copy records.
+// Regression guard for `Vec<Record>.contains` on equality-eligible Copy records.
 type Point {
     x: i64;
     y: i64;
 }
 
 fn main() {
-    let points: Vec<Point> = Vec::new();
+    let points: Vec<Point> = Vec.new();
     points.push(Point { x: 1, y: 2 });
     points.push(Point { x: 3, y: 4 });
     println(points.contains(Point { x: 1, y: 2 }));

--- a/examples/comparison/counter_service.hew
+++ b/examples/comparison/counter_service.hew
@@ -48,13 +48,13 @@ fn main() {
     // Read back the counts.
     let v1 = await c1.get_count();
     match v1 {
-        Ok(n) => println(f"Counter 1: {n}"),
-        Err(_) => println("Counter 1: err"),
+        .Ok(n) => println(f"Counter 1: {n}"),
+        .Err(_) => println("Counter 1: err"),
     }
     let v2 = await c2.get_count();
     match v2 {
-        Ok(n) => println(f"Counter 2: {n}"),
-        Err(_) => println("Counter 2: err"),
+        .Ok(n) => println(f"Counter 2: {n}"),
+        .Err(_) => println("Counter 2: err"),
     }
     println("=== Done ===");
 }

--- a/examples/curl_client.hew
+++ b/examples/curl_client.hew
@@ -11,11 +11,11 @@
 // Examples:
 //   curl_client http://example.com
 //   curl_client http://example.com page.html
-import std::net;
+import std.net;
 
-import std::fs;
+import std.fs;
 
-import std::os;
+import std.os;
 
 extern "C" {
     fn hew_bytes_to_string(data: bytes) -> string;
@@ -107,8 +107,8 @@ fn main() {
     let connect_timeout_usec: i64 = 0;
     let conn = net.connect_timeout(addr, connect_timeout_sec, connect_timeout_usec);
     match conn.set_read_timeout(-1) {
-        Ok(_) => {},
-        Err(_) => {
+        .Ok(_) => {},
+        .Err(_) => {
             let err = f"  Error: failed to set read timeout on connection to {addr}";
             panic(err);
         },
@@ -116,8 +116,8 @@ fn main() {
     // Build and send HTTP request
     let request = f"GET {path} HTTP/1.0\nHost: {host}\nUser-Agent: hew-curl/1.0\nAccept: */*\nConnection: close\n\n";
     match conn.write_string(request) {
-        Ok(_) => {},
-        Err(e) => {
+        .Ok(_) => {},
+        .Err(e) => {
             let err = f"  Error: failed to send request to {addr}: {net.write_error_message(e)}";
             panic(err);
         },

--- a/examples/custom_indexing.hew
+++ b/examples/custom_indexing.hew
@@ -1,5 +1,5 @@
 //! Status: runs
-//! Description: `obj[k]` desugars to `Index::at(obj, k)` via the Index trait,
+//! Description: `obj[k]` desugars to `Index.at(obj, k)` via the Index trait,
 //! mirroring the trait-based pattern used by Iterator (associated-type `Output`).
 //! A user composite implements both halves of the convergence: `get` returns
 //! `Option<Output>` (delegating to the wrapped leaf's `get`), and `at` is the
@@ -23,8 +23,8 @@ impl Index<i64> for Grid {
 
 fn main() {
     let g = Grid { data: [10, 20, 30, 40], width: 2 };
-    let val = g[0]; // desugars to Index::at(g, 0)
-    let val2 = g[2]; // desugars to Index::at(g, 2)
+    let val = g[0]; // desugars to Index.at(g, 0)
+    let val2 = g[2]; // desugars to Index.at(g, 2)
     println(val);
     println(val2);
 }

--- a/examples/d66_hashmap_point.hew
+++ b/examples/d66_hashmap_point.hew
@@ -2,7 +2,7 @@
 // W3.003-C: HashMap<Point, i64> and HashSet<Point> via alignment-aware layout ABI.
 //
 // All HashMap/HashSet operations are currently commented because the stdlib
-// method-rewrite surface is in flux in v05-integration: HashMap::new resolves
+// method-rewrite surface is in flux in v05-integration: HashMap.new resolves
 // to UnresolvedSymbol and HashMap method calls produce MethodCallNoRewrite at
 // the checker rewrite layer. Active code here only demonstrates the record type
 // that will eventually serve as a layout key.
@@ -36,7 +36,7 @@ fn main() {
 }
 // ── Scalar path (commented — stdlib method-rewrite surface in flux) ────────
 //
-// let scores: HashMap<string, i64> = HashMap::new();
+// let scores: HashMap<string, i64> = HashMap.new();
 // scores.insert("origin", 0);
 // scores.insert("a", 10);
 // scores.insert("b", 20);
@@ -46,14 +46,14 @@ fn main() {
 // let _n = scores.len();
 //
 // // bool, char, duration are admitted on the same scalar ABI path:
-// let flags: HashMap<string, bool>     = HashMap::new();
-// let chars: HashMap<string, char>     = HashMap::new();
-// let times: HashMap<string, duration> = HashMap::new();
+// let flags: HashMap<string, bool>     = HashMap.new();
+// let chars: HashMap<string, char>     = HashMap.new();
+// let times: HashMap<string, duration> = HashMap.new();
 // flags.insert("enabled", true);
 // chars.insert("sep", ',');
 // times.insert("delay", 500ms);
 //
-// let ids: HashSet<i64> = HashSet::new();
+// let ids: HashSet<i64> = HashSet.new();
 // ids.insert(1);
 // ids.insert(2);
 // let _present = ids.contains(1);
@@ -61,7 +61,7 @@ fn main() {
 
 // ── Layout-keyed path (commented — requires C-3 codegen thunks) ──────────
 //
-// let point_scores: HashMap<Point, i64> = HashMap::new();
+// let point_scores: HashMap<Point, i64> = HashMap.new();
 // let p1 = Point { x: 0, y: 0 };
 // let p2 = Point { x: 1, y: 2 };
 // point_scores.insert(p1, 42);
@@ -71,7 +71,7 @@ fn main() {
 // point_scores.remove(p1);
 // let _len = point_scores.len();            // i64
 //
-// let point_set: HashSet<Point> = HashSet::new();
+// let point_set: HashSet<Point> = HashSet.new();
 // point_set.insert(Point { x: 3, y: 4 });
 // let _has_p = point_set.contains(Point { x: 3, y: 4 }); // bool
 // point_set.remove(Point { x: 3, y: 4 });

--- a/examples/datastruct/adjacency_list.hew
+++ b/examples/datastruct/adjacency_list.hew
@@ -23,8 +23,8 @@ fn main() {
     var failed = 0;
     let num_nodes = 6;
     // Edge list: (0,1),(0,2),(1,2),(1,3),(2,4),(3,4),(3,5),(4,5)
-    let edge_src: Vec<i64> = Vec::new();
-    let edge_dst: Vec<i64> = Vec::new();
+    let edge_src: Vec<i64> = Vec.new();
+    let edge_dst: Vec<i64> = Vec.new();
     edge_src.push(0);
     edge_dst.push(1);
     edge_src.push(0);
@@ -43,7 +43,7 @@ fn main() {
     edge_dst.push(5);
     let num_edges = edge_src.len();
     // Count degree per node (undirected: each edge counted twice)
-    let degree: Vec<i64> = Vec::new();
+    let degree: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         degree.push(0);
     }
@@ -54,18 +54,18 @@ fn main() {
         degree.set(d, degree[d] + 1);
     }
     // Compute offsets (prefix sum)
-    let adj_offsets: Vec<i64> = Vec::new();
+    let adj_offsets: Vec<i64> = Vec.new();
     adj_offsets.push(0);
     for i in 0 .. num_nodes {
         adj_offsets.push(adj_offsets[i] + degree[i]);
     }
     // Fill adj_nodes
     let total = adj_offsets[num_nodes];
-    let adj_nodes: Vec<i64> = Vec::new();
+    let adj_nodes: Vec<i64> = Vec.new();
     for i in 0 .. total {
         adj_nodes.push(0);
     }
-    let pos: Vec<i64> = Vec::new();
+    let pos: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         pos.push(adj_offsets[i]);
     }

--- a/examples/datastruct/adjacency_matrix.hew
+++ b/examples/datastruct/adjacency_matrix.hew
@@ -48,7 +48,7 @@ fn main() {
     var failed = 0;
     let n = 6;
     // Initialize n*n matrix to 0
-    let matrix: Vec<i64> = Vec::new();
+    let matrix: Vec<i64> = Vec.new();
     for i in 0 .. n * n {
         matrix.push(0);
     }

--- a/examples/datastruct/avl_tree.hew
+++ b/examples/datastruct/avl_tree.hew
@@ -99,8 +99,8 @@ fn avl_insert(nodes: Vec<i64>, root: i64, val: i64, NIL: i64) -> i64 {
         return add_node(nodes, val, NIL);
     }
     // Track path from root to insertion point
-    let path: Vec<i64> = Vec::new();
-    let dirs: Vec<i64> = Vec::new(); // 0=left, 1=right
+    let path: Vec<i64> = Vec.new();
+    let dirs: Vec<i64> = Vec.new(); // 0=left, 1=right
     var cur = root;
     var placed = false;
     while !placed {
@@ -179,7 +179,7 @@ fn inorder(nodes: Vec<i64>, root: i64, result: Vec<i64>, NIL: i64) -> i64 {
     if root == NIL {
         return 0;
     }
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     var cur = root;
     var running = true;
     while running {
@@ -217,7 +217,7 @@ fn check_avl(nodes: Vec<i64>, root: i64, NIL: i64) -> bool {
     if root == NIL {
         return true;
     }
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     stack.push(root);
     var ok = true;
     while stack.len() > 0 {
@@ -243,7 +243,7 @@ fn check_avl(nodes: Vec<i64>, root: i64, NIL: i64) -> bool {
 
 fn test_basic_insert() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = avl_insert(nodes, root, 5, NIL);
     root = avl_insert(nodes, root, 3, NIL);
@@ -252,7 +252,7 @@ fn test_basic_insert() -> i64 {
     root = avl_insert(nodes, root, 4, NIL);
     root = avl_insert(nodes, root, 6, NIL);
     root = avl_insert(nodes, root, 8, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, root, result, NIL);
     if is_sorted(result) {
         if result.len() == 7 {
@@ -266,13 +266,13 @@ fn test_basic_insert() -> i64 {
 
 fn test_left_left() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = avl_insert(nodes, root, 30, NIL);
     root = avl_insert(nodes, root, 20, NIL);
     root = avl_insert(nodes, root, 10, NIL);
     let balanced = check_avl(nodes, root, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, root, result, NIL);
     if balanced {
         if is_sorted(result) {
@@ -288,13 +288,13 @@ fn test_left_left() -> i64 {
 
 fn test_right_right() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = avl_insert(nodes, root, 10, NIL);
     root = avl_insert(nodes, root, 20, NIL);
     root = avl_insert(nodes, root, 30, NIL);
     let balanced = check_avl(nodes, root, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, root, result, NIL);
     if balanced {
         if is_sorted(result) {
@@ -310,13 +310,13 @@ fn test_right_right() -> i64 {
 
 fn test_left_right() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = avl_insert(nodes, root, 30, NIL);
     root = avl_insert(nodes, root, 10, NIL);
     root = avl_insert(nodes, root, 20, NIL);
     let balanced = check_avl(nodes, root, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, root, result, NIL);
     if balanced {
         if is_sorted(result) {
@@ -332,7 +332,7 @@ fn test_left_right() -> i64 {
 
 fn test_many_inserts() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     var i = 1;
     while i <= 20 {
@@ -340,7 +340,7 @@ fn test_many_inserts() -> i64 {
         i = i + 1;
     }
     let balanced = check_avl(nodes, root, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, root, result, NIL);
     let h = node_height(nodes, root);
     if balanced {

--- a/examples/datastruct/binary_search_tree.hew
+++ b/examples/datastruct/binary_search_tree.hew
@@ -84,7 +84,7 @@ fn inorder(nodes: Vec<i64>, result: Vec<i64>, NIL: i64) -> i64 {
     if nodes.len() == 0 {
         return 0;
     }
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     var cur = 0;
     var running = true;
     while running {
@@ -128,7 +128,7 @@ fn print_vec(v: Vec<i64>) -> i64 {
 
 fn test_insert_and_inorder() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     // Insert [5, 3, 7, 1, 4, 6, 8]
     let _ = bst_insert(nodes, 5, NIL);
     let _ = bst_insert(nodes, 3, NIL);
@@ -137,10 +137,10 @@ fn test_insert_and_inorder() -> i64 {
     let _ = bst_insert(nodes, 4, NIL);
     let _ = bst_insert(nodes, 6, NIL);
     let _ = bst_insert(nodes, 8, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, result, NIL);
     // Inorder of BST should be sorted: 1 3 4 5 6 7 8
-    let expected: Vec<i64> = Vec::new();
+    let expected: Vec<i64> = Vec.new();
     expected.push(1);
     expected.push(3);
     expected.push(4);
@@ -160,7 +160,7 @@ fn test_insert_and_inorder() -> i64 {
 
 fn test_search() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = bst_insert(nodes, 5, NIL);
     let _ = bst_insert(nodes, 3, NIL);
     let _ = bst_insert(nodes, 7, NIL);
@@ -197,7 +197,7 @@ fn test_search() -> i64 {
 
 fn test_min_max() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = bst_insert(nodes, 5, NIL);
     let _ = bst_insert(nodes, 3, NIL);
     let _ = bst_insert(nodes, 7, NIL);
@@ -222,12 +222,12 @@ fn test_min_max() -> i64 {
 
 fn test_sorted_insert() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     // Insert in sorted order (worst case for BST)
     for i in 1 .. 11 {
         let _ = bst_insert(nodes, i, NIL);
     }
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, result, NIL);
     var ok = true;
     if result.len() != 10 {
@@ -250,7 +250,7 @@ fn test_sorted_insert() -> i64 {
 
 fn test_single_element() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = bst_insert(nodes, 42, NIL);
     let found = bst_search(nodes, 42, NIL);
     let not_found = bst_search(nodes, 99, NIL);

--- a/examples/datastruct/binary_tree.hew
+++ b/examples/datastruct/binary_tree.hew
@@ -16,7 +16,7 @@ fn insert_level_order(nodes: Vec<i64>, val: i64, NIL: i64) -> i64 {
         let _ = add_node(nodes, val, NIL);
         return 0;
     }
-    let queue: Vec<i64> = Vec::new();
+    let queue: Vec<i64> = Vec.new();
     queue.push(0);
     var head = 0;
     var done = false;
@@ -52,7 +52,7 @@ fn inorder(nodes: Vec<i64>, result: Vec<i64>, NIL: i64) -> i64 {
     if nodes.len() == 0 {
         return 0;
     }
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     var cur = 0;
     var running = true;
     while running {
@@ -76,7 +76,7 @@ fn preorder(nodes: Vec<i64>, result: Vec<i64>, NIL: i64) -> i64 {
     if nodes.len() == 0 {
         return 0;
     }
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     stack.push(0);
     while stack.len() > 0 {
         let cur = stack.pop();
@@ -98,8 +98,8 @@ fn postorder(nodes: Vec<i64>, result: Vec<i64>, NIL: i64) -> i64 {
     if nodes.len() == 0 {
         return 0;
     }
-    let s1: Vec<i64> = Vec::new();
-    let s2: Vec<i64> = Vec::new();
+    let s1: Vec<i64> = Vec.new();
+    let s2: Vec<i64> = Vec.new();
     s1.push(0);
     while s1.len() > 0 {
         let cur = s1.pop();
@@ -127,7 +127,7 @@ fn height(nodes: Vec<i64>, NIL: i64) -> i64 {
         return 0;
     }
     // Compute height for each node bottom-up
-    let heights: Vec<i64> = Vec::new();
+    let heights: Vec<i64> = Vec.new();
     for i in 0 .. count {
         heights.push(0);
     }
@@ -179,7 +179,7 @@ fn print_vec(v: Vec<i64>) -> i64 {
 
 fn test_inorder() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     //        1
     //       / \
     //      2   3
@@ -188,9 +188,9 @@ fn test_inorder() -> i64 {
     for i in 1 .. 8 {
         let _ = insert_level_order(nodes, i, NIL);
     }
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, result, NIL);
-    let expected: Vec<i64> = Vec::new();
+    let expected: Vec<i64> = Vec.new();
     expected.push(4);
     expected.push(2);
     expected.push(5);
@@ -210,13 +210,13 @@ fn test_inorder() -> i64 {
 
 fn test_preorder() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     for i in 1 .. 8 {
         let _ = insert_level_order(nodes, i, NIL);
     }
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = preorder(nodes, result, NIL);
-    let expected: Vec<i64> = Vec::new();
+    let expected: Vec<i64> = Vec.new();
     expected.push(1);
     expected.push(2);
     expected.push(4);
@@ -236,13 +236,13 @@ fn test_preorder() -> i64 {
 
 fn test_postorder() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     for i in 1 .. 8 {
         let _ = insert_level_order(nodes, i, NIL);
     }
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = postorder(nodes, result, NIL);
-    let expected: Vec<i64> = Vec::new();
+    let expected: Vec<i64> = Vec.new();
     expected.push(4);
     expected.push(5);
     expected.push(2);
@@ -262,7 +262,7 @@ fn test_postorder() -> i64 {
 
 fn test_height() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     for i in 1 .. 8 {
         let _ = insert_level_order(nodes, i, NIL);
     }
@@ -279,9 +279,9 @@ fn test_height() -> i64 {
 
 fn test_single_node() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = insert_level_order(nodes, 42, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, result, NIL);
     let h = height(nodes, NIL);
     if result.len() == 1 {

--- a/examples/datastruct/bipartite_check.hew
+++ b/examples/datastruct/bipartite_check.hew
@@ -1,7 +1,7 @@
 // Bipartite Check - 2-colouring BFS
 // Colour 0 = unvisited, 1 = colour A, 2 = colour B
 fn is_bipartite(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, num_nodes: i64) -> bool {
-    let colour: Vec<i64> = Vec::new();
+    let colour: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         colour.push(0);
     }
@@ -11,7 +11,7 @@ fn is_bipartite(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, num_nodes: i64) -> b
             // already coloured
         } else {
             colour.set(start, 1);
-            let queue: Vec<i64> = Vec::new();
+            let queue: Vec<i64> = Vec.new();
             queue.push(start);
             var head = 0;
             while head < queue.len() {
@@ -43,7 +43,7 @@ fn is_bipartite(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, num_nodes: i64) -> b
 
 fn build_undirected(num_nodes: i64, esrc: Vec<i64>, edst: Vec<i64>, adj_nodes: Vec<i64>, adj_offsets: Vec<i64>) {
     let num_edges = esrc.len();
-    let degree: Vec<i64> = Vec::new();
+    let degree: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         degree.push(0);
     }
@@ -61,7 +61,7 @@ fn build_undirected(num_nodes: i64, esrc: Vec<i64>, edst: Vec<i64>, adj_nodes: V
     for i in 0 .. total {
         adj_nodes.push(0);
     }
-    let pos: Vec<i64> = Vec::new();
+    let pos: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         pos.push(adj_offsets[i]);
     }
@@ -81,8 +81,8 @@ fn main() {
     // Graph 1: Bipartite (even cycle: 0-1-2-3-0)
     // Partitions: {0,2} and {1,3}
     let n1 = 4;
-    let s1: Vec<i64> = Vec::new();
-    let d1: Vec<i64> = Vec::new();
+    let s1: Vec<i64> = Vec.new();
+    let d1: Vec<i64> = Vec.new();
     s1.push(0);
     d1.push(1);
     s1.push(1);
@@ -91,8 +91,8 @@ fn main() {
     d1.push(3);
     s1.push(3);
     d1.push(0);
-    let an1: Vec<i64> = Vec::new();
-    let ao1: Vec<i64> = Vec::new();
+    let an1: Vec<i64> = Vec.new();
+    let ao1: Vec<i64> = Vec.new();
     build_undirected(n1, s1, d1, an1, ao1);
 
     // Test 1: 4-cycle is bipartite
@@ -105,16 +105,16 @@ fn main() {
     }
     // Graph 2: Non-bipartite (triangle: 0-1-2-0)
     let n2 = 3;
-    let s2: Vec<i64> = Vec::new();
-    let d2: Vec<i64> = Vec::new();
+    let s2: Vec<i64> = Vec.new();
+    let d2: Vec<i64> = Vec.new();
     s2.push(0);
     d2.push(1);
     s2.push(1);
     d2.push(2);
     s2.push(2);
     d2.push(0);
-    let an2: Vec<i64> = Vec::new();
-    let ao2: Vec<i64> = Vec::new();
+    let an2: Vec<i64> = Vec.new();
+    let ao2: Vec<i64> = Vec.new();
     build_undirected(n2, s2, d2, an2, ao2);
 
     // Test 2: Triangle is not bipartite
@@ -127,8 +127,8 @@ fn main() {
     }
     // Graph 3: Bipartite tree: 0-1, 0-2, 1-3, 1-4
     let n3 = 5;
-    let s3: Vec<i64> = Vec::new();
-    let d3: Vec<i64> = Vec::new();
+    let s3: Vec<i64> = Vec.new();
+    let d3: Vec<i64> = Vec.new();
     s3.push(0);
     d3.push(1);
     s3.push(0);
@@ -137,8 +137,8 @@ fn main() {
     d3.push(3);
     s3.push(1);
     d3.push(4);
-    let an3: Vec<i64> = Vec::new();
-    let ao3: Vec<i64> = Vec::new();
+    let an3: Vec<i64> = Vec.new();
+    let ao3: Vec<i64> = Vec.new();
     build_undirected(n3, s3, d3, an3, ao3);
 
     // Test 3: Tree is always bipartite
@@ -151,8 +151,8 @@ fn main() {
     }
     // Graph 4: 5-cycle (odd cycle, not bipartite)
     let n4 = 5;
-    let s4: Vec<i64> = Vec::new();
-    let d4: Vec<i64> = Vec::new();
+    let s4: Vec<i64> = Vec.new();
+    let d4: Vec<i64> = Vec.new();
     s4.push(0);
     d4.push(1);
     s4.push(1);
@@ -163,8 +163,8 @@ fn main() {
     d4.push(4);
     s4.push(4);
     d4.push(0);
-    let an4: Vec<i64> = Vec::new();
-    let ao4: Vec<i64> = Vec::new();
+    let an4: Vec<i64> = Vec.new();
+    let ao4: Vec<i64> = Vec.new();
     build_undirected(n4, s4, d4, an4, ao4);
 
     // Test 4: 5-cycle is not bipartite
@@ -177,10 +177,10 @@ fn main() {
     }
     // Graph 5: Single node (trivially bipartite)
     let n5 = 1;
-    let s5: Vec<i64> = Vec::new();
-    let d5: Vec<i64> = Vec::new();
-    let an5: Vec<i64> = Vec::new();
-    let ao5: Vec<i64> = Vec::new();
+    let s5: Vec<i64> = Vec.new();
+    let d5: Vec<i64> = Vec.new();
+    let an5: Vec<i64> = Vec.new();
+    let ao5: Vec<i64> = Vec.new();
     build_undirected(n5, s5, d5, an5, ao5);
 
     // Test 5: Single node
@@ -193,8 +193,8 @@ fn main() {
     }
     // Graph 6: Complete bipartite K(2,3): {0,1} x {2,3,4}
     let n6 = 5;
-    let s6: Vec<i64> = Vec::new();
-    let d6: Vec<i64> = Vec::new();
+    let s6: Vec<i64> = Vec.new();
+    let d6: Vec<i64> = Vec.new();
     s6.push(0);
     d6.push(2);
     s6.push(0);
@@ -207,8 +207,8 @@ fn main() {
     d6.push(3);
     s6.push(1);
     d6.push(4);
-    let an6: Vec<i64> = Vec::new();
-    let ao6: Vec<i64> = Vec::new();
+    let an6: Vec<i64> = Vec.new();
+    let ao6: Vec<i64> = Vec.new();
     build_undirected(n6, s6, d6, an6, ao6);
 
     // Test 6: K(2,3) is bipartite
@@ -221,8 +221,8 @@ fn main() {
     }
     // Graph 7: 6-cycle (even, bipartite)
     let n7 = 6;
-    let s7: Vec<i64> = Vec::new();
-    let d7: Vec<i64> = Vec::new();
+    let s7: Vec<i64> = Vec.new();
+    let d7: Vec<i64> = Vec.new();
     s7.push(0);
     d7.push(1);
     s7.push(1);
@@ -235,8 +235,8 @@ fn main() {
     d7.push(5);
     s7.push(5);
     d7.push(0);
-    let an7: Vec<i64> = Vec::new();
-    let ao7: Vec<i64> = Vec::new();
+    let an7: Vec<i64> = Vec.new();
+    let ao7: Vec<i64> = Vec.new();
     build_undirected(n7, s7, d7, an7, ao7);
 
     // Test 7: 6-cycle is bipartite
@@ -250,8 +250,8 @@ fn main() {
     // Graph 8: 6-cycle + chord creating odd cycle (0-1-2-3-4-5-0 + 0-2)
     // The chord 0-2 creates triangle 0-1-2-0 (odd cycle)
     let n8 = 6;
-    let s8: Vec<i64> = Vec::new();
-    let d8: Vec<i64> = Vec::new();
+    let s8: Vec<i64> = Vec.new();
+    let d8: Vec<i64> = Vec.new();
     s8.push(0);
     d8.push(1);
     s8.push(1);
@@ -266,8 +266,8 @@ fn main() {
     d8.push(0);
     s8.push(0);
     d8.push(2);
-    let an8: Vec<i64> = Vec::new();
-    let ao8: Vec<i64> = Vec::new();
+    let an8: Vec<i64> = Vec.new();
+    let ao8: Vec<i64> = Vec.new();
     build_undirected(n8, s8, d8, an8, ao8);
 
     // Test 8: 6-cycle+chord has odd cycle, not bipartite

--- a/examples/datastruct/bit_vector.hew
+++ b/examples/datastruct/bit_vector.hew
@@ -1,7 +1,7 @@
 // Bit Vector using Vec<i64> where each i64 stores 32 bits
 // Operations: set_bit, clear_bit, get_bit, count_ones
 fn bv_create(num_bits: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     let num_words = (num_bits + 31) / 32;
     for i in 0 .. num_words {
         v.push(0);

--- a/examples/datastruct/bloom_filter.hew
+++ b/examples/datastruct/bloom_filter.hew
@@ -28,7 +28,7 @@ fn h3(key: i64, m: i64) -> i64 {
 }
 
 fn make_bloom(size: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. size {
         v.push(0);
     }

--- a/examples/datastruct/circular_buffer.hew
+++ b/examples/datastruct/circular_buffer.hew
@@ -2,7 +2,7 @@
 // Layout: [capacity, head, tail, count, data...]
 // Data starts at index 4
 fn cb_new(capacity: i64) -> Vec<i64> {
-    let buf: Vec<i64> = Vec::new();
+    let buf: Vec<i64> = Vec.new();
     buf.push(capacity); // index 0: capacity
     buf.push(0); // index 1: head
     buf.push(0); // index 2: tail

--- a/examples/datastruct/circular_list.hew
+++ b/examples/datastruct/circular_list.hew
@@ -132,14 +132,14 @@ fn vecs_equal(a: Vec<i64>, b: Vec<i64>) -> i64 {
 
 // --- Tests ---
 fn test_insert_and_traverse() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_tail(n, head, 10);
     head = insert_tail(n, head, 20);
     head = insert_tail(n, head, 30);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -152,7 +152,7 @@ fn test_insert_and_traverse() -> i64 {
 }
 
 fn test_circular_property() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_tail(n, head, 1);
     head = insert_tail(n, head, 2);
@@ -176,15 +176,15 @@ fn test_circular_property() -> i64 {
 }
 
 fn test_delete_middle() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_tail(n, head, 10);
     head = insert_tail(n, head, 20);
     head = insert_tail(n, head, 30);
     head = delete_val(n, head, 20);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(10);
     e.push(30);
     if vecs_equal(r, e) == 1 {
@@ -196,15 +196,15 @@ fn test_delete_middle() -> i64 {
 }
 
 fn test_delete_head() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_tail(n, head, 10);
     head = insert_tail(n, head, 20);
     head = insert_tail(n, head, 30);
     head = delete_val(n, head, 10);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(20);
     e.push(30);
     if vecs_equal(r, e) == 1 {
@@ -219,7 +219,7 @@ fn test_delete_head() -> i64 {
 }
 
 fn test_single_element() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_tail(n, head, 42);
     if list_len(n, head) == 1 {
@@ -236,7 +236,7 @@ fn test_single_element() -> i64 {
 }
 
 fn test_length() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     if list_len(n, head) != 0 {
         println("FAIL: length");

--- a/examples/datastruct/consistent_hash.hew
+++ b/examples/datastruct/consistent_hash.hew
@@ -98,8 +98,8 @@ fn main() {
     var failed = 0;
     let ring_size = 10000;
     let replicas = 3;
-    let positions: Vec<i64> = Vec::new();
-    let nodes: Vec<i64> = Vec::new();
+    let positions: Vec<i64> = Vec.new();
+    let nodes: Vec<i64> = Vec.new();
     // Test 1: Add nodes and verify lookup returns valid node
     add_node(positions, nodes, 1, ring_size, replicas);
     add_node(positions, nodes, 2, ring_size, replicas);
@@ -160,7 +160,7 @@ fn main() {
         failed = failed + 1;
     }
     // Record mappings before adding a node
-    let before: Vec<i64> = Vec::new();
+    let before: Vec<i64> = Vec.new();
     var num_keys = 100;
     for k in 0 .. num_keys {
         let key = k * 37;
@@ -263,8 +263,8 @@ fn main() {
         failed = failed + 1;
     }
     // Test 8: Empty ring returns -1
-    let ep: Vec<i64> = Vec::new();
-    let en: Vec<i64> = Vec::new();
+    let ep: Vec<i64> = Vec.new();
+    let en: Vec<i64> = Vec.new();
     let empty_result = lookup(ep, en, 42, ring_size);
     if empty_result == 0 - 1 {
         println("PASS: empty ring lookup");

--- a/examples/datastruct/counting_map.hew
+++ b/examples/datastruct/counting_map.hew
@@ -10,7 +10,7 @@ fn hash(key: i64, capacity: i64) -> i64 {
 }
 
 fn make_keys(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     let EMPTY = 0 - 1;
     for i in 0 .. capacity {
         v.push(EMPTY);
@@ -19,7 +19,7 @@ fn make_keys(capacity: i64) -> Vec<i64> {
 }
 
 fn make_vals(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. capacity {
         v.push(0);
     }

--- a/examples/datastruct/cuckoo_hash.hew
+++ b/examples/datastruct/cuckoo_hash.hew
@@ -21,7 +21,7 @@ fn hash2(key: i64, capacity: i64) -> i64 {
 }
 
 fn make_table(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     let EMPTY = 0 - 1;
     for i in 0 .. capacity {
         v.push(EMPTY);

--- a/examples/datastruct/deque.hew
+++ b/examples/datastruct/deque.hew
@@ -2,7 +2,7 @@
 // Uses a Vec where index 0 = head pointer, rest is data
 // push_front shifts elements, push_back appends
 fn deque_new() -> Vec<i64> {
-    let d: Vec<i64> = Vec::new();
+    let d: Vec<i64> = Vec.new();
     d.push(0); // head pointer
     d
 }

--- a/examples/datastruct/directed_graph.hew
+++ b/examples/datastruct/directed_graph.hew
@@ -7,12 +7,12 @@ fn has_path_dfs(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, num_nodes: i64, src:
     if src == dst {
         return true;
     }
-    let visited: Vec<i64> = Vec::new();
+    let visited: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         visited.push(0);
     }
     // Stack-based DFS
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     stack.push(src);
     visited.set(src, 1);
     while stack.len() > 0 {
@@ -40,8 +40,8 @@ fn main() {
     var failed = 0;
     let num_nodes = 6;
     // Directed edges: 0->1, 0->2, 1->3, 2->1, 2->4, 3->5, 4->3, 4->5
-    let esrc: Vec<i64> = Vec::new();
-    let edst: Vec<i64> = Vec::new();
+    let esrc: Vec<i64> = Vec.new();
+    let edst: Vec<i64> = Vec.new();
     esrc.push(0);
     edst.push(1);
     esrc.push(0);
@@ -60,7 +60,7 @@ fn main() {
     edst.push(5);
     let num_edges = esrc.len();
     // Build forward graph
-    let degree: Vec<i64> = Vec::new();
+    let degree: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         degree.push(0);
     }
@@ -68,17 +68,17 @@ fn main() {
         let s = esrc[i];
         degree.set(s, degree[s] + 1);
     }
-    let adj_offsets: Vec<i64> = Vec::new();
+    let adj_offsets: Vec<i64> = Vec.new();
     adj_offsets.push(0);
     for i in 0 .. num_nodes {
         adj_offsets.push(adj_offsets[i] + degree[i]);
     }
-    let adj_nodes: Vec<i64> = Vec::new();
+    let adj_nodes: Vec<i64> = Vec.new();
     let total = adj_offsets[num_nodes];
     for i in 0 .. total {
         adj_nodes.push(0);
     }
-    let pos: Vec<i64> = Vec::new();
+    let pos: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         pos.push(adj_offsets[i]);
     }
@@ -89,7 +89,7 @@ fn main() {
         pos.set(s, pos[s] + 1);
     }
     // Compute in-degree
-    let in_deg: Vec<i64> = Vec::new();
+    let in_deg: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         in_deg.push(0);
     }
@@ -146,7 +146,7 @@ fn main() {
         passed = passed + 1;
     }
     // Build transpose graph (reverse all edges)
-    let tdeg: Vec<i64> = Vec::new();
+    let tdeg: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         tdeg.push(0);
     }
@@ -154,16 +154,16 @@ fn main() {
         let d = edst[i];
         tdeg.set(d, tdeg[d] + 1);
     }
-    let t_offsets: Vec<i64> = Vec::new();
+    let t_offsets: Vec<i64> = Vec.new();
     t_offsets.push(0);
     for i in 0 .. num_nodes {
         t_offsets.push(t_offsets[i] + tdeg[i]);
     }
-    let t_nodes: Vec<i64> = Vec::new();
+    let t_nodes: Vec<i64> = Vec.new();
     for i in 0 .. total {
         t_nodes.push(0);
     }
-    let tpos: Vec<i64> = Vec::new();
+    let tpos: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         tpos.push(t_offsets[i]);
     }

--- a/examples/datastruct/doubly_linked_list.hew
+++ b/examples/datastruct/doubly_linked_list.hew
@@ -115,14 +115,14 @@ fn vecs_equal(a: Vec<i64>, b: Vec<i64>) -> i64 {
 }
 
 fn test_insert_front() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_front(n, head, 30);
     head = insert_front(n, head, 20);
     head = insert_front(n, head, 10);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse_forward(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -135,14 +135,14 @@ fn test_insert_front() -> i64 {
 }
 
 fn test_insert_back() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
     head = insert_back(n, head, 30);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse_forward(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -155,14 +155,14 @@ fn test_insert_back() -> i64 {
 }
 
 fn test_backward_traverse() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
     head = insert_back(n, head, 30);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse_backward(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(30);
     e.push(20);
     e.push(10);
@@ -175,20 +175,20 @@ fn test_backward_traverse() -> i64 {
 }
 
 fn test_delete() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
     head = insert_back(n, head, 30);
     head = delete_val(n, head, 20);
-    let fwd: Vec<i64> = Vec::new();
+    let fwd: Vec<i64> = Vec.new();
     traverse_forward(n, head, fwd);
-    let ef: Vec<i64> = Vec::new();
+    let ef: Vec<i64> = Vec.new();
     ef.push(10);
     ef.push(30);
-    let bwd: Vec<i64> = Vec::new();
+    let bwd: Vec<i64> = Vec.new();
     traverse_backward(n, head, bwd);
-    let eb: Vec<i64> = Vec::new();
+    let eb: Vec<i64> = Vec.new();
     eb.push(30);
     eb.push(10);
     if vecs_equal(fwd, ef) == 1 {
@@ -202,7 +202,7 @@ fn test_delete() -> i64 {
 }
 
 fn test_delete_head() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
@@ -218,12 +218,12 @@ fn test_delete_head() -> i64 {
 }
 
 fn test_delete_tail() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
     head = delete_val(n, head, 20);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse_forward(n, head, r);
     if r.len() == 1 {
         if r[0] == 10 {

--- a/examples/datastruct/dynamic_array.hew
+++ b/examples/datastruct/dynamic_array.hew
@@ -2,7 +2,7 @@
 // Layout: Vec<i64> where index 0 = logical size, index 1 = capacity, rest is data
 // Data starts at index 2
 fn da_new(initial_cap: i64) -> Vec<i64> {
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(0); // index 0: logical size
     arr.push(initial_cap); // index 1: capacity
     // Pre-allocate slots

--- a/examples/datastruct/fenwick_tree.hew
+++ b/examples/datastruct/fenwick_tree.hew
@@ -56,7 +56,7 @@ fn fw_range_query(tree: Vec<i64>, l: i64, r: i64) -> i64 {
 }
 
 fn init_fenwick(n: i64) -> Vec<i64> {
-    let tree: Vec<i64> = Vec::new();
+    let tree: Vec<i64> = Vec.new();
     var i = 0;
     while i <= n {
         tree.push(0);
@@ -171,7 +171,7 @@ fn test_point_update() -> i64 {
 fn test_brute_force_verify() -> i64 {
     let n = 10;
     let tree = init_fenwick(n);
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(0); // index 0 unused
     // Fill with values
     var i = 1;

--- a/examples/datastruct/frequency_counter.hew
+++ b/examples/datastruct/frequency_counter.hew
@@ -10,7 +10,7 @@ fn hash(key: i64, capacity: i64) -> i64 {
 }
 
 fn make_keys(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     let EMPTY = 0 - 1;
     for i in 0 .. capacity {
         v.push(EMPTY);
@@ -19,7 +19,7 @@ fn make_keys(capacity: i64) -> Vec<i64> {
 }
 
 fn make_vals(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. capacity {
         v.push(0);
     }
@@ -103,7 +103,7 @@ fn find_topk(keys: Vec<i64>, vals: Vec<i64>, k: i64, result: Vec<i64>) {
     let capacity = keys.len();
     let EMPTY = 0 - 1;
     // Make a copy of vals to mark used entries
-    let used: Vec<i64> = Vec::new();
+    let used: Vec<i64> = Vec.new();
     for i in 0 .. capacity {
         used.push(0);
     }
@@ -138,7 +138,7 @@ fn main() {
     var failed = 0;
     // Test data: [1, 2, 3, 1, 2, 1, 4, 2, 1, 3]
     // Frequencies: 1->4, 2->3, 3->2, 4->1
-    let data: Vec<i64> = Vec::new();
+    let data: Vec<i64> = Vec.new();
     data.push(1);
     data.push(2);
     data.push(3);
@@ -211,7 +211,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: Top-3 frequent elements
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     find_topk(keys, vals, 3, result);
     if result.len() == 3 {
         let r0 = result[0];
@@ -240,7 +240,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 8: Larger dataset
-    let data2: Vec<i64> = Vec::new();
+    let data2: Vec<i64> = Vec.new();
     // 5 appears 10 times, 6 appears 5 times, 7 appears 1 time
     for i in 0 .. 10 {
         data2.push(5);

--- a/examples/datastruct/graph_colouring.hew
+++ b/examples/datastruct/graph_colouring.hew
@@ -2,7 +2,7 @@
 // Assign colours (ints starting from 0) so no two adjacent nodes share a colour
 fn build_undirected(num_nodes: i64, esrc: Vec<i64>, edst: Vec<i64>, adj_nodes: Vec<i64>, adj_offsets: Vec<i64>) {
     let num_edges = esrc.len();
-    let degree: Vec<i64> = Vec::new();
+    let degree: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         degree.push(0);
     }
@@ -20,7 +20,7 @@ fn build_undirected(num_nodes: i64, esrc: Vec<i64>, edst: Vec<i64>, adj_nodes: V
     for i in 0 .. total {
         adj_nodes.push(0);
     }
-    let pos: Vec<i64> = Vec::new();
+    let pos: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         pos.push(adj_offsets[i]);
     }
@@ -40,7 +40,7 @@ fn greedy_colour(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, num_nodes: i64, col
         colours.push(0 - 1);
     }
     // Track which colours are used by neighbours
-    let used: Vec<i64> = Vec::new();
+    let used: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         used.push(0);
     }
@@ -118,8 +118,8 @@ fn main() {
     // Graph 1: Petersen-like structure, 6 nodes
     // 0-1, 0-2, 0-3, 1-2, 1-4, 2-5, 3-4, 3-5, 4-5
     let n1 = 6;
-    let s1: Vec<i64> = Vec::new();
-    let d1: Vec<i64> = Vec::new();
+    let s1: Vec<i64> = Vec.new();
+    let d1: Vec<i64> = Vec.new();
     s1.push(0);
     d1.push(1);
     s1.push(0);
@@ -138,10 +138,10 @@ fn main() {
     d1.push(5);
     s1.push(4);
     d1.push(5);
-    let an1: Vec<i64> = Vec::new();
-    let ao1: Vec<i64> = Vec::new();
+    let an1: Vec<i64> = Vec.new();
+    let ao1: Vec<i64> = Vec.new();
     build_undirected(n1, s1, d1, an1, ao1);
-    let colours1: Vec<i64> = Vec::new();
+    let colours1: Vec<i64> = Vec.new();
     greedy_colour(an1, ao1, n1, colours1);
 
     // Test 1: Valid colouring
@@ -163,8 +163,8 @@ fn main() {
     }
     // Graph 2: Bipartite (4-cycle: 0-1-2-3-0), should need exactly 2 colours
     let n2 = 4;
-    let s2: Vec<i64> = Vec::new();
-    let d2: Vec<i64> = Vec::new();
+    let s2: Vec<i64> = Vec.new();
+    let d2: Vec<i64> = Vec.new();
     s2.push(0);
     d2.push(1);
     s2.push(1);
@@ -173,10 +173,10 @@ fn main() {
     d2.push(3);
     s2.push(3);
     d2.push(0);
-    let an2: Vec<i64> = Vec::new();
-    let ao2: Vec<i64> = Vec::new();
+    let an2: Vec<i64> = Vec.new();
+    let ao2: Vec<i64> = Vec.new();
     build_undirected(n2, s2, d2, an2, ao2);
-    let colours2: Vec<i64> = Vec::new();
+    let colours2: Vec<i64> = Vec.new();
     greedy_colour(an2, ao2, n2, colours2);
 
     // Test 3: Valid colouring
@@ -198,18 +198,18 @@ fn main() {
     }
     // Graph 3: Triangle (K3), needs exactly 3 colours
     let n3 = 3;
-    let s3: Vec<i64> = Vec::new();
-    let d3: Vec<i64> = Vec::new();
+    let s3: Vec<i64> = Vec.new();
+    let d3: Vec<i64> = Vec.new();
     s3.push(0);
     d3.push(1);
     s3.push(1);
     d3.push(2);
     s3.push(2);
     d3.push(0);
-    let an3: Vec<i64> = Vec::new();
-    let ao3: Vec<i64> = Vec::new();
+    let an3: Vec<i64> = Vec.new();
+    let ao3: Vec<i64> = Vec.new();
     build_undirected(n3, s3, d3, an3, ao3);
-    let colours3: Vec<i64> = Vec::new();
+    let colours3: Vec<i64> = Vec.new();
     greedy_colour(an3, ao3, n3, colours3);
 
     // Test 5: Valid colouring
@@ -231,8 +231,8 @@ fn main() {
     }
     // Graph 4: Star graph (0 connected to 1,2,3,4), needs 2 colours
     let n4 = 5;
-    let s4: Vec<i64> = Vec::new();
-    let d4: Vec<i64> = Vec::new();
+    let s4: Vec<i64> = Vec.new();
+    let d4: Vec<i64> = Vec.new();
     s4.push(0);
     d4.push(1);
     s4.push(0);
@@ -241,10 +241,10 @@ fn main() {
     d4.push(3);
     s4.push(0);
     d4.push(4);
-    let an4: Vec<i64> = Vec::new();
-    let ao4: Vec<i64> = Vec::new();
+    let an4: Vec<i64> = Vec.new();
+    let ao4: Vec<i64> = Vec.new();
     build_undirected(n4, s4, d4, an4, ao4);
-    let colours4: Vec<i64> = Vec::new();
+    let colours4: Vec<i64> = Vec.new();
     greedy_colour(an4, ao4, n4, colours4);
 
     // Test 7: Valid colouring

--- a/examples/datastruct/hash_map_open.hew
+++ b/examples/datastruct/hash_map_open.hew
@@ -10,7 +10,7 @@ fn hash(key: i64, capacity: i64) -> i64 {
 }
 
 fn make_keys(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     let EMPTY = 0 - 1;
     for i in 0 .. capacity {
         v.push(EMPTY);
@@ -19,7 +19,7 @@ fn make_keys(capacity: i64) -> Vec<i64> {
 }
 
 fn make_vals(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     for i in 0 .. capacity {
         v.push(0);
     }

--- a/examples/datastruct/hash_set.hew
+++ b/examples/datastruct/hash_set.hew
@@ -10,7 +10,7 @@ fn hash(key: i64, capacity: i64) -> i64 {
 }
 
 fn make_set(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     let EMPTY = 0 - 1;
     for i in 0 .. capacity {
         v.push(EMPTY);

--- a/examples/datastruct/interval_tree.hew
+++ b/examples/datastruct/interval_tree.hew
@@ -74,8 +74,8 @@ fn interval_insert(nodes: Vec<i64>, root: i64, low: i64, high: i64, NIL: i64) ->
     if root == NIL {
         return add_node(nodes, low, high, NIL);
     }
-    let path: Vec<i64> = Vec::new();
-    let dirs: Vec<i64> = Vec::new();
+    let path: Vec<i64> = Vec.new();
+    let dirs: Vec<i64> = Vec.new();
     var cur = root;
     var placed = false;
     while !placed {
@@ -124,7 +124,7 @@ fn query_point(nodes: Vec<i64>, root: i64, p: i64, result: Vec<i64>, NIL: i64) -
         return 0;
     }
     // Use iterative DFS with stack
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     stack.push(root);
     while stack.len() > 0 {
         let cur = stack.pop();
@@ -164,7 +164,7 @@ fn query_range(nodes: Vec<i64>, root: i64, ql: i64, qh: i64, result: Vec<i64>, N
     if root == NIL {
         return 0;
     }
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     stack.push(root);
     while stack.len() > 0 {
         let cur = stack.pop();
@@ -194,7 +194,7 @@ fn query_range(nodes: Vec<i64>, root: i64, ql: i64, qh: i64, result: Vec<i64>, N
 
 fn test_basic_overlap() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     // Insert intervals: [1,5], [3,8], [10,15], [6,7]
     root = interval_insert(nodes, root, 1, 5, NIL);
@@ -202,7 +202,7 @@ fn test_basic_overlap() -> i64 {
     root = interval_insert(nodes, root, 10, 15, NIL);
     root = interval_insert(nodes, root, 6, 7, NIL);
     // Query point 4: overlaps [1,5] and [3,8]
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = query_point(nodes, root, 4, result, NIL);
     if result.len() == 2 {
         println("PASS: basic point overlap query");
@@ -216,13 +216,13 @@ fn test_basic_overlap() -> i64 {
 
 fn test_no_overlap() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = interval_insert(nodes, root, 1, 3, NIL);
     root = interval_insert(nodes, root, 5, 7, NIL);
     root = interval_insert(nodes, root, 9, 11, NIL);
     // Query point 4: no overlap
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = query_point(nodes, root, 4, result, NIL);
     if result.len() == 0 {
         println("PASS: no overlap query");
@@ -236,13 +236,13 @@ fn test_no_overlap() -> i64 {
 
 fn test_all_overlap() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = interval_insert(nodes, root, 1, 10, NIL);
     root = interval_insert(nodes, root, 2, 8, NIL);
     root = interval_insert(nodes, root, 3, 12, NIL);
     // Query point 5: all three overlap
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = query_point(nodes, root, 5, result, NIL);
     if result.len() == 3 {
         println("PASS: all intervals overlap");
@@ -256,12 +256,12 @@ fn test_all_overlap() -> i64 {
 
 fn test_boundary_overlap() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = interval_insert(nodes, root, 1, 5, NIL);
     root = interval_insert(nodes, root, 5, 10, NIL);
     // Query point 5: both [1,5] and [5,10] overlap
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = query_point(nodes, root, 5, result, NIL);
     if result.len() == 2 {
         println("PASS: boundary overlap");
@@ -275,14 +275,14 @@ fn test_boundary_overlap() -> i64 {
 
 fn test_range_query() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = interval_insert(nodes, root, 1, 3, NIL);
     root = interval_insert(nodes, root, 5, 8, NIL);
     root = interval_insert(nodes, root, 10, 15, NIL);
     root = interval_insert(nodes, root, 12, 20, NIL);
     // Range query [6, 11]: overlaps [5,8] and [10,15]
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = query_range(nodes, root, 6, 11, result, NIL);
     if result.len() == 2 {
         println("PASS: range overlap query");

--- a/examples/datastruct/lru_cache.hew
+++ b/examples/datastruct/lru_cache.hew
@@ -68,7 +68,7 @@ fn set_size(m: Vec<i64>, s: i64) {
 }
 
 fn new_cache(capacity: i64) -> Vec<i64> {
-    let m: Vec<i64> = Vec::new();
+    let m: Vec<i64> = Vec.new();
     m.push(-1);
     m.push(-1);
     m.push(0);
@@ -173,7 +173,7 @@ fn vecs_equal(a: Vec<i64>, b: Vec<i64>) -> i64 {
 
 // --- Tests ---
 fn test_put_and_get() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     let m = new_cache(3);
     cache_put(n, m, 1, 100);
     cache_put(n, m, 2, 200);
@@ -194,7 +194,7 @@ fn test_put_and_get() -> i64 {
 }
 
 fn test_eviction() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     let m = new_cache(2);
     cache_put(n, m, 1, 100);
     cache_put(n, m, 2, 200);
@@ -216,7 +216,7 @@ fn test_eviction() -> i64 {
 }
 
 fn test_access_updates_order() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     let m = new_cache(3);
     cache_put(n, m, 1, 100);
     cache_put(n, m, 2, 200);
@@ -238,7 +238,7 @@ fn test_access_updates_order() -> i64 {
 }
 
 fn test_update_value() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     let m = new_cache(3);
     cache_put(n, m, 1, 100);
     cache_put(n, m, 1, 999);
@@ -254,7 +254,7 @@ fn test_update_value() -> i64 {
 }
 
 fn test_order_after_operations() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     let m = new_cache(3);
     cache_put(n, m, 1, 10);
     cache_put(n, m, 2, 20);
@@ -262,9 +262,9 @@ fn test_order_after_operations() -> i64 {
     // Order: 3(front) -> 2 -> 1(back)
     let _v = cache_get(n, m, 1);
     // Order: 1(front) -> 3 -> 2(back)
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     collect_keys(n, m, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(1);
     e.push(3);
     e.push(2);
@@ -277,7 +277,7 @@ fn test_order_after_operations() -> i64 {
 }
 
 fn test_miss() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     let m = new_cache(2);
     cache_put(n, m, 1, 100);
     let v = cache_get(n, m, 99);

--- a/examples/datastruct/matrix.hew
+++ b/examples/datastruct/matrix.hew
@@ -1,7 +1,7 @@
 // 2D Matrix using flat Vec<i64>
 // Layout: [rows, cols, data...] where data[r*cols + c] = element at (r,c)
 fn mat_create(rows: i64, cols: i64) -> Vec<i64> {
-    let m: Vec<i64> = Vec::new();
+    let m: Vec<i64> = Vec.new();
     m.push(rows);
     m.push(cols);
     let total = rows * cols;

--- a/examples/datastruct/max_heap.hew
+++ b/examples/datastruct/max_heap.hew
@@ -113,7 +113,7 @@ fn check_max_heap_property(heap: Vec<i32>) -> bool {
 }
 
 fn test_basic_max_heap() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 5);
     let _ = heap_push(heap, 3);
     let _ = heap_push(heap, 7);
@@ -131,7 +131,7 @@ fn test_basic_max_heap() -> i32 {
 }
 
 fn test_extract_max_order() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 5);
     let _ = heap_push(heap, 3);
     let _ = heap_push(heap, 7);
@@ -191,14 +191,14 @@ fn test_extract_max_order() -> i32 {
 }
 
 fn test_build_heap() -> i32 {
-    let arr: Vec<i32> = Vec::new();
+    let arr: Vec<i32> = Vec.new();
     arr.push(3);
     arr.push(1);
     arr.push(6);
     arr.push(5);
     arr.push(2);
     arr.push(4);
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = build_heap(arr, heap);
     let ok = check_max_heap_property(heap);
     if ok {
@@ -212,7 +212,7 @@ fn test_build_heap() -> i32 {
 }
 
 fn test_heap_property_after_ops() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 10);
     let _ = heap_push(heap, 20);
     let _ = heap_push(heap, 15);
@@ -232,7 +232,7 @@ fn test_heap_property_after_ops() -> i32 {
 }
 
 fn test_heapsort() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 8);
     let _ = heap_push(heap, 3);
     let _ = heap_push(heap, 10);
@@ -240,7 +240,7 @@ fn test_heapsort() -> i32 {
     let _ = heap_push(heap, 5);
     let _ = heap_push(heap, 7);
     // Extract all to get sorted descending
-    let sorted: Vec<i32> = Vec::new();
+    let sorted: Vec<i32> = Vec.new();
     while heap.len() > 0 {
         sorted.push(heap_pop(heap));
     }

--- a/examples/datastruct/max_stack.hew
+++ b/examples/datastruct/max_stack.hew
@@ -43,8 +43,8 @@ fn ms_size(data: Vec<i64>) -> i64 {
 fn main() {
     var total = 0;
     var passed = 0;
-    let data: Vec<i64> = Vec::new();
-    let maxs: Vec<i64> = Vec::new();
+    let data: Vec<i64> = Vec.new();
+    let maxs: Vec<i64> = Vec.new();
     // Test 1: push single, max is that element
     total = total + 1;
     ms_push(data, maxs, 5);
@@ -119,8 +119,8 @@ fn main() {
 
     // Test 8: many elements
     total = total + 1;
-    let d2: Vec<i64> = Vec::new();
-    let m2: Vec<i64> = Vec::new();
+    let d2: Vec<i64> = Vec.new();
+    let m2: Vec<i64> = Vec.new();
     ms_push(d2, m2, 10);
     ms_push(d2, m2, 30);
     ms_push(d2, m2, 20);

--- a/examples/datastruct/min_heap.hew
+++ b/examples/datastruct/min_heap.hew
@@ -58,7 +58,7 @@ fn heap_pop(heap: Vec<i32>) -> i32 {
 }
 
 fn test_basic_min_heap() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 5);
     let _ = heap_push(heap, 3);
     let _ = heap_push(heap, 7);
@@ -76,7 +76,7 @@ fn test_basic_min_heap() -> i32 {
 }
 
 fn test_extract_min_order() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 5);
     let _ = heap_push(heap, 3);
     let _ = heap_push(heap, 7);
@@ -137,7 +137,7 @@ fn test_extract_min_order() -> i32 {
 }
 
 fn test_heap_property() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 10);
     let _ = heap_push(heap, 4);
     let _ = heap_push(heap, 15);
@@ -170,7 +170,7 @@ fn test_heap_property() -> i32 {
 }
 
 fn test_single_element() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 42);
     let pk = heap_peek(heap);
     let popped = heap_pop(heap);
@@ -187,7 +187,7 @@ fn test_single_element() -> i32 {
 }
 
 fn test_duplicates() -> i32 {
-    let heap: Vec<i32> = Vec::new();
+    let heap: Vec<i32> = Vec.new();
     let _ = heap_push(heap, 3);
     let _ = heap_push(heap, 1);
     let _ = heap_push(heap, 3);

--- a/examples/datastruct/min_stack.hew
+++ b/examples/datastruct/min_stack.hew
@@ -12,8 +12,8 @@ fn run_test(name: string, passed: i64) -> i64 {
 fn main() {
     var total = 0;
     var passed = 0;
-    let data: Vec<i64> = Vec::new();
-    let mins: Vec<i64> = Vec::new();
+    let data: Vec<i64> = Vec.new();
+    let mins: Vec<i64> = Vec.new();
     // Helper: push onto min stack
     // Push val, and push min(val, current_min) onto mins
 
@@ -114,10 +114,10 @@ fn main() {
     // Test 8: many elements min tracking
     total = total + 1;
     // Reset
-    let data2: Vec<i64> = Vec::new();
-    let mins2: Vec<i64> = Vec::new();
+    let data2: Vec<i64> = Vec.new();
+    let mins2: Vec<i64> = Vec.new();
     // Push values: 50, 40, 60, 30, 70, 20, 80, 10
-    let vals: Vec<i64> = Vec::new();
+    let vals: Vec<i64> = Vec.new();
     vals.push(50);
     vals.push(40);
     vals.push(60);

--- a/examples/datastruct/monotonic_stack.hew
+++ b/examples/datastruct/monotonic_stack.hew
@@ -2,7 +2,7 @@
 // Maintains elements in decreasing order from bottom to top.
 // Used to find next-greater-element for each position in an array.
 fn stack_new() -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v
 }
 
@@ -32,7 +32,7 @@ fn stack_size(s: Vec<i64>) -> i64 {
 // Uses monotonic decreasing stack of indices.
 fn next_greater_element(arr: Vec<i64>) -> Vec<i64> {
     let n = arr.len();
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     for i in 0 .. n {
         result.push(0 - 1);
     }
@@ -123,7 +123,7 @@ fn main() {
     // Test 4: Next greater element - basic case
     // arr = [4, 5, 2, 10, 8]
     // NGE = [5, 10, 10, -1, -1]
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(4);
     arr.push(5);
     arr.push(2);
@@ -156,7 +156,7 @@ fn main() {
     // Test 5: NGE - all increasing
     // arr = [1, 2, 3, 4, 5]
     // NGE = [2, 3, 4, 5, -1]
-    let arr2: Vec<i64> = Vec::new();
+    let arr2: Vec<i64> = Vec.new();
     arr2.push(1);
     arr2.push(2);
     arr2.push(3);
@@ -189,7 +189,7 @@ fn main() {
     // Test 6: NGE - all decreasing
     // arr = [5, 4, 3, 2, 1]
     // NGE = [-1, -1, -1, -1, -1]
-    let arr3: Vec<i64> = Vec::new();
+    let arr3: Vec<i64> = Vec.new();
     arr3.push(5);
     arr3.push(4);
     arr3.push(3);
@@ -210,7 +210,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: NGE - single element
-    let arr4: Vec<i64> = Vec::new();
+    let arr4: Vec<i64> = Vec.new();
     arr4.push(42);
     let nge4 = next_greater_element(arr4);
     if nge4[0] == 0 - 1 {
@@ -223,7 +223,7 @@ fn main() {
     // Test 8: NGE - duplicates
     // arr = [3, 3, 3]
     // NGE = [-1, -1, -1] (no strictly greater)
-    let arr5: Vec<i64> = Vec::new();
+    let arr5: Vec<i64> = Vec.new();
     arr5.push(3);
     arr5.push(3);
     arr5.push(3);

--- a/examples/datastruct/multimap.hew
+++ b/examples/datastruct/multimap.hew
@@ -11,7 +11,7 @@ fn hash(key: i64, capacity: i64) -> i64 {
 
 // Hash table: maps key -> index into node arrays (head of linked list)
 fn make_ht_keys(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     let EMPTY = 0 - 1;
     for i in 0 .. capacity {
         v.push(EMPTY);
@@ -20,7 +20,7 @@ fn make_ht_keys(capacity: i64) -> Vec<i64> {
 }
 
 fn make_ht_vals(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     let NONE = 0 - 1;
     for i in 0 .. capacity {
         v.push(NONE);
@@ -169,8 +169,8 @@ fn main() {
     let cap = 32;
     let ht_keys = make_ht_keys(cap);
     let ht_heads = make_ht_vals(cap);
-    let node_vals: Vec<i64> = Vec::new();
-    let node_next: Vec<i64> = Vec::new();
+    let node_vals: Vec<i64> = Vec.new();
+    let node_next: Vec<i64> = Vec.new();
     // Test 1: Insert multiple values for same key
     mm_insert(ht_keys, ht_heads, node_vals, node_next, 1, 10);
     mm_insert(ht_keys, ht_heads, node_vals, node_next, 1, 20);
@@ -184,7 +184,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: Get all values for a key
-    let r1: Vec<i64> = Vec::new();
+    let r1: Vec<i64> = Vec.new();
     let gc1 = mm_get_all(ht_keys, ht_heads, node_vals, node_next, 1, r1);
     if gc1 == 3 {
         if vec_contains(r1, 10) {
@@ -242,7 +242,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: Removed value no longer in list
-    let r2: Vec<i64> = Vec::new();
+    let r2: Vec<i64> = Vec.new();
     let _ = mm_get_all(ht_keys, ht_heads, node_vals, node_next, 1, r2);
     if vec_contains(r2, 20) {
         println("FAIL: removed value still present");

--- a/examples/datastruct/ordered_list.hew
+++ b/examples/datastruct/ordered_list.hew
@@ -141,16 +141,16 @@ fn vecs_equal(a: Vec<i64>, b: Vec<i64>) -> i64 {
 
 // --- Tests ---
 fn test_sorted_insert() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_sorted(n, head, 50);
     head = insert_sorted(n, head, 10);
     head = insert_sorted(n, head, 30);
     head = insert_sorted(n, head, 20);
     head = insert_sorted(n, head, 40);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -165,7 +165,7 @@ fn test_sorted_insert() -> i64 {
 }
 
 fn test_duplicates() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_sorted(n, head, 20);
     head = insert_sorted(n, head, 10);
@@ -182,7 +182,7 @@ fn test_duplicates() -> i64 {
 }
 
 fn test_search() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_sorted(n, head, 10);
     head = insert_sorted(n, head, 30);
@@ -202,16 +202,16 @@ fn test_search() -> i64 {
 }
 
 fn test_delete() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_sorted(n, head, 10);
     head = insert_sorted(n, head, 20);
     head = insert_sorted(n, head, 30);
     head = insert_sorted(n, head, 40);
     head = delete_val(n, head, 20);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     traverse(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(10);
     e.push(30);
     e.push(40);
@@ -226,7 +226,7 @@ fn test_delete() -> i64 {
 }
 
 fn test_invariant_after_many() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     // Insert in scrambled order
     head = insert_sorted(n, head, 70);
@@ -250,7 +250,7 @@ fn test_invariant_after_many() -> i64 {
 }
 
 fn test_delete_nonexistent() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_sorted(n, head, 10);
     head = insert_sorted(n, head, 30);

--- a/examples/datastruct/persistent_stack.hew
+++ b/examples/datastruct/persistent_stack.hew
@@ -52,7 +52,7 @@ fn ps_size(store: Vec<i64>, head: i64) -> i64 {
 
 // Collect stack elements into a Vec (top to bottom order)
 fn ps_collect(store: Vec<i64>, head: i64) -> Vec<i64> {
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     var curr = head;
     while curr >= 0 {
         result.push(store[curr * 2]);
@@ -64,7 +64,7 @@ fn ps_collect(store: Vec<i64>, head: i64) -> Vec<i64> {
 fn main() {
     var passed = 0;
     var failed = 0;
-    let store: Vec<i64> = Vec::new();
+    let store: Vec<i64> = Vec.new();
     // v0 = empty stack
     let v0 = ps_new();
     // Test 1: Empty stack

--- a/examples/datastruct/priority_queue.hew
+++ b/examples/datastruct/priority_queue.hew
@@ -57,7 +57,7 @@ fn run_test(name: string, passed: i64) -> i64 {
 fn main() {
     var total = 0;
     var passed = 0;
-    let pq: Vec<i64> = Vec::new();
+    let pq: Vec<i64> = Vec.new();
     // Test 1: empty
     total = total + 1;
     let r1 = if pq_is_empty(pq) == 1 {
@@ -129,7 +129,7 @@ fn main() {
 
     // Test 7: ascending insert order
     total = total + 1;
-    let pq2: Vec<i64> = Vec::new();
+    let pq2: Vec<i64> = Vec.new();
     pq_insert(pq2, 1);
     pq_insert(pq2, 2);
     pq_insert(pq2, 3);
@@ -148,7 +148,7 @@ fn main() {
 
     // Test 8: descending insert order
     total = total + 1;
-    let pq3: Vec<i64> = Vec::new();
+    let pq3: Vec<i64> = Vec.new();
     pq_insert(pq3, 50);
     pq_insert(pq3, 40);
     pq_insert(pq3, 30);

--- a/examples/datastruct/queue.hew
+++ b/examples/datastruct/queue.hew
@@ -1,7 +1,7 @@
 // Queue - FIFO data structure using Vec<i64> with head index
 // Index 0 = head pointer, rest is data starting at index 1
 fn queue_new() -> Vec<i64> {
-    let q: Vec<i64> = Vec::new();
+    let q: Vec<i64> = Vec.new();
     q.push(0); // head index (relative to data start at 1)
     q
 }

--- a/examples/datastruct/ring_buffer.hew
+++ b/examples/datastruct/ring_buffer.hew
@@ -2,7 +2,7 @@
 // Layout: Vec<i64> = [capacity, head, tail, count, data...]
 // head = read position, tail = write position
 fn rb_create(capacity: i64) -> Vec<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(capacity); // index 0: capacity
     v.push(0); // index 1: head (read pos)
     v.push(0); // index 2: tail (write pos)

--- a/examples/datastruct/rope.hew
+++ b/examples/datastruct/rope.hew
@@ -107,7 +107,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Data array: [10, 20, 30, 40, 50, 60, 70, 80]
-    let data: Vec<i64> = Vec::new();
+    let data: Vec<i64> = Vec.new();
     data.push(10);
     data.push(20);
     data.push(30);
@@ -116,7 +116,7 @@ fn main() {
     data.push(60);
     data.push(70);
     data.push(80);
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     // Create leaves: [10,20,30] and [40,50] and [60,70,80]
     let leaf1 = make_leaf(nodes, 0, 3); // data[0..3] = [10,20,30]
     let leaf2 = make_leaf(nodes, 3, 2); // data[3..5] = [40,50]
@@ -217,7 +217,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 7: Collect all elements in order
-    let collected: Vec<i64> = Vec::new();
+    let collected: Vec<i64> = Vec.new();
     rope_collect(nodes, data, abc, collected);
     var col_ok = 1;
     if collected.len() != 8 {
@@ -239,8 +239,8 @@ fn main() {
         failed = failed + 1;
     }
     // Test 8: Build rope with different tree shape (right-heavy)
-    let nodes2: Vec<i64> = Vec::new();
-    let data2: Vec<i64> = Vec::new();
+    let nodes2: Vec<i64> = Vec.new();
+    let data2: Vec<i64> = Vec.new();
     data2.push(1);
     data2.push(2);
     data2.push(3);
@@ -277,8 +277,8 @@ fn main() {
         failed = failed + 1;
     }
     // Test 9: Single element rope
-    let nodes3: Vec<i64> = Vec::new();
-    let data3: Vec<i64> = Vec::new();
+    let nodes3: Vec<i64> = Vec.new();
+    let data3: Vec<i64> = Vec.new();
     data3.push(99);
     let single = make_leaf(nodes3, 0, 1);
     if rope_length(nodes3, single) == 1 {
@@ -294,8 +294,8 @@ fn main() {
         failed = failed + 1;
     }
     // Test 10: Concat single elements
-    let nodes4: Vec<i64> = Vec::new();
-    let data4: Vec<i64> = Vec::new();
+    let nodes4: Vec<i64> = Vec.new();
+    let data4: Vec<i64> = Vec.new();
     data4.push(100);
     data4.push(200);
     data4.push(300);

--- a/examples/datastruct/segment_tree.hew
+++ b/examples/datastruct/segment_tree.hew
@@ -47,7 +47,7 @@ fn seg_update(tree: Vec<i64>, node: i64, start: i64, end: i64, idx: i64, val: i6
 }
 
 fn init_tree(size: i64) -> Vec<i64> {
-    let tree: Vec<i64> = Vec::new();
+    let tree: Vec<i64> = Vec.new();
     for i in 0 .. 4 * size {
         tree.push(0);
     }
@@ -55,7 +55,7 @@ fn init_tree(size: i64) -> Vec<i64> {
 }
 
 fn test_basic_query() -> i64 {
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(1);
     arr.push(3);
     arr.push(5);
@@ -79,7 +79,7 @@ fn test_basic_query() -> i64 {
 }
 
 fn test_partial_query() -> i64 {
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(1);
     arr.push(3);
     arr.push(5);
@@ -120,7 +120,7 @@ fn test_partial_query() -> i64 {
 }
 
 fn test_point_update() -> i64 {
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(1);
     arr.push(3);
     arr.push(5);
@@ -150,7 +150,7 @@ fn test_point_update() -> i64 {
 }
 
 fn test_single_element() -> i64 {
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(42);
     let tree = init_tree(1);
     let _ = seg_build(tree, arr, 0, 0, 0);
@@ -165,7 +165,7 @@ fn test_single_element() -> i64 {
 }
 
 fn test_multiple_updates() -> i64 {
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(2);
     arr.push(4);
     arr.push(6);

--- a/examples/datastruct/singly_linked_list.hew
+++ b/examples/datastruct/singly_linked_list.hew
@@ -108,14 +108,14 @@ fn vecs_equal(a: Vec<i64>, b: Vec<i64>) -> i64 {
 
 // --- Tests ---
 fn test_prepend() -> i64 {
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var head = -1;
     head = prepend(nodes, head, 30);
     head = prepend(nodes, head, 20);
     head = prepend(nodes, head, 10);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     traverse(nodes, head, result);
-    let expected: Vec<i64> = Vec::new();
+    let expected: Vec<i64> = Vec.new();
     expected.push(10);
     expected.push(20);
     expected.push(30);
@@ -128,14 +128,14 @@ fn test_prepend() -> i64 {
 }
 
 fn test_append() -> i64 {
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var head = -1;
     head = append(nodes, head, 10);
     head = append(nodes, head, 20);
     head = append(nodes, head, 30);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     traverse(nodes, head, result);
-    let expected: Vec<i64> = Vec::new();
+    let expected: Vec<i64> = Vec.new();
     expected.push(10);
     expected.push(20);
     expected.push(30);
@@ -148,15 +148,15 @@ fn test_append() -> i64 {
 }
 
 fn test_delete_middle() -> i64 {
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var head = -1;
     head = append(nodes, head, 10);
     head = append(nodes, head, 20);
     head = append(nodes, head, 30);
     head = delete_val(nodes, head, 20);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     traverse(nodes, head, result);
-    let expected: Vec<i64> = Vec::new();
+    let expected: Vec<i64> = Vec.new();
     expected.push(10);
     expected.push(30);
     if vecs_equal(result, expected) == 1 {
@@ -168,12 +168,12 @@ fn test_delete_middle() -> i64 {
 }
 
 fn test_delete_head() -> i64 {
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var head = -1;
     head = append(nodes, head, 10);
     head = append(nodes, head, 20);
     head = delete_val(nodes, head, 10);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     traverse(nodes, head, result);
     if result.len() == 1 {
         if result[0] == 20 {
@@ -186,7 +186,7 @@ fn test_delete_head() -> i64 {
 }
 
 fn test_find() -> i64 {
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var head = -1;
     head = append(nodes, head, 10);
     head = append(nodes, head, 20);
@@ -206,7 +206,7 @@ fn test_find() -> i64 {
 }
 
 fn test_length() -> i64 {
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var head = -1;
     if list_len(nodes, head) != 0 {
         println("FAIL: length");

--- a/examples/datastruct/skip_list.hew
+++ b/examples/datastruct/skip_list.hew
@@ -176,7 +176,7 @@ fn bot_list_len(bot: Vec<i64>, head: i64) -> i64 {
 
 // --- Tests ---
 fn test_sorted_insert() -> i64 {
-    let bot: Vec<i64> = Vec::new();
+    let bot: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_bottom(bot, head, 30);
     head = insert_bottom(bot, head, 10);
@@ -206,8 +206,8 @@ fn test_sorted_insert() -> i64 {
 }
 
 fn test_skip_search() -> i64 {
-    let bot: Vec<i64> = Vec::new();
-    let top: Vec<i64> = Vec::new();
+    let bot: Vec<i64> = Vec.new();
+    let top: Vec<i64> = Vec.new();
     var head = -1;
     var i = 1;
     while i <= 10 {
@@ -215,7 +215,7 @@ fn test_skip_search() -> i64 {
         i = i + 1;
     }
     let top_head = rebuild_top(bot, top, head);
-    let comps: Vec<i64> = Vec::new();
+    let comps: Vec<i64> = Vec.new();
     let idx = search_skip(bot, top, top_head, 70, comps);
     if idx >= 0 {
         if bot_val(bot, idx) == 70 {
@@ -228,8 +228,8 @@ fn test_skip_search() -> i64 {
 }
 
 fn test_skip_not_found() -> i64 {
-    let bot: Vec<i64> = Vec::new();
-    let top: Vec<i64> = Vec::new();
+    let bot: Vec<i64> = Vec.new();
+    let top: Vec<i64> = Vec.new();
     var head = -1;
     var i = 1;
     while i <= 5 {
@@ -237,7 +237,7 @@ fn test_skip_not_found() -> i64 {
         i = i + 1;
     }
     let top_head = rebuild_top(bot, top, head);
-    let comps: Vec<i64> = Vec::new();
+    let comps: Vec<i64> = Vec.new();
     let idx = search_skip(bot, top, top_head, 35, comps);
     if idx == -1 {
         println("PASS: skip search not found");
@@ -248,8 +248,8 @@ fn test_skip_not_found() -> i64 {
 }
 
 fn test_fewer_comparisons() -> i64 {
-    let bot: Vec<i64> = Vec::new();
-    let top: Vec<i64> = Vec::new();
+    let bot: Vec<i64> = Vec.new();
+    let top: Vec<i64> = Vec.new();
     var head = -1;
     var i = 1;
     while i <= 20 {
@@ -257,9 +257,9 @@ fn test_fewer_comparisons() -> i64 {
         i = i + 1;
     }
     let top_head = rebuild_top(bot, top, head);
-    let skip_c: Vec<i64> = Vec::new();
+    let skip_c: Vec<i64> = Vec.new();
     let _skip_idx = search_skip(bot, top, top_head, 190, skip_c);
-    let lin_c: Vec<i64> = Vec::new();
+    let lin_c: Vec<i64> = Vec.new();
     let _lin_idx = search_linear(bot, head, 190, lin_c);
     let skip_comps = skip_c[0];
     let lin_comps = lin_c[0];
@@ -276,8 +276,8 @@ fn test_fewer_comparisons() -> i64 {
 }
 
 fn test_rebuild_top() -> i64 {
-    let bot: Vec<i64> = Vec::new();
-    let top: Vec<i64> = Vec::new();
+    let bot: Vec<i64> = Vec.new();
+    let top: Vec<i64> = Vec.new();
     var head = -1;
     head = insert_bottom(bot, head, 10);
     head = insert_bottom(bot, head, 20);
@@ -300,9 +300,9 @@ fn test_rebuild_top() -> i64 {
 }
 
 fn test_empty_search() -> i64 {
-    let bot: Vec<i64> = Vec::new();
-    let top: Vec<i64> = Vec::new();
-    let comps: Vec<i64> = Vec::new();
+    let bot: Vec<i64> = Vec.new();
+    let top: Vec<i64> = Vec.new();
+    let comps: Vec<i64> = Vec.new();
     let idx = search_skip(bot, top, -1, 42, comps);
     if idx == -1 {
         println("PASS: empty search");

--- a/examples/datastruct/sliding_window.hew
+++ b/examples/datastruct/sliding_window.hew
@@ -5,7 +5,7 @@
 // Deque using Vec<i64>: [front, back, capacity, data...]
 // front points to first element, back points past last element
 fn deque_create(capacity: i64) -> Vec<i64> {
-    let d: Vec<i64> = Vec::new();
+    let d: Vec<i64> = Vec.new();
     d.push(0); // index 0: front
     d.push(0); // index 1: back
     d.push(capacity); // index 2: capacity
@@ -66,7 +66,7 @@ fn deque_back(d: Vec<i64>) -> i64 {
 // Returns Vec<i64> with n-k+1 results
 fn sliding_window_max(arr: Vec<i64>, k: i64) -> Vec<i64> {
     let n = arr.len();
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let dq = deque_create(n + 1);
     for i in 0 .. n {
         // Remove elements outside the window from front
@@ -102,7 +102,7 @@ fn main() {
     // But no negative literals, use positive values:
     // arr = [1, 3, 2, 0, 5, 3, 6, 7], k = 3
     // Windows: [1,3,2]->3, [3,2,0]->3, [2,0,5]->5, [0,5,3]->5, [5,3,6]->6, [3,6,7]->7
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     arr.push(1);
     arr.push(3);
     arr.push(2);
@@ -144,7 +144,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 2: Window size = 1 (each element is its own max)
-    let arr2: Vec<i64> = Vec::new();
+    let arr2: Vec<i64> = Vec.new();
     arr2.push(5);
     arr2.push(2);
     arr2.push(8);
@@ -176,7 +176,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 3: Window size = array length (single result = global max)
-    let arr3: Vec<i64> = Vec::new();
+    let arr3: Vec<i64> = Vec.new();
     arr3.push(3);
     arr3.push(7);
     arr3.push(2);
@@ -196,7 +196,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: All same elements
-    let arr4: Vec<i64> = Vec::new();
+    let arr4: Vec<i64> = Vec.new();
     arr4.push(4);
     arr4.push(4);
     arr4.push(4);
@@ -223,7 +223,7 @@ fn main() {
     // Test 5: Increasing sequence
     // arr = [1, 2, 3, 4, 5], k=3
     // Windows: [1,2,3]->3, [2,3,4]->4, [3,4,5]->5
-    let arr5: Vec<i64> = Vec::new();
+    let arr5: Vec<i64> = Vec.new();
     arr5.push(1);
     arr5.push(2);
     arr5.push(3);
@@ -255,7 +255,7 @@ fn main() {
     // Test 6: Decreasing sequence
     // arr = [5, 4, 3, 2, 1], k=3
     // Windows: [5,4,3]->5, [4,3,2]->4, [3,2,1]->3
-    let arr6: Vec<i64> = Vec::new();
+    let arr6: Vec<i64> = Vec.new();
     arr6.push(5);
     arr6.push(4);
     arr6.push(3);
@@ -287,7 +287,7 @@ fn main() {
     // Test 7: Window size 2
     // arr = [10, 5, 2, 7, 8, 7], k=2
     // Windows: [10,5]->10, [5,2]->5, [2,7]->7, [7,8]->8, [8,7]->8
-    let arr7: Vec<i64> = Vec::new();
+    let arr7: Vec<i64> = Vec.new();
     arr7.push(10);
     arr7.push(5);
     arr7.push(2);

--- a/examples/datastruct/sorted_array.hew
+++ b/examples/datastruct/sorted_array.hew
@@ -87,7 +87,7 @@ fn run_test(name: string, passed: i64) -> i64 {
 fn main() {
     var total = 0;
     var passed = 0;
-    let arr: Vec<i64> = Vec::new();
+    let arr: Vec<i64> = Vec.new();
     // Test 1: insert maintains sorted order
     total = total + 1;
     sa_insert(arr, 30);
@@ -175,7 +175,7 @@ fn main() {
 
     // Test 8: many elements
     total = total + 1;
-    let arr2: Vec<i64> = Vec::new();
+    let arr2: Vec<i64> = Vec.new();
     // Insert in reverse order
     var j = 50;
     while j > 0 {

--- a/examples/datastruct/sparse_list.hew
+++ b/examples/datastruct/sparse_list.hew
@@ -127,7 +127,7 @@ fn vecs_equal(a: Vec<i64>, b: Vec<i64>) -> i64 {
 
 // --- Tests ---
 fn test_set_and_get() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = sparse_set(n, head, 100, 10);
     head = sparse_set(n, head, 500, 50);
@@ -148,7 +148,7 @@ fn test_set_and_get() -> i64 {
 }
 
 fn test_get_missing() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = sparse_set(n, head, 10, 100);
     let v = sparse_get(n, head, 5, -999);
@@ -161,7 +161,7 @@ fn test_get_missing() -> i64 {
 }
 
 fn test_update() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = sparse_set(n, head, 42, 100);
     head = sparse_set(n, head, 42, 200);
@@ -177,15 +177,15 @@ fn test_update() -> i64 {
 }
 
 fn test_sorted_order() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = sparse_set(n, head, 1000, 1);
     head = sparse_set(n, head, 10, 2);
     head = sparse_set(n, head, 500, 3);
     head = sparse_set(n, head, 50, 4);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     iterate(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(10);
     e.push(2);
     e.push(50);
@@ -203,7 +203,7 @@ fn test_sorted_order() -> i64 {
 }
 
 fn test_sparse_pattern() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     // Only store at indices 0, 100, 10000
     head = sparse_set(n, head, 0, 1);
@@ -228,12 +228,12 @@ fn test_sparse_pattern() -> i64 {
 }
 
 fn test_iterate() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = sparse_set(n, head, 5, 50);
     head = sparse_set(n, head, 2, 20);
     head = sparse_set(n, head, 8, 80);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     iterate(n, head, r);
     // Should be sorted by index: (2,20), (5,50), (8,80)
     if r.len() == 6 {

--- a/examples/datastruct/stack.hew
+++ b/examples/datastruct/stack.hew
@@ -1,6 +1,6 @@
 // Stack - LIFO data structure using Vec<i64>
 fn stack_new() -> Vec<i64> {
-    let s: Vec<i64> = Vec::new();
+    let s: Vec<i64> = Vec.new();
     s
 }
 

--- a/examples/datastruct/strongly_connected.hew
+++ b/examples/datastruct/strongly_connected.hew
@@ -3,7 +3,7 @@
 // Pass 2: DFS on transpose graph in reverse finish order
 fn build_directed(num_nodes: i64, esrc: Vec<i64>, edst: Vec<i64>, adj_nodes: Vec<i64>, adj_offsets: Vec<i64>) {
     let num_edges = esrc.len();
-    let degree: Vec<i64> = Vec::new();
+    let degree: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         degree.push(0);
     }
@@ -19,7 +19,7 @@ fn build_directed(num_nodes: i64, esrc: Vec<i64>, edst: Vec<i64>, adj_nodes: Vec
     for i in 0 .. total {
         adj_nodes.push(0);
     }
-    let pos: Vec<i64> = Vec::new();
+    let pos: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         pos.push(adj_offsets[i]);
     }
@@ -33,12 +33,12 @@ fn build_directed(num_nodes: i64, esrc: Vec<i64>, edst: Vec<i64>, adj_nodes: Vec
 
 fn dfs_finish_order(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, num_nodes: i64, order: Vec<i64>) {
     // Iterative DFS recording finish order
-    let visited: Vec<i64> = Vec::new();
+    let visited: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         visited.push(0);
     }
     // Stack entries: node*2 for "enter", node*2+1 for "exit"
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     for start in 0 .. num_nodes {
         if visited[start] == 0 {
             stack.push(start * 2);
@@ -82,7 +82,7 @@ fn assign_components(adj_nodes: Vec<i64>, adj_offsets: Vec<i64>, num_nodes: i64,
         }
         let node = order[idx];
         if comp[node] == 0 - 1 {
-            let stack: Vec<i64> = Vec::new();
+            let stack: Vec<i64> = Vec.new();
             stack.push(node);
             comp.set(node, comp_id);
             while stack.len() > 0 {
@@ -129,8 +129,8 @@ fn main() {
     // SCC2: {3,4} via 3->4->3
     // SCC3: {5,6,7} via 5->6->7->5
     // Cross edges: 2->3, 4->5 (one-way, not creating larger SCCs)
-    let esrc: Vec<i64> = Vec::new();
-    let edst: Vec<i64> = Vec::new();
+    let esrc: Vec<i64> = Vec.new();
+    let edst: Vec<i64> = Vec.new();
     // SCC1
     esrc.push(0);
     edst.push(1);
@@ -157,27 +157,27 @@ fn main() {
     edst.push(5);
     let num_edges = esrc.len();
     // Build forward graph
-    let fwd_nodes: Vec<i64> = Vec::new();
-    let fwd_offsets: Vec<i64> = Vec::new();
+    let fwd_nodes: Vec<i64> = Vec.new();
+    let fwd_offsets: Vec<i64> = Vec.new();
     build_directed(num_nodes, esrc, edst, fwd_nodes, fwd_offsets);
 
     // Build transpose graph
-    let tsrc: Vec<i64> = Vec::new();
-    let tdst: Vec<i64> = Vec::new();
+    let tsrc: Vec<i64> = Vec.new();
+    let tdst: Vec<i64> = Vec.new();
     for i in 0 .. num_edges {
         tsrc.push(edst[i]);
         tdst.push(esrc[i]);
     }
-    let rev_nodes: Vec<i64> = Vec::new();
-    let rev_offsets: Vec<i64> = Vec::new();
+    let rev_nodes: Vec<i64> = Vec.new();
+    let rev_offsets: Vec<i64> = Vec.new();
     build_directed(num_nodes, tsrc, tdst, rev_nodes, rev_offsets);
 
     // Pass 1: DFS on forward graph, get finish order
-    let order: Vec<i64> = Vec::new();
+    let order: Vec<i64> = Vec.new();
     dfs_finish_order(fwd_nodes, fwd_offsets, num_nodes, order);
 
     // Pass 2: Assign components using transpose in reverse finish order
-    let comp: Vec<i64> = Vec::new();
+    let comp: Vec<i64> = Vec.new();
     assign_components(rev_nodes, rev_offsets, num_nodes, order, comp);
 
     // Test 1: Exactly 3 SCCs

--- a/examples/datastruct/suffix_array.hew
+++ b/examples/datastruct/suffix_array.hew
@@ -31,7 +31,7 @@ fn compare_suffixes(text: Vec<i64>, a: i64, b: i64) -> i64 {
 // Build suffix array using insertion sort (O(n^2 * n) but simple)
 fn build_suffix_array(text: Vec<i64>) -> Vec<i64> {
     let n = text.len();
-    let sa: Vec<i64> = Vec::new();
+    let sa: Vec<i64> = Vec.new();
     for i in 0 .. n {
         sa.push(i);
     }
@@ -64,7 +64,7 @@ fn build_suffix_array(text: Vec<i64>) -> Vec<i64> {
 // lcp[i] = length of longest common prefix between sa[i-1] and sa[i]
 fn build_lcp_array(text: Vec<i64>, sa: Vec<i64>) -> Vec<i64> {
     let n = sa.len();
-    let lcp: Vec<i64> = Vec::new();
+    let lcp: Vec<i64> = Vec.new();
     lcp.push(0);
     var i = 1;
     while i < n {
@@ -136,7 +136,7 @@ fn main() {
     var passed = 0;
     var failed = 0;
     // Text: [3, 1, 4, 1, 5, 9, 2, 6]
-    let text: Vec<i64> = Vec::new();
+    let text: Vec<i64> = Vec.new();
     text.push(3);
     text.push(1);
     text.push(4);
@@ -184,7 +184,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 4: Search for pattern [1, 4] -> should find at index 1
-    let pat1: Vec<i64> = Vec::new();
+    let pat1: Vec<i64> = Vec.new();
     pat1.push(1);
     pat1.push(4);
     let pos1 = sa_search(text, sa, pat1);
@@ -197,7 +197,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 5: Search for pattern [9, 2, 6] -> should find at index 5
-    let pat2: Vec<i64> = Vec::new();
+    let pat2: Vec<i64> = Vec.new();
     pat2.push(9);
     pat2.push(2);
     pat2.push(6);
@@ -211,7 +211,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 6: Search for pattern not in text -> -1
-    let pat3: Vec<i64> = Vec::new();
+    let pat3: Vec<i64> = Vec.new();
     pat3.push(7);
     pat3.push(7);
     let pos3 = sa_search(text, sa, pat3);
@@ -238,7 +238,7 @@ fn main() {
     }
     // Test 8: LCP detects shared prefixes
     // Text with repeated prefix: [1, 2, 3, 1, 2, 4]
-    let text2: Vec<i64> = Vec::new();
+    let text2: Vec<i64> = Vec.new();
     text2.push(1);
     text2.push(2);
     text2.push(3);
@@ -262,7 +262,7 @@ fn main() {
         failed = failed + 1;
     }
     // Test 9: Search single element
-    let pat4: Vec<i64> = Vec::new();
+    let pat4: Vec<i64> = Vec.new();
     pat4.push(5);
     let pos4 = sa_search(text, sa, pat4);
     if pos4 == 4 {

--- a/examples/datastruct/treap.hew
+++ b/examples/datastruct/treap.hew
@@ -60,8 +60,8 @@ fn treap_insert(nodes: Vec<i64>, root: i64, key: i64, pri: i64, NIL: i64) -> i64
         return add_node(nodes, key, pri, NIL);
     }
     // Track path from root to insertion point
-    let path: Vec<i64> = Vec::new();
-    let dirs: Vec<i64> = Vec::new();
+    let path: Vec<i64> = Vec.new();
+    let dirs: Vec<i64> = Vec.new();
     var cur = root;
     var placed = false;
     while !placed {
@@ -137,7 +137,7 @@ fn inorder(nodes: Vec<i64>, root: i64, result: Vec<i64>, NIL: i64) -> i64 {
     if root == NIL {
         return 0;
     }
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     var cur = root;
     var running = true;
     while running {
@@ -158,7 +158,7 @@ fn inorder(nodes: Vec<i64>, root: i64, result: Vec<i64>, NIL: i64) -> i64 {
 
 // Verify BST property
 fn check_bst(nodes: Vec<i64>, root: i64, NIL: i64) -> bool {
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, root, result, NIL);
     if result.len() <= 1 {
         return true;
@@ -178,7 +178,7 @@ fn check_heap(nodes: Vec<i64>, root: i64, NIL: i64) -> bool {
     if root == NIL {
         return true;
     }
-    let stack: Vec<i64> = Vec::new();
+    let stack: Vec<i64> = Vec.new();
     stack.push(root);
     var ok = true;
     while stack.len() > 0 {
@@ -203,7 +203,7 @@ fn check_heap(nodes: Vec<i64>, root: i64, NIL: i64) -> bool {
 
 fn test_basic_treap() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     // key, priority pairs
     root = treap_insert(nodes, root, 5, 10, NIL);
@@ -228,7 +228,7 @@ fn test_basic_treap() -> i64 {
 
 fn test_inorder_sorted() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = treap_insert(nodes, root, 10, 50, NIL);
     root = treap_insert(nodes, root, 5, 30, NIL);
@@ -237,7 +237,7 @@ fn test_inorder_sorted() -> i64 {
     root = treap_insert(nodes, root, 7, 35, NIL);
     root = treap_insert(nodes, root, 12, 20, NIL);
     root = treap_insert(nodes, root, 20, 45, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, root, result, NIL);
     var ok = true;
     if result.len() != 7 {
@@ -277,7 +277,7 @@ fn test_inorder_sorted() -> i64 {
 
 fn test_high_priority_at_root() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = treap_insert(nodes, root, 5, 10, NIL);
     root = treap_insert(nodes, root, 3, 100, NIL); // highest priority
@@ -296,7 +296,7 @@ fn test_high_priority_at_root() -> i64 {
 
 fn test_sequential_inserts() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     // Use simple pseudo-random priorities
     var pri = 17;
@@ -308,7 +308,7 @@ fn test_sequential_inserts() -> i64 {
     }
     let bst_ok = check_bst(nodes, root, NIL);
     let heap_ok = check_heap(nodes, root, NIL);
-    let result: Vec<i64> = Vec::new();
+    let result: Vec<i64> = Vec.new();
     let _ = inorder(nodes, root, result, NIL);
     if bst_ok {
         if heap_ok {
@@ -324,7 +324,7 @@ fn test_sequential_inserts() -> i64 {
 
 fn test_single_node() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     var root = NIL;
     root = treap_insert(nodes, root, 42, 99, NIL);
     let bst_ok = check_bst(nodes, root, NIL);

--- a/examples/datastruct/trie.hew
+++ b/examples/datastruct/trie.hew
@@ -35,7 +35,7 @@ fn get_digits(num: i64, digits: Vec<i64>) -> i64 {
         return 0;
     }
     var n = num;
-    let tmp: Vec<i64> = Vec::new();
+    let tmp: Vec<i64> = Vec.new();
     while n > 0 {
         tmp.push(n - n / 10 * 10);
         n = n / 10;
@@ -50,7 +50,7 @@ fn get_digits(num: i64, digits: Vec<i64>) -> i64 {
 }
 
 fn trie_insert(nodes: Vec<i64>, num: i64, NIL: i64) -> i64 {
-    let digits: Vec<i64> = Vec::new();
+    let digits: Vec<i64> = Vec.new();
     let _ = get_digits(num, digits);
     var cur = 0;
     for d in digits {
@@ -68,7 +68,7 @@ fn trie_insert(nodes: Vec<i64>, num: i64, NIL: i64) -> i64 {
 }
 
 fn trie_search(nodes: Vec<i64>, num: i64, NIL: i64) -> bool {
-    let digits: Vec<i64> = Vec::new();
+    let digits: Vec<i64> = Vec.new();
     let _ = get_digits(num, digits);
     var cur = 0;
     var found = true;
@@ -89,7 +89,7 @@ fn trie_search(nodes: Vec<i64>, num: i64, NIL: i64) -> bool {
 }
 
 fn trie_starts_with(nodes: Vec<i64>, prefix: i64, NIL: i64) -> bool {
-    let digits: Vec<i64> = Vec::new();
+    let digits: Vec<i64> = Vec.new();
     let _ = get_digits(prefix, digits);
     var cur = 0;
     var found = true;
@@ -108,7 +108,7 @@ fn trie_starts_with(nodes: Vec<i64>, prefix: i64, NIL: i64) -> bool {
 
 fn test_insert_and_search() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = new_trie_node(nodes, NIL); // root
     let _ = trie_insert(nodes, 123, NIL);
     let _ = trie_insert(nodes, 456, NIL);
@@ -136,7 +136,7 @@ fn test_insert_and_search() -> i64 {
 
 fn test_starts_with() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = new_trie_node(nodes, NIL);
     let _ = trie_insert(nodes, 1234, NIL);
     let _ = trie_insert(nodes, 1256, NIL);
@@ -164,7 +164,7 @@ fn test_starts_with() -> i64 {
 
 fn test_zero() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = new_trie_node(nodes, NIL);
     let _ = trie_insert(nodes, 0, NIL);
     let found = trie_search(nodes, 0, NIL);
@@ -179,7 +179,7 @@ fn test_zero() -> i64 {
 
 fn test_overlapping_numbers() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = new_trie_node(nodes, NIL);
     let _ = trie_insert(nodes, 1, NIL);
     let _ = trie_insert(nodes, 12, NIL);
@@ -204,7 +204,7 @@ fn test_overlapping_numbers() -> i64 {
 
 fn test_many_numbers() -> i64 {
     let NIL = 0 - 1;
-    let nodes: Vec<i64> = Vec::new();
+    let nodes: Vec<i64> = Vec.new();
     let _ = new_trie_node(nodes, NIL);
     // Insert 100, 200, ..., 900
     var i = 1;

--- a/examples/datastruct/two_stack_queue.hew
+++ b/examples/datastruct/two_stack_queue.hew
@@ -50,8 +50,8 @@ fn run_test(name: string, passed: i64) -> i64 {
 fn main() {
     var total = 0;
     var passed = 0;
-    let inbox: Vec<i64> = Vec::new();
-    let outbox: Vec<i64> = Vec::new();
+    let inbox: Vec<i64> = Vec.new();
+    let outbox: Vec<i64> = Vec.new();
     // Test 1: empty
     total = total + 1;
     let r1 = if tsq_is_empty(inbox, outbox) == 1 {
@@ -126,8 +126,8 @@ fn main() {
 
     // Test 7: many elements
     total = total + 1;
-    let in2: Vec<i64> = Vec::new();
-    let out2: Vec<i64> = Vec::new();
+    let in2: Vec<i64> = Vec.new();
+    let out2: Vec<i64> = Vec.new();
     for i in 0 .. 50 {
         tsq_enqueue(in2, i);
     }

--- a/examples/datastruct/union_find.hew
+++ b/examples/datastruct/union_find.hew
@@ -53,8 +53,8 @@ fn main() {
     var failed = 0;
     let n = 8;
     // Initialize: each node is its own parent
-    let parent: Vec<i64> = Vec::new();
-    let rank: Vec<i64> = Vec::new();
+    let parent: Vec<i64> = Vec.new();
+    let rank: Vec<i64> = Vec.new();
     for i in 0 .. n {
         parent.push(i);
         rank.push(0);

--- a/examples/datastruct/unrolled_list.hew
+++ b/examples/datastruct/unrolled_list.hew
@@ -126,14 +126,14 @@ fn vecs_equal(a: Vec<i64>, b: Vec<i64>) -> i64 {
 
 // --- Tests ---
 fn test_insert_and_iterate() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = unrolled_insert(n, head, 10);
     head = unrolled_insert(n, head, 20);
     head = unrolled_insert(n, head, 30);
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     unrolled_iterate(n, head, r);
-    let e: Vec<i64> = Vec::new();
+    let e: Vec<i64> = Vec.new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -146,7 +146,7 @@ fn test_insert_and_iterate() -> i64 {
 }
 
 fn test_block_split() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     // Insert 5 elements - should create 2 blocks (4+1)
     head = unrolled_insert(n, head, 1);
@@ -165,13 +165,13 @@ fn test_block_split() -> i64 {
 }
 
 fn test_cross_block_iteration() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     // Insert 10 elements across 3 blocks (4+4+2)
     for i in 0 .. 10 {
         head = unrolled_insert(n, head, (i + 1) * 10);
     }
-    let r: Vec<i64> = Vec::new();
+    let r: Vec<i64> = Vec.new();
     unrolled_iterate(n, head, r);
     var ok = 1;
     for i in 0 .. 10 {
@@ -190,7 +190,7 @@ fn test_cross_block_iteration() -> i64 {
 }
 
 fn test_random_access() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     for i in 0 .. 8 {
         head = unrolled_insert(n, head, i * 100);
@@ -214,7 +214,7 @@ fn test_random_access() -> i64 {
 }
 
 fn test_single_block() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     head = unrolled_insert(n, head, 42);
     if block_count_total(n, head) == 1 {
@@ -228,7 +228,7 @@ fn test_single_block() -> i64 {
 }
 
 fn test_many_blocks() -> i64 {
-    let n: Vec<i64> = Vec::new();
+    let n: Vec<i64> = Vec.new();
     var head = -1;
     // 20 elements = 5 blocks of 4
     for i in 0 .. 20 {
@@ -237,7 +237,7 @@ fn test_many_blocks() -> i64 {
     if block_count_total(n, head) == 5 {
         if unrolled_len(n, head) == 20 {
             // Verify order
-            let r: Vec<i64> = Vec::new();
+            let r: Vec<i64> = Vec.new();
             unrolled_iterate(n, head, r);
             var ok = 1;
             for i in 0 .. 20 {

--- a/examples/datastruct/weighted_graph.hew
+++ b/examples/datastruct/weighted_graph.hew
@@ -59,9 +59,9 @@ fn main() {
     let num_nodes = 5;
     // Weighted edges: (src, dst, weight)
     // 0-1:4, 0-2:2, 1-2:5, 1-3:10, 2-3:3, 2-4:8, 3-4:7
-    let esrc: Vec<i64> = Vec::new();
-    let edst: Vec<i64> = Vec::new();
-    let ewt: Vec<i64> = Vec::new();
+    let esrc: Vec<i64> = Vec.new();
+    let edst: Vec<i64> = Vec.new();
+    let ewt: Vec<i64> = Vec.new();
     esrc.push(0);
     edst.push(1);
     ewt.push(4);
@@ -85,7 +85,7 @@ fn main() {
     ewt.push(7);
     let num_edges = esrc.len();
     // Count degrees (undirected)
-    let degree: Vec<i64> = Vec::new();
+    let degree: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         degree.push(0);
     }
@@ -96,20 +96,20 @@ fn main() {
         degree.set(d, degree[d] + 1);
     }
     // Build offsets
-    let adj_offsets: Vec<i64> = Vec::new();
+    let adj_offsets: Vec<i64> = Vec.new();
     adj_offsets.push(0);
     for i in 0 .. num_nodes {
         adj_offsets.push(adj_offsets[i] + degree[i]);
     }
     // Fill adj_nodes and adj_weights
     let total = adj_offsets[num_nodes];
-    let adj_nodes: Vec<i64> = Vec::new();
-    let adj_weights: Vec<i64> = Vec::new();
+    let adj_nodes: Vec<i64> = Vec.new();
+    let adj_weights: Vec<i64> = Vec.new();
     for i in 0 .. total {
         adj_nodes.push(0);
         adj_weights.push(0);
     }
-    let pos: Vec<i64> = Vec::new();
+    let pos: Vec<i64> = Vec.new();
     for i in 0 .. num_nodes {
         pos.push(adj_offsets[i]);
     }

--- a/examples/distributed/kv_client.hew
+++ b/examples/distributed/kv_client.hew
@@ -6,7 +6,7 @@
 //
 // Run after server.hew is already listening:
 //   hew run examples/distributed/kv_client.hew
-import std::os;
+import std.os;
 
 // Mirror the server's serializable types.  Both nodes must agree on these.
 record KvPut {
@@ -30,8 +30,8 @@ enum KvResp {
 actor KeyValue {
     receive fn handle(req: KvReq) -> KvResp {
         match req {
-            KvReq::Put(_) => KvResp::Ack,
-            KvReq::GetKey(_) => KvResp::Value(""),
+            KvReq.Put(_) => KvResp.Ack,
+            KvReq.GetKey(_) => KvResp.Value(""),
         }
     }
 }
@@ -52,96 +52,96 @@ fn main() -> i64 {
     }
     let remote_addr = f"{server_addr}:{port}";
     println(f"[kv-client] starting node, will connect to {remote_addr}");
-    Node::set_transport("tcp");
-    Node::start("0.0.0.0:0");
+    Node.set_transport("tcp");
+    Node.start("0.0.0.0:0");
     println("[kv-client] local node started");
     sleep(500ms);
-    Node::connect(remote_addr);
+    Node.connect(remote_addr);
     println(f"[kv-client] connected to {remote_addr}");
     // Wait for the connection handshake to complete and registry gossip to arrive.
     // hew_node_connect is non-blocking; gossip propagates asynchronously.
     sleep(2s);
-    let found: Result<RemotePid<KeyValue>, LookupError> = Node::lookup("kv");
+    let found: Result<RemotePid<KeyValue>, LookupError> = Node.lookup("kv");
     match found {
-        Err(_) => {
+        .Err(_) => {
             println("[kv-client] FAIL: 'kv' not found in registry");
-            Node::shutdown();
+            Node.shutdown();
             return 1;
         },
-        Ok(kv) => {
+        .Ok(kv) => {
             // Scenario 1: put("hello","world") — fire and forget via send.
-            let send1 = kv.send(KvReq::Put(KvPut { key: "hello", val: "world" }));
+            let send1 = kv.send(KvReq.Put(KvPut { key: "hello", val: "world" }));
             match send1 {
-                Err(_) => {
+                .Err(_) => {
                     println("[kv-client] FAIL: put('hello','world') send error");
-                    Node::shutdown();
+                    Node.shutdown();
                     return 2;
                 },
-                Ok(_) => {},
+                .Ok(_) => {},
             }
             // Scenario 2: put("count","42") — fire and forget via send.
-            let send2 = kv.send(KvReq::Put(KvPut { key: "count", val: "42" }));
+            let send2 = kv.send(KvReq.Put(KvPut { key: "count", val: "42" }));
             match send2 {
-                Err(_) => {
+                .Err(_) => {
                     println("[kv-client] FAIL: put('count','42') send error");
-                    Node::shutdown();
+                    Node.shutdown();
                     return 3;
                 },
-                Ok(_) => {},
+                .Ok(_) => {},
             }
             println("[kv-client] put('hello','world') and put('count','42') dispatched");
             // Give the server time to process the send messages before asking.
             sleep(500ms);
 
             // Scenario 3: get("hello") — blocking remote ask, exercises await-over-wire.
-            let ask1 = kv.ask(KvReq::GetKey("hello"), 5000);
+            let ask1 = kv.ask(KvReq.GetKey("hello"), 5000);
             match ask1 {
-                Err(_) => {
+                .Err(_) => {
                     println("[kv-client] FAIL: get('hello') remote ask error");
-                    Node::shutdown();
+                    Node.shutdown();
                     return 4;
                 },
-                Ok(resp) => {
+                .Ok(resp) => {
                     match resp {
-                        KvResp::Value(v) => {
+                        KvResp.Value(v) => {
                             if v == "world" {
                                 println("[kv-client] PASS: get('hello') == 'world'");
                             } else {
                                 println(f"[kv-client] FAIL: get('hello') returned '{v}', expected 'world'");
-                                Node::shutdown();
+                                Node.shutdown();
                                 return 5;
                             }
                         },
-                        KvResp::Ack => {
+                        KvResp.Ack => {
                             println("[kv-client] FAIL: get('hello') returned Ack, expected Value");
-                            Node::shutdown();
+                            Node.shutdown();
                             return 5;
                         },
                     }
                 },
             }
             // Scenario 4: get("count") — second blocking remote ask.
-            let ask2 = kv.ask(KvReq::GetKey("count"), 5000);
+            let ask2 = kv.ask(KvReq.GetKey("count"), 5000);
             match ask2 {
-                Err(_) => {
+                .Err(_) => {
                     println("[kv-client] FAIL: get('count') remote ask error");
-                    Node::shutdown();
+                    Node.shutdown();
                     return 6;
                 },
-                Ok(resp) => {
+                .Ok(resp) => {
                     match resp {
-                        KvResp::Value(v) => {
+                        KvResp.Value(v) => {
                             if v == "42" {
                                 println("[kv-client] PASS: get('count') == '42'");
                             } else {
                                 println(f"[kv-client] FAIL: get('count') returned '{v}', expected '42'");
-                                Node::shutdown();
+                                Node.shutdown();
                                 return 7;
                             }
                         },
-                        KvResp::Ack => {
+                        KvResp.Ack => {
                             println("[kv-client] FAIL: get('count') returned Ack, expected Value");
-                            Node::shutdown();
+                            Node.shutdown();
                             return 7;
                         },
                     }
@@ -150,7 +150,7 @@ fn main() -> i64 {
         },
     }
     println("[kv-client] all assertions passed");
-    Node::shutdown();
+    Node.shutdown();
     println("[kv-client] shutdown complete");
     0
 }

--- a/examples/distributed/kv_server.hew
+++ b/examples/distributed/kv_server.hew
@@ -11,7 +11,7 @@
 //
 // Or via the harness:
 //   .tmp/run-node-e2e.sh
-import std::os;
+import std.os;
 
 // `record` is Serializable (required for RemotePid messaging).
 record KvPut {
@@ -33,14 +33,14 @@ actor KeyValue {
     let store: HashMap<string, string>;
     receive fn handle(req: KvReq) -> KvResp {
         match req {
-            KvReq::Put(kv) => {
+            KvReq.Put(kv) => {
                 store.insert(kv.key, kv.val);
-                KvResp::Ack
+                KvResp.Ack
             },
-            KvReq::GetKey(k) => {
+            KvReq.GetKey(k) => {
                 match store.get(k) {
-                    Some(v) => KvResp::Value(v),
-                    None => KvResp::Value(""),
+                    .Some(v) => KvResp.Value(v),
+                    .None => KvResp.Value(""),
                 }
             },
         }
@@ -62,12 +62,12 @@ fn main() {
     }
     let addr = f"0.0.0.0:{port}";
     println(f"[kv-server] starting on {addr}");
-    Node::set_transport("tcp");
-    Node::start(addr);
+    Node.set_transport("tcp");
+    Node.start(addr);
     println("[kv-server] node started");
-    let s: HashMap<string, string> = HashMap::new();
+    let s: HashMap<string, string> = HashMap.new();
     let kv = spawn KeyValue(store: s);
-    Node::register("kv", kv);
+    Node.register("kv", kv);
     println("[kv-server] 'kv' actor registered; waiting for client...");
 
     // Wait for client to connect and run assertions.
@@ -77,9 +77,9 @@ fn main() {
     sleep(2m);
     let n = await kv.count();
     match n {
-        Ok(cnt) => println(f"[kv-server] entries stored: {cnt}"),
-        Err(_) => println("[kv-server] count ask failed"),
+        .Ok(cnt) => println(f"[kv-server] entries stored: {cnt}"),
+        .Err(_) => println("[kv-server] count ask failed"),
     }
-    Node::shutdown();
+    Node.shutdown();
     println("[kv-server] shutdown complete");
 }

--- a/examples/distributed_hello.hew
+++ b/examples/distributed_hello.hew
@@ -25,21 +25,21 @@ fn main() {
     // for out-of-band exchange. allow_peer binds a peer credential to this
     // process's receiver-local route slot 2; the numeric slot is not identity.
     // A peer presenting any other credential is rejected before it is routable.
-    Node::set_transport("quic-mesh");
-    Node::load_keys("node.key");
-    let me = Node::identity_key();
+    Node.set_transport("quic-mesh");
+    Node.load_keys("node.key");
+    let me = Node.identity_key();
     println(f"this node's pinnable credential: {me}");
-    Node::allow_peer(2, "3059301306072a8648ce3d020106082a8648ce3d030107");
-    Node::start("127.0.0.1:0");
-    match Node::id() {
-        Some(id) => println(f"this node's key-derived identity: {id}"),
-        None => println("node identity unavailable"),
+    Node.allow_peer(2, "3059301306072a8648ce3d020106082a8648ce3d030107");
+    Node.start("127.0.0.1:0");
+    match Node.id() {
+        .Some(id) => println(f"this node's key-derived identity: {id}"),
+        .None => println("node identity unavailable"),
     }
-    Node::register("counter", counter);
+    Node.register("counter", counter);
     // A second node that pinned this credential at its local route slot 2 would
-    // call Node::connect("2@127.0.0.1:9000"), then Node::lookup("counter") and
+    // call Node.connect("2@127.0.0.1:9000"), then Node.lookup("counter") and
     // message the returned RemotePid. The PID carries NodeId, actor slot, and
     // durable session incarnation, so a same-key restart fences the old value.
-    Node::shutdown();
+    Node.shutdown();
     println("Counter node demo complete");
 }

--- a/examples/enums/match_guard_catch_all_fallthrough.hew
+++ b/examples/enums/match_guard_catch_all_fallthrough.hew
@@ -8,9 +8,9 @@ fn is_never() -> bool {
 }
 
 fn main() {
-    let s: Score = Low(5);
+    let s: Score = .Low(5);
     match s {
-        High(n) if n > 90 => println("excellent"),
+        .High(n) if n > 90 => println("excellent"),
         _ if is_never() => println("never"),
         _ => panic("fallback"),
     }

--- a/examples/enums/run_colour.hew
+++ b/examples/enums/run_colour.hew
@@ -1,7 +1,7 @@
 // Exercises user-defined enum unit variant construction.
 //
 // This fixture verifies:
-//   1. Qualified constructor `Colour::Red` resolves and constructs correctly.
+//   1. Qualified constructor `Colour.Red` resolves and constructs correctly.
 //   2. Bare constructor `Green` resolves when unambiguous across all enums.
 //   3. Enum-typed values can be passed to and returned from functions.
 //
@@ -28,18 +28,18 @@ fn status_id(s: Status) -> Status {
 
 fn main() {
     // Qualified constructor.
-    let r: Colour = Colour::Red;
+    let r: Colour = Colour.Red;
     // Bare constructor (unambiguous — `Green` appears only in `Colour`).
-    let g: Colour = Green;
+    let g: Colour = .Green;
     // Bare constructor for a second enum.
-    let a: Status = Active;
+    let a: Status = .Active;
     // Round-trip through identity functions to confirm enum-typed locals
     // survive function call ABI correctly.
     let _r2 = colour_id(r);
     let _g2 = colour_id(g);
     let _a2 = status_id(a);
     // Qualified constructor of the second enum.
-    let i: Status = Status::Inactive;
+    let i: Status = Status.Inactive;
     let _i2 = status_id(i);
     println("colour-enum-ok");
 }

--- a/examples/enums/run_colour_eq.hew
+++ b/examples/enums/run_colour_eq.hew
@@ -9,12 +9,12 @@ enum Colour {
 }
 
 fn describe_eq(c: Colour) {
-    if c == Colour::Red {
+    if c == Colour.Red {
         println("red-eq");
     } else {
         println("not-red");
     }
-    if c != Colour::Blue {
+    if c != Colour.Blue {
         println("not-blue");
     } else {
         println("blue");
@@ -22,7 +22,7 @@ fn describe_eq(c: Colour) {
 }
 
 fn main() {
-    describe_eq(Colour::Red);
-    describe_eq(Colour::Green);
-    describe_eq(Colour::Blue);
+    describe_eq(Colour.Red);
+    describe_eq(Colour.Green);
+    describe_eq(Colour.Blue);
 }

--- a/examples/enums/run_colour_match.hew
+++ b/examples/enums/run_colour_match.hew
@@ -14,15 +14,15 @@ enum Colour {
 
 fn describe(c: Colour) {
     match c {
-        Colour::Red => println("red"),
-        Colour::Green => println("green"),
-        Colour::Blue => println("blue"),
+        Colour.Red => println("red"),
+        Colour.Green => println("green"),
+        Colour.Blue => println("blue"),
     }
 }
 
 fn main() {
-    describe(Colour::Red);
-    describe(Colour::Green);
-    describe(Colour::Blue);
+    describe(Colour.Red);
+    describe(Colour.Green);
+    describe(Colour.Blue);
     println("done");
 }

--- a/examples/enums/run_colour_match_let.hew
+++ b/examples/enums/run_colour_match_let.hew
@@ -12,23 +12,23 @@ enum Colour {
 
 fn pick(c: Colour) -> i64 {
     let n: i64 = match c {
-        Colour::Red => 10,
-        Colour::Green => 20,
-        Colour::Blue => 30,
+        Colour.Red => 10,
+        Colour.Green => 20,
+        Colour.Blue => 30,
     };
     n
 }
 
 fn report(c: Colour) {
     match c {
-        Colour::Green => println("green-twenty"),
+        Colour.Green => println("green-twenty"),
         _ => println("not-green"),
     }
 }
 
 fn main() {
-    let _n: i64 = pick(Colour::Green);
-    report(Colour::Green);
-    report(Colour::Red);
+    let _n: i64 = pick(Colour.Green);
+    report(Colour.Green);
+    report(Colour.Red);
     println("done");
 }

--- a/examples/enums/run_colour_match_wildcard.hew
+++ b/examples/enums/run_colour_match_wildcard.hew
@@ -12,14 +12,14 @@ enum Colour {
 
 fn describe(c: Colour) {
     match c {
-        Colour::Red => println("red-direct"),
+        Colour.Red => println("red-direct"),
         _ => println("not-red"),
     }
 }
 
 fn main() {
-    describe(Colour::Red);
-    describe(Colour::Green);
-    describe(Colour::Blue);
+    describe(Colour.Red);
+    describe(Colour.Green);
+    describe(Colour.Blue);
     println("done");
 }

--- a/examples/enums/run_indirect_enum_eval.hew
+++ b/examples/enums/run_indirect_enum_eval.hew
@@ -13,13 +13,13 @@ indirect enum Expr {
 
 fn eval(e: Expr) -> i64 {
     match e {
-        Lit(n) => n,
-        Neg(inner) => 0 - eval(inner),
+        .Lit(n) => n,
+        .Neg(inner) => 0 - eval(inner),
     }
 }
 
 fn main() {
-    println(eval(Neg(Lit(5))));
-    println(eval(Neg(Neg(Lit(3)))));
+    println(eval(.Neg(.Lit(5))));
+    println(eval(.Neg(.Neg(.Lit(3)))));
     println("done");
 }

--- a/examples/enums/run_indirect_tree_sum.hew
+++ b/examples/enums/run_indirect_tree_sum.hew
@@ -13,13 +13,13 @@ indirect enum Tree {
 
 fn sum(t: Tree) -> i64 {
     match t {
-        Leaf(n) => n,
-        Node(l, r) => sum(l) + sum(r),
+        .Leaf(n) => n,
+        .Node(l, r) => sum(l) + sum(r),
     }
 }
 
 fn main() {
-    let t = Node(Leaf(3), Leaf(4));
+    let t = Tree.Node(.Leaf(3), .Leaf(4));
     let s = sum(t);
     println(f"sum={s}");
 }

--- a/examples/enums/run_mutual_indirect_enum.hew
+++ b/examples/enums/run_mutual_indirect_enum.hew
@@ -19,24 +19,24 @@ indirect enum B {
 
 fn eval_a(a: A) -> i64 {
     match a {
-        ALeaf(n) => n,
-        AWrap(b) => eval_b(b),
+        .ALeaf(n) => n,
+        .AWrap(b) => eval_b(b),
     }
 }
 
 fn eval_b(b: B) -> i64 {
     match b {
-        BLeaf(n) => n,
-        BWrap(a) => eval_a(a),
+        .BLeaf(n) => n,
+        .BWrap(a) => eval_a(a),
     }
 }
 
 fn main() {
     // ALeaf(7) → 7
-    println(eval_a(ALeaf(7)));
+    println(eval_a(.ALeaf(7)));
     // AWrap(BLeaf(42)) → 42
-    println(eval_a(AWrap(BLeaf(42))));
+    println(eval_a(.AWrap(.BLeaf(42))));
     // BWrap(ALeaf(3)) → 3
-    println(eval_b(BWrap(ALeaf(3))));
+    println(eval_b(.BWrap(.ALeaf(3))));
     println("ok");
 }

--- a/examples/enums/run_payload_enum_eq.hew
+++ b/examples/enums/run_payload_enum_eq.hew
@@ -6,9 +6,9 @@ enum Shape {
 }
 
 fn main() {
-    let c1: Shape = Shape::Circle(3);
-    let c2: Shape = Shape::Circle(3);
-    let r1: Shape = Shape::Rect(3, 3);
+    let c1: Shape = Shape.Circle(3);
+    let c2: Shape = Shape.Circle(3);
+    let r1: Shape = Shape.Rect(3, 3);
     let some1: Option<i64> = Some(1);
     let some1b: Option<i64> = Some(1);
     let some2: Option<i64> = Some(2);

--- a/examples/enums/run_shape_mixed_match.hew
+++ b/examples/enums/run_shape_mixed_match.hew
@@ -15,15 +15,15 @@ enum Shape {
 
 fn measure(s: Shape) -> i64 {
     match s {
-        Shape::Point => 0,
-        Shape::Line(x) => x,
-        Shape::Box { w, h } => w * h,
+        Shape.Point => 0,
+        Shape.Line(x) => x,
+        Shape.Box { w, h } => w * h,
     }
 }
 
 fn main() {
-    println(measure(Shape::Point));
-    println(measure(Shape::Line(7)));
-    println(measure(Shape::Box { w: 2, h: 5 }));
+    println(measure(Shape.Point));
+    println(measure(Shape.Line(7)));
+    println(measure(Shape.Box { w: 2, h: 5 }));
     println("done");
 }

--- a/examples/enums/run_shape_struct_ctor.hew
+++ b/examples/enums/run_shape_struct_ctor.hew
@@ -2,9 +2,9 @@
 // destructuring end-to-end.
 //
 // This fixture verifies:
-//   1. `Shape::Box { w: 3, h: 4 }` constructs a tagged-union value at the
+//   1. `Shape.Box { w: 3, h: 4 }` constructs a tagged-union value at the
 //      variant index with two payload fields ordered by source declaration.
-//   2. A `match` arm `Shape::Box { w, h } => ...` binds both `w` and `h`
+//   2. A `match` arm `Shape.Box { w, h } => ...` binds both `w` and `h`
 //      from declaration-order payload slots.
 //   3. The arm body uses both bound payload values in a single expression.
 enum Shape {
@@ -14,13 +14,13 @@ enum Shape {
 
 fn area(s: Shape) -> i64 {
     match s {
-        Shape::Box { w, h } => w * h,
+        Shape.Box { w, h } => w * h,
         _ => 0,
     }
 }
 
 fn main() {
-    let b = Shape::Box { w: 3, h: 4 };
+    let b = Shape.Box { w: 3, h: 4 };
     println(area(b));
     println("done");
 }

--- a/examples/enums/run_shape_tuple_ctor.hew
+++ b/examples/enums/run_shape_tuple_ctor.hew
@@ -2,10 +2,10 @@
 // destructuring end-to-end.
 //
 // This fixture verifies:
-//   1. `Shape::Line(5)` constructs a tagged-union value at tag 1 carrying
+//   1. `Shape.Line(5)` constructs a tagged-union value at tag 1 carrying
 //      one i64 payload field.
-//   2. A `match` arm `Shape::Line(x) => ...` binds `x` to the payload value
-//      via `Place::EnumVariant { variant_idx: 1, field_idx: 0 }`.
+//   2. A `match` arm `Shape.Line(x) => ...` binds `x` to the payload value
+//      via `Place.EnumVariant { variant_idx: 1, field_idx: 0 }`.
 //   3. The arm body uses the bound payload value in an arithmetic
 //      expression that flows to observable output.
 enum Shape {
@@ -16,13 +16,13 @@ enum Shape {
 
 fn line_length(s: Shape) -> i64 {
     match s {
-        Shape::Line(x) => x,
+        Shape.Line(x) => x,
         _ => 0,
     }
 }
 
 fn main() {
-    let l = Shape::Line(7);
+    let l = Shape.Line(7);
     println(line_length(l));
     println("done");
 }

--- a/examples/enums/run_shape_tuple_ctor.hew
+++ b/examples/enums/run_shape_tuple_ctor.hew
@@ -5,7 +5,7 @@
 //   1. `Shape.Line(5)` constructs a tagged-union value at tag 1 carrying
 //      one i64 payload field.
 //   2. A `match` arm `Shape.Line(x) => ...` binds `x` to the payload value
-//      via `Place.EnumVariant { variant_idx: 1, field_idx: 0 }`.
+//      via `Place::EnumVariant { variant_idx: 1, field_idx: 0 }`.
 //   3. The arm body uses the bound payload value in an arithmetic
 //      expression that flows to observable output.
 enum Shape {

--- a/examples/enums/run_vec_enum_index.hew
+++ b/examples/enums/run_vec_enum_index.hew
@@ -12,27 +12,27 @@ enum Colour {
 }
 
 fn main() {
-    let v: Vec<Colour> = Vec::new();
-    v.push(Red);
-    v.push(Green(42));
-    v.push(Blue(10, 20));
+    let v: Vec<Colour> = Vec.new();
+    v.push(.Red);
+    v.push(.Green(42));
+    v.push(.Blue(10, 20));
     let c0 = v[0];
     let c1 = v[1];
     let c2 = v[2];
     match c0 {
-        Red => println("c0=Red"),
-        Green(n) => println(f"c0=Green({n})"),
-        Blue(a, b) => println(f"c0=Blue({a},{b})"),
+        .Red => println("c0=Red"),
+        .Green(n) => println(f"c0=Green({n})"),
+        .Blue(a, b) => println(f"c0=Blue({a},{b})"),
     }
     match c1 {
-        Red => println("c1=Red"),
-        Green(n) => println(f"c1=Green({n})"),
-        Blue(a, b) => println(f"c1=Blue({a},{b})"),
+        .Red => println("c1=Red"),
+        .Green(n) => println(f"c1=Green({n})"),
+        .Blue(a, b) => println(f"c1=Blue({a},{b})"),
     }
     match c2 {
-        Red => println("c2=Red"),
-        Green(n) => println(f"c2=Green({n})"),
-        Blue(a, b) => println(f"c2=Blue({a},{b})"),
+        .Red => println("c2=Red"),
+        .Green(n) => println(f"c2=Green({n})"),
+        .Blue(a, b) => println(f"c2=Blue({a},{b})"),
     }
     println("done");
 }

--- a/examples/enums_and_options.hew
+++ b/examples/enums_and_options.hew
@@ -10,15 +10,15 @@ enum Colour {
 
 fn colour_name(c: Colour) -> i32 {
     match c {
-        Red => {
+        .Red => {
             println("red");
             0
         },
-        Green => {
+        .Green => {
             println("green");
             1
         },
-        Blue => {
+        .Blue => {
             println("blue");
             2
         },
@@ -32,20 +32,20 @@ fn test_enum() {
 fn test_option_match() {
     let opt = Some(42);
     match opt {
-        Some(v) => {
+        .Some(v) => {
             println("PASS: Some pattern");
             println(v)
         },
-        None => {
+        .None => {
             println("FAIL: expected Some")
         },
     }
     let empty: Option<i64> = None;
     match empty {
-        Some(v) => {
+        .Some(v) => {
             println("FAIL: expected None")
         },
-        None => {
+        .None => {
             println("PASS: None pattern")
         },
     }
@@ -54,20 +54,20 @@ fn test_option_match() {
 fn test_result_match() {
     let ok_val: Result<i64, string> = Ok(99);
     match ok_val {
-        Ok(val) => {
+        .Ok(val) => {
             println("PASS: Ok pattern");
             println(val)
         },
-        Err(msg) => {
+        .Err(msg) => {
             println("FAIL: expected Ok")
         },
     }
     let err_val: Result<i64, string> = Err("something went wrong");
     match err_val {
-        Ok(val) => {
+        .Ok(val) => {
             println("FAIL: expected Err")
         },
-        Err(msg) => {
+        .Err(msg) => {
             println("PASS: Err pattern");
             println(msg)
         },

--- a/examples/file_reader.hew
+++ b/examples/file_reader.hew
@@ -21,7 +21,7 @@ actor FileReader {
     }
 }
 
-import std::fs;
+import std.fs;
 
 fn main() {
     println("=== File Reader via Actors ===");

--- a/examples/grep/grep.hew
+++ b/examples/grep/grep.hew
@@ -18,17 +18,17 @@
 // Error handling: file open failures print to stderr and continue; the
 // overall exit code is 1 if no matches were found, 2 if any error occurred,
 // 0 if at least one match was found.
-import std::fs;
+import std.fs;
 
-import std::io;
+import std.io;
 
-import std::os;
+import std.os;
 
-import std::path;
+import std.path;
 
-import std::string;
+import std.string;
 
-import std::text::regex;
+import std.text.regex;
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 type Config {
@@ -60,7 +60,7 @@ fn parse_args() -> Result<Config, string> {
     var flag_r = false;
     var pattern: string = "";
     var pattern_set = false;
-    let files: Vec<string> = Vec::new();
+    let files: Vec<string> = Vec.new();
     var i = 1;
     while i < argc {
         let arg = os.args(i);
@@ -168,12 +168,12 @@ fn grep_file(file_path: string, pat: regex.Pattern, cfg: Config, show_label: boo
     };
     let result = fs.try_read(file_path);
     match result {
-        Err(e) => {
+        .Err(e) => {
             let msg = fs.io_error_message(e);
             io.write_err(f"grep: {file_path}: {msg}\n");
             MatchState { found_any: state.found_any, had_error: true }
         },
-        Ok(content) => {
+        .Ok(content) => {
             let count = grep_content(content, pat, cfg, label, show_label);
             if cfg.flag_c {
                 if show_label {
@@ -195,12 +195,12 @@ fn grep_file(file_path: string, pat: regex.Pattern, cfg: Config, show_label: boo
 fn grep_dir(dir_path: string, pat: regex.Pattern, cfg: Config, state: MatchState) -> MatchState {
     let entries_result = fs.try_list_dir(dir_path);
     match entries_result {
-        Err(e) => {
+        .Err(e) => {
             let msg = fs.io_error_message(e);
             io.write_err(f"grep: {dir_path}: {msg}\n");
             MatchState { found_any: state.found_any, had_error: true }
         },
-        Ok(entries) => {
+        .Ok(entries) => {
             let n = entries.len();
             var ei = 0;
             var s = state;
@@ -235,11 +235,11 @@ fn grep_stdin(pat: regex.Pattern, cfg: Config, state: MatchState) -> MatchState 
 // ── Entry point ────────────────────────────────────────────────────────────────
 fn main() -> i64 {
     match parse_args() {
-        Err(msg) => {
+        .Err(msg) => {
             io.write_err(f"{msg}\n");
             2
         },
-        Ok(cfg) => {
+        .Ok(cfg) => {
             // For -i, fold the pattern to lowercase so it matches lowercased input.
             let compiled_pattern = if cfg.flag_i {
                 cfg.pattern.to_lower()

--- a/examples/hew-orch/main.hew
+++ b/examples/hew-orch/main.hew
@@ -15,7 +15,7 @@
 // `PRIMITIVE_ALIASES` (ty.rs:354) currently accepts are baggage scheduled
 // for removal; this file is written so it does not need re-editing when
 // they are dropped.
-import std::fs;
+import std.fs;
 
 // ---------------------------------------------------------------------------
 // Character classification
@@ -108,16 +108,16 @@ fn collect_md_files(dir: string, out: Vec<string>) {
 // `Option<i32>` returned by `get`.
 fn ingest_file(path: string, index: HashMap<string, i32>) {
     let content = fs.read(path);
-    let ids: Vec<string> = Vec::new();
+    let ids: Vec<string> = Vec.new();
     for line in content.lines() {
         extract_ids_in_line(line, ids);
     }
     for id in ids {
         match index.get(id) {
-            Some(prev) => {
+            .Some(prev) => {
                 index.insert(id, prev + 1);
             },
-            None => {
+            .None => {
                 index.insert(id, 1);
             },
         }
@@ -135,10 +135,10 @@ fn ingest_file(path: string, index: HashMap<string, i32>) {
 fn main() {
     let dir = ".tmp/orchestration";
     println(f"hew-orch ingest {dir}");
-    let files: Vec<string> = Vec::new();
+    let files: Vec<string> = Vec.new();
     collect_md_files(dir, files);
     println(f"files found: {files.len()}");
-    let index: HashMap<string, i32> = HashMap::new();
+    let index: HashMap<string, i32> = HashMap.new();
     for file in files {
         ingest_file(file, index);
     }
@@ -160,11 +160,11 @@ fn main() {
     for k in 0 .. limit {
         let id = keys[k];
         match index.get(id) {
-            Some(c) => {
+            .Some(c) => {
                 println(id);
                 println(c);
             },
-            None => {},
+            .None => {},
         }
     }
 }

--- a/examples/hew_grep.hew
+++ b/examples/hew_grep.hew
@@ -5,11 +5,11 @@
 // Searches for a pattern in files and prints matching lines.
 //
 // Usage: hew_grep <pattern> <file1> [file2...]
-import std::os;
+import std.os;
 
-import std::fs;
+import std.fs;
 
-import std::string;
+import std.string;
 
 fn search_file(filename: string, pattern: string, nl: string) -> i32 {
     if !fs.exists(filename) {

--- a/examples/http_json_demo.hew
+++ b/examples/http_json_demo.hew
@@ -3,7 +3,7 @@
 
 // HTTP + JSON pipeline demo.
 //
-// Demonstrates `std::net::http::http_client` and `std::encoding::json`
+// Demonstrates `std.net.http.http_client` and `std.encoding.json`
 // working together: fetch a JSON payload over HTTP, navigate a nested
 // object, extract typed fields, and count an array.
 //
@@ -28,9 +28,9 @@
 // heap-allocated Value clone. Each such handle is freed before the
 // enclosing scope exits. `print_field` frees the child Value it
 // fetches; it never frees the parent passed by the caller.
-import std::net::http::http_client;
+import std.net.http.http_client;
 
-import std::encoding::json::{Value};
+import std.encoding.json.{Value};
 
 // Fetch a URL and return the body string, or None on transport failure.
 fn fetch(url: string) -> Option<string> {
@@ -51,9 +51,9 @@ fn main() {
     let url = "https://httpbin.org/json";
     println(f"Fetching {url}...");
     match fetch(url) {
-        Some(body) => {
+        .Some(body) => {
             match json.try_parse(body) {
-                Ok(root) => {
+                .Ok(root) => {
                     // httpbin /json returns a "slideshow" object at the root.
                     // `get_field` returns a new owned clone — caller must free.
                     let slideshow = root.get_field("slideshow"); // owned
@@ -71,15 +71,15 @@ fn main() {
                     slideshow.free(); // free before root
                     root.free(); // outermost last
                 },
-                Err(_) => {
-                    // Err(ParseError::Invalid(msg)) is accepted by `hew check`
+                .Err(_) => {
+                    // Err(ParseError.Invalid(msg)) is accepted by `hew check`
                     // but fails at runtime with an undeclared-variable
                     // error. Use `Err(_)` and a static message instead.
                     println("json parse failed");
                 },
             }
         },
-        None => {
+        .None => {
             println("http request failed (no network or server unreachable)");
         },
     }

--- a/examples/http_server.hew
+++ b/examples/http_server.hew
@@ -7,15 +7,15 @@
 //
 // Usage: http_server [port] [root_dir]
 // Defaults: port=8080, root_dir="."
-import std::net::http::{Request, Server};
+import std.net.http.{Request, Server};
 
-import std::fs;
+import std.fs;
 
-import std::os;
+import std.os;
 
-import std::net::mime;
+import std.net.mime;
 
-import std::net;
+import std.net;
 
 fn serve_forever(root: string, srv: Server) {
     loop {
@@ -65,10 +65,10 @@ fn main() {
     println("=== Hew HTTP Static File Server ===");
     println(f"Listening on http://{addr}  root={root}");
     match http.listen(addr) {
-        Ok(srv) => {
+        .Ok(srv) => {
             serve_forever(root, srv);
         },
-        Err(err) => {
+        .Err(err) => {
             let reason = net.net_error_message(err);
             let detail = http.listen_error();
             println(f"cannot listen on {addr}: {reason} - {detail}");

--- a/examples/if_let.hew
+++ b/examples/if_let.hew
@@ -3,12 +3,12 @@
 
 fn main() {
     let value = Some(5);
-    let result = if let Some(x) = value {
+    let result = if let .Some(x) = value {
         x
     } else {
         0
     };
-    if let Some(x) = Some(result) {
+    if let .Some(x) = Some(result) {
         println(x);
     } else {
         println(0);

--- a/examples/log/logger_scoped.hew
+++ b/examples/log/logger_scoped.hew
@@ -9,32 +9,32 @@
 //!   HH:MM:SS.mmm ERROR service down  code=503
 //!   HH:MM:SS.mmm INFO  health ok  healthy=true
 
-import std::misc::log;
+import std.misc.log;
 
 fn main() {
     // JSON logger at DEBUG level — independent of global settings
     let json_lg = log.new_logger(log.DEBUG, log.JSON);
-    let f1: Vec<string> = Vec::new();
+    let f1: Vec<string> = Vec.new();
     f1.push(log.field("svc", "auth"));
     f1.push(log.field("region", "us-east"));
     log.logger_info(json_lg, "auth ready", f1);
-    let f2: Vec<string> = Vec::new();
+    let f2: Vec<string> = Vec.new();
     f2.push(log.field_int("uid", 99));
     log.logger_debug(json_lg, "token validated", f2);
 
     // Strict logger: ERROR threshold, TEXT format
     let strict = log.new_logger(log.ERROR, log.TEXT);
-    let f3: Vec<string> = Vec::new();
+    let f3: Vec<string> = Vec.new();
     f3.push(log.field("path", "/health"));
     // INFO (2) > ERROR (0) threshold: filtered, no output
     log.logger_info(strict, "this is filtered", f3);
-    let f4: Vec<string> = Vec::new();
+    let f4: Vec<string> = Vec.new();
     f4.push(log.field_int("code", 503));
     log.logger_error(strict, "service down", f4);
 
     // TEXT logger at INFO level — global settings unchanged
     let text_lg = log.new_logger(log.INFO, log.TEXT);
-    let f5: Vec<string> = Vec::new();
+    let f5: Vec<string> = Vec.new();
     f5.push(log.field_bool("healthy", true));
     log.logger_info(text_lg, "health ok", f5);
 }

--- a/examples/log/structured_json.hew
+++ b/examples/log/structured_json.hew
@@ -7,24 +7,24 @@
 //!   {"ts":...,"level":"WARN","msg":"high memory","threshold":"90%"}
 //!   {"ts":...,"level":"ERROR","msg":"request failed","status":"500","path":"/api"}
 
-import std::misc::log;
+import std.misc.log;
 
 fn main() {
     log.set_level(log.INFO);
     log.set_format(log.JSON);
-    let info_fields: Vec<string> = Vec::new();
+    let info_fields: Vec<string> = Vec.new();
     info_fields.push(log.field_int("port", 8080));
     info_fields.push(log.field("env", "prod"));
     log.info_with("server started", info_fields);
 
     // DEBUG is filtered — no JSON line emitted
-    let debug_fields: Vec<string> = Vec::new();
+    let debug_fields: Vec<string> = Vec.new();
     debug_fields.push(log.field("key", "user:42"));
     log.debug_with("filtered line", debug_fields);
-    let warn_fields: Vec<string> = Vec::new();
+    let warn_fields: Vec<string> = Vec.new();
     warn_fields.push(log.field("threshold", "90%"));
     log.warn_with("high memory", warn_fields);
-    let error_fields: Vec<string> = Vec::new();
+    let error_fields: Vec<string> = Vec.new();
     error_fields.push(log.field_int("status", 500));
     error_fields.push(log.field("path", "/api"));
     log.error_with("request failed", error_fields);

--- a/examples/log/structured_text.hew
+++ b/examples/log/structured_text.hew
@@ -11,30 +11,30 @@
 //!
 //! The DEBUG line is suppressed by the INFO threshold filter.
 
-import std::misc::log;
+import std.misc.log;
 
 fn main() {
     log.setup(); // INFO threshold, TEXT format
-    let info_fields: Vec<string> = Vec::new();
+    let info_fields: Vec<string> = Vec.new();
     info_fields.push(log.field_int("port", 8080));
     info_fields.push(log.field("env", "prod"));
     log.info_with("server started", info_fields);
 
     // DEBUG is filtered at the default INFO threshold
-    let debug_fields: Vec<string> = Vec::new();
+    let debug_fields: Vec<string> = Vec.new();
     debug_fields.push(log.field("key", "user:42"));
     log.debug_with("cache miss", debug_fields);
-    let warn_fields: Vec<string> = Vec::new();
+    let warn_fields: Vec<string> = Vec.new();
     warn_fields.push(log.field("usage", "90%"));
     log.warn_with("high cpu", warn_fields);
-    let error_fields: Vec<string> = Vec::new();
+    let error_fields: Vec<string> = Vec.new();
     error_fields.push(log.field_int("status", 500));
     error_fields.push(log.field("path", "/api"));
     log.error_with("request failed", error_fields);
 
     // Raise level to TRACE so this appears
     log.set_level(log.TRACE);
-    let trace_fields: Vec<string> = Vec::new();
+    let trace_fields: Vec<string> = Vec.new();
     trace_fields.push(log.field_float("elapsed_ms", 1.234));
     log.trace_with("span end", trace_fields);
 }

--- a/examples/machine/counter_machine.hew
+++ b/examples/machine/counter_machine.hew
@@ -1,10 +1,10 @@
 // Minimal payload-bearing machine — zero emits, simple state transitions
-// with payload fields that exercise the Place::MachineVariant codegen
+// with payload fields that exercise the Place.MachineVariant codegen
 // surface (state field read in a transition body, state field write in
 // a variant constructor).
 //
-// Drives `Place::MachineTag`, `Place::MachineVariant`, and the
-// event-companion `Instr::EnumTagLoad` end-to-end through codegen.
+// Drives `Place.MachineTag`, `Place.MachineVariant`, and the
+// event-companion `Instr.EnumTagLoad` end-to-end through codegen.
 machine Counter {
     events {
         Inc;

--- a/examples/machine/counter_machine.hew
+++ b/examples/machine/counter_machine.hew
@@ -1,10 +1,10 @@
 // Minimal payload-bearing machine — zero emits, simple state transitions
-// with payload fields that exercise the Place.MachineVariant codegen
+// with payload fields that exercise the Place::MachineVariant codegen
 // surface (state field read in a transition body, state field write in
 // a variant constructor).
 //
-// Drives `Place.MachineTag`, `Place.MachineVariant`, and the
-// event-companion `Instr.EnumTagLoad` end-to-end through codegen.
+// Drives `Place::MachineTag`, `Place::MachineVariant`, and the
+// event-companion `Instr::EnumTagLoad` end-to-end through codegen.
 machine Counter {
     events {
         Inc;

--- a/examples/machine/guard_fallthrough_traps.hew
+++ b/examples/machine/guard_fallthrough_traps.hew
@@ -15,7 +15,7 @@
 // transition in the machine carries a guard. Reaching `unreachable` there
 // would be undefined behaviour, not a diagnostic. The fix routes any
 // guard-bearing machine's fall-through to a real
-// `TrapKind.ExhaustivenessFallthrough` trap instead.
+// `TrapKind::ExhaustivenessFallthrough` trap instead.
 //
 // `m` starts `Closed { code: 1 }`; the guard evaluates false; the fixture
 // must exit non-zero with a "trap in main context" diagnostic on stderr —

--- a/examples/machine/guard_fallthrough_traps.hew
+++ b/examples/machine/guard_fallthrough_traps.hew
@@ -15,7 +15,7 @@
 // transition in the machine carries a guard. Reaching `unreachable` there
 // would be undefined behaviour, not a diagnostic. The fix routes any
 // guard-bearing machine's fall-through to a real
-// `TrapKind::ExhaustivenessFallthrough` trap instead.
+// `TrapKind.ExhaustivenessFallthrough` trap instead.
 //
 // `m` starts `Closed { code: 1 }`; the guard evaluates false; the fixture
 // must exit non-zero with a "trap in main context" diagnostic on stderr —

--- a/examples/machine/guard_false_falls_through_to_wildcard.hew
+++ b/examples/machine/guard_false_falls_through_to_wildcard.hew
@@ -10,7 +10,7 @@
 // whenever "any" same-event arm existed silently made it permanently
 // unreachable behind so much as one guarded sibling, so a false guard fell
 // all the way past the (missing) wildcard arm to
-// `TrapKind::ExhaustivenessFallthrough` instead.
+// `TrapKind.ExhaustivenessFallthrough` instead.
 //
 // `on Try: Closed => Open when self.code == 42` is the only explicit arm
 // for `(Closed, Try)`; `on Try: _ => Bailed` is the same-event wildcard.

--- a/examples/machine/guard_false_falls_through_to_wildcard.hew
+++ b/examples/machine/guard_false_falls_through_to_wildcard.hew
@@ -10,7 +10,7 @@
 // whenever "any" same-event arm existed silently made it permanently
 // unreachable behind so much as one guarded sibling, so a false guard fell
 // all the way past the (missing) wildcard arm to
-// `TrapKind.ExhaustivenessFallthrough` instead.
+// `TrapKind::ExhaustivenessFallthrough` instead.
 //
 // `on Try: Closed => Open when self.code == 42` is the only explicit arm
 // for `(Closed, Try)`; `on Try: _ => Bailed` is the same-event wildcard.

--- a/examples/machine/padded_payload_machine.hew
+++ b/examples/machine/padded_payload_machine.hew
@@ -6,7 +6,7 @@
 // is 16 bytes (7 bytes of padding after `tag_byte` to align `value` to
 // its 8-byte natural boundary). This fixture drives
 // `build_tagged_union_layout` to verify that the payload array is sized
-// to the ABI size reported by `TargetData::get_abi_size` — not the
+// to the ABI size reported by `TargetData.get_abi_size` — not the
 // field-width sum.
 machine PaddedPayload {
     events {

--- a/examples/machine/padded_payload_machine.hew
+++ b/examples/machine/padded_payload_machine.hew
@@ -6,7 +6,7 @@
 // is 16 bytes (7 bytes of padding after `tag_byte` to align `value` to
 // its 8-byte natural boundary). This fixture drives
 // `build_tagged_union_layout` to verify that the payload array is sized
-// to the ABI size reported by `TargetData.get_abi_size` — not the
+// to the ABI size reported by `TargetData::get_abi_size` — not the
 // field-width sum.
 machine PaddedPayload {
     events {

--- a/examples/machine/run_counter_qualified.hew
+++ b/examples/machine/run_counter_qualified.hew
@@ -1,6 +1,6 @@
 // Runnable fixture: exercises qualified-path machine state and event
 // constructors. Mirrors `run_traffic_light.hew` but uses the explicit
-// `Counter::Idle` and `CounterEvent::Tick` forms instead of bare names,
+// `Counter.Idle` and `CounterEvent.Tick` forms instead of bare names,
 // so the HIR module-scope ctor-resolution path is exercised through
 // the qualified registry entry rather than the unambiguous-bare one.
 machine Counter {
@@ -20,10 +20,10 @@ machine Counter {
 }
 
 fn main() {
-    var c: Counter = Counter::Idle;
+    var c: Counter = Counter.Idle;
     println(c.state_name());
-    c.step(CounterEvent::Tick);
+    c.step(CounterEvent.Tick);
     println(c.state_name());
-    c.step(CounterEvent::Tick);
+    c.step(CounterEvent.Tick);
     println(c.state_name());
 }

--- a/examples/machine/run_counter_qualified.hew
+++ b/examples/machine/run_counter_qualified.hew
@@ -1,8 +1,6 @@
-// Runnable fixture: exercises qualified-path machine state and event
-// constructors. Mirrors `run_traffic_light.hew` but uses the explicit
-// `Counter.Idle` and `CounterEvent.Tick` forms instead of bare names,
-// so the HIR module-scope ctor-resolution path is exercised through
-// the qualified registry entry rather than the unambiguous-bare one.
+// Runnable fixture: exercises contextual machine state and event constructors.
+// Mirrors `run_traffic_light.hew` but uses `.Idle` and `.Tick` instead of bare
+// names, so the HIR expected-type constructor path is exercised directly.
 machine Counter {
     events {
         Tick;
@@ -20,10 +18,10 @@ machine Counter {
 }
 
 fn main() {
-    var c: Counter = Counter.Idle;
+    var c: Counter = .Idle;
     println(c.state_name());
-    c.step(CounterEvent.Tick);
+    c.step(.Tick);
     println(c.state_name());
-    c.step(CounterEvent.Tick);
+    c.step(.Tick);
     println(c.state_name());
 }

--- a/examples/machine/run_cross_module_toggle.hew
+++ b/examples/machine/run_cross_module_toggle.hew
@@ -1,21 +1,21 @@
 // Runnable fixture: cross-module Moore machine driven end-to-end.
 //
-// Imports `Toggle` from `std::machines::toggle` and exercises the HIR
-// cross-module machine-binding path: the qualified `Toggle::Off` ctor and
+// Imports `Toggle` from `std.machines.toggle` and exercises the HIR
+// cross-module machine-binding path: the qualified `Toggle.Off` ctor and
 // the bare `Flip` event reference resolve through
 // `machine_ctor_registry` only when the HIR pre-pass walks
 // `program.module_graph` to register imported machines (see
 // `hew-hir/src/lower.rs`). Before that fix, this file failed at HIR with
-// `UnresolvedSymbol { name: "Toggle::Off" }` and `UnresolvedSymbol { name: "Flip" }`.
+// `UnresolvedSymbol { name: "Toggle.Off" }` and `UnresolvedSymbol { name: "Flip" }`.
 //
 // Gate: stdout must match `run_cross_module_toggle.expected` exactly.
-import std::machines::toggle::{Toggle};
+import std.machines.toggle.{Toggle};
 
 fn main() {
-    var t: Toggle = Toggle::Off;
+    var t: Toggle = Toggle.Off;
     println(t.state_name());
-    t.step(Flip);
+    t.step(std.machines.toggle.ToggleEvent.Flip);
     println(t.state_name());
-    t.step(Flip);
+    t.step(std.machines.toggle.ToggleEvent.Flip);
     println(t.state_name());
 }

--- a/examples/machine/run_cross_module_toggle.hew
+++ b/examples/machine/run_cross_module_toggle.hew
@@ -1,21 +1,21 @@
 // Runnable fixture: cross-module Moore machine driven end-to-end.
 //
 // Imports `Toggle` from `std.machines.toggle` and exercises the HIR
-// cross-module machine-binding path: the qualified `Toggle.Off` ctor and
-// the bare `Flip` event reference resolve through
+// cross-module machine-binding path: the contextual `.Off` state ctor and
+// explicitly imported `ToggleEvent.Flip` event reference resolve through
 // `machine_ctor_registry` only when the HIR pre-pass walks
 // `program.module_graph` to register imported machines (see
 // `hew-hir/src/lower.rs`). Before that fix, this file failed at HIR with
-// `UnresolvedSymbol { name: "Toggle.Off" }` and `UnresolvedSymbol { name: "Flip" }`.
+// `UnresolvedSymbol { name: "Toggle::Off" }` and `UnresolvedSymbol { name: "Flip" }`.
 //
 // Gate: stdout must match `run_cross_module_toggle.expected` exactly.
-import std.machines.toggle.{Toggle};
+import std.machines.toggle.{Toggle, ToggleEvent};
 
 fn main() {
-    var t: Toggle = Toggle.Off;
+    var t: Toggle = .Off;
     println(t.state_name());
-    t.step(std.machines.toggle.ToggleEvent.Flip);
+    t.step(ToggleEvent.Flip);
     println(t.state_name());
-    t.step(std.machines.toggle.ToggleEvent.Flip);
+    t.step(ToggleEvent.Flip);
     println(t.state_name());
 }

--- a/examples/machine/run_emit_signal.hew
+++ b/examples/machine/run_emit_signal.hew
@@ -12,14 +12,14 @@
 //      never emitted, so it is always 0.
 //
 // The emit call (`emit Ready {}`) is a unit-payload Mealy output. It lowers
-// through `Instr.MachineEmitPlaceholder` → `call void @hew_machine_emit_push`
+// through `Instr::MachineEmitPlaceholder` → `call void @hew_machine_emit_push`
 // in the LLVM IR, tagged with the machine's stable type id. The thread-local
 // EmitQueue keeps the event (the step-exit wrapper calls
 // `hew_machine_emit_step_exit_keep`, never draining) until `m.take_emits(ev)`
 // removes it — delivery is per-thread, per-machine-TYPE (see
 // docs/specs/MACHINE-SPEC.md's emit section).
 //
-// `tests/exec/machine_exec.rs.run_emit_signal_fixture_executes` is the
+// `tests/exec/machine_exec.rs::run_emit_signal_fixture_executes` is the
 // end-to-end signal for this fixture.
 machine Signal {
     events {

--- a/examples/machine/run_emit_signal.hew
+++ b/examples/machine/run_emit_signal.hew
@@ -12,14 +12,14 @@
 //      never emitted, so it is always 0.
 //
 // The emit call (`emit Ready {}`) is a unit-payload Mealy output. It lowers
-// through `Instr::MachineEmitPlaceholder` → `call void @hew_machine_emit_push`
+// through `Instr.MachineEmitPlaceholder` → `call void @hew_machine_emit_push`
 // in the LLVM IR, tagged with the machine's stable type id. The thread-local
 // EmitQueue keeps the event (the step-exit wrapper calls
 // `hew_machine_emit_step_exit_keep`, never draining) until `m.take_emits(ev)`
 // removes it — delivery is per-thread, per-machine-TYPE (see
 // docs/specs/MACHINE-SPEC.md's emit section).
 //
-// `tests/exec/machine_exec.rs::run_emit_signal_fixture_executes` is the
+// `tests/exec/machine_exec.rs.run_emit_signal_fixture_executes` is the
 // end-to-end signal for this fixture.
 machine Signal {
     events {

--- a/examples/machine/run_emit_two_machines.hew
+++ b/examples/machine/run_emit_two_machines.hew
@@ -10,7 +10,7 @@
 // `b.take_emits(Ring)` would misattribute `Alarm`'s queued event to
 // `Beacon` and wrongly report `1`; with the filter it must report `0`.
 //
-// `tests/exec/machine_exec.rs::run_emit_two_machines_fixture_executes` is
+// `tests/exec/machine_exec.rs.run_emit_two_machines_fixture_executes` is
 // the end-to-end signal for this fixture.
 machine Alarm {
     events {

--- a/examples/machine/run_emit_two_machines.hew
+++ b/examples/machine/run_emit_two_machines.hew
@@ -10,7 +10,7 @@
 // `b.take_emits(Ring)` would misattribute `Alarm`'s queued event to
 // `Beacon` and wrongly report `1`; with the filter it must report `0`.
 //
-// `tests/exec/machine_exec.rs.run_emit_two_machines_fixture_executes` is
+// `tests/exec/machine_exec.rs::run_emit_two_machines_fixture_executes` is
 // the end-to-end signal for this fixture.
 machine Alarm {
     events {

--- a/examples/machine/run_lifecycle.hew
+++ b/examples/machine/run_lifecycle.hew
@@ -1,22 +1,22 @@
 // Runnable fixture: generic stdlib Lifecycle<T> state machine.
-import std::concurrency::lifecycle;
+import std.concurrency.lifecycle;
 
 fn main() {
-    var service: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle::Created;
+    var service: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle.Created;
     println(service.state_name());
-    service.step(Initialise);
+    service.step(std.concurrency.lifecycle.LifecycleEvent.Initialise);
     println(service.state_name());
-    service.step(lifecycle.LifecycleEvent::Started { handle: 42 });
+    service.step(lifecycle.LifecycleEvent.Started { handle: 42 });
     println(service.state_name());
-    service.step(Stop);
+    service.step(std.concurrency.lifecycle.LifecycleEvent.Stop);
     println(service.state_name());
-    service.step(Stop);
+    service.step(std.concurrency.lifecycle.LifecycleEvent.Stop);
     println(service.state_name());
-    var crashing: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle::Created;
+    var crashing: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle.Created;
     println(crashing.state_name());
-    crashing.step(Initialise);
+    crashing.step(std.concurrency.lifecycle.LifecycleEvent.Initialise);
     println(crashing.state_name());
-    let err = Error::Code(7);
-    crashing.step(lifecycle.LifecycleEvent::Crashed { error: err });
+    let err = Error.Code(7);
+    crashing.step(lifecycle.LifecycleEvent.Crashed { error: err });
     println(crashing.state_name());
 }

--- a/examples/machine/run_lifecycle.hew
+++ b/examples/machine/run_lifecycle.hew
@@ -1,22 +1,22 @@
 // Runnable fixture: generic stdlib Lifecycle<T> state machine.
-import std.concurrency.lifecycle;
+import std.concurrency.lifecycle.{Lifecycle, LifecycleEvent};
 
 fn main() {
-    var service: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle.Created;
+    var service: Lifecycle<i64> = .Created;
     println(service.state_name());
-    service.step(std.concurrency.lifecycle.LifecycleEvent.Initialise);
+    service.step(LifecycleEvent.Initialise);
     println(service.state_name());
-    service.step(lifecycle.LifecycleEvent.Started { handle: 42 });
+    service.step(LifecycleEvent.Started { handle: 42 });
     println(service.state_name());
-    service.step(std.concurrency.lifecycle.LifecycleEvent.Stop);
+    service.step(LifecycleEvent.Stop);
     println(service.state_name());
-    service.step(std.concurrency.lifecycle.LifecycleEvent.Stop);
+    service.step(LifecycleEvent.Stop);
     println(service.state_name());
-    var crashing: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle.Created;
+    var crashing: Lifecycle<i64> = .Created;
     println(crashing.state_name());
-    crashing.step(std.concurrency.lifecycle.LifecycleEvent.Initialise);
+    crashing.step(LifecycleEvent.Initialise);
     println(crashing.state_name());
     let err = Error.Code(7);
-    crashing.step(lifecycle.LifecycleEvent.Crashed { error: err });
+    crashing.step(LifecycleEvent.Crashed { error: err });
     println(crashing.state_name());
 }

--- a/examples/machine/run_traffic_light.hew
+++ b/examples/machine/run_traffic_light.hew
@@ -8,10 +8,10 @@
 //
 // Resolved by the HIR module-scope constructor-resolution pass: bare
 // `Red` and `Tick` identifiers and the qualified forms
-// `TrafficLight::Red` / `TrafficLightEvent::Tick` all lower through
-// `HirExprKind::MachineVariantCtor`, which MIR and codegen turn into
+// `TrafficLight.Red` / `TrafficLightEvent.Tick` all lower through
+// `HirExprKind.MachineVariantCtor`, which MIR and codegen turn into
 // the tagged-union construction primitives the runtime expects.
-// `tests/machine_exec.rs::run_traffic_light_fixture_executes` is the
+// `tests/machine_exec.rs.run_traffic_light_fixture_executes` is the
 // end-to-end signal for this fixture.
 machine TrafficLight {
     events {

--- a/examples/machine/run_traffic_light.hew
+++ b/examples/machine/run_traffic_light.hew
@@ -9,9 +9,9 @@
 // Resolved by the HIR module-scope constructor-resolution pass: bare
 // `Red` and `Tick` identifiers and the qualified forms
 // `TrafficLight.Red` / `TrafficLightEvent.Tick` all lower through
-// `HirExprKind.MachineVariantCtor`, which MIR and codegen turn into
+// `HirExprKind::MachineVariantCtor`, which MIR and codegen turn into
 // the tagged-union construction primitives the runtime expects.
-// `tests/machine_exec.rs.run_traffic_light_fixture_executes` is the
+// `tests/machine_exec.rs::run_traffic_light_fixture_executes` is the
 // end-to-end signal for this fixture.
 machine TrafficLight {
     events {

--- a/examples/machine/select_on_transition.hew
+++ b/examples/machine/select_on_transition.hew
@@ -10,9 +10,9 @@
 // transitions-after-subscribe; the owner sends the current state as a
 // self-transition at attach so a watcher joining an already-started
 // machine fires immediately.
-import std::concurrency::lifecycle;
+import std.concurrency.lifecycle;
 
-import std::channel::channel;
+import std.channel.channel;
 
 /// One observed transition. Field names carry the `_state` suffix
 /// because `from` is a hard keyword (the select arm binder).
@@ -22,19 +22,19 @@ record Transition {
 }
 
 actor Owner {
-    var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle::Created;
+    var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle.Created;
     receive fn drive(tx: channel.Sender<Transition>) {
 
         // Attach snapshot: a self-transition naming the current state.
         let current = lc.state_name();
         tx.send(Transition { from_state: current, to_state: lc.state_name() });
         let before_init = lc.state_name();
-        lc.step(Initialise);
+        lc.step(std.concurrency.lifecycle.LifecycleEvent.Initialise);
         if before_init != lc.state_name() {
             tx.send(Transition { from_state: before_init, to_state: lc.state_name() });
         }
         let before_start = lc.state_name();
-        lc.step(lifecycle.LifecycleEvent::Started { handle: 7 });
+        lc.step(lifecycle.LifecycleEvent.Started { handle: 7 });
         if before_start != lc.state_name() {
             tx.send(Transition { from_state: before_start, to_state: lc.state_name() });
         }
@@ -49,7 +49,7 @@ actor Observer {
             select {
                 t from rx.recv() => {
                     match t {
-                        Some(tr) => {
+                        .Some(tr) => {
                             println(f"{tr.from_state} -> {tr.to_state}");
                             match tr.to_state {
                                 "Running" => println("observer: child is up"),
@@ -57,7 +57,7 @@ actor Observer {
                                 _ => {},
                             }
                         },
-                        None => {
+                        .None => {
                             println("watch closed");
                             waiting = false;
                         },

--- a/examples/machine/select_on_transition.hew
+++ b/examples/machine/select_on_transition.hew
@@ -10,7 +10,7 @@
 // transitions-after-subscribe; the owner sends the current state as a
 // self-transition at attach so a watcher joining an already-started
 // machine fires immediately.
-import std.concurrency.lifecycle;
+import std.concurrency.lifecycle.{Lifecycle, LifecycleEvent};
 
 import std.channel.channel;
 
@@ -22,19 +22,19 @@ record Transition {
 }
 
 actor Owner {
-    var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle.Created;
+    var lc: Lifecycle<i64> = .Created;
     receive fn drive(tx: channel.Sender<Transition>) {
 
         // Attach snapshot: a self-transition naming the current state.
         let current = lc.state_name();
         tx.send(Transition { from_state: current, to_state: lc.state_name() });
         let before_init = lc.state_name();
-        lc.step(std.concurrency.lifecycle.LifecycleEvent.Initialise);
+        lc.step(LifecycleEvent.Initialise);
         if before_init != lc.state_name() {
             tx.send(Transition { from_state: before_init, to_state: lc.state_name() });
         }
         let before_start = lc.state_name();
-        lc.step(lifecycle.LifecycleEvent.Started { handle: 7 });
+        lc.step(LifecycleEvent.Started { handle: 7 });
         if before_start != lc.state_name() {
             tx.send(Transition { from_state: before_start, to_state: lc.state_name() });
         }

--- a/examples/machine/transition_watch_baseline.hew
+++ b/examples/machine/transition_watch_baseline.hew
@@ -8,16 +8,16 @@
 // This baseline keeps owner and observer in one actor; the cross-actor
 // split (channel handles travelling through actor messages) builds on
 // the same shape.
-import std.concurrency.lifecycle;
+import std.concurrency.lifecycle.{Lifecycle, LifecycleEvent};
 
 import std.channel.channel;
 
 actor Combined {
     receive fn run() {
         let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(8);
-        var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle.Created;
+        var lc: Lifecycle<i64> = .Created;
         let before = lc.state_name();
-        lc.step(std.concurrency.lifecycle.LifecycleEvent.Initialise);
+        lc.step(LifecycleEvent.Initialise);
         let after_step = lc.state_name();
         if before != after_step {
             tx.send(f"{before} -> {after_step}");

--- a/examples/machine/transition_watch_baseline.hew
+++ b/examples/machine/transition_watch_baseline.hew
@@ -8,16 +8,16 @@
 // This baseline keeps owner and observer in one actor; the cross-actor
 // split (channel handles travelling through actor messages) builds on
 // the same shape.
-import std::concurrency::lifecycle;
+import std.concurrency.lifecycle;
 
-import std::channel::channel;
+import std.channel.channel;
 
 actor Combined {
     receive fn run() {
         let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(8);
-        var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle::Created;
+        var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle.Created;
         let before = lc.state_name();
-        lc.step(Initialise);
+        lc.step(std.concurrency.lifecycle.LifecycleEvent.Initialise);
         let after_step = lc.state_name();
         if before != after_step {
             tx.send(f"{before} -> {after_step}");
@@ -26,8 +26,8 @@ actor Combined {
         select {
             t from rx.recv() => {
                 match t {
-                    Some(tr) => println(tr),
-                    None => println("watch closed"),
+                    .Some(tr) => println(tr),
+                    .None => println("watch closed"),
                 }
             },
             after 2s => println("timeout"),

--- a/examples/metrics_smoke.hew
+++ b/examples/metrics_smoke.hew
@@ -1,13 +1,13 @@
 //! Status: runnable
 //! Description: metrics_smoke.hew — declare user metrics and read them back from the observe scrape
 
-// Declares a counter, a gauge, and a histogram through std::metrics, mutates
+// Declares a counter, a gauge, and a histogram through std.metrics, mutates
 // each, then reads the values back out of the shared observe scrape surface and
 // asserts the exact emitted values. The same scrape that carries the runtime
 // built-ins now also carries developer-defined metrics.
-import std::metrics;
+import std.metrics;
 
-import std::observe;
+import std.observe;
 
 fn main() {
     // Counter: register, increment five times, add four more → 9.
@@ -39,8 +39,8 @@ fn main() {
     // try_* recovers a structured error instead of panicking. Re-registering
     // an existing name returns a handle to the same slot.
     match metrics.try_counter("app.requests") {
-        Ok(again) => again.inc(), // app.requests → 10
-        Err(_) => println("unexpected counter rejection"),
+        .Ok(again) => again.inc(), // app.requests → 10
+        .Err(_) => println("unexpected counter rejection"),
     }
     let scrape = observe.scrape();
     println(scrape);

--- a/examples/module_generic_boundaries/main.hew
+++ b/examples/module_generic_boundaries/main.hew
@@ -1,4 +1,4 @@
-import myapp.widgets.*;
+import myapp::widgets::*;
 
 fn main() {
     println(describe(Label { text: "hello" }));

--- a/examples/module_generic_boundaries/main.hew
+++ b/examples/module_generic_boundaries/main.hew
@@ -1,4 +1,4 @@
-import myapp::widgets::*;
+import myapp.widgets.*;
 
 fn main() {
     println(describe(Label { text: "hello" }));

--- a/examples/mqtt_broker.hew
+++ b/examples/mqtt_broker.hew
@@ -16,11 +16,11 @@
 // Router state uses only clonable types (strings, i32, LocalPid handles) so the
 // actor is supervisor-restartable. Runtime stream/sink halves have one owner
 // each and close automatically with their actors.
-import std::net;
+import std.net;
 
-import std::stream::{Sink, Stream};
+import std.stream.{Sink, Stream};
 
-import std::os;
+import std.os;
 
 extern "C" {
     fn hew_actor_self_stop();
@@ -34,7 +34,7 @@ const MAX_PACKET_BYTES: i64 = 1048576;
 
 // ── Bytes helpers ─────────────────────────────────────────────────────────────
 fn bytes_slice(data: bytes, start: i64, end: i64) -> bytes {
-    let result = bytes::new();
+    let result = bytes.new();
     for i in start .. end {
         result.push(data[i]);
     }
@@ -127,7 +127,7 @@ fn mqtt_str_wire_len(data: bytes, offset: i64, limit: i64) -> i64 {
 // Read a length-prefixed MQTT string whose wire width was already validated.
 fn read_mqtt_str(data: bytes, offset: i64) -> string {
     let len: i64 = read_u16(data, offset) as i64;
-    let s = bytes::new();
+    let s = bytes.new();
     let start: i64 = offset + 2;
     for i in start .. start + len {
         s.push(data[i]);
@@ -137,7 +137,7 @@ fn read_mqtt_str(data: bytes, offset: i64) -> string {
 
 // ── Packet builders ───────────────────────────────────────────────────────────
 fn build_connack(session_present: i32, return_code: i32) -> bytes {
-    let buf = bytes::new();
+    let buf = bytes.new();
     buf.push(0x20 as u8);
     buf.push(2 as u8);
     buf.push(session_present as u8);
@@ -146,7 +146,7 @@ fn build_connack(session_present: i32, return_code: i32) -> bytes {
 }
 
 fn build_puback(packet_id: i32) -> bytes {
-    let buf = bytes::new();
+    let buf = bytes.new();
     buf.push(0x40 as u8);
     buf.push(2 as u8);
     push_u16(buf, packet_id);
@@ -154,10 +154,10 @@ fn build_puback(packet_id: i32) -> bytes {
 }
 
 fn build_suback(packet_id: i32, return_codes: bytes) -> bytes {
-    let body = bytes::new();
+    let body = bytes.new();
     push_u16(body, packet_id);
     body.append(return_codes);
-    let buf = bytes::new();
+    let buf = bytes.new();
     buf.push(0x90 as u8);
     push_varint(buf, body.len() as i32);
     buf.append(body);
@@ -165,7 +165,7 @@ fn build_suback(packet_id: i32, return_codes: bytes) -> bytes {
 }
 
 fn build_unsuback(packet_id: i32) -> bytes {
-    let buf = bytes::new();
+    let buf = bytes.new();
     buf.push(0xB0 as u8);
     buf.push(2 as u8);
     push_u16(buf, packet_id);
@@ -173,7 +173,7 @@ fn build_unsuback(packet_id: i32) -> bytes {
 }
 
 fn build_pingresp() -> bytes {
-    let buf = bytes::new();
+    let buf = bytes.new();
     buf.push(0xD0 as u8);
     buf.push(0 as u8);
     buf
@@ -181,14 +181,14 @@ fn build_pingresp() -> bytes {
 
 // Build a PUBLISH packet. payload is raw bytes (not a string).
 fn build_publish(topic: string, payload: bytes, qos: i32, packet_id: i32) -> bytes {
-    let body: bytes = bytes::new();
+    let body: bytes = bytes.new();
     push_mqtt_str(body, topic);
     if qos > 0 {
         push_u16(body, packet_id);
     }
     body.append(payload);
     let flags = 0x30 + qos * 2;
-    let buf = bytes::new();
+    let buf = bytes.new();
     buf.push(flags as u8);
     push_varint(buf, body.len() as i32);
     buf.append(body);
@@ -209,8 +209,8 @@ actor ClientHandler {
     var registered: bool;
     receive fn register(reader: LocalPid<ClientReader>) {
         let accepted = match await router.register_client(session_id.clone(), this) {
-            Ok(value) => value,
-            Err(_) => false,
+            .Ok(value) => value,
+            .Err(_) => false,
         };
         if accepted {
             registered = true;
@@ -230,7 +230,7 @@ actor ClientHandler {
     }
     receive fn on_data(chunk: bytes) -> bool {
         var connected = true;
-        let next_buf = bytes::new();
+        let next_buf = bytes.new();
         next_buf.append(buf);
         next_buf.append(chunk);
         buf = next_buf;
@@ -283,14 +283,14 @@ actor ClientHandler {
                             } else {
                                 let new_client_id = read_mqtt_str(buf, payload_off);
                                 let claim_status = match await router.claim_client_id(session_id.clone(), new_client_id.clone()) {
-                                    Ok(value) => {
+                                    .Ok(value) => {
                                         if value {
                                             1
                                         } else {
                                             0
                                         }
                                     },
-                                    Err(_) => -1,
+                                    .Err(_) => -1,
                                 };
                                 if claim_status == 1 {
                                     if new_client_id != "" {
@@ -352,7 +352,7 @@ actor ClientHandler {
                     } else {
                         let sub_packet_id = read_u16(buf, var_off);
                         var topic_off: i64 = var_off + 2;
-                        let return_codes: bytes = bytes::new();
+                        let return_codes: bytes = bytes.new();
                         while connected && topic_off < packet_end {
                             let tw = mqtt_str_wire_len(buf, topic_off, packet_end);
                             if tw <= 2 || !has_bytes(packet_end, topic_off + tw, 1) {
@@ -476,13 +476,13 @@ actor ClientReader {
         var reading = true;
         while reading {
             match await input.recv() {
-                Some(chunk) => {
+                .Some(chunk) => {
                     reading = match await client.on_data(chunk) {
-                        Ok(keep_reading) => keep_reading,
-                        Err(_) => false,
+                        .Ok(keep_reading) => keep_reading,
+                        .Err(_) => false,
                     };
                 },
-                None => {
+                .None => {
                     client.on_close();
                     reading = false;
                 },
@@ -571,9 +571,9 @@ actor Router {
     }
     receive fn unsubscribe(topic: string, session_id: string) {
         let before = sub_topics.len();
-        let new_topics: Vec<string> = Vec::new();
-        let new_sessions: Vec<string> = Vec::new();
-        let new_qos: Vec<i32> = Vec::new();
+        let new_topics: Vec<string> = Vec.new();
+        let new_sessions: Vec<string> = Vec.new();
+        let new_qos: Vec<i32> = Vec.new();
         for i in 0 .. sub_topics.len() {
             if sub_session_ids[i] == session_id {
                 if sub_topics[i] == topic {
@@ -594,9 +594,9 @@ actor Router {
         // Remove from client registry
         let clients_before = session_ids.len();
         let subscriptions_before = sub_topics.len();
-        let new_sessions: Vec<string> = Vec::new();
-        let new_client_ids: Vec<string> = Vec::new();
-        let new_clients: Vec<LocalPid<ClientHandler>> = Vec::new();
+        let new_sessions: Vec<string> = Vec.new();
+        let new_client_ids: Vec<string> = Vec.new();
+        let new_clients: Vec<LocalPid<ClientHandler>> = Vec.new();
         for i in 0 .. session_ids.len() {
             if session_ids[i] != session_id {
                 new_sessions.push(session_ids[i]);
@@ -608,9 +608,9 @@ actor Router {
         client_ids = new_client_ids;
         clients = new_clients;
         // Remove subscriptions for this client
-        let new_sub_topics: Vec<string> = Vec::new();
-        let new_sub_sessions: Vec<string> = Vec::new();
-        let new_sub_qos: Vec<i32> = Vec::new();
+        let new_sub_topics: Vec<string> = Vec.new();
+        let new_sub_sessions: Vec<string> = Vec.new();
+        let new_sub_qos: Vec<i32> = Vec.new();
         for j in 0 .. sub_session_ids.len() {
             if sub_session_ids[j] != session_id {
                 new_sub_topics.push(sub_topics[j]);
@@ -642,7 +642,7 @@ actor Acceptor {
             let conn = await lst.accept();
             let cid = f"client-{next_id}";
             let (input, sink) = conn.into_stream_sink();
-            let handler = spawn ClientHandler(sink: sink, session_id: cid.clone(), client_id: cid.clone(), router: router, buf: bytes::new(), registered: false);
+            let handler = spawn ClientHandler(sink: sink, session_id: cid.clone(), client_id: cid.clone(), router: router, buf: bytes.new(), registered: false);
             let reader = spawn ClientReader(input: input, client: handler);
             handler.register(reader);
             next_id = next_id + 1;
@@ -656,12 +656,12 @@ fn main() {
         port = os.args(1);
     }
     let addr = f"127.0.0.1:{port}";
-    let empty_sessions: Vec<string> = Vec::new();
-    let empty_ids: Vec<string> = Vec::new();
-    let empty_clients: Vec<LocalPid<ClientHandler>> = Vec::new();
-    let empty_sub_topics: Vec<string> = Vec::new();
-    let empty_sub_sessions: Vec<string> = Vec::new();
-    let empty_sub_qos: Vec<i32> = Vec::new();
+    let empty_sessions: Vec<string> = Vec.new();
+    let empty_ids: Vec<string> = Vec.new();
+    let empty_clients: Vec<LocalPid<ClientHandler>> = Vec.new();
+    let empty_sub_topics: Vec<string> = Vec.new();
+    let empty_sub_sessions: Vec<string> = Vec.new();
+    let empty_sub_qos: Vec<i32> = Vec.new();
     let router = spawn Router(session_ids: empty_sessions, client_ids: empty_ids, clients: empty_clients, sub_topics: empty_sub_topics, sub_session_ids: empty_sub_sessions, sub_qos: empty_sub_qos);
     let listener = spawn Acceptor(router: router, addr: addr);
     listener.start();

--- a/examples/multifile/02_geometry/main.hew
+++ b/examples/multifile/02_geometry/main.hew
@@ -7,7 +7,7 @@
 //
 // This file demonstrates three import styles against the same module:
 //
-//   import geo::{Point, origin, manhattan, chebyshev, bounding_area};
+//   import geo.{Point, origin, manhattan, chebyshev, bounding_area};
 //       → selective — only these names enter scope; no module prefix needed.
 //         No "unused import" warning as long as at least one imported name
 //         is called as a function.
@@ -15,7 +15,7 @@
 //   import geo;
 //       → bare — all pub names in scope, also available as geo.name(...).
 //
-//   import geo::*;
+//   import geo.*;
 //       → wildcard — all pub names in scope (same as bare), but the
 //         compiler currently emits a false-positive "unused import" warning
 //         when the import is consumed only through type/trait references.
@@ -23,7 +23,7 @@
 //
 // Run:   hew run   examples/multifile/02_geometry/main.hew
 // Check: hew check examples/multifile/02_geometry/main.hew
-import geo::{Point, origin, manhattan, chebyshev, bounding_area};
+import geo.{Point, origin, manhattan, chebyshev, bounding_area};
 
 fn main() {
     let o = origin();

--- a/examples/multifile/03_text_stats/main.hew
+++ b/examples/multifile/03_text_stats/main.hew
@@ -5,22 +5,22 @@
 //   text_stats/
 //     text_stats.hew     ← `text_stats` module entry
 //     words/
-//       words.hew        ← `text_stats::words` sub-module entry
+//       words.hew        ← `text_stats.words` sub-module entry
 //
-// Key point: `import text_stats;` and `import text_stats::words;` are two
+// Key point: `import text_stats;` and `import text_stats.words;` are two
 // independent imports.  The parent module does NOT automatically expose the
 // child module's symbols — you must import each level you want to use.
 //
 // This mirrors how large Hew projects are typically structured: a top-level
 // module (e.g. `http`) provides the most common API, while sub-modules
-// (e.g. `http::headers`, `http::status`) hold specialised helpers that
+// (e.g. `http.headers`, `http.status`) hold specialised helpers that
 // callers opt into individually.
 //
 // Run:   hew run   examples/multifile/03_text_stats/main.hew
 // Check: hew check examples/multifile/03_text_stats/main.hew
 import text_stats;
 
-import text_stats::words;
+import text_stats.words;
 
 fn main() {
     let sample = "the quick brown fox";

--- a/examples/multifile/03_text_stats/text_stats/text_stats.hew
+++ b/examples/multifile/03_text_stats/text_stats/text_stats.hew
@@ -1,9 +1,9 @@
 // text_stats.hew — entry file for the `text_stats` directory module.
 //
 // Provides top-level text analysis helpers.  The sub-directory
-// `words/` forms a child module (`text_stats::words`) with
+// `words/` forms a child module (`text_stats.words`) with
 // word-level utilities.  Importing `text_stats` does NOT
-// automatically import `text_stats::words`; callers must request
+// automatically import `text_stats.words`; callers must request
 // both explicitly when they want both.
 pub fn char_count(text: string) -> i64 {
     text.len()

--- a/examples/multifile/03_text_stats/text_stats/words/words.hew
+++ b/examples/multifile/03_text_stats/text_stats/words/words.hew
@@ -1,7 +1,7 @@
-// words.hew — the `text_stats::words` sub-module.
+// words.hew — the `text_stats.words` sub-module.
 //
 // Lives inside the `text_stats/words/` directory so its full import path
-// is `text_stats::words`.  This is a separate module from `text_stats`:
+// is `text_stats.words`.  This is a separate module from `text_stats`:
 // `import text_stats;` does not bring `words.*` into scope.
 //
 // A directory named `words` with a matching `words.hew` entry file is the

--- a/examples/net/await_http_codec_hardening.hew
+++ b/examples/net/await_http_codec_hardening.hew
@@ -8,13 +8,13 @@
 //! fails closed (400), and CRLF in caller-provided builder fields is rejected
 //! (no injected header). A clean run prints `codec-hardening-ok`.
 
-import std::net::http::http_async_server;
+import std.net.http.http_async_server;
 
-import std::net::http::http_async_client;
+import std.net.http.http_async_client;
 
-import std::string;
+import std.string;
 
-import std::testing;
+import std.testing;
 
 // ── F2: size caps fail closed (413 server / -1 client) ────────────────
 fn check_f2_size_caps() {

--- a/examples/net/await_http_roundtrip.hew
+++ b/examples/net/await_http_roundtrip.hew
@@ -13,13 +13,13 @@
 //! an opaque handle in actor state is rejected by the supervisor-restart clone
 //! gate.
 
-import std::net;
+import std.net;
 
-import std::net::http::http_async_server;
+import std.net.http.http_async_server;
 
-import std::net::http::http_async_client;
+import std.net.http.http_async_client;
 
-import std::string;
+import std.string;
 
 actor Server {
     let addr: string;

--- a/examples/net/await_read.hew
+++ b/examples/net/await_read.hew
@@ -11,7 +11,7 @@
 //! The `Connection` is a handler LOCAL (from `net.connect`), not actor state: an
 //! opaque handle in actor state is rejected by the supervisor-restart clone gate.
 
-import std::net;
+import std.net;
 
 actor Reader {
     let port: string;

--- a/examples/net/await_read_fanout.hew
+++ b/examples/net/await_read_fanout.hew
@@ -10,7 +10,7 @@
 //! deposit each socket's bytes into the right parked continuation, not cross
 //! them. A correct run prints `reader-i-got: payload-i` for every i.
 
-import std::net;
+import std.net;
 
 const READER_COUNT: i64 = 4;
 

--- a/examples/net/await_read_hup.hew
+++ b/examples/net/await_read_hup.hew
@@ -7,7 +7,7 @@
 //! blocking `hew_tcp_read`). A correct run resolves promptly — `read 0 bytes` —
 //! and exits, never deadlocking.
 
-import std::net;
+import std.net;
 
 actor Reader {
     receive fn go(unused: i64) {

--- a/examples/net/http_await_service.hew
+++ b/examples/net/http_await_service.hew
@@ -4,23 +4,23 @@
 //! The `Server` actor opens a listener and serves a fixed number of requests:
 //! for each it `await`s a connection, drives an `await conn.read_string()` loop
 //! until the request is fully buffered, parses it with the
-//! `std::net::http::http_async_server` codec, and dispatches on the path —
+//! `std.net.http.http_async_server` codec, and dispatches on the path —
 //! `/hello` returns plain text, `/health` returns JSON, anything else 404s.
 //! The `Client` actor issues two sequential requests with the
-//! `std::net::http::http_async_client` codec, `await`ing each response to close.
+//! `std.net.http.http_async_client` codec, `await`ing each response to close.
 //!
 //! Every `await` suspends the handler rather than blocking the worker, so a
 //! single worker (`HEW_WORKERS=1`) can both serve and fetch on the same thread.
 //! The `Listener` / `Connection` handles are handler LOCALS — an opaque handle
 //! in actor state is rejected by the supervisor-restart clone gate.
 
-import std::net;
+import std.net;
 
-import std::net::http::http_async_server;
+import std.net.http.http_async_server;
 
-import std::net::http::http_async_client;
+import std.net.http.http_async_client;
 
-import std::string;
+import std.string;
 
 actor Server {
     let addr: string;

--- a/examples/net/probe_a_conn_field.hew
+++ b/examples/net/probe_a_conn_field.hew
@@ -1,4 +1,4 @@
-import std::net::{Listener, Connection};
+import std.net.{Listener, Connection};
 
 extern "C" {
     fn hew_tcp_listener_local_port(listener: Listener) -> i32;

--- a/examples/net/probe_b2_closure_await_outer_crash.hew
+++ b/examples/net/probe_b2_closure_await_outer_crash.hew
@@ -17,7 +17,7 @@
 // resolves to `Err` (the empty crash fallback) and the program completes. The
 // `trigger` parameter is a runtime value so the panic is not statically
 // unreachable ahead of the await (the closure still classifies as suspending).
-import std::net::{Listener};
+import std.net.{Listener};
 
 extern "C" {
     fn hew_tcp_listener_local_port(listener: Listener) -> i32;
@@ -49,8 +49,8 @@ fn main() {
     let reader = spawn Reader(addr: f"127.0.0.1:{port}");
     let r = await reader.go(0);
     match r {
-        Ok(v) => println(f"reader-returned: {v}"),
-        Err(_) => println("reader-crash-fallback"),
+        .Ok(v) => println(f"reader-returned: {v}"),
+        .Err(_) => println("reader-crash-fallback"),
     }
     println("main-done");
 }

--- a/examples/net/probe_b2_closure_capture_await.hew
+++ b/examples/net/probe_b2_closure_capture_await.hew
@@ -1,4 +1,4 @@
-import std::net::{Listener};
+import std.net.{Listener};
 
 extern "C" {
     fn hew_tcp_listener_local_port(listener: Listener) -> i32;

--- a/examples/net/probe_b2_closure_multi_await.hew
+++ b/examples/net/probe_b2_closure_multi_await.hew
@@ -1,6 +1,6 @@
 //! Multi-suspend suspendable-callee: a closure whose body `await`s a captured
 //! Connection TWICE across the coroutine boundary. The driver
-//! (`Terminator.SuspendingCallClosure`) must re-park the calling actor on the
+//! (`Terminator::SuspendingCallClosure`) must re-park the calling actor on the
 //! SECOND await as well as the first — exercising the multi-suspend `.resume`
 //! edge (every park matched by exactly one resume). The first read binds the
 //! server's payload; the second read resumes on EOF (server close) and binds an

--- a/examples/net/probe_b2_closure_multi_await.hew
+++ b/examples/net/probe_b2_closure_multi_await.hew
@@ -1,13 +1,13 @@
 //! Multi-suspend suspendable-callee: a closure whose body `await`s a captured
 //! Connection TWICE across the coroutine boundary. The driver
-//! (`Terminator::SuspendingCallClosure`) must re-park the calling actor on the
+//! (`Terminator.SuspendingCallClosure`) must re-park the calling actor on the
 //! SECOND await as well as the first — exercising the multi-suspend `.resume`
 //! edge (every park matched by exactly one resume). The first read binds the
 //! server's payload; the second read resumes on EOF (server close) and binds an
 //! empty string (the NEW-1 EOF convention). Correct under HEW_WORKERS=1 proves
 //! the lone worker is freed across BOTH closure suspends.
 
-import std::net::{Listener};
+import std.net.{Listener};
 
 extern "C" {
     fn hew_tcp_listener_local_port(listener: Listener) -> i32;

--- a/examples/net/probe_b2_closure_unit_await.hew
+++ b/examples/net/probe_b2_closure_unit_await.hew
@@ -2,7 +2,7 @@
 //
 // `read_once` awaits the captured Connection but DISCARDS the read value, so the
 // closure's logical return is unit. The call site still lowers to
-// `Terminator.SuspendingCallClosure` (the body carries an `await` suspend), and
+// `Terminator::SuspendingCallClosure` (the body carries an `await` suspend), and
 // the driver's finish path takes the unit branch — which must release BOTH the
 // retained sender ref and the creator ref so the driver reply channel is
 // reclaimed exactly once (no leaked sender reference). Running it under both

--- a/examples/net/probe_b2_closure_unit_await.hew
+++ b/examples/net/probe_b2_closure_unit_await.hew
@@ -2,12 +2,12 @@
 //
 // `read_once` awaits the captured Connection but DISCARDS the read value, so the
 // closure's logical return is unit. The call site still lowers to
-// `Terminator::SuspendingCallClosure` (the body carries an `await` suspend), and
+// `Terminator.SuspendingCallClosure` (the body carries an `await` suspend), and
 // the driver's finish path takes the unit branch — which must release BOTH the
 // retained sender ref and the creator ref so the driver reply channel is
 // reclaimed exactly once (no leaked sender reference). Running it under both
 // pools proves the unit path suspends, resumes, and completes cleanly.
-import std::net::{Listener};
+import std.net.{Listener};
 
 extern "C" {
     fn hew_tcp_listener_local_port(listener: Listener) -> i32;

--- a/examples/net/probe_b3_closure_capture_noawait.hew
+++ b/examples/net/probe_b3_closure_capture_noawait.hew
@@ -1,4 +1,4 @@
-import std::net::{Listener};
+import std.net.{Listener};
 
 extern "C" {
     fn hew_tcp_listener_local_port(listener: Listener) -> i32;

--- a/examples/net/probe_opaque_actor_state.hew
+++ b/examples/net/probe_opaque_actor_state.hew
@@ -1,4 +1,4 @@
-import std::encoding::json;
+import std.encoding.json;
 
 actor Holder {
     let val: json.Value;

--- a/examples/net/tls_client.hew
+++ b/examples/net/tls_client.hew
@@ -2,7 +2,7 @@
 //!         status line over a real TLS round-trip.
 //! Description: TLS client — connect over TLS with system-root verification, then GET a page.
 //!
-//! This is the idiomatic `std::net::tls` client shape using the FREE-FUNCTION
+//! This is the idiomatic `std.net.tls` client shape using the FREE-FUNCTION
 //! surface (`tls.connect` / `tls.write` / `tls.read` / `tls.close`). The method
 //! form (`stream.read(n)`) is intentionally NOT used — it is not supported yet.
 //! Request/response bodies are `bytes`; build a request payload with the public
@@ -10,7 +10,7 @@
 //! The short write is detected with a fail-closed guard so the program
 //! terminates cleanly instead of blocking on a read that will never arrive.
 
-import std::net::tls;
+import std.net.tls;
 
 fn main() {
     let host = "example.com";
@@ -27,16 +27,16 @@ fn main() {
     // below runs.
     if sent == want {
         match tls.read(stream, 256) {
-            Ok(data) => {
+            .Ok(data) => {
                 let text = data.to_string();
                 let crlf = "\r\n";
                 let status_line = match text.find(crlf) {
-                    Some(cut) => text.slice(0, cut),
-                    None => text,
+                    .Some(cut) => text.slice(0, cut),
+                    .None => text,
                 };
                 println(f"response: {status_line}");
             },
-            Err(_) => println(f"read error: {tls.last_error()}"),
+            .Err(_) => println(f"read error: {tls.last_error()}"),
         }
     } else {
         println("short write — skipping read (TLS data-plane ABI gap)");

--- a/examples/network_file_reader.hew
+++ b/examples/network_file_reader.hew
@@ -17,7 +17,7 @@ fn fibonacci(n: i64) -> i64 {
     }
 }
 
-import std::fs;
+import std.fs;
 
 fn main() {
     println("=== File Reader + Actor Pipeline ===");

--- a/examples/observe-test-fixture.hew
+++ b/examples/observe-test-fixture.hew
@@ -1,4 +1,4 @@
-import std::observe;
+import std.observe;
 
 actor Counter {
     var count: i64;
@@ -29,12 +29,12 @@ fn main() {
     let counter = spawn Counter(count: 0);
     let pinger = spawn Pinger(target: counter);
     let sent = match await pinger.ping(7) {
-        Ok(value) => value,
-        Err(_) => -1,
+        .Ok(value) => value,
+        .Err(_) => -1,
     };
     let total = match await counter.total() {
-        Ok(value) => value,
-        Err(_) => -1,
+        .Ok(value) => value,
+        .Err(_) => -1,
     };
     println(f"observe fixture sent={sent} total={total}");
     let _barrier = observe.barrier();

--- a/examples/observe_showcase.hew
+++ b/examples/observe_showcase.hew
@@ -83,7 +83,7 @@ fn main() {
 
     // Start a distributed node — populates the Cluster tab with
     // membership, connection, and routing data.
-    Node::start("127.0.0.1:19000");
+    Node.start("127.0.0.1:19000");
 
     // Spawn a variety of actors with different workload profiles.
     let c1 = spawn Counter(name: 1, value: 0);
@@ -96,7 +96,7 @@ fn main() {
     sleep(100ms);
 
     // Register a named actor in the cluster registry.
-    Node::register("main_counter", c1);
+    Node.register("main_counter", c1);
     println("7 actors spawned. Running workload for 60 seconds...");
     println("Watch hew-observe tabs: Overview, Actors, Messages, Timeline");
     println("");
@@ -147,17 +147,17 @@ fn main() {
     let r2 = await c2.get();
     let r3 = await c3.get();
     let total = match r1 {
-        Ok(v) => v,
-        Err(_) => 0,
+        .Ok(v) => v,
+        .Err(_) => 0,
     } + match r2 {
-        Ok(v) => v,
-        Err(_) => 0,
+        .Ok(v) => v,
+        .Err(_) => 0,
     } + match r3 {
-        Ok(v) => v,
-        Err(_) => 0,
+        .Ok(v) => v,
+        .Err(_) => 0,
     };
     println("");
     println(f"Counter total: {total}");
-    Node::shutdown();
+    Node.shutdown();
     println("Showcase complete.");
 }

--- a/examples/observe_supervisor_showcase.hew
+++ b/examples/observe_supervisor_showcase.hew
@@ -183,12 +183,12 @@ fn main() {
     // Final tallies — proves the restarted worker kept processing and the
     // siblings were undisturbed by the crash.
     let a_total = match await alpha2.stats() {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     let b_total = match await beta.stats() {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     println("");
     print("alpha (restarted) processed: ");

--- a/examples/playground/concurrency/actor_pipeline.hew
+++ b/examples/playground/concurrency/actor_pipeline.hew
@@ -12,16 +12,16 @@ actor Doubler {
 fn main() {
     let doubler = spawn Doubler;
     let a = match await doubler.process(5) {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     let b = match await doubler.process(21) {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     let c = match await doubler.process(100) {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     println(f"got {a}, {b}, {c}");
 }

--- a/examples/playground/concurrency/async_await.hew
+++ b/examples/playground/concurrency/async_await.hew
@@ -21,7 +21,7 @@ fn main() {
     let fibber = spawn FibPrinter;
     let r = await fibber.print_fib(10);
     match r {
-        Ok(v) => println(f"awaited fib(10) = {v}"),
-        Err(_) => println("ask failed"),
+        .Ok(v) => println(f"awaited fib(10) = {v}"),
+        .Err(_) => println("ask failed"),
     }
 }

--- a/examples/playground/concurrency/counter_actor.hew
+++ b/examples/playground/concurrency/counter_actor.hew
@@ -21,8 +21,8 @@ fn main() {
     // hew:allow(must_use)
     await c.increment(3);
     let total = match await c.increment(12) {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     println(f"Final total: {total}");
 }

--- a/examples/playground/concurrency/supervisor.hew
+++ b/examples/playground/concurrency/supervisor.hew
@@ -23,12 +23,12 @@ fn main() {
     let w1 = workers.w1;
     let w2 = workers.w2;
     let a = match await w1.work(10) {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     let b = match await w2.work(20) {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     println(f"w1 -> {a}");
     println(f"w2 -> {b}");

--- a/examples/playground/language/match_guard.hew
+++ b/examples/playground/language/match_guard.hew
@@ -9,18 +9,18 @@ enum Score {
 
 fn classify(s: Score) -> string {
     match s {
-        High(n) if n > 90 => "excellent",
-        High(_) => "good",
-        Low(n) if n < 10 => "very low",
-        Low(_) => "low",
-        Zero => "zero",
+        .High(n) if n > 90 => "excellent",
+        .High(_) => "good",
+        .Low(n) if n < 10 => "very low",
+        .Low(_) => "low",
+        .Zero => "zero",
     }
 }
 
 fn main() {
-    println(classify(High(95)));
-    println(classify(High(70)));
-    println(classify(Low(5)));
-    println(classify(Low(40)));
-    println(classify(Zero));
+    println(classify(.High(95)));
+    println(classify(.High(70)));
+    println(classify(.Low(5)));
+    println(classify(.Low(40)));
+    println(classify(.Zero));
 }

--- a/examples/playground/language/wildcard_match.hew
+++ b/examples/playground/language/wildcard_match.hew
@@ -10,15 +10,15 @@ enum Signal {
 
 fn describe(s: Signal) -> string {
     match s {
-        Go => "proceed",
-        Stop => "halt",
+        .Go => "proceed",
+        .Stop => "halt",
         _ => "hold",
     }
 }
 
 fn main() {
-    println(describe(Go));
-    println(describe(Stop));
-    println(describe(Wait));
-    println(describe(Unknown));
+    println(describe(.Go));
+    println(describe(.Stop));
+    println(describe(.Wait));
+    println(describe(.Unknown));
 }

--- a/examples/playground/machines/traffic_light.hew
+++ b/examples/playground/machines/traffic_light.hew
@@ -22,12 +22,12 @@ machine TrafficLight {
 }
 
 fn main() {
-    var light = TrafficLight.Red;
+    var light: TrafficLight = .Red;
     println(light.state_name());
-    light.step(Tick);
+    light.step(.Tick);
     println(light.state_name());
-    light.step(Tick);
+    light.step(.Tick);
     println(light.state_name());
-    light.step(Tick);
+    light.step(.Tick);
     println(light.state_name());
 }

--- a/examples/playground/machines/traffic_light.hew
+++ b/examples/playground/machines/traffic_light.hew
@@ -22,7 +22,7 @@ machine TrafficLight {
 }
 
 fn main() {
-    var light = TrafficLight::Red;
+    var light = TrafficLight.Red;
     println(light.state_name());
     light.step(Tick);
     println(light.state_name());

--- a/examples/playground/manifest.json
+++ b/examples/playground/manifest.json
@@ -510,7 +510,7 @@
     "id": "types/vec_f64_nonfinite_contains",
     "category": "types",
     "name": "Vec<f64> Non-Finite Contains",
-    "description": "Vec<f64>::contains follows native fcmp-OEQ semantics for NaN and +-Infinity",
+    "description": "Vec<f64>.contains follows native fcmp-OEQ semantics for NaN and +-Infinity",
     "source_path": "types/vec_f64_nonfinite_contains.hew",
     "expected_path": "types/vec_f64_nonfinite_contains.expected",
     "capabilities": {

--- a/examples/playground/types/collections.hew
+++ b/examples/playground/types/collections.hew
@@ -2,7 +2,7 @@
 //! @description Vec collection: push, index, and iterate
 
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10);
     v.push(20);
     v.push(30);

--- a/examples/playground/types/generic_aggregate_eq.hew
+++ b/examples/playground/types/generic_aggregate_eq.hew
@@ -27,14 +27,14 @@ fn bag_same<T>(a: Bag<T>, b: Bag<T>) -> bool {
 }
 
 fn make_bag_1_2() -> Bag<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(1);
     v.push(2);
     Bag { items: v }
 }
 
 fn make_bag_1_3() -> Bag<i64> {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(1);
     v.push(3);
     Bag { items: v }

--- a/examples/playground/types/method_clone.hew
+++ b/examples/playground/types/method_clone.hew
@@ -7,8 +7,8 @@ fn takes_slice(xs: [i64]) -> i64 {
 }
 
 fn main() {
-    // Vec<T>::clone() — mutating the original after clone does not affect the copy.
-    let nums = Vec::new();
+    // Vec<T>.clone() — mutating the original after clone does not affect the copy.
+    let nums = Vec.new();
     nums.push(1);
     nums.push(2);
     let nums_copy = nums.clone();

--- a/examples/playground/types/pattern_matching.hew
+++ b/examples/playground/types/pattern_matching.hew
@@ -9,16 +9,16 @@ enum Shape {
 
 fn area(shape: Shape) -> i64 {
     match shape {
-        Circle(r) => r * r * 3,
-        Rectangle(w, h) => w * h,
-        Triangle(b, h) => b * h / 2,
+        .Circle(r) => r * r * 3,
+        .Rectangle(w, h) => w * h,
+        .Triangle(b, h) => b * h / 2,
     }
 }
 
 fn main() {
-    let c = Circle(5);
-    let r = Rectangle(4, 6);
-    let t = Triangle(3, 8);
+    let c = Shape.Circle(5);
+    let r = Shape.Rectangle(4, 6);
+    let t = Shape.Triangle(3, 8);
     print("Circle area: ");
     println(area(c));
     print("Rectangle area: ");

--- a/examples/playground/types/record_equality.hew
+++ b/examples/playground/types/record_equality.hew
@@ -19,9 +19,9 @@ fn main() {
     println(a == c);
     println(a != c);
     println(a != b);
-    let s1 = Circle(5);
-    let s2 = Circle(5);
-    let s3 = Square(5);
+    let s1 = Shape.Circle(5);
+    let s2 = Shape.Circle(5);
+    let s3 = Shape.Square(5);
     println(s1 == s2);
     println(s1 == s3);
     println(s1 != s3);

--- a/examples/playground/types/record_types.hew
+++ b/examples/playground/types/record_types.hew
@@ -18,16 +18,16 @@ enum Shape {
 
 fn area_description(s: Shape) -> string {
     match s {
-        Dot(_p) => "a single point",
-        Ring(c) => f"a circle with radius {c.radius}",
+        .Dot(_p) => "a single point",
+        .Ring(c) => f"a circle with radius {c.radius}",
     }
 }
 
 fn main() {
     let origin = Point { x: 0, y: 0 };
-    let dot = Dot(origin);
+    let dot = Shape.Dot(origin);
     println(area_description(dot));
     let centre = Point { x: 3, y: 4 };
-    let ring = Ring(Circle { centre: centre, radius: 10 });
+    let ring = Shape.Ring(Circle { centre: centre, radius: 10 });
     println(area_description(ring));
 }

--- a/examples/playground/types/vec_f64_nonfinite_contains.hew
+++ b/examples/playground/types/vec_f64_nonfinite_contains.hew
@@ -1,24 +1,24 @@
 //! @name Vec<f64> Non-Finite Contains
-//! @description Vec<f64>::contains follows native fcmp-OEQ semantics for NaN and +-Infinity
+//! @description Vec<f64>.contains follows native fcmp-OEQ semantics for NaN and +-Infinity
 
 fn main() {
     let zero: f64 = 0.0;
     let nan: f64 = zero / zero;
     let inf: f64 = 1.0 / zero;
     let neg_inf: f64 = -1.0 / zero;
-    let nans: Vec<f64> = Vec::new();
+    let nans: Vec<f64> = Vec.new();
     nans.push(nan);
     // NaN never compares equal to anything (fcmp OEQ returns false for any NaN
     // operand) — matches native hew_vec_contains_f64 exact-equality scan.
     println(f"[nan].contains(nan)   {nans.contains(nan)}");
     println(f"[nan].contains(inf)   {nans.contains(inf)}");
-    let infs: Vec<f64> = Vec::new();
+    let infs: Vec<f64> = Vec.new();
     infs.push(inf);
     // +Infinity and -Infinity are distinct values under OEQ.
     println(f"[inf].contains(-inf)  {infs.contains(neg_inf)}");
 
     // Positive control: finite exact match must still work.
-    let nums: Vec<f64> = Vec::new();
+    let nums: Vec<f64> = Vec.new();
     nums.push(2.5);
     println(f"[2.5].contains(2.5)   {nums.contains(2.5)}");
     println(f"[2.5].contains(nan)   {nums.contains(nan)}");

--- a/examples/playground/types/vec_inclusive_slice.hew
+++ b/examples/playground/types/vec_inclusive_slice.hew
@@ -3,7 +3,7 @@
 //! included in the slice, matching native semantics.
 
 fn main() {
-    let words: Vec<string> = Vec::new();
+    let words: Vec<string> = Vec.new();
     words.push("alpha");
     words.push("beta");
     words.push("gamma");
@@ -16,7 +16,7 @@ fn main() {
     println(f"slice[0]: {slice[0]}");
     println(f"slice[1]: {slice[1]}");
     println(f"slice[2]: {slice[2]}");
-    let nums: Vec<i64> = Vec::new();
+    let nums: Vec<i64> = Vec.new();
     nums.push(10);
     nums.push(20);
     nums.push(30);

--- a/examples/playground/types/vec_operations.hew
+++ b/examples/playground/types/vec_operations.hew
@@ -2,7 +2,7 @@
 //! @description Vec<T> element search and range slicing
 
 fn main() {
-    let words: Vec<string> = Vec::new();
+    let words: Vec<string> = Vec.new();
     words.push("alpha");
     words.push("beta");
     words.push("gamma");
@@ -13,7 +13,7 @@ fn main() {
     println(f"slice length:   {slice.len()}");
     println(f"slice[0]:       {slice[0]}");
     println(f"slice[1]:       {slice[1]}");
-    let nums: Vec<i64> = Vec::new();
+    let nums: Vec<i64> = Vec.new();
     nums.push(10);
     nums.push(20);
     nums.push(30);

--- a/examples/progressive/07_enums.hew
+++ b/examples/progressive/07_enums.hew
@@ -14,17 +14,17 @@ enum Status {
 
 fn colour_to_int(c: Colour) -> i64 {
     match c {
-        Red => 1,
-        Green => 2,
-        Blue => 3,
+        .Red => 1,
+        .Green => 2,
+        .Blue => 3,
     }
 }
 
 fn status_to_int(s: Status) -> i64 {
     match s {
-        Active => 100,
-        Inactive => 200,
-        Pending => 300,
+        .Active => 100,
+        .Inactive => 200,
+        .Pending => 300,
     }
 }
 

--- a/examples/progressive/08_vectors.hew
+++ b/examples/progressive/08_vectors.hew
@@ -1,7 +1,7 @@
 // Test 8: Vectors/Arrays
 // Testing Vec operations
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10);
     v.push(20);
     v.push(30);

--- a/examples/progressive/09_simple_actor.hew
+++ b/examples/progressive/09_simple_actor.hew
@@ -16,7 +16,7 @@ fn main() {
     counter.increment(10);
     // Actor asks return Result<T, string> — use `match await` to extract the value.
     match await counter.get_count() {
-        Ok(count) => println(count),
-        Err(_) => println("ask failed"),
+        .Ok(count) => println(count),
+        .Err(_) => println("ask failed"),
     }
 }

--- a/examples/progressive/10_lambda_actor.hew
+++ b/examples/progressive/10_lambda_actor.hew
@@ -6,16 +6,16 @@ fn main() {
         println(msg * 2);
     };
     match counter.send(5) {
-        Ok(_) => {},
-        Err(_) => panic("failed to send 5"),
+        .Ok(_) => {},
+        .Err(_) => panic("failed to send 5"),
     }
     match counter.send(10) {
-        Ok(_) => {},
-        Err(_) => panic("failed to send 10"),
+        .Ok(_) => {},
+        .Err(_) => panic("failed to send 10"),
     }
     match counter.send(15) {
-        Ok(_) => {},
-        Err(_) => panic("failed to send 15"),
+        .Ok(_) => {},
+        .Err(_) => panic("failed to send 15"),
     }
     await counter.close();
 }

--- a/examples/progressive/12_if_let.hew
+++ b/examples/progressive/12_if_let.hew
@@ -2,19 +2,19 @@
 // Testing pattern matching in conditionals and loops
 fn main() {
     let first: Option<i64> = Some(42);
-    if let Some(value) = first {
+    if let .Some(value) = first {
         println(value);
     } else {
         println(0);
     }
     let missing: Option<i64> = None;
-    if let Some(value) = missing {
+    if let .Some(value) = missing {
         println(value);
     } else {
         println("no value");
     }
     var current: Option<i64> = Some(3);
-    while let Some(value) = current {
+    while let .Some(value) = current {
         println(value);
         if value > 0 {
             current = Some(value - 1);

--- a/examples/quic_mesh/client.hew
+++ b/examples/quic_mesh/client.hew
@@ -16,7 +16,7 @@ actor Counter {
     var count: i64;
     receive fn handle(msg: CounterMsg) {
         match msg {
-            CounterMsg::Increment(n) => {
+            CounterMsg.Increment(n) => {
                 count = count + n;
             },
         }
@@ -33,10 +33,10 @@ impl ActorMsg for Counter {
 
 fn lookup_counter() -> Result<RemotePid<Counter>, LookupError> {
     for attempt in 0 .. 40 {
-        let found: Result<RemotePid<Counter>, LookupError> = Node::lookup("counter");
+        let found: Result<RemotePid<Counter>, LookupError> = Node.lookup("counter");
         match found {
-            Ok(counter) => return Ok(counter),
-            Err(error) => {
+            .Ok(counter) => return Ok(counter),
+            .Err(error) => {
                 if attempt == 39 {
                     return Err(error);
                 }
@@ -44,43 +44,43 @@ fn lookup_counter() -> Result<RemotePid<Counter>, LookupError> {
             },
         }
     }
-    Err(LookupError::NotFound)
+    Err(LookupError.NotFound)
 }
 
 fn main() {
     println("[client] starting QUIC mesh node...");
-    Node::set_transport("quic");
-    Node::start("127.0.0.1:9001");
+    Node.set_transport("quic");
+    Node.start("127.0.0.1:9001");
     println("[client] listening on 127.0.0.1:9001 (QUIC/TLS 1.3)");
 
     // Connect to the server node over QUIC.
     println("[client] connecting to server at 127.0.0.1:9000...");
-    Node::connect("127.0.0.1:9000");
+    Node.connect("127.0.0.1:9000");
     println("[client] connected (QUIC/TLS 1.3 encrypted)");
 
     // Look up the remote Counter actor via cross-node registry gossip.
     let found = lookup_counter();
     match found {
-        Err(_) => println("[client] remote 'counter' actor was not found"),
-        Ok(counter) => {
+        .Err(_) => println("[client] remote 'counter' actor was not found"),
+        .Ok(counter) => {
             println("[client] found remote 'counter' actor via registry gossip");
-            match counter.send(CounterMsg::Increment(10)) {
-                Ok(_) => {},
-                Err(_) => println("[client] failed to send increment 10"),
+            match counter.send(CounterMsg.Increment(10)) {
+                .Ok(_) => {},
+                .Err(_) => println("[client] failed to send increment 10"),
             }
-            match counter.send(CounterMsg::Increment(20)) {
-                Ok(_) => {},
-                Err(_) => println("[client] failed to send increment 20"),
+            match counter.send(CounterMsg.Increment(20)) {
+                .Ok(_) => {},
+                .Err(_) => println("[client] failed to send increment 20"),
             }
-            match counter.send(CounterMsg::Increment(30)) {
-                Ok(_) => {},
-                Err(_) => println("[client] failed to send increment 30"),
+            match counter.send(CounterMsg.Increment(30)) {
+                .Ok(_) => {},
+                .Err(_) => println("[client] failed to send increment 30"),
             }
             println("[client] sent 3 increments to remote counter");
         },
     }
     // Allow messages to be delivered.
     sleep(500ms);
-    Node::shutdown();
+    Node.shutdown();
     println("[client] shut down");
 }

--- a/examples/quic_mesh/node_namespace_smoke.hew
+++ b/examples/quic_mesh/node_namespace_smoke.hew
@@ -1,9 +1,9 @@
-// node_namespace_smoke.hew — exercises all four Node:: namespace builtins (A7 S1).
+// node_namespace_smoke.hew — exercises all four Node. namespace builtins (A7 S1).
 //
-// Validates that Node::set_transport, Node::start, Node::connect, and
-// Node::shutdown resolve in HIR (no UnresolvedSymbol) and run without panicking.
+// Validates that Node.set_transport, Node.start, Node.connect, and
+// Node.shutdown resolve in HIR (no UnresolvedSymbol) and run without panicking.
 //
-// Node::connect targets a loopback address with no listener; the underlying
+// Node.connect targets a loopback address with no listener; the underlying
 // hew_node_api_connect returns -1 and sets the last-error string, but since
 // the builtin is typed Unit the return value is discarded.  The program still
 // exits 0, which is the expected outcome for this smoke gate.
@@ -11,9 +11,9 @@
 // Run:
 //   hew run examples/quic_mesh/node_namespace_smoke.hew
 fn main() {
-    Node::set_transport("tcp");
-    Node::start("127.0.0.1:0");
-    Node::connect("127.0.0.1:9001");
-    Node::shutdown();
+    Node.set_transport("tcp");
+    Node.start("127.0.0.1:0");
+    Node.connect("127.0.0.1:9001");
+    Node.shutdown();
     println("node_namespace_smoke: ok");
 }

--- a/examples/quic_mesh/server.hew
+++ b/examples/quic_mesh/server.hew
@@ -1,7 +1,7 @@
 // quic_mesh/server.hew — QUIC mesh server node
 //
 // Demonstrates:
-//   - Node::set_transport("quic") for QUIC-based mesh (TLS 1.3)
+//   - Node.set_transport("quic") for QUIC-based mesh (TLS 1.3)
 //   - Spawning, registering, and serving a named actor
 //   - Receiving remote messages from a connected client
 //
@@ -16,7 +16,7 @@ actor Counter {
     var count: i64;
     receive fn handle(msg: CounterMsg) {
         match msg {
-            CounterMsg::Increment(n) => {
+            CounterMsg.Increment(n) => {
                 count = count + n;
                 println(f"[server] counter incremented by {n} → {count}");
             },
@@ -34,20 +34,20 @@ impl ActorMsg for Counter {
 
 fn main() {
     println("[server] starting QUIC mesh node...");
-    Node::set_transport("quic");
-    Node::start("127.0.0.1:9000");
+    Node.set_transport("quic");
+    Node.start("127.0.0.1:9000");
     println("[server] listening on 127.0.0.1:9000 (QUIC/TLS 1.3)");
     let counter = spawn Counter(count: 0);
-    Node::register("counter", counter);
+    Node.register("counter", counter);
     println("[server] registered 'counter' actor, waiting for clients...");
 
     // Keep alive to serve remote messages.
     sleep(5s);
     let final_count = await counter.get_count();
     match final_count {
-        Ok(n) => println(f"[server] final count: {n}"),
-        Err(_) => println("[server] failed to get count"),
+        .Ok(n) => println(f"[server] final count: {n}"),
+        .Err(_) => println("[server] failed to get count"),
     }
-    Node::shutdown();
+    Node.shutdown();
     println("[server] shut down");
 }

--- a/examples/quic_service/client.hew
+++ b/examples/quic_service/client.hew
@@ -1,7 +1,7 @@
 // client.hew — Minimal QUIC remote service client
 //
 // Demonstrates:
-//   - Using std::net::quic public API to create a QUIC client endpoint
+//   - Using std.net.quic public API to create a QUIC client endpoint
 //   - Dialing a remote QUIC server
 //   - Opening a stream and sending UTF-8 string messages
 //   - Preserving the finish/recv/close ordering used by the working loopback test
@@ -12,16 +12,16 @@
 //
 // Optional:
 //   HEW_QUIC_SERVICE_PORT=4545 hew run examples/quic_service/client.hew
-import std::net;
+import std.net;
 
-import std::net::quic;
+import std.net.quic;
 
-import std::os;
+import std.os;
 
 fn assert_ok(result: Result<(), net.NetError>) {
     match result {
-        Ok(_) => assert(true),
-        Err(e) => panic("quic operation failed: " + net.net_error_message(e)),
+        .Ok(_) => assert(true),
+        .Err(e) => panic("quic operation failed: " + net.net_error_message(e)),
     }
 }
 

--- a/examples/quic_service/server.hew
+++ b/examples/quic_service/server.hew
@@ -1,7 +1,7 @@
 // server.hew — Minimal QUIC-based remote service
 //
 // Demonstrates:
-//   - Using std::net::quic public API to bind a QUIC server endpoint
+//   - Using std.net.quic public API to bind a QUIC server endpoint
 //   - Accepting a remote connection
 //   - Receiving and sending UTF-8 string messages over QUIC streams
 //   - Preserving the finish/close/disconnect ordering used by the working loopback test
@@ -15,16 +15,16 @@
 //
 // Optional:
 //   HEW_QUIC_SERVICE_PORT=4545 hew run examples/quic_service/server.hew
-import std::net;
+import std.net;
 
-import std::net::quic;
+import std.net.quic;
 
-import std::os;
+import std.os;
 
 fn assert_ok(result: Result<(), net.NetError>) {
     match result {
-        Ok(_) => assert(true),
-        Err(e) => panic("quic operation failed: " + net.net_error_message(e)),
+        .Ok(_) => assert(true),
+        .Err(e) => panic("quic operation failed: " + net.net_error_message(e)),
     }
 }
 

--- a/examples/result_option_test.hew
+++ b/examples/result_option_test.hew
@@ -6,16 +6,16 @@
 fn test_option_some() -> i64 {
     let x = Some(42);
     match x {
-        Some(val) => val,
-        None => -1,
+        .Some(val) => val,
+        .None => -1,
     }
 }
 
 fn test_option_none() -> i64 {
     let x: Option<i64> = None;
     match x {
-        Some(val) => val,
-        None => -1,
+        .Some(val) => val,
+        .None => -1,
     }
 }
 
@@ -30,16 +30,16 @@ fn divide(a: i64, b: i64) -> Result<i64, string> {
 fn test_result_ok() -> i64 {
     let result = divide(10, 2);
     match result {
-        Ok(val) => val,
-        Err(_) => -1,
+        .Ok(val) => val,
+        .Err(_) => -1,
     }
 }
 
 fn test_result_err() -> i64 {
     let result = divide(10, 0);
     match result {
-        Ok(val) => val,
-        Err(_) => -1,
+        .Ok(val) => val,
+        .Err(_) => -1,
     }
 }
 
@@ -51,16 +51,16 @@ fn try_divide(a: i64, b: i64) -> Result<i64, string> {
 fn test_try_operator() -> i64 {
     let result = try_divide(10, 2);
     match result {
-        Ok(val) => val,
-        Err(_) => -999,
+        .Ok(val) => val,
+        .Err(_) => -999,
     }
 }
 
 fn test_try_operator_error() -> i64 {
     let result = try_divide(10, 0);
     match result {
-        Ok(val) => val,
-        Err(_) => -999,
+        .Ok(val) => val,
+        .Err(_) => -999,
     }
 }
 

--- a/examples/sandbox-graduation/option_some_none.hew
+++ b/examples/sandbox-graduation/option_some_none.hew
@@ -1,7 +1,7 @@
 fn describe(value: Option<i64>) -> i64 {
     match value {
-        Some(x) => x,
-        None => 0,
+        .Some(x) => x,
+        .None => 0,
     }
 }
 

--- a/examples/sandbox-graduation/regex_clone.hew
+++ b/examples/sandbox-graduation/regex_clone.hew
@@ -1,4 +1,4 @@
-import std::text::regex;
+import std.text.regex;
 
 fn main() {
     let re = regex.new("a+");

--- a/examples/sandbox-graduation/trap_residual.hew
+++ b/examples/sandbox-graduation/trap_residual.hew
@@ -58,19 +58,19 @@ fn main() {
     let letter: char = 'A';
     println(letter as u32);
     match try_result_ok() {
-        Ok(value) => println(value),
-        Err(error) => println(error),
+        .Ok(value) => println(value),
+        .Err(error) => println(error),
     }
     match try_result_err() {
-        Ok(value) => println(value),
-        Err(error) => println(error),
+        .Ok(value) => println(value),
+        .Err(error) => println(error),
     }
     match try_option_some() {
-        Some(value) => println(value),
-        None => println("none"),
+        .Some(value) => println(value),
+        .None => println("none"),
     }
     match try_option_none() {
-        Some(value) => println(value),
-        None => println("none"),
+        .Some(value) => println(value),
+        .None => println("none"),
     }
 }

--- a/examples/sandbox-graduation/wrapping_binary_operators.hew
+++ b/examples/sandbox-graduation/wrapping_binary_operators.hew
@@ -3,7 +3,7 @@
 // an operation overflows. This pins the parity fixed in #2341: before the VM
 // applied `asIntN(64)` truncation, an overflowing wrapping op produced a
 // mathematically-unbounded value (e.g. it kept 2^63 instead of wrapping to
-// `i64::MIN`).
+// `i64.MIN`).
 //
 // The overflowing values below are *computed* from safe-range literals via
 // wrapping multiplication, so every literal stays inside the JS safe-integer
@@ -16,7 +16,7 @@ fn main() {
     println(f"wsub: {a &- b}");
     println(f"wmul: {a &* b}");
 
-    // 3037000500^2 = 9223372037000250000 > i64::MAX, so the wrapping multiply
+    // 3037000500^2 = 9223372037000250000 > i64.MAX, so the wrapping multiply
     // overflows and wraps to a two's-complement negative. Non-truncating math
     // would instead keep the unbounded positive product.
     let base = 3037000500;

--- a/examples/sensor_mesh.hew
+++ b/examples/sensor_mesh.hew
@@ -16,17 +16,17 @@ actor Logger {
     // Simulate temperature with variation
 
     // ── In distributed mode, each of these would be on a different node:
-    // Node::start("0.0.0.0:9000");  // logger node
+    // Node.start("0.0.0.0:9000");  // logger node
 
-    // Node::register("logger", logger);
+    // Node.register("logger", logger);
 
-    // Node::start("0.0.0.0:9001");  // monitor node
-    // let logger = Node::lookup("logger");
+    // Node.start("0.0.0.0:9001");  // monitor node
+    // let logger = Node.lookup("logger");
 
-    // Node::register("monitor", monitor);
+    // Node.register("monitor", monitor);
 
-    // Node::start("0.0.0.0:9002");  // sensor node
-    // let monitor = Node::lookup("monitor");
+    // Node.start("0.0.0.0:9002");  // sensor node
+    // let monitor = Node.lookup("monitor");
 
     // Simulate 6 ticks
     var count: i32;
@@ -69,7 +69,7 @@ actor Sensor {
 fn main() {
     println("=== Sensor Mesh Demo ===");
     let logger = spawn Logger(count: 0);
-    let empty: Vec<i32> = Vec::new();
+    let empty: Vec<i32> = Vec.new();
     let monitor = spawn Monitor(readings: empty, logger: logger, threshold: 30);
     let s1 = spawn Sensor(sensor_id: "sensor-A", monitor: monitor, base_temp: 25);
     let s2 = spawn Sensor(sensor_id: "sensor-B", monitor: monitor, base_temp: 31);

--- a/examples/services/circuit_breaker.hew
+++ b/examples/services/circuit_breaker.hew
@@ -61,8 +61,8 @@ actor CircuitBreaker {
             -1
         } else {
             let result = match await backend.call(id) {
-                Ok(value) => value,
-                Err(_) => -1,
+                .Ok(value) => value,
+                .Err(_) => -1,
             };
             if result < 0 {
                 // Backend returned an error — count as failure
@@ -124,13 +124,13 @@ fn main() {
     println("");
     println("--- Breaker is open (fast-fail) ---");
     let rejected = match await breaker.request(7) {
-        Ok(value) => value,
-        Err(_) => -3,
+        .Ok(value) => value,
+        .Err(_) => -3,
     };
     println(f"Result while open: {rejected}");
     let rejected2 = match await breaker.request(8) {
-        Ok(value) => value,
-        Err(_) => -3,
+        .Ok(value) => value,
+        .Err(_) => -3,
     };
     println(f"Result while open: {rejected2}");
 
@@ -144,8 +144,8 @@ fn main() {
     breaker.probe();
     sleep(20ms);
     let probe_result = match await breaker.request(9) {
-        Ok(value) => value,
-        Err(_) => -3,
+        .Ok(value) => value,
+        .Err(_) => -3,
     };
     println(f"Probe request result: {probe_result}");
 
@@ -155,8 +155,8 @@ fn main() {
     let _ = await breaker.request(10);
     let _ = await breaker.request(11);
     let final_state = match await breaker.get_state() {
-        Ok(value) => value,
-        Err(_) => -1,
+        .Ok(value) => value,
+        .Err(_) => -1,
     };
     println(f"Final breaker state: {final_state} (0=Closed)");
     println("");

--- a/examples/services/distributed_counter.hew
+++ b/examples/services/distributed_counter.hew
@@ -17,7 +17,7 @@
 //
 // This example runs all replicas in one process to focus on the replication
 // pattern. A multi-node version would add a #[wire] message envelope and an
-// ActorMsg implementation before using Node::start/register/lookup.
+// ActorMsg implementation before using Node.start/register/lookup.
 
 // Coordinator — merges replica counts into a global total.
 actor Coordinator {
@@ -84,15 +84,15 @@ fn main() {
     println("");
 
     // Create coordinator
-    let empty_names: Vec<string> = Vec::new();
-    let empty_totals: Vec<i64> = Vec::new();
+    let empty_names: Vec<string> = Vec.new();
+    let empty_totals: Vec<i64> = Vec.new();
     let coord = spawn Coordinator(replica_names: empty_names, replica_totals: empty_totals, global_total: 0, sync_count: 0);
     // Create replicas (in production these would be on separate nodes)
-    // Node::start("0.0.0.0:9000");
+    // Node.start("0.0.0.0:9000");
     let r1 = spawn Replica(name: "node-1", coordinator: coord, local_count: 0);
     let r2 = spawn Replica(name: "node-2", coordinator: coord, local_count: 0);
     let r3 = spawn Replica(name: "node-3", coordinator: coord, local_count: 0);
-    // Node::register("counter-1", r1);
+    // Node.register("counter-1", r1);
 
     // Register replicas with coordinator
     coord.register_replica("node-1");
@@ -121,8 +121,8 @@ fn main() {
 
     // ── Read global total ──
     let global = match await coord.get_global() {
-        Ok(value) => value,
-        Err(_) => -1,
+        .Ok(value) => value,
+        .Err(_) => -1,
     };
     println(f"Global counter: {global}");
     // Expected: 5+3 + 10 + 7+2 = 27
@@ -140,8 +140,8 @@ fn main() {
     r3.sync_to_coordinator();
     sleep(30ms);
     let global2 = match await coord.get_global() {
-        Ok(value) => value,
-        Err(_) => -1,
+        .Ok(value) => value,
+        .Err(_) => -1,
     };
     println(f"Global counter after update: {global2}");
     // Expected: 108 + 210 + 9 = 327

--- a/examples/services/health_monitor.hew
+++ b/examples/services/health_monitor.hew
@@ -6,7 +6,7 @@
 // (Envoy, Linkerd) and orchestrators (Kubernetes liveness probes).
 //
 // In Go you'd write a goroutine with a time.Ticker, a map of health
-// statuses, and a mutex to protect it. In Rust you'd use tokio.time
+// statuses, and a mutex to protect it. In Rust you'd use tokio::time
 // with Arc<RwLock<HashMap>>.
 //
 // In Hew the monitor is an actor. Health state is actor state — no

--- a/examples/services/health_monitor.hew
+++ b/examples/services/health_monitor.hew
@@ -6,7 +6,7 @@
 // (Envoy, Linkerd) and orchestrators (Kubernetes liveness probes).
 //
 // In Go you'd write a goroutine with a time.Ticker, a map of health
-// statuses, and a mutex to protect it. In Rust you'd use tokio::time
+// statuses, and a mutex to protect it. In Rust you'd use tokio.time
 // with Arc<RwLock<HashMap>>.
 //
 // In Hew the monitor is an actor. Health state is actor state — no
@@ -56,8 +56,8 @@ actor HealthMonitor {
         println(f"[monitor] --- health check #{check_count} ---");
         for i in 0 .. svc_refs.len() {
             let svc = match svc_refs.get(i) {
-                Some(value) => value,
-                None => panic("service registry is inconsistent"),
+                .Some(value) => value,
+                .None => panic("service registry is inconsistent"),
             };
             // Use select with timeout — if the service doesn't respond
             // within 500ms, mark it unhealthy.
@@ -66,8 +66,8 @@ actor HealthMonitor {
                 after 500ms => -1,
             };
             let svc_name = match svc_names.get(i) {
-                Some(value) => value,
-                None => panic("service registry is inconsistent"),
+                .Some(value) => value,
+                .None => panic("service registry is inconsistent"),
             };
             if result == 1 {
                 svc_status.set(i, 1);
@@ -85,12 +85,12 @@ actor HealthMonitor {
         let total = svc_names.len();
         for i in 0 .. total {
             let name = match svc_names.get(i) {
-                Some(value) => value,
-                None => panic("service registry is inconsistent"),
+                .Some(value) => value,
+                .None => panic("service registry is inconsistent"),
             };
             let status = match svc_status.get(i) {
-                Some(value) => value,
-                None => panic("service registry is inconsistent"),
+                .Some(value) => value,
+                .None => panic("service registry is inconsistent"),
             };
             if status == 1 {
                 println(f"  {name}: UP");
@@ -113,9 +113,9 @@ fn main() {
     let api = spawn Service(name: "api", healthy: 1, requests: 0);
     let cache = spawn Service(name: "cache", healthy: 1, requests: 0);
     // Create monitor
-    let empty_names: Vec<string> = Vec::new();
-    let empty_refs: Vec<LocalPid<Service>> = Vec::new();
-    let empty_status: Vec<i64> = Vec::new();
+    let empty_names: Vec<string> = Vec.new();
+    let empty_refs: Vec<LocalPid<Service>> = Vec.new();
+    let empty_status: Vec<i64> = Vec.new();
     let monitor = spawn HealthMonitor(svc_names: empty_names, svc_refs: empty_refs, svc_status: empty_status, check_count: 0);
     // Register services
     monitor.register("auth", auth);

--- a/examples/services/pub_sub.hew
+++ b/examples/services/pub_sub.hew
@@ -7,7 +7,7 @@
 //
 // In Go you'd build this with channels, a map[string][]chan, and a
 // select loop (~120 lines plus race-condition debugging). In Rust
-// you'd use tokio.broadcast or a manual Arc<RwLock<HashMap>>.
+// you'd use tokio::broadcast or a manual Arc<RwLock<HashMap>>.
 //
 // In Hew the broker is an actor. Subscriptions are just state.
 // Fan-out is just a loop calling receive handlers. No locks, no

--- a/examples/services/pub_sub.hew
+++ b/examples/services/pub_sub.hew
@@ -7,7 +7,7 @@
 //
 // In Go you'd build this with channels, a map[string][]chan, and a
 // select loop (~120 lines plus race-condition debugging). In Rust
-// you'd use tokio::broadcast or a manual Arc<RwLock<HashMap>>.
+// you'd use tokio.broadcast or a manual Arc<RwLock<HashMap>>.
 //
 // In Hew the broker is an actor. Subscriptions are just state.
 // Fan-out is just a loop calling receive handlers. No locks, no
@@ -69,8 +69,8 @@ fn main() {
     println("");
 
     // Create broker
-    let empty_topics: Vec<string> = Vec::new();
-    let empty_actors: Vec<LocalPid<Subscriber>> = Vec::new();
+    let empty_topics: Vec<string> = Vec.new();
+    let empty_actors: Vec<LocalPid<Subscriber>> = Vec.new();
     let broker = spawn Broker(sub_topics: empty_topics, sub_actors: empty_actors, published: 0);
     // Create subscribers
     let alice = spawn Subscriber(name: "alice", received: 0);

--- a/examples/services/rate_limiter.hew
+++ b/examples/services/rate_limiter.hew
@@ -5,7 +5,7 @@
 // at a fixed rate up to a maximum, and each request consumes one token.
 //
 // In Go you'd use golang.org/x/time/rate (mutex-guarded float64 state).
-// In Rust you'd use governor or tower.limit (generic middleware layers).
+// In Rust you'd use governor or tower::limit (generic middleware layers).
 // In Hew the rate limiter is an actor — requests are serialised through
 // its mailbox, so there are no races, no mutexes, and no channels to
 // wire up. Callers simply `await limiter.acquire()`.

--- a/examples/services/rate_limiter.hew
+++ b/examples/services/rate_limiter.hew
@@ -5,7 +5,7 @@
 // at a fixed rate up to a maximum, and each request consumes one token.
 //
 // In Go you'd use golang.org/x/time/rate (mutex-guarded float64 state).
-// In Rust you'd use governor or tower::limit (generic middleware layers).
+// In Rust you'd use governor or tower.limit (generic middleware layers).
 // In Hew the rate limiter is an actor — requests are serialised through
 // its mailbox, so there are no races, no mutexes, and no channels to
 // wire up. Callers simply `await limiter.acquire()`.
@@ -68,8 +68,8 @@ actor ApiWorker {
         scope {
             let allowed_r = await limiter.acquire();
             let allowed = match allowed_r {
-                Ok(v) => v,
-                Err(_) => 0,
+                .Ok(v) => v,
+                .Err(_) => 0,
             };
             if allowed == 1 {
                 accepted = accepted + 1;
@@ -119,16 +119,16 @@ fn main() {
     sleep(100ms);
     let remaining_r = await limiter.available();
     match remaining_r {
-        Ok(n) => println(f"Tokens remaining after burst: {n}"),
-        Err(_) => println("Tokens remaining: err"),
+        .Ok(n) => println(f"Tokens remaining after burst: {n}"),
+        .Err(_) => println("Tokens remaining: err"),
     }
     println("");
     println("--- After refill ---");
     sleep(250ms);
     let after_refill_r = await limiter.available();
     match after_refill_r {
-        Ok(n) => println(f"Tokens after refill: {n}"),
-        Err(_) => println("Tokens after refill: err"),
+        .Ok(n) => println(f"Tokens after refill: {n}"),
+        .Err(_) => println("Tokens after refill: err"),
     }
     w1.handle_request(100);
     w2.handle_request(101);

--- a/examples/services/worker_pool.hew
+++ b/examples/services/worker_pool.hew
@@ -6,7 +6,7 @@
 //
 // In Go you'd write a goroutine pool with a WaitGroup, a work channel,
 // a results channel, and manual panic recovery in each goroutine (~80
-// lines). In Rust you'd use tokio.JoinSet or rayon, plus Arc<Mutex>
+// lines). In Rust you'd use tokio::JoinSet or rayon, plus Arc<Mutex>
 // for shared state.
 //
 // In Hew:

--- a/examples/services/worker_pool.hew
+++ b/examples/services/worker_pool.hew
@@ -6,7 +6,7 @@
 //
 // In Go you'd write a goroutine pool with a WaitGroup, a work channel,
 // a results channel, and manual panic recovery in each goroutine (~80
-// lines). In Rust you'd use tokio::JoinSet or rayon, plus Arc<Mutex>
+// lines). In Rust you'd use tokio.JoinSet or rayon, plus Arc<Mutex>
 // for shared state.
 //
 // In Hew:

--- a/examples/smtp_client.hew
+++ b/examples/smtp_client.hew
@@ -1,7 +1,7 @@
 //! Status: runnable
-//! Description: smtp_client.hew — std::net::smtp usage example
+//! Description: smtp_client.hew — std.net.smtp usage example
 
-// smtp_client.hew — std::net::smtp usage example
+// smtp_client.hew — std.net.smtp usage example
 //
 // This example requires a real SMTP server to run.  It is provided as a
 // documentation / API-discovery surface and is NOT part of the automated CI
@@ -18,34 +18,34 @@
 // payload type is unit — the checker treats the inner () as a zero-element
 // tuple destructor rather than the unit type.  The workaround is Ok(_).
 // Tracked: see hew-lang/hew#1598
-import std::net::smtp;
+import std.net.smtp;
 
 fn send_plain(host: string, port: i64, username: string, password: string, from: string, to: string) -> Result<i64, string> {
     match smtp.connect(host, port, username, password) {
-        Ok(conn) => {
+        .Ok(conn) => {
             let result = conn.try_send(from, to, "Hello from Hew", "This is a plain-text test email.");
             conn.close();
             match result {
-                Ok(_) => Ok(0),
-                Err(msg) => Err(msg),
+                .Ok(_) => Ok(0),
+                .Err(msg) => Err(msg),
             }
         },
-        Err(msg) => Err(msg),
+        .Err(msg) => Err(msg),
     }
 }
 
 fn send_html(host: string, port: i64, username: string, password: string, from: string, to: string) -> Result<i64, string> {
     match smtp.connect_tls(host, port, username, password) {
-        Ok(conn) => {
+        .Ok(conn) => {
             let body = "<h1>Hello</h1><p>This is an <b>HTML</b> test email sent from Hew.</p>";
             let result = conn.try_send_html(from, to, "HTML email from Hew", body);
             conn.close();
             match result {
-                Ok(_) => Ok(0),
-                Err(msg) => Err(msg),
+                .Ok(_) => Ok(0),
+                .Err(msg) => Err(msg),
             }
         },
-        Err(msg) => Err(msg),
+        .Err(msg) => Err(msg),
     }
 }
 
@@ -56,11 +56,11 @@ fn main() {
     let from = "sender@example.com";
     let to = "recipient@example.com";
     match send_plain(host, 587, username, password, from, to) {
-        Ok(_) => println("Plain-text email sent."),
-        Err(msg) => println("Error: " + msg),
+        .Ok(_) => println("Plain-text email sent."),
+        .Err(msg) => println("Error: " + msg),
     }
     match send_html(host, 465, username, password, from, to) {
-        Ok(_) => println("HTML email sent."),
-        Err(msg) => println("Error: " + msg),
+        .Ok(_) => println("HTML email sent."),
+        .Err(msg) => println("Error: " + msg),
     }
 }

--- a/examples/static_server.hew
+++ b/examples/static_server.hew
@@ -8,15 +8,15 @@
 //
 // Usage: hew build static_server.hew -o serve && ./serve [port] [root]
 // Defaults: port 8080, root "."
-import std::net::http::{Request, Server};
+import std.net.http.{Request, Server};
 
-import std::fs;
+import std.fs;
 
-import std::os;
+import std.os;
 
-import std::net::mime;
+import std.net.mime;
 
-import std::net;
+import std.net;
 
 fn resolve_path(root: string, url_path: string) -> string {
     let path = root + url_path;
@@ -71,10 +71,10 @@ fn main() {
     let addr = f"0.0.0.0:{port}";
     println(f"Serving {root} on http://{addr}");
     match http.listen(addr) {
-        Ok(server) => {
+        .Ok(server) => {
             serve_forever(root, server);
         },
-        Err(err) => {
+        .Err(err) => {
             let reason = net.net_error_message(err);
             let detail = http.listen_error();
             println(f"cannot listen on {addr}: {reason} - {detail}");

--- a/examples/stress_mailbox.hew
+++ b/examples/stress_mailbox.hew
@@ -27,8 +27,8 @@ fn send_batch(counter: LocalPid<Counter>, remaining: i64) {
 fn read_count(counter: LocalPid<Counter>) -> i64 {
     let count_result = await counter.report();
     match count_result {
-        Ok(value) => value,
-        Err(_) => -1,
+        .Ok(value) => value,
+        .Err(_) => -1,
     }
 }
 

--- a/examples/stress_match.hew
+++ b/examples/stress_match.hew
@@ -25,61 +25,61 @@ enum ProcessingResult {
 
 fn process_complex_data(data: ComplexData) -> i32 {
     match data {
-        Empty => 0,
-        Single(x) => x * 2,
-        Pair(x, y) => x + y,
-        Triple(x, y, z) => x * y * z,
-        Tagged(name, value) => value,
+        .Empty => 0,
+        .Single(x) => x * 2,
+        .Pair(x, y) => x + y,
+        .Triple(x, y, z) => x * y * z,
+        .Tagged(name, value) => value,
         _ => -1,
     }
 }
 
 fn process_message(msg: MessageType) -> ProcessingResult {
     match msg {
-        Text(content) => Success(42),
-        Binary(data) => {
+        .Text(content) => .Success(42),
+        .Binary(data) => {
             if data > 1000 {
-                Error(1)
+                .Error(1)
             } else if data > 500 {
-                Warning(data, 2)
+                .Warning(data, 2)
             } else {
-                Success(data)
+                .Success(data)
             }
         },
-        Structured(header, payload) => {
+        .Structured(header, payload) => {
             if header == payload {
-                Success(header)
+                .Success(header)
             } else {
-                Error(3)
+                .Error(3)
             }
         },
-        _ => Error(99),
+        _ => .Error(99),
     }
 }
 
 fn analyze_result(result: ProcessingResult, context: i32) -> i32 {
     match result {
-        Success(value) => value + context,
-        Warning(code, msg) => code,
-        Error(msg) => -1,
+        .Success(value) => value + context,
+        .Warning(code, msg) => code,
+        .Error(msg) => -1,
         _ => 0,
     }
 }
 
 fn main() {
     // Test complex data processing
-    let data1 = Triple(5, 10, 15);
+    let data1 = ComplexData.Triple(5, 10, 15);
     let result1 = process_complex_data(data1);
-    let data2 = Single(42);
+    let data2 = ComplexData.Single(42);
     let result2 = process_complex_data(data2);
     // Test message processing
-    let msg1 = Text(100);
+    let msg1 = MessageType.Text(100);
     let processed1 = process_message(msg1);
     let analyzed1 = analyze_result(processed1, 10);
-    let msg2 = Binary(750);
+    let msg2 = MessageType.Binary(750);
     let processed2 = process_message(msg2);
     let analyzed2 = analyze_result(processed2, 5);
-    let msg3 = Structured(5, 5);
+    let msg3 = MessageType.Structured(5, 5);
     let processed3 = process_message(msg3);
     let analyzed3 = analyze_result(processed3, 1);
     println("=== Stress Match Test ===");

--- a/examples/string_methods_smoke.hew
+++ b/examples/string_methods_smoke.hew
@@ -3,8 +3,8 @@ fn main() {
     println(s.slice(1, 3));
     println("aba".replace("a", "x"));
     let idx = match "banana".find("na") {
-        Some(v) => v,
-        None => -1,
+        .Some(v) => v,
+        .None => -1,
     };
     println(idx);
     let parts = "a,b,c".split(",");

--- a/examples/string_ops_test.hew
+++ b/examples/string_ops_test.hew
@@ -3,7 +3,7 @@
 
 // string operations test
 // Exercises string methods and operators
-import std::string;
+import std.string;
 
 fn main() {
     println("=== string Basics ===");

--- a/examples/test_actors_messaging.hew
+++ b/examples/test_actors_messaging.hew
@@ -32,7 +32,7 @@ fn test_basic_actor() -> i64 {
     counter.increment(12);
     let count_result = await counter.get_count();
     match count_result {
-        Ok(count) => {
+        .Ok(count) => {
             if count == 42 {
                 println("PASS: basic actor spawn + messaging");
                 1
@@ -41,7 +41,7 @@ fn test_basic_actor() -> i64 {
                 0
             }
         },
-        Err(_) => {
+        .Err(_) => {
             println("FAIL: basic actor spawn + messaging");
             0
         },
@@ -54,24 +54,24 @@ fn test_multiple_actors() -> i64 {
     let p2 = spawn Printer(prefix: 2);
     let first = await p1.print_msg(100);
     match first {
-        Ok(_) => {},
-        Err(_) => {
+        .Ok(_) => {},
+        .Err(_) => {
             println("FAIL: multiple actors");
             return 0;
         },
     }
     let second = await p2.print_msg(200);
     match second {
-        Ok(_) => {},
-        Err(_) => {
+        .Ok(_) => {},
+        .Err(_) => {
             println("FAIL: multiple actors");
             return 0;
         },
     }
     let third = await p1.print_msg(300);
     match third {
-        Ok(_) => {},
-        Err(_) => {
+        .Ok(_) => {},
+        .Err(_) => {
             println("FAIL: multiple actors");
             return 0;
         },

--- a/examples/test_collections.hew
+++ b/examples/test_collections.hew
@@ -5,7 +5,7 @@
 // Exercises: Vec<T>, HashMap<K,V> with push, len, get, pop, insert, contains_key, remove
 fn test_vec_basic() -> i32 {
     println("--- test_vec_basic ---");
-    let v: Vec<i32> = Vec::new();
+    let v: Vec<i32> = Vec.new();
     v.push(10);
     v.push(20);
     v.push(30);
@@ -35,7 +35,7 @@ fn test_vec_basic() -> i32 {
 
 fn test_vec_pop() -> i32 {
     println("--- test_vec_pop ---");
-    let v: Vec<i32> = Vec::new();
+    let v: Vec<i32> = Vec.new();
     v.push(1);
     v.push(2);
     v.push(3);
@@ -55,7 +55,7 @@ fn test_vec_pop() -> i32 {
 
 fn test_vec_many_elements() -> i32 {
     println("--- test_vec_many_elements ---");
-    let v: Vec<i32> = Vec::new();
+    let v: Vec<i32> = Vec.new();
     for i in 0 .. 100 {
         v.push(i);
     }
@@ -75,7 +75,7 @@ fn test_vec_many_elements() -> i32 {
 
 fn test_hashmap_basic() -> i32 {
     println("--- test_hashmap_basic ---");
-    let m: HashMap<string, i32> = HashMap::new();
+    let m: HashMap<string, i32> = HashMap.new();
     m.insert("one", 1);
     m.insert("two", 2);
     m.insert("three", 3);
@@ -100,7 +100,7 @@ fn test_hashmap_basic() -> i32 {
 
 fn test_hashmap_contains() -> i32 {
     println("--- test_hashmap_contains ---");
-    let m: HashMap<string, i32> = HashMap::new();
+    let m: HashMap<string, i32> = HashMap.new();
     m.insert("key1", 10);
     let has_key1 = m.contains_key("key1");
     let has_key2 = m.contains_key("key2");
@@ -118,7 +118,7 @@ fn test_hashmap_contains() -> i32 {
 
 fn test_hashmap_remove() -> i32 {
     println("--- test_hashmap_remove ---");
-    let m: HashMap<string, i32> = HashMap::new();
+    let m: HashMap<string, i32> = HashMap.new();
     m.insert("a", 1);
     m.insert("b", 2);
     let before = m.len();

--- a/examples/test_control_flow.hew
+++ b/examples/test_control_flow.hew
@@ -70,13 +70,13 @@ fn test_match_integers() -> i64 {
 fn test_match_option() -> i64 {
     let some_val: Option<i64> = Some(42);
     let r1 = match some_val {
-        Some(v) => v,
-        None => -1,
+        .Some(v) => v,
+        .None => -1,
     };
     let none_val: Option<i64> = None;
     let r2 = match none_val {
-        Some(v) => v,
-        None => -1,
+        .Some(v) => v,
+        .None => -1,
     };
     if r1 == 42 {
         if r2 == -1 {
@@ -94,12 +94,12 @@ fn test_match_result() -> i64 {
     let ok_val: Result<i64, i64> = Ok(99);
     let err_val: Result<i64, i64> = Err(-1);
     let r1 = match ok_val {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     let r2 = match err_val {
-        Ok(_v) => 0,
-        Err(e) => e,
+        .Ok(_v) => 0,
+        .Err(e) => e,
     };
     if r1 == 99 {
         if r2 == -1 {

--- a/examples/test_error_handling.hew
+++ b/examples/test_error_handling.hew
@@ -14,8 +14,8 @@ fn divide(a: i64, b: i64) -> Result<i64, string> {
 fn test_result_ok() -> i32 {
     let result = divide(10, 2);
     let val = match result {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     if val == 5 {
         println("PASS: Result Ok");
@@ -28,8 +28,8 @@ fn test_result_ok() -> i32 {
 fn test_result_err() -> i32 {
     let result = divide(10, 0);
     let val = match result {
-        Ok(v) => v,
-        Err(msg) => {
+        .Ok(v) => v,
+        .Err(msg) => {
             println(f"  error: {msg}");
             -1
         },
@@ -45,8 +45,8 @@ fn test_result_err() -> i32 {
 fn test_option_some() -> i32 {
     let x = Some(42);
     let val = match x {
-        Some(v) => v,
-        None => -1,
+        .Some(v) => v,
+        .None => -1,
     };
     if val == 42 {
         println("PASS: Option Some");
@@ -59,8 +59,8 @@ fn test_option_some() -> i32 {
 fn test_option_none() -> i32 {
     let x: Option<i64> = None;
     let val = match x {
-        Some(v) => v,
-        None => -1,
+        .Some(v) => v,
+        .None => -1,
     };
     if val == -1 {
         println("PASS: Option None");
@@ -79,8 +79,8 @@ fn try_divide(a: i64, b: i64) -> Result<i64, string> {
 fn test_try_ok() -> i32 {
     let result = try_divide(10, 2);
     let val = match result {
-        Ok(v) => v,
-        Err(_) => -999,
+        .Ok(v) => v,
+        .Err(_) => -999,
     };
     if val == 10 {
         println("PASS: ? operator (Ok path)");
@@ -93,8 +93,8 @@ fn test_try_ok() -> i32 {
 fn test_try_err() -> i32 {
     let result = try_divide(10, 0);
     let val = match result {
-        Ok(v) => v,
-        Err(_) => -999,
+        .Ok(v) => v,
+        .Err(_) => -999,
     };
     if val == -999 {
         println("PASS: ? operator (Err propagation)");
@@ -114,8 +114,8 @@ fn chain_divide(a: i64, b: i64, c: i64) -> Result<i64, string> {
 fn test_chained_try() -> i32 {
     let result = chain_divide(100, 5, 2);
     let val = match result {
-        Ok(v) => v,
-        Err(_) => -999,
+        .Ok(v) => v,
+        .Err(_) => -999,
     };
     // 100 / 5 = 20, 20 / 2 = 10
     if val == 10 {
@@ -129,8 +129,8 @@ fn test_chained_try() -> i32 {
 fn test_chained_try_err() -> i32 {
     let result = chain_divide(100, 0, 2);
     let val = match result {
-        Ok(v) => v,
-        Err(_) => -999,
+        .Ok(v) => v,
+        .Err(_) => -999,
     };
     if val == -999 {
         println("PASS: chained ? error propagation");

--- a/examples/test_match_guards.hew
+++ b/examples/test_match_guards.hew
@@ -10,19 +10,19 @@ enum Event {
 
 fn classify(e: Event) -> i32 {
     match e {
-        Number(n) if n != 0 && 100 / n > 5 => 3,
-        Number(n) if n == 0 || n < 0 => 2,
-        Number(_) => 1,
-        Text(s) if s.len() > 3 => 4,
-        Text(_) => 0,
-        Empty => -1,
+        .Number(n) if n != 0 && 100 / n > 5 => 3,
+        .Number(n) if n == 0 || n < 0 => 2,
+        .Number(_) => 1,
+        .Text(s) if s.len() > 3 => 4,
+        .Text(_) => 0,
+        .Empty => -1,
     }
 }
 
 fn main() {
-    println(classify(Number(20)));
-    println(classify(Number(0)));
-    println(classify(Text("hew")));
-    println(classify(Text("compiler")));
-    println(classify(Empty));
+    println(classify(.Number(20)));
+    println(classify(.Number(0)));
+    println(classify(.Text("hew")));
+    println(classify(.Text("compiler")));
+    println(classify(.Empty));
 }

--- a/examples/test_unsigned.hew
+++ b/examples/test_unsigned.hew
@@ -12,7 +12,7 @@ fn main() {
     let total: u32 = x * y + bonus;
     println(sum8 as i64);
     println(total as i64);
-    let m: HashMap<string, i32> = HashMap::new();
+    let m: HashMap<string, i32> = HashMap.new();
     m.insert("left", 10);
     m.insert("right", 32);
     let values = m.values();

--- a/examples/ux/04_counter_actor.hew
+++ b/examples/ux/04_counter_actor.hew
@@ -15,7 +15,7 @@ fn main() {
     counter.increment(10);
     // Actor asks return Result<T, string> — use `match await` to extract the value.
     match await counter.get_count() {
-        Ok(count) => println(count),
-        Err(_) => println("ask failed"),
+        .Ok(count) => println(count),
+        .Err(_) => println("ask failed"),
     }
 }

--- a/examples/ux/06_enum_match.hew
+++ b/examples/ux/06_enum_match.hew
@@ -7,9 +7,9 @@ enum Colour {
 
 fn colour_name(c: Colour) {
     match c {
-        Red => println("Red"),
-        Green => println("Green"),
-        Blue => println("Blue"),
+        .Red => println("Red"),
+        .Green => println("Green"),
+        .Blue => println("Blue"),
     }
 }
 

--- a/examples/ux/07_enum_payload.hew
+++ b/examples/ux/07_enum_payload.hew
@@ -2,8 +2,8 @@
 // Option<T> is a built-in enum — no import needed.
 fn unwrap_or(opt: Option<i64>, fallback: i64) -> i64 {
     match opt {
-        Some(v) => v,
-        None => fallback,
+        .Some(v) => v,
+        .None => fallback,
     }
 }
 
@@ -13,8 +13,8 @@ fn main() {
     let val2: Option<i64> = None;
     // match gives you full control over each case.
     match val1 {
-        Some(x) => println(x),
-        None => println("no value"),
+        .Some(x) => println(x),
+        .None => println("no value"),
     }
     // unwrap_or is the common pattern for a fallback value.
     println(unwrap_or(val1, 0));

--- a/examples/ux/09_vec.hew
+++ b/examples/ux/09_vec.hew
@@ -1,6 +1,6 @@
 // Vec operations
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10);
     v.push(20);
     v.push(30);

--- a/examples/ux/10_lambda_actor.hew
+++ b/examples/ux/10_lambda_actor.hew
@@ -4,16 +4,16 @@ fn main() {
         println(msg * 2);
     };
     match worker.send(5) {
-        Ok(_) => {},
-        Err(_) => panic("failed to send 5"),
+        .Ok(_) => {},
+        .Err(_) => panic("failed to send 5"),
     }
     match worker.send(10) {
-        Ok(_) => {},
-        Err(_) => panic("failed to send 10"),
+        .Ok(_) => {},
+        .Err(_) => panic("failed to send 10"),
     }
     match worker.send(15) {
-        Ok(_) => {},
-        Err(_) => panic("failed to send 15"),
+        .Ok(_) => {},
+        .Err(_) => panic("failed to send 15"),
     }
     await worker.close();
 }

--- a/examples/ux/14_error_test.hew
+++ b/examples/ux/14_error_test.hew
@@ -10,22 +10,22 @@ fn parse_number(s: string) -> Result<i64, string> {
 
 fn is_ok(r: Result<i64, i64>) -> bool {
     match r {
-        Ok(_) => true,
-        Err(_) => false,
+        .Ok(_) => true,
+        .Err(_) => false,
     }
 }
 
 fn is_err(r: Result<i64, i64>) -> bool {
     match r {
-        Ok(_) => false,
-        Err(_) => true,
+        .Ok(_) => false,
+        .Err(_) => true,
     }
 }
 
 fn unwrap_or(r: Result<i64, i64>, fallback: i64) -> i64 {
     match r {
-        Ok(v) => v,
-        Err(_) => fallback,
+        .Ok(v) => v,
+        .Err(_) => fallback,
     }
 }
 
@@ -34,12 +34,12 @@ fn main() {
     let failed = parse_number("oops");
     // match is the clearest way to handle a Result.
     match parsed {
-        Ok(n) => println(n),
-        Err(msg) => println(msg),
+        .Ok(n) => println(n),
+        .Err(msg) => println(msg),
     }
     match failed {
-        Ok(n) => println(n),
-        Err(msg) => println(msg),
+        .Ok(n) => println(n),
+        .Err(msg) => println(msg),
     }
     // Helper functions show common Result<i64, i64> patterns.
     let helper_ok: Result<i64, i64> = Ok(42);

--- a/examples/ux/15_hashmap.hew
+++ b/examples/ux/15_hashmap.hew
@@ -1,14 +1,14 @@
 // HashMap test
 fn main() {
-    let map: HashMap<string, i64> = HashMap::new();
+    let map: HashMap<string, i64> = HashMap.new();
     map.insert("a", 100);
     map.insert("b", 200);
     match map.get("a") {
-        Some(v) => println(v),
-        None => println("missing"),
+        .Some(v) => println(v),
+        .None => println("missing"),
     }
     match map.get("b") {
-        Some(v) => println(v),
-        None => println("missing"),
+        .Some(v) => println(v),
+        .None => println("missing"),
     }
 }

--- a/examples/v05/actor_ask_race.hew
+++ b/examples/v05/actor_ask_race.hew
@@ -14,7 +14,7 @@
 // so the value must be in 0..=255. 42 is the canonical fixture value.
 //
 // Cancel-loser proof: the compiler lowers the loser path through
-// hew_reply_channel_cancel + hew_reply_channel_free (see Terminator.Select
+// hew_reply_channel_cancel + hew_reply_channel_free (see Terminator::Select
 // codegen in hew-codegen-rs/src/llvm.rs). This fixture exercises that path
 // every run: SlowWorker is always the loser and its channel is cancelled.
 actor FastWorker {

--- a/examples/v05/actor_ask_race.hew
+++ b/examples/v05/actor_ask_race.hew
@@ -14,7 +14,7 @@
 // so the value must be in 0..=255. 42 is the canonical fixture value.
 //
 // Cancel-loser proof: the compiler lowers the loser path through
-// hew_reply_channel_cancel + hew_reply_channel_free (see Terminator::Select
+// hew_reply_channel_cancel + hew_reply_channel_free (see Terminator.Select
 // codegen in hew-codegen-rs/src/llvm.rs). This fixture exercises that path
 // every run: SlowWorker is always the loser and its channel is cancelled.
 actor FastWorker {

--- a/examples/v05/actor_closure_pid_send.hew
+++ b/examples/v05/actor_closure_pid_send.hew
@@ -20,7 +20,7 @@ fn main() -> i64 {
     bump(10);
     bump(32);
     match await counter.total() {
-        Ok(v) => v,
-        Err(_e) => 0,
+        .Ok(v) => v,
+        .Err(_e) => 0,
     }
 }

--- a/examples/v05/actor_counter.hew
+++ b/examples/v05/actor_counter.hew
@@ -15,7 +15,7 @@ fn main() -> i64 {
     counter.increment(10);
     counter.increment(32);
     match await counter.total() {
-        Ok(v) => v,
-        Err(_e) => 0,
+        .Ok(v) => v,
+        .Err(_e) => 0,
     }
 }

--- a/examples/v05/actor_counter_init.hew
+++ b/examples/v05/actor_counter_init.hew
@@ -23,7 +23,7 @@ fn main() -> i64 {
     let counter = spawn Counter(initial: 9);
     counter.increment(32);
     match await counter.total() {
-        Ok(v) => v,
-        Err(_e) => 0,
+        .Ok(v) => v,
+        .Err(_e) => 0,
     }
 }

--- a/examples/v05/actor_on_stop.hew
+++ b/examples/v05/actor_on_stop.hew
@@ -28,7 +28,7 @@ fn main() -> i64 {
     let counter = spawn Counter(initial: 9);
     counter.increment(32);
     match await counter.total() {
-        Ok(v) => v,
-        Err(_e) => 0,
+        .Ok(v) => v,
+        .Err(_e) => 0,
     }
 }

--- a/examples/v05/add42.hew
+++ b/examples/v05/add42.hew
@@ -1,5 +1,5 @@
 // Companion to hello_int.hew that proves the exit code is *computed* —
-// the lowering emits a real Instr.IntAdd rather than a hard-coded ConstI64.
+// the lowering emits a real Instr::IntAdd rather than a hard-coded ConstI64.
 // The binary returns 42 on both native and wasm targets.
 fn main() -> i64 {
     let a = 10;

--- a/examples/v05/add42.hew
+++ b/examples/v05/add42.hew
@@ -1,5 +1,5 @@
 // Companion to hello_int.hew that proves the exit code is *computed* —
-// the lowering emits a real Instr::IntAdd rather than a hard-coded ConstI64.
+// the lowering emits a real Instr.IntAdd rather than a hard-coded ConstI64.
 // The binary returns 42 on both native and wasm targets.
 fn main() -> i64 {
     let a = 10;

--- a/examples/v05/channel_vec_element_fails.hew
+++ b/examples/v05/channel_vec_element_fails.hew
@@ -8,7 +8,7 @@
 // admitted — the witness describes them (see
 // examples/v05/surfaces/channel_record_elements.hew). Only container/handle
 // elements and types without a clone/drop thunk path remain fail-closed.
-import std::channel::channel;
+import std.channel.channel;
 
 fn relay(items: Vec<i64>) {
     let (tx, rx): (channel.Sender<Vec<i64>>, channel.Receiver<Vec<i64>>) = channel.new(2);
@@ -21,7 +21,7 @@ fn relay(items: Vec<i64>) {
 }
 
 fn main() {
-    let items: Vec<i64> = Vec::new();
+    let items: Vec<i64> = Vec.new();
     items.push(1);
     relay(items);
 }

--- a/examples/v05/checked-mir/actor_ask_race.hew
+++ b/examples/v05/checked-mir/actor_ask_race.hew
@@ -14,7 +14,7 @@
 // so the value must be in 0..=255. 42 is the canonical fixture value.
 //
 // Cancel-loser proof: the compiler lowers the loser path through
-// hew_reply_channel_cancel + hew_reply_channel_free (see Terminator.Select
+// hew_reply_channel_cancel + hew_reply_channel_free (see Terminator::Select
 // codegen in hew-codegen-rs/src/llvm.rs). This fixture exercises that path
 // every run: SlowWorker is always the loser and its channel is cancelled.
 actor FastWorker {

--- a/examples/v05/checked-mir/actor_ask_race.hew
+++ b/examples/v05/checked-mir/actor_ask_race.hew
@@ -14,7 +14,7 @@
 // so the value must be in 0..=255. 42 is the canonical fixture value.
 //
 // Cancel-loser proof: the compiler lowers the loser path through
-// hew_reply_channel_cancel + hew_reply_channel_free (see Terminator::Select
+// hew_reply_channel_cancel + hew_reply_channel_free (see Terminator.Select
 // codegen in hew-codegen-rs/src/llvm.rs). This fixture exercises that path
 // every run: SlowWorker is always the loser and its channel is cancelled.
 actor FastWorker {

--- a/examples/v05/checked-mir/actor_counter_ask.hew
+++ b/examples/v05/checked-mir/actor_counter_ask.hew
@@ -18,7 +18,7 @@ fn main() {
     c.increment(32);
     let r = await c.total();
     match r {
-        Ok(v) => println(v),
-        Err(_) => println(-1),
+        .Ok(v) => println(v),
+        .Err(_) => println(-1),
     }
 }

--- a/examples/v05/checked-mir/actor_state_vec_take_all.hew
+++ b/examples/v05/checked-mir/actor_state_vec_take_all.hew
@@ -26,7 +26,7 @@ fn make_tag(label: string) -> dyn Labeled {
 }
 
 actor Registry {
-    var plugins: Vec<dyn Labeled> = Vec::new();
+    var plugins: Vec<dyn Labeled> = Vec.new();
     receive fn drain_total() -> i64 {
         var total: i64 = 0;
         for plugin in plugins.into_iter() {
@@ -51,18 +51,18 @@ fn main() {
     let registry = spawn Registry;
     let first = await registry.drain_total();
     match first {
-        Ok(total) => println(total),
-        Err(_) => println(-1),
+        .Ok(total) => println(total),
+        .Err(_) => println(-1),
     }
     let drained = await registry.drain_total();
     match drained {
-        Ok(total) => println(total),
-        Err(_) => println(-1),
+        .Ok(total) => println(total),
+        .Err(_) => println(-1),
     }
     registry.refill();
     let count = await registry.plugin_count();
     match count {
-        Ok(n) => println(n),
-        Err(_) => println(-1),
+        .Ok(n) => println(n),
+        .Err(_) => println(-1),
     }
 }

--- a/examples/v05/checked-mir/await_ask_deadline.hew
+++ b/examples/v05/checked-mir/await_ask_deadline.hew
@@ -17,8 +17,8 @@ actor Caller {
     receive fn go() -> i64 {
         let f = spawn Fast;
         match await f.answer() | after 5s {
-            Ok(v) => v,
-            Err(_e) => 7,
+            .Ok(v) => v,
+            .Err(_e) => 7,
         }
     }
 }
@@ -26,7 +26,7 @@ actor Caller {
 fn main() -> i64 {
     let c = spawn Caller;
     match await c.go() {
-        Ok(v) => v,
-        Err(_e) => 99,
+        .Ok(v) => v,
+        .Err(_e) => 99,
     }
 }

--- a/examples/v05/checked-mir/channel_auto_close_scope.hew
+++ b/examples/v05/checked-mir/channel_auto_close_scope.hew
@@ -2,13 +2,13 @@
 //
 // The function intentionally does not call tx.close() or rx.close(); the
 // elaborated MIR must emit scope-exit channel close drops for both handles.
-import std::channel::channel;
+import std.channel.channel;
 
 fn main() {
     let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(1);
     tx.send("ready");
     match rx.try_recv() {
-        Some(msg) => println(msg),
-        None => println("empty"),
+        .Some(msg) => println(msg),
+        .None => println("empty"),
     }
 }

--- a/examples/v05/checked-mir/channel_recv_select.hew
+++ b/examples/v05/checked-mir/channel_recv_select.hew
@@ -4,7 +4,7 @@
 // (`hew_channel_recv_layout` / `hew_channel_try_recv_layout`), the
 // send path (`hew_channel_send_layout`), the sender/receiver close
 // releases, and the select winner-picker (`hew_select_first`).
-import std::channel::channel;
+import std.channel.channel;
 
 actor Inbox {
     receive fn run(unused: i64) {
@@ -12,18 +12,18 @@ actor Inbox {
         tx.send("ready");
         tx.close();
         match await rx.recv() {
-            Some(msg) => println(msg),
-            None => println("closed"),
+            .Some(msg) => println(msg),
+            .None => println("closed"),
         }
         match rx.try_recv() {
-            Some(msg) => println(msg),
-            None => println("empty"),
+            .Some(msg) => println(msg),
+            .None => println("empty"),
         }
         select {
             again from rx.recv() => {
                 match again {
-                    Some(msg) => println(msg),
-                    None => println("closed"),
+                    .Some(msg) => println(msg),
+                    .None => println("closed"),
                 }
             },
             after 1s => println("timeout"),

--- a/examples/v05/checked-mir/duplex_split_half_ops.hew
+++ b/examples/v05/checked-mir/duplex_split_half_ops.hew
@@ -11,27 +11,27 @@ fn main() {
     let tx = a.send_half();
     let rx = b.recv_half();
     match tx.send(7) {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
     match tx.try_send(8) {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
     match rx.recv() {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
     match rx.try_recv() {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
     match tx.close() {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
     match rx.close() {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
 }

--- a/examples/v05/checked-mir/duplex_unified_recv.hew
+++ b/examples/v05/checked-mir/duplex_unified_recv.hew
@@ -7,15 +7,15 @@ fn main() {
     let (a, b) = duplex_pair<i64, i64>(4);
     let tx = a.send_half();
     match tx.send(55) {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
     match b.recv() {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
     match b.try_recv() {
-        Ok(_) => {},
-        Err(_) => {},
+        .Ok(_) => {},
+        .Err(_) => {},
     }
 }

--- a/examples/v05/checked-mir/hashmap_keys_values.hew
+++ b/examples/v05/checked-mir/hashmap_keys_values.hew
@@ -1,7 +1,7 @@
 // MIR-corpus fixture: HashMap key/value projection ops.
 //
 // Pins `hew_hashmap_keys_layout` and `hew_hashmap_values_layout` — the
-// projection entries ride the `Terminator.Call` route with their typed
+// projection entries ride the `Terminator::Call` route with their typed
 // `RuntimeCallFamily` carried on the call, and the codegen layout-fact
 // walker classifies them by family.
 fn main() {

--- a/examples/v05/checked-mir/hashmap_keys_values.hew
+++ b/examples/v05/checked-mir/hashmap_keys_values.hew
@@ -1,11 +1,11 @@
 // MIR-corpus fixture: HashMap key/value projection ops.
 //
 // Pins `hew_hashmap_keys_layout` and `hew_hashmap_values_layout` — the
-// projection entries ride the `Terminator::Call` route with their typed
+// projection entries ride the `Terminator.Call` route with their typed
 // `RuntimeCallFamily` carried on the call, and the codegen layout-fact
 // walker classifies them by family.
 fn main() {
-    let m: HashMap<string, i64> = HashMap::new();
+    let m: HashMap<string, i64> = HashMap.new();
     m.insert("alice", 10);
     m.insert("bob", 20);
     let ks = m.keys();

--- a/examples/v05/checked-mir/hashmap_ops.hew
+++ b/examples/v05/checked-mir/hashmap_ops.hew
@@ -5,26 +5,26 @@
 // `hew_hashmap_remove_take_layout`, `hew_hashmap_len_layout`, and the
 // scope-exit `hew_hashmap_free_layout` drop.
 fn main() {
-    let m: HashMap<string, i64> = HashMap::new();
+    let m: HashMap<string, i64> = HashMap.new();
     m.insert("alice", 10);
     m.insert("bob", 20);
     match m.get("alice") {
-        Some(v) => println(v),
-        None => println(-1),
+        .Some(v) => println(v),
+        .None => println(-1),
     }
     let has = m.contains_key("bob");
     let removed = m.remove("bob").is_some();
     println(f"has={has} removed={removed} len={m.len()}");
-    let flags: HashMap<string, bool> = HashMap::new();
+    let flags: HashMap<string, bool> = HashMap.new();
     flags.insert("debug", true);
     println(flags.len());
-    let ratios: HashMap<string, f64> = HashMap::new();
+    let ratios: HashMap<string, f64> = HashMap.new();
     ratios.insert("pi", 3.14);
     println(ratios.len());
-    let labels: HashMap<string, string> = HashMap::new();
+    let labels: HashMap<string, string> = HashMap.new();
     labels.insert("k", "v");
     match labels.get("k") {
-        Some(s) => println(s),
-        None => println("missing"),
+        .Some(s) => println(s),
+        .None => println("missing"),
     }
 }

--- a/examples/v05/checked-mir/hashset_insert_managed_string_move.hew
+++ b/examples/v05/checked-mir/hashset_insert_managed_string_move.hew
@@ -17,7 +17,7 @@ fn add_renamed(words: HashSet<string>, var member: string) {
 }
 
 fn main() {
-    let words: HashSet<string> = HashSet::new();
+    let words: HashSet<string> = HashSet.new();
     let word = "behaviour";
     words.insert(word);
     add_member(words, "colour");

--- a/examples/v05/checked-mir/hashset_ops.hew
+++ b/examples/v05/checked-mir/hashset_ops.hew
@@ -5,7 +5,7 @@
 // `hew_hashset_len_layout`, `hew_hashset_is_empty_layout`, and the
 // scope-exit `hew_hashset_free_layout` drop.
 fn main() {
-    let s: HashSet<i64> = HashSet::new();
+    let s: HashSet<i64> = HashSet.new();
     s.insert(1);
     s.insert(2);
     s.insert(2);
@@ -15,7 +15,7 @@ fn main() {
     println(f"n={n} has1={has1} removed={removed}");
     let empty = s.is_empty();
     println(empty);
-    let words: HashSet<string> = HashSet::new();
+    let words: HashSet<string> = HashSet.new();
     words.insert("colour");
     words.insert("behaviour");
     let hasc = words.contains("colour");

--- a/examples/v05/checked-mir/lambda_actor_lifecycle.hew
+++ b/examples/v05/checked-mir/lambda_actor_lifecycle.hew
@@ -17,7 +17,7 @@ fn main() {
     };
     let a = scale(3);
     match a {
-        Ok(v) => println(v),
-        Err(_) => println(-1),
+        .Ok(v) => println(v),
+        .Err(_) => println(-1),
     }
 }

--- a/examples/v05/checked-mir/match_skip_aggregate_field_drops.hew
+++ b/examples/v05/checked-mir/match_skip_aggregate_field_drops.hew
@@ -3,7 +3,7 @@
 //
 // Every arm binds only the BitCopy `n` field and wildcards one owned
 // aggregate sibling. The raw golden pins that each skipped aggregate emits
-// `drop_field_in_place` (the `Instr.FieldDropInPlace` op, type-directed at
+// `drop_field_in_place` (the `Instr::FieldDropInPlace` op, type-directed at
 // codegen through `emit_heap_slot_drop`), never a field load + `drop` pair
 // (the load path has no wired release for aggregates and would be a
 // wrong-ABI free):

--- a/examples/v05/checked-mir/match_skip_aggregate_field_drops.hew
+++ b/examples/v05/checked-mir/match_skip_aggregate_field_drops.hew
@@ -3,7 +3,7 @@
 //
 // Every arm binds only the BitCopy `n` field and wildcards one owned
 // aggregate sibling. The raw golden pins that each skipped aggregate emits
-// `drop_field_in_place` (the `Instr::FieldDropInPlace` op, type-directed at
+// `drop_field_in_place` (the `Instr.FieldDropInPlace` op, type-directed at
 // codegen through `emit_heap_slot_drop`), never a field load + `drop` pair
 // (the load path has no wired release for aggregates and would be a
 // wrong-ABI free):
@@ -60,7 +60,7 @@ fn skip_tuple_field(k: i64) -> i64 {
 }
 
 fn skip_enum_field(k: i64) -> i64 {
-    let t = HoldsEnum { n: k, shade: Shade::Named(string_concat("agg-e-", "payload")) };
+    let t = HoldsEnum { n: k, shade: Shade.Named(string_concat("agg-e-", "payload")) };
     let x = match t {
         HoldsEnum { n: x, shade: _ } => x,
     };

--- a/examples/v05/checked-mir/match_skip_leaf_field_drops.hew
+++ b/examples/v05/checked-mir/match_skip_leaf_field_drops.hew
@@ -6,14 +6,14 @@
 // the safety-drop loop emits per leaf shape:
 //
 //   - `string` (record AND tuple parents) — `drop_field_in_place` (the
-//     in-place `Instr.FieldDropInPlace`, raw slot load + `hew_string_drop`
+//     in-place `Instr::FieldDropInPlace`, raw slot load + `hew_string_drop`
 //     + pointer-word null-store at codegen). NOT a `RecordFieldLoad` /
 //     `TupleFieldLoad` + `drop` pair: string-typed field loads retain via
 //     `hew_string_clone`, so a load+drop pair retain-cancels and leaks the
 //     original slot value.
 //   - `Vec<string>` — field load into a temp + `drop` with the element-kind
 //     release symbol `hew_vec_free` (`string` is a Plain element: the
-//     runtime's buffer free walks `ElemKind.String` and frees each element;
+//     runtime's buffer free walks `ElemKind::String` and frees each element;
 //     non-string loads do not retain, so the load+drop pair stays the
 //     correct discharge).
 //   - `bytes` — field load + `drop` with `hew_bytes_drop`.

--- a/examples/v05/checked-mir/match_skip_leaf_field_drops.hew
+++ b/examples/v05/checked-mir/match_skip_leaf_field_drops.hew
@@ -6,14 +6,14 @@
 // the safety-drop loop emits per leaf shape:
 //
 //   - `string` (record AND tuple parents) — `drop_field_in_place` (the
-//     in-place `Instr::FieldDropInPlace`, raw slot load + `hew_string_drop`
+//     in-place `Instr.FieldDropInPlace`, raw slot load + `hew_string_drop`
 //     + pointer-word null-store at codegen). NOT a `RecordFieldLoad` /
 //     `TupleFieldLoad` + `drop` pair: string-typed field loads retain via
 //     `hew_string_clone`, so a load+drop pair retain-cancels and leaks the
 //     original slot value.
 //   - `Vec<string>` — field load into a temp + `drop` with the element-kind
 //     release symbol `hew_vec_free` (`string` is a Plain element: the
-//     runtime's buffer free walks `ElemKind::String` and frees each element;
+//     runtime's buffer free walks `ElemKind.String` and frees each element;
 //     non-string loads do not retain, so the load+drop pair stays the
 //     correct discharge).
 //   - `bytes` — field load + `drop` with `hew_bytes_drop`.
@@ -52,7 +52,7 @@ fn skip_string_tuple(k: i64) -> i64 {
 }
 
 fn skip_vec_record(k: i64) -> i64 {
-    let v: Vec<string> = Vec::new();
+    let v: Vec<string> = Vec.new();
     v.push(string_concat("leaf-v-", "payload"));
     let t = TaggedVec { n: k, items: v };
     let x = match t {

--- a/examples/v05/checked-mir/math_intrinsics.hew
+++ b/examples/v05/checked-mir/math_intrinsics.hew
@@ -3,7 +3,7 @@
 // Pins the user-visible callee names (`sqrt`, `pow`, `floor`, `ceil`,
 // `round`, `abs`, `min`, `max` and the f64 peers) dispatched by
 // codegen's math-intrinsic lookup.
-import std::math;
+import std.math;
 
 fn main() {
     println(math.sqrt(16.0));

--- a/examples/v05/checked-mir/metric_register_record.hew
+++ b/examples/v05/checked-mir/metric_register_record.hew
@@ -5,7 +5,7 @@
 // `hew_metric_gauge_register`, `hew_metric_histogram_register_simple`)
 // and the mutators reached through the handle methods — counter
 // inc/add, gauge inc/dec/set/add, and histogram record.
-import std::metrics;
+import std.metrics;
 
 fn main() {
     let hits = metrics.counter("app.cache_hits");

--- a/examples/v05/checked-mir/node_lookup_send.hew
+++ b/examples/v05/checked-mir/node_lookup_send.hew
@@ -1,4 +1,4 @@
-// Accept: Node::lookup(name) -> Result::Ok(RemotePid<T>) -> pid.send(msg)
+// Accept: Node.lookup(name) -> Result.Ok(RemotePid<T>) -> pid.send(msg)
 // delivers to a locally registered actor through the in-process send-by-id path.
 record Ping {
     n: i64
@@ -20,38 +20,38 @@ impl ActorMsg for Worker {
 }
 
 fn main() -> i64 {
-    Node::set_transport("tcp");
-    // Protocol v2 requires a durable identity before Node::start; without it
+    Node.set_transport("tcp");
+    // Protocol v2 requires a durable identity before Node.start; without it
     // start fails, register/lookup never see a running node, and main returns
     // the lookup-failure code 30.
-    Node::load_keys("/tmp/hew-checked-mir-node-lookup-send.key");
-    Node::start("127.0.0.1:0");
+    Node.load_keys("/tmp/hew-checked-mir-node-lookup-send.key");
+    Node.start("127.0.0.1:0");
     let worker = spawn Worker(count: 0);
-    Node::register("node-lookup-worker", worker);
-    let missing: Result<RemotePid<Worker>, LookupError> = Node::lookup("node-lookup-missing");
+    Node.register("node-lookup-worker", worker);
+    let missing: Result<RemotePid<Worker>, LookupError> = Node.lookup("node-lookup-missing");
     let missing_code = match missing {
-        Result::Ok(pid) => {
+        Result.Ok(pid) => {
             let unexpected = pid.send(Ping { n: 1 });
             match unexpected {
-                Result::Ok(_) => 10,
-                Result::Err(_) => 11,
+                Result.Ok(_) => 10,
+                Result.Err(_) => 11,
             }
         },
-        Result::Err(_) => 0,
+        Result.Err(_) => 0,
     };
     assert_eq(missing_code, 0);
-    let found: Result<RemotePid<Worker>, LookupError> = Node::lookup("node-lookup-worker");
+    let found: Result<RemotePid<Worker>, LookupError> = Node.lookup("node-lookup-worker");
     let status = match found {
-        Result::Ok(pid) => {
+        Result.Ok(pid) => {
             let delivered = pid.send(Ping { n: 42 });
             let send_code = match delivered {
-                Result::Ok(_) => 0,
-                Result::Err(_) => 20,
+                Result.Ok(_) => 0,
+                Result.Err(_) => 20,
             };
             if send_code == 0 {
                 let total = match await worker.total() {
-                    Ok(v) => v,
-                    Err(_e) => -1,
+                    .Ok(v) => v,
+                    .Err(_e) => -1,
                 };
                 assert_eq(total, 42);
                 0
@@ -59,8 +59,8 @@ fn main() -> i64 {
                 send_code
             }
         },
-        Result::Err(_) => 30,
+        Result.Err(_) => 30,
     };
-    Node::shutdown();
+    Node.shutdown();
     status
 }

--- a/examples/v05/checked-mir/option_result_predicates.hew
+++ b/examples/v05/checked-mir/option_result_predicates.hew
@@ -27,8 +27,8 @@ fn main() -> i64 {
     }
     let r: Result<i64, string> = Ok(7);
     let w = match r {
-        Ok(v) => v,
-        Err(_) => -1,
+        .Ok(v) => v,
+        .Err(_) => -1,
     };
     println(w);
     0

--- a/examples/v05/checked-mir/pattern_call_scrutinee_match.hew
+++ b/examples/v05/checked-mir/pattern_call_scrutinee_match.hew
@@ -10,16 +10,16 @@ enum Packet {
 
 fn make(good: bool) -> Packet {
     if good {
-        Packet::Data { a: "match-cs-a".to_upper(), b: "match-cs-b".to_upper() }
+        Packet.Data { a: "match-cs-a".to_upper(), b: "match-cs-b".to_upper() }
     } else {
-        Packet::Empty
+        Packet.Empty
     }
 }
 
 fn probe(good: bool) -> i64 {
     match make(good) {
-        Packet::Data { a, b } => a.len() + b.len(),
-        Packet::Empty => 0,
+        Packet.Data { a, b } => a.len() + b.len(),
+        Packet.Empty => 0,
     }
 }
 

--- a/examples/v05/checked-mir/pattern_call_scrutinee_while_let.hew
+++ b/examples/v05/checked-mir/pattern_call_scrutinee_while_let.hew
@@ -10,16 +10,16 @@ enum Feed {
 
 fn step(n: i64) -> Feed {
     if n > 0 {
-        Feed::Item { a: "feed-cs-a".to_upper(), b: "feed-cs-b".to_upper() }
+        Feed.Item { a: "feed-cs-a".to_upper(), b: "feed-cs-b".to_upper() }
     } else {
-        Feed::Done
+        Feed.Done
     }
 }
 
 fn main() -> i64 {
     var i = 3;
     var total = 0;
-    while let Feed::Item { a, b } = step(i) {
+    while let Feed.Item { a, b } = step(i) {
         total = total + a.len() + b.len();
         i = i - 1;
     }

--- a/examples/v05/checked-mir/pattern_enum_payload_if_let.hew
+++ b/examples/v05/checked-mir/pattern_enum_payload_if_let.hew
@@ -10,15 +10,15 @@ enum Packet {
 
 fn make(good: bool) -> Packet {
     if good {
-        Packet::Data { a: "if-let-a".to_upper(), b: "if-let-b".to_upper() }
+        Packet.Data { a: "if-let-a".to_upper(), b: "if-let-b".to_upper() }
     } else {
-        Packet::Empty
+        Packet.Empty
     }
 }
 
 fn probe(good: bool) -> i64 {
     let p = make(good);
-    if let Packet::Data { a, b: _ } = p {
+    if let Packet.Data { a, b: _ } = p {
         a.len()
     } else {
         0

--- a/examples/v05/checked-mir/pattern_enum_payload_if_let_rest.hew
+++ b/examples/v05/checked-mir/pattern_enum_payload_if_let_rest.hew
@@ -9,15 +9,15 @@ enum Packet {
 
 fn make(good: bool) -> Packet {
     if good {
-        Packet::Data { a: "if-let-a".to_upper(), b: "if-let-b".to_upper() }
+        Packet.Data { a: "if-let-a".to_upper(), b: "if-let-b".to_upper() }
     } else {
-        Packet::Empty
+        Packet.Empty
     }
 }
 
 fn probe(good: bool) -> i64 {
     let p = make(good);
-    if let Packet::Data { a, .. } = p {
+    if let Packet.Data { a, .. } = p {
         a.len()
     } else {
         0

--- a/examples/v05/checked-mir/pattern_enum_payload_let_else.hew
+++ b/examples/v05/checked-mir/pattern_enum_payload_let_else.hew
@@ -11,15 +11,15 @@ enum Packet {
 
 fn make(good: bool) -> Packet {
     if good {
-        Packet::Data { a: "let-else-a".to_upper(), b: "let-else-b".to_upper() }
+        Packet.Data { a: "let-else-a".to_upper(), b: "let-else-b".to_upper() }
     } else {
-        Packet::Empty
+        Packet.Empty
     }
 }
 
 fn probe(good: bool) -> i64 {
     let p = make(good);
-    let Packet::Data { a, b: _ } = p else {
+    let Packet.Data { a, b: _ } = p else {
         return 0;
     };
     a.len()

--- a/examples/v05/checked-mir/pattern_enum_payload_match.hew
+++ b/examples/v05/checked-mir/pattern_enum_payload_match.hew
@@ -12,17 +12,17 @@ enum Packet {
 
 fn make(good: bool) -> Packet {
     if good {
-        Packet::Data { a: "match-a".to_upper(), b: "match-b".to_upper() }
+        Packet.Data { a: "match-a".to_upper(), b: "match-b".to_upper() }
     } else {
-        Packet::Empty
+        Packet.Empty
     }
 }
 
 fn probe(good: bool) -> i64 {
     let p = make(good);
     match p {
-        Packet::Data { a, b: _ } => a.len(),
-        Packet::Empty => 0,
+        Packet.Data { a, b: _ } => a.len(),
+        Packet.Empty => 0,
     }
 }
 

--- a/examples/v05/checked-mir/rc_weak_graph.hew
+++ b/examples/v05/checked-mir/rc_weak_graph.hew
@@ -4,7 +4,7 @@ type Node {
 }
 
 fn build() -> Weak<Node> {
-    let root = Rc::new(Node { label: "root", parent: None });
+    let root = Rc.new(Node { label: "root", parent: None });
     let weak = root.downgrade();
     root.set(Node { label: "replacement", parent: Some(weak.clone()) });
     weak
@@ -13,7 +13,7 @@ fn build() -> Weak<Node> {
 fn main() -> i64 {
     let weak = build();
     match weak.upgrade() {
-        Some(_) => 9000,
-        None => 1,
+        .Some(_) => 9000,
+        .None => 1,
     }
 }

--- a/examples/v05/checked-mir/rc_weak_graph.hew
+++ b/examples/v05/checked-mir/rc_weak_graph.hew
@@ -4,7 +4,9 @@ type Node {
 }
 
 fn build() -> Weak<Node> {
-    let root = Rc.new(Node { label: "root", parent: None });
+    // Rc construction keeps the deprecated-accepted spelling until S7
+    // supplies a dotted specialized-builtin target.
+    let root = Rc::new(Node { label: "root", parent: None });
     let weak = root.downgrade();
     root.set(Node { label: "replacement", parent: Some(weak.clone()) });
     weak

--- a/examples/v05/checked-mir/rc_weak_lifecycle.hew
+++ b/examples/v05/checked-mir/rc_weak_lifecycle.hew
@@ -1,5 +1,5 @@
 fn live() -> i64 {
-    let rc = Rc::new(7);
+    let rc = Rc.new(7);
     let alias = rc.clone();
     let weak = rc.downgrade();
     let _weak_alias = weak.clone();
@@ -10,24 +10,24 @@ fn live() -> i64 {
         1
     };
     match weak.upgrade() {
-        Some(upgraded) => {
+        .Some(upgraded) => {
             rc.set(9);
             before + upgraded.strong_count() * 10 + alias.get() + uniqueness
         },
-        None => 9000,
+        .None => 9000,
     }
 }
 
 fn expired() -> Weak<i64> {
-    let rc = Rc::new(1);
+    let rc = Rc.new(1);
     rc.downgrade()
 }
 
 fn main() -> i64 {
     let weak = expired();
     let dead = match weak.upgrade() {
-        Some(_) => 9000,
-        None => 1,
+        .Some(_) => 9000,
+        .None => 1,
     };
     live() + dead
 }

--- a/examples/v05/checked-mir/rc_weak_lifecycle.hew
+++ b/examples/v05/checked-mir/rc_weak_lifecycle.hew
@@ -1,5 +1,7 @@
 fn live() -> i64 {
-    let rc = Rc.new(7);
+    // Rc construction keeps the deprecated-accepted spelling until S7
+    // supplies a dotted specialized-builtin target.
+    let rc = Rc::new(7);
     let alias = rc.clone();
     let weak = rc.downgrade();
     let _weak_alias = weak.clone();
@@ -19,7 +21,7 @@ fn live() -> i64 {
 }
 
 fn expired() -> Weak<i64> {
-    let rc = Rc.new(1);
+    let rc = Rc::new(1);
     rc.downgrade()
 }
 

--- a/examples/v05/checked-mir/reject/init_before_use.hew
+++ b/examples/v05/checked-mir/reject/init_before_use.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck::InitialisedBeforeUse`.
+// Reject fixture for `MirCheck.InitialisedBeforeUse`.
 //
 // `let x;` declares the binding without initialising it. `let _y = x;`
 // reads `x` before any `Bind` for it appears in the function's MIR

--- a/examples/v05/checked-mir/reject/init_before_use.hew
+++ b/examples/v05/checked-mir/reject/init_before_use.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck.InitialisedBeforeUse`.
+// Reject fixture for `MirCheck::InitialisedBeforeUse`.
 //
 // `let x;` declares the binding without initialising it. `let _y = x;`
 // reads `x` before any `Bind` for it appears in the function's MIR

--- a/examples/v05/checked-mir/reject/init_before_use_in_block.hew
+++ b/examples/v05/checked-mir/reject/init_before_use_in_block.hew
@@ -1,9 +1,9 @@
-// Reject fixture for `MirCheck.InitialisedBeforeUse` inside a
+// Reject fixture for `MirCheck::InitialisedBeforeUse` inside a
 // block expression.
 //
 // The nested `{ let x; let _y = x; }` would previously skip the
 // move-checker because the block expression's lowering only
-// forwarded `HirStmtKind.Expr` statements into the checker-authority
+// forwarded `HirStmtKind::Expr` statements into the checker-authority
 // stream. The `let` statements were dropped, and a real
 // `InitialisedBeforeUse` pattern produced a binary. With nested
 // statements lowered, `x` is read before any `Bind` for it appears

--- a/examples/v05/checked-mir/reject/init_before_use_in_block.hew
+++ b/examples/v05/checked-mir/reject/init_before_use_in_block.hew
@@ -1,9 +1,9 @@
-// Reject fixture for `MirCheck::InitialisedBeforeUse` inside a
+// Reject fixture for `MirCheck.InitialisedBeforeUse` inside a
 // block expression.
 //
 // The nested `{ let x; let _y = x; }` would previously skip the
 // move-checker because the block expression's lowering only
-// forwarded `HirStmtKind::Expr` statements into the checker-authority
+// forwarded `HirStmtKind.Expr` statements into the checker-authority
 // stream. The `let` statements were dropped, and a real
 // `InitialisedBeforeUse` pattern produced a binary. With nested
 // statements lowered, `x` is read before any `Bind` for it appears

--- a/examples/v05/checked-mir/reject/use_after_consume.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume.hew
@@ -1,9 +1,9 @@
-// Reject fixture for `MirCheck::UseAfterConsume`.
+// Reject fixture for `MirCheck.UseAfterConsume`.
 //
 // `s` is a string (a non-`BitCopy` value class). The `let t = s;`
 // consumes it. The trailing `return s;` reads `s` after the move,
 // which the Checked MIR move-checker rejects. `hew compile`
-// emits a `MirDiagnostic::UseAfterConsume` carrying both the
+// emits a `MirDiagnostic.UseAfterConsume` carrying both the
 // consume site and the offending use site, and exits non-zero
 // without producing a binary.
 fn main() -> string {

--- a/examples/v05/checked-mir/reject/use_after_consume.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume.hew
@@ -1,9 +1,9 @@
-// Reject fixture for `MirCheck.UseAfterConsume`.
+// Reject fixture for `MirCheck::UseAfterConsume`.
 //
 // `s` is a string (a non-`BitCopy` value class). The `let t = s;`
 // consumes it. The trailing `return s;` reads `s` after the move,
 // which the Checked MIR move-checker rejects. `hew compile`
-// emits a `MirDiagnostic.UseAfterConsume` carrying both the
+// emits a `MirDiagnostic::UseAfterConsume` carrying both the
 // consume site and the offending use site, and exits non-zero
 // without producing a binary.
 fn main() -> string {

--- a/examples/v05/checked-mir/reject/use_after_consume_in_block.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume_in_block.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck.UseAfterConsume` inside a block
+// Reject fixture for `MirCheck::UseAfterConsume` inside a block
 // expression.
 //
 // The nested block consumes `s` via `let t = s` (string is a

--- a/examples/v05/checked-mir/reject/use_after_consume_in_block.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume_in_block.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck::UseAfterConsume` inside a block
+// Reject fixture for `MirCheck.UseAfterConsume` inside a block
 // expression.
 //
 // The nested block consumes `s` via `let t = s` (string is a

--- a/examples/v05/checked-mir/reject/use_after_consume_in_if.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume_in_if.hew
@@ -1,8 +1,8 @@
-// Reject fixture for `MirCheck::UseAfterConsume` inside an `if`
+// Reject fixture for `MirCheck.UseAfterConsume` inside an `if`
 // expression arm.
 //
 // The `if` arm is a block expression; `lower_value` recurses through
-// the `HirExprKind::Block` arm into the nested `let s = "hello"`,
+// the `HirExprKind.Block` arm into the nested `let s = "hello"`,
 // `let t = s` (consume), `let _u = s` (use-after-consume). The
 // move-checker fires on the checker-authority statement stream;
 // Checked MIR rejects with `E_MIR_CHECK ... UseAfterConsume` and

--- a/examples/v05/checked-mir/reject/use_after_consume_in_if.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume_in_if.hew
@@ -1,8 +1,8 @@
-// Reject fixture for `MirCheck.UseAfterConsume` inside an `if`
+// Reject fixture for `MirCheck::UseAfterConsume` inside an `if`
 // expression arm.
 //
 // The `if` arm is a block expression; `lower_value` recurses through
-// the `HirExprKind.Block` arm into the nested `let s = "hello"`,
+// the `HirExprKind::Block` arm into the nested `let s = "hello"`,
 // `let t = s` (consume), `let _u = s` (use-after-consume). The
 // move-checker fires on the checker-authority statement stream;
 // Checked MIR rejects with `E_MIR_CHECK ... UseAfterConsume` and

--- a/examples/v05/checked-mir/reject/use_after_hashset_insert_managed_string.hew
+++ b/examples/v05/checked-mir/reject/use_after_hashset_insert_managed_string.hew
@@ -4,7 +4,7 @@
 // source binding after insert would leave both the set slot and source binding
 // on drop paths for the same heap owner.
 fn main() -> string {
-    let words: HashSet<string> = HashSet::new();
+    let words: HashSet<string> = HashSet.new();
     let word = "colour";
     words.insert(word);
     word

--- a/examples/v05/checked-mir/reject/use_after_move_into_free_fn.hew
+++ b/examples/v05/checked-mir/reject/use_after_move_into_free_fn.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck::UseAfterConsume` — value-move into a free
+// Reject fixture for `MirCheck.UseAfterConsume` — value-move into a free
 // function (#1941).
 //
 // `sink(c)` moves the `#[resource]` `c` BY VALUE into a free function. Hew
@@ -6,11 +6,11 @@
 // callee owns and closes `c`. The trailing `c.id_of()` reads `c` after the
 // move, which the Checked MIR move-checker rejects.
 //
-// Before the fix the by-value argument lowered with `IntentKind::Read`, so
+// Before the fix the by-value argument lowered with `IntentKind.Read`, so
 // the move was invisible to the checker: the read compiled clean (a
 // use-after-free) and the caller's implicit scope-exit drop double-closed
 // what `sink` had already closed. `hew compile` now emits a
-// `MirDiagnostic::UseAfterConsume` carrying both the consume site (the
+// `MirDiagnostic.UseAfterConsume` carrying both the consume site (the
 // `sink(c)` argument) and the offending use site, and exits non-zero without
 // producing a binary.
 #[resource]

--- a/examples/v05/checked-mir/reject/use_after_move_into_free_fn.hew
+++ b/examples/v05/checked-mir/reject/use_after_move_into_free_fn.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck.UseAfterConsume` — value-move into a free
+// Reject fixture for `MirCheck::UseAfterConsume` — value-move into a free
 // function (#1941).
 //
 // `sink(c)` moves the `#[resource]` `c` BY VALUE into a free function. Hew
@@ -6,11 +6,11 @@
 // callee owns and closes `c`. The trailing `c.id_of()` reads `c` after the
 // move, which the Checked MIR move-checker rejects.
 //
-// Before the fix the by-value argument lowered with `IntentKind.Read`, so
+// Before the fix the by-value argument lowered with `IntentKind::Read`, so
 // the move was invisible to the checker: the read compiled clean (a
 // use-after-free) and the caller's implicit scope-exit drop double-closed
 // what `sink` had already closed. `hew compile` now emits a
-// `MirDiagnostic.UseAfterConsume` carrying both the consume site (the
+// `MirDiagnostic::UseAfterConsume` carrying both the consume site (the
 // `sink(c)` argument) and the offending use site, and exits non-zero without
 // producing a binary.
 #[resource]

--- a/examples/v05/checked-mir/reject/use_after_move_into_tuple.hew
+++ b/examples/v05/checked-mir/reject/use_after_move_into_tuple.hew
@@ -1,9 +1,9 @@
-// Reject fixture for `MirCheck::UseAfterConsume` — use-after-move INTO A TUPLE.
+// Reject fixture for `MirCheck.UseAfterConsume` — use-after-move INTO A TUPLE.
 //
 // `h` is an `@resource` (an owned, single-owner value class with an
 // implicit `close` drop). Building the tuple `(h, g)` MOVES `h` into the
 // aggregate; the subsequent read of `h.fd` is a use after the move, which
-// the Checked MIR move-checker rejects with `MirDiagnostic::UseAfterConsume`
+// the Checked MIR move-checker rejects with `MirDiagnostic.UseAfterConsume`
 // carrying both the consume site (the tuple constructor) and the offending
 // use site.
 //

--- a/examples/v05/checked-mir/reject/use_after_move_into_tuple.hew
+++ b/examples/v05/checked-mir/reject/use_after_move_into_tuple.hew
@@ -1,9 +1,9 @@
-// Reject fixture for `MirCheck.UseAfterConsume` — use-after-move INTO A TUPLE.
+// Reject fixture for `MirCheck::UseAfterConsume` — use-after-move INTO A TUPLE.
 //
 // `h` is an `@resource` (an owned, single-owner value class with an
 // implicit `close` drop). Building the tuple `(h, g)` MOVES `h` into the
 // aggregate; the subsequent read of `h.fd` is a use after the move, which
-// the Checked MIR move-checker rejects with `MirDiagnostic.UseAfterConsume`
+// the Checked MIR move-checker rejects with `MirDiagnostic::UseAfterConsume`
 // carrying both the consume site (the tuple constructor) and the offending
 // use site.
 //

--- a/examples/v05/checked-mir/scope_fork_spawn_generic.hew
+++ b/examples/v05/checked-mir/scope_fork_spawn_generic.hew
@@ -5,8 +5,8 @@
 // each concrete instantiation gets its own adapter.
 //
 // Covers:
-//   - No-arg unit spawn: `fork { worker::<i64>(); }` (ForkBlock form)
-//   - No-arg value spawn: `fork t = compute::<i64>()` (named form)
+//   - No-arg unit spawn: `fork { worker.<i64>(); }` (ForkBlock form)
+//   - No-arg value spawn: `fork t = compute.<i64>()` (named form)
 fn worker<T>() {}
 
 fn compute<T>() -> i64 {

--- a/examples/v05/checked-mir/slice_annotation_alias.hew
+++ b/examples/v05/checked-mir/slice_annotation_alias.hew
@@ -3,7 +3,7 @@ fn takes(xs: [i32]) -> i64 {
 }
 
 fn main() {
-    let xs: Vec<i32> = Vec::new();
+    let xs: Vec<i32> = Vec.new();
     xs.push(1);
     xs.push(2);
     println(takes(xs));

--- a/examples/v05/checked-mir/stream_blocking_recv.hew
+++ b/examples/v05/checked-mir/stream_blocking_recv.hew
@@ -3,20 +3,20 @@
 //
 // `main` carries no execution context, so `input.recv()` keeps the
 // blocking layout-witness call (`hew_stream_next_layout` as a
-// Terminator::Call) instead of the suspending terminator, and
+// Terminator.Call) instead of the suspending terminator, and
 // `input.try_recv()` lowers to `hew_stream_try_next_layout`.
-import std::stream;
+import std.stream;
 
 fn main() {
     let (sink, input) = stream.bytes_pipe(2);
     sink.close();
     match input.recv() {
-        Some(b) => println(b.to_string()),
-        None => println("eof"),
+        .Some(b) => println(b.to_string()),
+        .None => println("eof"),
     }
     match input.try_recv() {
-        Some(b) => println(b.to_string()),
-        None => println("empty"),
+        .Some(b) => println(b.to_string()),
+        .None => println("empty"),
     }
     input.close();
 }

--- a/examples/v05/checked-mir/stream_blocking_recv.hew
+++ b/examples/v05/checked-mir/stream_blocking_recv.hew
@@ -3,7 +3,7 @@
 //
 // `main` carries no execution context, so `input.recv()` keeps the
 // blocking layout-witness call (`hew_stream_next_layout` as a
-// Terminator.Call) instead of the suspending terminator, and
+// Terminator::Call) instead of the suspending terminator, and
 // `input.try_recv()` lowers to `hew_stream_try_next_layout`.
 import std.stream;
 

--- a/examples/v05/checked-mir/stream_pipe_send_recv.hew
+++ b/examples/v05/checked-mir/stream_pipe_send_recv.hew
@@ -4,7 +4,7 @@
 // `hew_sink_write_bytes` symbol materialises at codegen), the
 // layout-witness stream recv, and the sink/stream close releases
 // (`hew_sink_close` / `hew_stream_close`).
-import std::stream;
+import std.stream;
 
 actor Echo {
     let n: i64;
@@ -18,8 +18,8 @@ actor Echo {
         while !done {
             let item = await input.recv();
             match item {
-                Some(b) => println(b.to_string()),
-                None => {
+                .Some(b) => println(b.to_string()),
+                .None => {
                     done = true;
                 },
             }

--- a/examples/v05/checked-mir/stream_string_pipe_send.hew
+++ b/examples/v05/checked-mir/stream_string_pipe_send.hew
@@ -6,7 +6,7 @@
 // describable element suspends now, not just bytes. Even a NON-awaited send
 // suspends in an execution-context caller (it must not block the scheduler
 // thread); a context-free caller (`fn main`) keeps the blocking call.
-import std::stream;
+import std.stream;
 
 actor Echo {
     receive fn run(unused: i64) {

--- a/examples/v05/checked-mir/stream_string_pipe_send_blocking.hew
+++ b/examples/v05/checked-mir/stream_string_pipe_send_blocking.hew
@@ -7,7 +7,7 @@
 // actor handler suspends instead: every describable sink-send element
 // suspends in a context-carrying caller, but a context-free caller keeps the
 // blocking call so it never parks a non-existent scheduler frame.
-import std::stream;
+import std.stream;
 
 fn main() {
     let (sink, input) = stream.pipe(2);

--- a/examples/v05/checked-mir/string_sentinel_ops.hew
+++ b/examples/v05/checked-mir/string_sentinel_ops.hew
@@ -1,6 +1,6 @@
 // MIR-corpus fixture: sentinel->Option string inspectors (D46).
 //
-// Pins the codegen-intercepted `Terminator.Call` producers for
+// Pins the codegen-intercepted `Terminator::Call` producers for
 // `hew_string_find` (`find -> Option<i64>`), `hew_string_char_at`
 // (`char_at -> Option<char>`), and `hew_string_char_at_utf8`
 // (`codepoint_at_utf8 -> Option<i64>`): each carries an Option dest the

--- a/examples/v05/checked-mir/string_sentinel_ops.hew
+++ b/examples/v05/checked-mir/string_sentinel_ops.hew
@@ -1,6 +1,6 @@
 // MIR-corpus fixture: sentinel->Option string inspectors (D46).
 //
-// Pins the codegen-intercepted `Terminator::Call` producers for
+// Pins the codegen-intercepted `Terminator.Call` producers for
 // `hew_string_find` (`find -> Option<i64>`), `hew_string_char_at`
 // (`char_at -> Option<char>`), and `hew_string_char_at_utf8`
 // (`codepoint_at_utf8 -> Option<i64>`): each carries an Option dest the
@@ -8,27 +8,27 @@
 fn main() {
     let s = "hello world";
     match s.find("world") {
-        Some(i) => println(i),
-        None => println(-1),
+        .Some(i) => println(i),
+        .None => println(-1),
     }
     match s.find("absent") {
-        Some(i) => println(i),
-        None => println(-1),
+        .Some(i) => println(i),
+        .None => println(-1),
     }
     match s.char_at(0) {
-        Some(c) => println(c as i64),
-        None => println(-1),
+        .Some(c) => println(c as i64),
+        .None => println(-1),
     }
     match s.char_at(99) {
-        Some(c) => println(c as i64),
-        None => println(-1),
+        .Some(c) => println(c as i64),
+        .None => println(-1),
     }
     match s.codepoint_at_utf8(1) {
-        Some(cp) => println(cp),
-        None => println(-1),
+        .Some(cp) => println(cp),
+        .None => println(-1),
     }
     match s.codepoint_at_utf8(99) {
-        Some(cp) => println(cp),
-        None => println(-1),
+        .Some(cp) => println(cp),
+        .None => println(-1),
     }
 }

--- a/examples/v05/checked-mir/supervisor_await_restart.hew
+++ b/examples/v05/checked-mir/supervisor_await_restart.hew
@@ -4,7 +4,7 @@
 // emitted by the contextless `await_restart` lowering path. When `main` (or a
 // free fn) calls `await_restart sup.child`, MIR lowers to a blocking wait on
 // the supervisor restart Condvar (safe here because main runs off the
-// cooperative scheduler). The resulting `Instr.CallRuntimeAbi` carries the
+// cooperative scheduler). The resulting `Instr::CallRuntimeAbi` carries the
 // quoted callee symbol, covering the SupervisorRestartAwaitBlocking family in
 // the coverage ratchet.
 actor Worker {

--- a/examples/v05/checked-mir/supervisor_await_restart.hew
+++ b/examples/v05/checked-mir/supervisor_await_restart.hew
@@ -4,7 +4,7 @@
 // emitted by the contextless `await_restart` lowering path. When `main` (or a
 // free fn) calls `await_restart sup.child`, MIR lowers to a blocking wait on
 // the supervisor restart Condvar (safe here because main runs off the
-// cooperative scheduler). The resulting `Instr::CallRuntimeAbi` carries the
+// cooperative scheduler). The resulting `Instr.CallRuntimeAbi` carries the
 // quoted callee symbol, covering the SupervisorRestartAwaitBlocking family in
 // the coverage ratchet.
 actor Worker {
@@ -26,7 +26,7 @@ fn main() -> i64 {
     // hew_supervisor_restart_await_blocking (CallRuntimeAbi).
     let w2 = await_restart sup.w;
     match await w2.ping() {
-        Ok(v) => v,
-        Err(_) => 0,
+        .Ok(v) => v,
+        .Err(_) => 0,
     }
 }

--- a/examples/v05/checked-mir/supervisor_config_init.hew
+++ b/examples/v05/checked-mir/supervisor_config_init.hew
@@ -5,7 +5,7 @@
 // cannot silently change it:
 //   - the supervisor config param threaded onto the bootstrap signature and the
 //     `spawn App(config: cfg)` bootstrap call carrying the config argument,
-//   - the `ChildInitArg::ConfigField` lowering (scalar `config.size` →
+//   - the `ChildInitArg.ConfigField` lowering (scalar `config.size` →
 //     `owned: false`; owned `config.label` → `owned: true`),
 //   - the `hew_supervisor_set_child_init_fn` RuntimeCall family the codegen
 //     bootstrap emits per config-init child (the #2229 corpus-pin discipline:

--- a/examples/v05/checked-mir/supervisor_config_init.hew
+++ b/examples/v05/checked-mir/supervisor_config_init.hew
@@ -5,7 +5,7 @@
 // cannot silently change it:
 //   - the supervisor config param threaded onto the bootstrap signature and the
 //     `spawn App(config: cfg)` bootstrap call carrying the config argument,
-//   - the `ChildInitArg.ConfigField` lowering (scalar `config.size` →
+//   - the `ChildInitArg::ConfigField` lowering (scalar `config.size` →
 //     `owned: false`; owned `config.label` → `owned: true`),
 //   - the `hew_supervisor_set_child_init_fn` RuntimeCall family the codegen
 //     bootstrap emits per config-init child (the #2229 corpus-pin discipline:

--- a/examples/v05/checked-mir/user_fn_shadows_builtin_name.hew
+++ b/examples/v05/checked-mir/user_fn_shadows_builtin_name.hew
@@ -3,7 +3,7 @@
 // Pins the Item-resolution guard in `runtime_symbol_for_call_expr`: a
 // REAL user `fn link(..)` / `fn monitor(..)` (low ItemId, not a seeded
 // synthetic-builtin sentinel) routes to its own definition —
-// `Terminator::Call { callee: "link" }` — and must NEVER be re-routed
+// `Terminator.Call { callee: "link" }` — and must NEVER be re-routed
 // through the user-name → C-symbol bridge to `hew_actor_link` /
 // `hew_actor_monitor`.
 actor Probe {

--- a/examples/v05/checked-mir/user_fn_shadows_builtin_name.hew
+++ b/examples/v05/checked-mir/user_fn_shadows_builtin_name.hew
@@ -3,7 +3,7 @@
 // Pins the Item-resolution guard in `runtime_symbol_for_call_expr`: a
 // REAL user `fn link(..)` / `fn monitor(..)` (low ItemId, not a seeded
 // synthetic-builtin sentinel) routes to its own definition —
-// `Terminator.Call { callee: "link" }` — and must NEVER be re-routed
+// `Terminator::Call { callee: "link" }` — and must NEVER be re-routed
 // through the user-name → C-symbol bridge to `hew_actor_link` /
 // `hew_actor_monitor`.
 actor Probe {

--- a/examples/v05/checked-mir/vec_descriptor_slice.hew
+++ b/examples/v05/checked-mir/vec_descriptor_slice.hew
@@ -11,20 +11,20 @@ type CheckedMirPoint {
 
 fn checked_mir_colour_tag(c: CheckedMirColour) -> i64 {
     match c {
-        CheckedMirColour::Red => 1,
-        CheckedMirColour::Green => 2,
-        CheckedMirColour::Blue => 3,
+        CheckedMirColour.Red => 1,
+        CheckedMirColour.Green => 2,
+        CheckedMirColour.Blue => 3,
     }
 }
 
 fn main() {
-    let colours: Vec<CheckedMirColour> = Vec::new();
-    colours.push(CheckedMirColour::Red);
-    colours.push(CheckedMirColour::Green);
-    colours.push(CheckedMirColour::Blue);
+    let colours: Vec<CheckedMirColour> = Vec.new();
+    colours.push(CheckedMirColour.Red);
+    colours.push(CheckedMirColour.Green);
+    colours.push(CheckedMirColour.Blue);
     let colour_slice = colours[1..3];
     println(checked_mir_colour_tag(colour_slice[0]));
-    let points: Vec<CheckedMirPoint> = Vec::new();
+    let points: Vec<CheckedMirPoint> = Vec.new();
     points.push(CheckedMirPoint { x: 10, y: 20 });
     points.push(CheckedMirPoint { x: 30, y: 40 });
     let point_slice = points[0..2];

--- a/examples/v05/checked-mir/vec_dyn_iter.hew
+++ b/examples/v05/checked-mir/vec_dyn_iter.hew
@@ -5,7 +5,7 @@
 // slot and the source slot's data word is nulled) alongside the
 // trait-object element push transfer and the descriptor-driven teardown
 // of a partially consumed Vec<dyn Trait>.
-import std::string;
+import std.string;
 
 trait Labeled {
     fn label_size(val: Self) -> i64;
@@ -42,7 +42,7 @@ fn make_parcel(seed: string) -> dyn Labeled {
 }
 
 fn main() {
-    let values: Vec<dyn Labeled> = Vec::new();
+    let values: Vec<dyn Labeled> = Vec.new();
     values.push(make_person("p"));
     values.push(make_parcel("q"));
     values.push(make_person("r"));
@@ -51,7 +51,7 @@ fn main() {
         total = total + value.label_size();
     }
     println(total);
-    let partial: Vec<dyn Labeled> = Vec::new();
+    let partial: Vec<dyn Labeled> = Vec.new();
     partial.push(make_person("a"));
     partial.push(make_parcel("b"));
     var seen: i64 = 0;

--- a/examples/v05/checked-mir/vec_element_widths.hew
+++ b/examples/v05/checked-mir/vec_element_widths.hew
@@ -4,7 +4,7 @@ type Point {
 }
 
 fn main() -> i64 {
-    let xs: Vec<i8> = Vec::new();
+    let xs: Vec<i8> = Vec.new();
     xs.push(-1);
     xs.push(7);
     if xs[0] != -1 {
@@ -13,22 +13,22 @@ fn main() -> i64 {
     if xs[1] != 7 {
         return 2;
     }
-    let u8s: Vec<u8> = Vec::new();
+    let u8s: Vec<u8> = Vec.new();
     u8s.push(200);
     if u8s[0] != 200 {
         return 5;
     }
-    let i16s: Vec<i16> = Vec::new();
+    let i16s: Vec<i16> = Vec.new();
     i16s.push(-1234);
     if i16s[0] != -1234 {
         return 6;
     }
-    let u16s: Vec<u16> = Vec::new();
+    let u16s: Vec<u16> = Vec.new();
     u16s.push(50000);
     if u16s[0] != 50000 {
         return 7;
     }
-    let ys: Vec<f32> = Vec::new();
+    let ys: Vec<f32> = Vec.new();
     ys.push(1.5);
     ys.push(2.5);
     let zs = ys[0..2];
@@ -38,7 +38,7 @@ fn main() -> i64 {
     if zs[1] != 2.5 {
         return 4;
     }
-    let points: Vec<Point> = Vec::new();
+    let points: Vec<Point> = Vec.new();
     points.push(Point { x: 3, y: 30 });
     let p = points[0];
     println(p.x + p.y);

--- a/examples/v05/checked-mir/vec_family_matrix.hew
+++ b/examples/v05/checked-mir/vec_family_matrix.hew
@@ -4,19 +4,19 @@ fn identity(x: i64) -> i64 {
 }
 
 fn shared_families() {
-    let left: Vec<i64> = Vec::new();
-    let right: Vec<i64> = Vec::new();
+    let left: Vec<i64> = Vec.new();
+    let right: Vec<i64> = Vec.new();
     left.append(right);
     let copy = left.clone();
     let _ = copy.is_empty();
     copy.clear();
-    let words: Vec<string> = Vec::new();
+    let words: Vec<string> = Vec.new();
     words.push("a");
     let _joined = words.join(",");
 }
 
 fn i8_families() {
-    let values: Vec<i8> = Vec::new();
+    let values: Vec<i8> = Vec.new();
     values.push(1 as i8);
     values.set(0, 2 as i8);
     let _ = values.pop();
@@ -25,7 +25,7 @@ fn i8_families() {
 }
 
 fn u8_families() {
-    let values: Vec<u8> = Vec::new();
+    let values: Vec<u8> = Vec.new();
     values.push(1 as u8);
     values.set(0, 2 as u8);
     let _ = values.pop();
@@ -34,7 +34,7 @@ fn u8_families() {
 }
 
 fn i16_families() {
-    let values: Vec<i16> = Vec::new();
+    let values: Vec<i16> = Vec.new();
     values.push(1 as i16);
     values.set(0, 2 as i16);
     let _ = values.pop();
@@ -43,7 +43,7 @@ fn i16_families() {
 }
 
 fn u16_families() {
-    let values: Vec<u16> = Vec::new();
+    let values: Vec<u16> = Vec.new();
     values.push(1 as u16);
     values.set(0, 2 as u16);
     let _ = values.pop();
@@ -52,7 +52,7 @@ fn u16_families() {
 }
 
 fn i32_families() {
-    let values: Vec<i32> = Vec::new();
+    let values: Vec<i32> = Vec.new();
     values.push(1 as i32);
     let _ = values.contains(1 as i32);
     let _ = values.pop();
@@ -61,7 +61,7 @@ fn i32_families() {
 }
 
 fn i64_families() {
-    let values: Vec<i64> = Vec::new();
+    let values: Vec<i64> = Vec.new();
     values.push(1);
     values.set(0, 2);
     let _ = values.contains(2);
@@ -71,7 +71,7 @@ fn i64_families() {
 }
 
 fn f32_families() {
-    let values: Vec<f32> = Vec::new();
+    let values: Vec<f32> = Vec.new();
     values.push(1.0 as f32);
     values.set(0, 2.0 as f32);
     let _ = values.pop();
@@ -80,7 +80,7 @@ fn f32_families() {
 }
 
 fn f64_families() {
-    let values: Vec<f64> = Vec::new();
+    let values: Vec<f64> = Vec.new();
     values.push(1.0);
     values.set(0, 2.0);
     let _ = values.contains(2.0);
@@ -90,7 +90,7 @@ fn f64_families() {
 }
 
 fn string_families() {
-    let values: Vec<string> = Vec::new();
+    let values: Vec<string> = Vec.new();
     values.push("a");
     values.set(0, "b");
     let _ = values.contains("b");
@@ -100,7 +100,7 @@ fn string_families() {
 }
 
 fn pointer_families() {
-    let values: Vec<fn(i64) -> i64> = Vec::new();
+    let values: Vec<fn(i64) -> i64> = Vec.new();
     values.push(identity);
     values.set(0, identity);
     let _ = values.pop();

--- a/examples/v05/checked-mir/vec_index_assign_consumed_move.hew
+++ b/examples/v05/checked-mir/vec_index_assign_consumed_move.hew
@@ -8,14 +8,14 @@ record Holder {
 }
 
 fn mkItems() -> Vec<string> {
-    let xs: Vec<string> = Vec::new();
+    let xs: Vec<string> = Vec.new();
     xs.push("deep-elem-a");
     xs.push("deep-elem-b");
     return xs;
 }
 
 fn main() {
-    var v: Vec<Holder> = Vec::new();
+    var v: Vec<Holder> = Vec.new();
     v.push(Holder { items: mkItems() });
     let h = Holder { items: mkItems() };
     v[0] = h;

--- a/examples/v05/checked-mir/vec_owned_elems.hew
+++ b/examples/v05/checked-mir/vec_owned_elems.hew
@@ -16,7 +16,7 @@ type Tag {
 }
 
 fn main() {
-    let names: Vec<string> = Vec::new();
+    let names: Vec<string> = Vec.new();
     names.push("ada");
     names.push("alan");
     names.push("grace");
@@ -28,12 +28,12 @@ fn main() {
     for n in names {
         println(n);
     }
-    let pts: Vec<Point> = Vec::new();
+    let pts: Vec<Point> = Vec.new();
     pts.push(Point { x: 1, y: 2 });
     pts.push(Point { x: 3, y: 4 });
     let p = pts[1];
     println(p.x);
-    let tags: Vec<Tag> = Vec::new();
+    let tags: Vec<Tag> = Vec.new();
     tags.push(Tag { name: "a", n: 1 });
     tags.push(Tag { name: "b", n: 2 });
     let t = tags[0];

--- a/examples/v05/checked-mir/vec_scalar_ops.hew
+++ b/examples/v05/checked-mir/vec_scalar_ops.hew
@@ -5,7 +5,7 @@
 // (`hew_vec_slice_range_*`), and the scope-exit `hew_vec_free` drop for
 // bit-copy element Vecs.
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(10);
     v.push(20);
     v.push(30);
@@ -15,17 +15,17 @@ fn main() {
     println(s.len());
     let last = v.pop();
     println(last);
-    let f: Vec<f64> = Vec::new();
+    let f: Vec<f64> = Vec.new();
     f.push(1.5);
     f.push(2.5);
     println(f[0]);
     let fs = f[0..1];
     println(fs.len());
-    let bs: Vec<bool> = Vec::new();
+    let bs: Vec<bool> = Vec.new();
     bs.push(true);
     let b0 = bs[0];
     println(b0);
-    let ws: Vec<i32> = Vec::new();
+    let ws: Vec<i32> = Vec.new();
     ws.push(1);
     ws.push(2);
     let w0 = ws[0];

--- a/examples/v05/checked-mir/vec_set_owned_move.hew
+++ b/examples/v05/checked-mir/vec_set_owned_move.hew
@@ -1,7 +1,7 @@
-// MIR-corpus fixture: owned-element `Vec::set` move-in.
+// MIR-corpus fixture: owned-element `Vec.set` move-in.
 //
 // Pins `hew_vec_set_owned_move`: a fresh, unbound aggregate rvalue used as a
-// `Vec::set` element source moves its owned heap into the slot (the slot's
+// `Vec.set` element source moves its owned heap into the slot (the slot's
 // prior element is dropped, the source temp is not). A DEEP-OWNED element (a
 // record carrying a nested `Vec<string>`) is required — a refcount-shared
 // string/Option field would not route to the move sibling.
@@ -10,14 +10,14 @@ record Holder {
 }
 
 fn mkItems() -> Vec<string> {
-    let xs: Vec<string> = Vec::new();
+    let xs: Vec<string> = Vec.new();
     xs.push("deep-elem-a");
     xs.push("deep-elem-b");
     return xs;
 }
 
 fn main() {
-    var v: Vec<Holder> = Vec::new();
+    var v: Vec<Holder> = Vec.new();
     v.push(Holder { items: mkItems() });
     v.set(0, Holder { items: mkItems() });
     println(v.len());

--- a/examples/v05/collection_actor_drop_run_pass.hew
+++ b/examples/v05/collection_actor_drop_run_pass.hew
@@ -35,25 +35,25 @@ actor CollectionHolder {
 
 fn main() {
     // Populate the map so state-drop frees NON-EMPTY layout storage.
-    let counts = HashMap::new<string, i64>();
+    let counts = HashMap.new<string, i64>();
     counts.insert("alpha", 1);
     counts.insert("beta", 2);
     counts.insert("gamma", 3);
     counts.insert("delta", 4);
 
     // Populate the vec so state-drop frees NON-EMPTY backing storage.
-    let scores = Vec::new<i64>();
+    let scores = Vec.new<i64>();
     scores.push(10);
     scores.push(20);
     scores.push(30);
     let holder = spawn CollectionHolder(counts: counts, scores: scores);
     let r = await holder.ping();
     match r {
-        Ok(acked) => {
+        .Ok(acked) => {
             if acked == 1 {
                 println("ok");
             }
         },
-        Err(_) => {},
+        .Err(_) => {},
     }
 }

--- a/examples/v05/hashmap_f64_key_fails.hew
+++ b/examples/v05/hashmap_f64_key_fails.hew
@@ -10,6 +10,6 @@
 //! contract).
 
 fn main() {
-    let m: HashMap<f64, i64> = HashMap::new();
+    let m: HashMap<f64, i64> = HashMap.new();
     m.insert(1.0, 42);
 }

--- a/examples/v05/hashmap_f64_key_is_empty_fails.hew
+++ b/examples/v05/hashmap_f64_key_is_empty_fails.hew
@@ -6,6 +6,6 @@
 //! `record_resolved_hashmap_call`.
 
 fn main() {
-    let m: HashMap<f64, i64> = HashMap::new();
+    let m: HashMap<f64, i64> = HashMap.new();
     let _ = m.is_empty();
 }

--- a/examples/v05/hashmap_run_pass.hew
+++ b/examples/v05/hashmap_run_pass.hew
@@ -27,7 +27,7 @@ record Point {
 fn main() {
     let _p = Point { x: 0, y: 0 };
     // ── HashMap<Point, i64> surface ─────────────────────────────────
-    let m: HashMap<Point, i64> = HashMap::new();
+    let m: HashMap<Point, i64> = HashMap.new();
     m.insert(Point { x: 1, y: 2 }, 10);
     let _v = m.get(Point { x: 1, y: 2 }); // Option<i64>
     let _has = m.contains_key(Point { x: 1, y: 2 }); // bool
@@ -35,7 +35,7 @@ fn main() {
     let _n = m.len(); // i64
 
     // ── HashSet<Point> surface ──────────────────────────────────────
-    let s: HashSet<Point> = HashSet::new();
+    let s: HashSet<Point> = HashSet.new();
     s.insert(Point { x: 3, y: 4 });
     let _has_p = s.contains(Point { x: 3, y: 4 }); // bool
     let _rm = s.remove(Point { x: 3, y: 4 }); // bool

--- a/examples/v05/hashset_actor_drop_run_pass.hew
+++ b/examples/v05/hashset_actor_drop_run_pass.hew
@@ -8,7 +8,7 @@
 // when the element type was a user record; scalar/string element sets
 // (`HashSet<i64>`, `HashSet<string>`) fell through to the *legacy*
 // `hew_hashset_free`, which reinterprets the 16-byte-stride layout entries as
-// 48-byte `HewMapEntry` records and `libc.free`s integer keys as pointers —
+// 48-byte `HewMapEntry` records and `libc::free`s integer keys as pointers —
 // heap corruption on actor shutdown. The corruption is reproduced
 // deterministically at the runtime level (calling the legacy free over a
 // layout-constructed non-empty set aborts under the allocator); see

--- a/examples/v05/hashset_actor_drop_run_pass.hew
+++ b/examples/v05/hashset_actor_drop_run_pass.hew
@@ -2,13 +2,13 @@
 //
 // Regression guard for W4.045 (P0 use-after-free / heap corruption).
 //
-// `HashSet::new()` always lowers to `hew_hashset_new_with_layout`, returning
+// `HashSet.new()` always lowers to `hew_hashset_new_with_layout`, returning
 // a layout-keyed `HewLayoutHashSet*`. Before W4.045 the state drop synthesis
 // (`drop_helper_for_kind`) only emitted the matching `hew_hashset_free_layout`
 // when the element type was a user record; scalar/string element sets
 // (`HashSet<i64>`, `HashSet<string>`) fell through to the *legacy*
 // `hew_hashset_free`, which reinterprets the 16-byte-stride layout entries as
-// 48-byte `HewMapEntry` records and `libc::free`s integer keys as pointers —
+// 48-byte `HewMapEntry` records and `libc.free`s integer keys as pointers —
 // heap corruption on actor shutdown. The corruption is reproduced
 // deterministically at the runtime level (calling the legacy free over a
 // layout-constructed non-empty set aborts under the allocator); see
@@ -49,7 +49,7 @@ fn main() {
     // Populate both sets so the state-drop path frees NON-EMPTY storage on
     // shutdown — an empty set never iterates occupied slots and so would not
     // exercise the corrupting free.
-    let ints = HashSet::new<i64>();
+    let ints = HashSet.new<i64>();
     ints.insert(1);
     ints.insert(2);
     ints.insert(3);
@@ -58,7 +58,7 @@ fn main() {
     ints.insert(6);
     ints.insert(7);
     ints.insert(8);
-    let names = HashSet::new<string>();
+    let names = HashSet.new<string>();
     names.insert("alpha");
     names.insert("beta");
     names.insert("gamma");
@@ -72,11 +72,11 @@ fn main() {
     // state_drop_fn free of both non-empty sets) runs as the program winds down.
     let r = await holder.ping();
     match r {
-        Ok(acked) => {
+        .Ok(acked) => {
             if acked == 1 {
                 println("ok");
             }
         },
-        Err(_) => {},
+        .Err(_) => {},
     }
 }

--- a/examples/v05/hashset_f64_clear_fails.hew
+++ b/examples/v05/hashset_f64_clear_fails.hew
@@ -6,6 +6,6 @@
 //! bypass `record_resolved_hashset_call`.
 
 fn main() {
-    let s: HashSet<f64> = HashSet::new();
+    let s: HashSet<f64> = HashSet.new();
     s.clear();
 }

--- a/examples/v05/indirect_enum_actor_message.hew
+++ b/examples/v05/indirect_enum_actor_message.hew
@@ -5,8 +5,8 @@ indirect enum Tree {
 
 fn sum(t: Tree) -> i64 {
     match t {
-        Leaf(value) => value,
-        Node(left, right) => sum(left) + sum(right),
+        .Leaf(value) => value,
+        .Node(left, right) => sum(left) + sum(right),
     }
 }
 
@@ -22,7 +22,7 @@ actor TestSink {
 
 fn main() -> i64 {
     let sink = spawn TestSink;
-    sink.take(Node(Leaf(4), Node(Leaf(5), Leaf(6))));
-    sink.tagged(10, Node(Leaf(1), Leaf(2)));
+    sink.take(.Node(.Leaf(4), .Node(.Leaf(5), .Leaf(6))));
+    sink.tagged(10, .Node(.Leaf(1), .Leaf(2)));
     0
 }

--- a/examples/v05/indirect_enum_actor_message_requests.hew
+++ b/examples/v05/indirect_enum_actor_message_requests.hew
@@ -5,8 +5,8 @@ indirect enum Tree {
 
 fn sum(t: Tree) -> i64 {
     match t {
-        Leaf(value) => value,
-        Node(left, right) => sum(left) + sum(right),
+        .Leaf(value) => value,
+        .Node(left, right) => sum(left) + sum(right),
     }
 }
 
@@ -21,8 +21,8 @@ actor Coordinator {
 
     receive fn ask_score(tag: i64, tree: Tree) -> i64 {
         match await scorer.score(tag, tree) {
-            Ok(value) => value,
-            Err(_) => -1,
+            .Ok(value) => value,
+            .Err(_) => -1,
         }
     }
 
@@ -37,25 +37,25 @@ actor Coordinator {
 fn main() -> i64 {
     let scorer = spawn Scorer;
     let coordinator = spawn Coordinator(scorer: scorer);
-    let direct = match await scorer.score(10, Node(Leaf(1), Leaf(2))) {
-        Ok(value) => value,
-        Err(_) => -3,
+    let direct = match await scorer.score(10, .Node(.Leaf(1), .Leaf(2))) {
+        .Ok(value) => value,
+        .Err(_) => -3,
     };
     let selected = select {
-        reply from scorer.score(20, Node(Leaf(3), Leaf(4))) => reply,
+        reply from scorer.score(20, .Node(.Leaf(3), .Leaf(4))) => reply,
         after 5s => -4,
     };
     let (joined_a, joined_b) = join {
-        scorer.score(30, Node(Leaf(5), Leaf(6))),
-        scorer.score(40, Node(Leaf(7), Leaf(8))),
+        scorer.score(30, .Node(.Leaf(5), .Leaf(6))),
+        scorer.score(40, .Node(.Leaf(7), .Leaf(8))),
     };
-    let suspended_ask = match await coordinator.ask_score(50, Node(Leaf(9), Leaf(10))) {
-        Ok(value) => value,
-        Err(_) => -5,
+    let suspended_ask = match await coordinator.ask_score(50, .Node(.Leaf(9), .Leaf(10))) {
+        .Ok(value) => value,
+        .Err(_) => -5,
     };
-    let suspended_select = match await coordinator.select_score(60, Node(Leaf(11), Leaf(12))) {
-        Ok(value) => value,
-        Err(_) => -6,
+    let suspended_select = match await coordinator.select_score(60, .Node(.Leaf(11), .Leaf(12))) {
+        .Ok(value) => value,
+        .Err(_) => -6,
     };
     print(f"{direct},{selected},{joined_a},{joined_b},{suspended_ask},{suspended_select}");
     0

--- a/examples/v05/linear/reject/linear_consumed_only_some_branches.hew
+++ b/examples/v05/linear/reject/linear_consumed_only_some_branches.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck::MustConsume` — partial-branch canary.
+// Reject fixture for `MirCheck.MustConsume` — partial-branch canary.
 //
 // `t` is consumed in the then-arm (`let _a = t`) but the else-arm
 // leaves it Live.  At the join point the state is MaybeConsumed; when

--- a/examples/v05/linear/reject/linear_consumed_only_some_branches.hew
+++ b/examples/v05/linear/reject/linear_consumed_only_some_branches.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck.MustConsume` — partial-branch canary.
+// Reject fixture for `MirCheck::MustConsume` — partial-branch canary.
 //
 // `t` is consumed in the then-arm (`let _a = t`) but the else-arm
 // leaves it Live.  At the join point the state is MaybeConsumed; when

--- a/examples/v05/linear/reject/linear_unconsumed_fall_through.hew
+++ b/examples/v05/linear/reject/linear_unconsumed_fall_through.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck::MustConsume` — unconsumed fall-through.
+// Reject fixture for `MirCheck.MustConsume` — unconsumed fall-through.
 //
 // `t` is a `#[linear]` binding.  The function returns without consuming
 // it on any path: the live binding reaches the implicit tail-return site.

--- a/examples/v05/linear/reject/linear_unconsumed_fall_through.hew
+++ b/examples/v05/linear/reject/linear_unconsumed_fall_through.hew
@@ -1,4 +1,4 @@
-// Reject fixture for `MirCheck.MustConsume` — unconsumed fall-through.
+// Reject fixture for `MirCheck::MustConsume` — unconsumed fall-through.
 //
 // `t` is a `#[linear]` binding.  The function returns without consuming
 // it on any path: the live binding reaches the implicit tail-return site.

--- a/examples/v05/surfaces/channel_record_elements.hew
+++ b/examples/v05/surfaces/channel_record_elements.hew
@@ -1,4 +1,4 @@
-//! Status: runnable (v0.5 record elements over std::channel)
+//! Status: runnable (v0.5 record elements over std.channel)
 //! Description: Round-trips a heap-owning record through a channel and
 //! breaks out of a `for await` drain early with items still queued.
 //!
@@ -10,7 +10,7 @@
 //! `break` below exercises that queue-drop path: two `Tagged` envelopes are
 //! still queued when `rx` goes out of scope.
 
-import std::channel::channel;
+import std.channel.channel;
 
 type Tagged {
     label: string;
@@ -44,11 +44,11 @@ fn main() {
     tx.send(Tagged { label: "polled", value: 9 });
     tx.close();
     match rx.try_recv() {
-        Some(item) => println(item.label),
-        None => println("empty"),
+        .Some(item) => println(item.label),
+        .None => println("empty"),
     }
     match rx.try_recv() {
-        Some(item) => println(item.value),
-        None => println("drained"),
+        .Some(item) => println(item.value),
+        .None => println("drained"),
     }
 }

--- a/examples/v05/surfaces/for_await_recv_f64.hew
+++ b/examples/v05/surfaces/for_await_recv_f64.hew
@@ -5,7 +5,7 @@
 //! describable element type and the recv path decodes the 8-byte Plain
 //! envelope through `hew_channel_recv_layout` — no per-type runtime symbol.
 
-import std::channel::channel;
+import std.channel.channel;
 
 actor DrainFloats {
     receive fn run(unused: i64) {

--- a/examples/v05/surfaces/for_await_recv_int.hew
+++ b/examples/v05/surfaces/for_await_recv_int.hew
@@ -1,7 +1,7 @@
 //! Status: runnable (v0.5 for-await over Receiver<i64>)
 //! Description: Drains an integer channel receiver with `for await`.
 
-import std::channel::channel;
+import std.channel.channel;
 
 actor DrainInts {
     receive fn run(unused: i64) {

--- a/examples/v05/surfaces/for_await_recv_string.hew
+++ b/examples/v05/surfaces/for_await_recv_string.hew
@@ -1,7 +1,7 @@
 //! Status: runnable (v0.5 for-await over Receiver<string>)
 //! Description: Drains a channel receiver with `for await`.
 
-import std::channel::channel;
+import std.channel.channel;
 
 actor DrainStrings {
     receive fn run(unused: i64) {

--- a/examples/v05/surfaces/for_await_stream_bytes.hew
+++ b/examples/v05/surfaces/for_await_stream_bytes.hew
@@ -1,7 +1,7 @@
 //! Status: runnable (v0.5 for-await over Stream<bytes>)
 //! Description: Drains a byte stream with `for await`.
 
-import std::stream;
+import std.stream;
 
 actor DrainBytes {
     let frames: i64;

--- a/examples/v05/surfaces/for_await_stream_string.hew
+++ b/examples/v05/surfaces/for_await_stream_string.hew
@@ -2,10 +2,10 @@
 //! Description: Drains a `Stream<string>` with `for await` end-to-end,
 //! including an empty `""` item to lock the empty-item invariant.
 //!
-//! `Stream<string>::recv` resolves to the layout-witness runtime entry
+//! `Stream<string>.recv` resolves to the layout-witness runtime entry
 //! `hew_stream_next_layout` (one symbol for every describable element
 //! type). The suspending coroutine path lowers it to
-//! `Terminator::SuspendingStreamNext`; the resume
+//! `Terminator.SuspendingStreamNext`; the resume
 //! edge pops the item via `hew_stream_pop_layout` and binds it as
 //! `Option<string>`. EOF is the sole `None`; an empty item surfaces as
 //! `Some("")` and the loop continues — the empty-item drain in this fixture
@@ -15,7 +15,7 @@
 //! once the loop body exits, and the stream handle is freed at end-of-scope
 //! (no extra free on the recv edge — see `is_handle_borrowing_call_abi`).
 
-import std::stream;
+import std.stream;
 
 actor DrainStrings {
     let frames: i64;

--- a/examples/v05/surfaces/for_await_stream_string.hew
+++ b/examples/v05/surfaces/for_await_stream_string.hew
@@ -5,7 +5,7 @@
 //! `Stream<string>.recv` resolves to the layout-witness runtime entry
 //! `hew_stream_next_layout` (one symbol for every describable element
 //! type). The suspending coroutine path lowers it to
-//! `Terminator.SuspendingStreamNext`; the resume
+//! `Terminator::SuspendingStreamNext`; the resume
 //! edge pops the item via `hew_stream_pop_layout` and binds it as
 //! `Option<string>`. EOF is the sole `None`; an empty item surfaces as
 //! `Some("")` and the loop continues — the empty-item drain in this fixture

--- a/examples/v05/surfaces/regex_captures.hew
+++ b/examples/v05/surfaces/regex_captures.hew
@@ -1,4 +1,4 @@
-//! Status: runnable (v0.5 std::text::regex captures surface)
+//! Status: runnable (v0.5 std.text.regex captures surface)
 //! Description: Regex capture groups — capture / capture_named / find_all / find_all_submatch.
 //!
 //! Compiles a date pattern with named groups, then pulls submatches out of an
@@ -7,19 +7,19 @@
 //! submatch table via `find_all_submatch`. `Option` results are matched, never
 //! unwrapped, and the compiled `Pattern` is released early with `close()`.
 
-import std::text::regex;
+import std.text.regex;
 
 fn main() {
     let re = regex.new("(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})");
     let text = "release 2026-06-07, patched 1999-12-31";
     // First match: one indexed group and one named group.
     match re.capture(text, 1) {
-        Some(year) => println(f"first year: {year}"),
-        None => println("no date found"),
+        .Some(year) => println(f"first year: {year}"),
+        .None => println("no date found"),
     }
     match re.capture_named(text, "month") {
-        Some(month) => println(f"first month: {month}"),
-        None => println("no month group"),
+        .Some(month) => println(f"first month: {month}"),
+        .None => println("no month group"),
     }
     // Every whole match as a flat Vec<string>.
     let wholes = re.find_all(text);
@@ -30,16 +30,16 @@ fn main() {
     println(f"rows={rows.len()} groups_per_row={rows.width()}");
     for i in 0 .. rows.len() {
         let whole = match rows.whole(i) {
-            Some(w) => w,
-            None => "?",
+            .Some(w) => w,
+            .None => "?",
         };
         let year = match rows.group(i, 1) {
-            Some(g) => g,
-            None => "?",
+            .Some(g) => g,
+            .None => "?",
         };
         let day = match rows.group(i, 3) {
-            Some(g) => g,
-            None => "?",
+            .Some(g) => g,
+            .None => "?",
         };
         println(f"row {i}: {whole} (year={year} day={day})");
     }

--- a/examples/v05/surfaces/scanner_tokens.hew
+++ b/examples/v05/surfaces/scanner_tokens.hew
@@ -1,13 +1,13 @@
-//! Scanner surface: line and word tokenisation through `std::io::scanner`.
+//! Scanner surface: line and word tokenisation through `std.io.scanner`.
 //!
 //! `Scanner` is a value-state API: each call to `scan` returns the next scanner
 //! state, and `text` is meaningful only while `has_next` is true.
 
-import std::io::scanner;
+import std.io.scanner;
 
 fn main() {
     var words = scanner.from_string("alpha beta\ncolour");
-    words = scanner.with_split(words, SplitWords);
+    words = scanner.with_split(words, .SplitWords);
     words = scanner.scan(words);
     while scanner.has_next(words) {
         println(f"word={scanner.text(words)}");
@@ -19,8 +19,8 @@ fn main() {
         let step = scanner.next_line(lines);
         lines = step.0;
         match step.1 {
-            Some(line) => println(f"line={line}"),
-            None => {
+            .Some(line) => println(f"line={line}"),
+            .None => {
                 done = true;
             },
         }

--- a/examples/v05/surfaces/template_render.hew
+++ b/examples/v05/surfaces/template_render.hew
@@ -1,4 +1,4 @@
-//! Status: runnable (v0.5 std::text::template parse/render surface)
+//! Status: runnable (v0.5 std.text.template parse/render surface)
 //! Description: Go-style text/template — parse a template then render it against a flat Ctx.
 //!
 //! Builds a flat context with scalar (`ctx_set_str` / `ctx_set_int` /
@@ -8,14 +8,14 @@
 //! `Result`. Method-style `t.render(ctx)` is deferred in v0.5, so the
 //! free-function `template.render_try(t, ctx)` form is used.
 
-import std::text::template;
+import std.text.template;
 
 fn main() {
     let ctx = template.new_ctx();
     template.ctx_set_str(ctx, "name", "Ada");
     template.ctx_set_int(ctx, "commits", 7);
     template.ctx_set_bool(ctx, "member", true);
-    let tags: Vec<string> = Vec::new();
+    let tags: Vec<string> = Vec.new();
     tags.push("compiler");
     tags.push("runtime");
     tags.push("docs");
@@ -23,7 +23,7 @@ fn main() {
     let src = "Hi {{.name}} — {{.commits}} commits{{if .member}} (core member){{end}}.\nTags:{{range .tags}} #{{.}}{{end}}";
     let tmpl = template.parse(src);
     match template.render_try(tmpl, ctx) {
-        Ok(rendered) => println(rendered),
-        Err(_) => println("template render failed"),
+        .Ok(rendered) => println(rendered),
+        .Err(_) => println("template render failed"),
     }
 }

--- a/examples/v05/surfaces/try_recv_stream_string.hew
+++ b/examples/v05/surfaces/try_recv_stream_string.hew
@@ -3,11 +3,11 @@
 //! `try_recv()` poll, including an empty `""` item to lock the empty-item
 //! invariant.
 //!
-//! `Stream<string>::try_recv` resolves to the runtime symbol
+//! `Stream<string>.try_recv` resolves to the runtime symbol
 //! `hew_stream_try_next_layout` (the layout-witness entry, one symbol for
 //! every describable element type). Unlike the blocking
 //! `recv` / suspending `await recv` siblings, try_recv lowers to a plain
-//! `Terminator::Call { callee: "hew_stream_try_next_layout" }` whose codegen
+//! `Terminator.Call { callee: "hew_stream_try_next_layout" }` whose codegen
 //! intercept emits the same header-aware pop + `Option<string>` bind on
 //! the call's `next` block.
 //!
@@ -22,7 +22,7 @@
 //! stream.pipe(N); input.try_recv()` shape does not trip the
 //! aggregate-handle double-free analysis.
 
-import std::stream;
+import std.stream;
 
 actor TryRecvStrings {
     receive fn run(unused: i64) {
@@ -37,11 +37,11 @@ actor TryRecvStrings {
         while !done {
             let item = input.try_recv();
             match item {
-                Some(frame) => {
+                .Some(frame) => {
                     println(f"poll [{frame}]");
                     received = received + 1;
                 },
-                None => {
+                .None => {
                     done = true;
                 },
             }

--- a/examples/v05/surfaces/try_recv_stream_string.hew
+++ b/examples/v05/surfaces/try_recv_stream_string.hew
@@ -7,7 +7,7 @@
 //! `hew_stream_try_next_layout` (the layout-witness entry, one symbol for
 //! every describable element type). Unlike the blocking
 //! `recv` / suspending `await recv` siblings, try_recv lowers to a plain
-//! `Terminator.Call { callee: "hew_stream_try_next_layout" }` whose codegen
+//! `Terminator::Call { callee: "hew_stream_try_next_layout" }` whose codegen
 //! intercept emits the same header-aware pop + `Option<string>` bind on
 //! the call's `next` block.
 //!

--- a/examples/v05/surfaces/typed_streams.hew
+++ b/examples/v05/surfaces/typed_streams.hew
@@ -20,7 +20,7 @@
 //! Frames are built from text with the public `string.to_bytes()` surface — no
 //! raw extern, no `unsafe`.
 
-import std::stream;
+import std.stream;
 
 actor Drainer {
     let input: stream.Stream<bytes>;
@@ -31,11 +31,11 @@ actor Drainer {
         var done = false;
         while !done {
             match await input.recv() {
-                Some(frame) => {
+                .Some(frame) => {
                     println(f"recv {frame.to_string()}");
                     received = received + 1;
                 },
-                None => {
+                .None => {
                     done = true;
                 },
             }

--- a/examples/v05/surfaces/typed_streams_string.hew
+++ b/examples/v05/surfaces/typed_streams_string.hew
@@ -6,7 +6,7 @@
 //! single `await stream.recv()`). `Stream<string>.recv` resolves to the
 //! layout-witness runtime entry `hew_stream_next_layout` (one symbol for
 //! every describable element type). Each `await input.recv()`
-//! lowers to `Terminator.SuspendingStreamNext`;
+//! lowers to `Terminator::SuspendingStreamNext`;
 //! the resume edge pops the item via `hew_stream_pop_layout` and binds an
 //! `Option<string>`. EOF is the sole `None`; an empty item surfaces as
 //! `Some("")` and the loop continues — the empty-item drain here is the

--- a/examples/v05/surfaces/typed_streams_string.hew
+++ b/examples/v05/surfaces/typed_streams_string.hew
@@ -3,21 +3,21 @@
 //! pipe, including an empty `""` item to lock the empty-item invariant.
 //!
 //! Companion to `typed_streams.hew` (which drains a `Stream<bytes>` with
-//! single `await stream.recv()`). `Stream<string>::recv` resolves to the
+//! single `await stream.recv()`). `Stream<string>.recv` resolves to the
 //! layout-witness runtime entry `hew_stream_next_layout` (one symbol for
 //! every describable element type). Each `await input.recv()`
-//! lowers to `Terminator::SuspendingStreamNext`;
+//! lowers to `Terminator.SuspendingStreamNext`;
 //! the resume edge pops the item via `hew_stream_pop_layout` and binds an
 //! `Option<string>`. EOF is the sole `None`; an empty item surfaces as
 //! `Some("")` and the loop continues — the empty-item drain here is the
 //! regression for that invariant.
 //!
-//! `Sink<string>::send` is now on the suspending-sink-send path too (every
+//! `Sink<string>.send` is now on the suspending-sink-send path too (every
 //! describable element suspends, not just `Sink<bytes>`): each
 //! `await sink.send(item)` writes a frame, suspending on a full ring
 //! (backpressure-aware). The `Sink`/`Stream` halves are locals in this handler.
 
-import std::stream;
+import std.stream;
 
 actor StringPipeline {
     receive fn run(unused: i64) {
@@ -35,11 +35,11 @@ actor StringPipeline {
         while !done {
             let item = await input.recv();
             match item {
-                Some(frame) => {
+                .Some(frame) => {
                     println(f"recv [{frame}]");
                     received = received + 1;
                 },
-                None => {
+                .None => {
                     done = true;
                 },
             }

--- a/examples/v05/surfaces/unicode_runes.hew
+++ b/examples/v05/surfaces/unicode_runes.hew
@@ -1,4 +1,4 @@
-//! Status: runnable (v0.5 std::text::unicode rune helpers + predicates)
+//! Status: runnable (v0.5 std.text.unicode rune helpers + predicates)
 //! Description: Unicode runes — decode a UTF-8 string into codepoints and classify each one.
 //!
 //! Uses `rune_count` (vs the byte `len()`), `runes` to decode a string into a
@@ -7,7 +7,7 @@
 //! / `is_letter` / `is_punct`) dispatched with `match` guards, and `to_upper`
 //! case folding on a per-rune basis.
 
-import std::text::unicode;
+import std.text.unicode;
 
 fn classify(cp: i64) -> string {
     match cp {

--- a/examples/v05/vec_indirect_enum_element_fails.hew
+++ b/examples/v05/vec_indirect_enum_element_fails.hew
@@ -15,7 +15,7 @@ indirect enum Foo {
 }
 
 fn main() {
-    let nodes: Vec<Foo> = Vec::new();
-    nodes.push(Foo::B);
-    nodes.push(Foo::A(42));
+    let nodes: Vec<Foo> = Vec.new();
+    nodes.push(Foo.B);
+    nodes.push(Foo.A(42));
 }

--- a/examples/v05/vec_indirect_enum_heap_payload_element_fails.hew
+++ b/examples/v05/vec_indirect_enum_heap_payload_element_fails.hew
@@ -18,7 +18,7 @@ indirect enum Foo {
 }
 
 fn main() {
-    let nodes: Vec<Foo> = Vec::new();
-    nodes.push(Foo::B);
-    nodes.push(Foo::A("boxed"));
+    let nodes: Vec<Foo> = Vec.new();
+    nodes.push(Foo.B);
+    nodes.push(Foo.A("boxed"));
 }

--- a/examples/v05/vec_recursive_enum_reply.hew
+++ b/examples/v05/vec_recursive_enum_reply.hew
@@ -17,10 +17,10 @@ fn main() {
     // shape a RESP array decode produces. Each `push` deep-clones the reply
     // (the `Array`'s inner `[RedisReply]` and all) into `replies`.
     var replies: [RedisReply] = [];
-    replies.push(RedisReply::Int(1));
-    replies.push(RedisReply::Int(2));
-    replies.push(RedisReply::Array([RedisReply::Int(10), RedisReply::Int(20)]));
-    replies.push(RedisReply::Text("OK"));
+    replies.push(RedisReply.Int(1));
+    replies.push(RedisReply.Int(2));
+    replies.push(RedisReply.Array([RedisReply.Int(10), RedisReply.Int(20)]));
+    replies.push(RedisReply.Text("OK"));
 
     // Read the batch back and classify each reply by its variant — proving the
     // stored tree is intact and matchable after the copy-in clone.
@@ -29,16 +29,16 @@ fn main() {
     var texts: i64 = 0;
     for reply in replies {
         match reply {
-            RedisReply::Int(n) => {
+            RedisReply.Int(n) => {
                 int_sum = int_sum + n;
             },
-            RedisReply::Array(_) => {
+            RedisReply.Array(_) => {
                 arrays = arrays + 1;
             },
-            RedisReply::Text(_) => {
+            RedisReply.Text(_) => {
                 texts = texts + 1;
             },
-            RedisReply::Nil => {},
+            RedisReply.Nil => {},
         }
     }
     println(f"replies={replies.len()}");

--- a/examples/v05/vec_run_join_pass.hew
+++ b/examples/v05/vec_run_join_pass.hew
@@ -1,6 +1,6 @@
-// Vec<string>::join accept fixture.
+// Vec<string>.join accept fixture.
 fn main() -> i64 {
-    let words: Vec<string> = Vec::new();
+    let words: Vec<string> = Vec.new();
     words.push("hew");
     words.push("lang");
     let _joined = words.join("-");

--- a/examples/v05/vec_run_pass.hew
+++ b/examples/v05/vec_run_pass.hew
@@ -9,7 +9,7 @@ record Point {
 }
 
 fn main() -> i64 {
-    let nums: Vec<i64> = Vec::new();
+    let nums: Vec<i64> = Vec.new();
     nums.push(1);
     nums.push(2);
     let _popped = nums.pop();
@@ -21,14 +21,14 @@ fn main() -> i64 {
     let _has = nums.contains(3);
     let _empty = nums.is_empty();
     let _copy = nums.clone();
-    let more: Vec<i64> = Vec::new();
+    let more: Vec<i64> = Vec.new();
     nums.append(more);
     nums.clear();
-    let words: Vec<string> = Vec::new();
+    let words: Vec<string> = Vec.new();
     words.push("a");
     words.push("b");
     let _joined = words.join(",");
-    let points: Vec<Point> = Vec::new();
+    let points: Vec<Point> = Vec.new();
     points.push(Point { x: 1, y: 2 });
     let _point = points.get(0);
     points.set(0, Point { x: 3, y: 4 });

--- a/examples/v05/vec_string_actor_drop_run_pass.hew
+++ b/examples/v05/vec_string_actor_drop_run_pass.hew
@@ -36,7 +36,7 @@ actor WordHolder {
 fn main() {
     // Populate with heap-owned strings so state-drop frees NON-EMPTY per-slot
     // storage through `hew_vec_free_managed`.
-    let words: Vec<string> = Vec::new();
+    let words: Vec<string> = Vec.new();
     words.push("alpha");
     words.push("beta");
     words.push("gamma");
@@ -46,11 +46,11 @@ fn main() {
     // "ok" is gated on both the populated-vec count (real data flow) and the
     // actor ack; teardown then exercises the managed per-slot string free.
     match r {
-        Ok(acked) => {
+        .Ok(acked) => {
             if acked == 1 && count == 3 {
                 println("ok");
             }
         },
-        Err(_) => {},
+        .Err(_) => {},
     }
 }

--- a/examples/v05/vec_unsupported_method_fails.hew
+++ b/examples/v05/vec_unsupported_method_fails.hew
@@ -1,5 +1,5 @@
 // Unsupported Vec method rejection fixture.
 fn main() {
-    let nums: Vec<i64> = Vec::new();
+    let nums: Vec<i64> = Vec.new();
     nums.nonsense();
 }

--- a/examples/vec_basic_methods.hew
+++ b/examples/vec_basic_methods.hew
@@ -1,5 +1,5 @@
 fn main() {
-    let v: Vec<i64> = Vec::new();
+    let v: Vec<i64> = Vec.new();
     v.push(1);
     v.push(42);
     v.push(3);

--- a/examples/vec_hashmap_test.hew
+++ b/examples/vec_hashmap_test.hew
@@ -4,7 +4,7 @@
 // Vec and HashMap test
 // Exercises the core collection types from Hew programs
 fn test_vec() -> i32 {
-    let v: Vec<i32> = Vec::new();
+    let v: Vec<i32> = Vec.new();
     v.push(10);
     v.push(20);
     v.push(30);
@@ -24,17 +24,17 @@ fn test_vec() -> i32 {
 }
 
 fn test_hashmap() -> i32 {
-    let m: HashMap<string, i32> = HashMap::new();
+    let m: HashMap<string, i32> = HashMap.new();
     m.insert("one", 1);
     m.insert("two", 2);
     m.insert("three", 3);
     let one: i32 = match m.get("one") {
-        Some(_) => 1,
-        None => 0,
+        .Some(_) => 1,
+        .None => 0,
     };
     let two: i32 = match m.get("two") {
-        Some(_) => 2,
-        None => 0,
+        .Some(_) => 2,
+        .None => 0,
     };
     let has_three = m.contains_key("three");
     let has_four = m.contains_key("four");

--- a/examples/while_let_iter.hew
+++ b/examples/while_let_iter.hew
@@ -9,7 +9,7 @@
 // scrutinee to a pre-built `None` sentinel.
 fn main() {
     var current: Option<i64> = Some(3);
-    while let Some(value) = current {
+    while let .Some(value) = current {
         println(value);
         if value > 0 {
             current = Some(value - 1);

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -70,28 +70,27 @@ spec-0009   4166606024   # SNIPPET: bare `worker.send` + `await counter.get()` �
 spec-0010   3633579472   # NYI: bare `scope { ... }` — scope/structured-concurrency not yet lowered
 spec-0011   3107872017   # FRAGMENT: calls `open(path)` with no import — context-dependent snippet
 spec-0012   3219419134   # SNIPPET: bare before/after code — ? operator syntax illustration
-spec-0013   788697440   # SNIPPET: bare `let buf: bytes = bytes::new()` — bytes type illustration
+spec-0013   506748282   # SNIPPET: bare `let buf: bytes = bytes::new()` — bytes type illustration
 spec-0014   3221762372   # SNIPPET: bare `let x = 5` / `var y = 0` — binding modes illustration
 spec-0015   1507524389   # SNIPPET: bare `type Point { ... }` + bare `var` — struct mutable field illustration
 spec-0020   3005964102   # SNIPPET: bare `let config = load_config()` — actor capture illustration
 spec-0021   667087144   # SNIPPET: bare `let local_ref = ...` — non-Send capture illustration
-spec-0022   1016251393   # FRAGMENT: actor calls undefined `process()` — allowed-ops illustration
+spec-0022   2513387504   # FRAGMENT: actor calls undefined `process()` — allowed-ops illustration
 spec-0023   3898239403   # ERROR-DEMO: intentionally shows non-Send send and non-Send capture errors
-spec-0024   2818127750   # SPEC-BUG: type mismatch in aspirational TCP module example
-spec-0025   1856890936   # FRAGMENT: imports `network::tcp` — hypothetical module, not in stdlib
-spec-0026   3837837927   # SNIPPET: bare code after import statement — illustration of import effect
+spec-0024   2265846331   # SPEC-BUG: type mismatch in aspirational TCP module example
+spec-0025   3374690289   # FRAGMENT: imports `network::tcp` — hypothetical module, not in stdlib
+spec-0026   593744325   # SNIPPET: bare code after import statement — illustration of import effect
 spec-0027   2603276079   # FRAGMENT: imports `greeting` — multi-file example, module not found
 spec-0030   53697221   # SNIPPET: bare code outside declarations — trait method dispatch illustration
 spec-0031   158863422   # SNIPPET: bare `let` + trait call — trait dispatch illustration
-spec-0034   1763016250   # IMPL-GAP: field-access result type failed checker-boundary conversion (E_HIR)
-spec-0035   527408783   # SNIPPET: bare `let` — type inference illustration
-spec-0044   1309713731   # SNIPPET: bare `let f = |...| ...` — lambda illustration
+spec-0035   1203364263   # SNIPPET: bare `let` — type inference illustration
+spec-0044   60603610   # SNIPPET: bare `let f = |...| ...` — lambda illustration
 spec-0045   166608112   # SPEC-BUG: references variant `Lit` not defined in the fence
 spec-0046   2554391900   # SNIPPET: bare `let` — fn-type variable illustration
 spec-0051   4288056281   # SPEC-BUG: struct `impl` using wrong syntax form (stray `;` before `fn`)
 spec-0054   4266594633   # SNIPPET: bare identifier `max` after trait definition — illustration
 spec-0056   1757877651   # SPEC-BUG: type mismatch in aspirational HashMap construction
-spec-0057   2930078218   # ERROR-DEMO: intentionally shows `cannot assign to immutable iter`
+spec-0057   2693165546   # ERROR-DEMO: intentionally shows `cannot assign to immutable iter`
 spec-0060   2014515248   # ERROR-DEMO: intentionally shows missing Send bound on actor-boundary call
 spec-0061   484878998   # SNIPPET: bare `let` after struct definitions — trait usage illustration
 spec-0062   3690728588   # SNIPPET: bare `let f: fn(i64) -> i64 = ...` — fn-type illustration
@@ -101,9 +100,9 @@ spec-0066   4058908296   # SNIPPET: bare `let` — generic function illustration
 spec-0069   1058274598   # SPEC-BUG: struct `impl` using incorrect syntax (stray `;` before `fn`)
 spec-0073   820125999   # SPEC-BUG: enum variants separated by `,` not `;` — illustrates wrong syntax
 spec-0075   4120679691   # SPEC-BUG: malformed struct `impl` syntax — aspirational (re-verified after Vec<T> method-table correction, still fails identically: signature-only `;`-terminated impl bodies, no `{ }`)
-spec-0076   1066583139   # SNIPPET: bare `var` — machine state body illustration
+spec-0076   2906582617   # SNIPPET: bare `var` — machine state body illustration
 spec-0077   3711765580   # SNIPPET: bare `let`/`var` — machine state illustration
-spec-0078   403715057   # SNIPPET: bare `let` after machine transitions — illustration
+spec-0078   1861586926   # SNIPPET: bare `let` after machine transitions — illustration
 spec-0079   3943447574   # SNIPPET: bare `let m = ...` — machine instantiation illustration
 spec-0080   249349858   # SNIPPET: bare `Option` identifier — option-type illustration
 spec-0081   2813060693   # IMPL-GAP: undefined `StateB` — machine-state enum reference illustration
@@ -111,19 +110,19 @@ spec-0082   3707425012   # SPEC-BUG: interleaved `event` declarations — old ma
 spec-0083   813722226   # SNIPPET: bare `on event { ... }` — machine transition illustration
 spec-0084   2915754722   # SNIPPET: bare `on event ...` — machine state illustration
 spec-0085   696588660   # SNIPPET: bare `on event ...` — machine event illustration
-spec-0086   909790399   # SNIPPET: bare `var` — machine initial-state illustration
+spec-0086   3858180891   # SNIPPET: bare `var` — machine initial-state illustration
 spec-0087   1402575065   # SNIPPET: bare `match state { ... }` — machine pattern illustration
-spec-0088   2573614970   # SPEC-BUG: references `TcpState::Closed` — undefined in this fence
+spec-0088   2705896423   # SPEC-BUG: references `TcpState::Closed` — undefined in this fence
 spec-0089   1156883475   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0090   1867383437   # SNIPPET: bare `var count = 0` — scope racing illustration
 spec-0091   3881963563   # SNIPPET: bare `let handle = fork { ... }` — scope handle illustration
 spec-0092   3357528238   # SNIPPET: bare `let` — scope result illustration
 spec-0093   2158893112   # SNIPPET: bare `var count = 0` — scoped counter illustration
-spec-0094   1894311003   # SNIPPET: bare `receive fn` — actor + scope illustration
+spec-0094   10384720   # SNIPPET: bare `receive fn` — actor + scope illustration
 spec-0095   3942350177   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0096   152741125   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0097   1539476359   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
-spec-0099   3605740155   # SNIPPET: bare `let` — async I/O illustration
+spec-0099   873326002   # SNIPPET: bare `let` — async I/O illustration
 spec-0101   823456055   # FRAGMENT: calls `process()` — undefined function from prior context
 spec-0102   920924201   # NYI: bare `select { ... }` — select statement not yet implemented
 spec-0103   1400469128   # SNIPPET: bare `let` — select illustration
@@ -133,7 +132,7 @@ spec-0106   868010148   # IMPL-GAP: supervisor init arg not a declared state fie
 spec-0107   982438679   # IMPL-GAP: `pool` is a reserved word — pool-supervisor API in flux
 spec-0108   3896519088   # IMPL-GAP: `pool` as pattern — reserved word clash in supervisor syntax
 spec-0110   3534476634   # FRAGMENT: references `prices` from prior fence context — context-dependent
-spec-0111   2311967485   # SNIPPET: bare `let` — wire schema illustration
+spec-0111   759184928   # SNIPPET: bare `let` — wire schema illustration
 spec-0112   3964649123   # SNIPPET: bare `match` — wire format pattern illustration
 spec-0123   3678662757   # SNIPPET: bare `let` — wire encode illustration
 spec-0124   866984589   # SNIPPET: bare `let` — wire decode illustration

--- a/std/channel/channel.hew
+++ b/std/channel/channel.hew
@@ -166,8 +166,8 @@ impl ReceiverMethods for Receiver {
 /// ```
 pub fn new(capacity: i64) -> (Sender, Receiver) {
     match try_new(capacity) {
-        Ok(pair) => pair,
-        Err(err) => panic(err),
+        .Ok(pair) => pair,
+        .Err(err) => panic(err),
     }
 }
 

--- a/std/io/scanner.hew
+++ b/std/io/scanner.hew
@@ -122,7 +122,7 @@ pub type Scanner {
 /// }
 /// ```
 pub fn from_string(s: string) -> Scanner {
-    Scanner { source: s, pos: 0, current: "", valid: false, done: false, mode: SplitLines }
+    Scanner { source: s, pos: 0, current: "", valid: false, done: false, mode: .SplitLines }
 }
 
 /// Create a scanner over all data read from standard input.
@@ -139,8 +139,8 @@ pub fn from_stdin() -> Scanner {
 /// Returns `Err(fs.IoError)` if the file cannot be opened or read.
 pub fn from_file(path: string) -> Result<Scanner, fs.IoError> {
     match fs.try_read(path) {
-        Ok(contents) => Ok(Scanner { source: contents, pos: 0, current: "", valid: false, done: false, mode: SplitLines }),
-        Err(e) => Err(e),
+        .Ok(contents) => Ok(Scanner { source: contents, pos: 0, current: "", valid: false, done: false, mode: .SplitLines }),
+        .Err(e) => Err(e),
     }
 }
 
@@ -190,8 +190,8 @@ pub fn with_split(sc: Scanner, mode: SplitMode) -> Scanner {
 /// ```
 pub fn scan(sc: Scanner) -> Scanner {
     match sc.mode {
-        SplitLines => scan_line(sc),
-        SplitWords => scan_word(sc),
+        .SplitLines => scan_line(sc),
+        .SplitWords => scan_word(sc),
     }
 }
 
@@ -201,7 +201,7 @@ pub fn scan(sc: Scanner) -> Scanner {
 /// A real empty line returns `Some("")`; EOF returns `None`.
 pub fn next_line(sc: Scanner) -> (Scanner, Option<string>) {
     let mode = sc.mode;
-    let line_sc = Scanner { source: sc.source, pos: sc.pos, current: sc.current, valid: sc.valid, done: sc.done, mode: SplitLines };
+    let line_sc = Scanner { source: sc.source, pos: sc.pos, current: sc.current, valid: sc.valid, done: sc.done, mode: .SplitLines };
     let next = scan(line_sc);
     let restored = Scanner { source: next.source, pos: next.pos, current: next.current, valid: next.valid, done: next.done, mode: mode };
     if has_next(next) {
@@ -284,7 +284,7 @@ pub fn words(s: string) -> Vec<string> {
         return result;
     }
     var sc = from_string(s);
-    sc = with_split(sc, SplitWords);
+    sc = with_split(sc, .SplitWords);
     sc = scan(sc);
     while has_next(sc) {
         result.push(sc.current);

--- a/std/net/http/http_async_client.hew
+++ b/std/net/http/http_async_client.hew
@@ -194,13 +194,13 @@ pub fn host_of(url_str: string) -> string {
     let (authority, _) = split_authority_path(after_scheme);
     if authority.starts_with("[") {
         match authority.find("]") {
-            Some(end) => authority.slice(0, end + 1),
-            None => authority,
+            .Some(end) => authority.slice(0, end + 1),
+            .None => authority,
         }
     } else {
         match authority.find(":") {
-            Some(colon) => authority.slice(0, colon),
-            None => authority,
+            .Some(colon) => authority.slice(0, colon),
+            .None => authority,
         }
     }
 }
@@ -209,18 +209,18 @@ fn split_authority_path(after_scheme: string) -> (string, string) {
     let slash = after_scheme.find("/");
     let query = after_scheme.find("?");
     let end = match slash {
-        Some(s) => match query {
-            Some(q) => if s < q {
+        .Some(s) => match query {
+            .Some(q) => if s < q {
                 Some(s)
             } else {
                 Some(q)
             },
-            None => Some(s),
+            .None => Some(s),
         },
-        None => query,
+        .None => query,
     };
     match end {
-        Some(i) => {
+        .Some(i) => {
             let authority = after_scheme.slice(0, i);
             let suffix = after_scheme.slice(i, after_scheme.len());
             if suffix.starts_with("?") {
@@ -229,7 +229,7 @@ fn split_authority_path(after_scheme: string) -> (string, string) {
                 (authority, suffix)
             }
         },
-        None => (after_scheme, "/"),
+        .None => (after_scheme, "/"),
     }
 }
 
@@ -245,16 +245,16 @@ pub fn default_port(scheme: string) -> i64 {
 /// The scheme of a URL (`http` / `https`), or `"http"` when none is present.
 fn scheme_of(url_str: string) -> string {
     match url_str.find("://") {
-        Some(mark) => url_str.slice(0, mark).to_lower(),
-        None => "http",
+        .Some(mark) => url_str.slice(0, mark).to_lower(),
+        .None => "http",
     }
 }
 
 /// Strip a `scheme://` prefix, leaving `authority[/path]`.
 fn strip_scheme(url_str: string) -> string {
     match url_str.find("://") {
-        Some(mark) => url_str.slice(mark + 3, url_str.len()),
-        None => url_str,
+        .Some(mark) => url_str.slice(mark + 3, url_str.len()),
+        .None => url_str,
     }
 }
 
@@ -263,19 +263,19 @@ fn strip_scheme(url_str: string) -> string {
 fn authority_with_port(authority: string, scheme: string) -> string {
     if authority.starts_with("[") {
         match authority.find("]") {
-            Some(end) => {
+            .Some(end) => {
                 if end + 1 < authority.len() && authority.slice(end + 1, end + 2) == ":" {
                     authority
                 } else {
                     f"{authority}:{default_port(scheme)}"
                 }
             },
-            None => f"{authority}:{default_port(scheme)}",
+            .None => f"{authority}:{default_port(scheme)}",
         }
     } else {
         match authority.find(":") {
-            Some(_) => authority,
-            None => f"{authority}:{default_port(scheme)}",
+            .Some(_) => authority,
+            .None => f"{authority}:{default_port(scheme)}",
         }
     }
 }
@@ -292,8 +292,8 @@ pub fn response_over_limit(raw: string) -> bool {
         return true;
     }
     let sep = match raw.find("\r\n\r\n") {
-        Some(i) => i,
-        None => return raw.len() > CLIENT_MAX_HEADER_BYTES,
+        .Some(i) => i,
+        .None => return raw.len() > CLIENT_MAX_HEADER_BYTES,
     };
     let head = raw.slice(0, sep);
     if head.len() > CLIENT_MAX_HEADER_BYTES {
@@ -317,9 +317,9 @@ pub fn parse_response(raw: string) -> AsyncResponse {
         return AsyncResponse { code: -1, body_text: "", header_section: "" };
     }
     let sep = match raw.find("\r\n\r\n") {
-        Some(i) => i,
+        .Some(i) => i,
         // SF2 — no header terminator: the response is not fully framed.
-        None => return AsyncResponse { code: -1, body_text: "", header_section: "" },
+        .None => return AsyncResponse { code: -1, body_text: "", header_section: "" },
     };
     let head = raw.slice(0, sep);
     let body = raw.slice(sep + 4, raw.len());
@@ -381,8 +381,8 @@ fn is_http_version(version: string) -> bool {
     }
     // len == 8 was checked above, so char_at(7) is always Some.
     let minor = match version.char_at(7) {
-        Some(c) => c as i64,
-        None => return false,
+        .Some(c) => c as i64,
+        .None => return false,
     };
     minor >= 48 && minor <= 57
 }
@@ -391,8 +391,8 @@ fn is_http_version(version: string) -> bool {
 /// re-joined with CRLF for [`find_response_header`].
 fn header_section_of(head: string) -> string {
     match head.find("\r\n") {
-        Some(first) => head.slice(first + 2, head.len()),
-        None => "",
+        .Some(first) => head.slice(first + 2, head.len()),
+        .None => "",
     }
 }
 
@@ -410,7 +410,7 @@ fn find_response_header(header_section: string, name: string) -> string {
         // A colon at index 0 is an empty header name — skip it, exactly as
         // the old `colon > 0` guard did.
         match line.find(":") {
-            Some(colon) if colon > 0 => {
+            .Some(colon) if colon > 0 => {
                 let key = string.trim(line.slice(0, colon)).to_lower();
                 if key == target {
                     found = string.trim(line.slice(colon + 1, line.len()));
@@ -439,8 +439,8 @@ fn declared_content_length(header_section: string) -> i64 {
         return 0;
     }
     match string.try_to_int(value) {
-        Ok(n) => n,
-        Err(_) => CLIENT_MAX_BODY_BYTES + 1,
+        .Ok(n) => n,
+        .Err(_) => CLIENT_MAX_BODY_BYTES + 1,
     }
 }
 
@@ -454,8 +454,8 @@ fn contains_control_char(s: string) -> bool {
         // In-bounds loop: char_at(i) is always Some; the unreachable None
         // fails CLOSED (treat as a control character -> reject).
         let b = match s.char_at(i) {
-            Some(c) => c as i64,
-            None => return true,
+            .Some(c) => c as i64,
+            .None => return true,
         };
         if b < 32 || b == 127 {
             return true;

--- a/std/net/http/http_async_server.hew
+++ b/std/net/http/http_async_server.hew
@@ -147,8 +147,8 @@ impl AsyncRequestMethods for AsyncRequest {
 /// for the peer to close).
 pub fn request_complete(raw: string) -> bool {
     let sep = match raw.find("\r\n\r\n") {
-        Some(i) => i,
-        None => return false,
+        .Some(i) => i,
+        .None => return false,
     };
     let head = raw.slice(0, sep);
     let body_start = sep + 4;
@@ -168,9 +168,9 @@ pub fn over_limit(raw: string) -> bool {
         return true;
     }
     let sep = match raw.find("\r\n\r\n") {
-        Some(i) => i,
+        .Some(i) => i,
         // No header terminator yet: bound the head we are willing to buffer.
-        None => return raw.len() > MAX_HEADER_BYTES,
+        .None => return raw.len() > MAX_HEADER_BYTES,
     };
     let head = raw.slice(0, sep);
     if head.len() > MAX_HEADER_BYTES {
@@ -190,12 +190,12 @@ pub fn over_limit(raw: string) -> bool {
 pub fn parse_request(raw: string) -> AsyncRequest {
     let sep = raw.find("\r\n\r\n");
     let head = match sep {
-        Some(i) => raw.slice(0, i),
-        None => raw,
+        .Some(i) => raw.slice(0, i),
+        .None => raw,
     };
     let body = match sep {
-        Some(i) => raw.slice(i + 4, raw.len()),
-        None => "",
+        .Some(i) => raw.slice(i + 4, raw.len()),
+        .None => "",
     };
     let head_lines = string.split(head, "\r\n");
     let request_line = if head_lines.len() > 0 {
@@ -334,8 +334,8 @@ fn token_at(line: string, index: i64) -> string {
 /// re-joined with CRLF for header lookups + Content-Length framing.
 fn header_section_after_request_line(head: string) -> string {
     match head.find("\r\n") {
-        Some(first) => head.slice(first + 2, head.len()),
-        None => "",
+        .Some(first) => head.slice(first + 2, head.len()),
+        .None => "",
     }
 }
 
@@ -355,8 +355,8 @@ fn content_length_of(header_section: string) -> i64 {
         return 0;
     }
     match string.try_to_int(value) {
-        Ok(n) => n,
-        Err(_) => MAX_BODY_BYTES + 1,
+        .Ok(n) => n,
+        .Err(_) => MAX_BODY_BYTES + 1,
     }
 }
 
@@ -374,7 +374,7 @@ fn find_header(header_section: string, name: string) -> string {
         // A colon at index 0 is an empty header name — skip it, exactly as
         // the old `colon > 0` guard did.
         match line.find(":") {
-            Some(colon) if colon > 0 => {
+            .Some(colon) if colon > 0 => {
                 let key = string.trim(line.slice(0, colon)).to_lower();
                 if key == target {
                     found = string.trim(line.slice(colon + 1, line.len()));
@@ -399,7 +399,7 @@ fn header_count(header_section: string, name: string) -> i64 {
     for i in 0 .. n {
         let line = lines[i];
         match line.find(":") {
-            Some(colon) if colon > 0 => {
+            .Some(colon) if colon > 0 => {
                 let key = string.trim(line.slice(0, colon)).to_lower();
                 if key == target {
                     count = count + 1;
@@ -428,7 +428,7 @@ fn headers_have_colons(header_section: string) -> bool {
             // are malformed — the old `<= 0` guard covered both; a blind
             // `is_some()` here would wrongly accept `:value`.
             match line.find(":") {
-                Some(colon) if colon > 0 => {},
+                .Some(colon) if colon > 0 => {},
                 _ => return false,
             }
         }
@@ -439,8 +439,8 @@ fn headers_have_colons(header_section: string) -> bool {
 /// The first CRLF-terminated line of a head block (the request line).
 fn first_line(head: string) -> string {
     match head.find("\r\n") {
-        Some(nl) => head.slice(0, nl),
-        None => head,
+        .Some(nl) => head.slice(0, nl),
+        .None => head,
     }
 }
 
@@ -481,8 +481,8 @@ fn is_alpha_token(s: string) -> bool {
         // In-bounds loop: char_at(i) is always Some; the unreachable None
         // fails CLOSED (not a valid method token).
         let b = match s.char_at(i) {
-            Some(c) => c as i64,
-            None => return false,
+            .Some(c) => c as i64,
+            .None => return false,
         };
         let upper = b >= 65 && b <= 90;
         let lower = b >= 97 && b <= 122;
@@ -503,8 +503,8 @@ fn has_control_char(s: string) -> bool {
         // In-bounds loop: char_at(i) is always Some; the unreachable None
         // fails CLOSED (treat as a control character -> reject).
         let b = match s.char_at(i) {
-            Some(c) => c as i64,
-            None => return true,
+            .Some(c) => c as i64,
+            .None => return true,
         };
         if b < 32 || b == 127 {
             return true;

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -224,8 +224,8 @@ fn try_endpoint_port(context: string, addr: string, text: string) -> Result<i64,
         return Err(endpoint_reject(context, addr, "empty port"));
     }
     match string.to_int(text) {
-        Some(port) => try_port_arg(context, port),
-        None => Err(endpoint_reject(context, addr, f"port '{text}' is not a number")),
+        .Some(port) => try_port_arg(context, port),
+        .None => Err(endpoint_reject(context, addr, f"port '{text}' is not a number")),
     }
 }
 
@@ -260,7 +260,7 @@ pub fn try_parse_endpoint(context: string, addr: string) -> Result<Endpoint, Net
     }
     let colon = addr.find(":");
     match colon {
-        Some(i) => {
+        .Some(i) => {
             let host = addr.slice(0, i);
             let port_text = addr.slice(i + 1, addr.len());
             // A second colon outside brackets is an unbracketed IPv6 literal:
@@ -276,14 +276,14 @@ pub fn try_parse_endpoint(context: string, addr: string) -> Result<Endpoint, Net
                 Ok(Endpoint { host: host, port: port })
             }
         },
-        None => Err(endpoint_reject(context, addr, "missing ':port'")),
+        .None => Err(endpoint_reject(context, addr, "missing ':port'")),
     }
 }
 
 fn try_parse_bracketed_endpoint(context: string, addr: string) -> Result<Endpoint, NetError> {
     let close = addr.find("]");
     match close {
-        Some(end) => {
+        .Some(end) => {
             let host = addr.slice(1, end);
             if host == "" {
                 return Err(endpoint_reject(context, addr, "empty bracketed host"));
@@ -298,7 +298,7 @@ fn try_parse_bracketed_endpoint(context: string, addr: string) -> Result<Endpoin
             let port = try_endpoint_port(context, addr, rest.slice(1, rest.len()))?;
             Ok(Endpoint { host: host, port: port })
         },
-        None => Err(endpoint_reject(context, addr, "unterminated '[' in IPv6 literal")),
+        .None => Err(endpoint_reject(context, addr, "unterminated '[' in IPv6 literal")),
     }
 }
 
@@ -621,10 +621,10 @@ impl ConnectionMethods for Connection {
     /// Read a UTF-8 string, reporting a read failure separately from EOF.
     fn try_read_string(conn: Connection) -> Result<string, NetError> {
         match conn.try_read() {
-            Ok(data) => Ok(unsafe {
+            .Ok(data) => Ok(unsafe {
                 hew_bytes_to_string(data)
             }),
-            Err(err) => Err(err),
+            .Err(err) => Err(err),
         }
     }
     /// Write raw bytes to the connection.
@@ -800,15 +800,15 @@ pub fn try_connect(addr: string) -> Result<Connection, NetError> {
 /// `try_connect_timeout` to observe those rejections instead.
 pub fn connect_timeout(addr: string, timeout_sec: i64, timeout_usec: i64) -> Connection {
     let Endpoint { host, port } = match try_parse_endpoint("net.connect_timeout", addr) {
-        Ok(endpoint) => endpoint,
-        Err(err) => {
+        .Ok(endpoint) => endpoint,
+        .Err(err) => {
             panic(f"net.connect_timeout failed: {net_error_message(err)}");
             Endpoint { host: "", port: 0 }
         },
     };
     let timeout_ms = match try_connect_timeout_ms(timeout_sec, timeout_usec) {
-        Ok(ms) => ms,
-        Err(err) => {
+        .Ok(ms) => ms,
+        .Err(err) => {
             panic(f"net.connect_timeout failed: {net_error_message(err)}");
             0
         },

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -69,8 +69,8 @@ pub type Sink<T> {
 /// Returns a `(Sink<string>, Stream<string>)` pair for writing and reading.
 pub fn pipe(capacity: i64) -> (Sink<string>, Stream<string>) {
     match try_pipe(capacity) {
-        Ok(pair) => pair,
-        Err(err) => panic(err),
+        .Ok(pair) => pair,
+        .Err(err) => panic(err),
     }
 }
 
@@ -101,8 +101,8 @@ pub fn try_pipe(capacity: i64) -> Result<(Sink<string>, Stream<string>), string>
 /// Returns a `(Sink<bytes>, Stream<bytes>)` pair for writing and reading.
 pub fn bytes_pipe(capacity: i64) -> (Sink<bytes>, Stream<bytes>) {
     match try_bytes_pipe(capacity) {
-        Ok(pair) => pair,
-        Err(err) => panic(err),
+        .Ok(pair) => pair,
+        .Err(err) => panic(err),
     }
 }
 

--- a/std/string.hew
+++ b/std/string.hew
@@ -80,8 +80,8 @@ pub fn from_char(code: i64) -> string {
 /// ```
 pub fn to_int(s: string) -> Option<i64> {
     match try_to_int(s) {
-        Ok(value) => Some(value),
-        Err(_) => None,
+        .Ok(value) => Some(value),
+        .Err(_) => None,
     }
 }
 
@@ -153,8 +153,8 @@ pub fn try_to_int(s: string) -> Result<i64, string> {
 /// ```
 pub fn to_float(s: string) -> f64 {
     match try_to_float(s) {
-        Ok(value) => value,
-        Err(_) => 0.0,
+        .Ok(value) => value,
+        .Err(_) => 0.0,
     }
 }
 
@@ -536,8 +536,8 @@ pub fn count(haystack: string, needle: string) -> i64 {
     while pos <= hlen - nlen {
         let rest = haystack.slice(pos, hlen);
         let idx = match rest.find(needle) {
-            Some(i) => i,
-            None => return n,
+            .Some(i) => i,
+            .None => return n,
         };
         n = n + 1;
         pos = pos + idx + nlen;
@@ -595,8 +595,8 @@ pub fn is_ascii(s: string) -> bool {
         // In-bounds loop: char_at(i) is always Some; treat the unreachable
         // None defensively as non-ASCII rather than unwrapping.
         let ch = match s.char_at(i) {
-            Some(c) => c,
-            None => return false,
+            .Some(c) => c,
+            .None => return false,
         };
         if ch as i64 > 127 {
             return false;

--- a/std/text/template/template.hew
+++ b/std/text/template/template.hew
@@ -224,16 +224,16 @@ fn consume_if_body(tmpl: string, start: i64, tlen: i64, ctx: Ctx, range_elem: st
     while pos < tlen {
         let rest = tmpl.slice(pos, tlen);
         let open = match rest.find("{{") {
-            Some(i) => i,
-            None => {
+            .Some(i) => i,
+            .None => {
                 return Err(TemplateError::UnclosedBlock("template: unclosed `{{if}}` — missing `{{end}}`"));
             },
         };
         let tag_start = pos + open + 2;
         let after_open = tmpl.slice(tag_start, tlen);
         let close = match after_open.find("}}") {
-            Some(i) => i,
-            None => {
+            .Some(i) => i,
+            .None => {
                 return Err(TemplateError::UnclosedDirective("template: unclosed `{{` inside `{{if}}` body"));
             },
         };
@@ -274,8 +274,8 @@ fn consume_if_body(tmpl: string, start: i64, tlen: i64, ctx: Ctx, range_elem: st
         let branch = tmpl.slice(start, true_end);
         let rendered = render_segment(branch, ctx, range_elem, in_range);
         match rendered {
-            Ok(s) => Ok(RenderPair { text: s, next_pos: end_pos }),
-            Err(e) => Err(e),
+            .Ok(s) => Ok(RenderPair { text: s, next_pos: end_pos }),
+            .Err(e) => Err(e),
         }
     } else {
         if false_start >= 0 {
@@ -287,8 +287,8 @@ fn consume_if_body(tmpl: string, start: i64, tlen: i64, ctx: Ctx, range_elem: st
             let branch = tmpl.slice(false_start, false_end);
             let rendered = render_segment(branch, ctx, range_elem, in_range);
             match rendered {
-                Ok(s) => Ok(RenderPair { text: s, next_pos: end_pos }),
-                Err(e) => Err(e),
+                .Ok(s) => Ok(RenderPair { text: s, next_pos: end_pos }),
+                .Err(e) => Err(e),
             }
         } else {
             Ok(RenderPair { text: "", next_pos: end_pos })
@@ -308,16 +308,16 @@ fn consume_range_body(tmpl: string, start: i64, tlen: i64, ctx: Ctx, key: string
     while pos < tlen {
         let rest = tmpl.slice(pos, tlen);
         let open = match rest.find("{{") {
-            Some(i) => i,
-            None => {
+            .Some(i) => i,
+            .None => {
                 return Err(TemplateError::UnclosedBlock("template: unclosed `{{range}}` — missing `{{end}}`"));
             },
         };
         let tag_start = pos + open + 2;
         let after_open = tmpl.slice(tag_start, tlen);
         let close = match after_open.find("}}") {
-            Some(i) => i,
-            None => {
+            .Some(i) => i,
+            .None => {
                 return Err(TemplateError::UnclosedDirective("template: unclosed `{{` inside `{{range}}` body"));
             },
         };
@@ -351,10 +351,10 @@ fn consume_range_body(tmpl: string, start: i64, tlen: i64, ctx: Ctx, key: string
             let elem = ctx.litems[list_start + i];
             let rendered = render_segment(body, ctx, elem, true);
             match rendered {
-                Ok(s) => {
+                .Ok(s) => {
                     out = out + s;
                 },
-                Err(e) => {
+                .Err(e) => {
                     return Err(e);
                 },
             }
@@ -371,8 +371,8 @@ fn render_segment(tmpl: string, ctx: Ctx, range_elem: string, in_range: bool) ->
     while pos < tlen {
         let rest = tmpl.slice(pos, tlen);
         let open = match rest.find("{{") {
-            Some(i) => i,
-            None => {
+            .Some(i) => i,
+            .None => {
                 out = out + rest;
                 return Ok(out);
             },
@@ -382,8 +382,8 @@ fn render_segment(tmpl: string, ctx: Ctx, range_elem: string, in_range: bool) ->
         let tag_start = pos + open + 2;
         let after_open = tmpl.slice(tag_start, tlen);
         let close = match after_open.find("}}") {
-            Some(i) => i,
-            None => {
+            .Some(i) => i,
+            .None => {
                 return Err(TemplateError::UnclosedDirective("template: unclosed `{{` directive"));
             },
         };
@@ -402,11 +402,11 @@ fn render_segment(tmpl: string, ctx: Ctx, range_elem: string, in_range: bool) ->
             let cond = is_truthy(ctx, key);
             let r = consume_if_body(tmpl, pos, tlen, ctx, range_elem, in_range, cond);
             match r {
-                Ok(pair) => {
+                .Ok(pair) => {
                     out = out + pair.text;
                     pos = pair.next_pos;
                 },
-                Err(e) => {
+                .Err(e) => {
                     return Err(e);
                 },
             }
@@ -414,11 +414,11 @@ fn render_segment(tmpl: string, ctx: Ctx, range_elem: string, in_range: bool) ->
             let key = range_key(tag);
             let r = consume_range_body(tmpl, pos, tlen, ctx, key);
             match r {
-                Ok(pair) => {
+                .Ok(pair) => {
                     out = out + pair.text;
                     pos = pair.next_pos;
                 },
-                Err(e) => {
+                .Err(e) => {
                     return Err(e);
                 },
             }
@@ -449,8 +449,8 @@ fn validate(tmpl: string) -> Result<i64, TemplateError> {
     while pos < tlen {
         let rest = tmpl.slice(pos, tlen);
         let open = match rest.find("{{") {
-            Some(i) => i,
-            None => {
+            .Some(i) => i,
+            .None => {
                 if stack.len() > 0 {
                     let top = stack[stack.len() - 1];
                     return Err(unclosed_block_error(top));
@@ -461,8 +461,8 @@ fn validate(tmpl: string) -> Result<i64, TemplateError> {
         let tag_start = pos + open + 2;
         let after_open = tmpl.slice(tag_start, tlen);
         let close = match after_open.find("}}") {
-            Some(i) => i,
-            None => {
+            .Some(i) => i,
+            .None => {
                 return Err(TemplateError::UnclosedDirective("template: unclosed `{{` directive"));
             },
         };
@@ -514,8 +514,8 @@ fn validate(tmpl: string) -> Result<i64, TemplateError> {
 /// Parse and validate a template string.
 pub fn try_parse(src: string) -> Result<Template, TemplateError> {
     match validate(src) {
-        Ok(_) => Ok(Template { src: src }),
-        Err(err) => Err(err),
+        .Ok(_) => Ok(Template { src: src }),
+        .Err(err) => Err(err),
     }
 }
 
@@ -525,8 +525,8 @@ pub fn parse(src: string) -> Template {
     // result, so matching the call directly would alias `src` (caller-owned).
     let parsed = try_parse(src);
     match parsed {
-        Ok(t) => t,
-        Err(err) => {
+        .Ok(t) => t,
+        .Err(err) => {
             panic(template_error_message(err));
             Template { src: "" }
         },
@@ -544,8 +544,8 @@ pub fn render_template(t: Template, ctx: Ctx) -> string {
     // caller-owned `t.src` place, so the call is not matched directly.
     let rendered = render_segment(t.src, ctx, "", false);
     match rendered {
-        Ok(s) => s,
-        Err(err) => {
+        .Ok(s) => s,
+        .Err(err) => {
             panic(template_error_message(err));
             ""
         },
@@ -658,13 +658,13 @@ pub fn render(tmpl: string, ctx: Ctx) -> Result<string, string> {
     // result, so matching the call directly would alias `tmpl` (caller-owned).
     let parsed = try_parse(tmpl);
     match parsed {
-        Ok(t) => {
+        .Ok(t) => {
             let rendered = render_segment(t.src, ctx, "", false);
             match rendered {
-                Ok(s) => Ok(s),
-                Err(err) => Err(template_error_message(err)),
+                .Ok(s) => Ok(s),
+                .Err(err) => Err(template_error_message(err)),
             }
         },
-        Err(err) => Err(template_error_message(err)),
+        .Err(err) => Err(template_error_message(err)),
     }
 }

--- a/std/text/unicode/unicode.hew
+++ b/std/text/unicode/unicode.hew
@@ -297,8 +297,8 @@ pub fn codepoint_at(s: string, i: i64) -> Option<i64> {
 /// ```
 pub fn try_codepoint_at(s: string, i: i64) -> Result<i64, string> {
     match codepoint_at(s, i) {
-        Some(cp) => Ok(cp),
-        None => Err("unicode.try_codepoint_at: index out of bounds"),
+        .Some(cp) => Ok(cp),
+        .None => Err("unicode.try_codepoint_at: index out of bounds"),
     }
 }
 
@@ -332,8 +332,8 @@ pub fn rune_count(s: string) -> i64 {
 /// ```
 pub fn rune_len(cp: i64) -> i64 {
     match try_rune_len(cp) {
-        Ok(n) => n,
-        Err(_) => -1,
+        .Ok(n) => n,
+        .Err(_) => -1,
     }
 }
 
@@ -380,8 +380,8 @@ pub fn runes(s: string) -> Vec<i64> {
         // In-bounds loop over the codepoint count: always Some. The
         // unreachable None is skipped rather than pushed as a sentinel.
         match s.codepoint_at_utf8(i) {
-            Some(cp) => result.push(cp),
-            None => {},
+            .Some(cp) => result.push(cp),
+            .None => {},
         }
     }
     result


### PR DESCRIPTION
Summary:
- Migrate examples, documentation, and spec grammars to the dotted surface.
- Refresh generated manifests and doc-test expectations.
- Migrate executed std variant patterns so surface output is warning-free.

Gate results:
- test-doc-examples: PASS (197 passed, 85 tracked expected failures, 23 skipped; ratchet matched).
- test-ux-examples: PASS (27/27).
- hew-fmt-check: PASS (652 sources).
- test-surface-examples: 13/14 pass; the HTTP loopback example deterministically returns -1 for both requests after migration, indicating a compiler/runtime gap rather than a migration diagnostic or outbound-network dependency.