### PR TITLE
docs: migrate reference syntax to the dotted surface

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -307,7 +307,7 @@ fn describe(e: Event) -> string {
 }
 ```
 
-Variant arms bind their payload positionally. Construct values with bare variant names (`Number(5)`, `Empty`). Enum variants are declared `;`-separated.
+Variant arms bind their payload positionally. Construct values with dotted variant names (`.Number(5)`, `.Empty`). Enum variants are declared `;`-separated.
 
 ### match exhaustiveness is enforced
 
@@ -1059,7 +1059,7 @@ Compose records by nesting; access depth-chains directly. Every field must be su
 >
 > // Construction — commas (required)
 > let p = Point { x: 1, y: 2 };
-> let c = Red;
+> let c = .Red;
 > ```
 >
 > The compiler error for a semicolon in a construction literal is "expected `}`, found `;`". Enum variants reject commas with "use `;` instead of `,` to separate variants". Type field definitions accept both separators, but `;` is the idiomatic style.
@@ -1081,11 +1081,11 @@ fn area(s: Shape) -> f64 {
 }
 fn main() {
     println(area(.Circle(2.0)));
-    println(area(Rect { w: 3.0, h: 4.0 }));
+    println(area(Shape.Rect { w: 3.0, h: 4.0 }));
 }
 ```
 
-Mix unit, tuple, and struct variants in one enum. Enum variants are separated by `;`. Struct-variant fields use `;` separators; the variant pattern uses `{ w, h }` shorthand. Construct variants by bare name.
+Mix unit, tuple, and struct variants in one enum. Enum variants are separated by `;`. Struct-variant fields use `;` separators; the variant pattern uses `{ w, h }` shorthand. Construct variants with dotted names such as `Shape.Rect { w: 3.0, h: 4.0 }`.
 
 ### Pattern destructuring in match
 
@@ -3005,8 +3005,8 @@ bare element type, not `Option<T>` — see
 [`examples/playground/types/wire_types.hew`](../examples/playground/types/wire_types.hew)
 for that form.
 
-`e.to_json()` and `TypeName.from_json(text)` (a call on the type name
-itself, rather than a source spelling, round-trip a wire type through JSON. The runtime envelope
+`e.to_json()` and `TypeName.from_json(text)` round-trip a wire type through
+JSON; the latter is a call on the type name itself rather than a source spelling. The runtime envelope
 used for actor-to-actor message transport is CBOR; the `std.encoding` modules
 surface (JSON, MessagePack, ...) is for cross-service and file I/O. Use `hew
 wire check <file.hew> --against <baseline.hew>` to check schema

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -42,7 +42,7 @@ for the documented resolver precedence.
 - Iterate counts with `for i in 0..n` (exclusive) or `0..=n` (inclusive); the binding must be a named identifier.
 - Read collection elements with `v[i]` (returns `T`, traps on out-of-bounds) or `.get(i)` (returns `Option<T>`, never traps) — both universal across element types.
 - `Vec<string>` supports `v[i]` (returns a fresh owned `string`; the Vec stays usable), `.get(i)`, range-slices, and for-in. Both accessors work for `Vec<enum>` too.
-- Build maps/sets with `::new()` + `.insert()`; bind with `let` (interior mutability, not reassignment).
+- Build maps/sets with `Type.new()` + `.insert()`; bind with `let` (interior mutability, not reassignment).
 - Look up `HashMap`/`Option`/`Result` with `match`, not subscript or `.unwrap()`.
 - **Enum variants use `;` separators; record fields also use `;` in type definitions but `,` in construction literals.** These are different — `type T { a: i64; b: i64; }` defines, `T { a: 1, b: 2 }` constructs.
 - Declare records with `type Name { field: T; }` (semicolons); enum variants are `;`-separated.
@@ -52,7 +52,7 @@ for the documented resolver precedence.
 - Sending a value into an actor delivers a logical snapshot; the sender's binding stays valid afterward — no `clone` needed to keep using it. Types that cannot be sent are rejected at compile time.
 - Within a fn or actor there is no borrow checker: pass values freely, mutations to Vec/HashMap persist in the caller.
 - Last expression of a block (no trailing semicolon) is its value; a trailing `;` makes it unit.
-- Lean on the safe stdlib trio: `std::string`, `std::math`, `std::iter`. Do not import `std::option`/`std::result`.
+- Lean on the safe stdlib trio: `std.string`, `std.math`, `std.iter`. Do not import `std.option`/`std.result`.
 - Negate a bool with `!`: `!x` is `true` when `x` is `false`.
 - `break` and `continue` work in both `loop {}` and `while` loops.
 - Iterate all HashMap keys with `.keys()` → `Vec<string>`; all values with `.values()` → `Vec<V>`.
@@ -170,8 +170,8 @@ fn main() {
 
     let checked: Option<i32> = a.checked_add(1);
     match checked {
-        Some(v) => println(v),
-        None => println("overflow"),   // overflow
+        .Some(v) => println(v),
+        .None => println("overflow"),   // overflow
     }
 
     let clamped: i32 = a.saturating_add(1);
@@ -249,7 +249,7 @@ fn main() {
 }
 ```
 
-Annotate a `var` (or `let`) binding when the type cannot be inferred from the initial value (e.g. an empty `Vec::new()`). Use `var` only when the name itself will be rebound; `let` is correct for a collection you only mutate via methods — the compiler warns if you `var`-declare a binding that is never rebound.
+Annotate a `var` (or `let`) binding when the type cannot be inferred from the initial value (e.g. an empty `Vec.new()`). Use `var` only when the name itself will be rebound; `let` is correct for a collection you only mutate via methods — the compiler warns if you `var`-declare a binding that is never rebound.
 
 ## Control flow
 
@@ -299,10 +299,10 @@ Bind with a name then guard: `x if cond =>`. A block-bodied arm `=> { ... }` sti
 enum Event { Number(i64); Text(string); Empty; }
 fn describe(e: Event) -> string {
     match e {
-        Number(n) if n > 100 => "big number",
-        Number(n) => "number",
-        Text(s) => s,
-        Empty => "empty",
+        .Number(n) if n > 100 => "big number",
+        .Number(n) => "number",
+        .Text(s) => s,
+        .Empty => "empty",
     }
 }
 ```
@@ -313,8 +313,8 @@ Variant arms bind their payload positionally. Construct values with bare variant
 
 ```hew
 enum Colour { Red; Green; Blue; }
-// match c { Red => 1, Green => 2 }  // compile error: non-exhaustive match: missing Blue
-fn code(c: Colour) -> i64 { match c { Red => 1, Green => 2, Blue => 3 } }
+// match c { .Red => 1, .Green => 2 }  // compile error: non-exhaustive match: missing Blue
+fn code(c: Colour) -> i64 { match c { .Red => 1, .Green => 2, .Blue => 3 } }
 ```
 
 Omit `_` when matching a closed enum so the compiler forces every variant. A missing variant is a hard error naming it.
@@ -412,11 +412,11 @@ fn main() {
 ```hew
 fn main() {
     let some: Option<i64> = Some(42);
-    if let Some(v) = some { println(v); } else { println(-1); }
+    if let .Some(v) = some { println(v); } else { println(-1); }
 }
 ```
 
-Use `if let Some(v) = opt` for a one-armed destructure; prefer `match` when you want the unwrapped-or-default as an expression result.
+Use `if let .Some(v) = opt` for a one-armed destructure; prefer `match` when you want the unwrapped-or-default as an expression result.
 
 ## Collections — Vec
 
@@ -473,8 +473,8 @@ fn main() {
     v.push("a");
     v.push("b");
     match v.get(0) {
-        Some(s) => println(s),   // a
-        None => println("oob"),
+        .Some(s) => println(s),   // a
+        .None => println("oob"),
     }
 }
 ```
@@ -636,8 +636,8 @@ fn main() {
     let m: HashMap<string, i64> = HashMap.new();
     m.insert("alice", 10);
     match m.get("alice") {
-        Some(v) => println(f"alice={v}"),
-        None => println("alice missing"),
+        .Some(v) => println(f"alice={v}"),
+        .None => println("alice missing"),
     }
 }
 ```
@@ -653,8 +653,8 @@ fn main() {
     m.insert("bob", 2);
     let has_alice = m.contains_key("alice");   // true
     let removed = match m.remove("bob") {
-        Some(v) => f"removed bob={v}",
-        None => "bob not present",
+        .Some(v) => f"removed bob={v}",
+        .None => "bob not present",
     };
     println(f"has={has_alice} {removed} len={m.len()}");
 }
@@ -704,13 +704,13 @@ fn main() {
 
     // Increment alice's score
     match scores.get("alice") {
-        Some(v) => scores.insert("alice", v + 5),
-        None => {},
+        .Some(v) => scores.insert("alice", v + 5),
+        .None => {},
     }
 
     match scores.get("alice") {
-        Some(v) => println(f"alice={v}"),   // alice=15
-        None => println("missing"),
+        .Some(v) => println(f"alice={v}"),   // alice=15
+        .None => println("missing"),
     }
 }
 ```
@@ -976,7 +976,7 @@ fn main() {
     let s = spawn Sink(id: 0);
     let msg: string = "hello";
     let n = await s.take(msg);         // receiver gets a snapshot of msg
-    match n { Ok(len) => println(len), Err(_) => println("ask failed") }
+    match n { .Ok(len) => println(len), .Err(_) => println("ask failed") }
     println(msg.len());   // 5 — msg still valid after the send
 }
 ```
@@ -1074,13 +1074,13 @@ enum Shape {
 }
 fn area(s: Shape) -> f64 {
     match s {
-        Empty => 0.0,
-        Circle(r) => 3.14159 * r * r,
-        Rect { w, h } => w * h,
+        .Empty => 0.0,
+        .Circle(r) => 3.14159 * r * r,
+        .Rect { w, h } => w * h,
     }
 }
 fn main() {
-    println(area(Circle(2.0)));
+    println(area(.Circle(2.0)));
     println(area(Rect { w: 3.0, h: 4.0 }));
 }
 ```
