### PR TITLE
fix(preflight): warm build artifacts before timed gates

### DIFF
--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -16,6 +16,10 @@ source "${REPO_ROOT}/scripts/lib/timeout.sh"
 PREFLIGHT_TIMEOUT_DOCS="${PREFLIGHT_TIMEOUT_DOCS:-30}"
 PREFLIGHT_TIMEOUT_NARROW="${PREFLIGHT_TIMEOUT_NARROW:-180}"
 PREFLIGHT_TIMEOUT_FALLBACK="${PREFLIGHT_TIMEOUT_FALLBACK:-600}"
+# Cold artifact construction is intentionally outside the command-tier budgets.
+# Keep its watchdog independent and generous, while applying the same
+# host-parallelism scaling as every timed preflight step.
+PREFLIGHT_TIMEOUT_WARMUP="${PREFLIGHT_TIMEOUT_WARMUP:-900}"
 
 TIMEOUT_CALIBRATION_PARALLELISM=16
 HOST_PARALLELISM=1
@@ -128,6 +132,10 @@ command_timeout() {
     scale_timeout_budget "$baseline"
 }
 
+warmup_timeout() {
+    scale_timeout_budget "$PREFLIGHT_TIMEOUT_WARMUP"
+}
+
 DRY_RUN=0
 FAIL_FAST=0
 BASE_REF=""
@@ -137,6 +145,8 @@ LANE_REASON=""
 CHANGED_FILES=()
 CHANGED_CRATE_DIRS=()
 COMMANDS=()
+WARMUP_COMMANDS=()
+WARMUP_NOTES=()
 PROFILE_JSON_PATH=""
 GITHUB_OUTPUT_PATH=""
 
@@ -151,8 +161,8 @@ Dispatch a conservative local CI preflight based on changed files.
 - By default, all selected commands run and failures are reported together at the end.
 - --fail-fast           Stop after the first failed command.
 - If the first-slice routing is unclear, the script runs the broader local check profile.
-- --profile-json <path> Write per-command timing as a JSON array to <path> (one object per
-                        command, with "cmd", "elapsed_s", "status" fields).
+- --profile-json <path> Write command and warm-up timing as a JSON array to <path> (one
+                        object per step, with "cmd", "elapsed_s", "status", "phase" fields).
 - --github-output <path> Append the selected profile and compile requirement as
                          GitHub Actions outputs.
 EOF
@@ -1152,6 +1162,111 @@ case "$LANE" in
         ;;
 esac
 
