### PR TITLE
Raise preflight lint and test timeout floors

### DIFF
--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -72,14 +72,21 @@ print_timeout_scaling() {
 # Per-command stuck ceilings from the local preflight timing audit.  These are
 # measurement-only hang budgets, not coverage skips or bypasses.  The effective
 # timeout is max(command floor, lane tier), so narrow lanes get enough time for
-# known-long suites while the fallback's 600s ceiling remains unchanged.
+# known-long suites while retaining finite stuck ceilings for every command.
 command_timeout_floor() {
     local cmd="$1"
     case "$cmd" in
         "make ci-preflight-smoke") echo 420 ;;
-        "make lint") echo 90 ;;
+        # A warm lint run measured 698 s on the 16-core developer machine.
+        # Add roughly 35% cache and host-load headroom, rounded to 945 s, while
+        # retaining a finite stuck ceiling.
+        "make lint") echo 945 ;;
         "make playground-check") echo 150 ;;
-        "make test") echo 360 ;;
+        # A warm workspace make test run measured 1129 s for 14,050 nextest
+        # tests on the 16-core developer machine.  Add roughly 35% cache and
+        # host-load headroom, rounded to 1530 s, while retaining a finite stuck
+        # ceiling.
+        "make test") echo 1530 ;;
         # test-compiler-pipeline carries the hew-cli consumer corpus (compiled
         # leak/drop oracles + e2e suites).  The 600 s figure came from ~234 s
         # on a warm 16-core developer machine; hosted runners have far fewer

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -173,14 +173,16 @@ def test_dry_run_scales_every_budget_from_detected_parallelism() -> None:
     assert "Host parallelism: 8 (nproc)" in result.stdout, result.stdout
     assert "max(1, 16 / 8) = 2.00x" in result.stdout, result.stdout
     assert "ceil(baseline * 16 / 8)" in result.stdout, result.stdout
-    assert "make lint  (budget: 1200s)" in result.stdout, result.stdout
+    assert "make lint  (budget: 1890s)" in result.stdout, result.stdout
+    assert "make test  (budget: 3060s)" in result.stdout, result.stdout
     assert "make test-hew-ratchet  (budget: 3000s)" in result.stdout, result.stdout
     assert "make test-o2-differential  (budget: 5400s)" in result.stdout, result.stdout
 
     fast_result = run_dispatcher("some-unclassified-root-file.txt", parallelism=32)
     assert fast_result.returncode == 0, fast_result.stderr
     assert "max(1, 16 / 32) = 1.00x" in fast_result.stdout, fast_result.stdout
-    assert "make lint  (budget: 600s)" in fast_result.stdout, fast_result.stdout
+    assert "make lint  (budget: 945s)" in fast_result.stdout, fast_result.stdout
+    assert "make test  (budget: 1530s)" in fast_result.stdout, fast_result.stdout
     assert "make test-hew-ratchet  (budget: 1500s)" in fast_result.stdout, (
         fast_result.stdout
     )


### PR DESCRIPTION
## Summary

- Raise the `make test` floor to 1530 seconds from a measured 1129-second warm run for 14,050 nextest tests on a 16-core host.
- Raise the `make lint` floor to 945 seconds from a measured 698-second warm run on the same host.
- Keep both ceilings finite and update dispatcher budget expectations.

## Verification

- `python3 scripts/tests/test_ci_preflight_dispatcher.py`
- `bash scripts/tests/test_ci_preflight_timeout.sh`
- `scripts/ci-preflight-dispatcher.sh --dry-run -- some-unclassified-root-file.txt`