### PR TITLE
feat(types): unify dotted type-member dispatch

### DIFF
--- a/hew-hir/tests/lowering_calls.rs
+++ b/hew-hir/tests/lowering_calls.rs
@@ -17,6 +17,8 @@ mod call_trait_method_static_creation_allowlist;
 mod closure_capture_lower;
 #[path = "lowering_calls/display_dispatch_lower.rs"]
 mod display_dispatch_lower;
+#[path = "lowering_calls/dotted_type_member_dispatch.rs"]
+mod dotted_type_member_dispatch;
 #[path = "lowering_calls/dyn_trait_type_annotation_lower.rs"]
 mod dyn_trait_type_annotation_lower;
 #[path = "lowering_calls/imported_free_fn_lower.rs"]

--- a/hew-hir/tests/lowering_calls/dotted_type_member_dispatch.rs
+++ b/hew-hir/tests/lowering_calls/dotted_type_member_dispatch.rs
@@ -1,0 +1,33 @@
+use crate::support;
+
+#[test]
+fn dotted_type_member_shapes_lower_from_checker_facts() {
+    let output = support::checker_pipeline::lower_through_checker(
+        r"
+machine Lifecycle {
+    events { Reset; }
+    state Start;
+    state Running { value: i64; }
+    on Reset: Running => Start { Start }
+    default { state }
+}
+
+fn main() -> i64 {
+    let start: Lifecycle = Lifecycle.Start;
+    let running: Lifecycle = Lifecycle.Running { value: 42 };
+    let some: Option<i64> = Option.Some(5);
+    let ok: Result<i64, string> = Result.Ok(6);
+    let set: HashSet<i64> = HashSet<i64>.new();
+    let explicit: Option<i64> = Option<i64>.Some(7);
+    set.insert(8);
+    some.unwrap() + ok.unwrap() + explicit.unwrap() + set.len()
+}
+",
+    );
+
+    assert!(
+        output.diagnostics.is_empty(),
+        "dotted type members must lower without re-resolving their heads: {:#?}",
+        output.diagnostics
+    );
+}

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -49,7 +49,10 @@ impl Checker {
                 })
                 .unwrap_or(type_prefix);
             let direct = self.type_defs.get(direct_key).and_then(|td| {
-                if td.kind != TypeDefKind::Enum && td.kind != TypeDefKind::Struct {
+                if !matches!(
+                    td.kind,
+                    TypeDefKind::Enum | TypeDefKind::Struct | TypeDefKind::Machine
+                ) {
                     return None;
                 }
                 td.variants.get(variant_name).and_then(|variant| {
@@ -73,7 +76,10 @@ impl Checker {
                 type_prefix.to_string(),
             ))?;
             self.type_defs.get(canonical.as_str()).and_then(|td| {
-                if td.kind != TypeDefKind::Enum && td.kind != TypeDefKind::Struct {
+                if !matches!(
+                    td.kind,
+                    TypeDefKind::Enum | TypeDefKind::Struct | TypeDefKind::Machine
+                ) {
                     return None;
                 }
                 td.variants.get(variant_name).and_then(|variant| {

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -6210,6 +6210,16 @@ impl Checker {
             return Ty::Error;
         }
 
+        if let Some(head) = self.resolve_dotted_type_head(object) {
+            if let Some(result) = self.dispatch_dotted_type_member(
+                &head,
+                field,
+                &DottedTypeMemberUse::Reference { span },
+            ) {
+                return result;
+            }
+        }
+
         if let Expr::Identifier(name) = &object.0 {
             if name == "self" {
                 if let Some(ty) = self.check_machine_transition_self_field_access(field, span) {
@@ -6237,15 +6247,9 @@ impl Checker {
                 }
             }
 
-            if self.env.lookup_ref(name).is_none() {
-                let canonical_type = self
-                    .resolve_nominal_declaration(NominalOrigin::Lexical, name)
-                    .unwrap_or_else(|| name.clone());
-                let dotted_variant = format!("{canonical_type}::{field}");
-                if self.lookup_variant_constructor(&dotted_variant).is_some() {
-                    return self.synthesize_identifier(&dotted_variant, span);
-                }
-            }
+            // Dotted type members were dispatched from the canonical head
+            // above. Remaining identifiers are ordinary value projections or
+            // unresolved names and continue through the existing diagnostics.
         }
 
         // Dotted module-qualified unit constructor:

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -4002,6 +4002,33 @@ impl Checker {
             }
 
             (
+                Expr::MethodCall {
+                    receiver,
+                    method,
+                    args,
+                },
+                _,
+            ) => {
+                let actual = self
+                    .check_dotted_type_member_call_against_expected(
+                        receiver, method, args, expected, span,
+                    )
+                    .unwrap_or_else(|| self.synthesize(expr, span));
+                if tail_ok_armed {
+                    if let Some(coerced) = self.try_tail_ok_coercion(expected, &actual, span) {
+                        return coerced;
+                    }
+                }
+                let n = self.errors.len();
+                self.expect_type(expected, &actual, span);
+                if self.errors.len() > n {
+                    Ty::Error
+                } else {
+                    actual
+                }
+            }
+
+            (
                 Expr::Call {
                     function,
                     type_args,

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -6210,7 +6210,7 @@ impl Checker {
             return Ty::Error;
         }
 
-        if let Some(head) = self.resolve_dotted_type_head(object) {
+        if let Some(head) = self.resolve_dotted_type_head(object, field) {
             if let Some(result) = self.dispatch_dotted_type_member(
                 &head,
                 field,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -7295,6 +7295,29 @@ impl Checker {
         result
     }
 
+    pub(super) fn check_dotted_type_member_call_against_expected(
+        &mut self,
+        receiver: &Spanned<Expr>,
+        method: &str,
+        args: &[CallArg],
+        expected: &Ty,
+        span: &Span,
+    ) -> Option<Ty> {
+        let head = self.resolve_dotted_type_head(receiver, method)?;
+        let result = self.dispatch_dotted_type_member(
+            &head,
+            method,
+            &DottedTypeMemberUse::Call {
+                args,
+                expected: Some(expected),
+                span,
+            },
+        )?;
+        self.mark_resolved_nominal_owner_used(&head.canonical_type);
+        self.record_resolved_method_call_ownership(receiver, method, args, span, &result);
+        Some(result)
+    }
+
     #[expect(
         clippy::too_many_lines,
         reason = "method ownership joins every resolved dispatch family at one authority seam"
@@ -7609,7 +7632,11 @@ impl Checker {
             if let Some(result) = self.dispatch_dotted_type_member(
                 head,
                 method,
-                &DottedTypeMemberUse::Call { args, span },
+                &DottedTypeMemberUse::Call {
+                    args,
+                    expected: None,
+                    span,
+                },
             ) {
                 self.mark_resolved_nominal_owner_used(&head.canonical_type);
                 return result;

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -7604,7 +7604,7 @@ impl Checker {
         args: &[CallArg],
         span: &Span,
     ) -> Ty {
-        let dotted_type_head = self.resolve_dotted_type_head(receiver);
+        let dotted_type_head = self.resolve_dotted_type_head(receiver, method);
         if let Some(head) = dotted_type_head.as_ref() {
             if let Some(result) = self.dispatch_dotted_type_member(
                 head,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -7593,115 +7593,6 @@ impl Checker {
         );
     }
 
-    fn dispatch_dotted_type_member(
-        &mut self,
-        canonical_type: &str,
-        explicit_type_args: Option<&[Spanned<TypeExpr>]>,
-        receiver_span: &Span,
-        method: &str,
-        args: &[CallArg],
-        span: &Span,
-    ) -> Option<Ty> {
-        let dotted_member = format!("{canonical_type}::{method}");
-        if let Some((type_name, _, _)) = self.lookup_variant_constructor(&dotted_member) {
-            let constructor = (Expr::Identifier(dotted_member), receiver_span.clone());
-            let result = self.check_call(&constructor, explicit_type_args, args, span);
-            self.record_method_call_receiver_kind(
-                span,
-                MethodCallReceiverKind::EnumConstructorPath { type_name },
-            );
-            return Some(result);
-        }
-
-        if self.fn_sigs.contains_key(&dotted_member) {
-            let function = (
-                Expr::Identifier(dotted_member.clone()),
-                receiver_span.clone(),
-            );
-            let result = self.check_call(&function, explicit_type_args, args, span);
-            let call_key = SpanKey::in_module(span, self.current_module_idx);
-            if let Some(target) = self.direct_call_targets.get(&call_key).cloned() {
-                self.record_method_call_rewrite(
-                    span,
-                    MethodCallRewrite::RewriteModuleQualifiedToFunction {
-                        target,
-                        c_symbol: dotted_member,
-                        elem_ty: None,
-                    },
-                );
-            }
-            return Some(result);
-        }
-
-        // Imported inherent impls retain their executable declaration under
-        // the exact owner (`pkg.Box::make`) even when the compatibility
-        // `fn_sigs` entry is bare (`Box::make`). Resolve the signature from the
-        // canonical TypeDef and the target from the canonical declaration map;
-        // never manufacture a leaf-key retry from `canonical_type`.
-        let type_def = self.type_defs.get(canonical_type).cloned()?;
-        let raw_sig = type_def.methods.get(method).cloned()?;
-        let (sig, explicit_owner_args) = if let Some(type_args) = explicit_type_args {
-            if type_args.len() != type_def.type_params.len() {
-                self.report_error(
-                    TypeErrorKind::ArityMismatch,
-                    span,
-                    format!(
-                        "type `{canonical_type}` has {} type parameter(s) but {} type argument(s) were supplied",
-                        type_def.type_params.len(),
-                        type_args.len()
-                    ),
-                );
-            }
-            let owner_args = type_args
-                .iter()
-                .map(|type_arg| self.resolve_type_expr(type_arg))
-                .collect::<Vec<_>>();
-            (
-                instantiate_stdlib_method_sig(&raw_sig, &type_def.type_params, &owner_args),
-                owner_args,
-            )
-        } else {
-            (raw_sig, Vec::new())
-        };
-        let applied = self.apply_instantiated_call_signature(
-            &sig,
-            None,
-            args,
-            span,
-            SignatureArgApplication::PositionalOnly {
-                arity_context: format!("associated function `{method}`"),
-            },
-            true,
-        );
-        if !explicit_owner_args.is_empty() {
-            self.record_concrete_call_type_args(span, &explicit_owner_args);
-        }
-        let declaration = self
-            .impl_method_declaration_ids
-            .get(&dotted_member)
-            .cloned()
-            .map_or_else(
-                || CallTarget::Unsupported {
-                    reason: format!(
-                        "associated function `{dotted_member}` has no registered declaration identity"
-                    ),
-                },
-                CallTarget::impl_method,
-            );
-        self.record_method_call_rewrite(
-            span,
-            MethodCallRewrite::RewriteModuleQualifiedToFunction {
-                target: declaration,
-                c_symbol: dotted_member,
-                elem_ty: None,
-            },
-        );
-        Some(self.qualify_method_return_to_receiver_owner(
-            canonical_type,
-            &self.subst.resolve(&applied.return_type),
-        ))
-    }
-
     #[expect(
         clippy::too_many_lines,
         reason = "pattern matching type checker with many variants"
@@ -7713,127 +7604,24 @@ impl Checker {
         args: &[CallArg],
         span: &Span,
     ) -> Ty {
-        if let Expr::GenericApplySuffix { target, type_args } = &receiver.0 {
-            let canonical_type = match &target.0 {
-                Expr::Identifier(type_name) if self.env.lookup_ref(type_name).is_none() => self
-                    .resolve_nominal_declaration(NominalOrigin::Lexical, type_name)
-                    .filter(|canonical| {
-                        self.lookup_type_def(canonical).is_some()
-                            || self.resolved_builtin_type(canonical).is_some()
-                    }),
-                Expr::FieldAccess { object, field } => {
-                    if let Expr::Identifier(module_short) = &object.0 {
-                        if self.env.lookup_ref(module_short).is_none() {
-                            self.resolve_module_type(module_short, field)
-                                .map(|type_def| {
-                                    self.used_modules.borrow_mut().insert(ImportKey::in_file(
-                                        self.current_module.clone(),
-                                        self.current_module_idx,
-                                        module_short.clone(),
-                                    ));
-                                    type_def.name
-                                })
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            };
-            if let Some(canonical_type) = canonical_type {
-                if let Some(result) = self.dispatch_dotted_type_member(
-                    &canonical_type,
-                    Some(type_args),
-                    &target.1,
-                    method,
-                    args,
-                    span,
-                ) {
-                    self.mark_resolved_nominal_owner_used(&canonical_type);
-                    return result;
-                }
-            }
-        }
-        // A module-qualified nominal head (`module.Type.member(...)`) reaches
-        // the parser as a method call whose receiver is a field access. Resolve
-        // that field through the exact module export table before the ordinary
-        // value-receiver path can synthesize `module.Type` as a value. This is
-        // the multi-segment counterpart of the lexical nominal ladder below;
-        // both publish the same canonical checker facts to lowering.
-        if let Expr::FieldAccess { object, field } = &receiver.0 {
-            if let Expr::Identifier(module_short) = &object.0 {
-                if self.env.lookup_ref(module_short).is_none() {
-                    if let Some(type_def) = self.resolve_module_type(module_short, field) {
-                        self.used_modules.borrow_mut().insert(ImportKey::in_file(
-                            self.current_module.clone(),
-                            self.current_module_idx,
-                            module_short.clone(),
-                        ));
-                        let canonical_type = type_def.name;
-                        if let Some(result) = self.dispatch_dotted_type_member(
-                            &canonical_type,
-                            None,
-                            &receiver.1,
-                            method,
-                            args,
-                            span,
-                        ) {
-                            return result;
-                        }
-                    }
-                }
+        let dotted_type_head = self.resolve_dotted_type_head(receiver);
+        if let Some(head) = dotted_type_head.as_ref() {
+            if let Some(result) = self.dispatch_dotted_type_member(
+                head,
+                method,
+                &DottedTypeMemberUse::Call { args, span },
+            ) {
+                self.mark_resolved_nominal_owner_used(&head.canonical_type);
+                return result;
             }
         }
         // Module-qualified calls: e.g. http.listen(addr) → lookup "http.listen" in fn_sigs
         if let Expr::Identifier(name) = &receiver.0 {
             let receiver_is_binding = self.env.lookup_ref(name).is_some();
-            let source_module_member =
-                format!("{}.{}", self.canonical_module_import_owner(name), method);
-            let receiver_is_module_binding = self.module_binding_in_current_file(name)
-                || self.modules.contains(name)
-                || self.module_fn_exports.contains(&source_module_member)
-                || self.fn_sigs.contains_key(&source_module_member);
-            // A dotted expression head is resolved through the checker's one
-            // nominal-declaration ladder before member lookup. Imported bare
-            // bindings no longer have a leaf entry in `type_defs`, so probing
-            // `type_defs[name]` here misclassified `Parcel.Filled(...)` and
-            // every imported associated call as a value receiver. The ladder
-            // returns only declaration-proven identities and refuses ambiguous
-            // spellings; there is deliberately no final-segment fallback.
-            let canonical_type = self
-                .resolve_nominal_declaration(NominalOrigin::Lexical, name)
-                .unwrap_or_else(|| name.clone());
-            // Primitive/source aliases such as lowercase `string` may also be
-            // module namespaces. They are not nominal type heads unless the
-            // source spelling itself is the canonical builtin declaration.
-            let source_is_noncanonical_builtin_alias =
-                canonical_type != name.as_str() && self.resolved_builtin_type(name).is_some();
-            let receiver_is_known_type = self.lookup_type_def(&canonical_type).is_some()
-                || self.resolved_builtin_type(&canonical_type).is_some();
-            if !receiver_is_binding
-                && !receiver_is_module_binding
-                && !source_is_noncanonical_builtin_alias
-            {
-                // Static/associated functions retain `::` in the declaration
-                // registry even though their source call surface is dotted.
-                // Route the call through ordinary call checking, then publish
-                // the same no-receiver rewrite used by module-qualified calls.
-                // The direct target written by `check_call` is the semantic
-                // authority; the string remains only the linker presentation.
-                if let Some(result) = self.dispatch_dotted_type_member(
-                    &canonical_type,
-                    None,
-                    &receiver.1,
-                    method,
-                    args,
-                    span,
-                ) {
-                    self.mark_resolved_nominal_owner_used(&canonical_type);
-                    return result;
-                }
-            }
+            // The shared type-head resolver already selected every
+            // declaration-proven nominal above. Preserve that classification
+            // while deciding whether an unresolved head is a module call.
+            let receiver_is_known_type = dotted_type_head.is_some();
             let receiver_shadows_module = receiver_is_binding
                 && self.module_import_bindings.contains_key(&(
                     self.current_module.clone(),

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -47,6 +47,8 @@ mod resolution;
 mod statements;
 #[cfg(test)]
 mod tests;
+mod type_members;
+use self::type_members::DottedTypeMemberUse;
 mod types;
 mod util;
 mod visibility;

--- a/hew-types/src/check/type_members.rs
+++ b/hew-types/src/check/type_members.rs
@@ -1,0 +1,301 @@
+#[allow(
+    clippy::wildcard_imports,
+    reason = "submodules mirror the legacy check namespace during the split"
+)]
+use super::*;
+use crate::check::calls::SignatureArgApplication;
+use crate::method_resolution::instantiate_stdlib_method_sig;
+
+pub(super) struct ResolvedDottedTypeHead {
+    pub(super) canonical_type: String,
+    builtin: Option<crate::BuiltinType>,
+    type_args: Option<Vec<Spanned<TypeExpr>>>,
+    span: Span,
+}
+
+pub(super) enum DottedTypeMemberUse<'a> {
+    Reference { span: &'a Span },
+    Call { args: &'a [CallArg], span: &'a Span },
+}
+
+impl Checker {
+    /// Resolve a dotted expression head to the declaration identity selected
+    /// by the checker. Value bindings win before this path, and every accepted
+    /// module/type spelling comes from a declaration or builtin authority.
+    pub(super) fn resolve_dotted_type_head(
+        &mut self,
+        head: &Spanned<Expr>,
+    ) -> Option<ResolvedDottedTypeHead> {
+        let (target, type_args) = match &head.0 {
+            Expr::GenericApplySuffix { target, type_args } => {
+                (target.as_ref(), Some(type_args.clone()))
+            }
+            _ => (head, None),
+        };
+
+        let (canonical_type, builtin) = match &target.0 {
+            Expr::Identifier(surface) => {
+                if self.env.lookup_ref(surface).is_some()
+                    || self.module_binding_in_current_file(surface)
+                {
+                    return None;
+                }
+                let canonical = self
+                    .resolve_nominal_declaration(NominalOrigin::Lexical, surface)
+                    .filter(|identity| {
+                        self.lookup_type_def(identity).is_some()
+                            || self.resolved_builtin_type(identity).is_some()
+                    })
+                    .or_else(|| self.resolved_builtin_type(surface).map(|_| surface.clone()))?;
+                let builtin = self.resolved_builtin_type(&canonical);
+                (canonical, builtin)
+            }
+            Expr::FieldAccess { object, field } => {
+                let Expr::Identifier(module_short) = &object.0 else {
+                    return None;
+                };
+                if self.env.lookup_ref(module_short).is_some() {
+                    return None;
+                }
+                let type_def = self.resolve_module_type(module_short, field)?;
+                self.used_modules.borrow_mut().insert(ImportKey::in_file(
+                    self.current_module.clone(),
+                    self.current_module_idx,
+                    module_short.clone(),
+                ));
+                let canonical = type_def.name;
+                let builtin = self.resolved_builtin_type(&canonical);
+                (canonical, builtin)
+            }
+            _ => return None,
+        };
+
+        Some(ResolvedDottedTypeHead {
+            canonical_type,
+            builtin,
+            type_args,
+            span: target.1.clone(),
+        })
+    }
+
+    /// Dispatch a member selected from a resolved type head. The declaration
+    /// identity is fixed before the semantic adapters run: declared variants
+    /// (including machine states), builtin Option/Result variants, and static
+    /// members all consume the same canonical fact.
+    pub(super) fn dispatch_dotted_type_member(
+        &mut self,
+        head: &ResolvedDottedTypeHead,
+        member: &str,
+        usage: &DottedTypeMemberUse<'_>,
+    ) -> Option<Ty> {
+        if let Some(result) = self.dispatch_declared_variant_member(head, member, usage) {
+            return Some(result);
+        }
+        if let Some(result) = self.dispatch_builtin_variant_member(head, member, usage) {
+            return Some(result);
+        }
+        let DottedTypeMemberUse::Call { args, span } = usage else {
+            return None;
+        };
+        self.dispatch_static_type_member(head, member, args, span)
+    }
+
+    fn dispatch_declared_variant_member(
+        &mut self,
+        head: &ResolvedDottedTypeHead,
+        member: &str,
+        usage: &DottedTypeMemberUse<'_>,
+    ) -> Option<Ty> {
+        let type_def = self.type_defs.get(&head.canonical_type)?;
+        if !matches!(
+            type_def.kind,
+            TypeDefKind::Enum | TypeDefKind::Struct | TypeDefKind::Machine
+        ) {
+            return None;
+        }
+        let variant = type_def.variants.get(member)?;
+        match usage {
+            DottedTypeMemberUse::Reference { span }
+                if matches!(variant, VariantDef::Unit | VariantDef::Tuple(_)) =>
+            {
+                let constructor = format!("{}::{member}", head.canonical_type);
+                Some(self.synthesize_identifier(&constructor, span))
+            }
+            DottedTypeMemberUse::Call { args, span }
+                if matches!(variant, VariantDef::Unit | VariantDef::Tuple(_)) =>
+            {
+                let constructor_name = format!("{}::{member}", head.canonical_type);
+                let constructor = (Expr::Identifier(constructor_name), head.span.clone());
+                let result = self.check_call(&constructor, head.type_args.as_deref(), args, span);
+                self.record_method_call_receiver_kind(
+                    span,
+                    MethodCallReceiverKind::EnumConstructorPath {
+                        type_name: head.canonical_type.clone(),
+                    },
+                );
+                Some(result)
+            }
+            _ => None,
+        }
+    }
+
+    fn dispatch_builtin_variant_member(
+        &mut self,
+        head: &ResolvedDottedTypeHead,
+        member: &str,
+        usage: &DottedTypeMemberUse<'_>,
+    ) -> Option<Ty> {
+        let (builtin, constructor, expected_arity) = match (head.builtin, member) {
+            (Some(crate::BuiltinType::Option), "Some" | "None") => {
+                (crate::BuiltinType::Option, member, 1)
+            }
+            (Some(crate::BuiltinType::Result), "Ok" | "Err") => {
+                (crate::BuiltinType::Result, member, 2)
+            }
+            _ => return None,
+        };
+
+        let result = match usage {
+            DottedTypeMemberUse::Reference { span } => {
+                self.synthesize_identifier(constructor, span)
+            }
+            DottedTypeMemberUse::Call { args, span } => {
+                let function = (Expr::Identifier(constructor.to_string()), head.span.clone());
+                let result = self.check_call(&function, None, args, span);
+                self.record_method_call_receiver_kind(
+                    span,
+                    MethodCallReceiverKind::EnumConstructorPath {
+                        type_name: head.canonical_type.clone(),
+                    },
+                );
+                result
+            }
+        };
+
+        let Some(type_args) = head.type_args.as_deref() else {
+            return Some(result);
+        };
+        if type_args.len() != expected_arity {
+            let span = match usage {
+                DottedTypeMemberUse::Reference { span }
+                | DottedTypeMemberUse::Call { span, .. } => *span,
+            };
+            self.report_error(
+                TypeErrorKind::ArityMismatch,
+                span,
+                format!(
+                    "type `{}` has {expected_arity} type parameter(s) but {} type argument(s) were supplied",
+                    head.canonical_type,
+                    type_args.len()
+                ),
+            );
+            return Some(Ty::Error);
+        }
+        let resolved_args = type_args
+            .iter()
+            .map(|type_arg| self.resolve_type_expr(type_arg))
+            .collect::<Vec<_>>();
+        let expected = Ty::Named {
+            builtin: Some(builtin),
+            name: head.canonical_type.clone(),
+            args: resolved_args,
+        };
+        let span = match usage {
+            DottedTypeMemberUse::Reference { span } | DottedTypeMemberUse::Call { span, .. } => {
+                *span
+            }
+        };
+        self.expect_type(&expected, &result, span);
+        Some(self.subst.resolve(&expected))
+    }
+
+    fn dispatch_static_type_member(
+        &mut self,
+        head: &ResolvedDottedTypeHead,
+        method: &str,
+        args: &[CallArg],
+        span: &Span,
+    ) -> Option<Ty> {
+        let dotted_member = format!("{}::{method}", head.canonical_type);
+        if self.fn_sigs.contains_key(&dotted_member) {
+            let function = (Expr::Identifier(dotted_member.clone()), head.span.clone());
+            let result = self.check_call(&function, head.type_args.as_deref(), args, span);
+            let call_key = SpanKey::in_module(span, self.current_module_idx);
+            if let Some(target) = self.direct_call_targets.get(&call_key).cloned() {
+                self.record_method_call_rewrite(
+                    span,
+                    MethodCallRewrite::RewriteModuleQualifiedToFunction {
+                        target,
+                        c_symbol: dotted_member,
+                        elem_ty: None,
+                    },
+                );
+            }
+            return Some(result);
+        }
+
+        let type_def = self.type_defs.get(&head.canonical_type).cloned()?;
+        let raw_sig = type_def.methods.get(method).cloned()?;
+        let (sig, explicit_owner_args) = if let Some(type_args) = head.type_args.as_deref() {
+            if type_args.len() != type_def.type_params.len() {
+                self.report_error(
+                    TypeErrorKind::ArityMismatch,
+                    span,
+                    format!(
+                        "type `{}` has {} type parameter(s) but {} type argument(s) were supplied",
+                        head.canonical_type,
+                        type_def.type_params.len(),
+                        type_args.len()
+                    ),
+                );
+            }
+            let owner_args = type_args
+                .iter()
+                .map(|type_arg| self.resolve_type_expr(type_arg))
+                .collect::<Vec<_>>();
+            (
+                instantiate_stdlib_method_sig(&raw_sig, &type_def.type_params, &owner_args),
+                owner_args,
+            )
+        } else {
+            (raw_sig, Vec::new())
+        };
+        let applied = self.apply_instantiated_call_signature(
+            &sig,
+            None,
+            args,
+            span,
+            SignatureArgApplication::PositionalOnly {
+                arity_context: format!("associated function `{method}`"),
+            },
+            true,
+        );
+        if !explicit_owner_args.is_empty() {
+            self.record_concrete_call_type_args(span, &explicit_owner_args);
+        }
+        let declaration = self
+            .impl_method_declaration_ids
+            .get(&dotted_member)
+            .cloned()
+            .map_or_else(
+                || CallTarget::Unsupported {
+                    reason: format!(
+                        "associated function `{dotted_member}` has no registered declaration identity"
+                    ),
+                },
+                CallTarget::impl_method,
+            );
+        self.record_method_call_rewrite(
+            span,
+            MethodCallRewrite::RewriteModuleQualifiedToFunction {
+                target: declaration,
+                c_symbol: dotted_member,
+                elem_ty: None,
+            },
+        );
+        Some(self.qualify_method_return_to_receiver_owner(
+            &head.canonical_type,
+            &self.subst.resolve(&applied.return_type),
+        ))
+    }
+}

--- a/hew-types/src/check/type_members.rs
+++ b/hew-types/src/check/type_members.rs
@@ -25,6 +25,7 @@ impl Checker {
     pub(super) fn resolve_dotted_type_head(
         &mut self,
         head: &Spanned<Expr>,
+        member: &str,
     ) -> Option<ResolvedDottedTypeHead> {
         let (target, type_args) = match &head.0 {
             Expr::GenericApplySuffix { target, type_args } => {
@@ -46,7 +47,12 @@ impl Checker {
                         self.lookup_type_def(identity).is_some()
                             || self.resolved_builtin_type(identity).is_some()
                     })
-                    .or_else(|| self.resolved_builtin_type(surface).map(|_| surface.clone()))?;
+                    .or_else(|| self.resolved_builtin_type(surface).map(|_| surface.clone()))
+                    .or_else(|| {
+                        self.fn_sigs
+                            .contains_key(&format!("{surface}::{member}"))
+                            .then(|| surface.clone())
+                    })?;
                 let builtin = self.resolved_builtin_type(&canonical);
                 (canonical, builtin)
             }

--- a/hew-types/src/check/type_members.rs
+++ b/hew-types/src/check/type_members.rs
@@ -63,13 +63,17 @@ impl Checker {
                 if self.env.lookup_ref(module_short).is_some() {
                     return None;
                 }
-                let type_def = self.resolve_module_type(module_short, field)?;
+                self.resolve_module_type(module_short, field)?;
                 self.used_modules.borrow_mut().insert(ImportKey::in_file(
                     self.current_module.clone(),
                     self.current_module_idx,
                     module_short.clone(),
                 ));
-                let canonical = type_def.name;
+                let canonical = format!(
+                    "{}.{}",
+                    self.canonical_module_import_owner(module_short),
+                    field
+                );
                 let builtin = self.resolved_builtin_type(&canonical);
                 (canonical, builtin)
             }

--- a/hew-types/src/check/type_members.rs
+++ b/hew-types/src/check/type_members.rs
@@ -14,8 +14,14 @@ pub(super) struct ResolvedDottedTypeHead {
 }
 
 pub(super) enum DottedTypeMemberUse<'a> {
-    Reference { span: &'a Span },
-    Call { args: &'a [CallArg], span: &'a Span },
+    Reference {
+        span: &'a Span,
+    },
+    Call {
+        args: &'a [CallArg],
+        expected: Option<&'a Ty>,
+        span: &'a Span,
+    },
 }
 
 impl Checker {
@@ -104,7 +110,7 @@ impl Checker {
         if let Some(result) = self.dispatch_builtin_variant_member(head, member, usage) {
             return Some(result);
         }
-        let DottedTypeMemberUse::Call { args, span } = usage else {
+        let DottedTypeMemberUse::Call { args, span, .. } = usage else {
             return None;
         };
         self.dispatch_static_type_member(head, member, args, span)
@@ -131,7 +137,7 @@ impl Checker {
                 let constructor = format!("{}::{member}", head.canonical_type);
                 Some(self.synthesize_identifier(&constructor, span))
             }
-            DottedTypeMemberUse::Call { args, span }
+            DottedTypeMemberUse::Call { args, span, .. }
                 if matches!(variant, VariantDef::Unit | VariantDef::Tuple(_)) =>
             {
                 let constructor_name = format!("{}::{member}", head.canonical_type);
@@ -169,9 +175,20 @@ impl Checker {
             DottedTypeMemberUse::Reference { span } => {
                 self.synthesize_identifier(constructor, span)
             }
-            DottedTypeMemberUse::Call { args, span } => {
+            DottedTypeMemberUse::Call {
+                args,
+                expected,
+                span,
+            } => {
                 let function = (Expr::Identifier(constructor.to_string()), head.span.clone());
-                let result = self.check_call(&function, None, args, span);
+                let result = expected
+                    .filter(|_| head.type_args.is_none())
+                    .and_then(|expected| {
+                        self.check_call_against_expected_constructor(
+                            &function, None, args, expected, span,
+                        )
+                    })
+                    .unwrap_or_else(|| self.check_call(&function, None, args, span));
                 self.record_method_call_receiver_kind(
                     span,
                     MethodCallReceiverKind::EnumConstructorPath {

--- a/hew-types/tests/registry_core.rs
+++ b/hew-types/tests/registry_core.rs
@@ -19,6 +19,8 @@ mod closure_escape_advisory;
 mod consumes_receiver_metadata;
 #[path = "registry_core/descriptor_authority.rs"]
 mod descriptor_authority;
+#[path = "registry_core/dotted_type_member_dispatch.rs"]
+mod dotted_type_member_dispatch;
 #[path = "registry_core/extern_symbol_runtime_descriptor_boundary.rs"]
 mod extern_symbol_runtime_descriptor_boundary;
 #[path = "registry_core/iterator_lazy_wrappers.rs"]

--- a/hew-types/tests/registry_core/dotted_type_member_dispatch.rs
+++ b/hew-types/tests/registry_core/dotted_type_member_dispatch.rs
@@ -1,0 +1,103 @@
+use crate::common::typecheck_isolated;
+use hew_types::error::TypeErrorKind;
+
+#[test]
+fn dotted_type_members_share_canonical_dispatch() {
+    let output = typecheck_isolated(
+        r#"
+machine Lifecycle {
+    events { Reset; }
+    state Start;
+    state Running { value: i64; }
+    on Reset: Running => Start { Start }
+    default { state }
+}
+
+fn main() {
+    let start: Lifecycle = Lifecycle.Start;
+    let running: Lifecycle = Lifecycle.Running { value: 42 };
+    let some: Option<i64> = Option.Some(5);
+    let ok: Result<i64, string> = Result.Ok(6);
+    let set: HashSet<i64> = HashSet<i64>.new();
+    let explicit: Option<i64> = Option<i64>.Some(7);
+    set.insert(8);
+    println(f"{start.state_name()} {running.state_name()} {some.unwrap()} {ok.unwrap()} {explicit.unwrap()} {set.len()}");
+}
+"#,
+    );
+
+    assert!(
+        output.errors.is_empty(),
+        "all dotted type-member shapes should typecheck: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn bare_type_without_member_remains_an_error() {
+    let output = typecheck_isolated(
+        r"
+machine Lifecycle {
+    events { Reset; }
+    state Start;
+    state Running;
+    on Reset: Running => Start { Start }
+    default { state }
+}
+
+fn main() {
+    let bad = Lifecycle;
+}
+",
+    );
+
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|error| error.kind == TypeErrorKind::TypeUsedAsValue),
+        "a type head with no selected member must remain a value error: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn dotted_builtin_head_arity_is_checked() {
+    let output = typecheck_isolated(
+        r"
+fn main() {
+    let bad = Option<i64, string>.Some(1);
+}
+",
+    );
+
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|error| error.kind == TypeErrorKind::ArityMismatch),
+        "an invalid explicit builtin head must fail at the type boundary: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn lexical_value_head_does_not_fall_back_to_builtin_leaf() {
+    let output = typecheck_isolated(
+        r"
+fn main() {
+    let Option = 1;
+    let bad = Option.Some(2);
+}
+",
+    );
+
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|error| error.message.contains("no method `Some` on `i64`")),
+        "a lexical value must win over the same-spelled builtin head: {:#?}",
+        output.errors
+    );
+}

--- a/hew-types/tests/registry_core/dotted_type_member_dispatch.rs
+++ b/hew-types/tests/registry_core/dotted_type_member_dispatch.rs
@@ -34,6 +34,34 @@ fn main() {
 }
 
 #[test]
+fn dotted_builtin_constructors_preserve_expected_types() {
+    let output = typecheck_isolated(
+        r#"
+fn main() {
+    let oa: Option<i64> = Option.Some(5);
+    let ob: Option<i64> = Option.Some(5);
+    let oc: Option<i64> = Option.Some(6);
+    let option_same = oa == ob;
+    let option_diff = oa == oc;
+
+    let ra: Result<i64, string> = Result.Ok(6);
+    let rb: Result<i64, string> = Result.Ok(6);
+    let rc: Result<i64, string> = Result.Ok(7);
+    let result_same = ra == rb;
+    let result_diff = ra == rc;
+    println(f"{option_same} {option_diff} {result_same} {result_diff}");
+}
+"#,
+    );
+
+    assert!(
+        output.errors.is_empty(),
+        "dotted builtin constructors should retain contextual payload types: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn bare_type_without_member_remains_an_error() {
     let output = typecheck_isolated(
         r"


### PR DESCRIPTION
## Summary

- resolve lexical nominal, module-owned, builtin, and generic-applied type heads once from canonical checker facts
- route machine state variants, Option and Result variants, and static members through one fail-closed dispatcher
- preserve contextual constructor types, exact static namespaces, lexical shadowing, and bare type-as-value errors

## Verification

- cargo test -p hew-types -p hew-hir
- make test-vertical-slice test-pkg-import test-hew-ratchet
- migrated core matrix with this build: CRASH=2 NYI-CLEAN=67 NYI-INTERNAL=34 PASS=275
- core matrix baseline: CRASH=2 NYI-CLEAN=95 NYI-INTERNAL=34 PASS=247