### PR TITLE
fix(types): treat intrinsic surfaces as local for impl coherence

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -453,16 +453,14 @@ fn mir_pointer_width(target: &target::TargetSpec) -> hew_mir::PointerWidth {
     }
 }
 
-/// `true` when `input` is the compiler's own `std/builtins.hew` substrate
-/// inside a Hew source checkout. Recognised by canonical path shape plus an
-/// enclosing checkout root (so an unrelated external `std/builtins.hew` is not
-/// matched). The substrate is pre-registered via `include_str!` and never
-/// compiled standalone, so `hew check` skips its HIR/MIR deep gates.
-fn is_embedded_stdlib_builtins(input: &str) -> bool {
+/// `true` when `input` is a compiler-owned, import-only stdlib substrate in a
+/// Hew source checkout. Recognised by canonical path shape plus an enclosing
+/// checkout root, so lookalike external paths cannot skip deep gates.
+fn is_embedded_stdlib_substrate(input: &str, source: &str) -> bool {
     let Ok(path) = std::path::Path::new(input).canonicalize() else {
         return false;
     };
-    if !path.ends_with("std/builtins.hew") {
+    if !path.ends_with(source) {
         return false;
     }
     hew_types::module_registry::find_enclosing_hew_root(&path).is_some()
@@ -474,15 +472,15 @@ fn run_check_deep_gates(
     state: &hew_compile::FileFrontendState,
     levels: &hew_types::LintLevels,
 ) -> Result<(), ()> {
-    // `std/builtins.hew` is the compiler's embedded builtin-surface substrate:
-    // it is consumed by the checker's builtins pre-registration (`include_str!`)
-    // and is never compiled as a standalone program. It carries inherent impls
-    // on builtin pid types (`LocalPid`/`RemotePid`) and `Display` blanket impls
-    // that route through the compiler-magic `to_string` — constructs the
-    // user-facing HIR/MIR deep gates correctly reject in user position. The
-    // type-check above already validated its declarations; the substrate has no
-    // standalone lowering to gate, so stop here.
-    if is_embedded_stdlib_builtins(input) {
+    // `std/builtins.hew` is compiler-embedded, while `std/prelude.hew` is an
+    // import-only authority manifest. Neither has a standalone lowering
+    // surface: the former is pre-registered by the checker and the latter's
+    // imports are consumed by later user programs. Their type-check above is
+    // authoritative, so do not lower their imported implementation bodies as
+    // though they belonged to a standalone executable.
+    if is_embedded_stdlib_substrate(input, "std/builtins.hew")
+        || is_embedded_stdlib_substrate(input, "std/prelude.hew")
+    {
         return Ok(());
     }
     let Some(tco) = state.typecheck_result.tco.as_ref() else {
@@ -2563,7 +2561,8 @@ fn exec_sibling_binary(binary_name: &str, extra_args: &[String]) -> ! {
 
 #[cfg(test)]
 mod version_tests {
-    use super::format_version;
+    use super::{format_version, is_embedded_stdlib_substrate};
+    use std::path::PathBuf;
 
     #[test]
     fn version_formats_present_git_metadata() {
@@ -2601,5 +2600,25 @@ mod version_tests {
                 "hash={hash:?}, dirty={dirty:?}"
             );
         }
+    }
+
+    #[test]
+    fn embedded_stdlib_substrates_require_their_canonical_checkout_path() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("hew-cli is in the workspace root")
+            .to_path_buf();
+        assert!(is_embedded_stdlib_substrate(
+            &root.join("std/builtins.hew").display().to_string(),
+            "std/builtins.hew"
+        ));
+        assert!(is_embedded_stdlib_substrate(
+            &root.join("std/prelude.hew").display().to_string(),
+            "std/prelude.hew"
+        ));
+        assert!(!is_embedded_stdlib_substrate(
+            &root.join("std/prelude.hew").display().to_string(),
+            "std/builtins.hew"
+        ));
     }
 }

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -2438,13 +2438,16 @@ impl Checker {
 
     /// Compiler-intrinsic types have no source declaration to seed
     /// `local_type_defs`. Their canonical declarative surface owns their impls
-    /// for coherence purposes.
+    /// for coherence purposes, but only when the active item's canonical path
+    /// is below the stdlib root selected for this checker invocation.
     fn intrinsic_type_is_local_to_builtin_surface(&self, type_name: &str) -> bool {
-        self.checking_canonical_stdlib_source("std.builtins")
-            && (Ty::from_name(type_name).is_some()
-                || self
-                    .resolved_builtin_type(type_name)
-                    .is_some_and(|builtin| !builtin.requires_source_import()))
+        self.current_item_source.as_ref().is_some_and(|source| {
+            self.module_registry
+                .source_has_stdlib_authority(source, "std.builtins")
+        }) && (Ty::from_name(type_name).is_some()
+            || self
+                .resolved_builtin_type(type_name)
+                .is_some_and(|builtin| !builtin.requires_source_import()))
     }
 }
 

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -2439,7 +2439,7 @@ impl Checker {
     /// Compiler-intrinsic types have no source declaration to seed
     /// `local_type_defs`. Their canonical declarative surface owns their impls
     /// for coherence purposes, but only when the active item's canonical path
-    /// is below the stdlib root selected for this checker invocation.
+    /// is below the stdlib root owned by the running compiler installation.
     fn intrinsic_type_is_local_to_builtin_surface(&self, type_name: &str) -> bool {
         self.current_item_source.as_ref().is_some_and(|source| {
             self.module_registry

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -2300,7 +2300,8 @@ impl Checker {
             // Orphan rule check: if implementing a trait, either the type or the
             // trait must be defined in the current compilation unit.
             if let Some(tb) = &id.trait_bound {
-                let type_is_local = self.local_type_defs.contains(type_name);
+                let type_is_local = self.local_type_defs.contains(type_name)
+                    || self.intrinsic_type_is_local_to_builtin_surface(type_name);
                 // Route through the one canonical resolver: a trait reference is
                 // "local" exactly when it resolves to a local declaration (the
                 // resolver's local-shadow step), so the orphan-rule warning keys
@@ -2433,6 +2434,17 @@ impl Checker {
                 self.generic_ctx.pop();
             }
         }
+    }
+
+    /// Compiler-intrinsic types have no source declaration to seed
+    /// `local_type_defs`. Their canonical declarative surface owns their impls
+    /// for coherence purposes.
+    fn intrinsic_type_is_local_to_builtin_surface(&self, type_name: &str) -> bool {
+        self.checking_canonical_stdlib_source("std.builtins")
+            && (Ty::from_name(type_name).is_some()
+                || self
+                    .resolved_builtin_type(type_name)
+                    .is_some_and(|builtin| !builtin.requires_source_import()))
     }
 }
 

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -745,6 +745,9 @@ impl Checker {
         // reference on later inputs, so suppress this lint for eval fragments.
         if !self.repl_fragment {
             for (key, (import_span, stored_module)) in &self.import_spans {
+                if self.is_canonical_prelude_manifest_import(stored_module.as_deref()) {
+                    continue;
+                }
                 if !self.used_modules.borrow().contains(key) {
                     self.warnings.push(TypeError {
                         severity: crate::error::Severity::Warning,
@@ -1449,6 +1452,13 @@ impl Checker {
         output.cycle_capable_actors = cycle_capable;
 
         output
+    }
+
+    /// The canonical prelude is an import-only authority manifest: its imports
+    /// are intentionally consumed by later user programs, not by its own body.
+    fn is_canonical_prelude_manifest_import(&self, stored_module: Option<&str>) -> bool {
+        stored_module == Some("std.prelude")
+            || (stored_module.is_none() && self.canonical_std_root_sources.contains("std.prelude"))
     }
 
     /// Validate the raw checker-authored ownership graph before following any

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -681,11 +681,18 @@ impl Checker {
                     }
 
                     for (item_idx, (item, span)) in module.items.iter().enumerate() {
+                        self.current_item_source = self
+                            .module_item_sources
+                            .get(&module_name)
+                            .and_then(|sources| sources.get(item_idx))
+                            .or_else(|| module.source_paths.first())
+                            .cloned();
                         self.current_module_idx = span_indices
                             .item_index(mod_id, item_idx)
                             .unwrap_or(self.current_module_idx);
                         self.check_item(item, span);
                     }
+                    self.current_item_source = None;
 
                     self.is_stdlib_source = saved_is_stdlib_source;
 

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -3090,7 +3090,7 @@ fn orphan_impl_emits_warning() {
 }
 
 #[test]
-fn canonical_builtin_surface_owns_intrinsic_impls_for_coherence() {
+fn canonical_builtin_source_owns_intrinsic_impls_for_coherence() {
     use hew_parser::ast::TraitBound;
 
     let impl_decl = ImplDecl {
@@ -3111,13 +3111,16 @@ fn canonical_builtin_surface_owns_intrinsic_impls_for_coherence() {
         type_aliases: vec![],
         methods: vec![],
     };
+    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("hew-types has a workspace parent")
+        .to_path_buf();
     let mut checker = Checker {
         current_module: Some("std.builtins".to_string()),
+        current_item_source: Some(workspace_root.join("std/builtins.hew")),
+        module_registry: ModuleRegistry::new(vec![workspace_root]),
         ..Default::default()
     };
-    checker
-        .canonical_std_module_sources
-        .insert("std.builtins".to_string());
     checker.check_impl(&impl_decl, &(0..0));
     let mut primitive_impl = impl_decl;
     primitive_impl.target_type.0 = TypeExpr::Named {
@@ -3131,7 +3134,7 @@ fn canonical_builtin_surface_owns_intrinsic_impls_for_coherence() {
             .warnings
             .iter()
             .any(|warning| warning.kind == crate::error::TypeErrorKind::OrphanImpl),
-        "the canonical builtin surface owns intrinsic type impls: {:?}",
+        "the canonical builtin source owns intrinsic type impls: {:?}",
         checker.warnings
     );
 }
@@ -3170,6 +3173,159 @@ fn noncanonical_builtin_spelling_does_not_own_intrinsic_impls() {
             .iter()
             .any(|warning| warning.kind == crate::error::TypeErrorKind::OrphanImpl),
         "a lookalike module must not gain intrinsic coherence authority"
+    );
+}
+
+struct IntrinsicCoherenceFixture {
+    root: std::path::PathBuf,
+}
+
+impl IntrinsicCoherenceFixture {
+    fn new(name: &str) -> Self {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock is after the Unix epoch")
+            .as_nanos();
+        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("hew-types has a workspace parent")
+            .join("target/test-workdirs")
+            .join(format!("{name}-{}-{unique}", std::process::id()));
+        std::fs::create_dir_all(&root).expect("create coherence fixture root");
+        Self { root }
+    }
+
+    fn write(&self, relative: &str, source: &str) -> std::path::PathBuf {
+        let path = self.root.join(relative);
+        std::fs::create_dir_all(path.parent().expect("fixture path has a parent"))
+            .expect("create coherence fixture directory");
+        std::fs::write(&path, source).expect("write coherence fixture source");
+        path
+    }
+}
+
+impl Drop for IntrinsicCoherenceFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn project_local_std_builtins_source_cannot_claim_intrinsic_coherence() {
+    let source = r"
+        impl ForeignTrait for Vec<i64> {}
+        impl ForeignTrait for i8 {}
+    ";
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "fixture parse: {:?}",
+        parsed.errors
+    );
+
+    let fixture = IntrinsicCoherenceFixture::new("user-std-builtins-coherence");
+    let user_builtins = fixture.write("std/builtins.hew", source);
+    let root_id = ModuleId::root();
+    let builtins_id = ModuleId::new(vec!["std".to_string(), "builtins".to_string()]);
+    let mut graph = ModuleGraph::new(root_id.clone());
+    graph
+        .add_module(Module {
+            id: builtins_id.clone(),
+            items: parsed.program.items,
+            imports: vec![],
+            source_paths: vec![user_builtins],
+            doc: None,
+        })
+        .expect("add user-owned std.builtins module");
+    graph.topo_order = vec![builtins_id, root_id];
+
+    let output = Checker::new(test_registry()).check_program(&Program {
+        module_graph: Some(graph),
+        items: vec![],
+        module_doc: None,
+    });
+    let orphan_warnings = output
+        .warnings
+        .iter()
+        .filter(|warning| warning.kind == TypeErrorKind::OrphanImpl)
+        .count();
+    assert_eq!(
+        orphan_warnings, 2,
+        "project-local std/builtins.hew must not own Vec or primitive impls: {:?}",
+        output.warnings
+    );
+}
+
+#[test]
+fn imported_foreign_trait_impl_for_intrinsic_type_warns() {
+    let foreign_source = "pub trait ForeignTrait {}";
+    let consumer_source = "import vendor::{ ForeignTrait }; impl ForeignTrait for Vec<i64> {}";
+    let foreign = hew_parser::parse(foreign_source);
+    let mut consumer = hew_parser::parse(consumer_source);
+    assert!(
+        foreign.errors.is_empty(),
+        "foreign parse: {:?}",
+        foreign.errors
+    );
+    assert!(
+        consumer.errors.is_empty(),
+        "consumer parse: {:?}",
+        consumer.errors
+    );
+
+    let fixture = IntrinsicCoherenceFixture::new("foreign-intrinsic-coherence");
+    let foreign_path = fixture.write("vendor.hew", foreign_source);
+    let consumer_path = fixture.write("consumer.hew", consumer_source);
+    let import_span = consumer.program.items[0].1.clone();
+    let Item::Import(import) = &mut consumer.program.items[0].0 else {
+        panic!("consumer starts with an import");
+    };
+    import.resolved_items = Some(foreign.program.items.clone());
+    import.resolved_source_paths = vec![foreign_path.clone()];
+
+    let root_id = ModuleId::root();
+    let foreign_id = ModuleId::new(vec!["vendor".to_string()]);
+    let consumer_id = ModuleId::new(vec!["consumer".to_string()]);
+    let mut graph = ModuleGraph::new(root_id.clone());
+    graph
+        .add_module(Module {
+            id: foreign_id.clone(),
+            items: foreign.program.items,
+            imports: vec![],
+            source_paths: vec![foreign_path],
+            doc: None,
+        })
+        .expect("add foreign trait module");
+    graph
+        .add_module(Module {
+            id: consumer_id.clone(),
+            items: consumer.program.items,
+            imports: vec![hew_parser::module::ModuleImport {
+                target: foreign_id.clone(),
+                spec: Some(ImportSpec::Names(vec![ImportName {
+                    name: "ForeignTrait".to_string(),
+                    alias: None,
+                }])),
+                span: import_span,
+            }],
+            source_paths: vec![consumer_path],
+            doc: None,
+        })
+        .expect("add consumer module");
+    graph.topo_order = vec![foreign_id, consumer_id, root_id];
+
+    let output = Checker::new(test_registry()).check_program(&Program {
+        module_graph: Some(graph),
+        items: vec![],
+        module_doc: None,
+    });
+    assert!(
+        output
+            .warnings
+            .iter()
+            .any(|warning| warning.kind == TypeErrorKind::OrphanImpl),
+        "a user module implementing a foreign trait for Vec must warn: {:?}",
+        output.warnings
     );
 }
 

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -3090,6 +3090,90 @@ fn orphan_impl_emits_warning() {
 }
 
 #[test]
+fn canonical_builtin_surface_owns_intrinsic_impls_for_coherence() {
+    use hew_parser::ast::TraitBound;
+
+    let impl_decl = ImplDecl {
+        type_params: None,
+        trait_bound: Some(TraitBound {
+            name: "ExternalTrait".to_string(),
+            type_args: None,
+            assoc_type_bindings: vec![],
+        }),
+        target_type: (
+            TypeExpr::Named {
+                name: "Vec".to_string(),
+                type_args: None,
+            },
+            0..0,
+        ),
+        where_clause: None,
+        type_aliases: vec![],
+        methods: vec![],
+    };
+    let mut checker = Checker {
+        current_module: Some("std.builtins".to_string()),
+        ..Default::default()
+    };
+    checker
+        .canonical_std_module_sources
+        .insert("std.builtins".to_string());
+    checker.check_impl(&impl_decl, &(0..0));
+    let mut primitive_impl = impl_decl;
+    primitive_impl.target_type.0 = TypeExpr::Named {
+        name: "i8".to_string(),
+        type_args: None,
+    };
+    checker.check_impl(&primitive_impl, &(0..0));
+
+    assert!(
+        !checker
+            .warnings
+            .iter()
+            .any(|warning| warning.kind == crate::error::TypeErrorKind::OrphanImpl),
+        "the canonical builtin surface owns intrinsic type impls: {:?}",
+        checker.warnings
+    );
+}
+
+#[test]
+fn noncanonical_builtin_spelling_does_not_own_intrinsic_impls() {
+    use hew_parser::ast::TraitBound;
+
+    let impl_decl = ImplDecl {
+        type_params: None,
+        trait_bound: Some(TraitBound {
+            name: "ExternalTrait".to_string(),
+            type_args: None,
+            assoc_type_bindings: vec![],
+        }),
+        target_type: (
+            TypeExpr::Named {
+                name: "Vec".to_string(),
+                type_args: None,
+            },
+            0..0,
+        ),
+        where_clause: None,
+        type_aliases: vec![],
+        methods: vec![],
+    };
+    let mut checker = Checker {
+        current_module: Some("std.builtins".to_string()),
+        ..Default::default()
+    };
+    checker.check_impl(&impl_decl, &(0..0));
+
+    assert!(
+        checker
+            .warnings
+            .iter()
+            .any(|warning| warning.kind == crate::error::TypeErrorKind::OrphanImpl),
+        "a lookalike module must not gain intrinsic coherence authority"
+    );
+}
+
+#[test]
 fn local_type_impl_no_orphan_warning() {
     use hew_parser::ast::TraitBound;
     // Locally defined type: impl SomeExternalTrait for LocalType → no orphan warning

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -3091,51 +3091,20 @@ fn orphan_impl_emits_warning() {
 
 #[test]
 fn canonical_builtin_source_owns_intrinsic_impls_for_coherence() {
-    use hew_parser::ast::TraitBound;
-
-    let impl_decl = ImplDecl {
-        type_params: None,
-        trait_bound: Some(TraitBound {
-            name: "ExternalTrait".to_string(),
-            type_args: None,
-            assoc_type_bindings: vec![],
-        }),
-        target_type: (
-            TypeExpr::Named {
-                name: "Vec".to_string(),
-                type_args: None,
-            },
-            0..0,
-        ),
-        where_clause: None,
-        type_aliases: vec![],
-        methods: vec![],
-    };
-    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("hew-types has a workspace parent")
-        .to_path_buf();
-    let mut checker = Checker {
-        current_module: Some("std.builtins".to_string()),
-        current_item_source: Some(workspace_root.join("std/builtins.hew")),
-        module_registry: ModuleRegistry::new(vec![workspace_root]),
-        ..Default::default()
-    };
-    checker.check_impl(&impl_decl, &(0..0));
-    let mut primitive_impl = impl_decl;
-    primitive_impl.target_type.0 = TypeExpr::Named {
-        name: "i8".to_string(),
-        type_args: None,
-    };
-    checker.check_impl(&primitive_impl, &(0..0));
+    let compiler_root = crate::module_registry::compiler_stdlib_root()
+        .expect("test executable must resolve its compiler-owned development stdlib");
+    let output = check_intrinsic_coherence_source(
+        &compiler_root.join("std/builtins.hew"),
+        ModuleRegistry::new(vec![]),
+    );
 
     assert!(
-        !checker
+        !output
             .warnings
             .iter()
             .any(|warning| warning.kind == crate::error::TypeErrorKind::OrphanImpl),
         "the canonical builtin source owns intrinsic type impls: {:?}",
-        checker.warnings
+        output.warnings
     );
 }
 
@@ -3186,11 +3155,7 @@ impl IntrinsicCoherenceFixture {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("clock is after the Unix epoch")
             .as_nanos();
-        let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .expect("hew-types has a workspace parent")
-            .join("target/test-workdirs")
-            .join(format!("{name}-{}-{unique}", std::process::id()));
+        let root = std::env::temp_dir().join(format!("{name}-{}-{unique}", std::process::id()));
         std::fs::create_dir_all(&root).expect("create coherence fixture root");
         Self { root }
     }
@@ -3210,8 +3175,10 @@ impl Drop for IntrinsicCoherenceFixture {
     }
 }
 
-#[test]
-fn project_local_std_builtins_source_cannot_claim_intrinsic_coherence() {
+fn check_intrinsic_coherence_source(
+    source_path: &std::path::Path,
+    registry: ModuleRegistry,
+) -> TypeCheckOutput {
     let source = r"
         impl ForeignTrait for Vec<i64> {}
         impl ForeignTrait for i8 {}
@@ -3223,8 +3190,6 @@ fn project_local_std_builtins_source_cannot_claim_intrinsic_coherence() {
         parsed.errors
     );
 
-    let fixture = IntrinsicCoherenceFixture::new("user-std-builtins-coherence");
-    let user_builtins = fixture.write("std/builtins.hew", source);
     let root_id = ModuleId::root();
     let builtins_id = ModuleId::new(vec!["std".to_string(), "builtins".to_string()]);
     let mut graph = ModuleGraph::new(root_id.clone());
@@ -3233,26 +3198,87 @@ fn project_local_std_builtins_source_cannot_claim_intrinsic_coherence() {
             id: builtins_id.clone(),
             items: parsed.program.items,
             imports: vec![],
-            source_paths: vec![user_builtins],
+            source_paths: vec![source_path.to_path_buf()],
             doc: None,
         })
-        .expect("add user-owned std.builtins module");
+        .expect("add std.builtins module");
     graph.topo_order = vec![builtins_id, root_id];
 
-    let output = Checker::new(test_registry()).check_program(&Program {
+    Checker::new(registry).check_program(&Program {
         module_graph: Some(graph),
         items: vec![],
         module_doc: None,
-    });
-    let orphan_warnings = output
-        .warnings
-        .iter()
-        .filter(|warning| warning.kind == TypeErrorKind::OrphanImpl)
-        .count();
-    assert_eq!(
-        orphan_warnings, 2,
-        "project-local std/builtins.hew must not own Vec or primitive impls: {:?}",
-        output.warnings
+    })
+}
+
+#[test]
+fn project_local_std_builtins_source_cannot_claim_intrinsic_coherence() {
+    const CHILD_MARKER: &str = "HEW_INTRINSIC_COHERENCE_ATTACK_CHILD";
+
+    if std::env::var_os(CHILD_MARKER).is_some() {
+        let attacker_root = std::env::current_dir().expect("attacker cwd is available");
+        let search_paths = crate::module_registry::build_module_search_paths_for(None);
+        assert_eq!(
+            search_paths
+                .first()
+                .and_then(|path| path.canonicalize().ok()),
+            attacker_root.canonicalize().ok(),
+            "production module discovery must select the attacker's std root"
+        );
+        let compiler_root = crate::module_registry::compiler_stdlib_root()
+            .expect("test executable must resolve its compiler-owned development stdlib");
+        assert_ne!(
+            attacker_root.canonicalize().ok(),
+            Some(compiler_root.clone()),
+            "attacker cwd must be distinct from compiler authority"
+        );
+
+        let attacker_builtins = attacker_root.join("std/builtins.hew");
+        let output =
+            check_intrinsic_coherence_source(&attacker_builtins, ModuleRegistry::new(search_paths));
+        let orphan_warnings = output
+            .warnings
+            .iter()
+            .filter(|warning| warning.kind == TypeErrorKind::OrphanImpl)
+            .count();
+        println!("attack module root: {}", attacker_root.display());
+        println!("compiler authority root: {}", compiler_root.display());
+        println!("attack orphan warnings: {orphan_warnings}");
+        assert_eq!(
+            orphan_warnings, 2,
+            "project-local std/builtins.hew must not own Vec or primitive impls: {:?}",
+            output.warnings
+        );
+        return;
+    }
+
+    let fixture = IntrinsicCoherenceFixture::new("user-std-builtins-coherence");
+    fixture.write(
+        "std/builtins.hew",
+        "// attacker-controlled builtins marker\n",
+    );
+    let child = std::process::Command::new(
+        std::env::current_exe().expect("resolve current hew-types test executable"),
+    )
+    .args([
+        "--exact",
+        "check::tests::imports::project_local_std_builtins_source_cannot_claim_intrinsic_coherence",
+        "--nocapture",
+    ])
+    .current_dir(&fixture.root)
+    .env(CHILD_MARKER, "1")
+    .env_remove("HEWPATH")
+    .env_remove("HEW_STD")
+    .output()
+    .expect("run production-shaped attacker-cwd check_program child");
+    let stdout = String::from_utf8_lossy(&child.stdout);
+    let stderr = String::from_utf8_lossy(&child.stderr);
+    print!("{stdout}");
+    eprint!("{stderr}");
+    assert!(
+        child.status.success(),
+        "attacker-cwd child failed with {}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        child.status
     );
 }
 

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -103,6 +103,18 @@ fn no_warn_underscore_prefix() {
 // Lint / warning regression tests
 // -----------------------------------------------------------------------
 
+#[test]
+fn canonical_prelude_manifest_imports_are_exempt_from_unused_imports() {
+    let mut checker = Checker::default();
+    checker
+        .canonical_std_root_sources
+        .insert("std.prelude".to_string());
+
+    assert!(checker.is_canonical_prelude_manifest_import(None));
+    assert!(checker.is_canonical_prelude_manifest_import(Some("std.prelude")));
+    assert!(!checker.is_canonical_prelude_manifest_import(Some("std.math")));
+}
+
 /// `set_repl_fragment` suppresses the four whole-program completeness lints
 /// (`UnusedImport`, `DeadCode`, `UnusedVariable`, `UnusedMut`) that misfire on
 /// a synthetic `hew eval` fragment, while the default checker still emits every

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2535,9 +2535,10 @@ pub struct Checker {
     /// import copies use this table to re-enter their declaration's file-local
     /// import scope instead of resolving signatures in the importing file.
     pub(super) source_file_span_indices: HashMap<std::path::PathBuf, u32>,
-    /// Defining source file of the item currently being registered, when the
-    /// enclosing module recorded per-item attribution. `None` for the root
-    /// unit and for hand-built module graphs.
+    /// Defining source file of the item currently being registered or checked.
+    /// Per-item attribution wins for directory modules; their primary source
+    /// is the fail-closed fallback when no item table was recorded. `None` for
+    /// root items and source-less hand-built graphs.
     pub(super) current_item_source: Option<std::path::PathBuf>,
     /// Type names declared per source FILE (populated during type
     /// collection from per-item attribution). This is the lexical authority

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -21,6 +21,13 @@ pub struct ModuleRegistry {
     modules: HashMap<ModuleId, ModuleInfo>,
     /// Ordered search paths for module resolution.
     search_paths: Vec<PathBuf>,
+    /// Compiler-owned root that may confer stdlib-only authority.
+    ///
+    /// This is resolved exclusively from the running compiler's installation
+    /// or development-binary layout. It is deliberately independent of
+    /// `search_paths`, which may contain project-, cwd-, or environment-owned
+    /// roots.
+    compiler_stdlib_root: Option<PathBuf>,
     /// Accumulated handle types from all loaded modules.
     handle_types: HashSet<String>,
     /// Accumulated fielded `#[resource]` handle-wrapper types from all loaded
@@ -70,6 +77,40 @@ pub fn find_enclosing_hew_root(from: &std::path::Path) -> Option<PathBuf> {
             None => return None,
         }
     }
+}
+
+/// Resolve the standard-library root owned by the running compiler binary.
+///
+/// Installed binaries use `<bin>/../share/hew`; development binaries use the
+/// checkout above `target/<profile>`. Rust test executables add a `deps/`
+/// component below the same development layout. No project path, cwd, or
+/// environment override participates in this decision. If neither layout has
+/// the compiler's `std/builtins.hew`, authority is unavailable and callers
+/// must fail closed.
+#[must_use]
+pub fn compiler_stdlib_root() -> Option<PathBuf> {
+    let executable = std::env::current_exe().ok()?.canonicalize().ok()?;
+    compiler_stdlib_root_for_executable(&executable)
+}
+
+fn compiler_stdlib_root_for_executable(executable: &std::path::Path) -> Option<PathBuf> {
+    let executable_dir = executable.parent()?;
+    let installed = executable_dir.parent()?.join("share/hew");
+    let development = if executable_dir
+        .file_name()
+        .is_some_and(|name| name == "deps")
+    {
+        executable_dir.parent()?.parent()?.parent()?.to_path_buf()
+    } else {
+        executable_dir.parent()?.parent()?.to_path_buf()
+    };
+
+    [installed, development].into_iter().find_map(|root| {
+        root.join("std/builtins.hew")
+            .is_file()
+            .then(|| root.canonicalize().ok())
+            .flatten()
+    })
 }
 
 /// Build the stdlib search-path list, applying exclusive precedence tiers.
@@ -142,14 +183,10 @@ pub fn build_module_search_paths_for(source_hint: Option<&std::path::Path>) -> V
     // --- Tier 3: installed binary / external project ---
     let mut tier3: Vec<PathBuf> = Vec::new();
 
-    // FHS: <exe>/../share/hew
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(exe_dir) = exe.parent() {
-            let share_hew = exe_dir.join("../share/hew");
-            if share_hew.join("std").exists() && !tier3.contains(&share_hew) {
-                tier3.push(share_hew);
-            }
-        }
+    // Compiler-owned installed or development layout. This resolver is also
+    // the sole source of stdlib authority inside `ModuleRegistry`.
+    if let Some(root) = compiler_stdlib_root() {
+        tier3.push(root);
     }
 
     // XDG: ~/.local/share/hew
@@ -173,22 +210,6 @@ pub fn build_module_search_paths_for(source_hint: Option<&std::path::Path>) -> V
         let p = PathBuf::from(prefix);
         if p.join("std").exists() && !tier3.contains(&p) {
             tier3.push(p);
-        }
-    }
-
-    // Dev fallback: two levels above the binary (e.g. target/debug/hew → repo root).
-    // Only reached for an installed/external project when tier-2 found nothing —
-    // i.e. a developer binary compiling a project outside any Hew checkout.
-    // WHY: `cargo run` builds land in target/debug/ so exe/../.. is the repo root.
-    // WHEN obsolete: when Hew has a proper install prefix and std is co-installed.
-    // WHAT the real solution is: install std alongside the binary under share/hew.
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(exe_dir) = exe.parent() {
-            if let Some(repo_root) = exe_dir.parent().and_then(|p| p.parent()) {
-                if repo_root.join("std").exists() && !tier3.contains(&repo_root.to_path_buf()) {
-                    tier3.push(repo_root.to_path_buf());
-                }
-            }
         }
     }
 
@@ -505,6 +526,7 @@ impl ModuleRegistry {
         Self {
             modules: HashMap::new(),
             search_paths,
+            compiler_stdlib_root: compiler_stdlib_root(),
             handle_types: HashSet::new(),
             resource_wrapper_types: HashSet::new(),
             drop_types: HashSet::new(),
@@ -516,19 +538,24 @@ impl ModuleRegistry {
         !self.search_paths.is_empty()
     }
 
-    /// Whether `source_file` is the exact source for `dotted_module` below one
-    /// of this registry's configured stdlib roots.
+    /// Whether `source_file` is the exact source for `dotted_module` below the
+    /// running compiler's own stdlib root.
     ///
-    /// Unlike [`is_canonical_stdlib_module_source`], this does not rediscover a
-    /// root from the source path. The compiler selects these search roots before
-    /// constructing the registry, so a project-local `std/builtins.hew` cannot
-    /// make its own ancestor authoritative merely by existing.
+    /// Module search paths are intentionally excluded: projects, cwd, `HEWPATH`,
+    /// and `HEW_STD` may affect resolution but cannot confer compiler authority.
+    /// A missing compiler-owned root returns `false`.
     pub(crate) fn source_has_stdlib_authority(
         &self,
         source_file: &std::path::Path,
         dotted_module: &str,
     ) -> bool {
-        canonical_stdlib_module_source_in_roots(source_file, dotted_module, &self.search_paths)
+        self.compiler_stdlib_root.as_ref().is_some_and(|root| {
+            canonical_stdlib_module_source_in_roots(
+                source_file,
+                dotted_module,
+                std::slice::from_ref(root),
+            )
+        })
     }
 
     /// Load a module by its full path (e.g. `std::encoding::json`).
@@ -1038,6 +1065,43 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.root);
         }
+    }
+
+    #[test]
+    fn compiler_stdlib_root_uses_only_binary_relative_layouts() {
+        let installed = TestDir::new("compiler-stdlib-installed");
+        let installed_root = installed.root.join("share/hew");
+        fs::create_dir_all(installed_root.join("std")).unwrap();
+        fs::write(
+            installed_root.join("std/builtins.hew"),
+            "// installed compiler std\n",
+        )
+        .unwrap();
+        let installed_executable = installed.root.join("bin/hew");
+        assert_eq!(
+            compiler_stdlib_root_for_executable(&installed_executable),
+            installed_root.canonicalize().ok()
+        );
+
+        let development = TestDir::new("compiler-stdlib-development");
+        fs::create_dir_all(development.root.join("std")).unwrap();
+        fs::write(
+            development.root.join("std/builtins.hew"),
+            "// development compiler std\n",
+        )
+        .unwrap();
+        let development_executable = development.root.join("target/debug/hew");
+        assert_eq!(
+            compiler_stdlib_root_for_executable(&development_executable),
+            development.root.canonicalize().ok()
+        );
+
+        let missing = TestDir::new("compiler-stdlib-missing");
+        assert_eq!(
+            compiler_stdlib_root_for_executable(&missing.root.join("bin/hew")),
+            None,
+            "a compiler without its own stdlib layout must fail closed"
+        );
     }
 
     #[test]
@@ -1673,6 +1737,20 @@ mod tests {
         fn root(&self) -> &PathBuf {
             &self.dir.root
         }
+    }
+
+    #[test]
+    fn missing_compiler_stdlib_root_confers_no_authority() {
+        let project = TestHewTree::new("missing-compiler-authority");
+        let mut registry = ModuleRegistry::new(vec![project.root().clone()]);
+        registry.compiler_stdlib_root = None;
+        assert!(
+            !registry.source_has_stdlib_authority(
+                &project.root().join("std/builtins.hew"),
+                "std.builtins"
+            ),
+            "project search paths cannot replace unavailable compiler authority"
+        );
     }
 
     /// HEWPATH set → tier-1 returns exactly those paths, no dev/cwd leakage.

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -262,6 +262,18 @@ pub fn is_canonical_stdlib_module_source(
     source_file: &std::path::Path,
     dotted_module: &str,
 ) -> bool {
+    canonical_stdlib_module_source_in_roots(
+        source_file,
+        dotted_module,
+        &build_module_search_paths_for(Some(source_file)),
+    )
+}
+
+fn canonical_stdlib_module_source_in_roots(
+    source_file: &std::path::Path,
+    dotted_module: &str,
+    roots: &[PathBuf],
+) -> bool {
     let Ok(input_canonical) = std::fs::canonicalize(source_file) else {
         return false;
     };
@@ -272,26 +284,24 @@ pub fn is_canonical_stdlib_module_source(
     let rel = segments.iter().collect::<PathBuf>();
     let candidates = [rel.join(format!("{last}.hew")), rel.with_extension("hew")];
 
-    build_module_search_paths_for(Some(source_file))
-        .iter()
-        .any(|root| {
-            candidates.iter().any(|candidate| {
-                std::fs::canonicalize(root.join(candidate))
-                    .is_ok_and(|canonical| canonical == input_canonical)
-            }) || {
-                // Directory modules are assembled from their primary source
-                // plus peer `.hew` files.  A direct check of one such peer
-                // must retain the same canonical module authority as an
-                // import of the directory; comparing its canonical parent to
-                // the trusted stdlib module directory keeps this provenance
-                // path-based rather than granting it from a filename.
-                input_canonical.extension().is_some_and(|ext| ext == "hew")
-                    && input_canonical.parent().is_some_and(|parent| {
-                        std::fs::canonicalize(root.join(&rel))
-                            .is_ok_and(|module_dir| module_dir == parent)
-                    })
-            }
-        })
+    roots.iter().any(|root| {
+        candidates.iter().any(|candidate| {
+            std::fs::canonicalize(root.join(candidate))
+                .is_ok_and(|canonical| canonical == input_canonical)
+        }) || {
+            // Directory modules are assembled from their primary source
+            // plus peer `.hew` files.  A direct check of one such peer
+            // must retain the same canonical module authority as an
+            // import of the directory; comparing its canonical parent to
+            // the trusted stdlib module directory keeps this provenance
+            // path-based rather than granting it from a filename.
+            input_canonical.extension().is_some_and(|ext| ext == "hew")
+                && input_canonical.parent().is_some_and(|parent| {
+                    std::fs::canonicalize(root.join(&rel))
+                        .is_ok_and(|module_dir| module_dir == parent)
+                })
+        }
+    })
 }
 
 /// Return the declaration owner selected by an import's resolved source.
@@ -504,6 +514,21 @@ impl ModuleRegistry {
 
     pub(crate) fn has_search_paths(&self) -> bool {
         !self.search_paths.is_empty()
+    }
+
+    /// Whether `source_file` is the exact source for `dotted_module` below one
+    /// of this registry's configured stdlib roots.
+    ///
+    /// Unlike [`is_canonical_stdlib_module_source`], this does not rediscover a
+    /// root from the source path. The compiler selects these search roots before
+    /// constructing the registry, so a project-local `std/builtins.hew` cannot
+    /// make its own ancestor authoritative merely by existing.
+    pub(crate) fn source_has_stdlib_authority(
+        &self,
+        source_file: &std::path::Path,
+        dotted_module: &str,
+    ) -> bool {
+        canonical_stdlib_module_source_in_roots(source_file, dotted_module, &self.search_paths)
     }
 
     /// Load a module by its full path (e.g. `std::encoding::json`).


### PR DESCRIPTION
Summary — the orphan-impl coherence rule now recognizes an intrinsic type's canonical surface module as its defining module, so std/builtins' impls for intrinsic types (IntoIterator for Vec and peers) are coherent rather than flagged; a genuinely foreign impl still warns. With this, the migrated stdlib corpus type-checks clean (74 files, 0 failures).