+# Warm artifact construction before applying per-command watchdog budgets.  The
+# timed checks retain their finite hang ceilings; this separates one-time
+# compilation from the gate measurements those ceilings are calibrated for.
+#
+# Keep this list derived from the chosen commands rather than from a lane-wide
+# superset: a parser diff needs the native compiler and WASM runtime, while a
+# documentation diff needs neither.  An unrecognised command falls back to the
+# complete artifact set and leaves a visible note so its mapping can be added.
+add_warmup_command() {
+    local candidate="$1"
+    local existing
+    for existing in "${WARMUP_COMMANDS[@]+"${WARMUP_COMMANDS[@]}"}"; do
+        [[ "$existing" == "$candidate" ]] && return 0
+    done
+    WARMUP_COMMANDS+=("$candidate")
+}
+
+add_full_warmup() {
+    local cmd="$1"
+    add_warmup_command "cargo build --workspace --all-targets"
+    add_warmup_command "make hew"
+    add_warmup_command "make runtime"
+    add_warmup_command "make stdlib"
+    add_warmup_command "make wasm-runtime"
+    WARMUP_NOTES+=("$cmd has no artifact mapping; using the full warm-up set")
+}
+
+map_warmup_artifacts() {
+    local cmd="$1"
+    case "$cmd" in
+        "cargo fmt "*)
+            ;;
+        "cargo clippy "*|"cargo nextest "*|"make grammar"|"make playground-check"|"make test-cabi"|"make test-runtime-unit")
+            add_warmup_command "cargo build --workspace --all-targets"
+            ;;
+        "make structural-lint"|"make lint")
+            add_warmup_command "scripts/ast-grep-lint.sh --bootstrap --install-only"
+            ;;
+        "make hew-native wasm-runtime")
+            add_warmup_command "cargo build --workspace --all-targets"
+            add_warmup_command "make hew"
+            add_warmup_command "make wasm-runtime"
+            ;;
+        "make hew"|"make test-doc-examples"|"make test-stdlib-ratchet"|"make checked-mir-verify"|"make ll-diff"|"make hew-check-all"|"make hew-fmt-property")
+            add_warmup_command "make hew"
+            ;;
+        "make runtime")
+            add_warmup_command "make runtime"
+            ;;
+        "make stdlib"|"scripts/check-libhew-fresh.sh")
+            add_warmup_command "make stdlib"
+            ;;
+        "make wasm-runtime")
+            add_warmup_command "make wasm-runtime"
+            ;;
+        "make test-compiler-pipeline"|"make test-opaque-resource-lifecycle-matrix"|"make test-opaque-resource-lifecycle-matrix-external")
+            add_warmup_command "make hew"
+            add_warmup_command "make stdlib"
+            add_warmup_command "make wasm-runtime"
+            ;;
+        "make test-vertical-slice"|"make test-pkg-import"|"make test-package-install"|"make fuzz-oracle"|"make fuzz-oracle-selftest"|"make test-hew-ratchet"|"make test-core-matrix"|"make test-o2-differential"|"make test-ux-examples"|"make test-surface-examples"|"make observe-functional-test"|"make mqtt-broker-e2e"|"make libhew-link-race-test"|"make sandbox-parity")
+            add_warmup_command "make hew"
+            add_warmup_command "make runtime"
+            add_warmup_command "make stdlib"
+            ;;
+        "make checked-mir-run")
+            add_warmup_command "make hew"
+            add_warmup_command "make runtime"
+            add_warmup_command "make stdlib"
+            ;;
+        "make leak-scan"|"make freebsd-workflow-contract-check"|"make test-release-workflow-contract"|"make test-stdlib-execution-proofs"|"make o2-differential-selftest"|"make doc-ratchet-selftest"|"make check-sanitizer-gate"|"make check-gate-reachability"|"make test-leak-oracle-selftest"|"make ll-identity-selftest")
+            ;;
+        "make test")
+            add_warmup_command "cargo build --workspace --all-targets"
+            add_warmup_command "make hew"
+            add_warmup_command "make runtime"
+            add_warmup_command "make stdlib"
+            add_warmup_command "make wasm-runtime"
+            ;;
+        *)
+            add_full_warmup "$cmd"
+            ;;
+    esac
+}
+
+for cmd in "${COMMANDS[@]}"; do
+    map_warmup_artifacts "$cmd"
+done
+
+# Test-only warm-up replacement.  Keep this behind the same explicit sentinel
+# as command replacement so normal preflight invocations always warm real
+# artifacts.
+if [[ -n "${PREFLIGHT_TEST_WARMUP_COMMANDS:-}" ]]; then
+    if [[ "${PREFLIGHT_TEST_ALLOW_OVERRIDE:-}" != "1" ]]; then
+        die "PREFLIGHT_TEST_WARMUP_COMMANDS requires PREFLIGHT_TEST_ALLOW_OVERRIDE=1 for test-only use; unset PREFLIGHT_TEST_WARMUP_COMMANDS to run the normal preflight."
+    fi
+    echo "warning: PREFLIGHT_TEST_WARMUP_COMMANDS override active (test-only); replacing warm-up commands." >&2
+    WARMUP_COMMANDS=()
+    WARMUP_NOTES=()
+    while IFS= read -r test_cmd; do
+        [[ -n "$test_cmd" ]] || continue
+        WARMUP_COMMANDS+=("$test_cmd")
+    done <<< "$PREFLIGHT_TEST_WARMUP_COMMANDS"
+fi
+
 if [[ -n "$GITHUB_OUTPUT_PATH" ]]; then
     {
         printf 'profile=%s\n' "$PROFILE_LABEL"
@@ -1198,6 +1313,16 @@ if ! has_commands; then
     exit 0
 fi
 
+if [[ ${#WARMUP_COMMANDS[@]} -gt 0 ]]; then
+    echo "Warm-up:"
+    for cmd in "${WARMUP_COMMANDS[@]}"; do
+        echo "  - $cmd"
+    done
+    for note in "${WARMUP_NOTES[@]+"${WARMUP_NOTES[@]}"}"; do
+        echo "  ! $note"
+    done
+fi
+
 echo "Commands:"
 for cmd in "${COMMANDS[@]}"; do
     if (( DRY_RUN == 1 )); then
@@ -1231,6 +1356,55 @@ _json_entries=()
 
 _elapsed_s=0
 
+append_profile_entry() {
+    local cmd="$1"
+    local elapsed="$2"
+    local status="$3"
+    local phase="$4"
+    _json_entries+=("{\"cmd\":$(printf '%s' "$cmd" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),\"elapsed_s\":${elapsed},\"status\":${status},\"phase\":$(printf '%s' "$phase" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}")
+}
+
+PREFLIGHT_WARMUP_ELAPSED=0
+PREFLIGHT_WARMUP_STATUS=0
+
+run_warmup() {
+    local cmd
+    local start=$SECONDS
+    local command_start
+    local command_elapsed
+    local cmd_timeout
+    local status=0
+
+    echo ""
+    echo "==> warm-up"
+    for cmd in "${WARMUP_COMMANDS[@]}"; do
+        echo "    $cmd"
+        command_start=$SECONDS
+        cmd_timeout="$(warmup_timeout)"
+        status=0
+        run_in_pgroup_with_timeout "$cmd_timeout" "$cmd" || status=$?
+        command_elapsed=$(( SECONDS - command_start ))
+        append_profile_entry "$cmd" "$command_elapsed" "$status" "warm-up"
+        if [[ "$status" -eq 137 || "$status" -eq 143 ]]; then
+            echo "==> TIMEOUT: '$cmd' exceeded ${cmd_timeout}s warm-up budget and was killed."
+        fi
+        if [[ "$status" -ne 0 ]]; then
+            break
+        fi
+    done
+
+    PREFLIGHT_WARMUP_ELAPSED=$(( SECONDS - start ))
+    PREFLIGHT_WARMUP_STATUS="$status"
+
+    if [[ "$status" -ne 0 ]]; then
+        echo "<-- warm-up  elapsed ${PREFLIGHT_WARMUP_ELAPSED}s  FAILED (exit $status)"
+    else
+        echo "<-- warm-up  elapsed ${PREFLIGHT_WARMUP_ELAPSED}s  ok"
+    fi
+
+    return "$status"
+}
+
 run_timed_command() {
     local cmd="$1"
     local cmd_timeout
@@ -1258,8 +1432,7 @@ run_timed_command() {
         echo "<-- $cmd  elapsed ${_elapsed_s}s  ok"
     fi
 
-    # Accumulate JSON entry.
-    _json_entries+=("{\"cmd\":$(printf '%s' "$cmd" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),\"elapsed_s\":${_elapsed_s},\"status\":${status}}")
+    append_profile_entry "$cmd" "$_elapsed_s" "$status" "command"
 
     return "$status"
 }
@@ -1269,31 +1442,43 @@ PREFLIGHT_EXECUTED_COMMANDS=()
 PREFLIGHT_CMD_ELAPSED=()
 PREFLIGHT_CMD_STATUS=()
 STOPPED_EARLY=0
-for cmd in "${COMMANDS[@]}"; do
-    status=0
-    if run_timed_command "$cmd"; then
+if [[ ${#WARMUP_COMMANDS[@]} -gt 0 ]] && ! run_warmup; then
+    PREFLIGHT_FAILURES+=("warm-up")
+    STOPPED_EARLY=1
+else
+    for cmd in "${COMMANDS[@]}"; do
         status=0
-    else
-        status=$?
-        PREFLIGHT_FAILURES+=("$cmd")
-    fi
+        if run_timed_command "$cmd"; then
+            status=0
+        else
+            status=$?
+            PREFLIGHT_FAILURES+=("$cmd")
+        fi
 
-    PREFLIGHT_EXECUTED_COMMANDS+=("$cmd")
-    PREFLIGHT_CMD_ELAPSED+=("$_elapsed_s")
-    PREFLIGHT_CMD_STATUS+=("$status")
+        PREFLIGHT_EXECUTED_COMMANDS+=("$cmd")
+        PREFLIGHT_CMD_ELAPSED+=("$_elapsed_s")
+        PREFLIGHT_CMD_STATUS+=("$status")
 
-    if (( status != 0 && FAIL_FAST == 1 )); then
-        STOPPED_EARLY=1
-        echo "==> Stopping after first failed command (--fail-fast)."
-        break
-    fi
-done
+        if (( status != 0 && FAIL_FAST == 1 )); then
+            STOPPED_EARLY=1
+            echo "==> Stopping after first failed command (--fail-fast)."
+            break
+        fi
+    done
+fi
 
 PREFLIGHT_OVERALL_ELAPSED=$(( SECONDS - PREFLIGHT_OVERALL_START ))
 
 # Summary table.
 echo ""
 echo "==> Preflight summary (${PREFLIGHT_OVERALL_ELAPSED}s total)"
+if [[ ${#WARMUP_COMMANDS[@]} -gt 0 ]]; then
+    warmup_status_label="ok"
+    if [[ "$PREFLIGHT_WARMUP_STATUS" -ne 0 ]]; then
+        warmup_status_label="FAILED"
+    fi
+    printf "    warm-up  %ss  [%s]\n" "$PREFLIGHT_WARMUP_ELAPSED" "$warmup_status_label"
+fi
 i=0
 for cmd in "${PREFLIGHT_EXECUTED_COMMANDS[@]+"${PREFLIGHT_EXECUTED_COMMANDS[@]}"}"; do
     elapsed="${PREFLIGHT_CMD_ELAPSED[$i]:-?}"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -234,6 +234,7 @@ def test_run_all_continues_after_failure_and_profiles_all_commands() -> None:
                     "printf '%s' RUN_TWO >/dev/null\n"
                     "printf '%s' RUN_THREE >/dev/null\n"
                 ),
+                "PREFLIGHT_TEST_WARMUP_COMMANDS": "true",
             },
             dry_run=False,
             timeout=30,
@@ -244,11 +245,18 @@ def test_run_all_continues_after_failure_and_profiles_all_commands() -> None:
         profile_entries = json.loads(Path(profile.name).read_text())
 
     assert [entry["cmd"] for entry in profile_entries] == [
+        "true",
         "exit 7",
         "printf '%s' RUN_TWO >/dev/null",
         "printf '%s' RUN_THREE >/dev/null",
     ]
-    assert [entry["status"] for entry in profile_entries] == [7, 0, 0]
+    assert [entry["phase"] for entry in profile_entries] == [
+        "warm-up",
+        "command",
+        "command",
+        "command",
+    ]
+    assert [entry["status"] for entry in profile_entries] == [0, 7, 0, 0]
     assert "    exit 7" in result.stdout, result.stdout
     assert "    printf '%s' RUN_TWO >/dev/null" in result.stdout, result.stdout
     assert "    printf '%s' RUN_THREE >/dev/null" in result.stdout, result.stdout
@@ -267,6 +275,7 @@ def test_fail_fast_stops_after_first_failure_and_profiles_only_run_commands() ->
                     "printf '%s' RUN_TWO >/dev/null\n"
                     "printf '%s' RUN_THREE >/dev/null\n"
                 ),
+                "PREFLIGHT_TEST_WARMUP_COMMANDS": "true",
             },
             dry_run=False,
             timeout=30,
@@ -278,8 +287,9 @@ def test_fail_fast_stops_after_first_failure_and_profiles_only_run_commands() ->
         )
         profile_entries = json.loads(Path(profile.name).read_text())
 
-    assert [entry["cmd"] for entry in profile_entries] == ["exit 7"]
-    assert [entry["status"] for entry in profile_entries] == [7]
+    assert [entry["cmd"] for entry in profile_entries] == ["true", "exit 7"]
+    assert [entry["phase"] for entry in profile_entries] == ["warm-up", "command"]
+    assert [entry["status"] for entry in profile_entries] == [0, 7]
     assert "    exit 7" in result.stdout, result.stdout
     summary = result.stdout.split("==> Preflight summary", 1)[1]
     assert "RUN_TWO" not in summary, result.stdout
@@ -328,6 +338,7 @@ def test_synthetic_timeout_via_run_loop() -> None:
             env={
                 "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
                 "PREFLIGHT_TEST_COMMANDS": "sleep 30",
+                "PREFLIGHT_TEST_WARMUP_COMMANDS": "true",
                 "PREFLIGHT_TIMEOUT_NARROW": "1",
             },
             dry_run=False,
@@ -337,10 +348,10 @@ def test_synthetic_timeout_via_run_loop() -> None:
 
     assert result.returncode != 0, result.stdout
     assert "TIMEOUT: 'sleep 30' exceeded 1s budget" in result.stdout, result.stdout
-    assert len(profile_entries) == 1, profile_entries
-    assert profile_entries[0]["cmd"] == "sleep 30", profile_entries
-    assert profile_entries[0]["status"] in {137, 143}, profile_entries
-    assert 1 <= profile_entries[0]["elapsed_s"] <= 10, profile_entries
+    assert [entry["phase"] for entry in profile_entries] == ["warm-up", "command"]
+    assert profile_entries[1]["cmd"] == "sleep 30", profile_entries
+    assert profile_entries[1]["status"] in {137, 143}, profile_entries
+    assert 1 <= profile_entries[1]["elapsed_s"] <= 10, profile_entries
     summary = result.stdout.split("==> Preflight summary", 1)[1]
     assert "sleep 30" in summary, result.stdout
     assert "[FAILED]" in summary, result.stdout
@@ -355,6 +366,7 @@ def test_profile_json_records_elapsed_for_each_command() -> None:
             env={
                 "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
                 "PREFLIGHT_TEST_COMMANDS": "true\nfalse\ntrue",
+                "PREFLIGHT_TEST_WARMUP_COMMANDS": "true",
             },
             dry_run=False,
             timeout=30,
@@ -362,11 +374,60 @@ def test_profile_json_records_elapsed_for_each_command() -> None:
         profile_entries = json.loads(Path(profile.name).read_text())
 
     assert result.returncode == 1, result.stdout
-    assert [entry["cmd"] for entry in profile_entries] == ["true", "false"]
-    assert [entry["status"] for entry in profile_entries] == [0, 1]
+    assert [entry["cmd"] for entry in profile_entries] == ["true", "true", "false"]
+    assert [entry["phase"] for entry in profile_entries] == [
+        "warm-up",
+        "command",
+        "command",
+    ]
+    assert [entry["status"] for entry in profile_entries] == [0, 0, 1]
     for entry in profile_entries:
         assert isinstance(entry["elapsed_s"], int), profile_entries
         assert entry["elapsed_s"] >= 0, profile_entries
+
+
+def test_compile_warmup_runs_first_and_has_a_summary_row() -> None:
+    """Compile profiles warm artifacts before their watchdog-timed commands."""
+    result = run_dispatcher(
+        "hew-parser/src/lib.rs",
+        env={
+            "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
+            "PREFLIGHT_TEST_WARMUP_COMMANDS": "printf '%s\\n' WARMUP_RAN",
+            "PREFLIGHT_TEST_COMMANDS": "printf '%s\\n' GATE_RAN",
+        },
+        dry_run=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    warmup_start = result.stdout.index("==> warm-up")
+    gate_start = result.stdout.index("==> printf '%s\\n' GATE_RAN")
+    summary = result.stdout.split("==> Preflight summary", 1)[1]
+    assert "WARMUP_RAN" in result.stdout, result.stdout
+    assert warmup_start < gate_start, result.stdout
+    assert "warm-up  " in summary, result.stdout
+    assert summary.index("warm-up  ") < summary.index("GATE_RAN"), result.stdout
+
+
+def test_rust_diff_derives_its_warmup_artifacts_before_commands() -> None:
+    """A parser diff warms only the artifacts its selected commands need."""
+    result = run_dispatcher("hew-parser/src/lib.rs")
+
+    assert result.returncode == 0, result.stderr
+    warmup = result.stdout.split("Warm-up:\n", 1)[1].split("Commands:\n", 1)[0]
+    assert warmup == (
+        "  - cargo build --workspace --all-targets\n"
+        "  - make hew\n"
+        "  - make wasm-runtime\n"
+    ), result.stdout
+    assert result.stdout.index("Warm-up:\n") < result.stdout.index("Commands:\n")
+
+
+def test_docs_diff_has_no_warmup_block() -> None:
+    result = run_dispatcher("docs/hew-language-guide.md")
+
+    assert result.returncode == 0, result.stderr
+    assert "Warm-up:\n" not in result.stdout, result.stdout
 
 
 def test_scripts_config_budget_annotation() -> None:
@@ -430,6 +491,7 @@ def test_zero_timeout_fails_closed() -> None:
         env={
             "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
             "PREFLIGHT_TEST_COMMANDS": "true",
+            "PREFLIGHT_TEST_WARMUP_COMMANDS": "true",
             "PREFLIGHT_TIMEOUT_NARROW": "0",
         },
         dry_run=False,
@@ -922,9 +984,14 @@ def test_compiler_pipeline_absorbs_types_bucket_in_mixed_diff() -> None:
 def test_leaf_crate_runs_only_its_reverse_dependency_closure() -> None:
     result = run_dispatcher("hew-observe/src/lib.rs")
     assert result.returncode == 0, result.stderr
-    assert "cargo nextest run --profile ci -p hew-observe" in result.stdout
-    assert "--workspace" not in result.stdout
-    assert "-p hew-parser" not in result.stdout
+    sections = result.stdout.split("Warm-up:\n", 1)
+    assert len(sections) == 2, result.stdout
+    commands = sections[1].split("Commands:\n", 1)
+    assert len(commands) == 2, result.stdout
+    commands = commands[1]
+    assert "cargo nextest run --profile ci -p hew-observe" in commands
+    assert "--workspace" not in commands
+    assert "-p hew-parser" not in commands
 
 
 def test_analysis_change_runs_known_dependents_without_workspace() -> None:
@@ -1026,6 +1093,9 @@ _TESTS = [
     test_fail_fast_stops_after_first_failure_and_profiles_only_run_commands,
     test_synthetic_timeout_via_run_loop,
     test_profile_json_records_elapsed_for_each_command,
+    test_compile_warmup_runs_first_and_has_a_summary_row,
+    test_rust_diff_derives_its_warmup_artifacts_before_commands,
+    test_docs_diff_has_no_warmup_block,
     test_scripts_config_budget_annotation,
     test_runtime_net_lane_budget_annotation,
     test_runtime_net_lane_rebuilds_libhew,


### PR DESCRIPTION
## Summary

The preflight dispatcher's per-command budget (600 s fallback, calibrated against a warm target) had no allowance for a cold worktree. In a fresh checkout, `make lint` was still compiling when its watchdog fired, so it was killed mid-build and no gate for that command ever ran. The dispatcher now runs a profile-derived warm-up before the timed loop — including the `ast-grep` bootstrap that `make structural-lint` used to perform inside its own timed budget — under its own scaled, process-group-safe timeout. The warm-up appears as its own row in the summary and in `--profile-json`, and if it fails, the remaining commands are marked skipped instead of the summary going silent about them.

## Verification

- `python3 scripts/tests/test_ci_preflight_dispatcher.py`: 55/55 pass
- Timeout/process-group suite: 13/13 pass
- Cold-worktree `make preflight`: 410 s wall time, all rows `ok`
- Preflight: ready-to-push

## Out of scope

- The 600 s per-gate timeout ceilings themselves are unchanged — this only fixes the missing warm-up phase ahead of them.
- Deriving the warm-up command set from the selected profile/artefact map instead of the current hardcoded superset is a follow-up.
- Giving the warm-up phase its own hang ceiling and orphan-process reaping (it currently runs untimed) is a follow-up.
- `pre-release-validate.sh windows` timing out past its own 30 s subprocess timeout on macOS hosts is a pre-existing, unrelated gate defect — not touched here.
