### PR TITLE
fix(mir): complete owned temporary receivers

### DIFF
--- a/hew-cli/tests/projection_temporary_receiver_leak_oracle.rs
+++ b/hew-cli/tests/projection_temporary_receiver_leak_oracle.rs
@@ -36,7 +36,7 @@ fn projection_shapes_source(frames: usize) -> String {
          \x20       + map.values().len()\n\
          \x20       + set.clone().len()\n\
          \x20       + values[..].len()\n\
-         \x20       + make_vec(seed).len();\n\
+         \x20       + make_vec(seed).clone().len();\n\
          \x20   var iterated = 0;\n\
          \x20   for key in map.keys() {{\n\
          \x20       if key.len() > 0 {{ iterated = iterated + 1; }}\n\

--- a/hew-cli/tests/projection_temporary_receiver_leak_oracle.rs
+++ b/hew-cli/tests/projection_temporary_receiver_leak_oracle.rs
@@ -1,0 +1,93 @@
+//! Leak and double-free oracle for owned temporaries used as method receivers.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+fn projection_shapes_source(frames: usize) -> String {
+    format!(
+        "fn inspect(values: Vec<string>) -> i64 {{\n\
+         \x20   var count = 0;\n\
+         \x20   for value in values {{\n\
+         \x20       if value.len() > 0 {{ count = count + 1; }}\n\
+         \x20   }}\n\
+         \x20   count\n\
+         }}\n\
+         fn make_vec(seed: i64) -> Vec<string> {{\n\
+         \x20   [f\"made-{{seed}}-a\", f\"made-{{seed}}-b\", f\"made-{{seed}}-c\"]\n\
+         }}\n\
+         fn frame(seed: i64) -> i64 {{\n\
+         \x20   let map: HashMap<string, string> = HashMap.new();\n\
+         \x20   let set: HashSet<string> = HashSet.new();\n\
+         \x20   let values: Vec<string> = Vec.new();\n\
+         \x20   var i = 0;\n\
+         \x20   while i < 3 {{\n\
+         \x20       map.insert(f\"key-{{seed}}-{{i}}\", f\"value-{{seed}}-{{i}}\");\n\
+         \x20       set.insert(f\"member-{{seed}}-{{i}}\");\n\
+         \x20       values.push(f\"item-{{seed}}-{{i}}\");\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   let receiver = map.keys().len()\n\
+         \x20       + map.values().len()\n\
+         \x20       + set.clone().len()\n\
+         \x20       + values[..].len()\n\
+         \x20       + make_vec(seed).len();\n\
+         \x20   var iterated = 0;\n\
+         \x20   for key in map.keys() {{\n\
+         \x20       if key.len() > 0 {{ iterated = iterated + 1; }}\n\
+         \x20   }}\n\
+         \x20   let argument = inspect(map.keys());\n\
+         \x20   let bound = map.keys();\n\
+         \x20   receiver + iterated + argument + bound.len()\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + frame(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total == {expected} {{ 0 }} else {{ 95 }}\n\
+         }}\n",
+        expected = frames * 24,
+    )
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn all_temporary_shapes_have_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("projection_temporary_receiver", projection_shapes_source);
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn all_temporary_shapes_release_exactly_once() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("projection-temporary-receiver-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        &projection_shapes_source(200),
+        dir.path(),
+        "projection_temporary_receiver_exactly_once",
+    );
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "temporary receiver, for-loop, call-argument, and binding owners must each release once:\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -22347,6 +22347,9 @@ fn call_destination_has_specialized_crash_cleanup_lifecycle(
             matches!(
                 family,
                 Family::VecGet(hew_types::runtime_call::VecGetElem::Clone)
+                    | Family::VecClone
+                    | Family::VecCloneLayout
+                    | Family::VecCloneOwned
             ) || matches!(
                 family.abi_shape(),
                 Shape::HashCollectionLayoutOp | Shape::HashMapLayoutGet

--- a/hew-mir/src/lower/borrowed_argument_owner.rs
+++ b/hew-mir/src/lower/borrowed_argument_owner.rs
@@ -1,9 +1,137 @@
 use super::{
     Builder, HashSet, HirExpr, MirDiagnostic, MirDiagnosticKind, Place, ProducedValueOwnership,
-    ResolvedTy, ValueClass, SYNTHETIC_TEMP_ARG_NAME,
+    ResolvedTy, ValueClass, SYNTHETIC_TEMP_ARG_NAME, SYNTHETIC_TEMP_RECEIVER_NAME,
 };
 
+#[derive(Clone, Copy)]
+enum BorrowedValueRole {
+    Argument,
+    Receiver,
+}
+
+impl BorrowedValueRole {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Argument => "argument",
+            Self::Receiver => "receiver",
+        }
+    }
+}
+
 impl Builder {
+    fn finalize_borrowed_value_owner(
+        &mut self,
+        value: &HirExpr,
+        place: Place,
+        role: BorrowedValueRole,
+    ) {
+        let ownership = self
+            .param_ownership
+            .produced_value_facts
+            .get(&value.site)
+            .map(|fact| fact.ownership);
+        let owned_ty = self.subst_ty(&value.ty);
+        if ValueClass::of_ty(&owned_ty, &self.type_classes) == ValueClass::Linear
+            || (!matches!(owned_ty, ResolvedTy::TraitObject { .. })
+                && !crate::model::ty_owns_heap_mir(
+                    &owned_ty,
+                    &self.record_field_orders,
+                    &self.enum_layouts,
+                ))
+        {
+            return;
+        }
+        if matches!(ownership, Some(ProducedValueOwnership::Unknown) | None) {
+            let construct = match role {
+                BorrowedValueRole::Argument => "borrowing argument ownership is unresolved",
+                BorrowedValueRole::Receiver => "borrowing receiver ownership is unresolved",
+            };
+            self.typed_produced_value_demand_is_resolved(value, construct);
+            return;
+        }
+        if !matches!(ownership, Some(ProducedValueOwnership::Owned { .. })) {
+            return;
+        }
+        let Place::Local(local) = place else {
+            return;
+        };
+        if self.parameter_locals.contains(&local) {
+            return;
+        }
+        let owners = self.finalize_typed_produced_value_owners(
+            match role {
+                BorrowedValueRole::Argument => SYNTHETIC_TEMP_ARG_NAME,
+                BorrowedValueRole::Receiver => SYNTHETIC_TEMP_RECEIVER_NAME,
+            },
+            value.site,
+            Place::Local(local),
+        );
+        if owners.is_empty() {
+            if self.typed_projection_has_live_parent_owner(value)
+                || matches!(role, BorrowedValueRole::Receiver)
+            {
+                return;
+            }
+            let construct = format!("owned borrowing {} without provisional owner", role.label());
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct,
+                    site: value.site,
+                },
+                note: format!(
+                    "the typed owned {} must publish its exact MIR generation before the borrowing {} sink",
+                    role.label(),
+                    if matches!(role, BorrowedValueRole::Argument) {
+                        "call"
+                    } else {
+                        "method"
+                    }
+                ),
+            });
+            return;
+        }
+        if owners
+            .iter()
+            .any(|(_, published_ty)| *published_ty != owned_ty)
+        {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: format!("borrowing {} owner changed type at handoff", role.label()),
+                    site: value.site,
+                },
+                note: format!(
+                    "typed {} has type {owned_ty:?}, but its provisional owners are {owners:?}",
+                    role.label()
+                ),
+            });
+            return;
+        }
+        if matches!(owned_ty, ResolvedTy::TraitObject { .. }) {
+            for (binding, _) in owners {
+                self.dyn_trait_storage
+                    .insert(binding, crate::TraitObjectStorage::HeapBoxed);
+            }
+        }
+    }
+
+    /// Hand a borrowing method's anonymous owned receiver from its typed
+    /// publication generation to the ordinary scope-exit planner.
+    pub(super) fn finalize_borrowed_receiver_owner(
+        &mut self,
+        receiver: &HirExpr,
+        receiver_place: Place,
+    ) {
+        if !self
+            .param_ownership
+            .produced_value_facts
+            .get(&receiver.site)
+            .is_some_and(|fact| matches!(fact.ownership, ProducedValueOwnership::Owned { .. }))
+        {
+            return;
+        }
+        self.finalize_borrowed_value_owner(receiver, receiver_place, BorrowedValueRole::Receiver);
+    }
+
     /// Hand a borrowing call's anonymous owned arguments from their typed
     /// publication generation to the ordinary scope-exit planner.
     pub(super) fn finalize_borrowed_argument_owners(
@@ -14,11 +142,6 @@ impl Builder {
         proven_borrow_args: &HashSet<usize>,
     ) {
         for (index, arg) in hir_args.iter().enumerate() {
-            let ownership = self
-                .param_ownership
-                .produced_value_facts
-                .get(&arg.site)
-                .map(|fact| fact.ownership);
             let owned_ty = self.subst_ty(&arg.ty);
             if ValueClass::of_ty(&owned_ty, &self.type_classes) == ValueClass::Linear
                 || (!matches!(owned_ty, ResolvedTy::TraitObject { .. })
@@ -43,62 +166,10 @@ impl Builder {
             if !callee_borrows {
                 continue;
             }
-            if matches!(ownership, Some(ProducedValueOwnership::Unknown) | None) {
-                self.typed_produced_value_demand_is_resolved(
-                    arg,
-                    "borrowing argument ownership is unresolved",
-                );
-                continue;
-            }
-            if !matches!(ownership, Some(ProducedValueOwnership::Owned { .. })) {
-                continue;
-            }
-            let Some(Place::Local(local)) = arg_places.get(index).copied() else {
+            let Some(place) = arg_places.get(index).copied() else {
                 continue;
             };
-            if self.parameter_locals.contains(&local) {
-                continue;
-            }
-            let owners = self.finalize_typed_produced_value_owners(
-                SYNTHETIC_TEMP_ARG_NAME,
-                arg.site,
-                Place::Local(local),
-            );
-            if owners.is_empty() {
-                if self.typed_projection_has_live_parent_owner(arg) {
-                    continue;
-                }
-                self.diagnostics.push(MirDiagnostic {
-                    kind: MirDiagnosticKind::NotYetImplemented {
-                        construct: "owned borrowing argument without provisional owner".to_string(),
-                        site: arg.site,
-                    },
-                    note: "the typed owned argument must publish its exact MIR generation before the borrowing call sink"
-                        .to_string(),
-                });
-                continue;
-            }
-            if owners
-                .iter()
-                .any(|(_, published_ty)| *published_ty != owned_ty)
-            {
-                self.diagnostics.push(MirDiagnostic {
-                    kind: MirDiagnosticKind::NotYetImplemented {
-                        construct: "borrowing argument owner changed type at handoff".to_string(),
-                        site: arg.site,
-                    },
-                    note: format!(
-                        "typed argument has type {owned_ty:?}, but its provisional owners are {owners:?}"
-                    ),
-                });
-                continue;
-            }
-            if matches!(owned_ty, ResolvedTy::TraitObject { .. }) {
-                for (binding, _) in owners {
-                    self.dyn_trait_storage
-                        .insert(binding, crate::TraitObjectStorage::HeapBoxed);
-                }
-            }
+            self.finalize_borrowed_value_owner(arg, place, BorrowedValueRole::Argument);
         }
     }
 }

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -5751,6 +5751,12 @@ impl Builder {
                 // COPY-IN param embeds stay caller-borrowed; only the source
                 // temp's independently retained string share gains an owner.
                 self.finalize_vec_copy_in_source_owner(&callee, args, &arg_places);
+                let receiver_contract = crate::runtime_symbols::callee_ownership_contract(&callee);
+                if receiver_contract.borrows_vec_receiver()
+                    || receiver_contract.borrows_collection_receiver()
+                {
+                    self.finalize_borrowed_receiver_owner(receiver, receiver_place);
+                }
                 let dest = if matches!(ret_ty, ResolvedTy::Unit) {
                     None
                 } else {

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -325,6 +325,10 @@ const SYNTHETIC_DISCARDED_CALL_RESULT_NAME: &str = "__hew_discarded_call_result"
 /// once at caller scope exit. Gated on the target param being BORROW (a CONSUME
 /// target's temporary is the callee's obligation — no caller drop).
 const SYNTHETIC_TEMP_ARG_NAME: &str = "__hew_temp_arg";
+/// Name for a provisional owned result completed when a resolved method borrows
+/// it as an anonymous receiver. Named receivers keep their ordinary binding;
+/// specialised cursor rewrites keep their dedicated transfer authority.
+const SYNTHETIC_TEMP_RECEIVER_NAME: &str = "__hew_temp_receiver";
 /// Name for the owner minted over a fresh Vec COPY-IN element temporary when
 /// every whole by-value parameter embedded in it is a retained string share.
 /// The binding owns the temporary's retained share only; the parameter remains

--- a/tests/vertical-slice/accept/temporary_receiver_argument.hew
+++ b/tests/vertical-slice/accept/temporary_receiver_argument.hew
@@ -1,0 +1,20 @@
+fn inspect(values: Vec<string>) -> i64 {
+    var count = 0;
+    for value in values {
+        if value.len() > 0 {
+            count = count + 1;
+        }
+    }
+    count
+}
+
+fn main() -> i64 {
+    let map: HashMap<string, string> = HashMap.new();
+    var i = 0;
+    while i < 3 {
+        map.insert(f"key-{i}", f"value-{i}");
+        i = i + 1;
+    }
+
+    if inspect(map.keys()) == 3 { 0 } else { 93 }
+}

--- a/tests/vertical-slice/accept/temporary_receiver_binding.hew
+++ b/tests/vertical-slice/accept/temporary_receiver_binding.hew
@@ -1,0 +1,17 @@
+fn main() -> i64 {
+    let map: HashMap<string, string> = HashMap.new();
+    var i = 0;
+    while i < 3 {
+        map.insert(f"key-{i}", f"value-{i}");
+        i = i + 1;
+    }
+
+    let keys = map.keys();
+    var count = 0;
+    var length = 0;
+    for key in keys {
+        count = count + 1;
+        length = length + key.len();
+    }
+    if count == 3 && length == 15 { 0 } else { 94 }
+}

--- a/tests/vertical-slice/accept/temporary_receiver_for.hew
+++ b/tests/vertical-slice/accept/temporary_receiver_for.hew
@@ -1,0 +1,16 @@
+fn main() -> i64 {
+    let map: HashMap<string, string> = HashMap.new();
+    var i = 0;
+    while i < 3 {
+        map.insert(f"key-{i}", f"value-{i}");
+        i = i + 1;
+    }
+
+    var count = 0;
+    var length = 0;
+    for key in map.keys() {
+        count = count + 1;
+        length = length + key.len();
+    }
+    if count == 3 && length == 15 { 0 } else { 92 }
+}

--- a/tests/vertical-slice/accept/temporary_receiver_method.hew
+++ b/tests/vertical-slice/accept/temporary_receiver_method.hew
@@ -18,6 +18,6 @@ fn main() -> i64 {
         + map.values().len()
         + set.clone().len()
         + values[..].len()
-        + make_vec(7).len();
+        + make_vec(7).clone().len();
     if total == 15 { 0 } else { 91 }
 }

--- a/tests/vertical-slice/accept/temporary_receiver_method.hew
+++ b/tests/vertical-slice/accept/temporary_receiver_method.hew
@@ -1,0 +1,23 @@
+fn make_vec(seed: i64) -> Vec<string> {
+    [f"made-{seed}-a", f"made-{seed}-b", f"made-{seed}-c"]
+}
+
+fn main() -> i64 {
+    let map: HashMap<string, string> = HashMap.new();
+    let set: HashSet<string> = HashSet.new();
+    let values: Vec<string> = Vec.new();
+    var i = 0;
+    while i < 3 {
+        map.insert(f"key-{i}", f"value-{i}");
+        set.insert(f"member-{i}");
+        values.push(f"item-{i}");
+        i = i + 1;
+    }
+
+    let total = map.keys().len()
+        + map.values().len()
+        + set.clone().len()
+        + values[..].len()
+        + make_vec(7).len();
+    if total == 15 { 0 } else { 91 }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3735,6 +3735,10 @@ run_accept_expect_status "vec_range_slice_inclusive" 3
 run_accept_expect_stdout "hashmap_values_scalar"
 run_accept_expect_stdout "hashmap_values_string"
 run_accept_expect_status "hashmap_generic_ops" 0
+run_accept_expect_status "temporary_receiver_method" 0
+run_accept_expect_status "temporary_receiver_for" 0
+run_accept_expect_status "temporary_receiver_argument" 0
+run_accept_expect_status "temporary_receiver_binding" 0
 run_accept_expect_stdout "vec_scalar_range_slice"
 run_accept_expect_stdout "vec_string_range_slice"
 run_accept_expect_stdout "vec_record_range_slice"


### PR DESCRIPTION
Chained receivers over an owned temporary failed closed. `make_vec(7).clone().len()` reported that the shape was not yet implemented, because a cloned producer had no crash-cleanup lifecycle while indexed and direct receivers already did — so an ordinary chain a user writes on a first attempt hit a wall.

The temporary-receiver lifecycle is now complete rather than special-cased: owned temporaries carry their cleanup through the chain, and cloned collection receivers arm the same cleanup path the other receiver forms use.

Proven by execution, not inspection. A vertical-slice fixture compiles and runs the exact chain alongside HashMap key/value, HashSet clone, and slice receiver chains, and a leak oracle exercises those shapes under both leak-slope and poisoned-allocator exactly-once-release checks. Unsupported collection and type combinations now fail at their existing typed capability gates rather than at the temporary-receiver hole.