### PR TITLE
fix(types): resolve peer state constructors in directory modules

### DIFF
--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -4651,6 +4651,35 @@ extern "C" { fn hew_tcp_read(foo: Foo); }
     }
 
     #[test]
+    fn std_concurrency_peer_bodies_accept_both_import_spellings() {
+        let dir = tempfile::tempdir().expect("create temp project");
+        for (name, import) in [
+            ("dotted.hew", "import std.concurrency.{ScopeError};"),
+            ("legacy.hew", "import std::concurrency::{ScopeError};"),
+        ] {
+            let source = format!(
+                "{import}\n\
+                 \n\
+                 fn main() {{\n\
+                     let error: ScopeError<i64> = ScopeError {{\n\
+                         primary: 1,\n\
+                         also_failed: [],\n\
+                         cancelled_count: 0,\n\
+                     }};\n\
+                     let _ = error;\n\
+                 }}\n"
+            );
+            let input = write_source(dir.path(), name, &source);
+            let result = check_file(&input, &FrontendOptions::default());
+            assert!(
+                result.is_ok(),
+                "{import} must check the assembled std.concurrency peer bodies: {:#?}",
+                result.err()
+            );
+        }
+    }
+
+    #[test]
     fn bundled_empty_type_decls_publish_owner_qualified_mir_layouts() {
         fn lower_to_mir(input: &str) -> hew_mir::IrPipeline {
             let state = run_file_frontend_to_typecheck(input, &FrontendOptions::default())

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -4355,6 +4355,10 @@ extern "C" { fn hew_tcp_read(foo: Foo); }
             "    }\n",
             "    default { state }\n",
             "}\n",
+            "\n",
+            "pub fn deferred_error() {\n",
+            "    let value: Vec<_> = [];\n",
+            "}\n",
         );
         write_source(&workflow_dir, "state.hew", peer_source);
 
@@ -4387,6 +4391,37 @@ extern "C" { fn hew_tcp_read(foo: Foo); }
             .count()
             + 1;
         assert_eq!(line, 6, "diagnostic must point at the deliberate error");
+
+        let inference = failure
+            .diagnostics
+            .iter()
+            .find_map(|diagnostic| match &diagnostic.kind {
+                FrontendDiagnosticKind::Type(error)
+                    if error.message.contains("cannot infer type") =>
+                {
+                    Some((diagnostic, error))
+                }
+                _ => None,
+            })
+            .expect("deferred inference diagnostic");
+        assert!(
+            inference
+                .0
+                .filename
+                .as_deref()
+                .is_some_and(|filename| filename.ends_with("workflow/state.hew")),
+            "deferred diagnostic must name the declaring peer, got {:?}",
+            inference.0.filename
+        );
+        let inference_line = peer_source[..inference.1.span.start]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count()
+            + 1;
+        assert_eq!(
+            inference_line, 12,
+            "deferred diagnostic must point at the inference error"
+        );
     }
 
     #[test]

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -4331,6 +4331,65 @@ extern "C" { fn hew_tcp_read(foo: Foo); }
     }
 
     #[test]