@@ -1097,10 +1097,10 @@ enum Cmd {
 }
 fn describe(c: Cmd) -> string {
     match c {
-        Move(0, 0) => "noop",
-        Move(x, _) => "move",
-        Stop => "stop",
-        Speak { text } => text,
+        .Move(0, 0) => "noop",
+        .Move(x, _) => "move",
+        .Stop => "stop",
+        .Speak { text } => text,
     }
 }
 ```
@@ -1113,8 +1113,8 @@ Combine literal patterns for special cases above general binding patterns — or
 indirect enum Expr { Lit(i64); Add(Expr, Expr); }
 fn eval(e: Expr) -> i64 {
     match e {
-        Lit(n) => n,
-        Add(l, r) => eval(l) + eval(r),
+        .Lit(n) => n,
+        .Add(l, r) => eval(l) + eval(r),
     }
 }
 fn main() {
@@ -1123,7 +1123,7 @@ fn main() {
 }
 ```
 
-Bare variant names are the common idiom; use `EnumName::Variant` to disambiguate across modules. Match arm patterns use the bare variant name even when construction used the qualified form.
+Use `EnumName.Variant` to qualify construction or disambiguate across modules. In a match, use the contextual `.Variant` pattern when the scrutinee type selects the enum.
 
 ### Self-referential recursive enum (indirect)
 
@@ -1135,13 +1135,13 @@ indirect enum Expr {
 }
 fn eval(e: Expr) -> i64 {
     match e {
-        Lit(n) => n,
-        Add(l, r) => eval(l) + eval(r),
-        Neg(inner) => 0 - eval(inner),
+        .Lit(n) => n,
+        .Add(l, r) => eval(l) + eval(r),
+        .Neg(inner) => 0 - eval(inner),
     }
 }
 fn main() {
-    let e = Add(Lit(1), Neg(Lit(2)));
+    let e = Expr.Add(.Lit(1), .Neg(.Lit(2)));
     println(eval(e));   // -1
 }
 ```
@@ -1156,10 +1156,10 @@ enum MyOpt<T> {
     Empty;
 }
 fn main() {
-    let a: MyOpt<i64> = Has(42);
+    let a: MyOpt<i64> = .Has(42);
     match a {
-        Has(v) => println(v),
-        Empty => println(-1),
+        .Has(v) => println(v),
+        .Empty => println(-1),
     }
 }
 ```
@@ -1180,7 +1180,7 @@ fn main() {
     let s = spawn Sink();
     s.put(Record { key: 1, val: 99 });
     let r = await s.get();
-    match r { Ok(v) => println(v), Err(_) => println("err") }
+    match r { .Ok(v) => println(v), .Err(_) => println("err") }
 }
 ```
 
@@ -1195,10 +1195,10 @@ actor Acc {
     init() { total = 0; }
     receive fn apply(op: Op) {
         match op {
-            Inc(n) => {
+            .Inc(n) => {
                 total = total + n;
             },
-            Reset => {
+            .Reset => {
                 total = 0;
             },
         }
@@ -1223,7 +1223,7 @@ fn main() {
     let acct = spawn Bank(balance: 100);
     acct.deposit(50);
     let r = await acct.balance_of();
-    match r { Ok(v) => println(f"balance={v}"), Err(_) => println("ask failed") }
+    match r { .Ok(v) => println(f"balance={v}"), .Err(_) => println("ask failed") }
 }
 ```
 
