### PR TITLE
refactor(lint): narrow the leaf-name guard to identity sinks

### DIFF
--- a/hew-cli/tests/artifact_platform_neutrality_selftest.rs
+++ b/hew-cli/tests/artifact_platform_neutrality_selftest.rs
@@ -49,7 +49,6 @@ const ARTIFACT_ROOTS: &[&str] = &[
 const ARTIFACT_FILES: &[&str] = &[
     "scripts/stdlib-execution-proofs.tsv",
     "scripts/structural-authority-inventory.tsv",
-    "scripts/structural-authority-presentation.tsv",
     "wasm-capability-manifest.toml",
     "hew-types/src/wasm_capabilities_generated.rs",
     "examples/playground/wasm-capabilities.json",

--- a/scripts/structural-authority-audit.py
+++ b/scripts/structural-authority-audit.py
@@ -26,9 +26,7 @@ COMPILER_ROOTS = (
     "hew-mir/src",
     "hew-codegen-rs/src",
 )
-PRESENTATION_CATEGORIES = {"debug-metadata"}
 ALL_GROUPS = {
-    "semantic-leaf-name",
     "semantic-owner-shortening-sink",
     "string-method-identity",
     "legacy-heap-reader",
@@ -102,21 +100,6 @@ ITEM_KINDS = (
     "enum_variant",
     "expression_statement",
 )
-DEBUG_CONTEXT_PATTERNS = {
-    "debug-struct-type-argument": (
-        "$R.create_struct_type($A0, $D1, $A2, $A3, $A4, $A5, "
-        "$A6, $A7, $A8, $A9, $A10, $D11)",
-        ("D1", "D11"),
-    ),
-    "debug-enumerator-argument": (
-        "$R.create_enumerator($D0, $A1, $A2)",
-        ("D0",),
-    ),
-    "debug-member-type-argument": (
-        "$R.create_member_type($A0, $D1, $A2, $A3, $A4, $A5, $A6, $A7, $A8)",
-        ("D1",),
-    ),
-}
 
 
 def generated_builtin_enum_leaves(root: Path) -> set[str]:
@@ -1086,31 +1069,6 @@ def discover(ast_grep: Path, root: Path) -> tuple[set[Finding], list[SyntaxRange
     findings: set[Finding] = set()
     generated_enum_leaves = generated_builtin_enum_leaves(root)
 
-    # Identifier nodes remain parsed inside Rust macro token trees. This closes
-    # the call-expression blind spot without treating comments or string tokens
-    # as code. Imports, declarations, local names, qualified calls, and macro
-    # arguments all stay visible until their path/form inventory is retired.
-    for match in run_query(ast_grep, root, kind="identifier"):
-        forms = {
-            "short_name": "short-name-identifier",
-            "rsplit": "leaf-rsplit-identifier",
-            "rsplit_once": "leaf-rsplit-once-identifier",
-        }
-        if str(match["text"]) in forms:
-            findings.add(
-                finding("semantic-leaf-name", forms[str(match["text"])], match)
-            )
-    for match in run_query(ast_grep, root, kind="field_identifier"):
-        forms = {
-            "short_name": "short-name-field",
-            "rsplit": "leaf-rsplit-field",
-            "rsplit_once": "leaf-rsplit-once-field",
-        }
-        if str(match["text"]) in forms:
-            findings.add(
-                finding("semantic-leaf-name", forms[str(match["text"])], match)
-            )
-
     calls = run_query(ast_grep, root, pattern="$F($$$ARGS)")
     for match in calls:
         callee = single_meta(match, "F")
@@ -1177,38 +1135,6 @@ def discover(ast_grep: Path, root: Path) -> tuple[set[Finding], list[SyntaxRange
     reject_raw_codegen_call_dispatch(ast_grep, root)
     findings.update(rc1_structural_authority_findings(ast_grep, root, test_ranges))
     return {item for item in findings if not excluded(item, test_ranges)}, test_ranges
-
-
-def presentation_candidates(
-    ast_grep: Path, root: Path, findings: set[Finding], test_ranges: list[SyntaxRange]
-) -> set[tuple[str, int, int, str, str]]:
-    short_name_calls = {
-        node_range(match)
-        for match in run_query(ast_grep, root, pattern="short_name($X)")
-    }
-    contexts: list[tuple[str, SyntaxRange]] = []
-    for context_form, (pattern, designated_names) in DEBUG_CONTEXT_PATTERNS.items():
-        for match in run_query(ast_grep, root, pattern=pattern):
-            receiver = single_meta(match, "R")
-            if receiver.split(".")[-1] == "di_builder":
-                for name in designated_names:
-                    designated = single_meta_range(match, name)
-                    if designated is not None and designated in short_name_calls:
-                        contexts.append((context_form, designated))
-    candidates = set()
-    for item in findings:
-        if item.form != "short-name-identifier" or excluded(item, test_ranges):
-            continue
-        for context_form, context in contexts:
-            if (
-                item.path == context.path
-                and item.byte_start == context.byte_start
-                and item.byte_end == context.byte_start + len("short_name")
-            ):
-                candidates.add(
-                    (item.path, item.line, item.column, item.form, context_form)
-                )
-    return candidates
 
 
 def split_top_level(text: str) -> list[str]:
@@ -1388,62 +1314,6 @@ def canonical_stage(group: str, form: str, path: str) -> str:
         if path.endswith(("lower/drop_plan.rs", "lower/mod.rs")):
             return "stage-3"
         return "stage-5"
-    if group != "semantic-leaf-name" or form not in {
-        "short-name-identifier",
-        "short-name-field",
-        "leaf-rsplit-identifier",
-        "leaf-rsplit-once-identifier",
-        "leaf-rsplit-field",
-        "leaf-rsplit-once-field",
-    }:
-        raise SystemExit(f"no canonical cutover stage for {group}/{form} at {path}")
-    if path.startswith(("hew-types/", "hew-hir/", "hew-analysis/")):
-        return "stage-1"
-    if path.startswith("hew-codegen-rs/"):
-        return "stage-5"
-    if path.endswith(("lower/drop_plan.rs", "lower/mod.rs")):
-        return "stage-3"
-    if path.endswith(("model.rs", "state_clone.rs", "thunk_requirements.rs")):
-        return "stage-5"
-    return "stage-4"
-
-
-def load_presentation(
-    path: Path,
-) -> dict[tuple[str, int, int, str, str], dict[str, str]]:
-    rows: dict[tuple[str, int, int, str, str], dict[str, str]] = {}
-    with path.open(newline="") as handle:
-        source = (line for line in handle if line.strip() and not line.startswith("#"))
-        for row in csv.DictReader(source, delimiter="\t"):
-            required = (
-                "path",
-                "line",
-                "column",
-                "form",
-                "context_form",
-                "category",
-                "retirement_stage",
-                "reason",
-            )
-            if any(not row.get(field) for field in required):
-                raise SystemExit(f"invalid presentation baseline row: {row}")
-            if row["category"] not in PRESENTATION_CATEGORIES:
-                raise SystemExit(f"invalid presentation category: {row['category']}")
-            if row["retirement_stage"] != "post-stage-5":
-                raise SystemExit(f"presentation retirement must follow Stage 5: {row}")
-            if not row["line"].isdigit() or not row["column"].isdigit():
-                raise SystemExit(f"invalid presentation location: {row}")
-            key = (
-                row["path"],
-                int(row["line"]),
-                int(row["column"]),
-                row["form"],
-                row["context_form"],
-            )
-            if key in rows:
-                raise SystemExit(f"duplicate presentation baseline row: {key}")
-            rows[key] = row
-    return rows
 
 
 def load_inventory(path: Path) -> dict[tuple[str, str, str], int]:
@@ -1706,7 +1576,6 @@ def main() -> int:
         "--root", type=Path, default=Path(__file__).resolve().parents[1]
     )
     parser.add_argument("--inventory", type=Path)
-    parser.add_argument("--presentation-baseline", type=Path)
     parser.add_argument("--ast-grep", type=Path)
     parser.add_argument(
         "--opaque-resource-facts",
@@ -1742,34 +1611,17 @@ def main() -> int:
             return 0
 
     inventory = args.inventory or root / "scripts/structural-authority-inventory.tsv"
-    presentation_path = (
-        args.presentation_baseline
-        or root / "scripts/structural-authority-presentation.tsv"
-    )
     expected = load_inventory(inventory)
-    presentation = load_presentation(presentation_path)
     findings, test_ranges = discover(ast_grep, root)
-    candidates = presentation_candidates(ast_grep, root, findings, test_ranges)
-    stale_presentation = sorted(set(presentation) - candidates)
-    exempt_locations = {
-        (path, line, column, form) for path, line, column, form, _ in presentation
-    }
-    semantic = {
-        item
-        for item in findings
-        if (item.path, item.line, item.column, item.form) not in exempt_locations
-    }
 
     actual: defaultdict[tuple[str, str, str], int] = defaultdict(int)
-    for item in semantic:
+    for item in findings:
         actual[(item.group, item.form, item.path)] += 1
     failures = []
     for key in sorted(set(expected) | set(actual)):
         want, got = expected.get(key, 0), actual.get(key, 0)
         if want != got:
             failures.append(f"{key[0]}/{key[1]} {key[2]}: expected {want}, found {got}")
-    for key in stale_presentation:
-        failures.append(f"presentation AST context disappeared or drifted: {key}")
     forbidden = scalar_span_site_findings(ast_grep, root, test_ranges)
     for item in forbidden:
         failures.append(
@@ -1789,16 +1641,8 @@ def main() -> int:
         print("\n".join(f"  - {item}" for item in failures), file=sys.stderr)
         return 1
 
-    semantic_leaf_count = sum(
-        count
-        for (group, _, _), count in actual.items()
-        if group == "semantic-leaf-name"
-    )
     print(
         "structural authority inventory: "
-        f"{semantic_leaf_count} semantic leaf-name syntax nodes in "
-        f"{sum(group == 'semantic-leaf-name' for group, _, _ in expected)} form/path rows; "
-        f"{len(presentation)} exact presentation AST contexts; "
         f"{len(expected)} authority form/path rows; "
         f"{len(test_ranges)} parsed test-only item ranges; "
         f"{len(opaque_facts)} AST-derived opaque resource lifecycle candidates; "

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -65,54 +65,6 @@ runtime-call-authority	runtime-call-family-use	hew-mir/src/lower/vec_index.rs	2	
 runtime-call-authority	runtime-call-family-use	hew-mir/src/runtime_symbols.rs	3	stage-4	typed runtime-family dispatch carrier
 runtime-call-authority	runtime-call-family-use	hew-types/src/runtime_call.rs	16	stage-4	typed runtime-family dispatch carrier
 runtime-call-authority	runtime-call-family-variant	hew-types/src/runtime_call.rs	229	stage-4	typed runtime-family dispatch carrier
-semantic-leaf-name	leaf-rsplit-field	hew-analysis/src/hover.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-analysis/src/inlay_hints.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-analysis/src/signature_help.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-mir/src/lower/consts.rs	1	stage-4	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-types/src/check/calls.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-types/src/check/diagnostics.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-types/src/check/expressions.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-types/src/check/patterns.rs	11	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-types/src/check/registration.rs	4	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-types/src/check/resolution.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-field	hew-types/src/stdlib_loader.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-identifier	hew-types/src/check/registration.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-analysis/src/completions.rs	1	stage-1	reviewed module-qualified actor completion compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-analysis/src/signature_help.rs	1	stage-1	reviewed editor-buffer binding split; the buffer holds a spelling and the binding resolves through module_import_bindings
-semantic-leaf-name	leaf-rsplit-once-field	hew-hir/src/lower.rs	12	stage-1	reviewed unique imported constructor and canonical impl-body owner compatibility seams
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/builtin_type.rs	1	stage-1	reviewed dotted builtin-type leaf extraction
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/calls.rs	4	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/expressions.rs	4	stage-1	reviewed qualified-variant surface split resolved through expected-nominal identity
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/generics.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/methods.rs	8	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/registration.rs	8	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/check/resolution.rs	13	stage-1	reviewed root builtin-shadow owner filtering plus remaining leaf-name presentation or compatibility seams
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/error.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/ffi_contracts.rs	3	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/lib.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/module_registry.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	leaf-rsplit-once-field	hew-types/src/ty.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-field	hew-types/src/check/resolution.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-field	hew-types/src/check/types.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-analysis/src/hover.rs	4	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-analysis/src/signature_help.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-codegen-rs/src/llvm.rs	10	stage-5	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-hir/src/lower.rs	12	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-hir/src/stdlib_catalog.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-mir/src/lib.rs	1	stage-4	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-mir/src/lower/drop_plan.rs	3	stage-3	reviewed remaining leaf-name presentation or compatibility seam after exact resource owner cutover
-semantic-leaf-name	short-name-identifier	hew-mir/src/lower/mod.rs	1	stage-3	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/check/calls.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/check/expressions.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/check/generics.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/check/mod.rs	1	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/check/patterns.rs	27	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/check/registration.rs	4	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/check/resolution.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/check/types.rs	2	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/lib.rs	3	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/module_registry.rs	4	stage-1	reviewed remaining leaf-name presentation or compatibility seam
-semantic-leaf-name	short-name-identifier	hew-types/src/stdlib_loader.rs	5	stage-1	reviewed remaining leaf-name presentation or compatibility seam
 semantic-owner-shortening-sink	registry-key	hew-types/src/check/registration.rs	8	stage-1	reviewed remaining owner-shortening sink
 string-method-identity	qualified-format-macro	hew-analysis/src/hover.rs	5	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-analysis/src/inlay_hints.rs	5	stage-1	reviewed qualified string identity construction

--- a/scripts/structural-authority-presentation.tsv
+++ b/scripts/structural-authority-presentation.tsv
@@ -1,3 +1,0 @@
-# Exact short_name identifier nodes proven to be arguments of parsed LLVM
-# debug-info builder calls. A location without the recorded AST context is debt.
-path	line	column	form	context_form	category	retirement_stage	reason

--- a/scripts/tests/test_structural_authority_audit.py
+++ b/scripts/tests/test_structural_authority_audit.py
@@ -10,9 +10,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 AUDIT = ROOT / "scripts/structural-authority-audit.py"
 INVENTORY_HEADER = "group\tform\tpath\tcount\tretirement_stage\treason\n"
-PRESENTATION_HEADER = (
-    "path\tline\tcolumn\tform\tcontext_form\tcategory\tretirement_stage\treason\n"
-)
 
 
 def run(
@@ -28,15 +25,11 @@ def set_inventory(root: Path, body: str = "") -> None:
     (root / "scripts/structural-authority-inventory.tsv").write_text(
         INVENTORY_HEADER + body
     )
-    presentation = root / "scripts/structural-authority-presentation.tsv"
 
 
 with tempfile.TemporaryDirectory() as temp:
     work = Path(temp)
     (work / "scripts").mkdir()
-    (work / "scripts/structural-authority-presentation.tsv").write_text(
-        PRESENTATION_HEADER
-    )
     source = work / "hew-mir/src/lower"
     source.mkdir(parents=True)
     target = source / "new_authority.rs"
@@ -71,10 +64,8 @@ with tempfile.TemporaryDirectory() as temp:
         "comments and strings must not create findings: " + result.stderr
     )
 
-    target.write_text("fn authority() { let _ = short_name(name); }\n")
-    result = run(work)
-    assert result.returncode != 0, "a new semantic short-name use must fail"
-    assert "short-name-identifier" in result.stderr
+    target.write_text('fn display(name: &str) { eprintln!("{}", short_name(name)); }\n')
+    assert run(work).returncode == 0, "presentation leaf extraction must stay ungated"
 
     target.write_text(
         "fn bad() { let _ = ResolvedTy::Named {\n"
@@ -144,48 +135,44 @@ with tempfile.TemporaryDirectory() as temp:
         "];\n"
     )
 
-    # Macro token trees are not call-expression ASTs, but their parsed
-    # identifier/field-identifier nodes remain mandatory inventory findings.
+    # Presentation leaf extraction remains outside the identity guard, including
+    # macro token trees.
     target.write_text('fn authority() { format!("{}", short_name(name)); }\n')
-    result = run(work)
-    assert result.returncode != 0, "short_name inside a production macro must fail"
-    assert "short-name-identifier" in result.stderr
+    assert run(work).returncode == 0
     target.write_text(
         'fn authority() { format!("{}", name.rsplit("::").next().unwrap_or(name)); }\n'
     )
-    result = run(work)
-    assert result.returncode != 0, "rsplit leaf extraction inside a macro must fail"
-    assert "leaf-rsplit-" in result.stderr
+    assert run(work).returncode == 0
 
     # Parsed cfg(test) module and item ranges are excluded, including macro
     # token trees and forbidden-looking type syntax nested inside them.
     target.write_text(
         "#[cfg(test)]\n"
         "mod tests {\n"
-        '    fn macro_authority() { format!("{}", short_name(name)); }\n'
-        '    fn macro_leaf() { format!("{}", name.rsplit("::").next()); }\n'
+        "    fn macro_authority() { let leaf = short_name(name); let _ = DefId::new(leaf); }\n"
+        '    fn macro_leaf() { let leaf = name.rsplit("::").next().unwrap(); let _ = DefId::new(leaf); }\n'
         "    fn scalar() { let _: HashMap<SpanKey, SiteId> = HashMap::new(); }\n"
         "}\n"
         "#[cfg(test)]\n"
-        'fn item_macro() { format!("{}", short_name(name)); }\n'
+        "fn item_macro() { let leaf = short_name(name); let _ = DefId::new(leaf); }\n"
         "fn production() {}\n"
     )
     assert run(work).returncode == 0, "parsed test-only module/items must be excluded"
 
     target.write_text(
         "#[cfg(all(test))]\n"
-        "fn all_single() { let _ = short_name(name); }\n"
+        "fn all_single() { let leaf = short_name(name); let _ = DefId::new(leaf); }\n"
         '#[cfg(all(feature = "x", test))]\n'
-        "fn all_reordered() { let _ = short_name(name); }\n"
+        "fn all_reordered() { let leaf = short_name(name); let _ = DefId::new(leaf); }\n"
     )
     assert run(work).returncode == 0, "all(...) test guards must be order-independent"
     target.write_text(
         '#[cfg(any(test, feature = "x"))]\n'
-        "fn any_guard() { let _ = short_name(name); }\n"
+        "fn any_guard() { let leaf = short_name(name); let _ = DefId::new(leaf); }\n"
     )
     assert run(work).returncode != 0, "cfg(any(test, feature)) is production-capable"
     target.write_text(
-        "#[cfg(not(test))]\nfn non_test_guard() { let _ = short_name(name); }\n"
+        "#[cfg(not(test))]\nfn non_test_guard() { let leaf = short_name(name); let _ = DefId::new(leaf); }\n"
     )
     assert run(work).returncode != 0, "cfg(not(test)) is production authority"
 
@@ -462,12 +449,17 @@ with tempfile.TemporaryDirectory() as temp:
     )
     assert run(work).returncode == 0, "test-only RC1 carriers must be excluded"
 
-    # hew-analysis is an audited production root, not a display-shaped escape.
+    # hew-analysis remains an audited production root for identity construction.
     target.write_text("fn production() {}\n")
     analysis = work / "hew-analysis/src/new_display.rs"
     analysis.parent.mkdir(parents=True)
-    analysis.write_text('fn display() { format!("{}", short_name(name)); }\n')
-    assert run(work).returncode != 0, "hew-analysis leaf-name seams must be audited"
+    analysis.write_text(
+        "fn authority(name: &str) {\n"
+        "    let leaf = short_name(name);\n"
+        "    let _ = DefId::new(leaf);\n"
+        "}\n"
+    )
+    assert run(work).returncode != 0, "hew-analysis identity sinks must be audited"
     analysis.unlink()
 
     # Leaf ownership is forbidden when it flows into an executable identity
@@ -558,15 +550,8 @@ with tempfile.TemporaryDirectory() as temp:
     target.write_text(
         'fn display(current_module: &str) { eprintln!("{}", short_name(current_module)); }\n'
     )
-    display_inventory = (
-        "semantic-leaf-name\tshort-name-identifier\t"
-        "hew-mir/src/lower/new_authority.rs\t1\tstage-4\t"
-        "display-only short name fixture\n"
-    )
-    set_inventory(work, display_inventory)
-    assert run(work).returncode == 0, (
-        "an inventoried display-only short_name must not become an executable sink"
-    )
+    set_inventory(work)
+    assert run(work).returncode == 0, "display-only short_name must stay ungated"
 
     target.write_text(
         "fn canonical(declaring_module: &str, signature_key: &str) {\n"
@@ -575,12 +560,7 @@ with tempfile.TemporaryDirectory() as temp:
         "    let _ = DefId::new(declaration);\n"
         "}\n"
     )
-    canonical_inventory = (
-        "semantic-leaf-name\tleaf-rsplit-field\t"
-        "hew-mir/src/lower/new_authority.rs\t1\tstage-4\t"
-        "canonical owner reattachment fixture\n"
-    )
-    set_inventory(work, canonical_inventory)
+    set_inventory(work)
     assert run(work).returncode == 0, (
         "an item leaf reattached to a resolved full owner must remain canonical"
     )
@@ -626,78 +606,17 @@ with tempfile.TemporaryDirectory() as temp:
             f"source-to-sites collection {collection_value} must remain allowed"
         )
 
-    # Presentation is exempt only under the exact parsed debug-builder call
-    # context. A same-location substitution of an authority call is debt.
+    # A leaf may be displayed freely, but it may not mint compiler identity.
     target.write_text(
-        "fn f() { dctx.di_builder.create_enumerator(short_name(name), 0, false); }\n"
-    )
-    (work / "scripts/structural-authority-presentation.tsv").write_text(
-        PRESENTATION_HEADER
-        + "hew-mir/src/lower/new_authority.rs\t1\t44\tshort-name-identifier\t"
-        "debug-enumerator-argument\tdebug-metadata\tpost-stage-5\t"
-        "test debug display\n"
+        "fn bad(name: &str) {\n"
+        "    let leaf = short_name(name);\n"
+        "    let _ = DefId::new(leaf);\n"
+        "}\n"
     )
     set_inventory(work)
-    assert run(work).returncode == 0, "an exact debug AST context may be exempted"
-    target.write_text(
-        "fn f() { dctx.di_builder.semantic_resolver(short_name(name), 0, false); }\n"
-    )
     result = run(work)
-    assert result.returncode != 0, "same-location semantic substitution must fail"
-    assert "presentation AST context disappeared" in result.stderr
-    assert "short-name-identifier" in result.stderr
-
-    # An exact presentation finding cannot hide a semantic sibling on its line.
-    target.write_text(
-        "fn f() { dctx.di_builder.create_enumerator(short_name(name), 0, false); let _ = short_name(key); }\n"
-    )
-    result = run(work)
-    assert result.returncode != 0, "same-line presentation must not exempt semantic use"
-    assert "expected 0, found 1" in result.stderr
-
-    # The exemption binds the exact designated debug argument expression. A
-    # nested semantic sibling elsewhere in that same debug call remains debt.
-    target.write_text(
-        "fn f() { dctx.di_builder.create_enumerator(short_name(name), semantic(short_name(key)), false); }\n"
-    )
-    result = run(work)
-    assert result.returncode != 0, (
-        "a nested sibling in one debug call must remain semantic"
-    )
-    assert "expected 0, found 1" in result.stderr
-
-    # Restore an empty presentation baseline and prove syntax-form drift,
-    # corpus shrink, count drift, and arbitrary retirement-stage edits fail.
-    (work / "scripts/structural-authority-presentation.tsv").write_text(
-        PRESENTATION_HEADER
-    )
-    target.write_text("fn authority() { let _ = short_name(name); }\n")
-    inventory_row = (
-        "semantic-leaf-name\tshort-name-identifier\t"
-        "hew-mir/src/lower/new_authority.rs\t1\tstage-4\ttest fixture\n"
-    )
-    set_inventory(work, inventory_row)
-    assert run(work).returncode == 0, "a fully explicit current inventory must pass"
-    target.write_text(
-        'fn authority() { let _ = name.rsplit("::").next().unwrap_or(name); }\n'
-    )
-    result = run(work)
-    assert result.returncode != 0, "short_name-to-rsplit form drift must fail"
-    assert (
-        "short-name-identifier" in result.stderr
-        and "leaf-rsplit-field" in result.stderr
-    )
-    target.write_text("fn authority() {}\n")
-    assert run(work).returncode != 0, "inventory shrink must fail"
-    target.write_text("fn authority() { let _ = short_name(name); }\n")
-    drifted_row = inventory_row.replace("\t1\tstage-4", "\t2\tstage-4")
-    set_inventory(work, drifted_row)
-    assert run(work).returncode != 0, "inventory count drift must fail"
-    wrong_stage = inventory_row.replace("\tstage-4\t", "\tstage-5\t")
-    set_inventory(work, wrong_stage)
-    result = run(work)
-    assert result.returncode != 0, "non-canonical retirement stages must fail"
-    assert "requires stage-4" in result.stderr
+    assert result.returncode != 0, "a leaf-derived DefId must fail"
+    assert "semantic-owner-shortening-sink/def-id" in result.stderr
 
     # Preserve qualified-string identity under every binding/assignment form;
     # the authority is the parsed format macro, not a particular let shape.


### PR DESCRIPTION
The structural-authority inventory pinned per-file counts of every leaf-name extraction site. A count is a change-detector, not a correctness test: it cannot tell a correct new leaf-name use from a wrong one, and it fired on presentation and interop code where identity was never at stake.

Classifying the sites gives 141 identity, 28 presentation, and 13 interop. The blanket tally and its empty presentation baseline are retired. What remains is the parsed, taint-based gate over leaf-derived values that reach compiler identity sinks - `DefId`, `NominalId`, `CallTarget`, runtime resolution, and the semantic registries - which is the class canonical identity actually forbids.

The replacement is proven rather than asserted: a counterfactual deriving a `DefId` from a shortened name now fails the gate, while display-only extraction stays ungated. A stale counterfactual that asserted the retired syntax-only behaviour was converted to exercise the identity-sink protection instead.

This narrows ceremony without weakening enforcement. Closing the class by construction is still open and blocked on the identity constructors: `DefId::new` and `NominalId::new` accept arbitrary non-empty strings, `Ty::Named` stores a public string, `short_name` is public, and `IdentityTable` does not mint declaration IDs.