### PR TITLE
fix(mir): preserve moved scope closure ownership

### DIFF
--- a/hew-mir/src/lower/task.rs
+++ b/hew-mir/src/lower/task.rs
@@ -1080,7 +1080,24 @@ impl Builder {
             fn_symbol,
             env: env_place,
             env_ty,
-            env_ownership: vec![SpawnEnvFieldOwnership::BorrowsOnly; captures.len()],
+            env_ownership: captures
+                .iter()
+                .map(|capture| {
+                    let ty = self.subst_ty(&capture.ty);
+                    match self.closure_env_capture_ownership(
+                        crate::closure_env::AllocationStrategy::ScopeOwned,
+                        &ty,
+                        Some(capture.binding),
+                        capture.mode,
+                    ) {
+                        ClosureEnvFieldOwnership::OwnsMoved => SpawnEnvFieldOwnership::OwnsMoved,
+                        ClosureEnvFieldOwnership::BorrowsOnly
+                        | ClosureEnvFieldOwnership::OwnsClonedOrRetained => {
+                            SpawnEnvFieldOwnership::BorrowsOnly
+                        }
+                    }
+                })
+                .collect(),
         });
         Some(task_place)
     }

--- a/hew-mir/tests/actor/cancellation_scope.rs
+++ b/hew-mir/tests/actor/cancellation_scope.rs
@@ -278,6 +278,45 @@ fn fork_string_arg_spawn_env_owns_the_moved_field() {
 }
 
 #[test]
+fn spawned_move_closure_env_owns_its_scope_owned_capture() {
+    let mir = lower_clean_to_mir(
+        r#"
+        actor _Driver {
+            receive fn drive() {
+                let greeting = "hello" + " world";
+                scope {
+                    (move || println(greeting))();
+                };
+            }
+        }
+
+        fn main() -> i64 {
+            let d = spawn _Driver;
+            d.drive();
+            0
+        }
+        "#,
+    );
+    let ownership = mir
+        .raw_mir
+        .iter()
+        .flat_map(|func| &func.blocks)
+        .flat_map(|block| block.instructions.iter())
+        .find_map(|instr| match instr {
+            Instr::SpawnTaskClosure { env_ownership, .. } if !env_ownership.is_empty() => {
+                Some(env_ownership)
+            }
+            _ => None,
+        })
+        .expect("spawned move closure must emit a non-empty scope-owned environment manifest");
+    assert_eq!(
+        ownership,
+        &[SpawnEnvFieldOwnership::OwnsMoved],
+        "the task environment must release the moved capture after the parent transfers it"
+    );
+}
+
+#[test]
 fn spawned_closure_env_borrows_its_scope_owned_capture() {
     let mir = lower_clean_to_mir(
         r#"


### PR DESCRIPTION
## Summary
- preserve `ScopeOwned` moved-capture ownership in spawned closure manifests
- cover explicit `move` and borrowed scope-closure captures

## Verification
- `cargo test -p hew-mir --test actor spawned_`
- `cargo test -p hew-mir`
- `cargo fmt --check`
- `cargo clippy -p hew-mir --all-targets -- -D warnings`