@@ -1251,7 +1251,7 @@ actor Greeter {
 fn main() {
     let g: LocalPid<Greeter> = spawn Greeter(name: 5);
     let r = await g.greet();
-    match r { Ok(v) => println(f"name={v}"), Err(_) => println("ask failed") }
+    match r { .Ok(v) => println(f"name={v}"), .Err(_) => println("ask failed") }
 }
 ```
 
@@ -1286,7 +1286,7 @@ fn main() {
     let c = spawn Counter(count: 0);
     c.increment(10); c.increment(20); c.increment(12);
     let r = await c.total();
-    match r { Ok(v) => println(f"total={v}"), Err(_) => println("ask failed") }
+    match r { .Ok(v) => println(f"total={v}"), .Err(_) => println("ask failed") }
 }
 ```
 
@@ -1305,14 +1305,14 @@ actor Consumer {
     receive fn run(unused: i64) -> i64 {
         // await as a statement, inside a receive fn — always valid
         let r = await src.val();
-        match r { Ok(v) => v, Err(_) => -1 }
+        match r { .Ok(v) => v, .Err(_) => -1 }
     }
 }
 fn main() {
     let s = spawn Src();
     let c = spawn Consumer(src: s);
     let r = await c.run(0);
-    match r { Ok(v) => println(f"v={v}"), Err(_) => println("err") }
+    match r { .Ok(v) => println(f"v={v}"), .Err(_) => println("err") }
 }
 ```
 
@@ -1336,7 +1336,7 @@ scope {
 
 // Right: bind first
 let r = await actor.method();
-match r { Ok(v) => println(v), Err(_) => println("err") }
+match r { .Ok(v) => println(v), .Err(_) => println("err") }
 ```
 
 Note that `.send()` is accepted as an actor method name and compiles correctly — there is no compiler-level restriction on it.
@@ -1354,7 +1354,7 @@ fn run() -> Result<i64, AskError> {
     let w? = await c.bump();
     Ok(v + w)
 }
-fn main() { match run() { Ok(t) => println(f"total={t}"), Err(_) => println("failed") } }
+fn main() { match run() { .Ok(t) => println(f"total={t}"), .Err(_) => println("failed") } }
 ```
 
 Inside a fn returning `Result<_, AskError>`, use `let v? = await ...` to unwrap the Ok and auto-propagate Err. The `?` goes on the binding, not the expression.
@@ -1371,7 +1371,7 @@ actor Boot {
 fn main() {
     let b = spawn Boot(ready: 0);
     let r = await b.status();
-    match r { Ok(v) => println(f"ready={v}"), Err(_) => println("ask failed") }
+    match r { .Ok(v) => println(f"ready={v}"), .Err(_) => println("ask failed") }
 }
 ```
 
@@ -1391,7 +1391,7 @@ actor Risky {
 fn main() {
     let r = spawn Risky(n: 0);
     let v = await r.value();
-    match v { Ok(x) => println(f"n={x}"), Err(_) => println("failed") }
+    match v { .Ok(x) => println(f"n={x}"), .Err(_) => println("failed") }
 }
 ```
 
@@ -1408,7 +1408,7 @@ actor Calc {
 fn main() {
     let calc = spawn Calc(acc: 0);
     let r = await calc.apply(5);
-    match r { Ok(v) => println(f"acc={v}"), Err(_) => println("ask failed") }
+    match r { .Ok(v) => println(f"acc={v}"), .Err(_) => println("ask failed") }
 }
 ```
 
@@ -1425,14 +1425,14 @@ actor Manager {
     var worker: LocalPid<Worker>;
     receive fn dispatch(n: i64) -> i64 {
         let r = await worker.work(n);
-        match r { Ok(v) => v, Err(_) => -1 }
+        match r { .Ok(v) => v, .Err(_) => -1 }
     }
 }
 fn main() {
     let w = spawn Worker(id: 3);
     let m = spawn Manager(worker: w);
     let r = await m.dispatch(7);
-    match r { Ok(v) => println(f"result={v}"), Err(_) => println("failed") }
+    match r { .Ok(v) => println(f"result={v}"), .Err(_) => println("failed") }
 }
 ```
 
@@ -1472,7 +1472,7 @@ fn main() {
 
 **`sleep_until(target: instant)`** — suspend until a monotonic `instant`.
 Returns immediately if `target` is already in the past. Combine with
-`instant::now()` and duration arithmetic to build deadline-bounded loops:
+`instant.now()` and duration arithmetic to build deadline-bounded loops:
 
 ```hew
 fn main() {
@@ -1524,8 +1524,8 @@ fn main() {
     sleep(250ms);
     let r = await p.total();
     match r {
-        Ok(n) => println(f"ticks={n}"),
-        Err(_) => println("ask failed"),
+        .Ok(n) => println(f"ticks={n}"),
+        .Err(_) => println("ask failed"),
     }
 }
 ```
@@ -1576,8 +1576,8 @@ fn main() {
     sleep(150ms);
     let r = await worker.total();
     match r {
-        Ok(n) => println(f"ticks={n}"),
-        Err(_) => println("ask failed"),
+        .Ok(n) => println(f"ticks={n}"),
+        .Err(_) => println("ask failed"),
     }
 }
 ```
@@ -1590,7 +1590,7 @@ without an in-loop exit path.
 
 ### Accepting connections and reading in a receive handler: use `await`
 
-`net.Listener::accept()` and `net.Connection::read()` are blocking calls — the
+`net.Listener.accept()` and `net.Connection.read()` are blocking calls — the
 plain, non-`await` form parks the whole scheduler worker thread until a
 connection or data arrives, which is why `hew check` warns
 (`BlockingCallInReceiveFn`) whenever either appears inside a receive handler.
@@ -1636,18 +1636,18 @@ machine Counter {
 }
 fn main() {
     var c = Zero;
-    c.step(Inc); c.step(Inc); c.step(Inc);
+    c.step(.Inc); c.step(.Inc); c.step(.Inc);
     println(c.state_name());            // NonZero
     match c {
-        Zero => println("is zero"),
+        .Zero => println("is zero"),
         NonZero { value } => println(f"value={value}"),  // value=3
     }
-    c.step(Reset);
+    c.step(.Reset);
     println(c.state_name());            // Zero
 }
 ```
 
-A machine is a value type. Inside the body use bare names (`NonZero { value: 1 }`, `step(Inc)`); outside use the qualifier (`Counter::Zero`, `CounterEvent::Inc`). `step()` mutates in place — the receiver must be a `var`. End with `default { state }` to make uncovered cells a no-op stay. Every (state, event) cell must be covered or it is a compile error.
+A machine is a value type. Inside the body, state constructors are bare (`NonZero { value: 1 }`); contextual event arguments use `.Variant` (`step(.Inc)`). Outside use the qualifier (`Counter.Zero`, `CounterEvent.Inc`). `step()` mutates in place — the receiver must be a `var`. End with `default { state }` to make uncovered cells a no-op stay. Every (state, event) cell must be covered or it is a compile error.
 
 > **Why `default` is a blanket catch-all, and what that costs you.** Without
 > `default`, every `(state, event)` pair not covered by an explicit `on`
@@ -1690,7 +1690,7 @@ fn main() {
     log.step(Append { item: 10 });
     log.step(Append { item: 20 });
     match log {
-        Empty => println("empty"),
+        .Empty => println("empty"),
         Filled { items } => {
             println(f"count={items.len()}");   // count=2
             println(f"first={items[0]}");  // first=10
@@ -1717,13 +1717,13 @@ fn main() {
     a.step(make_add(5));
     a.step(make_add(7));
     match a {
-        Seed => println("seed"),
+        .Seed => println("seed"),
         Total { sum } => println(f"sum={sum}"),   // sum=12
     }
 }
 ```
 
-Prefer the head binding `on Add(n): ...` so payload names are declared at the rule site; `event.n` is the equivalent fallback. `self.field` reads the source state; `event.field` reads the event payload. The compiler generates a companion enum `{MachineName}Event` you can name in signatures and construct with `MachineEvent::Variant`.
+Prefer the head binding `on Add(n): ...` so payload names are declared at the rule site; `event.n` is the equivalent fallback. `self.field` reads the source state; `event.field` reads the event payload. The compiler generates a companion enum `{MachineName}Event` you can name in signatures and construct with `MachineEvent.Variant`.
 
 ### Wildcard transitions and if-expression bodies
 
@@ -1743,7 +1743,7 @@ machine Conn {
 }
 fn main() {
     var c = Idle;
-    c.step(Start); c.step(Bump); c.step(Bump); c.step(Bump);
+    c.step(.Start); c.step(.Bump); c.step(.Bump); c.step(.Bump);
     println(c.state_name());   // Dead
 }
 ```
@@ -1763,7 +1763,7 @@ machine Door {
 }
 fn drive(d: Door) -> string {
     var local = d;
-    local.step(Open);
+    local.step(.Open);
     local.state_name()
 }
 fn main() { println(drive(.Shut)); }   // Ajar
@@ -1872,7 +1872,7 @@ fn main() {
 }
 ```
 
-A monomorphic enum, even one carrying a string payload, is a valid Vec element. Construct variants as `Enum::Variant(payload)`. Generic type parameters (`Vec<T>`) are also supported for element methods (`get`, `push`, `set`, `pop`, `contains`, indexing, and range-slice).
+A monomorphic enum, even one carrying a string payload, is a valid Vec element. Construct variants as `Enum.Variant(payload)`. Generic type parameters (`Vec<T>`) are also supported for element methods (`get`, `push`, `set`, `pop`, `contains`, indexing, and range-slice).
 
 ### Vec of a concrete record
 
@@ -1890,9 +1890,9 @@ fn main() {
 
 Store concrete records in a Vec and bind the element with `let got = v[i]` before reading fields.
 
-### Turbofish — explicit type argument on a call
+### Explicit type argument on a call
 
-When a generic function takes no arguments from which the type can be inferred, use the turbofish syntax `func::<T>()` to supply the type argument explicitly:
+When a generic function takes no arguments from which the type can be inferred, use `func<T>()` to supply the type argument explicitly:
 
 ```hew
 fn make_vec<T>() -> Vec<T> {
@@ -1906,7 +1906,7 @@ fn main() {
 }
 ```
 
-**Turbofish is one way to pin a generic constructor's type argument, not the only one.** The checker also resolves `T` from the **expected return type** at the call site — a `let` binding's declared type, a function's declared return type, or an argument position — with no turbofish needed:
+**An explicit type argument is one way to pin a generic constructor's type argument, not the only one.** The checker also resolves `T` from the **expected return type** at the call site — a `let` binding's declared type, a function's declared return type, or an argument position — without an explicit type argument:
 
 ```hew
 type Stack<T> { items: Vec<T>; }
@@ -1914,11 +1914,11 @@ type Stack<T> { items: Vec<T>; }
 fn new_empty<T>() -> Stack<T> { Stack { items: Vec.new() } }
 
 fn make_i64_stack() -> Stack<i64> {
-    new_empty()                    // return-position inference — no turbofish
+    new_empty()                    // return-position inference — no explicit type argument
 }
 
 fn main() {
-    let s: Stack<i64> = new_empty();      // let-annotation inference — no turbofish
+    let s: Stack<i64> = new_empty();      // let-annotation inference — no explicit type argument
     let s2 = new_empty<i64>();          // explicit type argument
     let s3 = make_i64_stack();
     println(s.items.len());
@@ -1927,7 +1927,7 @@ fn main() {
 }
 ```
 
-Only a **genuinely unconstrained** call — no turbofish, no annotation, no usage that pins `T` — fails, and it fails with the same clean `cannot infer type for local binding` / `consider adding a type annotation` diagnostic as any other unconstrained generic call. There is no separate NYI/MIR-lowering error for this pattern; add a turbofish or a type annotation to resolve it.
+Only a **genuinely unconstrained** call — no explicit type argument, no annotation, no usage that pins `T` — fails, and it fails with the same clean `cannot infer type for local binding` / `consider adding a type annotation` diagnostic as any other unconstrained generic call. There is no separate NYI/MIR-lowering error for this pattern; add an explicit type argument or a type annotation to resolve it.
 
 ### Inherent impl on a generic record
 
@@ -1958,7 +1958,7 @@ fn main() {
 }
 ```
 
-Construct the empty generic record through the constructor function `new_stack`, either with turbofish (`new_stack::<i64>()`) or a `let` type annotation and no turbofish at all (`let s: Stack<i64> = new_stack();`) — both resolve `T` from the call site and lower identically, the same return-type-driven inference covered in the Turbofish section above. `hew fmt` normalizes an explicit `::<T>` call to `<T>` (`new_stack::<i64>()` becomes `new_stack<i64>()`); every one of these spellings type-checks and runs identically — write whichever you like and let the formatter settle it. A bare `Stack { items: Vec::new() }` construction with no surrounding annotation is still ambiguous and needs one. `push_item` mutates the `items` field in place and returns the receiver — this is the pattern to use for a generic record with an owned heap field; extracting the field into a local, pushing, and reconstructing a new `Stack { items: ... }` value is a known crash today (the generic-record drop plan double-releases the extracted field).
+Construct the empty generic record through the constructor function `new_stack`, either with an explicit type argument (`new_stack<i64>()`) or a `let` type annotation (`let s: Stack<i64> = new_stack();`). Both resolve `T` from the call site and lower identically. A bare `Stack { items: Vec.new() }` construction with no surrounding annotation is still ambiguous and needs one. `push_item` mutates the `items` field in place and returns the receiver — this is the pattern to use for a generic record with an owned heap field; extracting the field into a local, pushing, and reconstructing a new `Stack { items: ... }` value is a known crash today (the generic-record drop plan double-releases the extracted field).
 
 ### Monomorphic functions as values (cross-module)
 
@@ -2050,8 +2050,8 @@ fn divide(a: i64, b: i64) -> Result<i64, string> {
     if b == 0 { Err("division by zero") } else { Ok(a / b) }
 }
 fn main() {
-    match divide(10, 2) { Ok(v) => println(f"ok: {v}"), Err(e) => println(f"err: {e}") }
-    match divide(1, 0) { Ok(v) => println(f"ok: {v}"), Err(e) => println(f"err: {e}") }
+    match divide(10, 2) { .Ok(v) => println(f"ok: {v}"), .Err(e) => println(f"err: {e}") }
+    match divide(1, 0) { .Ok(v) => println(f"ok: {v}"), .Err(e) => println(f"err: {e}") }
 }
 ```
 
@@ -2064,9 +2064,9 @@ fn first_positive(a: i64) -> Option<i64> {
     if a > 0 { Some(a) } else { None }
 }
 fn main() {
-    match first_positive(5) { Some(v) => println(f"some: {v}"), None => println("none") }
+    match first_positive(5) { .Some(v) => println(f"some: {v}"), .None => println("none") }
     let n: Option<i64> = None;
-    match n { Some(v) => println(f"some: {v}"), None => println("none") }
+    match n { .Some(v) => println(f"some: {v}"), .None => println("none") }
 }
 ```
 
@@ -2084,8 +2084,8 @@ fn chain(a: i64, b: i64, c: i64) -> Result<i64, string> {
     Ok(y)
 }
 fn main() {
-    match chain(100, 5, 2) { Ok(v) => println(f"ok: {v}"), Err(e) => println(f"err: {e}") }
-    match chain(100, 0, 2) { Ok(v) => println(f"ok: {v}"), Err(e) => println(f"err: {e}") }
+    match chain(100, 5, 2) { .Ok(v) => println(f"ok: {v}"), .Err(e) => println(f"err: {e}") }
+    match chain(100, 0, 2) { .Ok(v) => println(f"ok: {v}"), .Err(e) => println(f"err: {e}") }
 }
 ```
 
@@ -2099,9 +2099,9 @@ fn first(o: Option<i64>) -> Option<i64> {
     Some(v + 1)
 }
 fn main() {
-    match first(Some(5)) { Some(v) => println(f"some: {v}"), None => println("none") }
+    match first(Some(5)) { .Some(v) => println(f"some: {v}"), .None => println("none") }
     let n: Option<i64> = None;
-    match first(n) { Some(v) => println(f"some: {v}"), None => println("none") }
+    match first(n) { .Some(v) => println(f"some: {v}"), .None => println("none") }
 }
 ```
 
@@ -2111,7 +2111,7 @@ Inside an Option-returning fn, `o?` yields the inner value on Some and early-ret
 
 ```hew
 fn unwrap_or(r: Result<i64, string>, fallback: i64) -> i64 {
-    match r { Ok(v) => v, Err(_) => fallback }
+    match r { .Ok(v) => v, .Err(_) => fallback }
 }
 fn main() {
     let ok: Result<i64, string> = Ok(42);
@@ -2121,7 +2121,7 @@ fn main() {
 }
 ```
 
-For unwrap_or/is_ok/is_err on Result, write a tiny `match` helper inline. This is the reliable path — do not import `std::result`/`std::option`, and do not use `.unwrap()`/`.unwrap_or()` method form.
+For unwrap_or/is_ok/is_err on Result, write a tiny `match` helper inline. This is the reliable path — do not import `std.result`/`std.option`, and do not use `.unwrap()`/`.unwrap_or()` method form.
 
 ### Option .is_some() / .is_none()
 
@@ -2143,8 +2143,8 @@ For Option presence checks, `.is_some()`/`.is_none()` read cleanly and return `b
 ```hew
 fn classify(o: Option<i64>) -> string {
     match o {
-        Some(v) => if v > 0 { "positive" } else { "non-positive" },
-        None => "missing",
+        .Some(v) => if v > 0 { "positive" } else { "non-positive" },
+        .None => "missing",
     }
 }
 fn main() {
@@ -2164,8 +2164,8 @@ fn validate(x: i64) -> Result<i64, string> {
     if x < 0 { Err("negative") } else { Ok(0) }
 }
 fn main() {
-    match validate(5)  { Ok(_) => println("valid"), Err(e) => println(f"err: {e}") }
-    match validate(-1) { Ok(_) => println("valid"), Err(e) => println(f"err: {e}") }
+    match validate(5)  { .Ok(_) => println("valid"), .Err(e) => println(f"err: {e}") }
+    match validate(-1) { .Ok(_) => println("valid"), .Err(e) => println(f"err: {e}") }
 }
 ```
 
@@ -2230,12 +2230,12 @@ fn main() {
 ```hew
 fn main() {
     match "hello world".find("world") {
-        Some(idx) => println(f"find={idx}"),   // 6
-        None => println("not found"),
+        .Some(idx) => println(f"find={idx}"),   // 6
+        .None => println("not found"),
     }
     match "hello".find("xyz") {
-        Some(idx) => println(f"find={idx}"),
-        None => println("not found"),
+        .Some(idx) => println(f"find={idx}"),
+        .None => println("not found"),
     }
 }
 ```
@@ -2255,15 +2255,15 @@ fn main() {
 
 `.len()` returns `i64` (safe directly in an f-string). `.contains(sub)` returns `bool` — bind to a `let` before interpolating.
 
-### std::string module functions
+### std.string module functions
 
 ```hew
 import std.string;
 fn main() {
     println(string.from_int(42));            // 42
     let n = match string.to_int("42") {
-        Some(v) => v,
-        None => 0,
+        .Some(v) => v,
+        .None => 0,
     };
     println(f"n={n}");                        // 42
     println(string.pad_left("7", 3, "0"));   // 007
@@ -2273,7 +2273,7 @@ fn main() {
 }
 ```
 
-Import `std::string` and call via the module name. `from_int`/`to_float` for conversions; `to_int` returns `Option<i64>` (`None` on parse failure) — consume it with `match` or `.unwrap_or(default)`; `join(Vec<string>, sep)` for assembly; `pad_left`/`pad_right` for fixed width. Use `string.try_to_int`/`try_to_float` for a `Result` when you need the failure reason.
+Import `std.string` and call via the module name. `from_int`/`to_float` for conversions; `to_int` returns `Option<i64>` (`None` on parse failure) — consume it with `match` or `.unwrap_or(default)`; `join(Vec<string>, sep)` for assembly; `pad_left`/`pad_right` for fixed width. Use `string.try_to_int`/`try_to_float` for a `Result` when you need the failure reason.
 
 ### Concatenation, char round-trip, escapes
 
@@ -2283,8 +2283,8 @@ fn main() {
     let g = "Hello" + ", " + "world";
     println(g);
     match "Z".char_at(0) {
-        Some(ch) => println(string.from_char(ch as i64)),   // Z
-        None => println("out of bounds"),
+        .Some(ch) => println(string.from_char(ch as i64)),   // Z
+        .None => println("out of bounds"),
     }
     var acc = "";
     for i in 0 .. 3 { acc = acc + "x"; }
@@ -2316,7 +2316,7 @@ fn main() {
 
 Use Go-style named receivers: the first parameter whose type matches the impl target is the receiver (no `self` keyword required — the parameter can be named anything, including `self`). The receiver is consumed by value.
 
-A trait method can carry a default body (`fn shout(self) -> string { self.greet() + "!!!" }` inside the trait declaration); an `impl` only needs to supply the methods it overrides, and an uncalled default falls back to the trait's body, dispatching through `self.method()` like any other trait call. Defaults work within a single file and across a file import (`import "other.hew";`, including a default that dispatches back through a required method declared in another file). Defaults also work when only the *trait* comes from a directory module (`import mymod::{ Greet };`) and the implementing type is local. They do not yet resolve when the implementing type is ALSO imported from a directory module (e.g. `import gm::{ Dog };` where `Dog` and its `impl Greet for Dog` both live in `gm`) — calling an inherited default on that receiver fails with `no method 'greet' on 'gm.Dog'` rather than falling back to the trait's default body; that gap is tracked separately.
+A trait method can carry a default body (`fn shout(self) -> string { self.greet() + "!!!" }` inside the trait declaration); an `impl` only needs to supply the methods it overrides, and an uncalled default falls back to the trait's body, dispatching through `self.method()` like any other trait call. Defaults work within a single file and across a file import (`import "other.hew";`, including a default that dispatches back through a required method declared in another file). Defaults also work when only the *trait* comes from a directory module (`import mymod.{ Greet };`) and the implementing type is local. They do not yet resolve when the implementing type is ALSO imported from a directory module (e.g. `import gm.{ Dog };` where `Dog` and its `impl Greet for Dog` both live in `gm`) — calling an inherited default on that receiver fails with `no method 'greet' on 'gm.Dog'` rather than falling back to the trait's default body; that gap is tracked separately.
 
 ### Display trait (fmt) for f-string interpolation
 
@@ -2401,17 +2401,17 @@ You may add trait impls for builtin nominal types like `Vec`. (A bare inherent `
 ```hew
 fn main() {
     let x = Some(42);
-    let v = match x { Some(n) => n, None => 0 };
+    let v = match x { .Some(n) => n, .None => 0 };
     println(v);   // 42
     let r: Result<i64, i64> = Ok(7);
-    let w = match r { Ok(n) => n, Err(e) => e };
+    let w = match r { .Ok(n) => n, .Err(e) => e };
     println(w);   // 7
     let y: Option<i64> = None;
-    println(match y { Some(n) => n, None => -1 });   // -1
+    println(match y { .Some(n) => n, .None => -1 });   // -1
 }
 ```
 
-Option/Result and their constructors are builtin — do not import `std::option`/`std::result`. Unwrap with `match`. Annotate a standalone `None` with a type.
+Option/Result and their constructors are builtin — do not import `std.option`/`std.result`. Unwrap with `match`. Annotate a standalone `None` with a type.
 
 ### The ? operator on Result
 
@@ -2425,14 +2425,14 @@ fn parse_add(a: string, b: string) -> Result<i64, string> {
     Ok(x + y)
 }
 fn main() {
-    match parse_add("a", "b") { Ok(n) => println(n), Err(e) => println(e) }       // 20
-    match parse_add("bad", "b") { Ok(n) => println(n), Err(e) => println(e) }     // bad input
+    match parse_add("a", "b") { .Ok(n) => println(n), .Err(e) => println(e) }       // 20
+    match parse_add("bad", "b") { .Ok(n) => println(n), .Err(e) => println(e) }     // bad input
 }
 ```
 
 Use `?` to short-circuit Err and propagate it; the enclosing fn must return a Result whose Err type matches.
 
-### std::string helpers
+### std.string helpers
 
 ```hew
 import std.string;
@@ -2444,9 +2444,9 @@ fn main() {
 }
 ```
 
-Import `std::string` and call via the module name. Most case/slice/trim/find operations are builtin methods on `string` itself; `std::string` is for conversions and padding. `to_int` returns `Option<i64>` — use `.unwrap_or(default)` or `match` to handle a parse failure.
+Import `std.string` and call via the module name. Most case/slice/trim/find operations are builtin methods on `string` itself; `std.string` is for conversions and padding. `to_int` returns `Option<i64>` — use `.unwrap_or(default)` or `match` to handle a parse failure.
 
-### std::math helpers
+### std.math helpers
 
 ```hew
 import std.math;
@@ -2460,7 +2460,7 @@ fn main() {
 
 `abs`/`min`/`max` are generic over Num (work on `i64` and `f64`); `sqrt`/`pow`/`floor`/`ceil`/`round` take `f64`. Use `math.pi()`/`math.e()` (functions, not bare constants).
 
-### std::iter — lazy iterator combinators
+### std.iter — lazy iterator combinators
 
 ```hew
 import std.iter;
@@ -2472,11 +2472,11 @@ fn main() {
 }
 ```
 
-`std::iter` builds lazy adapters (`map`, `filter`, `take`, `skip`) over any `Iterator`; terminal helpers (`fold`, `count`, `collect`, `any`, `all`, `sum`, `sum_f64`, `product`, `product_f64`) drive an adapter chain to completion. Drive a `Vec<T>` through the lazy surface via `v.iter()` (clones elements out, `v` stays live) or `v.into_iter()` (consumes `v`).
+`std.iter` builds lazy adapters (`map`, `filter`, `take`, `skip`) over any `Iterator`; terminal helpers (`fold`, `count`, `collect`, `any`, `all`, `sum`, `sum_f64`, `product`, `product_f64`) drive an adapter chain to completion. Drive a `Vec<T>` through the lazy surface via `v.iter()` (clones elements out, `v` stays live) or `v.into_iter()` (consumes `v`).
 
 When the receiver is a `Vec` field in actor state, `into_iter()` DRAINS the field: the iteration consumes every element and the field is left a valid empty vec. A later message may push new elements into it or iterate it again (yielding nothing). This is the only iteration form for `Vec<dyn Trait>` fields — trait objects cannot be cloned, so there is no non-consuming snapshot to hand out.
 
-### std::sort — sorting vectors
+### std.sort — sorting vectors
 
 ```hew
 import std.sort;
@@ -2502,7 +2502,7 @@ fn main() {
 
 `sort_ints` / `sort_strings` / `sort_floats` return new sorted Vecs (ascending); `reverse_ints` / `reverse_strings` / `reverse_floats` return new reversed Vecs. The original is never modified. Integer and string sorting use iterative merge passes, so their comparison count is O(n log n); float sorting retains its total-order runtime implementation.
 
-### std::random — pseudo-random number generation
+### std.random — pseudo-random number generation
 
 ```hew
 import std.random;
@@ -2521,7 +2521,7 @@ fn main() {
 
 Backed by a CPython-compatible MT19937 Mersenne Twister — the same seed produces the same sequence as CPython's `random` module. Call `seed(n)` first for reproducible output; without a seed, the state is initialised from OS entropy. `randint(lo, hi)` returns in the half-open range `[lo, hi)`.
 
-### std::time::datetime — timestamps and date arithmetic
+### std.time.datetime — timestamps and date arithmetic
 
 ```hew
 import std.time.datetime;
@@ -2541,15 +2541,15 @@ fn main() {
     println(diff);                  // 86400
 
     match datetime.try_parse("2026-01-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ") {
-        Ok(ts) => println(datetime.year(ts)),   // 2026
-        Err(e) => println(f"parse error: {e}"),
+        .Ok(ts) => println(datetime.year(ts)),   // 2026
+        .Err(e) => println(f"parse error: {e}"),
     }
 }
 ```
 
 Timestamps are `i64` epoch milliseconds throughout. `to_iso8601` formats as RFC 3339 UTC; `format(ts, fmt)` uses strftime-style patterns. `year`/`month`/`day`/`hour`/`minute`/`second`/`weekday` extract components. `add_days` / `add_hours` perform arithmetic; `diff_secs` returns the signed difference. Use `try_parse` when the input may be malformed; the format string must describe a complete date and time (a date-only pattern such as `"%Y-%m-%d"` fails with "input is not enough for unique date and time").
 
-### std::deque — double-ended queue
+### std.deque — double-ended queue
 
 ```hew
 import std.deque;
@@ -2581,9 +2581,9 @@ fn main() {
 }
 ```
 
-`std::string`, `std::math`, `std::iter` import together cleanly — the safe stdlib trio to lean on. An unused import warns but still compiles.
+`std.string`, `std.math`, `std.iter` import together cleanly — the safe stdlib trio to lean on. An unused import warns but still compiles.
 
-### std::encoding::json — parsing and building JSON
+### std.encoding.json — parsing and building JSON
 
 ```hew
 import std.encoding.json;
@@ -2640,29 +2640,29 @@ fn main() {
 }
 ```
 
-**Fallible parsing with `try_parse`** returns `Result<Value, ParseError>`. Match on the module-qualified `ParseError::Invalid(msg)` pattern to recover the native parser's message, or match `Err(_)` to ignore it:
+**Fallible parsing with `try_parse`** returns `Result<Value, ParseError>`. Match on the module-qualified `ParseError.Invalid(msg)` pattern to recover the native parser's message, or match `.Err(_)` to ignore it:
 
 ```hew
 import std.encoding.json;
 
 fn main() {
     match json.try_parse("{\"ok\": true}") {
-        Ok(v) => {
+        .Ok(v) => {
             println("parsed ok");
             v.free();
         },
-        Err(ParseError.Invalid(msg)) => println(f"parse failed: {msg}"),
+        .Err(ParseError.Invalid(msg)) => println(f"parse failed: {msg}"),
     }
     match json.try_parse("not valid json {") {
-        Ok(v) => { v.free(); },
-        Err(ParseError.Invalid(msg)) => println(f"bad json rejected: {msg}"),
+        .Ok(v) => { v.free(); },
+        .Err(ParseError.Invalid(msg)) => println(f"bad json rejected: {msg}"),
     }
 }
 ```
 
 **Memory management:** every `Value` (from `parse`, `get_field`, `array_get`, `from_*`, `object()`, `array()`) must be freed with `.free()` before it goes out of scope. Omitting `.free()` is a resource leak. Values returned by `get_field` and `array_get` are heap-allocated clones — free them independently of the parent.
 
-**Naming the `Value` type** — a plain `import std::encoding::json;` publishes the `json` module alias (`json.parse(...)`, `json.Value` as a qualified type) but does not put the bare `Value` name in scope. Use `Value` unqualified in a function signature (a parameter or return type) by importing it alongside the module in one combined import:
+**Naming the `Value` type** — a plain `import std.encoding.json;` publishes the `json` module alias (`json.parse(...)`, `json.Value` as a qualified type) but does not put the bare `Value` name in scope. Use `Value` unqualified in a function signature (a parameter or return type) by importing it alongside the module in one combined import:
 
 ```hew
 import std.encoding.json.{self, Value};
@@ -2728,11 +2728,11 @@ A quoted string path (`import "relative/path.hew";`) pulls in a sibling
 source file directly — no project layout is required. This is the fastest
 way to split a script into files.
 
-For a project with a `src/` tree, `import src::a::b::c;` addresses
+For a project with a `src/` tree, `import src.a.b.c;` addresses
 `src/a/b/c.hew` by dotted path and binds the module under its last
 segment (`c` here) — call its public items as `c.function_name()` /
-`c.CONST_NAME`, the same dotted-access form used for `std::string`,
-`std::math`, and every other stdlib module:
+`c.CONST_NAME`, the same dotted-access form used for `std.string`,
+`std.math`, and every other stdlib module:
 
 ```hew
 import std.string;
@@ -2742,20 +2742,19 @@ fn main() {
 }
 ```
 
-Selective import (`import src::a::b::{Thing, other_fn};`) brings specific
+Selective import (`import src.a.b.{Thing, other_fn};`) brings specific
 names into scope unqualified instead of binding the module name. Both forms
 resolve `pub` items only — a non-`pub` fn, type, `machine`, or `const` is
 invisible outside its defining file.
 
-**Reserved-word module path segments.** A path segment in `::`-dotted form may
-be a keyword: `import src::workflow::machine::{Thing};` (and the bare and
-`::*` forms) parse and resolve normally, as do `type` and `trait` segments.
+**Reserved-word module path segments.** A dotted path segment may be a
+keyword: `import src.workflow.machine.{Thing};`. Bare and selective imports
+parse and resolve normally, as do `type` and `trait` segments.
 The remaining restriction is on the *binding*, not the path — a bare
-`import src::workflow::machine;` binds the module under the name `machine`,
+`import src.workflow.machine;` binds the module under the name `machine`,
 and writing `machine.Thing` is then a parse error
 (`` unexpected `.` in block ``). The same is true of `actor`. Use the
-selective (`::{Name}`) or wildcard (`::*`) form for a keyword-named module,
-or reach it via the quoted string-path import form above.
+selective (`.{ Name }`) form for a keyword-named module, or reach it via the quoted string-path import form above. Wildcard imports are retired.
 
 ### `pub const` — module-level constants
 
@@ -2771,7 +2770,7 @@ fn main() {
 exports it. A const is evaluated once and is immutable — there is no `var
 const`. Read a `pub const` from another module via dotted access on the
 imported module (`reasons.MAX_RETRIES`) — selective import of a `const`
-(`import src::reasons::reasons::{MAX_RETRIES};`, then bare `MAX_RETRIES`)
+(`import src.reasons.reasons.{MAX_RETRIES};`, then bare `MAX_RETRIES`)
 currently fails to resolve; dotted access is the only working form today.
 Prefer a `pub const` over a zero-argument wrapper function
 (`pub fn max_retries() -> i64 { 3 }`) for a fixed value — the const form is
@@ -2850,7 +2849,7 @@ fn main() {
 }
 ```
 
-### Vec::contains relies on structural equality
+### Vec.contains relies on structural equality
 
 `Vec<T>.contains(v)` walks the vector using the same element-wise equality,
 so records and enums with payloads work transparently:
@@ -2934,7 +2933,7 @@ implies an equal hash and a float-bearing `record` is a sound `HashMap` key.
 > `[nan].contains(nan)` is `false` (scalar IEEE `==`, NaN ≠ NaN), while
 > `HashSet<f64>` (which stores `f64` as a structural position) treats two
 > identical NaN bit-patterns as equal. The reflexive/bitwise guarantee does
-> not extend to `Vec<f64>::contains` or direct `f64 == f64` expressions.
+> not extend to `Vec<f64>.contains` or direct `f64 == f64` expressions.
 
 ```hew
 record Coord { x: f64, y: f64 }
@@ -2944,8 +2943,8 @@ fn main() {
     m.insert(Coord { x: 1.5, y: 2.5 }, 42);
     let v = m.get(Coord { x: 1.5, y: 2.5 });
     match v {
-        Some(n) => println(n),   // 42 — structurally equal key round-trips
-        None => println(-1),
+        .Some(n) => println(n),   // 42 — structurally equal key round-trips
+        .None => println(-1),
     }
 }
 ```
@@ -2992,8 +2991,8 @@ fn main() {
     let j = e.to_json();
     println(j);                          // {"id":42,"name":"ada"}
     match UserCreated.from_json(j) {
-        Ok(back) => println(back.name),  // ada
-        Err(_) => println("parse failed"),
+        .Ok(back) => println(back.name),  // ada
+        .Err(_) => println("parse failed"),
     }
 }
 ```
@@ -3007,8 +3006,8 @@ bare element type, not `Option<T>` — see
 for that form.
 
 `e.to_json()` and `TypeName.from_json(text)` (a call on the type name
-itself, not `::`) round-trip a wire type through JSON. The runtime envelope
-used for actor-to-actor message transport is CBOR; the `std::encoding::*`
+itself, rather than a source spelling, round-trip a wire type through JSON. The runtime envelope
+used for actor-to-actor message transport is CBOR; the `std.encoding` modules
 surface (JSON, MessagePack, ...) is for cross-service and file I/O. Use `hew
 wire check <file.hew> --against <baseline.hew>` to check schema
 compatibility between two versions of a wire type.
@@ -3101,8 +3100,8 @@ actor Echo {
         while !done {
             let item = await input.recv();
             match item {
-                Some(b) => println(b.to_string()),  // x0, x1
-                None => { done = true; },
+                .Some(b) => println(b.to_string()),  // x0, x1
+                .None => { done = true; },
             }
         }
     }
@@ -3121,7 +3120,7 @@ Only `Stream<bytes>` / `Sink<bytes>` suspend (the canonical element type), and t
 canonical method names are `recv()` / `send()` — not `next()` / `write()`. `recv()`
 yields `Option<bytes>` (`None` is EOF); match it, never unwrap. `await sink.send`
 is statement-position only. Build the pipe with the public
-`std::stream.bytes_pipe(capacity)` constructor — no raw extern, no `unsafe` — and
+`std.stream.bytes_pipe(capacity)` constructor — no raw extern, no `unsafe` — and
 turn text into a frame with the public `string.to_bytes()` surface. Keep both
 ends in one handler: moving an owned `Stream`/`Sink` into actor state is not
 yet supported (`OwnedHandleAggregateExtractionUnsupported`). Full example:
@@ -3139,15 +3138,15 @@ actor Inbox {
         tx.close();
 
         match await rx.recv() {
-            Some(msg) => println(msg),   // ready
-            None => println("closed"),
+            .Some(msg) => println(msg),   // ready
+            .None => println("closed"),
         }
 
         select {
             again from rx.recv() => {
                 match again {
-                    Some(msg) => println(msg),
-                    None => println("closed"),
+                    .Some(msg) => println(msg),
+                    .None => println("closed"),
                 }
             },
             after 1s => println("timeout"),
@@ -3177,13 +3176,13 @@ fn main() {
     let re = regex.new("(?P<k>[a-z]+)=(?P<v>[0-9]+)");
     let text = "a=1 bb=22";
     match re.capture_named(text, "v") {
-        Some(v) => println(f"first value: {v}"),   // first value: 1
-        None => println("none"),
+        .Some(v) => println(f"first value: {v}"),   // first value: 1
+        .None => println("none"),
     }
     let rows = re.find_all_submatch(text);
     for i in 0..rows.len() {
-        let key = match rows.group(i, 1) { Some(g) => g, None => "?" };
-        let val = match rows.group(i, 2) { Some(g) => g, None => "?" };
+        let key = match rows.group(i, 1) { .Some(g) => g, .None => "?" };
+        let val = match rows.group(i, 2) { .Some(g) => g, .None => "?" };
         println(f"{key} -> {val}");   // a -> 1 ; bb -> 22
     }
     re.close();
@@ -3214,8 +3213,8 @@ fn main() {
     template.ctx_set_list(ctx, "xs", xs);
     let t = template.parse("hi {{.name}}:{{range .xs}} {{.}}{{end}}");
     match template.render_try(t, ctx) {
-        Ok(s) => println(s),   // hi Hew: a b
-        Err(_) => println("error"),
+        .Ok(s) => println(s),   // hi Hew: a b
+        .Err(_) => println("error"),
     }
 }
 ```
@@ -3262,7 +3261,7 @@ import std.io.scanner;
 
 fn main() {
     var sc = scanner.from_string("alpha beta\ncolour");
-    sc = scanner.with_split(sc, SplitWords);
+    sc = scanner.with_split(sc, .SplitWords);
     sc = scanner.scan(sc);
     while scanner.has_next(sc) {
         println(scanner.text(sc));
@@ -3271,8 +3270,8 @@ fn main() {
 
     let (next, line) = scanner.next_line(scanner.from_string("first\nsecond"));
     match line {
-        Some(s) => println(s),   // first
-        None => println("none"),
+        .Some(s) => println(s),   // first
+        .None => println("none"),
     }
     let _ = next;
 }
@@ -3291,7 +3290,7 @@ scanner plus `Option<string>`. Full example:
 
 The flagship networking surface is an `await`-suspended HTTP/1.1 client and
 server built on `net.connect` / `net.listen` plus the pure-Hew codecs in
-`std::net::http::http_async_client` / `http_async_server`. A server handler
+`std.net.http.http_async_client` / `http_async_server`. A server handler
 `await`s a connection, drives an `await conn.read_string()` loop until the
 request is buffered, then replies; a client writes a request and `await`s the
 response. Every `await` suspends the handler (not the worker), so one worker can
@@ -3336,8 +3335,8 @@ operations, converting a plain suspend into a timed suspend that returns
 | `await ln.accept() \| after d` | `Result<net.Connection, IoError>` |
 
 If explicit runtime shutdown begins while a deadline-form read or accept is
-already parked, it resumes as `Err(NetError::Cancelled(0))`. Its own deadline
-still reports `Err(NetError::TimedOut(_))`. Plain forms have no `Result` error
+already parked, it resumes as `Err(NetError.Cancelled(0))`. Its own deadline
+still reports `Err(NetError.TimedOut(_))`. Plain forms have no `Result` error
 surface and retain their existing fail-closed empty/invalid value behaviour.
 
 Use inside a `scope` body to bound how long a handler waits for a peer:
@@ -3347,8 +3346,8 @@ Use inside a `scope` body to bound how long a handler waits for a peer:
 scope {
     fork {
         match await conn.read_string() | after 5s {
-            Ok(data) => conn.write_string(data),
-            Err(_)   => conn.close(),
+            .Ok(data) => conn.write_string(data),
+            .Err(_)   => conn.close(),
         }
     }
 }
@@ -3373,14 +3372,14 @@ actor Client {
     receive fn go(unused: i64) {
         let found: Result<RemotePid<Echo>, LookupError> = Node.lookup("echo");
         match found {
-            Ok(peer) => {
+            .Ok(peer) => {
                 let reply = peer.ask(7, 1000);
                 match reply {
-                    Ok(n) => println(f"answer={n}"),
-                    Err(_) => println("ask failed"),
+                    .Ok(n) => println(f"answer={n}"),
+                    .Err(_) => println("ask failed"),
                 }
             },
-            Err(_) => println("lookup failed"),
+            .Err(_) => println("lookup failed"),
         }
     }
 }
@@ -3388,10 +3387,10 @@ actor Client {
 
 `RemotePid<T>` names an actor discovered through the node registry. From an
 actor handler, `peer.ask(msg, timeout_ms)` lowers to the cross-node suspending
-remote-ask path and returns `Result<T::Reply, AskError>` on resume; match
+remote-ask path and returns `Result<T.Reply, AskError>` on resume; match
 `Ok`/`Err` instead of assuming a reply. A same-node lookup can still return a
 `RemotePid<T>`, but the local-mailbox bridge for the remote-ask path is scoped
-to fail closed as `AskError::RoutingFailed`; use a `LocalPid<T>` direct actor
+to fail closed as `AskError.RoutingFailed`; use a `LocalPid<T>` direct actor
 call when both actors are intentionally local. Full example:
 [`examples/distributed/kv_client.hew`](../examples/distributed/kv_client.hew)
 and [`examples/distributed/kv_server.hew`](../examples/distributed/kv_server.hew).
@@ -3399,8 +3398,8 @@ and [`examples/distributed/kv_server.hew`](../examples/distributed/kv_server.hew
 #### Key-backed node identity and peer authentication (native only)
 
 Every distributed node identity is derived from its stable authenticated public
-credential. `Node::load_keys(path)` loads or creates that credential, and
-`Node::identity_key()` returns the public half as lowercase hexadecimal for
+credential. `Node.load_keys(path)` loads or creates that credential, and
+`Node.identity_key()` returns the public half as lowercase hexadecimal for
 out-of-band exchange.
 
 The runtime computes:
@@ -3419,12 +3418,12 @@ credential-kind byte is `1` for a TCP Noise static key and `2` for a canonical
 TLS leaf SPKI. Keeping the key preserves the `NodeId`; rotating the key rotates
 the identity.
 
-`Node::allow_peer(route_slot, credential)` binds a peer credential to a
+`Node.allow_peer(route_slot, credential)` binds a peer credential to a
 receiver-local non-zero `u16` route slot. Slot `0` is reserved for local
 dispatch. A route slot is only a compact alias inside the configuring process:
 it never becomes the peer's identity and may differ on every node.
 
-Call all identity and pinning operations before `Node::start`:
+Call all identity and pinning operations before `Node.start`:
 
 <!-- doctest: skip -->
 ```hew
@@ -3465,7 +3464,7 @@ integers. A PID captured before a same-key restart fails with `StaleRef`, even
 if the replacement process reuses the same actor slot.
 
 Registry names are discovery aliases. Repointing a name affects future
-`Node::lookup` calls but does not rewrite or revoke a previously issued
+`Node.lookup` calls but does not rewrite or revoke a previously issued
 `RemotePid`.
 
 Remote monitors deliver one typed notification through `#[on(down)]`:
@@ -3487,7 +3486,7 @@ actor Watcher {
 }
 ```
 
-`MonitorRef::id()` matches `DownNotification.monitor`. Closing the handle
+`MonitorRef.id()` matches `DownNotification.monitor`. Closing the handle
 removes the registration and delivers no notification.
 
 The complete protocol and identity rules are normative in
@@ -3506,7 +3505,7 @@ fn main() {
     let payload = req.to_bytes();
     let sent = tls.write(stream, payload);
     println(f"sent {sent}/{payload.len()} bytes");
-    // match tls.read(stream, 256) { Ok(data) => ..., Err(_) => ... }
+    // match tls.read(stream, 256) { .Ok(data) => ..., .Err(_) => ... }
     tls.close(stream);
 }
 ```
@@ -3590,7 +3589,7 @@ test result: ok. 2 passed; 0 failed; 1 ignored
 ```
 
 Each test compiles and runs as its own native subprocess — one test's
-panic, timeout, or stray `std::process::exit` cannot take down another
+panic, timeout, or stray `std.process.exit` cannot take down another
 test in the same run, and there is no shared global state between tests by
 default.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,9 +30,9 @@ this progression:
    directory-module pattern, but with peer files contributing types and trait
    impls.
 3. [`multifile/README.md`](multifile/README.md) / `02_geometry/` — selective
-   `import mod::{A, B}` from a shared module namespace.
+   `import mod.{ A, B }` from a shared module namespace.
 4. [`multifile/README.md`](multifile/README.md) / `03_text_stats/` — nested
-   modules where `import parent;` and `import parent::child;` are distinct.
+   modules where `import parent;` and `import parent.child;` are distinct.
 
 Whichever layout you use, point `hew check`, `hew build`, and `hew run` at the
 example's `main.hew` entry file; imports resolve the rest.
@@ -64,8 +64,8 @@ If the diff is empty the output matches exactly. A non-empty diff means the prog
 - **module_generic_boundaries/** -- Small two-file demo showing generic trait APIs crossing a module boundary (`main.hew` + `src/widgets.hew`)
 - **multifile/** -- Progressive multi-file examples showing peer-file type contribution, selective imports, and two-level module hierarchies ([README](multifile/README.md)):
   - `01_shapes/` — directory module with peer-file types + trait impls; bare import + qualified access
-  - `02_geometry/` — peer files sharing a type across functions; selective `import mod::{A, B}`
-  - `03_text_stats/` — two-level hierarchy; `import parent;` vs `import parent::child;`
+  - `02_geometry/` — peer files sharing a type across functions; selective `import mod.{ A, B }`
+  - `03_text_stats/` — two-level hierarchy; `import parent;` vs `import parent.child;`
 
 ### From Examples to Stdlib
 
@@ -73,12 +73,12 @@ The learning paths here are mostly language-focused. When you want shipped libra
 
 | After this part of `examples/` | Start with these modules | Why |
 | --- | --- | --- |
-| `ux/` and `progressive/` | `std::string`, `std::fmt`, `std::vec`, `std::option`, `std::result`, `std::math` | Next stop after the core syntax, collections, and expression lessons |
-| Root-level utilities such as `file_reader`, `cli_argparse`, `hew_grep`, and `regex_demo` | `std::io`, `std::fs`, `std::path`, `std::os`, `std::string`, `std::text::regex` | CLI I/O, files, paths, env access, and text scanning |
-| Root-level networking examples such as `http_server`, `static_server`, `curl_client`, `http_json_demo`, and `chat_*` | `std::net`, `std::net::http`, `std::net::mime`, `std::net::url`, `std::encoding::json` | TCP, HTTP, content types, URLs, and JSON client payloads |
-| `smtp_client.hew` (requires a real SMTP server; see file header) | `std::net::smtp` | Connecting via STARTTLS or implicit TLS, sending plain-text and HTML email |
-| Root-level async/concurrency examples such as `async_demo` and `scope_*` | `std::stream`, `std::channel::channel`, `std::semaphore` | Stream pipelines, MPSC channels, and coordination primitives |
-| `benchmark_demo.hew` and `benchmarks/` | `std::bench`, `std::net::http` | Benchmark harness plus the HTTP surfaces used in the server comparison |
+| `ux/` and `progressive/` | `std.string`, `std.fmt`, `std.vec`, `std.option`, `std.result`, `std.math` | Next stop after the core syntax, collections, and expression lessons |
+| Root-level utilities such as `file_reader`, `cli_argparse`, `hew_grep`, and `regex_demo` | `std.io`, `std.fs`, `std.path`, `std.os`, `std.string`, `std.text.regex` | CLI I/O, files, paths, env access, and text scanning |
+| Root-level networking examples such as `http_server`, `static_server`, `curl_client`, `http_json_demo`, and `chat_*` | `std.net`, `std.net.http`, `std.net.mime`, `std.net.url`, `std.encoding.json` | TCP, HTTP, content types, URLs, and JSON client payloads |
+| `smtp_client.hew` (requires a real SMTP server; see file header) | `std.net.smtp` | Connecting via STARTTLS or implicit TLS, sending plain-text and HTML email |
+| Root-level async/concurrency examples such as `async_demo` and `scope_*` | `std.stream`, `std.channel.channel`, `std.semaphore` | Stream pipelines, MPSC channels, and coordination primitives |
+| `benchmark_demo.hew` and `benchmarks/` | `std.bench`, `std.net.http` | Benchmark harness plus the HTTP surfaces used in the server comparison |
 
 ### Topic Collections
 
@@ -102,7 +102,7 @@ The learning paths here are mostly language-focused. When you want shipped libra
   - [`regex_captures.hew`](v05/surfaces/regex_captures.hew) -- regex capture groups (`capture` / `capture_named` / `find_all` / `find_all_submatch`)
   - [`template_render.hew`](v05/surfaces/template_render.hew) -- Go-style text templates (`parse` + `render_try`)
   - [`unicode_runes.hew`](v05/surfaces/unicode_runes.hew) -- unicode rune helpers + classification predicates
-  - [`scanner_tokens.hew`](v05/surfaces/scanner_tokens.hew) -- line and word tokenisation through the value-state `std::io::scanner` API. It is admitted to `make test-surface-examples` with an exact five-line normalized-output expectation and no diagnostic allowances, so output, diagnostics, status, and timeout drift all fail the gate.
+  - [`scanner_tokens.hew`](v05/surfaces/scanner_tokens.hew) -- line and word tokenisation through the value-state `std.io.scanner` API. It is admitted to `make test-surface-examples` with an exact five-line normalized-output expectation and no diagnostic allowances, so output, diagnostics, status, and timeout drift all fail the gate.
 - Networking surfaces live under **net/**:
   - [`http_await_service.hew`](net/http_await_service.hew) -- async HTTP/1.1 client + server over `await` (two routes). Loopback-only (`127.0.0.1`), so it is offline and deterministic — it **is** wired into the `make test-surface-examples` gate alongside the pure surface demos, with a paired `.expected`.
   - [`tls_client.hew`](net/tls_client.hew) -- TLS client free-function surface (`tls.connect`/`write`/`read`/`close`); type-checks + runs, encrypted round-trip gated on a known v0.5 data-plane ABI fix. **Excluded from `make test-surface-examples`** on purpose: it dials a real public host (`example.com:443`), a genuine outbound network dependency that cannot run offline, and it deliberately fails closed on the data-plane gap. It ships a paired `.expected` for local diffing only.
@@ -117,7 +117,7 @@ The learning paths here are mostly language-focused. When you want shipped libra
 - **services/** -- Distributed service patterns that showcase Hew's actor model ([README](services/README.md)):
   - Circuit breaker, rate limiter, worker pool, pub/sub broker, health monitor, distributed counter
 - **quic_mesh/** -- Two-node QUIC/TLS mesh demo with separate `server.hew` and `client.hew`
-- **quic_service/** -- Minimal QUIC client/server round-trip using only the public `std::net::quic` API
+- **quic_service/** -- Minimal QUIC client/server round-trip using only the public `std.net.quic` API
 - **Root-level network/distributed demos** -- `distributed_hello`, `sensor_mesh`, `http_server`, `static_server`, `mqtt_broker`, `chat_*`, `curl_client`, `actor_net_reader`, `network_file_reader`, and `http_json_demo` (HTTP fetch + JSON parse pipeline; requires internet access)
 
 ### Root-Level Examples

--- a/examples/machine/guard_default_stays.hew
+++ b/examples/machine/guard_default_stays.hew
@@ -24,6 +24,6 @@ machine Latch {
 
 fn main() {
     var m = Closed { code: 1 };
-    m.step(Try);
+    m.step(.Try);
     println(m.state_name());
 }

--- a/examples/machine/guard_fallthrough_traps.hew
+++ b/examples/machine/guard_fallthrough_traps.hew
@@ -42,6 +42,6 @@ machine Latch {
 
 fn main() {
     var m = Closed { code: 1 };
-    m.step(Try);
+    m.step(.Try);
     println(m.state_name());
 }

--- a/examples/machine/guard_false_falls_through_to_wildcard.hew
+++ b/examples/machine/guard_false_falls_through_to_wildcard.hew
@@ -41,6 +41,6 @@ machine Latch {
 
 fn main() {
     var m = Closed { code: 1 };
-    m.step(Try);
+    m.step(.Try);
     println(m.state_name());
 }

--- a/examples/machine/guard_gates_transition.hew
+++ b/examples/machine/guard_gates_transition.hew
@@ -34,6 +34,6 @@ machine Latch {
 
 fn main() {
     var m = Closed { code: 1 };
-    m.step(Try);
+    m.step(.Try);
     println(m.state_name());
 }

--- a/examples/machine/guard_true_fires.hew
+++ b/examples/machine/guard_true_fires.hew
@@ -27,6 +27,6 @@ machine Latch {
 
 fn main() {
     var m = Closed { code: 42 };
-    m.step(Try);
+    m.step(.Try);
     println(m.state_name());
 }

--- a/examples/machine/run_connection_lifecycle.hew
+++ b/examples/machine/run_connection_lifecycle.hew
@@ -81,10 +81,10 @@ machine ConnectionLifecycle {
 fn main() {
     var c = Disconnected;
     println(c.state_name());
-    c.step(Connect);
+    c.step(.Connect);
     println(c.state_name());
-    c.step(AuthOk);
+    c.step(.AuthOk);
     println(c.state_name());
-    c.step(Disconnect);
+    c.step(.Disconnect);
     println(c.state_name());
 }

--- a/examples/machine/run_default_stay.hew
+++ b/examples/machine/run_default_stay.hew
@@ -30,12 +30,12 @@ fn main() {
     var t = Filling;
     println(t.state_name());
     // Unhandled (Filling, Fill): stays in Filling.
-    t.step(Fill);
+    t.step(.Fill);
     println(t.state_name());
     // Handled (Filling, Drain): transitions to Draining.
-    t.step(Drain);
+    t.step(.Drain);
     println(t.state_name());
     // Unhandled (Draining, Drain): stays in Draining.
-    t.step(Drain);
+    t.step(.Drain);
     println(t.state_name());
 }

--- a/examples/machine/run_emit_signal.hew
+++ b/examples/machine/run_emit_signal.hew
@@ -59,11 +59,11 @@ machine Signal {
 fn main() {
     var s = Idle;
     println(s.state_name());
-    s.step(Start);
+    s.step(.Start);
     println(s.state_name());
-    println(s.take_emits(Ready));
-    println(s.take_emits(Ready));
-    println(s.take_emits(Stop));
-    s.step(Stop);
+    println(s.take_emits(.Ready));
+    println(s.take_emits(.Ready));
+    println(s.take_emits(.Stop));
+    s.step(.Stop);
     println(s.state_name());
 }

--- a/examples/machine/run_emit_two_machines.hew
+++ b/examples/machine/run_emit_two_machines.hew
@@ -7,7 +7,7 @@
 // `Alarm` emits `Ring` (triggered by its own `Trigger` step, a distinct
 // event from the one it emits — machines cannot emit the event that
 // re-triggers their own transition). Without the machine-id filter,
-// `b.take_emits(Ring)` would misattribute `Alarm`'s queued event to
+// `b.take_emits(.Ring)` would misattribute `Alarm`'s queued event to
 // `Beacon` and wrongly report `1`; with the filter it must report `0`.
 //
 // `tests/exec/machine_exec.rs::run_emit_two_machines_fixture_executes` is
@@ -60,7 +60,7 @@ machine Beacon {
 fn main() {
     var a = Armed;
     let b = Idle;
-    a.step(Trigger);
-    println(a.take_emits(Ring));
-    println(b.take_emits(Ring));
+    a.step(.Trigger);
+    println(a.take_emits(.Ring));
+    println(b.take_emits(.Ring));
 }

--- a/examples/machine/run_tcp_handshake.hew
+++ b/examples/machine/run_tcp_handshake.hew
@@ -36,10 +36,10 @@ machine TcpHandshake {
 fn main() {
     var tcp = Closed;
     println(tcp.state_name());
-    tcp.step(Syn);
+    tcp.step(.Syn);
     println(tcp.state_name());
-    tcp.step(Ack);
+    tcp.step(.Ack);
     println(tcp.state_name());
-    tcp.step(Reset);
+    tcp.step(.Reset);
     println(tcp.state_name());
 }

--- a/examples/machine/run_traffic_light.hew
+++ b/examples/machine/run_traffic_light.hew
@@ -3,7 +3,7 @@
 // Drives the user-visible machine substrate via `hew run`:
 //   1. Construct a `TrafficLight` machine at its initial state.
 //   2. Read the current state name via `m.state_name()`.
-//   3. Advance the machine with `m.step(Tick)` and observe the next
+//   3. Advance the machine with `m.step(.Tick)` and observe the next
 //      state name.
 //
 // Resolved by the HIR module-scope constructor-resolution pass: bare
@@ -36,10 +36,10 @@ machine TrafficLight {
 fn main() {
     var light = Red;
     println(light.state_name());
-    light.step(Tick);
+    light.step(.Tick);
     println(light.state_name());
-    light.step(Tick);
+    light.step(.Tick);
     println(light.state_name());
-    light.step(Tick);
+    light.step(.Tick);
     println(light.state_name());
 }

--- a/examples/multifile/README.md
+++ b/examples/multifile/README.md
@@ -8,8 +8,8 @@ scales from a single file to a layered directory structure.
 | # | Directory | What it teaches |
 |---|-----------|-----------------|
 | 1 | `01_shapes/` | Directory-form module; peer files contribute types + trait impls |
-| 2 | `02_geometry/` | Peer-file type sharing; selective `import mod::{A, B}` |
-| 3 | `03_text_stats/` | Two-level hierarchy; `import parent;` vs `import parent::child;` |
+| 2 | `02_geometry/` | Peer-file type sharing; selective `import mod.{ A, B }` |
+| 3 | `03_text_stats/` | Two-level hierarchy; `import parent;` vs `import parent.child;` |
 
 ---
 
@@ -73,7 +73,7 @@ statement — they are all part of the same `geo` module.
 `main.hew` uses a selective import:
 
 ```hew
-import geo::{Point, origin, manhattan, chebyshev, bounding_area};
+import geo.{ Point, origin, manhattan, chebyshev, bounding_area };
 
 let o = origin();
 let p = Point { x: 3, y: 4 };
@@ -85,8 +85,7 @@ println(manhattan(o, p));        // 7
 | Style | Syntax | Notes |
 |-------|--------|-------|
 | Bare | `import geo;` | All `pub` names in scope; also available as `geo.name(...)`. No false-positive warning when functions are called. |
-| Selective | `import geo::{Point, manhattan}` | Only named symbols enter scope. Preferred when callers only need a subset. |
-| Wildcard | `import geo::*;` | Same as bare, but currently emits a **false-positive "unused import" warning** when the import is consumed only through type references and no function call uses the `geo.name(...)` form. Prefer bare or selective to avoid the noise. |
+| Selective | `import geo.{ Point, manhattan }` | Only named symbols enter scope. Preferred when callers only need a subset. |
 
 Run it:
 ```sh
@@ -118,13 +117,13 @@ bounding_area(o, q) = 48
 ```
 
 **Pattern:** `text_stats/words/` is a **sub-module** of `text_stats`.
-Its full import path is `text_stats::words`.
+Its full import path is `text_stats.words`.
 
 Importing the parent does **not** automatically expose the child:
 
 ```hew
 import text_stats;           // gives text_stats.char_count, etc.
-import text_stats::words;    // gives words.word_count, words.first_word, etc.
+import text_stats.words;    // gives words.word_count, words.first_word, etc.
 ```
 
 This means callers opt into sub-modules explicitly — a standard approach
@@ -154,7 +153,7 @@ The compiler's unused-import checker currently tracks whether an import is
 unqualified type construction or trait usage as evidence of use.  Concretely:
 
 ```hew
-import shapes::{Circle};   // <-- warning: "unused import: shapes"
+import shapes.{ Circle };   // <-- warning: "unused import: shapes"
 let c = Circle { ... };    //     even though Circle came from this import
 ```
 
@@ -163,5 +162,5 @@ function (`shapes.make_circle(...)`, or add the function to the selective
 list).  Using a bare import (`import shapes;`) with a qualified call
 (`shapes.some_fn(...)`) is the most reliable style until this is fixed.
 
-This affects all three import forms: bare, selective, and wildcard.
+This affects both import forms: bare and selective.
 The false positive is filed as a known issue.

--- a/examples/playground/basics/stmt_control_flow.hew
+++ b/examples/playground/basics/stmt_control_flow.hew
@@ -21,9 +21,9 @@ fn check_number(n: i64) {
 fn describe_mood(mood: Mood) {
     // Statement-position match with side-effecting arms.
     match mood {
-        Happy => println("feeling happy"),
-        Sad => println("feeling sad"),
-        Neutral => println("feeling neutral"),
+        .Happy => println("feeling happy"),
+        .Sad => println("feeling sad"),
+        .Neutral => println("feeling neutral"),
     }
 }
 
@@ -31,9 +31,9 @@ fn main() {
     check_number(5);
     check_number(-3);
     check_number(0);
-    describe_mood(Happy);
-    describe_mood(Sad);
-    describe_mood(Neutral);
+    describe_mood(.Happy);
+    describe_mood(.Sad);
+    describe_mood(.Neutral);
 
     // Statement-position if in main body.
     let x = 10;
@@ -43,17 +43,17 @@ fn main() {
     // Statement-position match in main body.
     let m = Neutral;
     match m {
-        Happy => println("main: happy"),
-        Sad => println("main: sad"),
-        Neutral => println("main: neutral branch"),
+        .Happy => println("main: happy"),
+        .Sad => println("main: sad"),
+        .Neutral => println("main: neutral branch"),
     }
     // Statement-position if-let.
     let opt: Option<i64> = Some(42);
-    if let Some(v) = opt {
+    if let .Some(v) = opt {
         println(f"got value: {v}");
     }
     let none_opt: Option<i64> = None;
-    if let Some(v) = none_opt {
+    if let .Some(v) = none_opt {
         println(f"should not print: {v}");
     } else {
         println("none branch taken");

--- a/examples/playground/basics/stmt_if_let.hew
+++ b/examples/playground/basics/stmt_if_let.hew
@@ -24,7 +24,7 @@ fn main() {
     if let .Value(n) = x {
         println(f"x is {n}");
     }
-    let y = Empty;
+    let y: Wrapped = .Empty;
     if let .Value(n) = y {
         println(f"should not print: {n}");
     }

--- a/examples/playground/basics/stmt_if_let.hew
+++ b/examples/playground/basics/stmt_if_let.hew
@@ -7,7 +7,7 @@ enum Wrapped {
 }
 
 fn announce(w: Wrapped) {
-    if let Value(n) = w {
+    if let .Value(n) = w {
         println(f"value: {n}");
     } else {
         println("empty");
@@ -15,17 +15,17 @@ fn announce(w: Wrapped) {
 }
 
 fn main() {
-    announce(Value(10));
-    announce(Empty);
-    announce(Value(99));
+    announce(.Value(10));
+    announce(.Empty);
+    announce(.Value(99));
 
     // No-else form: only fires when pattern matches.
-    let x = Value(7);
-    if let Value(n) = x {
+    let x: Wrapped = .Value(7);
+    if let .Value(n) = x {
         println(f"x is {n}");
     }
     let y = Empty;
-    if let Value(n) = y {
+    if let .Value(n) = y {
         println(f"should not print: {n}");
     }
     println("done");

--- a/examples/playground/basics/stmt_match.hew
+++ b/examples/playground/basics/stmt_match.hew
@@ -9,20 +9,20 @@ enum Color {
 
 fn describe(c: Color) {
     match c {
-        Red => println("red"),
-        Green => println("green"),
-        Blue => println("blue"),
+        .Red => println("red"),
+        .Green => println("green"),
+        .Blue => println("blue"),
     }
 }
 
 fn main() {
-    describe(Red);
-    describe(Green);
-    describe(Blue);
+    describe(.Red);
+    describe(.Green);
+    describe(.Blue);
     let c = Green;
     match c {
-        Red => println("stop"),
-        Green => println("go"),
-        Blue => println("other"),
+        .Red => println("stop"),
+        .Green => println("go"),
+        .Blue => println("other"),
     }
 }

--- a/examples/showcase.hew
+++ b/examples/showcase.hew
@@ -20,13 +20,13 @@ enum Shape {
 
 fn describe_shape(s: Shape) {
     match s {
-        Circle => {
+        .Circle => {
             println("  A circle")
         },
-        Square => {
+        .Square => {
             println("  A square")
         },
-        Triangle => {
+        .Triangle => {
             println("  A triangle")
         },
     }
@@ -122,8 +122,8 @@ fn main() {
     c.increment();
     let r = await c.get_count();
     match r {
-        Ok(count) => println(f"  Counter after 3 increments: {count}"),
-        Err(_) => println("  Counter: ask failed"),
+        .Ok(count) => println(f"  Counter after 3 increments: {count}"),
+        .Err(_) => println("  Counter: ask failed"),
     }
     // 10. Boolean operators
     println("10. Boolean operators:");

--- a/examples/smtp_client.hew
+++ b/examples/smtp_client.hew
@@ -14,9 +14,9 @@
 //
 // Replace the string literals in main() with real values before running.
 //
-// NOTE: Ok(()) as a match pattern is rejected by the checker when the Ok
+// NOTE: .Ok(()) as a match pattern is rejected by the checker when the .Ok
 // payload type is unit — the checker treats the inner () as a zero-element
-// tuple destructor rather than the unit type.  The workaround is Ok(_).
+// tuple destructor rather than the unit type.  The workaround is .Ok(_).
 // Tracked: see hew-lang/hew#1598
 import std.net.smtp;
 

--- a/examples/v05/channel_vec_element_fails.hew
+++ b/examples/v05/channel_vec_element_fails.hew
@@ -15,8 +15,8 @@ fn relay(items: Vec<i64>) {
     tx.send(items);
     tx.close();
     match rx.try_recv() {
-        Some(v) => println(v.len()),
-        None => println("drained"),
+        .Some(v) => println(v.len()),
+        .None => println("drained"),
     }
 }
 

--- a/examples/while_let_iter.hew
+++ b/examples/while_let_iter.hew
@@ -1,5 +1,5 @@
 //! Status: stable (Hew roadmap: v0.5 while-let substrate)
-//! Description: Exercises the `while let Some(_) = …` HIR/MIR lowering.
+//! Description: Exercises the `while let .Some(_) = …` HIR/MIR lowering.
 
 //
 // Demonstrates the canonical iteration substrate: a `var` scrutinee


### PR DESCRIPTION
The shipped language guide taught the pre-migration idiom. It stated that bare variant names are the common idiom and that the retired separator disambiguates across modules — both of which the current compiler rejects on sight. A developer following our own documentation wrote code that did not compile.

The guide and the examples now use dotted paths, selective imports, explicit generic arguments, and contextual variant patterns. All 170 Hew fences in the guide were compiled against the current toolchain rather than eyeballed as migrated.

Found by dogfooding: three of five developers given real tasks hit this, making it the highest-frequency friction in that run.

Two findings are out of scope here and left for their own fix. Machine transition declarations emit bare-variant diagnostics whose suggested contextual form the machine grammar then rejects, so no migration of those sites is currently possible; and `examples/v05/bounded_resource` carries a pre-existing checker-boundary failure. The remaining reference targets — editor grammars, website, playground, ecosystem packages — are not covered by this sweep.