+    fn state_constructor_error_in_peer_routes_to_its_source_line() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let workflow_dir = dir.path().join("workflow");
+        fs::create_dir(&workflow_dir).expect("create workflow dir");
+        let main = write_source(
+            dir.path(),
+            "main.hew",
+            "import workflow.{Workflow};\nfn main() {}\n",
+        );
+        write_source(
+            &workflow_dir,
+            "workflow.hew",
+            "pub type Marker { value: i64; }\n",
+        );
+        let peer_source = concat!(
+            "pub machine Workflow {\n",
+            "    events { Crash; }\n",
+            "    state Ready;\n",
+            "    state Faulted { code: i64; }\n",
+            "    on Crash: Ready => Faulted {\n",
+            "        Workflow.Faulted { wrong: 1 }\n",
+            "    }\n",
+            "    default { state }\n",
+            "}\n",
+        );
+        write_source(&workflow_dir, "state.hew", peer_source);
+
+        let failure = check_file(&main, &FrontendOptions::default())
+            .expect_err("the deliberate state-field error must reject the fixture");
+        let diagnostic = failure
+            .diagnostics
+            .iter()
+            .find_map(|diagnostic| match &diagnostic.kind {
+                FrontendDiagnosticKind::Type(error)
+                    if error.message.contains("no field `wrong`") =>
+                {
+                    Some((diagnostic, error))
+                }
+                _ => None,
+            })
+            .expect("state constructor field diagnostic");
+        assert!(
+            diagnostic
+                .0
+                .filename
+                .as_deref()
+                .is_some_and(|filename| filename.ends_with("workflow/state.hew")),
+            "diagnostic must name the declaring peer, got {:?}",
+            diagnostic.0.filename
+        );
+        let line = peer_source[..diagnostic.1.span.start]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count()
+            + 1;
+        assert_eq!(line, 6, "diagnostic must point at the deliberate error");
+    }
+
+    #[test]
     fn hir_diagnostic_routes_to_imported_module_source() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let main = write_source(

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -7400,7 +7400,7 @@ impl Checker {
             let segments = name.split('.').collect::<Vec<_>>();
             match segments.as_slice() {
                 [surface_type, variant] if self.env.lookup_ref(surface_type).is_none() => self
-                    .resolve_nominal_declaration(NominalOrigin::Lexical, surface_type)
+                    .source_nominal_declaration(surface_type)
                     .and_then(|canonical_type| {
                         self.lookup_type_def(&canonical_type)
                             .filter(|type_def| {

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -651,13 +651,6 @@ impl Checker {
                         }
                     }
 
-                    // Snapshot error/warning counts before body-checking this module.
-                    // Everything emitted during the body check that still has
-                    // `source_module: None` is tagged below with the module name,
-                    // so the CLI can route it to the correct source file.
-                    let err_before = self.errors.len();
-                    let warn_before = self.warnings.len();
-
                     // Builtin/standard-library modules (`std::`, `hew::`,
                     // `ecosystem::`) ship with the compiler; scope-level lints
                     // inside them (UnusedVariable, UnusedMut) are implementation
@@ -692,24 +685,43 @@ impl Checker {
                         self.current_module_idx = span_indices
                             .item_index(mod_id, item_idx)
                             .unwrap_or(self.current_module_idx);
+                        let diagnostic_source = self
+                            .item_file_routing_token(
+                                Some(&module_name),
+                                self.current_item_source.as_ref(),
+                            )
+                            .unwrap_or_else(|| module_name.clone());
+                        let err_before = self.errors.len();
+                        let warn_before = self.warnings.len();
                         self.check_item(item, span);
+
+                        // An assembled peer retains file-relative spans, so
+                        // tag each item's diagnostics before advancing to the
+                        // next file. Replace the aggregate module fallback as
+                        // well as an absent source, while preserving an
+                        // explicitly different diagnostic owner.
+                        for error in &mut self.errors[err_before..] {
+                            if error
+                                .source_module
+                                .as_deref()
+                                .is_none_or(|source| source == module_name)
+                            {
+                                error.source_module = Some(diagnostic_source.clone());
+                            }
+                        }
+                        for warning in &mut self.warnings[warn_before..] {
+                            if warning
+                                .source_module
+                                .as_deref()
+                                .is_none_or(|source| source == module_name)
+                            {
+                                warning.source_module = Some(diagnostic_source.clone());
+                            }
+                        }
                     }
                     self.current_item_source = None;
 
                     self.is_stdlib_source = saved_is_stdlib_source;
-
-                    // Tag diagnostics that were not already tagged (e.g. by a
-                    // nested call that already knew the origin).
-                    for e in &mut self.errors[err_before..] {
-                        if e.source_module.is_none() {
-                            e.source_module = Some(module_name.clone());
-                        }
-                    }
-                    for w in &mut self.warnings[warn_before..] {
-                        if w.source_module.is_none() {
-                            w.source_module = Some(module_name.clone());
-                        }
-                    }
 
                     self.local_type_defs = saved_local_type_defs;
                     self.source_type_defs = saved_source_type_defs;

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -10984,9 +10984,17 @@ impl Checker {
                         continue;
                     }
                     let event_name = format!("{}Event", md.name);
+                    // Resolved stdlib items are registered while the importer
+                    // is the active checker frame. Re-enter the declaration's
+                    // assembled module before building the machine and its
+                    // generated event/method signatures, matching the module-
+                    // graph pre-registration and ordinary source-body context.
+                    let saved_importer_module =
+                        self.current_module.replace(module_full_path.to_string());
                     self.register_machine_decl(md, span);
                     let machine_def = self.type_defs.get(&md.name).cloned();
                     let event_def = self.type_defs.get(&event_name).cloned();
+                    self.current_module = saved_importer_module;
                     self.known_types.insert(md.name.clone());
                     self.known_types.insert(event_name.clone());
                     self.register_qualified_type_alias(module_short, &md.name);

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -9578,7 +9578,7 @@ impl Checker {
     /// source (a peer file of a directory module), else `None` (the module
     /// identity routes as before). The CLI/LSP source maps carry an entry per
     /// source file keyed by this exact rendering.
-    fn item_file_routing_token(
+    pub(super) fn item_file_routing_token(
         &self,
         module: Option<&str>,
         file: Option<&std::path::PathBuf>,

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -9588,6 +9588,17 @@ impl Checker {
         (file != primary).then(|| file.display().to_string())
     }
 
+    /// Capture the source identity that diagnostic emission must use after the
+    /// current item frame has been cleared. Peer files need their path rather
+    /// than the assembled directory module's identity.
+    pub(super) fn current_diagnostic_source_module(&self) -> Option<String> {
+        self.item_file_routing_token(
+            self.current_module.as_deref(),
+            self.current_item_source.as_ref(),
+        )
+        .or_else(|| self.current_module.clone())
+    }
+
     /// Resolve one extern declaration against the single-owner table
     /// (rc1-F1 stage B): mint the symbol's contract, or run the canonicalized
     /// structural compare against the established one — adopt on agreement,

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -1449,7 +1449,7 @@ impl Checker {
             span: first_infer_span_in_type_expr(annotation).unwrap_or_else(|| annotation.1.clone()),
             context: context.into(),
             hole_vars,
-            source_module: self.current_module.clone(),
+            source_module: self.current_diagnostic_source_module(),
         });
     }
 
@@ -1468,7 +1468,7 @@ impl Checker {
             actual: actual.clone(),
             target: target.clone(),
             target_hole_vars,
-            source_module: self.current_module.clone(),
+            source_module: self.current_diagnostic_source_module(),
         });
     }
 
@@ -1485,7 +1485,7 @@ impl Checker {
                 context: context.into(),
                 ty: ty.clone(),
                 more_specific_hole_vars,
-                source_module: self.current_module.clone(),
+                source_module: self.current_diagnostic_source_module(),
             });
     }
 

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -334,6 +334,20 @@ impl Checker {
         if crate::lookup_builtin_type(name).is_some() || builtin_named_type(name).is_some() {
             return None;
         }
+        // A directory module checks every peer body in the assembled module's
+        // lexical namespace while retaining the peer file as source provenance.
+        // Prefer that module-local declaration before the file-oriented nominal
+        // ladder: the latter exists for ABI declarations that must retain their
+        // minting file identity, whereas ordinary source types are registered
+        // under the assembled module owner.
+        if !name.contains('.') && self.local_type_defs.contains(name) {
+            if let Some(module) = self.current_module_identity() {
+                let local = format!("{module}.{name}");
+                if self.type_defs.contains_key(&local) || self.known_types.contains(&local) {
+                    return Some(local);
+                }
+            }
+        }
         let declaration = self.resolve_nominal_declaration(NominalOrigin::Lexical, name)?;
         // Compiler catalog nominals keep their own namespace. `Location`,
         // `NodeId` and the other entries the compiler declares in

--- a/hew-types/src/check/type_members.rs
+++ b/hew-types/src/check/type_members.rs
@@ -48,7 +48,7 @@ impl Checker {
                     return None;
                 }
                 let canonical = self
-                    .resolve_nominal_declaration(NominalOrigin::Lexical, surface)
+                    .source_nominal_declaration(surface)
                     .filter(|identity| {
                         self.lookup_type_def(identity).is_some()
                             || self.resolved_builtin_type(identity).is_some()

--- a/hew-types/src/check/type_members.rs
+++ b/hew-types/src/check/type_members.rs
@@ -49,6 +49,7 @@ impl Checker {
                 }
                 let canonical = self
                     .source_nominal_declaration(surface)
+                    .or_else(|| self.resolve_nominal_declaration(NominalOrigin::Lexical, surface))
                     .filter(|identity| {
                         self.lookup_type_def(identity).is_some()
                             || self.resolved_builtin_type(identity).is_some()

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2420,7 +2420,7 @@ pub(super) struct DeferredInferenceHole {
     pub(super) span: Span,
     pub(super) context: String,
     pub(super) hole_vars: Vec<TypeVar>,
-    /// Module path where this hole was recorded (None = root module).
+    /// Diagnostic routing token captured while the source item was active.
     pub(super) source_module: Option<String>,
 }
 
@@ -2430,7 +2430,7 @@ pub(super) struct DeferredCastCheck {
     pub(super) actual: Ty,
     pub(super) target: Ty,
     pub(super) target_hole_vars: Vec<TypeVar>,
-    /// Module path where this cast check was recorded (None = root module).
+    /// Diagnostic routing token captured while the source item was active.
     pub(super) source_module: Option<String>,
 }
 
@@ -2440,7 +2440,7 @@ pub(super) struct DeferredMonomorphicSite {
     pub(super) context: String,
     pub(super) ty: Ty,
     pub(super) more_specific_hole_vars: Vec<TypeVar>,
-    /// Module path where this site was recorded (None = root module).
+    /// Diagnostic routing token captured while the source item was active.
     pub(super) source_module: Option<String>,
 }
 


### PR DESCRIPTION
## Summary

- re-enter the assembled declaration owner when stdlib machine items rebuild generated event and method signatures
- route dotted state-record initialization through canonical source nominal resolution while retaining compiler-catalog constructor dispatch
- preserve each peer files routing token during body checking so diagnostics use the declaring file and line
- cover std.concurrency ScopeError imports with dotted and legacy spellings and assert a deliberate peer state-constructor error reports workflow/state.hew:6

## Verification

- cargo test -p hew-types -p hew-hir
- make test-stdlib-ratchet test-hew-ratchet
- cargo test -p hew-compile peer -- --nocapture
- make test-pkg-import