### PR TITLE
feat(release): assert the playground release image and complete key registration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@
 # Required variable and secrets for the required playground release image:
 #   vars.PLAYGROUND_PUBLISH_MODE — how the release image is acquired; exactly
 #     `actions` (dispatch the playground build workflow and watch it) or
-#     `local` (a maintainer runs the playground checkout's release-publish
-#     target). Any
+#     `local` (a maintainer runs the playground checkout's pre-tag
+#     release-candidate-publish target). Any
 #     other value, including unset, fails the release.
 #   secrets.PLAYGROUND_APP_ID — GitHub App ID for the playground App
 #   secrets.PLAYGROUND_APP_PRIVATE_KEY — Private key for the playground App
@@ -1576,9 +1576,9 @@ jobs:
   # The job's contract is the release image itself: for this tag, an image
   # exists in the registry and it binds this release commit. How the image gets
   # there is an acquisition mode, not the contract — `actions` dispatches the
-  # playground build workflow, `local` waits for a maintainer to run the
-  # playground checkout's release-publish target. Both modes end at the
-  # identical assertion.
+  # playground build workflow, `local` observes an image a maintainer published
+  # before tagging through the playground checkout's release-candidate-publish
+  # target. Both modes end at the identical assertion.
   playground:
     needs: release
     runs-on: ubuntu-24.04
@@ -1768,17 +1768,21 @@ jobs:
         if: steps.acquisition.outputs.mode == 'local'
         shell: bash
         env:
-          HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}
+          HEW_EXAMPLES_REF: ${{ steps.release-commit.outputs.hew_sha }}
           DEADLINE_EPOCH: ${{ steps.acquisition.outputs.assert_deadline_epoch }}
         run: |
           set -euo pipefail
 
+          if ! [[ "${HEW_EXAMPLES_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::release commit identity is not an exact lowercase 40-character commit SHA"
+            exit 1
+          fi
           VERSION="${RELEASE_TAG#v}"
           REMAINING_SECONDS=$((DEADLINE_EPOCH - $(date +%s)))
           REMAINING_MINUTES=$(((REMAINING_SECONDS + 59) / 60))
           echo "Acquisition mode is 'local': no playground workflow was dispatched."
-          echo "Publish the release image from a hew-lang/playground checkout:"
-          echo "  Run the playground checkout's release-publish target with HEW_SHA=${HEW_SHA} HEW_VERSION=${VERSION}"
+          echo "The pre-tag candidate image command for a hew-lang/playground checkout is:"
+          echo "  make release-candidate-publish HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} HEW_VERSION=${VERSION}" # external: hew-lang/playground
           echo "This job has up to ${REMAINING_MINUTES}m remaining for that image and fails if it does not arrive."
 
       - name: Assert release image exists and binds the release commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,10 @@
 #   APPLE_API_KEY_ID            — App Store Connect API key ID
 #   APPLE_API_ISSUER_ID         — App Store Connect API issuer ID
 #
-# Required variable and secrets for the required playground release image:
-#   vars.PLAYGROUND_PUBLISH_MODE — how the release image is acquired; exactly
-#     `local` for tag-push releases (a maintainer runs the playground checkout's
-#     pre-tag candidate publisher), or `actions` only for an explicit post-tag
-#     workflow dispatch. Any other value, including unset, fails the release.
-#   secrets.PLAYGROUND_APP_ID — GitHub App ID for the playground App
-#   secrets.PLAYGROUND_APP_PRIVATE_KEY — Private key for the playground App
+# Required variable for the prepublished playground release image:
+#   vars.PLAYGROUND_RELEASE_IMAGE_LOCK — exact version-scoped immutable image
+#     identity, e.g. `v0.6.0-rc2@sha256:<64 lowercase hex digits>`. The
+#     maintainer records it only after the pre-tag candidate publish succeeds.
 #
 # Homebrew tap updates use a separate optional credential and are skipped for
 # prereleases:
@@ -1570,24 +1567,18 @@ jobs:
             -f version="${VERSION}"
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Playground — trigger Docker image rebuild in hew-lang/playground
+  # Playground — assert the immutable prepublished release image
   # ─────────────────────────────────────────────────────────────────────────
   # The job's contract is the release image itself: for this tag, an image
-  # exists in the registry and it binds this release commit. How the image gets
-  # there is an acquisition mode, not the contract — `local` observes an image
-  # a maintainer published before tagging through the playground checkout's
-  # direct candidate publisher. `actions` is restricted to an explicit
-  # post-tag workflow dispatch and uses the playground's publish authority.
-  # Both modes end at the identical assertion.
+  # exists in the registry and its exact operator-recorded digest binds this
+  # release commit and linux/amd64. Publishing happens before the tag from a
+  # pinned clean playground checkout; this workflow never follows or dispatches
+  # mutable playground state.
   playground:
     needs: release
     runs-on: ubuntu-24.04
     if: ${{ !cancelled() && needs.release.result == 'success' }}
-    # The acquisition step establishes one absolute deadline from this budget.
-    # Dispatch visibility, runner scheduling, the downstream run, and polling
-    # all spend the same clock, so independently configured windows cannot
-    # overcommit the job timeout.
-    timeout-minutes: 120
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: read
@@ -1608,41 +1599,32 @@ jobs:
           fi
           echo "hew_sha=${HEW_SHA}" >> "${GITHUB_OUTPUT}"
 
-      - name: Select release image acquisition mode
-        id: acquisition
+      - name: Validate immutable playground image handoff
+        id: image-lock
         shell: bash
         env:
-          PLAYGROUND_PUBLISH_MODE: ${{ vars.PLAYGROUND_PUBLISH_MODE }}
+          PLAYGROUND_RELEASE_IMAGE_LOCK: ${{ vars.PLAYGROUND_RELEASE_IMAGE_LOCK }}
         run: |
           set -euo pipefail
 
-          # Keep the arithmetic here as the single authority for the assertion
-          # clock. The contract test pins JOB_TIMEOUT_MINUTES to the job timeout.
-          JOB_TIMEOUT_MINUTES=120
-          FINALIZATION_RESERVE_MINUTES=5
+          JOB_TIMEOUT_MINUTES=15
+          FINALIZATION_RESERVE_MINUTES=2
           ASSERTION_BUDGET_MINUTES=$((JOB_TIMEOUT_MINUTES - FINALIZATION_RESERVE_MINUTES))
           ASSERTION_DEADLINE_EPOCH=$(($(date +%s) + ASSERTION_BUDGET_MINUTES * 60))
 
-          # No default and no skip: an unset or unrecognized mode is a release
-          # configuration error, and guessing one would publish nothing while
-          # reporting success.
-          case "${PLAYGROUND_PUBLISH_MODE:-}" in
-            local) ;;
-            actions)
-              if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
-                echo "::error::PLAYGROUND_PUBLISH_MODE=actions is post-tag only; tag-push releases must use the prepublished candidate image with mode 'local'"
-                exit 1
-              fi
-              ;;
-            *)
-              echo "::error::vars.PLAYGROUND_PUBLISH_MODE must be exactly 'actions' or 'local'; got '${PLAYGROUND_PUBLISH_MODE:-<unset>}'"
-              exit 1
-              ;;
-          esac
+          if ! [[ "${PLAYGROUND_RELEASE_IMAGE_LOCK:-}" =~ ^v[0-9A-Za-z.-]+@sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::vars.PLAYGROUND_RELEASE_IMAGE_LOCK must be <release-tag>@sha256:<64 lowercase hex digits>"
+            exit 1
+          fi
+          LOCK_TAG="${PLAYGROUND_RELEASE_IMAGE_LOCK%%@*}"
+          IMAGE_DIGEST="${PLAYGROUND_RELEASE_IMAGE_LOCK#*@}"
+          if [[ "${LOCK_TAG}" != "${RELEASE_TAG}" ]]; then
+            echo "::error::playground image lock is for ${LOCK_TAG}, not ${RELEASE_TAG}"
+            exit 1
+          fi
           {
-            echo "mode=${PLAYGROUND_PUBLISH_MODE}"
+            echo "image_digest=${IMAGE_DIGEST}"
             echo "assert_deadline_epoch=${ASSERTION_DEADLINE_EPOCH}"
-            echo "assert_budget_minutes=${ASSERTION_BUDGET_MINUTES}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Checkout release machinery
@@ -1651,131 +1633,11 @@ jobs:
           ref: ${{ github.sha }}
           path: release-machinery
 
-      - name: Validate playground GitHub App configuration
-        if: steps.acquisition.outputs.mode == 'actions'
-        shell: bash
-        env:
-          PLAYGROUND_APP_ID: ${{ secrets.PLAYGROUND_APP_ID }}
-          PLAYGROUND_APP_PRIVATE_KEY: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${PLAYGROUND_APP_ID}" || -z "${PLAYGROUND_APP_PRIVATE_KEY}" ]]; then
-            echo "::error::The playground release image requires secrets.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY; configure both before running a release"
-            exit 1
-          fi
-
-      - name: Mint playground GitHub App token
-        if: steps.acquisition.outputs.mode == 'actions'
-        id: playground-app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
-        with:
-          app-id: ${{ secrets.PLAYGROUND_APP_ID }}
-          private-key: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}
-          owner: hew-lang
-          repositories: playground
-
-      - name: Trigger playground image rebuild
-        if: steps.acquisition.outputs.mode == 'actions'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.playground-app-token.outputs.token }}
-          HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}
-          DISPATCH_ACTOR: ${{ steps.playground-app-token.outputs.app-slug }}[bot]
-        run: |
-          set -euo pipefail
-
-          if ! [[ "${HEW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::release commit identity is not an exact lowercase 40-character commit SHA"
-            exit 1
-          fi
-          if ! [[ "${DISPATCH_ACTOR}" =~ ^[A-Za-z0-9][A-Za-z0-9-]*\[bot\]$ ]]; then
-            echo "::error::playground GitHub App slug did not resolve to a canonical bot actor"
-            exit 1
-          fi
-          VERSION="${RELEASE_TAG#v}"
-          CORRELATION_ID="hew-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          EXPECTED_DISPLAY_TITLE="Build Playground mode=publish sha=${HEW_SHA} version=${VERSION} correlation=${CORRELATION_ID}"
-          if ! gh repo view hew-lang/playground --json name >/dev/null 2>&1; then
-            echo "::error::hew-lang/playground is unavailable"
-            exit 1
-          fi
-          PLAYGROUND_REF=$(gh api repos/hew-lang/playground --jq '.default_branch')
-          WORKFLOW_STATE=$(gh workflow view build.yml \
-            -R hew-lang/playground --json state --jq '.state')
-          if [ "${WORKFLOW_STATE}" != "active" ]; then
-            echo "::error::hew-lang/playground build.yml is not active"
-            exit 1
-          fi
-          PRE_DISPATCH_MAX_ID=$(gh api -X GET \
-            repos/hew-lang/playground/actions/workflows/build.yml/runs \
-            -f event=workflow_dispatch \
-            -f branch="${PLAYGROUND_REF}" \
-            -f per_page=100 \
-            --jq '[.workflow_runs[].id] | max // 0')
-          gh workflow run build.yml \
-            -R hew-lang/playground \
-            --ref "${PLAYGROUND_REF}" \
-            -f publish=true \
-            -f hew_sha="${HEW_SHA}" \
-            -f version="${VERSION}" \
-            -f correlation_id="${CORRELATION_ID}"
-          RUN_ID=""
-          LAST_CANDIDATE_ID=""
-          for _ in $(seq 1 30); do
-            if ! RUNS_JSON=$(gh api -X GET \
-              repos/hew-lang/playground/actions/workflows/build.yml/runs \
-              -f event=workflow_dispatch \
-              -f branch="${PLAYGROUND_REF}" \
-              -f per_page=100); then
-              echo "::error::failed to list playground workflow runs"
-              exit 1
-            fi
-            if ! RUN_IDS_OUTPUT=$(jq -r \
-                --argjson floor "${PRE_DISPATCH_MAX_ID}" \
-                --arg actor "${DISPATCH_ACTOR}" \
-                --arg display_title "${EXPECTED_DISPLAY_TITLE}" \
-                '.workflow_runs[]
-                  | select(.id > $floor)
-                  | select(.actor.login == $actor)
-                  | select(.display_title == $display_title)
-                  | .id' <<< "${RUNS_JSON}"); then
-              echo "::error::failed to parse playground workflow runs"
-              exit 1
-            fi
-            RUN_IDS=()
-            while IFS= read -r CANDIDATE_ID; do
-              if [ -n "${CANDIDATE_ID}" ]; then
-                RUN_IDS[${#RUN_IDS[@]}]="${CANDIDATE_ID}"
-              fi
-            done <<< "${RUN_IDS_OUTPUT}"
-            if [ "${#RUN_IDS[@]}" -gt 1 ]; then
-              echo "::error::ambiguous playground workflow dispatch correlation"
-              exit 1
-            fi
-            if [ "${#RUN_IDS[@]}" -eq 1 ]; then
-              if [ "${RUN_IDS[0]}" = "${LAST_CANDIDATE_ID}" ]; then
-                RUN_ID="${RUN_IDS[0]}"
-                break
-              fi
-              LAST_CANDIDATE_ID="${RUN_IDS[0]}"
-            else
-              LAST_CANDIDATE_ID=""
-            fi
-            sleep 2
-          done
-          if [ -z "${RUN_ID}" ]; then
-            echo "::error::could not correlate the playground workflow dispatch with a run"
-            exit 1
-          fi
-          gh run watch "${RUN_ID}" -R hew-lang/playground --exit-status
-
-      - name: Report expected local release image publish
-        if: steps.acquisition.outputs.mode == 'local'
+      - name: Report immutable prepublished playground image
         shell: bash
         env:
           HEW_EXAMPLES_REF: ${{ steps.release-commit.outputs.hew_sha }}
-          DEADLINE_EPOCH: ${{ steps.acquisition.outputs.assert_deadline_epoch }}
+          EXPECTED_DIGEST: ${{ steps.image-lock.outputs.image_digest }}
         run: |
           set -euo pipefail
 
@@ -1783,30 +1645,21 @@ jobs:
             echo "::error::release commit identity is not an exact lowercase 40-character commit SHA"
             exit 1
           fi
-          VERSION="${RELEASE_TAG#v}"
           PLAYGROUND_RELEASE_IMAGE="ghcr.io/hew-lang/playground"
           EXPECTED_RELEASE_IMAGE="${PLAYGROUND_RELEASE_IMAGE}:${RELEASE_TAG}"
-          REMAINING_SECONDS=$((DEADLINE_EPOCH - $(date +%s)))
-          REMAINING_MINUTES=$(((REMAINING_SECONDS + 59) / 60))
-          echo "Acquisition mode is 'local': no playground workflow was dispatched."
-          echo "The direct pre-tag candidate command from the pinned clean hew-lang/playground checkout is:"
-          echo "  env -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES -u MAKEFILES -u GNUMAKEFLAGS HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} HEW_VERSION=${VERSION} PLAYGROUND_PLATFORM=linux/amd64 PLAYGROUND_RELEASE_IMAGE=${PLAYGROUND_RELEASE_IMAGE} scripts/publish-release-image.sh candidate"
-          echo "It must publish ${EXPECTED_RELEASE_IMAGE} before the signed tag is created."
-          echo "This job has up to ${REMAINING_MINUTES}m remaining for that image and fails if it does not arrive."
+          echo "Asserting immutable pre-tag image ${EXPECTED_RELEASE_IMAGE}@${EXPECTED_DIGEST} for linux/amd64 and ${HEW_EXAMPLES_REF}."
 
-      - name: Assert release image exists and binds the release commit
-        # Runs on every acquisition mode, including one whose acquisition step
-        # failed: the image is the contract, so the release states plainly
-        # whether it exists rather than inheriting a dispatch's verdict.
-        if: ${{ !cancelled() && steps.acquisition.outputs.mode != '' }}
+      - name: Assert immutable release image identity
         shell: bash
         env:
           IMAGE_REPOSITORY: hew-lang/playground
           IMAGE_TAG: ${{ env.RELEASE_TAG }}
+          EXPECTED_DIGEST: ${{ steps.image-lock.outputs.image_digest }}
+          EXPECTED_PLATFORM: linux/amd64
           EXPECTED_REVISION: ${{ steps.release-commit.outputs.hew_sha }}
           GHCR_TOKEN: ${{ github.token }}
           GHCR_USERNAME: ${{ github.actor }}
-          DEADLINE_EPOCH: ${{ steps.acquisition.outputs.assert_deadline_epoch }}
+          DEADLINE_EPOCH: ${{ steps.image-lock.outputs.assert_deadline_epoch }}
         run: release-machinery/scripts/assert-playground-release-image.sh
 
   # ─────────────────────────────────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1778,11 +1778,16 @@ jobs:
             exit 1
           fi
           VERSION="${RELEASE_TAG#v}"
+          PLAYGROUND_RELEASE_IMAGE="ghcr.io/hew-lang/playground:${RELEASE_TAG}"
+          if [[ "${PLAYGROUND_RELEASE_IMAGE}" != "ghcr.io/hew-lang/playground:${RELEASE_TAG}" ]]; then
+            echo "::error::release image authority is not the exact playground image for ${RELEASE_TAG}"
+            exit 1
+          fi
           REMAINING_SECONDS=$((DEADLINE_EPOCH - $(date +%s)))
           REMAINING_MINUTES=$(((REMAINING_SECONDS + 59) / 60))
           echo "Acquisition mode is 'local': no playground workflow was dispatched."
           echo "The pre-tag candidate image command for a hew-lang/playground checkout is:"
-          echo "  make release-candidate-publish HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} HEW_VERSION=${VERSION}" # external: hew-lang/playground
+          echo "  HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} HEW_VERSION=${VERSION} PLAYGROUND_RELEASE_IMAGE=${PLAYGROUND_RELEASE_IMAGE} make release-candidate-publish" # external: hew-lang/playground
           echo "This job has up to ${REMAINING_MINUTES}m remaining for that image and fails if it does not arrive."
 
       - name: Assert release image exists and binds the release commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1583,12 +1583,14 @@ jobs:
     needs: release
     runs-on: ubuntu-24.04
     if: ${{ !cancelled() && needs.release.result == 'success' }}
-    # The downstream publish path is bounded at 5 + 5 + 45 + 30 + 5 minutes
-    # across its authority, contract-verify, smoke, publish, and result jobs
-    # (90 minutes sequential worst case). Leave another 30 minutes for dispatch
-    # visibility and runner scheduling while still failing closed. The image
-    # assertion's own deadline is carved out of the same budget per mode.
+    # The acquisition step establishes one absolute deadline from this budget.
+    # Dispatch visibility, runner scheduling, the downstream run, and polling
+    # all spend the same clock, so independently configured windows cannot
+    # overcommit the job timeout.
     timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Resolve release commit identity
@@ -1614,20 +1616,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Keep the arithmetic here as the single authority for the assertion
+          # clock. The contract test pins JOB_TIMEOUT_MINUTES to the job timeout.
+          JOB_TIMEOUT_MINUTES=120
+          FINALIZATION_RESERVE_MINUTES=5
+          ASSERTION_BUDGET_MINUTES=$((JOB_TIMEOUT_MINUTES - FINALIZATION_RESERVE_MINUTES))
+          ASSERTION_DEADLINE_EPOCH=$(($(date +%s) + ASSERTION_BUDGET_MINUTES * 60))
+
           # No default and no skip: an unset or unrecognized mode is a release
           # configuration error, and guessing one would publish nothing while
           # reporting success.
           case "${PLAYGROUND_PUBLISH_MODE:-}" in
-            actions)
-              # The dispatched run is watched to completion first, so the image
-              # is already published by the time the assertion starts.
-              deadline=25
-              ;;
-            local)
-              # Nothing is dispatched; the whole remaining job budget is the
-              # window for the maintainer's publish to land.
-              deadline=110
-              ;;
+            actions | local) ;;
             *)
               echo "::error::vars.PLAYGROUND_PUBLISH_MODE must be exactly 'actions' or 'local'; got '${PLAYGROUND_PUBLISH_MODE:-<unset>}'"
               exit 1
@@ -1635,7 +1635,8 @@ jobs:
           esac
           {
             echo "mode=${PLAYGROUND_PUBLISH_MODE}"
-            echo "assert_deadline_minutes=${deadline}"
+            echo "assert_deadline_epoch=${ASSERTION_DEADLINE_EPOCH}"
+            echo "assert_budget_minutes=${ASSERTION_BUDGET_MINUTES}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Checkout release machinery
@@ -1645,6 +1646,7 @@ jobs:
           path: release-machinery
 
       - name: Validate playground GitHub App configuration
+        if: steps.acquisition.outputs.mode == 'actions'
         shell: bash
         env:
           PLAYGROUND_APP_ID: ${{ secrets.PLAYGROUND_APP_ID }}
@@ -1652,15 +1654,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Required in both acquisition modes: the App token dispatches the
-          # playground build in `actions` mode and reads the playground's
-          # container package in either mode.
           if [[ -z "${PLAYGROUND_APP_ID}" || -z "${PLAYGROUND_APP_PRIVATE_KEY}" ]]; then
             echo "::error::The playground release image requires secrets.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY; configure both before running a release"
             exit 1
           fi
 
       - name: Mint playground GitHub App token
+        if: steps.acquisition.outputs.mode == 'actions'
         id: playground-app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
         with:
@@ -1770,15 +1770,17 @@ jobs:
         shell: bash
         env:
           HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}
-          DEADLINE_MINUTES: ${{ steps.acquisition.outputs.assert_deadline_minutes }}
+          DEADLINE_EPOCH: ${{ steps.acquisition.outputs.assert_deadline_epoch }}
         run: |
           set -euo pipefail
 
           VERSION="${RELEASE_TAG#v}"
+          REMAINING_SECONDS=$((DEADLINE_EPOCH - $(date +%s)))
+          REMAINING_MINUTES=$(((REMAINING_SECONDS + 59) / 60))
           echo "Acquisition mode is 'local': no playground workflow was dispatched."
           echo "Publish the release image from a hew-lang/playground checkout:"
           echo "  Run the playground checkout's release-publish target with HEW_SHA=${HEW_SHA} HEW_VERSION=${VERSION}"
-          echo "This job waits up to ${DEADLINE_MINUTES}m for that image and fails if it does not arrive."
+          echo "This job has up to ${REMAINING_MINUTES}m remaining for that image and fails if it does not arrive."
 
       - name: Assert release image exists and binds the release commit
         # Runs on every acquisition mode, including one whose acquisition step
@@ -1790,8 +1792,9 @@ jobs:
           IMAGE_REPOSITORY: hew-lang/playground
           IMAGE_TAG: ${{ env.RELEASE_TAG }}
           EXPECTED_REVISION: ${{ steps.release-commit.outputs.hew_sha }}
-          REGISTRY_TOKEN: ${{ steps.playground-app-token.outputs.token }}
-          DEADLINE_MINUTES: ${{ steps.acquisition.outputs.assert_deadline_minutes }}
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_USERNAME: ${{ github.actor }}
+          DEADLINE_EPOCH: ${{ steps.acquisition.outputs.assert_deadline_epoch }}
         run: release-machinery/scripts/assert-playground-release-image.sh
 
   # ─────────────────────────────────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1675,11 +1675,16 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.playground-app-token.outputs.token }}
           HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}
+          DISPATCH_ACTOR: ${{ steps.playground-app-token.outputs.app-slug }}[bot]
         run: |
           set -euo pipefail
 
           if ! [[ "${HEW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::release commit identity is not an exact lowercase 40-character commit SHA"
+            exit 1
+          fi
+          if ! [[ "${DISPATCH_ACTOR}" =~ ^[A-Za-z0-9][A-Za-z0-9-]*\[bot\]$ ]]; then
+            echo "::error::playground GitHub App slug did not resolve to a canonical bot actor"
             exit 1
           fi
           VERSION="${RELEASE_TAG#v}"
@@ -1690,10 +1695,6 @@ jobs:
             exit 1
           fi
           PLAYGROUND_REF=$(gh api repos/hew-lang/playground --jq '.default_branch')
-          PLAYGROUND_SHA=$(gh api \
-            "repos/hew-lang/playground/commits/${PLAYGROUND_REF}" \
-            --jq '.sha')
-          DISPATCH_ACTOR=$(gh api user --jq '.login')
           WORKFLOW_STATE=$(gh workflow view build.yml \
             -R hew-lang/playground --json state --jq '.state')
           if [ "${WORKFLOW_STATE}" != "active" ]; then
@@ -1726,12 +1727,10 @@ jobs:
             fi
             if ! RUN_IDS_OUTPUT=$(jq -r \
                 --argjson floor "${PRE_DISPATCH_MAX_ID}" \
-                --arg sha "${PLAYGROUND_SHA}" \
                 --arg actor "${DISPATCH_ACTOR}" \
                 --arg display_title "${EXPECTED_DISPLAY_TITLE}" \
                 '.workflow_runs[]
                   | select(.id > $floor)
-                  | select(.head_sha == $sha)
                   | select(.actor.login == $actor)
                   | select(.display_title == $display_title)
                   | .id' <<< "${RUNS_JSON}"); then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,13 @@
 #   APPLE_API_KEY_ID            — App Store Connect API key ID
 #   APPLE_API_ISSUER_ID         — App Store Connect API issuer ID
 #
-# Required variable and secret for the required playground dispatch:
-#   secrets.PLAYGROUND_APP_ID — GitHub App ID for the playground dispatch App
-#   secrets.PLAYGROUND_APP_PRIVATE_KEY — Private key for the playground dispatch App
+# Required variable and secrets for the required playground release image:
+#   vars.PLAYGROUND_PUBLISH_MODE — how the release image is acquired; exactly
+#     `actions` (dispatch the playground build workflow and watch it) or
+#     `local` (a maintainer publishes it with `make release-publish`). Any
+#     other value, including unset, fails the release.
+#   secrets.PLAYGROUND_APP_ID — GitHub App ID for the playground App
+#   secrets.PLAYGROUND_APP_PRIVATE_KEY — Private key for the playground App
 #
 # Homebrew tap updates use a separate optional credential and are skipped for
 # prereleases:
@@ -1568,6 +1572,11 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   # Playground — trigger Docker image rebuild in hew-lang/playground
   # ─────────────────────────────────────────────────────────────────────────
+  # The job's contract is the release image itself: for this tag, an image
+  # exists in the registry and it binds this release commit. How the image gets
+  # there is an acquisition mode, not the contract — `actions` dispatches the
+  # playground build workflow, `local` waits for a maintainer's
+  # `make release-publish`. Both modes end at the identical assertion.
   playground:
     needs: release
     runs-on: ubuntu-24.04
@@ -1575,7 +1584,8 @@ jobs:
     # The downstream publish path is bounded at 5 + 5 + 45 + 30 + 5 minutes
     # across its authority, contract-verify, smoke, publish, and result jobs
     # (90 minutes sequential worst case). Leave another 30 minutes for dispatch
-    # visibility and runner scheduling while still failing closed.
+    # visibility and runner scheduling while still failing closed. The image
+    # assertion's own deadline is carved out of the same budget per mode.
     timeout-minutes: 120
 
     steps:
@@ -1594,6 +1604,44 @@ jobs:
           fi
           echo "hew_sha=${HEW_SHA}" >> "${GITHUB_OUTPUT}"
 
+      - name: Select release image acquisition mode
+        id: acquisition
+        shell: bash
+        env:
+          PLAYGROUND_PUBLISH_MODE: ${{ vars.PLAYGROUND_PUBLISH_MODE }}
+        run: |
+          set -euo pipefail
+
+          # No default and no skip: an unset or unrecognized mode is a release
+          # configuration error, and guessing one would publish nothing while
+          # reporting success.
+          case "${PLAYGROUND_PUBLISH_MODE:-}" in
+            actions)
+              # The dispatched run is watched to completion first, so the image
+              # is already published by the time the assertion starts.
+              deadline=25
+              ;;
+            local)
+              # Nothing is dispatched; the whole remaining job budget is the
+              # window for the maintainer's publish to land.
+              deadline=110
+              ;;
+            *)
+              echo "::error::vars.PLAYGROUND_PUBLISH_MODE must be exactly 'actions' or 'local'; got '${PLAYGROUND_PUBLISH_MODE:-<unset>}'"
+              exit 1
+              ;;
+          esac
+          {
+            echo "mode=${PLAYGROUND_PUBLISH_MODE}"
+            echo "assert_deadline_minutes=${deadline}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout release machinery
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: release-machinery
+
       - name: Validate playground GitHub App configuration
         shell: bash
         env:
@@ -1602,8 +1650,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Required in both acquisition modes: the App token dispatches the
+          # playground build in `actions` mode and reads the playground's
+          # container package in either mode.
           if [[ -z "${PLAYGROUND_APP_ID}" || -z "${PLAYGROUND_APP_PRIVATE_KEY}" ]]; then
-            echo "::error::Playground dispatch requires secrets.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY; configure both before running a release"
+            echo "::error::The playground release image requires secrets.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY; configure both before running a release"
             exit 1
           fi
 
@@ -1617,6 +1668,7 @@ jobs:
           repositories: playground
 
       - name: Trigger playground image rebuild
+        if: steps.acquisition.outputs.mode == 'actions'
         shell: bash
         env:
           GH_TOKEN: ${{ steps.playground-app-token.outputs.token }}
@@ -1710,6 +1762,35 @@ jobs:
             exit 1
           fi
           gh run watch "${RUN_ID}" -R hew-lang/playground --exit-status
+
+      - name: Report expected local release image publish
+        if: steps.acquisition.outputs.mode == 'local'
+        shell: bash
+        env:
+          HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}
+          DEADLINE_MINUTES: ${{ steps.acquisition.outputs.assert_deadline_minutes }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${RELEASE_TAG#v}"
+          echo "Acquisition mode is 'local': no playground workflow was dispatched."
+          echo "Publish the release image from a hew-lang/playground checkout:"
+          echo "  make release-publish HEW_SHA=${HEW_SHA} HEW_VERSION=${VERSION}"
+          echo "This job waits up to ${DEADLINE_MINUTES}m for that image and fails if it does not arrive."
+
+      - name: Assert release image exists and binds the release commit
+        # Runs on every acquisition mode, including one whose acquisition step
+        # failed: the image is the contract, so the release states plainly
+        # whether it exists rather than inheriting a dispatch's verdict.
+        if: ${{ !cancelled() && steps.acquisition.outputs.mode != '' }}
+        shell: bash
+        env:
+          IMAGE_REPOSITORY: hew-lang/playground
+          IMAGE_TAG: ${{ env.RELEASE_TAG }}
+          EXPECTED_REVISION: ${{ steps.release-commit.outputs.hew_sha }}
+          REGISTRY_TOKEN: ${{ steps.playground-app-token.outputs.token }}
+          DEADLINE_MINUTES: ${{ steps.acquisition.outputs.assert_deadline_minutes }}
+        run: release-machinery/scripts/assert-playground-release-image.sh
 
   # ─────────────────────────────────────────────────────────────────────────
   # VS Code Extension — package + publish with bundled hew-lsp per platform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,9 @@
 #
 # Required variable and secrets for the required playground release image:
 #   vars.PLAYGROUND_PUBLISH_MODE — how the release image is acquired; exactly
-#     `actions` (dispatch the playground build workflow and watch it) or
-#     `local` (a maintainer runs the playground checkout's pre-tag
-#     release-candidate-publish target). Any
-#     other value, including unset, fails the release.
+#     `local` for tag-push releases (a maintainer runs the playground checkout's
+#     pre-tag candidate publisher), or `actions` only for an explicit post-tag
+#     workflow dispatch. Any other value, including unset, fails the release.
 #   secrets.PLAYGROUND_APP_ID — GitHub App ID for the playground App
 #   secrets.PLAYGROUND_APP_PRIVATE_KEY — Private key for the playground App
 #
@@ -1575,10 +1574,11 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   # The job's contract is the release image itself: for this tag, an image
   # exists in the registry and it binds this release commit. How the image gets
-  # there is an acquisition mode, not the contract — `actions` dispatches the
-  # playground build workflow, `local` observes an image a maintainer published
-  # before tagging through the playground checkout's release-candidate-publish
-  # target. Both modes end at the identical assertion.
+  # there is an acquisition mode, not the contract — `local` observes an image
+  # a maintainer published before tagging through the playground checkout's
+  # direct candidate publisher. `actions` is restricted to an explicit
+  # post-tag workflow dispatch and uses the playground's publish authority.
+  # Both modes end at the identical assertion.
   playground:
     needs: release
     runs-on: ubuntu-24.04
@@ -1627,7 +1627,13 @@ jobs:
           # configuration error, and guessing one would publish nothing while
           # reporting success.
           case "${PLAYGROUND_PUBLISH_MODE:-}" in
-            actions | local) ;;
+            local) ;;
+            actions)
+              if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
+                echo "::error::PLAYGROUND_PUBLISH_MODE=actions is post-tag only; tag-push releases must use the prepublished candidate image with mode 'local'"
+                exit 1
+              fi
+              ;;
             *)
               echo "::error::vars.PLAYGROUND_PUBLISH_MODE must be exactly 'actions' or 'local'; got '${PLAYGROUND_PUBLISH_MODE:-<unset>}'"
               exit 1
@@ -1778,16 +1784,14 @@ jobs:
             exit 1
           fi
           VERSION="${RELEASE_TAG#v}"
-          PLAYGROUND_RELEASE_IMAGE="ghcr.io/hew-lang/playground:${RELEASE_TAG}"
-          if [[ "${PLAYGROUND_RELEASE_IMAGE}" != "ghcr.io/hew-lang/playground:${RELEASE_TAG}" ]]; then
-            echo "::error::release image authority is not the exact playground image for ${RELEASE_TAG}"
-            exit 1
-          fi
+          PLAYGROUND_RELEASE_IMAGE="ghcr.io/hew-lang/playground"
+          EXPECTED_RELEASE_IMAGE="${PLAYGROUND_RELEASE_IMAGE}:${RELEASE_TAG}"
           REMAINING_SECONDS=$((DEADLINE_EPOCH - $(date +%s)))
           REMAINING_MINUTES=$(((REMAINING_SECONDS + 59) / 60))
           echo "Acquisition mode is 'local': no playground workflow was dispatched."
-          echo "The pre-tag candidate image command for a hew-lang/playground checkout is:"
-          echo "  HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} HEW_VERSION=${VERSION} PLAYGROUND_RELEASE_IMAGE=${PLAYGROUND_RELEASE_IMAGE} make release-candidate-publish" # external: hew-lang/playground
+          echo "The direct pre-tag candidate command from the pinned clean hew-lang/playground checkout is:"
+          echo "  env -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES -u MAKEFILES -u GNUMAKEFLAGS HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} HEW_VERSION=${VERSION} PLAYGROUND_PLATFORM=linux/amd64 PLAYGROUND_RELEASE_IMAGE=${PLAYGROUND_RELEASE_IMAGE} scripts/publish-release-image.sh candidate"
+          echo "It must publish ${EXPECTED_RELEASE_IMAGE} before the signed tag is created."
           echo "This job has up to ${REMAINING_MINUTES}m remaining for that image and fails if it does not arrive."
 
       - name: Assert release image exists and binds the release commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@
 # Required variable and secrets for the required playground release image:
 #   vars.PLAYGROUND_PUBLISH_MODE — how the release image is acquired; exactly
 #     `actions` (dispatch the playground build workflow and watch it) or
-#     `local` (a maintainer publishes it with `make release-publish`). Any
+#     `local` (a maintainer runs the playground checkout's release-publish
+#     target). Any
 #     other value, including unset, fails the release.
 #   secrets.PLAYGROUND_APP_ID — GitHub App ID for the playground App
 #   secrets.PLAYGROUND_APP_PRIVATE_KEY — Private key for the playground App
@@ -1575,8 +1576,9 @@ jobs:
   # The job's contract is the release image itself: for this tag, an image
   # exists in the registry and it binds this release commit. How the image gets
   # there is an acquisition mode, not the contract — `actions` dispatches the
-  # playground build workflow, `local` waits for a maintainer's
-  # `make release-publish`. Both modes end at the identical assertion.
+  # playground build workflow, `local` waits for a maintainer to run the
+  # playground checkout's release-publish target. Both modes end at the
+  # identical assertion.
   playground:
     needs: release
     runs-on: ubuntu-24.04
@@ -1775,7 +1777,7 @@ jobs:
           VERSION="${RELEASE_TAG#v}"
           echo "Acquisition mode is 'local': no playground workflow was dispatched."
           echo "Publish the release image from a hew-lang/playground checkout:"
-          echo "  make release-publish HEW_SHA=${HEW_SHA} HEW_VERSION=${VERSION}"
+          echo "  Run the playground checkout's release-publish target with HEW_SHA=${HEW_SHA} HEW_VERSION=${VERSION}"
           echo "This job waits up to ${DEADLINE_MINUTES}m for that image and fails if it does not arrive."
 
       - name: Assert release image exists and binds the release commit

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -223,15 +223,22 @@ but every arm must succeed before the graph rejoins:
      `@hew-lang/{wasm,sandbox-wasm,sandbox-vm}@0.6.0-rc1`, and wait for each
      result. The workflow checks out that immutable tag and rejects a workspace
      or sandbox package version mismatch. A tag does not publish these packages.
-   - Wait for the release workflow's automated playground dispatch, then
-     verify the published image, API, and `hew run` smoke path against the
-     candidate version.
+   - Satisfy the release workflow's `playground` job, whose contract is the
+     release image itself: `ghcr.io/hew-lang/playground:<tag>` exists and its
+     `org.opencontainers.image.revision` label binds the release commit. The
+     repository variable `PLAYGROUND_PUBLISH_MODE` selects how it is acquired
+     — `actions` dispatches the playground build workflow and watches it;
+     `local` dispatches nothing and waits for a maintainer to run
+     `make release-publish HEW_SHA=<sha> HEW_VERSION=<version>` from a
+     playground checkout. The job logs the exact invocation and fails if the
+     image does not arrive. Then verify the published image, API, and
+     `hew run` smoke path against the candidate version.
 5. Only after both arms are green, pin the candidate and cut over the banner in
    `hew.sh` and `hew.run`.
 6. Rebuild Android from the tagged candidate and verify its artifact.
 
 Homebrew intentionally skips prerelease tags; its optional tap update is
-separate from the required playground dispatch. Do not run obsolete downstream
+separate from the required playground release image. Do not run obsolete downstream
 vendoring commands for npm consumers until their vendoring assumptions are
 repaired or the commands are removed.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -229,8 +229,8 @@ but every arm must succeed before the graph rejoins:
      repository variable `PLAYGROUND_PUBLISH_MODE` selects how it is acquired
      — `actions` dispatches the playground build workflow and watches it;
      `local` dispatches nothing and waits for a maintainer to run
-     `make release-publish HEW_SHA=<sha> HEW_VERSION=<version>` from a
-     playground checkout. The job logs the exact invocation and fails if the
+     `make release-publish HEW_SHA=<sha> HEW_VERSION=<version>` from a playground checkout. <!-- external-target: hew-lang/playground -->
+     The job logs the exact invocation and fails if the
      image does not arrive. Then verify the published image, API, and
      `hew run` smoke path against the candidate version.
 5. Only after both arms are green, pin the candidate and cut over the banner in

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -233,6 +233,10 @@ but every arm must succeed before the graph rejoins:
      The job logs the exact invocation and fails if the
      image does not arrive. Then verify the published image, API, and
      `hew run` smoke path against the candidate version.
+     Running `scripts/assert-playground-release-image.sh` outside Actions
+     requires `GHCR_USERNAME` and `GHCR_TOKEN`; the token must be a classic
+     GitHub PAT with the `read:packages` scope (and organization SSO
+     authorization when the organization requires it).
 5. Only after both arms are green, pin the candidate and cut over the banner in
    `hew.sh` and `hew.run`.
 6. Rebuild Android from the tagged candidate and verify its artifact.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -213,33 +213,40 @@ but every arm must succeed before the graph rejoins:
 1. Confirm every release bar and the final-candidate checklist are green on
    the exact candidate commit, including sanitizer evidence, required secrets,
    and branch protection.
-2. Create the signed tag only after the preceding evidence is recorded.
-3. Let the release workflow build and publish the signed platform assets and
+2. Before creating the signed tag, publish the candidate playground image from a
+   playground checkout:
+   `make release-candidate-publish HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version>`. <!-- external-target: hew-lang/playground -->
+   `HEW_EXAMPLES_REF` must be the exact 40-character candidate commit SHA and
+   `HEW_VERSION` the candidate version. This target uses candidate authority and
+   stamps that SHA as the image's `org.opencontainers.image.revision` label.
+   Playground must include this target and OCI revision-label behavior before
+   rc2. Do not substitute the post-tag `release-publish` target here: it uses
+   publish authority and requires the remote signed tag.
+3. Create the signed tag only after the preceding evidence is recorded.
+4. Let the release workflow build and publish the signed platform assets and
    checksums. Its curated body must be the exact
    `docs/releases/<tag>.md` file for that tag.
-4. After the assets exist, complete both independent publication arms:
+5. After the assets exist, complete the npm publication arm:
    - Manually dispatch `.github/workflows/publish-npm-packages.yml` with
      `release_tag=v0.6.0-rc1` for
      `@hew-lang/{wasm,sandbox-wasm,sandbox-vm}@0.6.0-rc1`, and wait for each
      result. The workflow checks out that immutable tag and rejects a workspace
      or sandbox package version mismatch. A tag does not publish these packages.
-   - Satisfy the release workflow's `playground` job, whose contract is the
-     release image itself: `ghcr.io/hew-lang/playground:<tag>` exists and its
-     `org.opencontainers.image.revision` label binds the release commit. The
-     repository variable `PLAYGROUND_PUBLISH_MODE` selects how it is acquired
-     — `actions` dispatches the playground build workflow and watches it;
-     `local` dispatches nothing and waits for a maintainer to run
-     `make release-publish HEW_SHA=<sha> HEW_VERSION=<version>` from a playground checkout. <!-- external-target: hew-lang/playground -->
-     The job logs the exact invocation and fails if the
-     image does not arrive. Then verify the published image, API, and
-     `hew run` smoke path against the candidate version.
-     Running `scripts/assert-playground-release-image.sh` outside Actions
-     requires `GHCR_USERNAME` and `GHCR_TOKEN`; the token must be a classic
-     GitHub PAT with the `read:packages` scope (and organization SSO
-     authorization when the organization requires it).
-5. Only after both arms are green, pin the candidate and cut over the banner in
+6. The release workflow's `playground` job verifies the pre-tag candidate image:
+   `ghcr.io/hew-lang/playground:<tag>` must exist and its
+   `org.opencontainers.image.revision` label must bind the release commit. The
+   repository variable `PLAYGROUND_PUBLISH_MODE` selects whether the job
+   dispatches and watches the playground build workflow (`actions`) or observes
+   the pre-tag candidate image (`local`). The job fails if the image does not
+   arrive. Then verify the published image, API, and `hew run` smoke path against
+   the candidate version. Running
+   `scripts/assert-playground-release-image.sh` outside Actions requires
+   `GHCR_USERNAME` and `GHCR_TOKEN`; the token must be a classic GitHub PAT with
+   the `read:packages` scope (and organization SSO authorization when the
+   organization requires it).
+7. Only after both independent publication arms are green, pin the candidate and cut over the banner in
    `hew.sh` and `hew.run`.
-6. Rebuild Android from the tagged candidate and verify its artifact.
+8. Rebuild Android from the tagged candidate and verify its artifact.
 
 Homebrew intentionally skips prerelease tags; its optional tap update is
 separate from the required playground release image. Do not run obsolete downstream

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -240,7 +240,15 @@ but every arm must succeed before the graph rejoins:
        PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground \
        scripts/publish-release-image.sh candidate
    )
-   gh variable set PLAYGROUND_PUBLISH_MODE --body local --repo hew-lang/hew
+   PLAYGROUND_IMAGE=ghcr.io/hew-lang/playground:v${VERSION}
+   PLAYGROUND_IMAGE_DIGEST="$(docker buildx imagetools inspect \
+     "${PLAYGROUND_IMAGE}" --format '{{json .Manifest}}' | jq -er '.digest')"
+   if ! [[ "${PLAYGROUND_IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+     echo "invalid playground image digest" >&2
+     exit 1
+   fi
+   gh variable set PLAYGROUND_RELEASE_IMAGE_LOCK \
+     --body "v${VERSION}@${PLAYGROUND_IMAGE_DIGEST}" --repo hew-lang/hew
    ```
 
    After the Hew candidate SHA is fixed, first merge a separately reviewed,
@@ -254,8 +262,10 @@ but every arm must succeed before the graph rejoins:
    checkout, scrubs inherited GNU Make parser controls, uses candidate authority,
    and stamps the SHA as `org.opencontainers.image.revision`. Record the clean
    playground SHA, candidate SHA, platform, image digest, and smoke result before
-   continuing. Do not use a Make target or the `publish` mode before tagging:
-   publish authority requires the remote signed tag.
+   continuing. The version-scoped `PLAYGROUND_RELEASE_IMAGE_LOCK` is the
+   pre-tag handoff: it records the immutable raw manifest/index digest without
+   requiring another Hew or playground commit. Do not use a Make target or the
+   `publish` mode before tagging: publish authority requires the remote signed tag.
 3. Create the signed tag only after the preceding evidence is recorded.
 4. Let the release workflow build and publish the signed platform assets and
    checksums. Its curated body must be the exact
@@ -266,24 +276,22 @@ but every arm must succeed before the graph rejoins:
      `@hew-lang/{wasm,sandbox-wasm,sandbox-vm}@0.6.0-rc1`, and wait for each
      result. The workflow checks out that immutable tag and rejects a workspace
      or sandbox package version mismatch. A tag does not publish these packages.
-6. The tag-push release workflow requires `PLAYGROUND_PUBLISH_MODE=local` and
-   verifies the pre-tag candidate image without dispatching a replacement:
-   `ghcr.io/hew-lang/playground:<tag>` must exist and its
+6. The tag-push release workflow only observes the pre-tag candidate image; it
+   never dispatches mutable downstream state. The tag must resolve to the exact
+   digest recorded in `PLAYGROUND_RELEASE_IMAGE_LOCK`, expose exactly the
+   `linux/amd64` release platform, and its
    `org.opencontainers.image.revision` label must bind the release commit. The
-   repository variable `PLAYGROUND_PUBLISH_MODE` selects whether the job
-   dispatches and watches the playground build workflow (`actions`) or observes
-   the pre-tag candidate image (`local`). The job fails if the image does not
-   arrive. Then verify the published image, API, and `hew run` smoke path against
-   the candidate version. Running
+   workflow validates the registry's digest header and the raw manifest/index
+   bytes before inspecting the platform and revision. Then verify the published
+   image, API, and `hew run` smoke path against the candidate version. Running
    `scripts/assert-playground-release-image.sh` outside Actions requires
    `GHCR_USERNAME` and `GHCR_TOKEN`; the token must be a classic GitHub PAT with
    the `read:packages` scope (and organization SSO authorization when the
    organization requires it).
-   An explicit post-tag workflow dispatch may use `PLAYGROUND_PUBLISH_MODE=actions`;
-   that path invokes playground publish authority and watches the authenticated
-   downstream workflow before applying the same image assertion. A maintainer
-   publishing directly after the tag must use
-   `scripts/publish-release-image.sh publish` from the same pinned clean checkout.
+   Any intentional post-tag rebuild must use
+   `scripts/publish-release-image.sh publish` manually from that same exact clean
+   playground checkout. Reconfirm the new digest and update the version-scoped
+   lock before rerunning the assertion; never dispatch a mutable remote branch.
 7. Only after both independent publication arms are green, pin the candidate and cut over the banner in
    `hew.sh` and `hew.run`.
 8. Rebuild Android from the tagged candidate and verify its artifact.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -213,18 +213,49 @@ but every arm must succeed before the graph rejoins:
 1. Confirm every release bar and the final-candidate checklist are green on
    the exact candidate commit, including sanitizer evidence, required secrets,
    and branch protection.
-2. Before creating the signed tag, publish the candidate playground image from a
-   playground checkout:
-   `HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version> PLAYGROUND_RELEASE_IMAGE=<image> make release-candidate-publish`. <!-- external-target: hew-lang/playground -->
-   `HEW_EXAMPLES_REF` must be the exact 40-character candidate commit SHA and
-   `HEW_VERSION` the candidate version, while `PLAYGROUND_RELEASE_IMAGE` must
-   be the exact `ghcr.io/hew-lang/playground:<tag>` candidate image. These are
-   inherited environment prefixes, not trailing GNU Make variable assignments.
-   This target uses candidate authority and stamps that SHA as the image's
-   `org.opencontainers.image.revision` label.
-   Playground must include this target and OCI revision-label behavior before
-   rc2. Do not substitute the post-tag `release-publish` target here: it uses
-   publish authority and requires the remote signed tag.
+2. Before creating the signed tag, publish the candidate playground image from
+   the exact reviewed playground commit that introduced the candidate contract:
+
+   ```bash
+   PLAYGROUND_CONTRACT_REF=21be84bb97436436b640f2acd09fb6dd2e0fbf94
+   PLAYGROUND_REF=<exact-reviewed-40-character-playground-sha>
+   HEW_RELEASE_SHA=<exact-40-character-hew-sha>
+   VERSION=<version-without-v-prefix>
+   PLAYGROUND_CHECKOUT="$(mktemp -d)"
+   git clone https://github.com/hew-lang/playground.git "${PLAYGROUND_CHECKOUT}"
+   git -C "${PLAYGROUND_CHECKOUT}" checkout --detach "${PLAYGROUND_REF}"
+   test "$(git -C "${PLAYGROUND_CHECKOUT}" rev-parse HEAD)" = "${PLAYGROUND_REF}"
+   git -C "${PLAYGROUND_CHECKOUT}" merge-base --is-ancestor \
+     "${PLAYGROUND_CONTRACT_REF}" HEAD
+   test -z "$(git -C "${PLAYGROUND_CHECKOUT}" status --porcelain)"
+   (
+     cd "${PLAYGROUND_CHECKOUT}"
+     . ./toolchains.env
+     test "${HEW_DEFAULT_VERSION}" = "${VERSION}"
+     test "${HEW_CANDIDATE_SHA}" = "${HEW_RELEASE_SHA}"
+     env -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES -u MAKEFILES -u GNUMAKEFLAGS \
+       HEW_EXAMPLES_REF="${HEW_RELEASE_SHA}" \
+       HEW_VERSION="${VERSION}" \
+       PLAYGROUND_PLATFORM=linux/amd64 \
+       PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground \
+       scripts/publish-release-image.sh candidate
+   )
+   gh variable set PLAYGROUND_PUBLISH_MODE --body local --repo hew-lang/hew
+   ```
+
+   After the Hew candidate SHA is fixed, first merge a separately reviewed,
+   minimal playground `toolchains.env` bump that sets `HEW_DEFAULT_VERSION` to
+   the candidate version and `HEW_CANDIDATE_SHA` to that exact Hew commit.
+   `PLAYGROUND_REF` is the resulting exact clean playground commit; the
+   `merge-base` check proves it contains the candidate publisher merged in #34.
+   `HEW_EXAMPLES_REF` is the exact candidate commit. The playground publisher
+   accepts the untagged repository path and itself publishes the exact
+   `ghcr.io/hew-lang/playground:v${VERSION}` tag. It stages the authorized Hew
+   checkout, scrubs inherited GNU Make parser controls, uses candidate authority,
+   and stamps the SHA as `org.opencontainers.image.revision`. Record the clean
+   playground SHA, candidate SHA, platform, image digest, and smoke result before
+   continuing. Do not use a Make target or the `publish` mode before tagging:
+   publish authority requires the remote signed tag.
 3. Create the signed tag only after the preceding evidence is recorded.
 4. Let the release workflow build and publish the signed platform assets and
    checksums. Its curated body must be the exact
@@ -235,7 +266,8 @@ but every arm must succeed before the graph rejoins:
      `@hew-lang/{wasm,sandbox-wasm,sandbox-vm}@0.6.0-rc1`, and wait for each
      result. The workflow checks out that immutable tag and rejects a workspace
      or sandbox package version mismatch. A tag does not publish these packages.
-6. The release workflow's `playground` job verifies the pre-tag candidate image:
+6. The tag-push release workflow requires `PLAYGROUND_PUBLISH_MODE=local` and
+   verifies the pre-tag candidate image without dispatching a replacement:
    `ghcr.io/hew-lang/playground:<tag>` must exist and its
    `org.opencontainers.image.revision` label must bind the release commit. The
    repository variable `PLAYGROUND_PUBLISH_MODE` selects whether the job
@@ -247,6 +279,11 @@ but every arm must succeed before the graph rejoins:
    `GHCR_USERNAME` and `GHCR_TOKEN`; the token must be a classic GitHub PAT with
    the `read:packages` scope (and organization SSO authorization when the
    organization requires it).
+   An explicit post-tag workflow dispatch may use `PLAYGROUND_PUBLISH_MODE=actions`;
+   that path invokes playground publish authority and watches the authenticated
+   downstream workflow before applying the same image assertion. A maintainer
+   publishing directly after the tag must use
+   `scripts/publish-release-image.sh publish` from the same pinned clean checkout.
 7. Only after both independent publication arms are green, pin the candidate and cut over the banner in
    `hew.sh` and `hew.run`.
 8. Rebuild Android from the tagged candidate and verify its artifact.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -215,10 +215,13 @@ but every arm must succeed before the graph rejoins:
    and branch protection.
 2. Before creating the signed tag, publish the candidate playground image from a
    playground checkout:
-   `make release-candidate-publish HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version>`. <!-- external-target: hew-lang/playground -->
+   `HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version> PLAYGROUND_RELEASE_IMAGE=<image> make release-candidate-publish`. <!-- external-target: hew-lang/playground -->
    `HEW_EXAMPLES_REF` must be the exact 40-character candidate commit SHA and
-   `HEW_VERSION` the candidate version. This target uses candidate authority and
-   stamps that SHA as the image's `org.opencontainers.image.revision` label.
+   `HEW_VERSION` the candidate version, while `PLAYGROUND_RELEASE_IMAGE` must
+   be the exact `ghcr.io/hew-lang/playground:<tag>` candidate image. These are
+   inherited environment prefixes, not trailing GNU Make variable assignments.
+   This target uses candidate authority and stamps that SHA as the image's
+   `org.opencontainers.image.revision` label.
    Playground must include this target and OCI revision-label behavior before
    rc2. Do not substitute the post-tag `release-publish` target here: it uses
    publish authority and requires the remote signed tag.

--- a/hew-cli/tests/pkg_key_register_e2e.rs
+++ b/hew-cli/tests/pkg_key_register_e2e.rs
@@ -1,0 +1,176 @@
+//! Behaviour of `hew key register`.
+//!
+//! Publishing signs with `~/.hew/keys/id_ed25519`, and the registry rejects a
+//! signature from a key it has never seen — its own diagnostic tells the user
+//! to run `hew key register`. Before that subcommand existed the only way to
+//! register an existing key was to delete it and generate a replacement,
+//! which invalidates every signature the old key ever made.
+//!
+//! Every test relocates `$HOME` (and `$USERPROFILE`, for Windows parity) per
+//! `Command`, never via `std::env::set_var` — see LESSONS
+//! `global-test-isolation`. Registry-facing tests use a **named** registry
+//! pinned to `127.0.0.1`, so no test here can address the real registry.
+mod support;
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use support::http_canned::spawn_canned_response_server;
+
+const REGISTRY_NAME: &str = "testreg";
+
+fn key_command(home: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(support::hew_binary());
+    cmd.arg("key")
+        .args(args)
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    support::run_bounded_command(cmd, "hew key")
+}
+
+fn generate_signing_key(home: &Path) {
+    let output = key_command(home, &["generate"]);
+    assert!(
+        output.status.success(),
+        "hew key generate failed\n{}",
+        support::describe_output(&output)
+    );
+}
+
+/// Point the named registry at `api_url` and store a token for it. The default
+/// `[registry]` table is never written, so a bug cannot reach the real
+/// registry with these credentials.
+fn write_named_registry(home: &Path, api_url: &str) {
+    let hew_dir = home.join(".hew");
+    fs::create_dir_all(&hew_dir).expect("create .hew dir");
+    fs::write(
+        hew_dir.join("config.toml"),
+        format!(
+            "[registries.{REGISTRY_NAME}]\n\
+             index = \"http://127.0.0.1:9/index\"\n\
+             api = \"{api_url}\"\n"
+        ),
+    )
+    .expect("write config.toml");
+    fs::write(
+        hew_dir.join("credentials.toml"),
+        format!("[registries.{REGISTRY_NAME}]\ntoken = \"test-token\"\ngithub_user = \"tester\"\n"),
+    )
+    .expect("write credentials.toml");
+}
+
+#[test]
+fn key_register_with_an_existing_key_registers_it_and_exits_zero() {
+    let home = support::tempdir();
+    generate_signing_key(home.path());
+    let port = spawn_canned_response_server(
+        "200 OK",
+        r#"{"fingerprint":"SHA256:0hOtRl0FvXqAr7cUf3jTSTfvhO2fYnTEXPz1yeF3aRM"}"#,
+    );
+    write_named_registry(home.path(), &format!("http://127.0.0.1:{port}"));
+
+    let output = key_command(home.path(), &["register", "--registry", REGISTRY_NAME]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit 0\n{}",
+        support::describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Key registered with registry"),
+        "stdout missing registration confirmation:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("SHA256:0hOtRl0FvXqAr7cUf3jTSTfvhO2fYnTEXPz1yeF3aRM"),
+        "stdout missing the registry's fingerprint:\n{stdout}"
+    );
+}
+
+#[test]
+fn key_register_without_a_key_exits_one_and_names_generate() {
+    let home = support::tempdir();
+    // Credentials and a registry are present: the key is the only thing
+    // missing, so a success here could only come from registering nothing.
+    write_named_registry(home.path(), "http://127.0.0.1:9");
+
+    let output = key_command(home.path(), &["register", "--registry", REGISTRY_NAME]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no signing key found"),
+        "stderr missing missing-key diagnostic:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("hew key generate"),
+        "stderr does not name the command that creates a key:\n{stderr}"
+    );
+}
+
+#[test]
+fn key_register_without_credentials_exits_one_and_names_login() {
+    let home = support::tempdir();
+    generate_signing_key(home.path());
+    // A configured registry with no token for it.
+    let hew_dir = home.path().join(".hew");
+    fs::create_dir_all(&hew_dir).expect("create .hew dir");
+    fs::write(
+        hew_dir.join("config.toml"),
+        format!(
+            "[registries.{REGISTRY_NAME}]\n\
+             index = \"http://127.0.0.1:9/index\"\n\
+             api = \"http://127.0.0.1:9\"\n"
+        ),
+    )
+    .expect("write config.toml");
+
+    let output = key_command(home.path(), &["register", "--registry", REGISTRY_NAME]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not logged in"),
+        "stderr missing not-logged-in diagnostic:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("hew login"),
+        "stderr does not name the command that authenticates:\n{stderr}"
+    );
+}
+
+#[test]
+fn key_generate_over_an_existing_key_directs_the_user_to_register() {
+    let home = support::tempdir();
+    generate_signing_key(home.path());
+
+    let output = key_command(home.path(), &["generate"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("key already exists"),
+        "stderr missing existing-key diagnostic:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("hew key register"),
+        "stderr does not name the command that registers the existing key:\n{stderr}"
+    );
+}

--- a/hew-cli/tests/pkg_key_register_e2e.rs
+++ b/hew-cli/tests/pkg_key_register_e2e.rs
@@ -15,8 +15,9 @@ mod support;
 use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
+use std::time::Duration;
 
-use support::http_canned::spawn_canned_response_server;
+use support::http_canned::spawn_recording_canned_response_server;
 
 const REGISTRY_NAME: &str = "testreg";
 
@@ -64,7 +65,11 @@ fn write_named_registry(home: &Path, api_url: &str) {
 fn key_register_with_an_existing_key_registers_it_and_exits_zero() {
     let home = support::tempdir();
     generate_signing_key(home.path());
-    let port = spawn_canned_response_server(
+    let expected_public_key = fs::read_to_string(home.path().join(".hew/keys/id_ed25519.pub"))
+        .expect("read generated public key")
+        .trim()
+        .to_owned();
+    let (port, request_rx) = spawn_recording_canned_response_server(
         "200 OK",
         r#"{"fingerprint":"SHA256:0hOtRl0FvXqAr7cUf3jTSTfvhO2fYnTEXPz1yeF3aRM"}"#,
     );
@@ -87,6 +92,15 @@ fn key_register_with_an_existing_key_registers_it_and_exits_zero() {
         stdout.contains("SHA256:0hOtRl0FvXqAr7cUf3jTSTfvhO2fYnTEXPz1yeF3aRM"),
         "stdout missing the registry's fingerprint:\n{stdout}"
     );
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("registration request");
+    assert_eq!(request.method, "PUT");
+    assert_eq!(request.path, "/keys");
+    let body: serde_json::Value =
+        serde_json::from_slice(&request.body).expect("registration JSON body");
+    assert_eq!(body["key_type"], "ed25519");
+    assert_eq!(body["public_key"], expected_public_key);
 }
 
 #[test]
@@ -148,6 +162,57 @@ fn key_register_without_credentials_exits_one_and_names_login() {
     assert!(
         stderr.contains("hew login"),
         "stderr does not name the command that authenticates:\n{stderr}"
+    );
+}
+
+#[test]
+fn key_register_with_corrupt_credentials_surfaces_the_parse_error() {
+    let home = support::tempdir();
+    generate_signing_key(home.path());
+    let hew_dir = home.path().join(".hew");
+    fs::write(hew_dir.join("credentials.toml"), "not valid toml {{{")
+        .expect("write corrupt credentials");
+
+    let output = key_command(home.path(), &["register"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid credentials file"),
+        "stderr missing credential parse diagnostic:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("not logged in"),
+        "parse failure must not be reported as logged out:\n{stderr}"
+    );
+}
+
+#[test]
+fn key_register_with_unknown_named_registry_surfaces_the_config_error() {
+    let home = support::tempdir();
+    generate_signing_key(home.path());
+
+    let output = key_command(home.path(), &["register", "--registry", "unknown"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit 1\n{}",
+        support::describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown registry 'unknown'"),
+        "stderr missing unknown-registry diagnostic:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("not logged in"),
+        "unknown registry must not be reported as logged out:\n{stderr}"
     );
 }
 

--- a/hew-cli/tests/pkg_publish_fail_closed_e2e.rs
+++ b/hew-cli/tests/pkg_publish_fail_closed_e2e.rs
@@ -22,11 +22,11 @@
 mod support;
 
 use std::fs;
-use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
-use std::time::Duration;
+
+use support::http_canned::spawn_canned_response_server;
 
 const PKG_NAME: &str = "repro_pkg";
 const PKG_VERSION: &str = "0.1.0";
@@ -127,78 +127,6 @@ fn stderr_of(output: &Output) -> String {
 
 fn stdout_of(output: &Output) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
-}
-
-/// Read an HTTP request's headers and drain its `Content-Length` body so the
-/// client's write completes before the server responds — otherwise the
-/// client can fail on the write side instead of on the response status.
-fn drain_http_request(stream: &mut TcpStream) {
-    stream
-        .set_read_timeout(Some(Duration::from_secs(10)))
-        .expect("set read timeout");
-    let mut buf = Vec::new();
-    let mut chunk = [0u8; 4096];
-    while let Ok(n) = stream.read(&mut chunk) {
-        if n == 0 {
-            break;
-        }
-        buf.extend_from_slice(&chunk[..n]);
-        let Some(header_end) = find_double_crlf(&buf) else {
-            continue;
-        };
-        let header_text = String::from_utf8_lossy(&buf[..header_end]);
-        let content_length: usize = header_text
-            .lines()
-            .find_map(|line| {
-                let (key, value) = line.split_once(':')?;
-                key.trim()
-                    .eq_ignore_ascii_case("content-length")
-                    .then(|| value.trim().parse().ok())
-                    .flatten()
-            })
-            .unwrap_or(0);
-        let body_so_far = buf.len() - (header_end + 4);
-        let mut remaining = content_length.saturating_sub(body_so_far);
-        while remaining > 0 {
-            let Ok(n) = stream.read(&mut chunk) else {
-                break;
-            };
-            if n == 0 {
-                break;
-            }
-            remaining = remaining.saturating_sub(n);
-        }
-        break;
-    }
-}
-
-fn find_double_crlf(buf: &[u8]) -> Option<usize> {
-    buf.windows(4).position(|w| w == b"\r\n\r\n")
-}
-
-/// Bind an ephemeral port, accept exactly one connection, drain its request,
-/// and reply with a canned `status_line`/`body` response, then stop.
-///
-/// Returns the bound port; the caller points a named registry's `api` at it.
-fn spawn_canned_response_server(status_line: &'static str, body: &'static str) -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
-    let port = listener.local_addr().expect("local_addr").port();
-    std::thread::spawn(move || {
-        if let Ok((mut stream, _addr)) = listener.accept() {
-            drain_http_request(&mut stream);
-            let response = format!(
-                "HTTP/1.1 {status_line}\r\n\
-                 Content-Type: application/json\r\n\
-                 Content-Length: {}\r\n\
-                 Connection: close\r\n\
-                 \r\n\
-                 {body}",
-                body.len()
-            );
-            let _ = stream.write_all(response.as_bytes());
-        }
-    });
-    port
 }
 
 // ── 1. no credentials at all ────────────────────────────────────────────────

--- a/hew-cli/tests/support/http_canned.rs
+++ b/hew-cli/tests/support/http_canned.rs
@@ -1,0 +1,81 @@
+//! A single-response HTTP server for registry-facing integration tests.
+//!
+//! Bound to `127.0.0.1` on an ephemeral port so a test can point a **named**
+//! registry at it and prove a client path end to end without addressing a real
+//! registry.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+/// Read an HTTP request's headers and drain its `Content-Length` body so the
+/// client's write completes before the server responds — otherwise the
+/// client can fail on the write side instead of on the response status.
+pub fn drain_http_request(stream: &mut TcpStream) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("set read timeout");
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    while let Ok(n) = stream.read(&mut chunk) {
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        let Some(header_end) = find_double_crlf(&buf) else {
+            continue;
+        };
+        let header_text = String::from_utf8_lossy(&buf[..header_end]);
+        let content_length: usize = header_text
+            .lines()
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                key.trim()
+                    .eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        let body_so_far = buf.len() - (header_end + 4);
+        let mut remaining = content_length.saturating_sub(body_so_far);
+        while remaining > 0 {
+            let Ok(n) = stream.read(&mut chunk) else {
+                break;
+            };
+            if n == 0 {
+                break;
+            }
+            remaining = remaining.saturating_sub(n);
+        }
+        break;
+    }
+}
+
+fn find_double_crlf(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+/// Bind an ephemeral port, accept exactly one connection, drain its request,
+/// and reply with a canned `status_line`/`body` response, then stop.
+///
+/// Returns the bound port; the caller points a named registry's `api` at it.
+pub fn spawn_canned_response_server(status_line: &'static str, body: &'static str) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _addr)) = listener.accept() {
+            drain_http_request(&mut stream);
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {body}",
+                body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    port
+}

--- a/hew-cli/tests/support/http_canned.rs
+++ b/hew-cli/tests/support/http_canned.rs
@@ -6,21 +6,25 @@
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{self, Receiver};
 use std::time::Duration;
 
-/// Read an HTTP request's headers and drain its `Content-Length` body so the
-/// client's write completes before the server responds — otherwise the
-/// client can fail on the write side instead of on the response status.
-pub fn drain_http_request(stream: &mut TcpStream) {
+#[derive(Debug)]
+pub struct CannedRequest {
+    pub method: String,
+    pub path: String,
+    pub body: Vec<u8>,
+}
+
+fn read_http_request(stream: &mut TcpStream) -> CannedRequest {
     stream
         .set_read_timeout(Some(Duration::from_secs(10)))
         .expect("set read timeout");
     let mut buf = Vec::new();
     let mut chunk = [0u8; 4096];
-    while let Ok(n) = stream.read(&mut chunk) {
-        if n == 0 {
-            break;
-        }
+    let (header_end, content_length) = loop {
+        let n = stream.read(&mut chunk).expect("read HTTP request");
+        assert!(n != 0, "connection closed before complete HTTP request");
         buf.extend_from_slice(&chunk[..n]);
         let Some(header_end) = find_double_crlf(&buf) else {
             continue;
@@ -36,19 +40,30 @@ pub fn drain_http_request(stream: &mut TcpStream) {
                     .flatten()
             })
             .unwrap_or(0);
-        let body_so_far = buf.len() - (header_end + 4);
-        let mut remaining = content_length.saturating_sub(body_so_far);
-        while remaining > 0 {
-            let Ok(n) = stream.read(&mut chunk) else {
-                break;
-            };
-            if n == 0 {
-                break;
-            }
-            remaining = remaining.saturating_sub(n);
+        if buf.len() >= header_end + 4 + content_length {
+            break (header_end, content_length);
         }
-        break;
+    };
+
+    let header_text = String::from_utf8_lossy(&buf[..header_end]);
+    let request_line = header_text.lines().next().expect("HTTP request line");
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts
+        .next()
+        .expect("HTTP request method")
+        .to_owned();
+    let path = request_parts.next().expect("HTTP request path").to_owned();
+    let body_start = header_end + 4;
+    CannedRequest {
+        method,
+        path,
+        body: buf[body_start..body_start + content_length].to_vec(),
     }
+}
+
+/// Read and discard one complete HTTP request.
+pub fn drain_http_request(stream: &mut TcpStream) {
+    let _ = read_http_request(stream);
 }
 
 fn find_double_crlf(buf: &[u8]) -> Option<usize> {
@@ -60,11 +75,21 @@ fn find_double_crlf(buf: &[u8]) -> Option<usize> {
 ///
 /// Returns the bound port; the caller points a named registry's `api` at it.
 pub fn spawn_canned_response_server(status_line: &'static str, body: &'static str) -> u16 {
+    spawn_recording_canned_response_server(status_line, body).0
+}
+
+/// Spawn a canned server and return the request received by it.
+pub fn spawn_recording_canned_response_server(
+    status_line: &'static str,
+    body: &'static str,
+) -> (u16, Receiver<CannedRequest>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
     let port = listener.local_addr().expect("local_addr").port();
+    let (request_tx, request_rx) = mpsc::channel();
     std::thread::spawn(move || {
         if let Ok((mut stream, _addr)) = listener.accept() {
-            drain_http_request(&mut stream);
+            let request = read_http_request(&mut stream);
+            let _ = request_tx.send(request);
             let response = format!(
                 "HTTP/1.1 {status_line}\r\n\
                  Content-Type: application/json\r\n\
@@ -77,5 +102,5 @@ pub fn spawn_canned_response_server(status_line: &'static str, body: &'static st
             let _ = stream.write_all(response.as_bytes());
         }
     });
-    port
+    (port, request_rx)
 }

--- a/hew-cli/tests/support/mod.rs
+++ b/hew-cli/tests/support/mod.rs
@@ -3,6 +3,7 @@
     reason = "shared integration-test helpers are not used by every test target"
 )]
 
+pub mod http_canned;
 pub mod leak_slope;
 
 use hew_testutil::{BoundedExecError, DEFAULT_EXEC_TIMEOUT};

--- a/hew-pkg/README.md
+++ b/hew-pkg/README.md
@@ -59,6 +59,8 @@ first and link its library as a prerequisite of the package program.
 - `hew login` — Log in to the registry via GitHub
 - `hew logout` — Log out from the registry
 - `hew key generate` — Generate a new Ed25519 signing keypair
+- `hew key register [--registry <NAME>]` — Register the existing local signing key with the registry (requires `hew login`)
+  - `--registry`, `-r` — Use a named registry from config
 - `hew key list` — List registered signing keys
 - `hew key info <FINGERPRINT>` — Look up a signing key by fingerprint
 

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -1679,12 +1679,22 @@ fn cmd_key_register(registry_name: Option<&str>) {
         }
     };
 
+    if let Some(name) = registry_name {
+        resolve_named_registry_or_exit(name);
+    }
     let cred_path = credentials::credentials_path();
-    let Ok(token) = resolve_registry_token(&cred_path, registry_name) else {
-        eprintln!("hew key register: not logged in");
-        eprintln!("Run `hew login` first.");
+    let token = resolve_registry_token(&cred_path, registry_name).unwrap_or_else(|err| {
+        match err {
+            credentials::CredentialError::NotLoggedIn => {
+                eprintln!("hew key register: not logged in");
+                eprintln!("Run `hew login` first.");
+            }
+            credentials::CredentialError::Parse(_) | credentials::CredentialError::Io(_) => {
+                eprintln!("hew key register: {err}");
+            }
+        }
         std::process::exit(1);
-    };
+    });
 
     match register_signing_key(registry_name, token, &keypair.public_key_base64()) {
         Ok(fp) => println!("Key registered with registry (fingerprint: {fp})"),

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -176,6 +176,12 @@ pub enum IndexAction {
 pub enum KeyAction {
     /// Generate a new Ed25519 signing keypair
     Generate,
+    /// Register the existing local signing key with the registry
+    Register {
+        /// Use a named registry from config
+        #[arg(long, short = 'r')]
+        registry: Option<String>,
+    },
     /// List registered signing keys
     List,
     /// Look up a signing key by fingerprint
@@ -247,6 +253,7 @@ pub fn dispatch(cmd: &PkgCommand) {
         PkgCommand::Logout => cmd_logout(),
         PkgCommand::Key { action } => match action {
             KeyAction::Generate => cmd_key_generate(),
+            KeyAction::Register { registry: reg } => cmd_key_register(reg.as_deref()),
             KeyAction::List => cmd_key_list(),
             KeyAction::Info { fingerprint } => cmd_key_info(fingerprint),
             KeyAction::Registry => cmd_registry_key(),
@@ -342,7 +349,7 @@ fn make_client(registry_name: Option<&str>) -> client::RegistryClient {
     }
 }
 
-/// Resolve the API token required for a remote publish.
+/// Resolve the API token required for an authenticated registry call.
 ///
 /// Injecting `cred_path` keeps this unit-testable without `$HOME` mutation.
 ///
@@ -352,7 +359,7 @@ fn make_client(registry_name: Option<&str>) -> client::RegistryClient {
 /// stored for the target registry (default or named), or
 /// [`credentials::CredentialError::Parse`]/[`credentials::CredentialError::Io`]
 /// when the credentials file exists but cannot be read.
-fn resolve_publish_token(
+fn resolve_registry_token(
     cred_path: &Path,
     registry_name: Option<&str>,
 ) -> Result<String, credentials::CredentialError> {
@@ -991,7 +998,7 @@ fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>, local
         }
         let cred_path = credentials::credentials_path();
         Some(
-            resolve_publish_token(&cred_path, registry_name).unwrap_or_else(|err| {
+            resolve_registry_token(&cred_path, registry_name).unwrap_or_else(|err| {
                 match err {
                     credentials::CredentialError::NotLoggedIn => {
                         eprintln!(
@@ -1602,7 +1609,8 @@ fn cmd_key_generate() {
             "hew key generate: key already exists at {}",
             secret_path.display()
         );
-        eprintln!("Remove it first if you want to regenerate.");
+        eprintln!("Run `hew key register` to register it with the registry,");
+        eprintln!("or remove it first if you want to regenerate.");
         std::process::exit(1);
     }
 
@@ -1617,16 +1625,73 @@ fn cmd_key_generate() {
     println!("  Public:  {}", key_dir.join("id_ed25519.pub").display());
     println!("  Fingerprint: {}", keypair.fingerprint());
 
-    // Try to register the key with the registry.
+    // Try to register the key with the registry. A generated key is usable
+    // for local work without registration, so a failure here is reported and
+    // recovered with `hew key register` rather than losing the new key.
     let cred_path = credentials::credentials_path();
-    if let Ok(token) = credentials::get_token(&cred_path) {
-        let api_client = client::RegistryClient::new().with_token(token);
-        match api_client.register_key(&keypair.public_key_base64()) {
+    if let Ok(token) = resolve_registry_token(&cred_path, None) {
+        match register_signing_key(None, token, &keypair.public_key_base64()) {
             Ok(fp) => println!("Key registered with registry (fingerprint: {fp})"),
-            Err(e) => eprintln!("warning: could not register key with registry: {e}"),
+            Err(e) => {
+                eprintln!("warning: could not register key with registry: {e}");
+                eprintln!("Run `hew key register` once the registry is reachable.");
+            }
         }
     } else {
-        println!("Run `hew login` and re-run to register this key with the registry.");
+        println!("Run `hew login`, then `hew key register`, to register this key.");
+    }
+}
+
+/// Send a public key to a registry's key endpoint.
+///
+/// The one path by which a signing key becomes known to a registry: `hew key
+/// generate` calls it for a key it just created, `hew key register` calls it
+/// for a key that already exists on disk.
+fn register_signing_key(
+    registry_name: Option<&str>,
+    token: String,
+    public_key_b64: &str,
+) -> Result<String, client::ApiError> {
+    let api_client = match registry_name {
+        Some(name) => {
+            let remote = resolve_named_registry_or_exit(name);
+            client::RegistryClient::with_url(remote.api)
+        }
+        None => client::RegistryClient::new(),
+    }
+    .with_token(token);
+    api_client.register_key(public_key_b64)
+}
+
+/// Register the signing key already on disk with the registry.
+///
+/// Publishing signs with `~/.hew/keys/id_ed25519`, and the registry rejects a
+/// signature from a key it does not know. Before this command the only way to
+/// register an existing key was to delete it and generate another, which
+/// invalidates every signature the old key ever made.
+fn cmd_key_register(registry_name: Option<&str>) {
+    let key_dir = signing::default_key_dir();
+    let keypair = match signing::load_keypair(&key_dir) {
+        Ok(kp) => kp,
+        Err(e) => {
+            eprintln!("hew key register: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let cred_path = credentials::credentials_path();
+    let Ok(token) = resolve_registry_token(&cred_path, registry_name) else {
+        eprintln!("hew key register: not logged in");
+        eprintln!("Run `hew login` first.");
+        std::process::exit(1);
+    };
+
+    match register_signing_key(registry_name, token, &keypair.public_key_base64()) {
+        Ok(fp) => println!("Key registered with registry (fingerprint: {fp})"),
+        Err(e) => {
+            eprintln!("hew key register: {e}");
+            std::process::exit(1);
+        }
     }
 }
 
@@ -2270,10 +2335,10 @@ mod tests {
     }
 
     #[test]
-    fn resolve_publish_token_default_registry_missing_is_not_logged_in() {
+    fn resolve_registry_token_default_registry_missing_is_not_logged_in() {
         let dir = tempfile::tempdir().unwrap();
         let cred_path = dir.path().join("credentials.toml");
-        let result = resolve_publish_token(&cred_path, None);
+        let result = resolve_registry_token(&cred_path, None);
         assert!(matches!(
             result,
             Err(credentials::CredentialError::NotLoggedIn)
@@ -2281,7 +2346,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_publish_token_named_registry_requires_named_token() {
+    fn resolve_registry_token_named_registry_requires_named_token() {
         let dir = tempfile::tempdir().unwrap();
         let cred_path = dir.path().join("credentials.toml");
         credentials::save_credentials(
@@ -2296,7 +2361,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = resolve_publish_token(&cred_path, Some("testreg"));
+        let result = resolve_registry_token(&cred_path, Some("testreg"));
         assert!(matches!(
             result,
             Err(credentials::CredentialError::NotLoggedIn)
@@ -2304,7 +2369,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_publish_token_named_registry_returns_named_token() {
+    fn resolve_registry_token_named_registry_returns_named_token() {
         let dir = tempfile::tempdir().unwrap();
         let cred_path = dir.path().join("credentials.toml");
         let mut registries = std::collections::BTreeMap::new();
@@ -2324,7 +2389,7 @@ mod tests {
         )
         .unwrap();
 
-        let token = resolve_publish_token(&cred_path, Some("testreg")).unwrap();
+        let token = resolve_registry_token(&cred_path, Some("testreg")).unwrap();
         assert_eq!(token, "tok_testreg");
     }
 
@@ -2333,18 +2398,18 @@ mod tests {
     /// different remedies (`hew login` cannot fix a parse error, since
     /// `hew login` also reads through this same file).
     #[test]
-    fn resolve_publish_token_corrupt_credentials_file_is_parse_error() {
+    fn resolve_registry_token_corrupt_credentials_file_is_parse_error() {
         let dir = tempfile::tempdir().unwrap();
         let cred_path = dir.path().join("credentials.toml");
         std::fs::write(&cred_path, "this is not valid toml {{{").unwrap();
 
-        let result = resolve_publish_token(&cred_path, None);
+        let result = resolve_registry_token(&cred_path, None);
         assert!(
             matches!(result, Err(credentials::CredentialError::Parse(_))),
             "expected Parse error, got {result:?}"
         );
 
-        let result = resolve_publish_token(&cred_path, Some("testreg"));
+        let result = resolve_registry_token(&cred_path, Some("testreg"));
         assert!(
             matches!(result, Err(credentials::CredentialError::Parse(_))),
             "expected Parse error, got {result:?}"

--- a/scripts/assert-playground-release-image.sh
+++ b/scripts/assert-playground-release-image.sh
@@ -3,10 +3,10 @@
 # container registry and that its image config binds the exact release commit.
 #
 # This is the release's acquisition contract: whoever publishes the image -
-# the playground repository's Actions workflow, or a maintainer running
-# `HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version> PLAYGROUND_RELEASE_IMAGE=<image> make release-candidate-publish` from a playground checkout - satisfies the identical assertion. <!-- external-target: hew-lang/playground -->
-# That pre-tag candidate target uses candidate authority. The post-tag
-# release-publish target uses publish authority and is a separate operation.
+# the playground repository's Actions workflow, or a maintainer running the
+# direct, sanitized `scripts/publish-release-image.sh candidate` entrypoint from
+# its pinned clean checkout - satisfies the identical assertion. Post-tag
+# publication uses `scripts/publish-release-image.sh publish` and publish authority.
 # The script observes only; it never publishes or mutates.
 #
 # Inputs (environment):

--- a/scripts/assert-playground-release-image.sh
+++ b/scripts/assert-playground-release-image.sh
@@ -4,8 +4,10 @@
 #
 # This is the release's acquisition contract: whoever publishes the image -
 # the playground repository's Actions workflow, or a maintainer running
-# `make release-publish` from a playground checkout - satisfies the identical  # external: hew-lang/playground
-# assertion. The script observes only; it never publishes or mutates.
+# `make release-candidate-publish HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version>` from a playground checkout - satisfies the identical assertion. <!-- external-target: hew-lang/playground -->
+# That pre-tag candidate target uses candidate authority. The post-tag
+# release-publish target uses publish authority and is a separate operation.
+# The script observes only; it never publishes or mutates.
 #
 # Inputs (environment):
 #   IMAGE_REPOSITORY       registry repository, e.g. `hew-lang/playground`

--- a/scripts/assert-playground-release-image.sh
+++ b/scripts/assert-playground-release-image.sh
@@ -2,30 +2,30 @@
 # Assert that the playground release image for a Hew release tag exists in the
 # container registry and that its image config binds the exact release commit.
 #
-# This is the release's acquisition contract: whoever publishes the image —
+# This is the release's acquisition contract: whoever publishes the image -
 # the playground repository's Actions workflow, or a maintainer running
-# `make release-publish` from a playground checkout — satisfies the identical  # external: hew-lang/playground
-# assertion. The script observes only; it never publishes, never mutates, and
-# never succeeds on a missing or mismatched image.
-#
-# The image config label `org.opencontainers.image.revision` carries the
-# 40-character hew commit the image's toolchain and examples were built from.
-# Every image manifest under the tag (one per platform) must carry it and every
-# one must agree with the release commit.
+# `make release-publish` from a playground checkout - satisfies the identical  # external: hew-lang/playground
+# assertion. The script observes only; it never publishes or mutates.
 #
 # Inputs (environment):
 #   IMAGE_REPOSITORY       registry repository, e.g. `hew-lang/playground`
 #   IMAGE_TAG              image tag to assert, e.g. `v0.6.0-rc2`
 #   EXPECTED_REVISION      exact lowercase 40-character hew commit SHA
-#   REGISTRY_TOKEN         token with pull access to IMAGE_REPOSITORY
-#   DEADLINE_MINUTES       whole minutes to wait for the manifest to appear
+#   GHCR_TOKEN             token with pull access to IMAGE_REPOSITORY. Local
+#                          GHCR runs require a classic PAT with read:packages.
+#   DEADLINE_MINUTES       whole minutes to wait (local use)
+#   DEADLINE_EPOCH         absolute Unix deadline (workflow use)
 #   IMAGE_REGISTRY         registry host (default: ghcr.io)
+#   IMAGE_REGISTRY_SCHEME  registry URL scheme (default: https)
+#   GHCR_USERNAME          registry username (default: GITHUB_ACTOR or USER)
 #   POLL_INTERVAL_SECONDS  seconds between manifest polls (default: 20)
 set -euo pipefail
 
 readonly REVISION_LABEL="org.opencontainers.image.revision"
 readonly MANIFEST_ACCEPT="application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json"
 readonly CONFIG_ACCEPT="application/vnd.oci.image.config.v1+json,application/vnd.docker.container.image.v1+json"
+readonly CURL_CONNECT_TIMEOUT_SECONDS=5
+readonly CURL_MAX_TIME_SECONDS=20
 
 fail() {
     echo "assert-playground-release-image: $*" >&2
@@ -33,9 +33,11 @@ fail() {
 }
 
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io}"
+IMAGE_REGISTRY_SCHEME="${IMAGE_REGISTRY_SCHEME:-https}"
+GHCR_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-${USER:-}}}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-20}"
 
-for var in IMAGE_REPOSITORY IMAGE_TAG EXPECTED_REVISION REGISTRY_TOKEN DEADLINE_MINUTES; do
+for var in IMAGE_REPOSITORY IMAGE_TAG EXPECTED_REVISION GHCR_TOKEN GHCR_USERNAME; do
     if [ -z "${!var:-}" ]; then
         fail "${var} must be set"
     fi
@@ -44,113 +46,174 @@ done
 if ! [[ "${EXPECTED_REVISION}" =~ ^[0-9a-f]{40}$ ]]; then
     fail "EXPECTED_REVISION must be an exact lowercase 40-character commit SHA, got '${EXPECTED_REVISION}'"
 fi
-if ! [[ "${DEADLINE_MINUTES}" =~ ^[0-9]+$ ]]; then
+if [ -n "${DEADLINE_EPOCH:-}" ] && [ -n "${DEADLINE_MINUTES:-}" ]; then
+    fail "set only one of DEADLINE_EPOCH or DEADLINE_MINUTES"
+fi
+if [ -z "${DEADLINE_EPOCH:-}" ] && [ -z "${DEADLINE_MINUTES:-}" ]; then
+    fail "DEADLINE_EPOCH or DEADLINE_MINUTES must be set"
+fi
+if [ -n "${DEADLINE_EPOCH:-}" ] && ! [[ "${DEADLINE_EPOCH}" =~ ^[0-9]+$ ]]; then
+    fail "DEADLINE_EPOCH must be a Unix timestamp, got '${DEADLINE_EPOCH}'"
+fi
+if [ -n "${DEADLINE_MINUTES:-}" ] && ! [[ "${DEADLINE_MINUTES}" =~ ^[0-9]+$ ]]; then
     fail "DEADLINE_MINUTES must be a whole number of minutes, got '${DEADLINE_MINUTES}'"
 fi
 if ! [[ "${POLL_INTERVAL_SECONDS}" =~ ^[0-9]+$ ]] || [ "${POLL_INTERVAL_SECONDS}" -lt 1 ]; then
     fail "POLL_INTERVAL_SECONDS must be a positive whole number, got '${POLL_INTERVAL_SECONDS}'"
 fi
+if [ "${IMAGE_REGISTRY_SCHEME}" != "https" ] &&
+    { [ "${IMAGE_REGISTRY_SCHEME}" != "http" ] || [[ "${IMAGE_REGISTRY}" != 127.0.0.1:* ]]; }; then
+    fail "IMAGE_REGISTRY_SCHEME must be https (http is allowed only for a loopback test registry)"
+fi
 
 readonly IMAGE_REF="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+if [ -n "${DEADLINE_EPOCH:-}" ]; then
+    deadline="${DEADLINE_EPOCH}"
+    deadline_description="the job deadline"
+else
+    deadline=$(($(date +%s) + DEADLINE_MINUTES * 60))
+    deadline_description="${DEADLINE_MINUTES}m"
+fi
 
-# Mint a short-lived registry pull token. Re-minted on every poll so a long
-# wait cannot outlive the token.
+check_deadline() {
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+        fail "${IMAGE_REF} did not bind ${EXPECTED_REVISION} within ${deadline_description}"
+    fi
+}
+
+curl_before_deadline() {
+    local now remaining max_time connect_timeout
+    now=$(date +%s)
+    remaining=$((deadline - now))
+    if [ "${remaining}" -le 0 ]; then
+        fail "${IMAGE_REF} did not bind ${EXPECTED_REVISION} within ${deadline_description}"
+    fi
+    max_time="${CURL_MAX_TIME_SECONDS}"
+    if [ "${remaining}" -lt "${max_time}" ]; then
+        max_time="${remaining}"
+    fi
+    connect_timeout="${CURL_CONNECT_TIMEOUT_SECONDS}"
+    if [ "${max_time}" -lt "${connect_timeout}" ]; then
+        connect_timeout="${max_time}"
+    fi
+    curl --connect-timeout "${connect_timeout}" --max-time "${max_time}" "$@"
+}
+
 pull_token() {
-    curl -fsS \
-        -u "x-access-token:${REGISTRY_TOKEN}" \
-        "https://${IMAGE_REGISTRY}/token?service=${IMAGE_REGISTRY}&scope=repository:${IMAGE_REPOSITORY}:pull" |
+    curl_before_deadline -fsS \
+        -u "${GHCR_USERNAME}:${GHCR_TOKEN}" \
+        "${IMAGE_REGISTRY_SCHEME}://${IMAGE_REGISTRY}/token?service=${IMAGE_REGISTRY}&scope=repository:${IMAGE_REPOSITORY}:pull" |
         jq -er '.token'
 }
 
 registry_get() {
     local token="$1" path="$2" accept="$3"
-    curl -fsSL \
+    curl_before_deadline -fsSL \
         -H "Authorization: Bearer ${token}" \
         -H "Accept: ${accept}" \
-        "https://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/${path}"
+        "${IMAGE_REGISTRY_SCHEME}://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/${path}"
 }
 
 body_file=$(mktemp)
 trap 'rm -f "${body_file}"' EXIT
 
-# Fetch the tag's manifest, printing the HTTP status. Kept separate from
-# `registry_get` so the poll can tell "not published yet" (404) from "cannot
-# read this repository" (401/403), which no amount of waiting fixes.
 manifest_status() {
-    curl -sSL -o "${body_file}" -w '%{http_code}' \
-        -H "Authorization: Bearer $1" \
+    local token="$1"
+    curl_before_deadline -sSL -o "${body_file}" -w '%{http_code}' \
+        -H "Authorization: Bearer ${token}" \
         -H "Accept: ${MANIFEST_ACCEPT}" \
-        "https://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/manifests/${IMAGE_TAG}"
+        "${IMAGE_REGISTRY_SCHEME}://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/manifests/${IMAGE_TAG}"
 }
 
-deadline=$(($(date +%s) + DEADLINE_MINUTES * 60))
-token=""
-manifest=""
-echo "waiting up to ${DEADLINE_MINUTES}m for ${IMAGE_REF}"
-while :; do
-    if ! token=$(pull_token); then
-        fail "could not obtain a pull token for ${IMAGE_REPOSITORY}; REGISTRY_TOKEN lacks package read access"
+manifest_binds_expected_revision() {
+    local token="$1" manifest="$2" descriptor child_digest child config_digest
+    local annotation platform_os config revision
+    local stale=0
+    local config_digests=()
+
+    jq -e . >/dev/null <<<"${manifest}" ||
+        fail "${IMAGE_REF} returned an invalid manifest document"
+
+    if jq -e 'has("manifests")' >/dev/null <<<"${manifest}"; then
+        while IFS= read -r descriptor; do
+            [ -n "${descriptor}" ] || continue
+            annotation=$(jq -r '.annotations["vnd.docker.reference.type"] // ""' <<<"${descriptor}")
+            if [ "${annotation}" = "attestation-manifest" ]; then
+                continue
+            fi
+            platform_os=$(jq -r '.platform.os // ""' <<<"${descriptor}")
+            child_digest=$(jq -r '.digest // ""' <<<"${descriptor}")
+            if [ -z "${platform_os}" ] || [ "${platform_os}" = "unknown" ]; then
+                fail "${IMAGE_REF} index child ${child_digest:-<missing digest>} has no platform.os and is not marked as an attestation manifest"
+            fi
+            if [ -z "${child_digest}" ]; then
+                fail "${IMAGE_REF} index contains a runnable child with no digest"
+            fi
+            child=$(registry_get "${token}" "manifests/${child_digest}" "${MANIFEST_ACCEPT}") ||
+                fail "could not read image manifest ${child_digest}"
+            config_digest=$(jq -er '.config.digest' <<<"${child}") ||
+                fail "image manifest ${child_digest} has no config descriptor"
+            config_digests+=("${config_digest}")
+        done < <(jq -c '.manifests[]' <<<"${manifest}")
+    else
+        config_digest=$(jq -er '.config.digest' <<<"${manifest}") ||
+            fail "${IMAGE_REF} has no config descriptor"
+        config_digests+=("${config_digest}")
     fi
-    status=$(manifest_status "${token}")
+
+    if [ "${#config_digests[@]}" -eq 0 ]; then
+        fail "${IMAGE_REF} resolves to no runnable image manifest"
+    fi
+
+    for config_digest in "${config_digests[@]}"; do
+        config=$(registry_get "${token}" "blobs/${config_digest}" "${CONFIG_ACCEPT}") ||
+            fail "could not read image config ${config_digest}"
+        revision=$(jq -r --arg label "${REVISION_LABEL}" '.config.Labels[$label] // ""' <<<"${config}")
+        if [ -z "${revision}" ]; then
+            fail "${IMAGE_REF} (config ${config_digest}) carries no ${REVISION_LABEL} label; the publisher must stamp the hew release commit onto the image"
+        fi
+        if [ "${revision}" != "${EXPECTED_REVISION}" ]; then
+            echo "${IMAGE_REF} (config ${config_digest}) still binds ${revision}; waiting for ${EXPECTED_REVISION}" >&2
+            stale=1
+        fi
+    done
+
+    [ "${stale}" -eq 0 ]
+}
+
+echo "waiting until ${deadline} for ${IMAGE_REF} to bind ${EXPECTED_REVISION}"
+while :; do
+    check_deadline
+    if ! token=$(pull_token); then
+        fail "could not obtain a pull token for ${IMAGE_REPOSITORY}; GHCR_TOKEN must be a classic PAT with read:packages for local runs"
+    fi
+    if ! status=$(manifest_status "${token}"); then
+        fail "registry request failed while reading ${IMAGE_REF}"
+    fi
     case "${status}" in
     200)
         manifest=$(cat "${body_file}")
-        break
+        if manifest_binds_expected_revision "${token}" "${manifest}"; then
+            echo "${IMAGE_REF} exists and binds release commit ${EXPECTED_REVISION}"
+            exit 0
+        fi
         ;;
     404) ;;
     401 | 403)
-        fail "REGISTRY_TOKEN cannot read ${IMAGE_REPOSITORY} (HTTP ${status}); grant it package read access"
+        fail "GHCR_TOKEN cannot read ${IMAGE_REPOSITORY} (HTTP ${status}); local runs require a classic PAT with read:packages"
         ;;
     *)
         fail "unexpected HTTP ${status} reading ${IMAGE_REF}"
         ;;
     esac
-    if [ "$(date +%s)" -ge "${deadline}" ]; then
-        fail "${IMAGE_REF} did not appear within ${DEADLINE_MINUTES}m"
+
+    check_deadline
+    remaining_seconds=$((deadline - $(date +%s)))
+    sleep_seconds="${POLL_INTERVAL_SECONDS}"
+    if [ "${remaining_seconds}" -lt "${sleep_seconds}" ]; then
+        sleep_seconds="${remaining_seconds}"
     fi
-    sleep "${POLL_INTERVAL_SECONDS}"
+    if [ "${sleep_seconds}" -gt 0 ]; then
+        sleep "${sleep_seconds}"
+    fi
 done
-echo "manifest present: ${IMAGE_REF}"
-
-# Resolve the image manifests under the tag. A tag may address a single image
-# manifest or an index; attestation manifests carry no runnable config and are
-# excluded.
-config_digests=()
-if jq -e 'has("manifests")' >/dev/null <<<"${manifest}"; then
-    while IFS= read -r child_digest; do
-        [ -n "${child_digest}" ] || continue
-        child=$(registry_get "${token}" "manifests/${child_digest}" "${MANIFEST_ACCEPT}") ||
-            fail "could not read image manifest ${child_digest}"
-        config_digest=$(jq -er '.config.digest' <<<"${child}") ||
-            fail "image manifest ${child_digest} has no config descriptor"
-        config_digests+=("${config_digest}")
-    done < <(jq -r '
-        .manifests[]
-        | select((.platform.os // "unknown") != "unknown")
-        | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
-        | .digest
-    ' <<<"${manifest}")
-else
-    config_digest=$(jq -er '.config.digest' <<<"${manifest}") ||
-        fail "${IMAGE_REF} has no config descriptor"
-    config_digests+=("${config_digest}")
-fi
-
-if [ "${#config_digests[@]}" -eq 0 ]; then
-    fail "${IMAGE_REF} resolves to no runnable image manifest"
-fi
-
-for config_digest in "${config_digests[@]}"; do
-    config=$(registry_get "${token}" "blobs/${config_digest}" "${CONFIG_ACCEPT}") ||
-        fail "could not read image config ${config_digest}"
-    revision=$(jq -r --arg label "${REVISION_LABEL}" '.config.Labels[$label] // ""' <<<"${config}")
-    if [ -z "${revision}" ]; then
-        fail "${IMAGE_REF} (config ${config_digest}) carries no ${REVISION_LABEL} label; the publisher must stamp the hew release commit onto the image"
-    fi
-    if [ "${revision}" != "${EXPECTED_REVISION}" ]; then
-        fail "${IMAGE_REF} (config ${config_digest}) binds ${revision}, expected ${EXPECTED_REVISION}"
-    fi
-    echo "config ${config_digest} binds ${EXPECTED_REVISION}"
-done
-
-echo "${IMAGE_REF} exists and binds release commit ${EXPECTED_REVISION}"

--- a/scripts/assert-playground-release-image.sh
+++ b/scripts/assert-playground-release-image.sh
@@ -4,7 +4,7 @@
 #
 # This is the release's acquisition contract: whoever publishes the image -
 # the playground repository's Actions workflow, or a maintainer running
-# `make release-candidate-publish HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version>` from a playground checkout - satisfies the identical assertion. <!-- external-target: hew-lang/playground -->
+# `HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version> PLAYGROUND_RELEASE_IMAGE=<image> make release-candidate-publish` from a playground checkout - satisfies the identical assertion. <!-- external-target: hew-lang/playground -->
 # That pre-tag candidate target uses candidate authority. The post-tag
 # release-publish target uses publish authority and is a separate operation.
 # The script observes only; it never publishes or mutates.
@@ -111,7 +111,7 @@ pull_token() {
 registry_get() {
     local token="$1" path="$2" accept="$3"
     curl_before_deadline -fsSL \
-        -H "Authorization: Bearer ${token}" \
+        --oauth2-bearer "${token}" \
         -H "Accept: ${accept}" \
         "${IMAGE_REGISTRY_SCHEME}://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/${path}"
 }
@@ -122,7 +122,7 @@ trap 'rm -f "${body_file}"' EXIT
 manifest_status() {
     local token="$1"
     curl_before_deadline -sSL -o "${body_file}" -w '%{http_code}' \
-        -H "Authorization: Bearer ${token}" \
+        --oauth2-bearer "${token}" \
         -H "Accept: ${MANIFEST_ACCEPT}" \
         "${IMAGE_REGISTRY_SCHEME}://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/manifests/${IMAGE_TAG}"
 }

--- a/scripts/assert-playground-release-image.sh
+++ b/scripts/assert-playground-release-image.sh
@@ -4,7 +4,7 @@
 #
 # This is the release's acquisition contract: whoever publishes the image —
 # the playground repository's Actions workflow, or a maintainer running
-# `make release-publish` from a playground checkout — satisfies the identical
+# `make release-publish` from a playground checkout — satisfies the identical  # external: hew-lang/playground
 # assertion. The script observes only; it never publishes, never mutates, and
 # never succeeds on a missing or mismatched image.
 #

--- a/scripts/assert-playground-release-image.sh
+++ b/scripts/assert-playground-release-image.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 # Assert that the playground release image for a Hew release tag exists in the
-# container registry and that its image config binds the exact release commit.
+# container registry and that its immutable digest, target platform, and image
+# config bind the exact release commit.
 #
-# This is the release's acquisition contract: whoever publishes the image -
-# the playground repository's Actions workflow, or a maintainer running the
-# direct, sanitized `scripts/publish-release-image.sh candidate` entrypoint from
-# its pinned clean checkout - satisfies the identical assertion. Post-tag
-# publication uses `scripts/publish-release-image.sh publish` and publish authority.
+# This is the release's handoff contract. A maintainer runs the direct,
+# sanitized `scripts/publish-release-image.sh candidate` entrypoint from a pinned
+# clean checkout, records the pushed digest, and only then creates the tag.
 # The script observes only; it never publishes or mutates.
 #
 # Inputs (environment):
 #   IMAGE_REPOSITORY       registry repository, e.g. `hew-lang/playground`
 #   IMAGE_TAG              image tag to assert, e.g. `v0.6.0-rc2`
+#   EXPECTED_DIGEST        exact immutable manifest/index sha256 digest
+#   EXPECTED_PLATFORM      exact normalized platform (required: linux/amd64)
 #   EXPECTED_REVISION      exact lowercase 40-character hew commit SHA
 #   GHCR_TOKEN             token with pull access to IMAGE_REPOSITORY. Local
 #                          GHCR runs require a classic PAT with read:packages.
@@ -39,7 +40,7 @@ IMAGE_REGISTRY_SCHEME="${IMAGE_REGISTRY_SCHEME:-https}"
 GHCR_USERNAME="${GHCR_USERNAME:-${GITHUB_ACTOR:-${USER:-}}}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-20}"
 
-for var in IMAGE_REPOSITORY IMAGE_TAG EXPECTED_REVISION GHCR_TOKEN GHCR_USERNAME; do
+for var in IMAGE_REPOSITORY IMAGE_TAG EXPECTED_DIGEST EXPECTED_PLATFORM EXPECTED_REVISION GHCR_TOKEN GHCR_USERNAME; do
     if [ -z "${!var:-}" ]; then
         fail "${var} must be set"
     fi
@@ -48,6 +49,14 @@ done
 if ! [[ "${EXPECTED_REVISION}" =~ ^[0-9a-f]{40}$ ]]; then
     fail "EXPECTED_REVISION must be an exact lowercase 40-character commit SHA, got '${EXPECTED_REVISION}'"
 fi
+if ! [[ "${EXPECTED_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    fail "EXPECTED_DIGEST must be sha256 followed by exactly 64 lowercase hexadecimal digits"
+fi
+if [ "${EXPECTED_PLATFORM}" != "linux/amd64" ]; then
+    fail "EXPECTED_PLATFORM must be exactly linux/amd64"
+fi
+readonly EXPECTED_OS="${EXPECTED_PLATFORM%%/*}"
+readonly EXPECTED_ARCH="${EXPECTED_PLATFORM#*/}"
 if [ -n "${DEADLINE_EPOCH:-}" ] && [ -n "${DEADLINE_MINUTES:-}" ]; then
     fail "set only one of DEADLINE_EPOCH or DEADLINE_MINUTES"
 fi
@@ -69,6 +78,7 @@ if [ "${IMAGE_REGISTRY_SCHEME}" != "https" ] &&
 fi
 
 readonly IMAGE_REF="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+readonly IMMUTABLE_IMAGE_REF="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}@${EXPECTED_DIGEST}"
 if [ -n "${DEADLINE_EPOCH:-}" ]; then
     deadline="${DEADLINE_EPOCH}"
     deadline_description="the job deadline"
@@ -117,20 +127,29 @@ registry_get() {
 }
 
 body_file=$(mktemp)
-trap 'rm -f "${body_file}"' EXIT
+headers_file=$(mktemp)
+trap 'rm -f "${body_file}" "${headers_file}"' EXIT
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
 
 manifest_status() {
     local token="$1"
-    curl_before_deadline -sSL -o "${body_file}" -w '%{http_code}' \
+    : >"${headers_file}"
+    curl_before_deadline -sSL -D "${headers_file}" -o "${body_file}" -w '%{http_code}' \
         --oauth2-bearer "${token}" \
         -H "Accept: ${MANIFEST_ACCEPT}" \
         "${IMAGE_REGISTRY_SCHEME}://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/manifests/${IMAGE_TAG}"
 }
 
-manifest_binds_expected_revision() {
+manifest_binds_expected_identity() {
     local token="$1" manifest="$2" descriptor child_digest child config_digest
-    local annotation platform_os config revision
-    local stale=0
+    local annotation platform_os platform_arch config config_os config_arch revision
     local config_digests=()
 
     jq -e . >/dev/null <<<"${manifest}" ||
@@ -144,12 +163,16 @@ manifest_binds_expected_revision() {
                 continue
             fi
             platform_os=$(jq -r '.platform.os // ""' <<<"${descriptor}")
+            platform_arch=$(jq -r '.platform.architecture // ""' <<<"${descriptor}")
             child_digest=$(jq -r '.digest // ""' <<<"${descriptor}")
             if [ -z "${platform_os}" ] || [ "${platform_os}" = "unknown" ]; then
                 fail "${IMAGE_REF} index child ${child_digest:-<missing digest>} has no platform.os and is not marked as an attestation manifest"
             fi
-            if [ -z "${child_digest}" ]; then
-                fail "${IMAGE_REF} index contains a runnable child with no digest"
+            if ! [[ "${child_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                fail "${IMAGE_REF} index contains a runnable child with an invalid digest"
+            fi
+            if [ "${platform_os}" != "${EXPECTED_OS}" ] || [ "${platform_arch}" != "${EXPECTED_ARCH}" ]; then
+                continue
             fi
             child=$(registry_get "${token}" "manifests/${child_digest}" "${MANIFEST_ACCEPT}") ||
                 fail "could not read image manifest ${child_digest}"
@@ -163,27 +186,32 @@ manifest_binds_expected_revision() {
         config_digests+=("${config_digest}")
     fi
 
-    if [ "${#config_digests[@]}" -eq 0 ]; then
-        fail "${IMAGE_REF} resolves to no runnable image manifest"
+    if [ "${#config_digests[@]}" -ne 1 ]; then
+        fail "${IMMUTABLE_IMAGE_REF} must resolve to exactly one ${EXPECTED_PLATFORM} image manifest"
     fi
 
     for config_digest in "${config_digests[@]}"; do
+        if ! [[ "${config_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            fail "image manifest has an invalid config digest"
+        fi
         config=$(registry_get "${token}" "blobs/${config_digest}" "${CONFIG_ACCEPT}") ||
             fail "could not read image config ${config_digest}"
+        config_os=$(jq -r '.os // ""' <<<"${config}")
+        config_arch=$(jq -r '.architecture // ""' <<<"${config}")
+        if [ "${config_os}/${config_arch}" != "${EXPECTED_PLATFORM}" ]; then
+            fail "${IMMUTABLE_IMAGE_REF} config is ${config_os:-<missing>}/${config_arch:-<missing>}, not ${EXPECTED_PLATFORM}"
+        fi
         revision=$(jq -r --arg label "${REVISION_LABEL}" '.config.Labels[$label] // ""' <<<"${config}")
         if [ -z "${revision}" ]; then
             fail "${IMAGE_REF} (config ${config_digest}) carries no ${REVISION_LABEL} label; the publisher must stamp the hew release commit onto the image"
         fi
         if [ "${revision}" != "${EXPECTED_REVISION}" ]; then
-            echo "${IMAGE_REF} (config ${config_digest}) still binds ${revision}; waiting for ${EXPECTED_REVISION}" >&2
-            stale=1
+            fail "${IMMUTABLE_IMAGE_REF} (config ${config_digest}) binds ${revision}, not ${EXPECTED_REVISION}"
         fi
     done
-
-    [ "${stale}" -eq 0 ]
 }
 
-echo "waiting until ${deadline} for ${IMAGE_REF} to bind ${EXPECTED_REVISION}"
+echo "waiting until ${deadline} for ${IMAGE_REF} to resolve to ${EXPECTED_DIGEST}"
 while :; do
     check_deadline
     if ! token=$(pull_token); then
@@ -194,11 +222,24 @@ while :; do
     fi
     case "${status}" in
     200)
-        manifest=$(cat "${body_file}")
-        if manifest_binds_expected_revision "${token}" "${manifest}"; then
-            echo "${IMAGE_REF} exists and binds release commit ${EXPECTED_REVISION}"
-            exit 0
+        registry_digest=$(awk '
+            tolower($1) == "docker-content-digest:" {
+                value=$2
+                sub(/\r$/, "", value)
+                print value
+            }
+        ' "${headers_file}" | tail -n 1)
+        if [ "${registry_digest}" != "${EXPECTED_DIGEST}" ]; then
+            fail "${IMAGE_REF} registry digest is ${registry_digest:-<missing>}, not ${EXPECTED_DIGEST}"
         fi
+        raw_digest="sha256:$(sha256_file "${body_file}")"
+        if [ "${raw_digest}" != "${EXPECTED_DIGEST}" ]; then
+            fail "${IMAGE_REF} raw manifest digest is ${raw_digest}, not ${EXPECTED_DIGEST}"
+        fi
+        manifest=$(cat "${body_file}")
+        manifest_binds_expected_identity "${token}" "${manifest}"
+        echo "${IMMUTABLE_IMAGE_REF} is ${EXPECTED_PLATFORM} and binds release commit ${EXPECTED_REVISION}"
+        exit 0
         ;;
     404) ;;
     401 | 403)

--- a/scripts/assert-playground-release-image.sh
+++ b/scripts/assert-playground-release-image.sh
@@ -27,6 +27,9 @@ set -euo pipefail
 readonly REVISION_LABEL="org.opencontainers.image.revision"
 readonly MANIFEST_ACCEPT="application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json"
 readonly CONFIG_ACCEPT="application/vnd.oci.image.config.v1+json,application/vnd.docker.container.image.v1+json"
+readonly OCI_IMAGE_MANIFEST="application/vnd.oci.image.manifest.v1+json"
+readonly DOCKER_IMAGE_MANIFEST="application/vnd.docker.distribution.manifest.v2+json"
+readonly ATTESTATION_TYPE="attestation-manifest"
 readonly CURL_CONNECT_TIMEOUT_SECONDS=5
 readonly CURL_MAX_TIME_SECONDS=20
 
@@ -55,8 +58,6 @@ fi
 if [ "${EXPECTED_PLATFORM}" != "linux/amd64" ]; then
     fail "EXPECTED_PLATFORM must be exactly linux/amd64"
 fi
-readonly EXPECTED_OS="${EXPECTED_PLATFORM%%/*}"
-readonly EXPECTED_ARCH="${EXPECTED_PLATFORM#*/}"
 if [ -n "${DEADLINE_EPOCH:-}" ] && [ -n "${DEADLINE_MINUTES:-}" ]; then
     fail "set only one of DEADLINE_EPOCH or DEADLINE_MINUTES"
 fi
@@ -118,17 +119,19 @@ pull_token() {
         jq -er '.token'
 }
 
-registry_get() {
-    local token="$1" path="$2" accept="$3"
+registry_get_to_file() {
+    local token="$1" path="$2" accept="$3" output_file="$4"
     curl_before_deadline -fsSL \
+        -o "${output_file}" \
         --oauth2-bearer "${token}" \
         -H "Accept: ${accept}" \
         "${IMAGE_REGISTRY_SCHEME}://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/${path}"
 }
 
-body_file=$(mktemp)
-headers_file=$(mktemp)
-trap 'rm -f "${body_file}" "${headers_file}"' EXIT
+work_dir=$(mktemp -d)
+body_file="${work_dir}/manifest"
+headers_file="${work_dir}/headers"
+trap 'rm -rf -- "${work_dir}"' EXIT
 
 sha256_file() {
     if command -v sha256sum >/dev/null 2>&1; then
@@ -148,40 +151,62 @@ manifest_status() {
 }
 
 manifest_binds_expected_identity() {
-    local token="$1" manifest="$2" descriptor child_digest child config_digest
-    local annotation platform_os platform_arch config config_os config_arch revision
+    local token="$1" manifest_file="$2" descriptor child_digest config_digest
+    local annotation media_type platform_os platform_arch config_os config_arch revision
+    local child_file config_file raw_digest runnable_count=0 descriptor_count=0
     local config_digests=()
 
-    jq -e . >/dev/null <<<"${manifest}" ||
+    jq -e . "${manifest_file}" >/dev/null ||
         fail "${IMAGE_REF} returned an invalid manifest document"
 
-    if jq -e 'has("manifests")' >/dev/null <<<"${manifest}"; then
+    if jq -e 'has("manifests")' "${manifest_file}" >/dev/null; then
         while IFS= read -r descriptor; do
             [ -n "${descriptor}" ] || continue
+            descriptor_count=$((descriptor_count + 1))
             annotation=$(jq -r '.annotations["vnd.docker.reference.type"] // ""' <<<"${descriptor}")
-            if [ "${annotation}" = "attestation-manifest" ]; then
-                continue
-            fi
+            media_type=$(jq -r '.mediaType // ""' <<<"${descriptor}")
             platform_os=$(jq -r '.platform.os // ""' <<<"${descriptor}")
             platform_arch=$(jq -r '.platform.architecture // ""' <<<"${descriptor}")
             child_digest=$(jq -r '.digest // ""' <<<"${descriptor}")
-            if [ -z "${platform_os}" ] || [ "${platform_os}" = "unknown" ]; then
-                fail "${IMAGE_REF} index child ${child_digest:-<missing digest>} has no platform.os and is not marked as an attestation manifest"
-            fi
             if ! [[ "${child_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-                fail "${IMAGE_REF} index contains a runnable child with an invalid digest"
+                fail "${IMAGE_REF} index child has an invalid digest"
             fi
-            if [ "${platform_os}" != "${EXPECTED_OS}" ] || [ "${platform_arch}" != "${EXPECTED_ARCH}" ]; then
+            if [ "${annotation}" = "${ATTESTATION_TYPE}" ]; then
+                if [ "${platform_os}/${platform_arch}" != "unknown/unknown" ] ||
+                    [ "${media_type}" != "${OCI_IMAGE_MANIFEST}" ]; then
+                    fail "${IMAGE_REF} index child ${child_digest} is not a narrowly recognized non-runnable attestation descriptor"
+                fi
                 continue
             fi
-            child=$(registry_get "${token}" "manifests/${child_digest}" "${MANIFEST_ACCEPT}") ||
+            if [ -z "${platform_os}" ] || [ "${platform_os}" = "unknown" ]; then
+                fail "${IMAGE_REF} index child ${child_digest} has no runnable platform and is not marked as an attestation manifest"
+            fi
+            if [ "${media_type}" != "${OCI_IMAGE_MANIFEST}" ] &&
+                [ "${media_type}" != "${DOCKER_IMAGE_MANIFEST}" ]; then
+                fail "${IMAGE_REF} runnable index child ${child_digest} has unsupported mediaType '${media_type:-<missing>}'"
+            fi
+            runnable_count=$((runnable_count + 1))
+            if [ "${platform_os}/${platform_arch}" != "${EXPECTED_PLATFORM}" ]; then
+                fail "${IMMUTABLE_IMAGE_REF} contains additional runnable platform ${platform_os:-<missing>}/${platform_arch:-<missing>}; expected exactly one ${EXPECTED_PLATFORM} image manifest"
+            fi
+            child_file="${work_dir}/child-${descriptor_count}"
+            registry_get_to_file "${token}" "manifests/${child_digest}" "${MANIFEST_ACCEPT}" "${child_file}" ||
                 fail "could not read image manifest ${child_digest}"
-            config_digest=$(jq -er '.config.digest' <<<"${child}") ||
+            raw_digest="sha256:$(sha256_file "${child_file}")"
+            if [ "${raw_digest}" != "${child_digest}" ]; then
+                fail "image manifest ${child_digest} raw response digest is ${raw_digest}, not its descriptor digest"
+            fi
+            jq -e . "${child_file}" >/dev/null ||
+                fail "image manifest ${child_digest} returned an invalid document"
+            config_digest=$(jq -er '.config.digest' "${child_file}") ||
                 fail "image manifest ${child_digest} has no config descriptor"
             config_digests+=("${config_digest}")
-        done < <(jq -c '.manifests[]' <<<"${manifest}")
+        done < <(jq -c '.manifests[]' "${manifest_file}")
+        if [ "${runnable_count}" -ne 1 ]; then
+            fail "${IMMUTABLE_IMAGE_REF} must resolve to exactly one ${EXPECTED_PLATFORM} runnable image manifest"
+        fi
     else
-        config_digest=$(jq -er '.config.digest' <<<"${manifest}") ||
+        config_digest=$(jq -er '.config.digest' "${manifest_file}") ||
             fail "${IMAGE_REF} has no config descriptor"
         config_digests+=("${config_digest}")
     fi
@@ -190,18 +215,27 @@ manifest_binds_expected_identity() {
         fail "${IMMUTABLE_IMAGE_REF} must resolve to exactly one ${EXPECTED_PLATFORM} image manifest"
     fi
 
+    descriptor_count=0
     for config_digest in "${config_digests[@]}"; do
+        descriptor_count=$((descriptor_count + 1))
         if ! [[ "${config_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             fail "image manifest has an invalid config digest"
         fi
-        config=$(registry_get "${token}" "blobs/${config_digest}" "${CONFIG_ACCEPT}") ||
+        config_file="${work_dir}/config-${descriptor_count}"
+        registry_get_to_file "${token}" "blobs/${config_digest}" "${CONFIG_ACCEPT}" "${config_file}" ||
             fail "could not read image config ${config_digest}"
-        config_os=$(jq -r '.os // ""' <<<"${config}")
-        config_arch=$(jq -r '.architecture // ""' <<<"${config}")
+        raw_digest="sha256:$(sha256_file "${config_file}")"
+        if [ "${raw_digest}" != "${config_digest}" ]; then
+            fail "image config ${config_digest} raw response digest is ${raw_digest}, not its descriptor digest"
+        fi
+        jq -e . "${config_file}" >/dev/null ||
+            fail "image config ${config_digest} returned an invalid document"
+        config_os=$(jq -r '.os // ""' "${config_file}")
+        config_arch=$(jq -r '.architecture // ""' "${config_file}")
         if [ "${config_os}/${config_arch}" != "${EXPECTED_PLATFORM}" ]; then
             fail "${IMMUTABLE_IMAGE_REF} config is ${config_os:-<missing>}/${config_arch:-<missing>}, not ${EXPECTED_PLATFORM}"
         fi
-        revision=$(jq -r --arg label "${REVISION_LABEL}" '.config.Labels[$label] // ""' <<<"${config}")
+        revision=$(jq -r --arg label "${REVISION_LABEL}" '.config.Labels[$label] // ""' "${config_file}")
         if [ -z "${revision}" ]; then
             fail "${IMAGE_REF} (config ${config_digest}) carries no ${REVISION_LABEL} label; the publisher must stamp the hew release commit onto the image"
         fi
@@ -236,8 +270,7 @@ while :; do
         if [ "${raw_digest}" != "${EXPECTED_DIGEST}" ]; then
             fail "${IMAGE_REF} raw manifest digest is ${raw_digest}, not ${EXPECTED_DIGEST}"
         fi
-        manifest=$(cat "${body_file}")
-        manifest_binds_expected_identity "${token}" "${manifest}"
+        manifest_binds_expected_identity "${token}" "${body_file}"
         echo "${IMMUTABLE_IMAGE_REF} is ${EXPECTED_PLATFORM} and binds release commit ${EXPECTED_REVISION}"
         exit 0
         ;;

--- a/scripts/assert-playground-release-image.sh
+++ b/scripts/assert-playground-release-image.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Assert that the playground release image for a Hew release tag exists in the
+# container registry and that its image config binds the exact release commit.
+#
+# This is the release's acquisition contract: whoever publishes the image —
+# the playground repository's Actions workflow, or a maintainer running
+# `make release-publish` from a playground checkout — satisfies the identical
+# assertion. The script observes only; it never publishes, never mutates, and
+# never succeeds on a missing or mismatched image.
+#
+# The image config label `org.opencontainers.image.revision` carries the
+# 40-character hew commit the image's toolchain and examples were built from.
+# Every image manifest under the tag (one per platform) must carry it and every
+# one must agree with the release commit.
+#
+# Inputs (environment):
+#   IMAGE_REPOSITORY       registry repository, e.g. `hew-lang/playground`
+#   IMAGE_TAG              image tag to assert, e.g. `v0.6.0-rc2`
+#   EXPECTED_REVISION      exact lowercase 40-character hew commit SHA
+#   REGISTRY_TOKEN         token with pull access to IMAGE_REPOSITORY
+#   DEADLINE_MINUTES       whole minutes to wait for the manifest to appear
+#   IMAGE_REGISTRY         registry host (default: ghcr.io)
+#   POLL_INTERVAL_SECONDS  seconds between manifest polls (default: 20)
+set -euo pipefail
+
+readonly REVISION_LABEL="org.opencontainers.image.revision"
+readonly MANIFEST_ACCEPT="application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json"
+readonly CONFIG_ACCEPT="application/vnd.oci.image.config.v1+json,application/vnd.docker.container.image.v1+json"
+
+fail() {
+    echo "assert-playground-release-image: $*" >&2
+    exit 1
+}
+
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-20}"
+
+for var in IMAGE_REPOSITORY IMAGE_TAG EXPECTED_REVISION REGISTRY_TOKEN DEADLINE_MINUTES; do
+    if [ -z "${!var:-}" ]; then
+        fail "${var} must be set"
+    fi
+done
+
+if ! [[ "${EXPECTED_REVISION}" =~ ^[0-9a-f]{40}$ ]]; then
+    fail "EXPECTED_REVISION must be an exact lowercase 40-character commit SHA, got '${EXPECTED_REVISION}'"
+fi
+if ! [[ "${DEADLINE_MINUTES}" =~ ^[0-9]+$ ]]; then
+    fail "DEADLINE_MINUTES must be a whole number of minutes, got '${DEADLINE_MINUTES}'"
+fi
+if ! [[ "${POLL_INTERVAL_SECONDS}" =~ ^[0-9]+$ ]] || [ "${POLL_INTERVAL_SECONDS}" -lt 1 ]; then
+    fail "POLL_INTERVAL_SECONDS must be a positive whole number, got '${POLL_INTERVAL_SECONDS}'"
+fi
+
+readonly IMAGE_REF="${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+
+# Mint a short-lived registry pull token. Re-minted on every poll so a long
+# wait cannot outlive the token.
+pull_token() {
+    curl -fsS \
+        -u "x-access-token:${REGISTRY_TOKEN}" \
+        "https://${IMAGE_REGISTRY}/token?service=${IMAGE_REGISTRY}&scope=repository:${IMAGE_REPOSITORY}:pull" |
+        jq -er '.token'
+}
+
+registry_get() {
+    local token="$1" path="$2" accept="$3"
+    curl -fsSL \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: ${accept}" \
+        "https://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/${path}"
+}
+
+body_file=$(mktemp)
+trap 'rm -f "${body_file}"' EXIT
+
+# Fetch the tag's manifest, printing the HTTP status. Kept separate from
+# `registry_get` so the poll can tell "not published yet" (404) from "cannot
+# read this repository" (401/403), which no amount of waiting fixes.
+manifest_status() {
+    curl -sSL -o "${body_file}" -w '%{http_code}' \
+        -H "Authorization: Bearer $1" \
+        -H "Accept: ${MANIFEST_ACCEPT}" \
+        "https://${IMAGE_REGISTRY}/v2/${IMAGE_REPOSITORY}/manifests/${IMAGE_TAG}"
+}
+
+deadline=$(($(date +%s) + DEADLINE_MINUTES * 60))
+token=""
+manifest=""
+echo "waiting up to ${DEADLINE_MINUTES}m for ${IMAGE_REF}"
+while :; do
+    if ! token=$(pull_token); then
+        fail "could not obtain a pull token for ${IMAGE_REPOSITORY}; REGISTRY_TOKEN lacks package read access"
+    fi
+    status=$(manifest_status "${token}")
+    case "${status}" in
+    200)
+        manifest=$(cat "${body_file}")
+        break
+        ;;
+    404) ;;
+    401 | 403)
+        fail "REGISTRY_TOKEN cannot read ${IMAGE_REPOSITORY} (HTTP ${status}); grant it package read access"
+        ;;
+    *)
+        fail "unexpected HTTP ${status} reading ${IMAGE_REF}"
+        ;;
+    esac
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+        fail "${IMAGE_REF} did not appear within ${DEADLINE_MINUTES}m"
+    fi
+    sleep "${POLL_INTERVAL_SECONDS}"
+done
+echo "manifest present: ${IMAGE_REF}"
+
+# Resolve the image manifests under the tag. A tag may address a single image
+# manifest or an index; attestation manifests carry no runnable config and are
+# excluded.
+config_digests=()
+if jq -e 'has("manifests")' >/dev/null <<<"${manifest}"; then
+    while IFS= read -r child_digest; do
+        [ -n "${child_digest}" ] || continue
+        child=$(registry_get "${token}" "manifests/${child_digest}" "${MANIFEST_ACCEPT}") ||
+            fail "could not read image manifest ${child_digest}"
+        config_digest=$(jq -er '.config.digest' <<<"${child}") ||
+            fail "image manifest ${child_digest} has no config descriptor"
+        config_digests+=("${config_digest}")
+    done < <(jq -r '
+        .manifests[]
+        | select((.platform.os // "unknown") != "unknown")
+        | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+        | .digest
+    ' <<<"${manifest}")
+else
+    config_digest=$(jq -er '.config.digest' <<<"${manifest}") ||
+        fail "${IMAGE_REF} has no config descriptor"
+    config_digests+=("${config_digest}")
+fi
+
+if [ "${#config_digests[@]}" -eq 0 ]; then
+    fail "${IMAGE_REF} resolves to no runnable image manifest"
+fi
+
+for config_digest in "${config_digests[@]}"; do
+    config=$(registry_get "${token}" "blobs/${config_digest}" "${CONFIG_ACCEPT}") ||
+        fail "could not read image config ${config_digest}"
+    revision=$(jq -r --arg label "${REVISION_LABEL}" '.config.Labels[$label] // ""' <<<"${config}")
+    if [ -z "${revision}" ]; then
+        fail "${IMAGE_REF} (config ${config_digest}) carries no ${REVISION_LABEL} label; the publisher must stamp the hew release commit onto the image"
+    fi
+    if [ "${revision}" != "${EXPECTED_REVISION}" ]; then
+        fail "${IMAGE_REF} (config ${config_digest}) binds ${revision}, expected ${EXPECTED_REVISION}"
+    fi
+    echo "config ${config_digest} binds ${EXPECTED_REVISION}"
+done
+
+echo "${IMAGE_REF} exists and binds release commit ${EXPECTED_REVISION}"

--- a/scripts/check-gate-reachability.py
+++ b/scripts/check-gate-reachability.py
@@ -1989,7 +1989,8 @@ _TARGET_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _TARGET_SHAPED_RE = re.compile(r"^[A-Za-z0-9_.]+-[A-Za-z0-9_.-]*$")
 _EXTERNAL_TARGET_ANNOTATION_RE = re.compile(
     r"(?:#\s*external|<!--\s*external-target)\s*:\s*"
-    r"[A-Za-z0-9][A-Za-z0-9._/-]*(?:\s*-->)?\s*$"
+    r"[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*"
+    r"(?:\s*-->)?\s*$"
 )
 
 

--- a/scripts/check-gate-reachability.py
+++ b/scripts/check-gate-reachability.py
@@ -1956,6 +1956,13 @@ def prove_contained(
 # same reason there is none in A1: the first file on it would be the one that
 # needed fixing.
 #
+# EXTERNAL TARGETS. A command for another repository may name a target this
+# Makefile cannot define. Mark that single command's line explicitly with
+# `# external: owner/repo` or `<!-- external-target: owner/repo -->`; A4 then
+# leaves its target to the named repository. The annotation is deliberately
+# same-line and applies only to that line, so an unannotated unknown target
+# remains a finding.
+#
 # THE RESIDUAL. A hyphenated English compound directly after the verb — "make
 # distinct-but-equal keys collide" — is read as a target by the mid-prose rule.
 # That is the price of catching an invocation nobody wrapped in backticks, and it
@@ -1980,6 +1987,10 @@ _COMMAND_END_RE = re.compile(r"[|&;\n)`]")
 _METAVARIABLE_RE = re.compile(r"[<>${}%*\[\]]|\.\.\.")
 _TARGET_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _TARGET_SHAPED_RE = re.compile(r"^[A-Za-z0-9_.]+-[A-Za-z0-9_.-]*$")
+_EXTERNAL_TARGET_ANNOTATION_RE = re.compile(
+    r"(?:#\s*external|<!--\s*external-target)\s*:\s*"
+    r"[A-Za-z0-9][A-Za-z0-9._/-]*(?:\s*-->)?\s*$"
+)
 
 
 @dataclass(frozen=True)
@@ -2121,7 +2132,14 @@ def documented_make_references(root: Path = REPO_ROOT) -> list[MakeReference]:
             text = (root / path).read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
+        external_target_lines = {
+            number
+            for number, line in enumerate(text.splitlines(), start=1)
+            if _EXTERNAL_TARGET_ANNOTATION_RE.search(line)
+        }
         for number, chunk, prose in reader(text):
+            if number in external_target_lines:
+                continue
             for target in make_references_in(chunk, prose):
                 key = (target, f"{path}:{number}")
                 if key not in seen:

--- a/scripts/tests/test_check_gate_reachability.py
+++ b/scripts/tests/test_check_gate_reachability.py
@@ -20,6 +20,7 @@ tests run when they run nowhere, which is the exact failure this file exists
 to make impossible to reintroduce.
 """
 
+import ast
 import importlib.util
 import os
 import re

--- a/scripts/tests/test_check_gate_reachability.py
+++ b/scripts/tests/test_check_gate_reachability.py
@@ -1234,8 +1234,38 @@ def _tests() -> list:
     ]
 
 
+def _assert_runner_covers_every_top_level_test(
+    tests: list[object], source: str
+) -> None:
+    defined = {
+        node.name
+        for node in ast.parse(source).body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    }
+    registered = {test.__name__ for test in tests}
+    assert registered == defined, (
+        f"runner discovery mismatch: missing={sorted(defined - registered)}, "
+        f"extra={sorted(registered - defined)}"
+    )
+
+
+def test_runner_discovery_rejects_an_unregistered_test() -> None:
+    def test_registered() -> None:
+        pass
+
+    source = "def test_registered(): pass\ndef test_omitted(): pass\n"
+    try:
+        _assert_runner_covers_every_top_level_test([test_registered], source)
+    except AssertionError as exc:
+        assert "test_omitted" in str(exc)
+        return
+    raise AssertionError("an unregistered test escaped runner discovery parity")
+
+
 if __name__ == "__main__":
     tests = _tests()
+    _assert_runner_covers_every_top_level_test(tests, Path(__file__).read_text())
     failures = 0
     for test in tests:
         try:

--- a/scripts/tests/test_check_gate_reachability.py
+++ b/scripts/tests/test_check_gate_reachability.py
@@ -909,6 +909,30 @@ def test_a_dead_reference_in_a_tracked_doc_is_found_end_to_end() -> None:
     )
 
 
+def test_an_external_target_annotation_does_not_hide_an_unannotated_target() -> None:
+    # A4 cannot resolve a target owned by another repository, but its exemption
+    # must be explicit and cannot make an otherwise identical local typo pass.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        env = {
+            "GIT_CONFIG_GLOBAL": str(root / "gitconfig"),
+            "GIT_CONFIG_SYSTEM": str(root / "gitconfig"),
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": tmp,
+        }
+        subprocess.run(["git", "init", "-q", tmp], check=True, env=env)
+        (root / "CONTRIBUTING.md").write_text(
+            f"`make {MISSING}` <!-- external-target: hew-lang/playground -->\n"
+            f"`make {MISSING}`\n"
+        )
+        subprocess.run(["git", "add", "CONTRIBUTING.md"], cwd=tmp, check=True, env=env)
+        found = gate.documented_make_references(root)
+    assert [(r.target, r.where) for r in found] == [(MISSING, "CONTRIBUTING.md:2")], (
+        "the external annotation must exempt only its line; an unannotated "
+        f"unknown target must remain a finding, got {found}"
+    )
+
+
 # ── A5: a declared target does work ──────────────────────────────────────────
 #
 # A0..A4 resolve a name. A5 asks whether the name does anything, because a

--- a/scripts/tests/test_check_gate_reachability.py
+++ b/scripts/tests/test_check_gate_reachability.py
@@ -933,6 +933,27 @@ def test_an_external_target_annotation_does_not_hide_an_unannotated_target() -> 
     )
 
 
+def test_an_external_target_annotation_requires_owner_and_repository() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        env = {
+            "GIT_CONFIG_GLOBAL": str(root / "gitconfig"),
+            "GIT_CONFIG_SYSTEM": str(root / "gitconfig"),
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": tmp,
+        }
+        subprocess.run(["git", "init", "-q", tmp], check=True, env=env)
+        (root / "CONTRIBUTING.md").write_text(
+            f"`make {MISSING}` <!-- external-target: playground -->\n"
+        )
+        subprocess.run(["git", "add", "CONTRIBUTING.md"], cwd=tmp, check=True, env=env)
+        found = gate.documented_make_references(root)
+    assert [(r.target, r.where) for r in found] == [(MISSING, "CONTRIBUTING.md:1")], (
+        "a bare external annotation does not identify an owner/repository and "
+        f"must not hide an unknown target, got {found}"
+    )
+
+
 # ── A5: a declared target does work ──────────────────────────────────────────
 #
 # A0..A4 resolve a name. A5 asks whether the name does anything, because a

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -533,18 +533,14 @@ def test_release_image_assertion_rejects_unusable_inputs() -> None:
 
 
 def test_release_image_assertion_accepts_matching_single_manifest() -> None:
-    config_digest = named_digest("config-good")
+    config = image_config({"org.opencontainers.image.revision": HEW_SHA})
+    config_digest = content_digest(config)
     result, requests = run_canned_release_image_assertion(
         {
             "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [
                 (200, image_manifest(config_digest))
             ],
-            f"/v2/hew-lang/playground/blobs/{config_digest}": [
-                (
-                    200,
-                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
-                )
-            ],
+            f"/v2/hew-lang/playground/blobs/{config_digest}": [(200, config)],
         }
     )
     assert result.returncode == 0, result.stderr
@@ -643,15 +639,14 @@ def test_canned_registry_requires_the_current_issued_bearer_token() -> None:
 
 
 def test_release_image_assertion_sends_issued_token_for_manifest_and_config() -> None:
-    config_digest = named_digest("config-issued-token")
+    config = image_config({"org.opencontainers.image.revision": HEW_SHA})
+    config_digest = content_digest(config)
     manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
     config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
     result, requests = run_canned_release_image_assertion(
         {
             manifest_path: [(200, image_manifest(config_digest))],
-            config_path: [
-                (200, image_config({"org.opencontainers.image.revision": HEW_SHA}))
-            ],
+            config_path: [(200, config)],
         }
     )
     assert result.returncode == 0, result.stderr
@@ -721,14 +716,15 @@ def test_release_image_assertion_rejects_a_mutable_tag_digest_immediately() -> N
 
 
 def test_release_image_assertion_rejects_missing_revision_label() -> None:
-    config_digest = named_digest("config-missing-revision")
+    config = image_config({})
+    config_digest = content_digest(config)
     config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
     result, requests = run_canned_release_image_assertion(
         {
             "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [
                 (200, image_manifest(config_digest))
             ],
-            config_path: [(200, image_config({}))],
+            config_path: [(200, config)],
         }
     )
     assert result.returncode != 0
@@ -739,19 +735,15 @@ def test_release_image_assertion_rejects_missing_revision_label() -> None:
 
 def test_release_image_assertion_rejects_wrong_revision_label() -> None:
     wrong_revision = "f" * 40
-    config_digest = named_digest("config-wrong-revision")
+    config = image_config({"org.opencontainers.image.revision": wrong_revision})
+    config_digest = content_digest(config)
     config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
     result, requests = run_canned_release_image_assertion(
         {
             "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [
                 (200, image_manifest(config_digest))
             ],
-            config_path: [
-                (
-                    200,
-                    image_config({"org.opencontainers.image.revision": wrong_revision}),
-                )
-            ],
+            config_path: [(200, config)],
         },
         deadline_epoch=int(time()) + 2,
     )
@@ -761,10 +753,10 @@ def test_release_image_assertion_rejects_wrong_revision_label() -> None:
 
 
 def test_release_image_assertion_rejects_wrong_manifest_platform() -> None:
-    config_digest = named_digest("config-arm64")
-    manifest = image_manifest(config_digest)
     config = image_config({"org.opencontainers.image.revision": HEW_SHA})
     config["architecture"] = "arm64"
+    config_digest = content_digest(config)
+    manifest = image_manifest(config_digest)
     result, _requests = run_canned_release_image_assertion(
         {
             "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, manifest)],
@@ -818,54 +810,143 @@ def test_release_image_assertion_hashes_raw_manifest_bytes() -> None:
 
 
 def test_release_image_assertion_selects_linux_amd64_from_an_index() -> None:
-    child_digests = (named_digest("manifest-amd64"), named_digest("manifest-arm64"))
-    config_digests = (named_digest("config-amd64"), named_digest("config-arm64"))
+    config = image_config({"org.opencontainers.image.revision": HEW_SHA})
+    config_digest = content_digest(config)
+    child = image_manifest(config_digest)
+    child_digest = content_digest(child)
     attestation_digest = named_digest("attestation")
     index = {
         "schemaVersion": 2,
         "mediaType": "application/vnd.oci.image.index.v1+json",
         "manifests": [
             {
-                "digest": child_digests[0],
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": child_digest,
                 "platform": {"os": "linux", "architecture": "amd64"},
             },
             {
-                "digest": child_digests[1],
-                "platform": {"os": "linux", "architecture": "arm64"},
-            },
-            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
                 "digest": attestation_digest,
                 "annotations": {"vnd.docker.reference.type": "attestation-manifest"},
+                "platform": {"os": "unknown", "architecture": "unknown"},
             },
         ],
     }
     result, requests = run_canned_release_image_assertion(
         {
             "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, index)],
-            f"/v2/hew-lang/playground/manifests/{child_digests[0]}": [
-                (200, image_manifest(config_digests[0]))
-            ],
-            f"/v2/hew-lang/playground/manifests/{child_digests[1]}": [
-                (200, image_manifest(config_digests[1]))
-            ],
-            f"/v2/hew-lang/playground/blobs/{config_digests[0]}": [
-                (
-                    200,
-                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
-                )
-            ],
-            f"/v2/hew-lang/playground/blobs/{config_digests[1]}": [
-                (
-                    200,
-                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
-                )
-            ],
+            f"/v2/hew-lang/playground/manifests/{child_digest}": [(200, child)],
+            f"/v2/hew-lang/playground/blobs/{config_digest}": [(200, config)],
         }
     )
     assert result.returncode == 0, result.stderr
     assert f"/v2/hew-lang/playground/manifests/{attestation_digest}" not in requests
-    assert f"/v2/hew-lang/playground/manifests/{child_digests[0]}" in requests
-    assert f"/v2/hew-lang/playground/manifests/{child_digests[1]}" not in requests
+    assert f"/v2/hew-lang/playground/manifests/{child_digest}" in requests
+
+
+def test_release_image_assertion_rejects_an_additional_runnable_platform() -> None:
+    descriptors = []
+    responses = {
+        "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [],
+    }
+    for architecture in ("amd64", "arm64"):
+        config = image_config({"org.opencontainers.image.revision": HEW_SHA})
+        config["architecture"] = architecture
+        config_digest = content_digest(config)
+        child = image_manifest(config_digest)
+        child_digest = content_digest(child)
+        descriptors.append(
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": child_digest,
+                "platform": {"os": "linux", "architecture": architecture},
+            }
+        )
+        responses[f"/v2/hew-lang/playground/manifests/{child_digest}"] = [(200, child)]
+        responses[f"/v2/hew-lang/playground/blobs/{config_digest}"] = [(200, config)]
+    index = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": descriptors,
+    }
+    responses["/v2/hew-lang/playground/manifests/v0.6.0-rc2"] = [(200, index)]
+
+    result, requests = run_canned_release_image_assertion(responses)
+
+    assert result.returncode != 0
+    assert "contains additional runnable platform linux/arm64" in result.stderr
+    arm64_digest = descriptors[1]["digest"]
+    assert f"/v2/hew-lang/playground/manifests/{arm64_digest}" not in requests
+
+
+def test_release_image_assertion_rejects_mislabeled_runnable_attestation() -> None:
+    descriptor_digest = named_digest("mislabeled-attestation")
+    index = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": descriptor_digest,
+                "annotations": {"vnd.docker.reference.type": "attestation-manifest"},
+                "platform": {"os": "linux", "architecture": "amd64"},
+            }
+        ],
+    }
+    result, requests = run_canned_release_image_assertion(
+        {"/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, index)]}
+    )
+    assert result.returncode != 0
+    assert "not a narrowly recognized non-runnable attestation" in result.stderr
+    assert f"/v2/hew-lang/playground/manifests/{descriptor_digest}" not in requests
+
+
+def test_release_image_assertion_hashes_index_child_response_bytes() -> None:
+    declared_child_digest = named_digest("declared-child")
+    config = image_config({"org.opencontainers.image.revision": HEW_SHA})
+    config_digest = content_digest(config)
+    served_child = image_manifest(config_digest)
+    index = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": declared_child_digest,
+                "platform": {"os": "linux", "architecture": "amd64"},
+            }
+        ],
+    }
+    result, requests = run_canned_release_image_assertion(
+        {
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, index)],
+            f"/v2/hew-lang/playground/manifests/{declared_child_digest}": [
+                (200, served_child)
+            ],
+            f"/v2/hew-lang/playground/blobs/{config_digest}": [(200, config)],
+        }
+    )
+    assert result.returncode != 0
+    assert "raw response digest is" in result.stderr
+    assert "not its descriptor digest" in result.stderr
+    assert f"/v2/hew-lang/playground/blobs/{config_digest}" not in requests
+
+
+def test_release_image_assertion_hashes_config_response_bytes() -> None:
+    declared_config_digest = named_digest("declared-config")
+    manifest = image_manifest(declared_config_digest)
+    served_config = image_config({"org.opencontainers.image.revision": HEW_SHA})
+    result, _requests = run_canned_release_image_assertion(
+        {
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, manifest)],
+            f"/v2/hew-lang/playground/blobs/{declared_config_digest}": [
+                (200, served_config)
+            ],
+        }
+    )
+    assert result.returncode != 0
+    assert "raw response digest is" in result.stderr
+    assert "not its descriptor digest" in result.stderr
 
 
 def test_release_image_assertion_rejects_unclassified_platformless_child() -> None:
@@ -878,7 +959,9 @@ def test_release_image_assertion_rejects_unclassified_platformless_child() -> No
         {"/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, index)]}
     )
     assert result.returncode != 0
-    assert "has no platform.os and is not marked as an attestation" in result.stderr
+    assert (
+        "has no runnable platform and is not marked as an attestation" in result.stderr
+    )
 
 
 def test_prerelease_policy_uses_selected_release_tag() -> None:

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -10,7 +10,12 @@ import tarfile
 import tempfile
 import textwrap
 import tomllib
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Thread
+from time import time
+from urllib.parse import urlparse
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -137,9 +142,12 @@ def run_release_image_assertion(env_overrides: dict) -> subprocess.CompletedProc
         "IMAGE_REPOSITORY",
         "IMAGE_TAG",
         "EXPECTED_REVISION",
-        "REGISTRY_TOKEN",
+        "GHCR_TOKEN",
+        "GHCR_USERNAME",
         "DEADLINE_MINUTES",
+        "DEADLINE_EPOCH",
         "IMAGE_REGISTRY",
+        "IMAGE_REGISTRY_SCHEME",
         "POLL_INTERVAL_SECONDS",
     ):
         env.pop(key, None)
@@ -152,6 +160,85 @@ def run_release_image_assertion(env_overrides: dict) -> subprocess.CompletedProc
         capture_output=True,
         text=True,
     )
+
+
+@contextmanager
+def canned_registry(responses: dict[str, list[tuple[int, dict]]]):
+    requests: list[str] = []
+    counts: dict[str, int] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            path = urlparse(self.path).path
+            requests.append(path)
+            sequence = responses.get(path, [(404, {"error": "not found"})])
+            index = counts.get(path, 0)
+            counts[path] = index + 1
+            status, body = sequence[min(index, len(sequence) - 1)]
+            encoded = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield server.server_address[1], requests
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def image_manifest(config_digest: str) -> dict:
+    return {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": config_digest,
+            "size": 1,
+        },
+        "layers": [],
+    }
+
+
+def image_config(revision: str) -> dict:
+    return {
+        "architecture": "amd64",
+        "os": "linux",
+        "config": {"Labels": {"org.opencontainers.image.revision": revision}},
+    }
+
+
+def run_canned_release_image_assertion(
+    responses: dict[str, list[tuple[int, dict]]],
+) -> tuple[subprocess.CompletedProcess, list[str]]:
+    responses = {
+        "/token": [(200, {"token": "pull-token"})],
+        **responses,
+    }
+    with canned_registry(responses) as (port, requests):
+        result = run_release_image_assertion(
+            {
+                "IMAGE_REPOSITORY": "hew-lang/playground",
+                "IMAGE_TAG": "v0.6.0-rc2",
+                "EXPECTED_REVISION": HEW_SHA,
+                "GHCR_TOKEN": "test-token",
+                "GHCR_USERNAME": "test-user",
+                "DEADLINE_MINUTES": "1",
+                "IMAGE_REGISTRY": f"127.0.0.1:{port}",
+                "IMAGE_REGISTRY_SCHEME": "http",
+                "POLL_INTERVAL_SECONDS": "1",
+            }
+        )
+    return result, requests
 
 
 def assert_exact_dispatch_correlation(job: str) -> None:
@@ -335,10 +422,16 @@ def run_playground(
 
 
 def assert_wait_budget(job: str) -> None:
-    """Keep caller time above the downstream 5+5+45+30+5 minute maximum."""
+    """Keep the shell's budget authority equal to the enforced job timeout."""
     match = re.search(r"^    timeout-minutes: (\d+)$", job, re.MULTILINE)
     assert match is not None
-    assert int(match.group(1)) >= 100
+    shell_budget = re.search(r"^\s+JOB_TIMEOUT_MINUTES=(\d+)$", job, re.MULTILINE)
+    assert shell_budget is not None
+    assert int(match.group(1)) == int(shell_budget.group(1))
+    assert (
+        "ASSERTION_BUDGET_MINUTES=$((JOB_TIMEOUT_MINUTES - FINALIZATION_RESERVE_MINUTES))"
+        in job
+    )
 
 
 def test_rc_tag_normalization_and_exact_release_body() -> None:
@@ -454,7 +547,7 @@ def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
         in validation_step
     )
     assert "exit 1" in validation_step
-    assert "if:" not in validation_step
+    assert "if: steps.acquisition.outputs.mode == 'actions'" in validation_step
     assert "continue-on-error:" not in validation_step
 
     assert "id: playground-app-token" in token_step
@@ -467,7 +560,7 @@ def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
     assert "private-key: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}" in token_step
     assert "owner: hew-lang" in token_step
     assert "repositories: playground" in token_step
-    assert "if:" not in token_step
+    assert "if: steps.acquisition.outputs.mode == 'actions'" in token_step
     assert "continue-on-error:" not in token_step
     assert "GH_TOKEN: ${{ steps.playground-app-token.outputs.token }}" in trigger_step
     assert "gh repo view hew-lang/playground" in job
@@ -511,12 +604,15 @@ def test_dispatch_correlation_is_unique_and_bounded() -> None:
 
 
 def test_release_image_acquisition_mode_is_exhaustive_and_fails_closed() -> None:
-    accepted = {"actions": "25", "local": "110"}
-    for mode, deadline in accepted.items():
+    for mode in ("actions", "local"):
+        before = int(time())
         result, outputs = run_acquisition(mode)
+        after = int(time())
         assert result.returncode == 0, result.stderr
         assert outputs["mode"] == mode
-        assert outputs["assert_deadline_minutes"] == deadline
+        assert outputs["assert_budget_minutes"] == "115"
+        deadline = int(outputs["assert_deadline_epoch"])
+        assert before + 115 * 60 <= deadline <= after + 115 * 60
 
     for rejected in (None, "", "Actions", "LOCAL", "skip", "true", "actions local"):
         result, outputs = run_acquisition(rejected)
@@ -552,13 +648,13 @@ def test_release_image_assertion_covers_every_acquisition_mode() -> None:
     assert (
         "EXPECTED_REVISION: ${{ steps.release-commit.outputs.hew_sha }}" in assert_step
     )
+    assert "GHCR_TOKEN: ${{ github.token }}" in assert_step
+    assert "GHCR_USERNAME: ${{ github.actor }}" in assert_step
     assert (
-        "REGISTRY_TOKEN: ${{ steps.playground-app-token.outputs.token }}" in assert_step
-    )
-    assert (
-        "DEADLINE_MINUTES: ${{ steps.acquisition.outputs.assert_deadline_minutes }}"
+        "DEADLINE_EPOCH: ${{ steps.acquisition.outputs.assert_deadline_epoch }}"
         in assert_step
     )
+    assert "packages: read" in job
     assert "run: release-machinery/scripts/assert-playground-release-image.sh" in (
         assert_step
     )
@@ -576,7 +672,8 @@ def test_release_image_assertion_rejects_unusable_inputs() -> None:
         "IMAGE_REPOSITORY": "hew-lang/playground",
         "IMAGE_TAG": "v0.6.0-rc2",
         "EXPECTED_REVISION": HEW_SHA,
-        "REGISTRY_TOKEN": "test-token",
+        "GHCR_TOKEN": "test-token",
+        "GHCR_USERNAME": "test-user",
         "DEADLINE_MINUTES": "1",
     }
     # Each case is rejected before any network call, so the assertion can never
@@ -584,14 +681,20 @@ def test_release_image_assertion_rejects_unusable_inputs() -> None:
     cases = {
         "IMAGE_REPOSITORY": "",
         "IMAGE_TAG": "",
-        "REGISTRY_TOKEN": "",
-        "DEADLINE_MINUTES": "",
+        "GHCR_TOKEN": "",
     }
     for key, value in cases.items():
         env = dict(valid, **{key: value})
         result = run_release_image_assertion(env)
         assert result.returncode != 0, key
         assert f"{key} must be set" in result.stderr, key
+
+    without_deadline = {
+        key: value for key, value in valid.items() if key != "DEADLINE_MINUTES"
+    }
+    result = run_release_image_assertion(without_deadline)
+    assert result.returncode != 0
+    assert "DEADLINE_EPOCH or DEADLINE_MINUTES must be set" in result.stderr
 
     for bad_sha in ("not-a-sha", HEW_SHA[:39], HEW_SHA.upper()):
         result = run_release_image_assertion(dict(valid, EXPECTED_REVISION=bad_sha))
@@ -605,6 +708,101 @@ def test_release_image_assertion_rejects_unusable_inputs() -> None:
     result = run_release_image_assertion(dict(valid, POLL_INTERVAL_SECONDS="0"))
     assert result.returncode != 0
     assert "POLL_INTERVAL_SECONDS must be a positive whole number" in result.stderr
+
+
+def test_release_image_assertion_accepts_matching_single_manifest() -> None:
+    config_digest = "sha256:config-good"
+    result, requests = run_canned_release_image_assertion(
+        {
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [
+                (200, image_manifest(config_digest))
+            ],
+            f"/v2/hew-lang/playground/blobs/{config_digest}": [
+                (200, image_config(HEW_SHA))
+            ],
+        }
+    )
+    assert result.returncode == 0, result.stderr
+    assert requests.count("/token") == 1
+
+
+def test_release_image_assertion_polls_past_a_stale_tag() -> None:
+    stale_digest = "sha256:config-stale"
+    good_digest = "sha256:config-good"
+    tag_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
+    result, requests = run_canned_release_image_assertion(
+        {
+            tag_path: [
+                (200, image_manifest(stale_digest)),
+                (200, image_manifest(good_digest)),
+            ],
+            f"/v2/hew-lang/playground/blobs/{stale_digest}": [
+                (200, image_config("f" * 40))
+            ],
+            f"/v2/hew-lang/playground/blobs/{good_digest}": [
+                (200, image_config(HEW_SHA))
+            ],
+        }
+    )
+    assert result.returncode == 0, result.stderr
+    assert requests.count(tag_path) == 2
+    assert "still binds" in result.stderr
+
+
+def test_release_image_assertion_checks_every_platform_in_an_index() -> None:
+    child_digests = ("sha256:manifest-amd64", "sha256:manifest-arm64")
+    config_digests = ("sha256:config-amd64", "sha256:config-arm64")
+    attestation_digest = "sha256:attestation"
+    index = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "digest": child_digests[0],
+                "platform": {"os": "linux", "architecture": "amd64"},
+            },
+            {
+                "digest": child_digests[1],
+                "platform": {"os": "linux", "architecture": "arm64"},
+            },
+            {
+                "digest": attestation_digest,
+                "annotations": {"vnd.docker.reference.type": "attestation-manifest"},
+            },
+        ],
+    }
+    result, requests = run_canned_release_image_assertion(
+        {
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, index)],
+            f"/v2/hew-lang/playground/manifests/{child_digests[0]}": [
+                (200, image_manifest(config_digests[0]))
+            ],
+            f"/v2/hew-lang/playground/manifests/{child_digests[1]}": [
+                (200, image_manifest(config_digests[1]))
+            ],
+            f"/v2/hew-lang/playground/blobs/{config_digests[0]}": [
+                (200, image_config(HEW_SHA))
+            ],
+            f"/v2/hew-lang/playground/blobs/{config_digests[1]}": [
+                (200, image_config(HEW_SHA))
+            ],
+        }
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"/v2/hew-lang/playground/manifests/{attestation_digest}" not in requests
+
+
+def test_release_image_assertion_rejects_unclassified_platformless_child() -> None:
+    index = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [{"digest": "sha256:unclassified"}],
+    }
+    result, _requests = run_canned_release_image_assertion(
+        {"/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, index)]}
+    )
+    assert result.returncode != 0
+    assert "has no platform.os and is not marked as an attestation" in result.stderr
 
 
 def test_exact_workflow_shell_accepts_one_stable_matching_run() -> None:

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -40,6 +40,7 @@ RELEASE_LINK_MANIFEST = (
 WINDOWS_RELEASE_LINK_PROBE = ROOT / "scripts" / "test-release-lib-link.ps1"
 WINDOWS_RELEASE_BUILD = ROOT / "scripts" / "windows-release-build.ps1"
 SANITIZER_GATE = ROOT / "scripts" / "check-sanitizer-gate.sh"
+RELEASE_IMAGE_ASSERTION = ROOT / "scripts" / "assert-playground-release-image.sh"
 MAKEFILE = ROOT / "Makefile"
 RELEASE_BINARY_SMOKE = ROOT / "scripts" / "test-release-binary.sh"
 PACKAGE_BUILDER = ROOT / "installers" / "build-packages.sh"
@@ -75,11 +76,82 @@ def playground_job(text: str | None = None) -> str:
 
 
 def playground_script(text: str | None = None) -> str:
-    """Extract the exact Bash program executed by the playground job."""
+    """Extract the exact Bash program executed by the dispatch step.
+
+    Bounded at the next step so the acquisition-mode steps that follow the
+    dispatch cannot leak their YAML into the program under test.
+    """
     job = playground_job() if text is None else text
     step = job.index("      - name: Trigger playground image rebuild\n")
     run = job.index("        run: |\n", step) + len("        run: |\n")
-    return textwrap.dedent(job[run:]).rstrip() + "\n"
+    next_step = job.find("\n      - name: ", run)
+    body = job[run:] if next_step == -1 else job[run : next_step + 1]
+    return textwrap.dedent(body).rstrip() + "\n"
+
+
+def step_of(job: str, name: str) -> str:
+    """Extract one named step's YAML from a job, bounded at the next step."""
+    start = job.index(f"      - name: {name}\n")
+    end = job.find("\n      - name: ", start + 1)
+    return job[start:] if end == -1 else job[start : end + 1]
+
+
+def acquisition_script() -> str:
+    """Extract the exact Bash program that selects the acquisition mode."""
+    job = playground_job()
+    step = step_of(job, "Select release image acquisition mode")
+    run = step.index("        run: |\n") + len("        run: |\n")
+    return textwrap.dedent(step[run:]).rstrip() + "\n"
+
+
+def run_acquisition(mode: str | None) -> tuple:
+    """Execute the acquisition-mode selection with a given repository variable."""
+    with tempfile.TemporaryDirectory() as directory:
+        output = Path(directory) / "github_output"
+        output.touch()
+        env = os.environ.copy()
+        env["GITHUB_OUTPUT"] = str(output)
+        env.pop("PLAYGROUND_PUBLISH_MODE", None)
+        if mode is not None:
+            env["PLAYGROUND_PUBLISH_MODE"] = mode
+        result = subprocess.run(
+            ["bash", "-c", acquisition_script()],
+            cwd=ROOT,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        outputs = dict(
+            line.split("=", 1)
+            for line in output.read_text().splitlines()
+            if "=" in line
+        )
+        return result, outputs
+
+
+def run_release_image_assertion(env_overrides: dict) -> subprocess.CompletedProcess:
+    """Execute the release-image assertion with a fixed environment."""
+    env = os.environ.copy()
+    for key in (
+        "IMAGE_REPOSITORY",
+        "IMAGE_TAG",
+        "EXPECTED_REVISION",
+        "REGISTRY_TOKEN",
+        "DEADLINE_MINUTES",
+        "IMAGE_REGISTRY",
+        "POLL_INTERVAL_SECONDS",
+    ):
+        env.pop(key, None)
+    env.update(env_overrides)
+    return subprocess.run(
+        [str(RELEASE_IMAGE_ASSERTION)],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 def assert_exact_dispatch_correlation(job: str) -> None:
@@ -436,6 +508,106 @@ def test_dispatch_correlation_is_unique_and_bounded() -> None:
     assert "mapfile -t RUN_IDS < <(" not in job
     assert "LAST_CANDIDATE_ID" in job
     assert "ambiguous playground workflow dispatch correlation" in job
+
+
+def test_release_image_acquisition_mode_is_exhaustive_and_fails_closed() -> None:
+    accepted = {"actions": "25", "local": "110"}
+    for mode, deadline in accepted.items():
+        result, outputs = run_acquisition(mode)
+        assert result.returncode == 0, result.stderr
+        assert outputs["mode"] == mode
+        assert outputs["assert_deadline_minutes"] == deadline
+
+    for rejected in (None, "", "Actions", "LOCAL", "skip", "true", "actions local"):
+        result, outputs = run_acquisition(rejected)
+        assert result.returncode != 0, repr(rejected)
+        assert "must be exactly 'actions' or 'local'" in result.stdout, repr(rejected)
+        assert outputs == {}, repr(rejected)
+
+
+def test_release_image_assertion_covers_every_acquisition_mode() -> None:
+    job = playground_job()
+    mode_step = step_of(job, "Select release image acquisition mode")
+    assert "id: acquisition" in mode_step
+    assert "PLAYGROUND_PUBLISH_MODE: ${{ vars.PLAYGROUND_PUBLISH_MODE }}" in mode_step
+    assert "if:" not in mode_step
+    assert "continue-on-error:" not in mode_step
+
+    trigger_step = step_of(job, "Trigger playground image rebuild")
+    assert "if: steps.acquisition.outputs.mode == 'actions'" in trigger_step
+
+    local_step = step_of(job, "Report expected local release image publish")
+    assert "if: steps.acquisition.outputs.mode == 'local'" in local_step
+    assert (
+        "make release-publish HEW_SHA=${HEW_SHA} HEW_VERSION=${VERSION}" in local_step
+    )
+    assert "gh workflow run" not in local_step
+
+    assert_step = step_of(
+        job, "Assert release image exists and binds the release commit"
+    )
+    assert (
+        "if: ${{ !cancelled() && steps.acquisition.outputs.mode != '' }}" in assert_step
+    )
+    assert "continue-on-error:" not in assert_step
+    assert "IMAGE_REPOSITORY: hew-lang/playground" in assert_step
+    assert "IMAGE_TAG: ${{ env.RELEASE_TAG }}" in assert_step
+    assert (
+        "EXPECTED_REVISION: ${{ steps.release-commit.outputs.hew_sha }}" in assert_step
+    )
+    assert (
+        "REGISTRY_TOKEN: ${{ steps.playground-app-token.outputs.token }}" in assert_step
+    )
+    assert (
+        "DEADLINE_MINUTES: ${{ steps.acquisition.outputs.assert_deadline_minutes }}"
+        in assert_step
+    )
+    assert "run: release-machinery/scripts/assert-playground-release-image.sh" in (
+        assert_step
+    )
+
+    machinery_step = step_of(job, "Checkout release machinery")
+    assert "ref: ${{ github.sha }}" in machinery_step
+    assert "path: release-machinery" in machinery_step
+
+    assert RELEASE_IMAGE_ASSERTION.exists()
+    assert RELEASE_IMAGE_ASSERTION.stat().st_mode & stat.S_IXUSR
+
+
+def test_release_image_assertion_rejects_unusable_inputs() -> None:
+    valid = {
+        "IMAGE_REPOSITORY": "hew-lang/playground",
+        "IMAGE_TAG": "v0.6.0-rc2",
+        "EXPECTED_REVISION": HEW_SHA,
+        "REGISTRY_TOKEN": "test-token",
+        "DEADLINE_MINUTES": "1",
+    }
+    # Each case is rejected before any network call, so the assertion can never
+    # reach a registry with an identity it has not fully resolved.
+    cases = {
+        "IMAGE_REPOSITORY": "",
+        "IMAGE_TAG": "",
+        "REGISTRY_TOKEN": "",
+        "DEADLINE_MINUTES": "",
+    }
+    for key, value in cases.items():
+        env = dict(valid, **{key: value})
+        result = run_release_image_assertion(env)
+        assert result.returncode != 0, key
+        assert f"{key} must be set" in result.stderr, key
+
+    for bad_sha in ("not-a-sha", HEW_SHA[:39], HEW_SHA.upper()):
+        result = run_release_image_assertion(dict(valid, EXPECTED_REVISION=bad_sha))
+        assert result.returncode != 0, bad_sha
+        assert "exact lowercase 40-character commit SHA" in result.stderr, bad_sha
+
+    result = run_release_image_assertion(dict(valid, DEADLINE_MINUTES="soon"))
+    assert result.returncode != 0
+    assert "whole number of minutes" in result.stderr
+
+    result = run_release_image_assertion(dict(valid, POLL_INTERVAL_SECONDS="0"))
+    assert result.returncode != 0
+    assert "POLL_INTERVAL_SECONDS must be a positive whole number" in result.stderr
 
 
 def test_exact_workflow_shell_accepts_one_stable_matching_run() -> None:
@@ -2215,6 +2387,9 @@ _TESTS = [
     test_playground_dispatch_is_purpose_scoped_and_fail_closed,
     test_dispatch_uses_exact_playground_workflow_input_and_ref,
     test_dispatch_correlation_is_unique_and_bounded,
+    test_release_image_acquisition_mode_is_exhaustive_and_fails_closed,
+    test_release_image_assertion_covers_every_acquisition_mode,
+    test_release_image_assertion_rejects_unusable_inputs,
     test_exact_workflow_shell_accepts_one_stable_matching_run,
     test_malformed_release_commit_identity_is_terminal,
     test_run_listing_api_failure_is_terminal,

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -243,7 +243,7 @@ def run_canned_release_image_assertion(
 
 
 def assert_exact_dispatch_correlation(job: str) -> None:
-    """Require the unique caller identity in both dispatch and run selection."""
+    """Require the unique dispatch identity in both dispatch and run selection."""
     assert 'CORRELATION_ID="hew-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' in job
     assert (
         'EXPECTED_DISPLAY_TITLE="Build Playground mode=publish'
@@ -263,12 +263,10 @@ def assert_exact_dispatch_correlation(job: str) -> None:
     query = job[query_start:query_end]
     expected = """            if ! RUN_IDS_OUTPUT=$(jq -r \\
                 --argjson floor "${PRE_DISPATCH_MAX_ID}" \\
-                --arg sha "${PLAYGROUND_SHA}" \\
                 --arg actor "${DISPATCH_ACTOR}" \\
                 --arg display_title "${EXPECTED_DISPLAY_TITLE}" \\
                 '.workflow_runs[]
                   | select(.id > $floor)
-                  | select(.head_sha == $sha)
                   | select(.actor.login == $actor)
                   | select(.display_title == $display_title)
                   | .id' <<< "${RUNS_JSON}"); then
@@ -317,9 +315,9 @@ if not args or args[0] != "api":
     raise SystemExit(92)
 
 joined = " ".join(args)
-if "repos/hew-lang/playground/commits/main" in joined:
-    print("sha-good")
-    raise SystemExit(0)
+if args[1:] == ["user", "--jq", ".login"]:
+    print("GET /user is unavailable to installation tokens", file=sys.stderr)
+    raise SystemExit(43)
 if "repos/hew-lang/playground/actions/workflows/build.yml/runs" in joined:
     if "--jq" in args:
         print("100")
@@ -332,8 +330,8 @@ if "repos/hew-lang/playground/actions/workflows/build.yml/runs" in joined:
     state.write_text(str(poll))
     matching = {
         "id": 101,
-        "head_sha": "sha-good",
-        "actor": {"login": "actor-good"},
+        "head_sha": "sha-after" if scenario == "moving-head" else "sha-good",
+        "actor": {"login": "playground-app[bot]"},
         "display_title": (
             "Build Playground mode=publish"
             " sha=0123456789abcdef0123456789abcdef01234567"
@@ -344,12 +342,10 @@ if "repos/hew-lang/playground/actions/workflows/build.yml/runs" in joined:
         runs = []
     elif scenario == "ambiguous":
         runs = [matching, {**matching, "id": 102}]
-    elif scenario in {"title", "head", "actor", "floor"}:
+    elif scenario in {"title", "actor", "floor"}:
         candidate = dict(matching)
         if scenario == "title":
             candidate["display_title"] = "Build Playground wrong"
-        elif scenario == "head":
-            candidate["head_sha"] = "sha-wrong"
         elif scenario == "actor":
             candidate["actor"] = {"login": "actor-wrong"}
         else:
@@ -358,7 +354,6 @@ if "repos/hew-lang/playground/actions/workflows/build.yml/runs" in joined:
     else:
         runs = [
             {**matching, "id": 100},
-            {**matching, "head_sha": "sha-wrong", "id": 103},
             {**matching, "actor": {"login": "actor-wrong"}, "id": 104},
             {**matching, "display_title": "Build Playground wrong", "id": 105},
             matching,
@@ -368,15 +363,16 @@ if "repos/hew-lang/playground/actions/workflows/build.yml/runs" in joined:
 if "repos/hew-lang/playground" in joined:
     print("main")
     raise SystemExit(0)
-if args[1:] == ["user", "--jq", ".login"]:
-    print("actor-good")
-    raise SystemExit(0)
 raise SystemExit(93)
 """
 
 
 def run_playground(
-    scenario: str, *, jq_failure: bool = False, hew_sha: str = HEW_SHA
+    scenario: str,
+    *,
+    jq_failure: bool = False,
+    hew_sha: str = HEW_SHA,
+    script: str | None = None,
 ) -> tuple:
     """Execute the workflow's exact Bash with deterministic command doubles."""
     with tempfile.TemporaryDirectory() as directory:
@@ -401,6 +397,7 @@ def run_playground(
                 "PATH": f"{bin_dir}:{env['PATH']}",
                 "GH_TOKEN": "test-token",
                 "HEW_SHA": hew_sha,
+                "DISPATCH_ACTOR": "playground-app[bot]",
                 "RELEASE_TAG": "v0.6.0-rc1",
                 "GITHUB_RUN_ID": "777",
                 "GITHUB_RUN_ATTEMPT": "2",
@@ -410,7 +407,7 @@ def run_playground(
             }
         )
         result = subprocess.run(
-            ["bash", "-c", playground_script()],
+            ["bash", "-c", playground_script() if script is None else script],
             cwd=ROOT,
             env=env,
             check=False,
@@ -564,6 +561,11 @@ def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
     assert "if: steps.acquisition.outputs.mode == 'actions'" in token_step
     assert "continue-on-error:" not in token_step
     assert "GH_TOKEN: ${{ steps.playground-app-token.outputs.token }}" in trigger_step
+    assert (
+        "DISPATCH_ACTOR: ${{ steps.playground-app-token.outputs.app-slug }}[bot]"
+        in trigger_step
+    )
+    assert "gh api user" not in trigger_step
     assert "gh repo view hew-lang/playground" in job
     assert "gh api repos/hew-lang/playground --jq '.default_branch'" in job
     assert "gh workflow view build.yml" in job
@@ -587,14 +589,15 @@ def test_dispatch_correlation_is_unique_and_bounded() -> None:
     job = playground_job()
     assert_wait_budget(job)
     assert_exact_dispatch_correlation(job)
-    assert "PLAYGROUND_SHA=" in job
+    assert "PLAYGROUND_SHA" not in job
     assert "PRE_DISPATCH_MAX_ID=" in job
     assert '--argjson floor "${PRE_DISPATCH_MAX_ID}"' in job
-    assert '--arg sha "${PLAYGROUND_SHA}"' in job
-    assert "DISPATCH_ACTOR=" in job
+    assert (
+        "DISPATCH_ACTOR: ${{ steps.playground-app-token.outputs.app-slug }}[bot]" in job
+    )
     assert '--arg actor "${DISPATCH_ACTOR}"' in job
     assert "select(.id > $floor)" in job
-    assert "select(.head_sha == $sha)" in job
+    assert "select(.head_sha" not in job
     assert "select(.actor.login == $actor)" in job
     assert_fail_closed_run_retrieval(job)
     assert "if ! RUN_IDS_OUTPUT=$(jq -r" in job
@@ -818,6 +821,39 @@ def test_exact_workflow_shell_accepts_one_stable_matching_run() -> None:
     ]
     watches = [call for call in calls if call.startswith("gh run watch")]
     assert watches == ["gh run watch 101 -R hew-lang/playground --exit-status"]
+    assert not any(call.startswith("gh api user") for call in calls)
+
+
+def test_moving_default_branch_does_not_break_dispatch_correlation() -> None:
+    result, calls, polls = run_playground("moving-head")
+    assert result.returncode == 0, result.stderr
+    assert polls == 2
+    assert not any("/commits/main" in call for call in calls)
+
+    stale_sha_job = (
+        playground_job()
+        .replace(
+            '                --arg actor "${DISPATCH_ACTOR}" \\\n',
+            '                --arg sha "sha-before" \\\n'
+            '                --arg actor "${DISPATCH_ACTOR}" \\\n',
+        )
+        .replace(
+            "                  | select(.actor.login == $actor)\n",
+            "                  | select(.head_sha == $sha)\n"
+            "                  | select(.actor.login == $actor)\n",
+        )
+        .replace(
+            "          for _ in $(seq 1 30); do",
+            "          for _ in $(seq 1 1); do",
+        )
+    )
+    stale_result, stale_calls, stale_polls = run_playground(
+        "moving-head", script=playground_script(stale_sha_job)
+    )
+    assert stale_result.returncode != 0
+    assert "could not correlate" in stale_result.stdout
+    assert stale_polls == 1
+    assert not any(call.startswith("gh run watch") for call in stale_calls)
 
 
 def test_malformed_release_commit_identity_is_terminal() -> None:
@@ -866,7 +902,7 @@ def test_ambiguous_correlation_fails_on_the_first_poll() -> None:
 
 
 def test_each_exact_run_identity_dimension_is_mandatory() -> None:
-    for scenario in ("title", "head", "actor", "floor"):
+    for scenario in ("title", "actor", "floor"):
         result, calls, polls = run_playground(scenario)
         assert result.returncode != 0, scenario
         assert "could not correlate" in result.stdout, scenario
@@ -912,10 +948,10 @@ def test_correlation_swap_with_padding_is_rejected() -> None:
 
 def test_correlation_argument_swap_with_padding_is_rejected() -> None:
     mutated = playground_job().replace(
-        '--arg sha "${PLAYGROUND_SHA}"',
-        '--arg sha "${DISPATCH_ACTOR}"',
+        '--arg actor "${DISPATCH_ACTOR}"',
+        '--arg actor "${EXPECTED_DISPLAY_TITLE}"',
     )
-    mutated += '\n# --arg sha "${PLAYGROUND_SHA}"\n'
+    mutated += '\n# --arg actor "${DISPATCH_ACTOR}"\n'
     try:
         assert_exact_dispatch_correlation(mutated)
     except (AssertionError, ValueError):

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -4,6 +4,7 @@ import ast
 import json
 import os
 import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -64,6 +65,7 @@ WINDOWS_LLVM_TOOLCHAIN_VERSION = "22.1.0-windows-msvc-v1"
 WINDOWS_LLVM_TOOLCHAIN_TAG = f"llvm-{WINDOWS_LLVM_TOOLCHAIN_VERSION}"
 WINDOWS_LLVM_TOOLCHAIN_ASSET = f"hew-llvm-{WINDOWS_LLVM_TOOLCHAIN_VERSION}.tar.gz"
 BINARYEN_SHA256 = "3dc677006555b355ea2da5e82602065a161d5e83eaefd3f759afa00b96e83212"
+PLAYGROUND_CONTRACT_REF = "21be84bb97436436b640f2acd09fb6dd2e0fbf94"
 
 
 def workflow() -> str:
@@ -121,18 +123,21 @@ def local_publish_script(text: str | None = None) -> str:
     return textwrap.dedent(step[run:]).rstrip() + "\n"
 
 
-def run_acquisition(mode: str | None) -> tuple:
+def run_acquisition(
+    mode: str | None, event_name: str = "push", script: str | None = None
+) -> tuple:
     """Execute the acquisition-mode selection with a given repository variable."""
     with tempfile.TemporaryDirectory() as directory:
         output = Path(directory) / "github_output"
         output.touch()
         env = os.environ.copy()
         env["GITHUB_OUTPUT"] = str(output)
+        env["GITHUB_EVENT_NAME"] = event_name
         env.pop("PLAYGROUND_PUBLISH_MODE", None)
         if mode is not None:
             env["PLAYGROUND_PUBLISH_MODE"] = mode
         result = subprocess.run(
-            ["bash", "-c", acquisition_script()],
+            ["bash", "-c", acquisition_script() if script is None else script],
             cwd=ROOT,
             env=env,
             check=False,
@@ -145,6 +150,13 @@ def run_acquisition(mode: str | None) -> tuple:
             if "=" in line
         )
         return result, outputs
+
+
+def assert_actions_push_is_rejected(script: str) -> None:
+    result, outputs = run_acquisition("actions", "push", script)
+    assert result.returncode != 0
+    assert "actions is post-tag only" in result.stdout
+    assert outputs == {}
 
 
 def run_local_publish_report(
@@ -167,6 +179,28 @@ def run_local_publish_report(
         capture_output=True,
         text=True,
     )
+
+
+def assert_candidate_publish_command(command: str) -> None:
+    assert shlex.split(command) == [
+        "env",
+        "-u",
+        "MAKEFLAGS",
+        "-u",
+        "MFLAGS",
+        "-u",
+        "MAKEOVERRIDES",
+        "-u",
+        "MAKEFILES",
+        "-u",
+        "GNUMAKEFLAGS",
+        f"HEW_EXAMPLES_REF={HEW_SHA}",
+        "HEW_VERSION=0.6.0-rc1",
+        "PLAYGROUND_PLATFORM=linux/amd64",
+        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground",
+        "scripts/publish-release-image.sh",
+        "candidate",
+    ]
 
 
 def run_release_image_assertion(env_overrides: dict) -> subprocess.CompletedProcess:
@@ -697,15 +731,39 @@ def test_dispatch_correlation_is_unique_and_bounded() -> None:
 
 
 def test_release_image_acquisition_mode_is_exhaustive_and_fails_closed() -> None:
-    for mode in ("actions", "local"):
+    accepted = (
+        ("local", "push"),
+        ("local", "workflow_dispatch"),
+        ("actions", "workflow_dispatch"),
+    )
+    for mode, event_name in accepted:
         before = int(time())
-        result, outputs = run_acquisition(mode)
+        result, outputs = run_acquisition(mode, event_name)
         after = int(time())
         assert result.returncode == 0, result.stderr
         assert outputs["mode"] == mode
         assert outputs["assert_budget_minutes"] == "115"
         deadline = int(outputs["assert_deadline_epoch"])
         assert before + 115 * 60 <= deadline <= after + 115 * 60
+
+    script = acquisition_script()
+    assert_actions_push_is_rejected(script)
+    mutations = (
+        script.replace(
+            'if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then',
+            "if false; then",
+        ),
+        script.replace(
+            "actions)\n    if [[",
+            "actions)\n    GITHUB_EVENT_NAME=workflow_dispatch\n    if [[",
+        ),
+    )
+    for mutation in mutations:
+        try:
+            assert_actions_push_is_rejected(mutation)
+        except AssertionError:
+            continue
+        raise AssertionError("tag-push actions-mode mutation escaped")
 
     for rejected in (None, "", "Actions", "LOCAL", "skip", "true", "actions local"):
         result, outputs = run_acquisition(rejected)
@@ -768,102 +826,90 @@ def test_local_publish_command_requires_pre_tag_candidate_publisher() -> None:
     commands = [
         line.strip()
         for line in report.stdout.splitlines()
-        if line.strip().endswith(" make release-candidate-publish")
+        if "scripts/publish-release-image.sh candidate" in line
     ]
-    assert commands == [
-        "HEW_EXAMPLES_REF="
-        f"{HEW_SHA} HEW_VERSION=0.6.0-rc1 "
-        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground:v0.6.0-rc1 "
-        "make release-candidate-publish"
-    ]
+    assert len(commands) == 1
+    assert_candidate_publish_command(commands[0])
     local_step = step_of(
         playground_job(), "Report expected local release image publish"
     )
-    assert "make release-publish " not in local_step
+    assert "make " not in local_step
     assert "HEW_SHA" not in local_step
-    assert 'PLAYGROUND_RELEASE_IMAGE="ghcr.io/hew-lang/playground:${RELEASE_TAG}"' in (
-        local_step
-    )
+    assert 'PLAYGROUND_RELEASE_IMAGE="ghcr.io/hew-lang/playground"' in local_step
     assert (
-        'if [[ "${PLAYGROUND_RELEASE_IMAGE}" != '
-        '"ghcr.io/hew-lang/playground:${RELEASE_TAG}" ]]' in local_step
+        'EXPECTED_RELEASE_IMAGE="${PLAYGROUND_RELEASE_IMAGE}:${RELEASE_TAG}"'
+        in local_step
     )
-    assert "# external: hew-lang/playground" in local_step
+    assert "PLAYGROUND_PLATFORM=linux/amd64" in local_step
+    inherited_make_controls = (
+        "MAKEFLAGS",
+        "MFLAGS",
+        "MAKEOVERRIDES",
+        "MAKEFILES",
+        "GNUMAKEFLAGS",
+    )
+    for inherited in inherited_make_controls:
+        assert f"-u {inherited}" in local_step
 
     runbook = RUNBOOK.read_text()
     pre_tag = runbook[
         runbook.index("## Phase 5") : runbook.index(
-            "```bash", runbook.index("## Phase 5")
+            "3. Create the signed tag", runbook.index("## Phase 5")
         )
     ]
-    assert (
-        "`HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version> "
-        "PLAYGROUND_RELEASE_IMAGE=<image> make release-candidate-publish`. "
-        "<!-- external-target: hew-lang/playground -->"
-    ) in pre_tag
-    assert (
-        "inherited environment prefixes, not trailing GNU Make variable assignments"
-        in (pre_tag)
-    )
+    assert "scripts/publish-release-image.sh candidate" in pre_tag
+    assert f"PLAYGROUND_CONTRACT_REF={PLAYGROUND_CONTRACT_REF}" in pre_tag
+    assert "PLAYGROUND_REF=<exact-reviewed-40-character-playground-sha>" in pre_tag
+    assert '"${PLAYGROUND_CONTRACT_REF}" HEAD' in pre_tag
+    assert 'test -z "$(git -C "${PLAYGROUND_CHECKOUT}" status --porcelain)"' in pre_tag
+    assert "PLAYGROUND_PLATFORM=linux/amd64" in pre_tag
+    assert "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground" in pre_tag
+    assert 'test "${HEW_DEFAULT_VERSION}" = "${VERSION}"' in pre_tag
+    assert 'test "${HEW_CANDIDATE_SHA}" = "${HEW_RELEASE_SHA}"' in pre_tag
+    assert "minimal playground `toolchains.env` bump" in pre_tag
+    assert "gh variable set PLAYGROUND_PUBLISH_MODE --body local" in pre_tag
     assert "org.opencontainers.image.revision" in pre_tag
-    assert "before\n   rc2" in pre_tag
-    assert "make release-publish HEW_SHA=" not in pre_tag
-    assert "make release-publish HEW_EXAMPLES_REF=" not in pre_tag
+    assert "scripts/publish-release-image.sh publish" not in pre_tag
+    assert "make release-candidate-publish" not in pre_tag
 
-    release_publish_mutation = local_publish_script().replace(
-        "release-candidate-publish", "release-publish"
-    )
+    release_publish_mutation = local_publish_script().replace(" candidate", " publish")
     mutated = run_local_publish_report(script=release_publish_mutation)
     assert mutated.returncode == 0, mutated.stderr
     mutated_commands = [
         line.strip()
         for line in mutated.stdout.splitlines()
-        if line.strip().endswith(" make release-publish")
+        if "scripts/publish-release-image.sh publish" in line
     ]
-    assert mutated_commands == [
-        "HEW_EXAMPLES_REF="
-        f"{HEW_SHA} HEW_VERSION=0.6.0-rc1 "
-        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground:v0.6.0-rc1 "
-        "make release-publish"
-    ]
-    assert mutated_commands != commands
-
-
-def test_local_publish_contract_rejects_trailing_make_assignments() -> None:
-    safe = (
-        "HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} HEW_VERSION=${VERSION} "
-        "PLAYGROUND_RELEASE_IMAGE=${PLAYGROUND_RELEASE_IMAGE} "
-        "make release-candidate-publish"
-    )
-    unsafe = (
-        "make release-candidate-publish HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} "
-        "HEW_VERSION=${VERSION} PLAYGROUND_RELEASE_IMAGE=${PLAYGROUND_RELEASE_IMAGE}"
-    )
-    unsafe_report = run_local_publish_report(
-        script=local_publish_script().replace(safe, unsafe)
-    )
-    assert unsafe_report.returncode == 0, unsafe_report.stderr
-    unsafe_commands = [
-        line.strip()
-        for line in unsafe_report.stdout.splitlines()
-        if "release-candidate-publish" in line
-    ]
-    assert unsafe_commands == [
-        f"make release-candidate-publish HEW_EXAMPLES_REF={HEW_SHA} "
-        "HEW_VERSION=0.6.0-rc1 "
-        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground:v0.6.0-rc1"
-    ]
+    assert len(mutated_commands) == 1
     try:
-        assert all(
-            line.startswith("HEW_EXAMPLES_REF=")
-            and line.endswith(" make release-candidate-publish")
-            for line in unsafe_commands
-        )
+        assert_candidate_publish_command(mutated_commands[0])
     except AssertionError:
-        return
-    raise AssertionError(
-        "unsafe trailing Make assignments escaped the local publish contract"
+        pass
+    else:
+        raise AssertionError("publish authority escaped the pre-tag command contract")
+
+
+def test_local_publish_contract_rejects_interface_mutations() -> None:
+    command = next(
+        line.strip()
+        for line in run_local_publish_report().stdout.splitlines()
+        if "scripts/publish-release-image.sh candidate" in line
     )
+    mutations = (
+        command.replace("-u MAKEFLAGS ", ""),
+        command.replace("PLAYGROUND_PLATFORM=linux/amd64 ", ""),
+        command.replace("PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground ", ""),
+        command.replace("HEW_EXAMPLES_REF=", "HEW_SHA="),
+        command.replace(
+            "scripts/publish-release-image.sh", "make release-candidate-publish"
+        ),
+    )
+    for mutation in mutations:
+        try:
+            assert_candidate_publish_command(mutation)
+        except AssertionError:
+            continue
+        raise AssertionError(f"candidate interface mutation escaped: {mutation}")
 
 
 def test_local_publish_report_rejects_mutated_or_malformed_authority() -> None:
@@ -871,7 +917,7 @@ def test_local_publish_report_rejects_mutated_or_malformed_authority() -> None:
         result = run_local_publish_report(bad_sha)
         assert result.returncode != 0, bad_sha
         assert "release commit identity is not an exact lowercase" in result.stdout
-        assert "make release-candidate-publish" not in result.stdout
+        assert "scripts/publish-release-image.sh candidate" not in result.stdout
 
     mutation = local_publish_script().replace("${HEW_EXAMPLES_REF}", "${HEW_SHA}")
     result = run_local_publish_report(script=mutation)

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -538,9 +538,6 @@ def test_release_image_assertion_covers_every_acquisition_mode() -> None:
 
     local_step = step_of(job, "Report expected local release image publish")
     assert "if: steps.acquisition.outputs.mode == 'local'" in local_step
-    assert (
-        "make release-publish HEW_SHA=${HEW_SHA} HEW_VERSION=${VERSION}" in local_step
-    )
     assert "gh workflow run" not in local_step
 
     assert_step = step_of(

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -1,10 +1,10 @@
 """Static contract tests for the release workflow's prerelease handoff."""
 
 import ast
+import hashlib
 import json
 import os
 import re
-import shlex
 import shutil
 import stat
 import subprocess
@@ -86,20 +86,6 @@ def playground_job(text: str | None = None) -> str:
     return text[start:end]
 
 
-def playground_script(text: str | None = None) -> str:
-    """Extract the exact Bash program executed by the dispatch step.
-
-    Bounded at the next step so the acquisition-mode steps that follow the
-    dispatch cannot leak their YAML into the program under test.
-    """
-    job = playground_job() if text is None else text
-    step = job.index("      - name: Trigger playground image rebuild\n")
-    run = job.index("        run: |\n", step) + len("        run: |\n")
-    next_step = job.find("\n      - name: ", run)
-    body = job[run:] if next_step == -1 else job[run : next_step + 1]
-    return textwrap.dedent(body).rstrip() + "\n"
-
-
 def step_of(job: str, name: str) -> str:
     """Extract one named step's YAML from a job, bounded at the next step."""
     start = job.index(f"      - name: {name}\n")
@@ -107,37 +93,27 @@ def step_of(job: str, name: str) -> str:
     return job[start:] if end == -1 else job[start : end + 1]
 
 
-def acquisition_script() -> str:
-    """Extract the exact Bash program that selects the acquisition mode."""
+def image_handoff_script() -> str:
+    """Extract the exact Bash program that validates the immutable handoff."""
     job = playground_job()
-    step = step_of(job, "Select release image acquisition mode")
+    step = step_of(job, "Validate immutable playground image handoff")
     run = step.index("        run: |\n") + len("        run: |\n")
     return textwrap.dedent(step[run:]).rstrip() + "\n"
 
 
-def local_publish_script(text: str | None = None) -> str:
-    """Extract the exact Bash program that reports the local publish command."""
-    job = playground_job() if text is None else text
-    step = step_of(job, "Report expected local release image publish")
-    run = step.index("        run: |\n") + len("        run: |\n")
-    return textwrap.dedent(step[run:]).rstrip() + "\n"
-
-
-def run_acquisition(
-    mode: str | None, event_name: str = "push", script: str | None = None
-) -> tuple:
-    """Execute the acquisition-mode selection with a given repository variable."""
+def run_image_handoff(lock: str | None, script: str | None = None) -> tuple:
+    """Execute the immutable handoff validator with a repository variable."""
     with tempfile.TemporaryDirectory() as directory:
         output = Path(directory) / "github_output"
         output.touch()
         env = os.environ.copy()
         env["GITHUB_OUTPUT"] = str(output)
-        env["GITHUB_EVENT_NAME"] = event_name
-        env.pop("PLAYGROUND_PUBLISH_MODE", None)
-        if mode is not None:
-            env["PLAYGROUND_PUBLISH_MODE"] = mode
+        env["RELEASE_TAG"] = "v0.6.0-rc2"
+        env.pop("PLAYGROUND_RELEASE_IMAGE_LOCK", None)
+        if lock is not None:
+            env["PLAYGROUND_RELEASE_IMAGE_LOCK"] = lock
         result = subprocess.run(
-            ["bash", "-c", acquisition_script() if script is None else script],
+            ["bash", "-c", image_handoff_script() if script is None else script],
             cwd=ROOT,
             env=env,
             check=False,
@@ -152,63 +128,14 @@ def run_acquisition(
         return result, outputs
 
 
-def assert_actions_push_is_rejected(script: str) -> None:
-    result, outputs = run_acquisition("actions", "push", script)
-    assert result.returncode != 0
-    assert "actions is post-tag only" in result.stdout
-    assert outputs == {}
-
-
-def run_local_publish_report(
-    release_ref: str = HEW_SHA, script: str | None = None
-) -> subprocess.CompletedProcess:
-    env = os.environ.copy()
-    env.update(
-        {
-            "HEW_EXAMPLES_REF": release_ref,
-            "RELEASE_TAG": "v0.6.0-rc1",
-            "DEADLINE_EPOCH": str(int(time()) + 60),
-        }
-    )
-    env.pop("HEW_SHA", None)
-    return subprocess.run(
-        ["bash", "-c", local_publish_script() if script is None else script],
-        cwd=ROOT,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-
-def assert_candidate_publish_command(command: str) -> None:
-    assert shlex.split(command) == [
-        "env",
-        "-u",
-        "MAKEFLAGS",
-        "-u",
-        "MFLAGS",
-        "-u",
-        "MAKEOVERRIDES",
-        "-u",
-        "MAKEFILES",
-        "-u",
-        "GNUMAKEFLAGS",
-        f"HEW_EXAMPLES_REF={HEW_SHA}",
-        "HEW_VERSION=0.6.0-rc1",
-        "PLAYGROUND_PLATFORM=linux/amd64",
-        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground",
-        "scripts/publish-release-image.sh",
-        "candidate",
-    ]
-
-
 def run_release_image_assertion(env_overrides: dict) -> subprocess.CompletedProcess:
     """Execute the release-image assertion with a fixed environment."""
     env = os.environ.copy()
     for key in (
         "IMAGE_REPOSITORY",
         "IMAGE_TAG",
+        "EXPECTED_DIGEST",
+        "EXPECTED_PLATFORM",
         "EXPECTED_REVISION",
         "GHCR_TOKEN",
         "GHCR_USERNAME",
@@ -231,7 +158,12 @@ def run_release_image_assertion(env_overrides: dict) -> subprocess.CompletedProc
 
 
 @contextmanager
-def canned_registry(responses: dict[str, list[tuple[int, dict]]]):
+def canned_registry(
+    responses: dict[str, list[tuple[int, dict]]],
+    digest_headers: dict[str, str] | None = None,
+):
+    digest_headers = digest_headers or {}
+
     class RequestLog(list[str]):
         authorization_headers: dict[str, list[str]]
         raw_authorization_headers: dict[str, list[str]]
@@ -254,33 +186,33 @@ def canned_registry(responses: dict[str, list[tuple[int, dict]]]):
             requests.raw_authorization_headers.setdefault(path, []).append(
                 authorization
             )
-            if authorization == f"{BEARER_SCHEME} {issued_token}":
-                authorization = "******"
-            elif (
-                self.headers.get("User-Agent", "").startswith("curl/")
-                and authorization == "******"
-            ):
-                # The test runner redacts curl's Authorization header in transit.
-                authorization = "******"
-            if (
-                authorization == "******"
-                and self.headers.get("X-Registry-Contract", "") == "direct"
-            ):
-                authorization = ""
-            requests.authorization_headers.setdefault(path, []).append(authorization)
+            logged_authorization = (
+                "******"
+                if authorization.startswith(f"{BEARER_SCHEME} ")
+                else authorization
+            )
+            requests.authorization_headers.setdefault(path, []).append(
+                logged_authorization
+            )
             sequence = responses.get(path, [(404, {"error": "not found"})])
             index = counts.get(path, 0)
             counts[path] = index + 1
             status, body = sequence[min(index, len(sequence) - 1)]
-            if path.startswith("/v2/") and authorization != f"Bearer {issued_token}":
+            if path.startswith("/v2/") and (
+                issued_token is None
+                or authorization != f"{BEARER_SCHEME} {issued_token}"
+            ):
                 status, body = 401, {"error": "invalid bearer token"}
             elif path == "/token":
                 issued_token = body.get("token")
-            if path.startswith("/v2/") and "X-Registry-Contract" not in self.headers:
-                status, body = sequence[min(index, len(sequence) - 1)]
             encoded = json.dumps(body).encode()
             self.send_response(status)
             self.send_header("Content-Type", "application/json")
+            if path.startswith("/v2/") and status == 200:
+                self.send_header(
+                    "Docker-Content-Digest",
+                    digest_headers.get(path, content_digest(body)),
+                )
             self.send_header("Content-Length", str(len(encoded)))
             self.end_headers()
             self.wfile.write(encoded)
@@ -312,6 +244,15 @@ def image_manifest(config_digest: str) -> dict:
     }
 
 
+def content_digest(document: dict) -> str:
+    encoded = json.dumps(document).encode()
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def named_digest(name: str) -> str:
+    return f"sha256:{hashlib.sha256(name.encode()).hexdigest()}"
+
+
 def image_config(labels: dict[str, str] | None) -> dict:
     config = {}
     if labels is not None:
@@ -327,15 +268,23 @@ def run_canned_release_image_assertion(
     responses: dict[str, list[tuple[int, dict]]],
     *,
     deadline_epoch: int | None = None,
+    expected_digest: str | None = None,
+    expected_platform: str = "linux/amd64",
+    digest_headers: dict[str, str] | None = None,
 ) -> tuple[subprocess.CompletedProcess, list[str]]:
     responses = {
         "/token": [(200, {"token": "pull-token"})],
         **responses,
     }
-    with canned_registry(responses) as (port, requests):
+    with canned_registry(responses, digest_headers) as (port, requests):
+        manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
+        if expected_digest is None:
+            expected_digest = content_digest(responses[manifest_path][-1][1])
         env = {
             "IMAGE_REPOSITORY": "hew-lang/playground",
             "IMAGE_TAG": "v0.6.0-rc2",
+            "EXPECTED_DIGEST": expected_digest,
+            "EXPECTED_PLATFORM": expected_platform,
             "EXPECTED_REVISION": HEW_SHA,
             "GHCR_TOKEN": "test-token",
             "GHCR_USERNAME": "test-user",
@@ -365,200 +314,11 @@ def registry_request_status(
         return error.code
 
 
-def assert_exact_dispatch_correlation(job: str) -> None:
-    """Require the unique dispatch identity in both dispatch and run selection."""
-    assert 'CORRELATION_ID="hew-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' in job
-    assert (
-        'EXPECTED_DISPLAY_TITLE="Build Playground mode=publish'
-        ' sha=${HEW_SHA} version=${VERSION} correlation=${CORRELATION_ID}"' in job
-    )
-
-    dispatch_start = job.index("          gh workflow run build.yml")
-    dispatch_end = job.index('          RUN_ID=""', dispatch_start)
-    dispatch = job[dispatch_start:dispatch_end]
-    assert "-f publish=true \\\n" in dispatch
-    assert '-f hew_sha="${HEW_SHA}" \\\n' in dispatch
-    assert '-f version="${VERSION}" \\\n' in dispatch
-    assert '-f correlation_id="${CORRELATION_ID}"' in dispatch
-
-    query_start = job.index("            if ! RUN_IDS_OUTPUT=$(jq -r")
-    query_end = job.index("            RUN_IDS=()", query_start)
-    query = job[query_start:query_end]
-    expected = """            if ! RUN_IDS_OUTPUT=$(jq -r \\
-                --argjson floor "${PRE_DISPATCH_MAX_ID}" \\
-                --arg actor "${DISPATCH_ACTOR}" \\
-                --arg display_title "${EXPECTED_DISPLAY_TITLE}" \\
-                '.workflow_runs[]
-                  | select(.id > $floor)
-                  | select(.actor.login == $actor)
-                  | select(.display_title == $display_title)
-                  | .id' <<< "${RUNS_JSON}"); then
-              echo "::error::failed to parse playground workflow runs"
-              exit 1
-            fi
-"""
-    assert query == expected
-
-
-def assert_fail_closed_run_retrieval(job: str) -> None:
-    """Require API retrieval and jq parsing to have independent status checks."""
-    assert "        shell: bash\n" in job
-    script = playground_script(job)
-    assert script.startswith("set -euo pipefail\n")
-    start = job.index("            if ! RUNS_JSON=$(gh api -X GET")
-    end = job.index("            if ! RUN_IDS_OUTPUT=$(jq -r", start)
-    retrieval = job[start:end]
-    assert "| jq" not in retrieval
-    assert 'echo "::error::failed to list playground workflow runs"' in retrieval
-    assert "              exit 1\n" in retrieval
-
-
-_MOCK_GH = r"""#!/usr/bin/env python3
-import json
-import os
-import sys
-from pathlib import Path
-
-args = sys.argv[1:]
-state = Path(os.environ["MOCK_STATE"])
-log = Path(os.environ["MOCK_LOG"])
-with log.open("a") as stream:
-    stream.write("gh " + " ".join(args) + "\n")
-
-if args[:2] == ["repo", "view"]:
-    raise SystemExit(0)
-if args[:2] == ["workflow", "view"]:
-    print("active")
-    raise SystemExit(0)
-if args[:2] == ["workflow", "run"]:
-    raise SystemExit(0)
-if args[:2] == ["run", "watch"]:
-    raise SystemExit(0 if args[2] == "101" else 91)
-if not args or args[0] != "api":
-    raise SystemExit(92)
-
-joined = " ".join(args)
-if args[1:] == ["user", "--jq", ".login"]:
-    print("GET /user is unavailable to installation tokens", file=sys.stderr)
-    raise SystemExit(43)
-if "repos/hew-lang/playground/actions/workflows/build.yml/runs" in joined:
-    if "--jq" in args:
-        print("100")
-        raise SystemExit(0)
-    scenario = os.environ["MOCK_SCENARIO"]
-    if scenario == "api-failure":
-        print("mock API failure", file=sys.stderr)
-        raise SystemExit(42)
-    poll = int(state.read_text() or "0") + 1 if state.exists() else 1
-    state.write_text(str(poll))
-    matching = {
-        "id": 101,
-        "head_sha": "sha-after" if scenario == "moving-head" else "sha-good",
-        "actor": {"login": "playground-app[bot]"},
-        "display_title": (
-            "Build Playground mode=publish"
-            " sha=0123456789abcdef0123456789abcdef01234567"
-            " version=0.6.0-rc1 correlation=hew-777-2"
-        ),
-    }
-    if scenario == "empty":
-        runs = []
-    elif scenario == "ambiguous":
-        runs = [matching, {**matching, "id": 102}]
-    elif scenario in {"title", "actor", "floor"}:
-        candidate = dict(matching)
-        if scenario == "title":
-            candidate["display_title"] = "Build Playground wrong"
-        elif scenario == "actor":
-            candidate["actor"] = {"login": "actor-wrong"}
-        else:
-            candidate["id"] = 100
-        runs = [candidate]
-    else:
-        runs = [
-            {**matching, "id": 100},
-            {**matching, "actor": {"login": "actor-wrong"}, "id": 104},
-            {**matching, "display_title": "Build Playground wrong", "id": 105},
-            matching,
-        ]
-    print(json.dumps({"workflow_runs": runs}))
-    raise SystemExit(0)
-if "repos/hew-lang/playground" in joined:
-    print("main")
-    raise SystemExit(0)
-raise SystemExit(93)
-"""
-
-
-def run_playground(
-    scenario: str,
-    *,
-    jq_failure: bool = False,
-    hew_sha: str = HEW_SHA,
-    script: str | None = None,
-) -> tuple:
-    """Execute the workflow's exact Bash with deterministic command doubles."""
-    with tempfile.TemporaryDirectory() as directory:
-        root = Path(directory)
-        bin_dir = root / "bin"
-        bin_dir.mkdir()
-        gh = bin_dir / "gh"
-        gh.write_text(_MOCK_GH)
-        gh.chmod(0o755)
-        sleep = bin_dir / "sleep"
-        sleep.write_text("#!/usr/bin/env bash\nexit 0\n")
-        sleep.chmod(0o755)
-        if jq_failure:
-            jq = bin_dir / "jq"
-            jq.write_text("#!/usr/bin/env bash\nexit 23\n")
-            jq.chmod(0o755)
-        state = root / "state"
-        log = root / "calls.log"
-        env = os.environ.copy()
-        env.update(
-            {
-                "PATH": f"{bin_dir}:{env['PATH']}",
-                "GH_TOKEN": "test-token",
-                "HEW_SHA": hew_sha,
-                "DISPATCH_ACTOR": "playground-app[bot]",
-                "RELEASE_TAG": "v0.6.0-rc1",
-                "GITHUB_RUN_ID": "777",
-                "GITHUB_RUN_ATTEMPT": "2",
-                "MOCK_SCENARIO": scenario,
-                "MOCK_STATE": str(state),
-                "MOCK_LOG": str(log),
-            }
-        )
-        result = subprocess.run(
-            ["bash", "-c", playground_script() if script is None else script],
-            cwd=ROOT,
-            env=env,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        calls = log.read_text().splitlines() if log.exists() else []
-        polls = int(state.read_text()) if state.exists() else 0
-        return result, calls, polls
-
-
-def assert_wait_budget(job: str) -> None:
-    """Keep the shell's budget authority equal to the enforced job timeout."""
-    match = re.search(r"^    timeout-minutes: (\d+)$", job, re.MULTILINE)
-    assert match is not None
-    shell_budget = re.search(r"^\s+JOB_TIMEOUT_MINUTES=(\d+)$", job, re.MULTILINE)
-    assert shell_budget is not None
-    assert int(match.group(1)) == int(shell_budget.group(1))
-    assert (
-        "ASSERTION_BUDGET_MINUTES=$((JOB_TIMEOUT_MINUTES - FINALIZATION_RESERVE_MINUTES))"
-        in job
-    )
-
-
 def test_rc_tag_normalization_and_exact_release_body() -> None:
     text = workflow()
     assert "RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}" in text
-    assert 'VERSION="${RELEASE_TAG#v}"' in playground_job()
+    assert 'LOCK_TAG="${PLAYGROUND_RELEASE_IMAGE_LOCK%%@*}"' in playground_job()
+    assert 'if [[ "${LOCK_TAG}" != "${RELEASE_TAG}" ]]' in playground_job()
     assert "body_path: docs/releases/${{ env.RELEASE_TAG }}.md" in text
     assert RELEASE_NOTES.exists()
 
@@ -636,299 +396,79 @@ def test_current_sandbox_vm_version_matches_workspace_version() -> None:
     assert lockfile["packages"][""]["version"] == workspace_version
 
 
-def test_playground_dispatch_is_purpose_scoped_and_fail_closed() -> None:
-    text = workflow()
+def test_playground_release_uses_only_an_immutable_pretag_handoff() -> None:
+    digest = named_digest("candidate-index")
+    result, outputs = run_image_handoff(f"v0.6.0-rc2@{digest}")
+    assert result.returncode == 0, result.stderr
+    assert outputs["image_digest"] == digest
+
+    for bad_lock in (
+        None,
+        "",
+        digest,
+        f"v0.6.0-rc3@{digest}",
+        "v0.6.0-rc2@sha256:short",
+        f"v0.6.0-rc2@{digest.upper()}",
+        f"v0.6.0-rc2@sha512:{'a' * 64}",
+    ):
+        rejected, rejected_outputs = run_image_handoff(bad_lock)
+        assert rejected.returncode != 0, bad_lock
+        assert rejected_outputs == {}, bad_lock
+
     job = playground_job()
-    assert "      - name: Resolve release commit identity\n" in job
     assert (
-        "gh api \"repos/${GITHUB_REPOSITORY}/commits/${RELEASE_TAG}\" --jq '.sha'"
-    ) in job
-    assert "did not resolve to an exact lowercase" in job
-    assert "HEW_SHA: ${{ steps.release-commit.outputs.hew_sha }}" in job
-    assert "PLAYGROUND_DISPATCH_TOKEN" not in text
-    assert "HOMEBREW_TAP_TOKEN" not in job
-    assert "#   secrets.PLAYGROUND_APP_ID" in text
-    assert "#   secrets.PLAYGROUND_APP_PRIVATE_KEY" in text
-
-    validate = job.index("      - name: Validate playground GitHub App configuration\n")
-    mint = job.index("      - name: Mint playground GitHub App token\n")
-    trigger = job.index("      - name: Trigger playground image rebuild\n")
-    assert validate < mint < trigger
-    validation_step = job[validate:mint]
-    token_step = job[mint:trigger]
-    trigger_step = job[trigger:]
-
-    assert "PLAYGROUND_APP_ID: ${{ secrets.PLAYGROUND_APP_ID }}" in validation_step
-    assert (
-        "PLAYGROUND_APP_PRIVATE_KEY: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}"
-        in validation_step
+        "PLAYGROUND_RELEASE_IMAGE_LOCK: ${{ vars.PLAYGROUND_RELEASE_IMAGE_LOCK }}"
+        in job
     )
-    assert (
-        "requires secrets.PLAYGROUND_APP_ID and secrets.PLAYGROUND_APP_PRIVATE_KEY"
-        in validation_step
-    )
-    assert "exit 1" in validation_step
-    assert "if: steps.acquisition.outputs.mode == 'actions'" in validation_step
-    assert "continue-on-error:" not in validation_step
-
-    assert "id: playground-app-token" in token_step
-    assert re.search(
-        r"uses: actions/create-github-app-token@[0-9a-f]{40}  # v2\.2\.2$",
-        token_step,
-        re.MULTILINE,
-    )
-    assert "app-id: ${{ secrets.PLAYGROUND_APP_ID }}" in token_step
-    assert "private-key: ${{ secrets.PLAYGROUND_APP_PRIVATE_KEY }}" in token_step
-    assert "owner: hew-lang" in token_step
-    assert "repositories: playground" in token_step
-    assert "if: steps.acquisition.outputs.mode == 'actions'" in token_step
-    assert "continue-on-error:" not in token_step
-    assert "GH_TOKEN: ${{ steps.playground-app-token.outputs.token }}" in trigger_step
-    assert (
-        "DISPATCH_ACTOR: ${{ steps.playground-app-token.outputs.app-slug }}[bot]"
-        in trigger_step
-    )
-    assert "gh api user" not in trigger_step
-    assert "gh repo view hew-lang/playground" in job
-    assert "gh api repos/hew-lang/playground --jq '.default_branch'" in job
-    assert "gh workflow view build.yml" in job
-    assert '!= "active"' in job
-    assert "could not correlate" in job
-
-
-def test_dispatch_uses_exact_playground_workflow_input_and_ref() -> None:
-    job = playground_job()
-    assert "gh workflow run build.yml" in job
-    assert '--ref "${PLAYGROUND_REF}"' in job
-    assert "-f publish=true" in job
-    assert '-f hew_sha="${HEW_SHA}"' in job
-    assert '-f version="${VERSION}"' in job
-    assert "-f event=workflow_dispatch" in job
-    assert '-f branch="${PLAYGROUND_REF}"' in job
-    assert 'gh run watch "${RUN_ID}" -R hew-lang/playground --exit-status' in job
-
-
-def test_dispatch_correlation_is_unique_and_bounded() -> None:
-    job = playground_job()
-    assert_wait_budget(job)
-    assert_exact_dispatch_correlation(job)
-    assert "PLAYGROUND_SHA" not in job
-    assert "PRE_DISPATCH_MAX_ID=" in job
-    assert '--argjson floor "${PRE_DISPATCH_MAX_ID}"' in job
-    assert (
-        "DISPATCH_ACTOR: ${{ steps.playground-app-token.outputs.app-slug }}[bot]" in job
-    )
-    assert '--arg actor "${DISPATCH_ACTOR}"' in job
-    assert "select(.id > $floor)" in job
-    assert "select(.head_sha" not in job
-    assert "select(.actor.login == $actor)" in job
-    assert_fail_closed_run_retrieval(job)
-    assert "if ! RUN_IDS_OUTPUT=$(jq -r" in job
-    assert 'if [ -n "${CANDIDATE_ID}" ]; then' in job
-    assert "mapfile -t RUN_IDS < <(" not in job
-    assert "LAST_CANDIDATE_ID" in job
-    assert "ambiguous playground workflow dispatch correlation" in job
-
-
-def test_release_image_acquisition_mode_is_exhaustive_and_fails_closed() -> None:
-    accepted = (
-        ("local", "push"),
-        ("local", "workflow_dispatch"),
-        ("actions", "workflow_dispatch"),
-    )
-    for mode, event_name in accepted:
-        before = int(time())
-        result, outputs = run_acquisition(mode, event_name)
-        after = int(time())
-        assert result.returncode == 0, result.stderr
-        assert outputs["mode"] == mode
-        assert outputs["assert_budget_minutes"] == "115"
-        deadline = int(outputs["assert_deadline_epoch"])
-        assert before + 115 * 60 <= deadline <= after + 115 * 60
-
-    script = acquisition_script()
-    assert_actions_push_is_rejected(script)
-    mutations = (
-        script.replace(
-            'if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then',
-            "if false; then",
-        ),
-        script.replace(
-            "actions)\n    if [[",
-            "actions)\n    GITHUB_EVENT_NAME=workflow_dispatch\n    if [[",
-        ),
-    )
-    for mutation in mutations:
-        try:
-            assert_actions_push_is_rejected(mutation)
-        except AssertionError:
-            continue
-        raise AssertionError("tag-push actions-mode mutation escaped")
-
-    for rejected in (None, "", "Actions", "LOCAL", "skip", "true", "actions local"):
-        result, outputs = run_acquisition(rejected)
-        assert result.returncode != 0, repr(rejected)
-        assert "must be exactly 'actions' or 'local'" in result.stdout, repr(rejected)
-        assert outputs == {}, repr(rejected)
-
-
-def test_release_image_assertion_covers_every_acquisition_mode() -> None:
-    job = playground_job()
-    mode_step = step_of(job, "Select release image acquisition mode")
-    assert "id: acquisition" in mode_step
-    assert "PLAYGROUND_PUBLISH_MODE: ${{ vars.PLAYGROUND_PUBLISH_MODE }}" in mode_step
-    assert "if:" not in mode_step
-    assert "continue-on-error:" not in mode_step
-
-    trigger_step = step_of(job, "Trigger playground image rebuild")
-    assert "if: steps.acquisition.outputs.mode == 'actions'" in trigger_step
-
-    local_step = step_of(job, "Report expected local release image publish")
-    assert "if: steps.acquisition.outputs.mode == 'local'" in local_step
-    assert "gh workflow run" not in local_step
-    assert "HEW_EXAMPLES_REF: ${{ steps.release-commit.outputs.hew_sha }}" in local_step
-    assert "HEW_SHA:" not in local_step
-
-    assert_step = step_of(
-        job, "Assert release image exists and binds the release commit"
-    )
-    assert (
-        "if: ${{ !cancelled() && steps.acquisition.outputs.mode != '' }}" in assert_step
-    )
-    assert "continue-on-error:" not in assert_step
-    assert "IMAGE_REPOSITORY: hew-lang/playground" in assert_step
-    assert "IMAGE_TAG: ${{ env.RELEASE_TAG }}" in assert_step
-    assert (
-        "EXPECTED_REVISION: ${{ steps.release-commit.outputs.hew_sha }}" in assert_step
-    )
-    assert "GHCR_TOKEN: ${{ github.token }}" in assert_step
-    assert "GHCR_USERNAME: ${{ github.actor }}" in assert_step
-    assert (
-        "DEADLINE_EPOCH: ${{ steps.acquisition.outputs.assert_deadline_epoch }}"
-        in assert_step
-    )
+    assert "EXPECTED_DIGEST: ${{ steps.image-lock.outputs.image_digest }}" in job
+    assert "EXPECTED_PLATFORM: linux/amd64" in job
+    assert "gh workflow run" not in job
+    assert "actions/create-github-app-token" not in job
+    assert "PLAYGROUND_PUBLISH_MODE" not in job
+    assert "PLAYGROUND_APP" not in job
     assert "packages: read" in job
-    assert "run: release-machinery/scripts/assert-playground-release-image.sh" in (
-        assert_step
-    )
-
-    machinery_step = step_of(job, "Checkout release machinery")
-    assert "ref: ${{ github.sha }}" in machinery_step
-    assert "path: release-machinery" in machinery_step
-
-    assert RELEASE_IMAGE_ASSERTION.exists()
-    assert RELEASE_IMAGE_ASSERTION.stat().st_mode & stat.S_IXUSR
 
 
-def test_local_publish_command_requires_pre_tag_candidate_publisher() -> None:
-    report = run_local_publish_report()
-    assert report.returncode == 0, report.stderr
-    commands = [
-        line.strip()
-        for line in report.stdout.splitlines()
-        if "scripts/publish-release-image.sh candidate" in line
-    ]
-    assert len(commands) == 1
-    assert_candidate_publish_command(commands[0])
-    local_step = step_of(
-        playground_job(), "Report expected local release image publish"
-    )
-    assert "make " not in local_step
-    assert "HEW_SHA" not in local_step
-    assert 'PLAYGROUND_RELEASE_IMAGE="ghcr.io/hew-lang/playground"' in local_step
-    assert (
-        'EXPECTED_RELEASE_IMAGE="${PLAYGROUND_RELEASE_IMAGE}:${RELEASE_TAG}"'
-        in local_step
-    )
-    assert "PLAYGROUND_PLATFORM=linux/amd64" in local_step
-    inherited_make_controls = (
-        "MAKEFLAGS",
-        "MFLAGS",
-        "MAKEOVERRIDES",
-        "MAKEFILES",
-        "GNUMAKEFLAGS",
-    )
-    for inherited in inherited_make_controls:
-        assert f"-u {inherited}" in local_step
-
+def test_pretag_runbook_pins_candidate_command_digest_and_posttag_authority() -> None:
     runbook = RUNBOOK.read_text()
     pre_tag = runbook[
         runbook.index("## Phase 5") : runbook.index(
             "3. Create the signed tag", runbook.index("## Phase 5")
         )
     ]
-    assert "scripts/publish-release-image.sh candidate" in pre_tag
     assert f"PLAYGROUND_CONTRACT_REF={PLAYGROUND_CONTRACT_REF}" in pre_tag
     assert "PLAYGROUND_REF=<exact-reviewed-40-character-playground-sha>" in pre_tag
-    assert '"${PLAYGROUND_CONTRACT_REF}" HEAD' in pre_tag
     assert 'test -z "$(git -C "${PLAYGROUND_CHECKOUT}" status --porcelain)"' in pre_tag
+    for inherited in (
+        "MAKEFLAGS",
+        "MFLAGS",
+        "MAKEOVERRIDES",
+        "MAKEFILES",
+        "GNUMAKEFLAGS",
+    ):
+        assert f"-u {inherited}" in pre_tag
+    assert 'HEW_EXAMPLES_REF="${HEW_RELEASE_SHA}"' in pre_tag
+    assert 'HEW_VERSION="${VERSION}"' in pre_tag
     assert "PLAYGROUND_PLATFORM=linux/amd64" in pre_tag
     assert "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground" in pre_tag
-    assert 'test "${HEW_DEFAULT_VERSION}" = "${VERSION}"' in pre_tag
-    assert 'test "${HEW_CANDIDATE_SHA}" = "${HEW_RELEASE_SHA}"' in pre_tag
-    assert "minimal playground `toolchains.env` bump" in pre_tag
-    assert "gh variable set PLAYGROUND_PUBLISH_MODE --body local" in pre_tag
-    assert "org.opencontainers.image.revision" in pre_tag
+    assert "scripts/publish-release-image.sh candidate" in pre_tag
+    assert "docker buildx imagetools inspect" in pre_tag
+    assert "--format '{{json .Manifest}}' | jq -er '.digest'" in pre_tag
+    assert "^sha256:[0-9a-f]{64}$" in pre_tag
+    assert "gh variable set PLAYGROUND_RELEASE_IMAGE_LOCK" in pre_tag
+    assert '"v${VERSION}@${PLAYGROUND_IMAGE_DIGEST}"' in pre_tag
     assert "scripts/publish-release-image.sh publish" not in pre_tag
-    assert "make release-candidate-publish" not in pre_tag
-
-    release_publish_mutation = local_publish_script().replace(" candidate", " publish")
-    mutated = run_local_publish_report(script=release_publish_mutation)
-    assert mutated.returncode == 0, mutated.stderr
-    mutated_commands = [
-        line.strip()
-        for line in mutated.stdout.splitlines()
-        if "scripts/publish-release-image.sh publish" in line
-    ]
-    assert len(mutated_commands) == 1
-    try:
-        assert_candidate_publish_command(mutated_commands[0])
-    except AssertionError:
-        pass
-    else:
-        raise AssertionError("publish authority escaped the pre-tag command contract")
-
-
-def test_local_publish_contract_rejects_interface_mutations() -> None:
-    command = next(
-        line.strip()
-        for line in run_local_publish_report().stdout.splitlines()
-        if "scripts/publish-release-image.sh candidate" in line
-    )
-    mutations = (
-        command.replace("-u MAKEFLAGS ", ""),
-        command.replace("PLAYGROUND_PLATFORM=linux/amd64 ", ""),
-        command.replace("PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground ", ""),
-        command.replace("HEW_EXAMPLES_REF=", "HEW_SHA="),
-        command.replace(
-            "scripts/publish-release-image.sh", "make release-candidate-publish"
-        ),
-    )
-    for mutation in mutations:
-        try:
-            assert_candidate_publish_command(mutation)
-        except AssertionError:
-            continue
-        raise AssertionError(f"candidate interface mutation escaped: {mutation}")
-
-
-def test_local_publish_report_rejects_mutated_or_malformed_authority() -> None:
-    for bad_sha in ("not-a-sha", HEW_SHA[:39], HEW_SHA.upper()):
-        result = run_local_publish_report(bad_sha)
-        assert result.returncode != 0, bad_sha
-        assert "release commit identity is not an exact lowercase" in result.stdout
-        assert "scripts/publish-release-image.sh candidate" not in result.stdout
-
-    mutation = local_publish_script().replace("${HEW_EXAMPLES_REF}", "${HEW_SHA}")
-    result = run_local_publish_report(script=mutation)
-    assert result.returncode != 0
-    assert "HEW_SHA: unbound variable" in result.stderr
+    assert "PLAYGROUND_PUBLISH_MODE" not in runbook
+    assert "gh workflow run" not in runbook
+    assert "scripts/publish-release-image.sh publish" in runbook
 
 
 def test_release_image_assertion_rejects_unusable_inputs() -> None:
     valid = {
         "IMAGE_REPOSITORY": "hew-lang/playground",
         "IMAGE_TAG": "v0.6.0-rc2",
+        "EXPECTED_DIGEST": named_digest("candidate"),
+        "EXPECTED_PLATFORM": "linux/amd64",
         "EXPECTED_REVISION": HEW_SHA,
         "GHCR_TOKEN": "test-token",
         "GHCR_USERNAME": "test-user",
@@ -939,6 +479,8 @@ def test_release_image_assertion_rejects_unusable_inputs() -> None:
     cases = {
         "IMAGE_REPOSITORY": "",
         "IMAGE_TAG": "",
+        "EXPECTED_DIGEST": "",
+        "EXPECTED_PLATFORM": "",
         "GHCR_TOKEN": "",
     }
     for key, value in cases.items():
@@ -959,6 +501,28 @@ def test_release_image_assertion_rejects_unusable_inputs() -> None:
         assert result.returncode != 0, bad_sha
         assert "exact lowercase 40-character commit SHA" in result.stderr, bad_sha
 
+    for bad_digest in (
+        "not-a-digest",
+        "sha256:short",
+        f"sha256:{'A' * 64}",
+        f"sha512:{'a' * 64}",
+    ):
+        result = run_release_image_assertion(dict(valid, EXPECTED_DIGEST=bad_digest))
+        assert result.returncode != 0, bad_digest
+        assert "exactly 64 lowercase hexadecimal" in result.stderr, bad_digest
+
+    for bad_platform in ("", "linux", "linux/arm64", "darwin/amd64"):
+        result = run_release_image_assertion(
+            dict(valid, EXPECTED_PLATFORM=bad_platform)
+        )
+        assert result.returncode != 0, bad_platform
+        expected = (
+            "EXPECTED_PLATFORM must be set"
+            if bad_platform == ""
+            else "EXPECTED_PLATFORM must be exactly linux/amd64"
+        )
+        assert expected in result.stderr, bad_platform
+
     result = run_release_image_assertion(dict(valid, DEADLINE_MINUTES="soon"))
     assert result.returncode != 0
     assert "whole number of minutes" in result.stderr
@@ -968,8 +532,8 @@ def test_release_image_assertion_rejects_unusable_inputs() -> None:
     assert "POLL_INTERVAL_SECONDS must be a positive whole number" in result.stderr
 
 
-def _test_release_image_assertion_accepts_matching_single_manifest() -> None:
-    config_digest = "sha256:config-good"
+def test_release_image_assertion_accepts_matching_single_manifest() -> None:
+    config_digest = named_digest("config-good")
     result, requests = run_canned_release_image_assertion(
         {
             "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [
@@ -987,15 +551,13 @@ def _test_release_image_assertion_accepts_matching_single_manifest() -> None:
     assert requests.count("/token") == 1
     assert requests.authorization_headers[
         "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
-    ] == ["Bearer pull-token"]
+    ] == ["******"]
     assert requests.authorization_headers[
         f"/v2/hew-lang/playground/blobs/{config_digest}"
-    ] == ["Bearer pull-token"]
+    ] == ["******"]
 
 
-def _test_canned_registry_rejects_missing_masked_wrong_and_stale_bearer_tokens() -> (
-    None
-):
+def test_canned_registry_rejects_missing_masked_wrong_and_stale_bearer_tokens() -> None:
     manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
     with canned_registry(
         {
@@ -1003,7 +565,7 @@ def _test_canned_registry_rejects_missing_masked_wrong_and_stale_bearer_tokens()
                 (200, {"token": "first-pull-token"}),
                 (200, {"token": "second-pull-token"}),
             ],
-            manifest_path: [(200, image_manifest("sha256:config-good"))],
+            manifest_path: [(200, image_manifest(named_digest("config-good")))],
         }
     ) as (port, requests):
         assert registry_request_status(port, manifest_path) == 401
@@ -1026,14 +588,14 @@ def _test_canned_registry_rejects_missing_masked_wrong_and_stale_bearer_tokens()
     assert requests.authorization_headers[manifest_path] == [
         "",
         "******",
-        "Bearer wrong-token",
-        "Bearer first-pull-token",
-        "Bearer first-pull-token",
-        "Bearer second-pull-token",
+        "******",
+        "******",
+        "******",
+        "******",
     ]
 
 
-def _test_canned_registry_requires_the_current_issued_bearer_token() -> None:
+def test_canned_registry_requires_the_current_issued_bearer_token() -> None:
     manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
     with canned_registry(
         {
@@ -1041,7 +603,7 @@ def _test_canned_registry_requires_the_current_issued_bearer_token() -> None:
                 (200, {"token": "first-pull-token"}),
                 (200, {"token": "second-pull-token"}),
             ],
-            manifest_path: [(200, image_manifest("sha256:config-good"))],
+            manifest_path: [(200, image_manifest(named_digest("config-good")))],
         }
     ) as (port, requests):
         assert registry_request_status(port, manifest_path) == 401
@@ -1080,8 +642,8 @@ def _test_canned_registry_requires_the_current_issued_bearer_token() -> None:
     ]
 
 
-def _test_release_image_assertion_sends_issued_token_for_manifest_and_config() -> None:
-    config_digest = "sha256:config-issued-token"
+def test_release_image_assertion_sends_issued_token_for_manifest_and_config() -> None:
+    config_digest = named_digest("config-issued-token")
     manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
     config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
     result, requests = run_canned_release_image_assertion(
@@ -1101,15 +663,37 @@ def _test_release_image_assertion_sends_issued_token_for_manifest_and_config() -
     ]
 
 
+def test_release_image_assertion_redacts_raw_tokens_on_terminal_failure() -> None:
+    issued_token = "issued-super-secret-token"
+    config_digest = named_digest("missing-config")
+    manifest = image_manifest(config_digest)
+    result, requests = run_canned_release_image_assertion(
+        {
+            "/token": [(200, {"token": issued_token})],
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, manifest)],
+            f"/v2/hew-lang/playground/blobs/{config_digest}": [
+                (403, {"error": "terminal"})
+            ],
+        }
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert issued_token not in combined
+    assert "test-token" not in combined
+    assert requests.raw_authorization_headers[
+        f"/v2/hew-lang/playground/blobs/{config_digest}"
+    ] == [f"{BEARER_SCHEME} {issued_token}"]
+
+
 def test_release_image_assertion_uses_acquired_token_for_manifest_and_config() -> None:
     script = RELEASE_IMAGE_ASSERTION.read_text()
     assert script.count('--oauth2-bearer "${token}"') == 2
     assert "Authorization: ******" not in script
 
 
-def test_release_image_assertion_polls_past_a_stale_tag() -> None:
-    stale_digest = "sha256:config-stale"
-    good_digest = "sha256:config-good"
+def test_release_image_assertion_rejects_a_mutable_tag_digest_immediately() -> None:
+    stale_digest = named_digest("config-stale")
+    good_digest = named_digest("config-good")
     tag_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
     result, requests = run_canned_release_image_assertion(
         {
@@ -1131,13 +715,13 @@ def test_release_image_assertion_polls_past_a_stale_tag() -> None:
             ],
         }
     )
-    assert result.returncode == 0, result.stderr
-    assert requests.count(tag_path) == 2
-    assert "still binds" in result.stderr
+    assert result.returncode != 0
+    assert requests.count(tag_path) == 1
+    assert "registry digest is" in result.stderr
 
 
 def test_release_image_assertion_rejects_missing_revision_label() -> None:
-    config_digest = "sha256:config-missing-revision"
+    config_digest = named_digest("config-missing-revision")
     config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
     result, requests = run_canned_release_image_assertion(
         {
@@ -1155,7 +739,7 @@ def test_release_image_assertion_rejects_missing_revision_label() -> None:
 
 def test_release_image_assertion_rejects_wrong_revision_label() -> None:
     wrong_revision = "f" * 40
-    config_digest = "sha256:config-wrong-revision"
+    config_digest = named_digest("config-wrong-revision")
     config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
     result, requests = run_canned_release_image_assertion(
         {
@@ -1173,14 +757,70 @@ def test_release_image_assertion_rejects_wrong_revision_label() -> None:
     )
     assert result.returncode != 0
     assert config_path in requests
-    assert f"still binds {wrong_revision}; waiting for {HEW_SHA}" in result.stderr
-    assert f"did not bind {HEW_SHA}" in result.stderr
+    assert f"binds {wrong_revision}, not {HEW_SHA}" in result.stderr
 
 
-def test_release_image_assertion_checks_every_platform_in_an_index() -> None:
-    child_digests = ("sha256:manifest-amd64", "sha256:manifest-arm64")
-    config_digests = ("sha256:config-amd64", "sha256:config-arm64")
-    attestation_digest = "sha256:attestation"
+def test_release_image_assertion_rejects_wrong_manifest_platform() -> None:
+    config_digest = named_digest("config-arm64")
+    manifest = image_manifest(config_digest)
+    config = image_config({"org.opencontainers.image.revision": HEW_SHA})
+    config["architecture"] = "arm64"
+    result, _requests = run_canned_release_image_assertion(
+        {
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, manifest)],
+            f"/v2/hew-lang/playground/blobs/{config_digest}": [(200, config)],
+        }
+    )
+    assert result.returncode != 0
+    assert "config is linux/arm64, not linux/amd64" in result.stderr
+
+
+def test_release_image_assertion_rejects_wrong_recorded_digest() -> None:
+    config_digest = named_digest("config-good")
+    manifest = image_manifest(config_digest)
+    result, requests = run_canned_release_image_assertion(
+        {
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, manifest)],
+            f"/v2/hew-lang/playground/blobs/{config_digest}": [
+                (
+                    200,
+                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
+                )
+            ],
+        },
+        expected_digest=named_digest("wrong-recorded-digest"),
+    )
+    assert result.returncode != 0
+    assert requests.count("/v2/hew-lang/playground/manifests/v0.6.0-rc2") == 1
+    assert "registry digest is" in result.stderr
+
+
+def test_release_image_assertion_hashes_raw_manifest_bytes() -> None:
+    config_digest = named_digest("config-good")
+    manifest = image_manifest(config_digest)
+    forged_digest = named_digest("forged-header")
+    manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
+    result, _requests = run_canned_release_image_assertion(
+        {
+            manifest_path: [(200, manifest)],
+            f"/v2/hew-lang/playground/blobs/{config_digest}": [
+                (
+                    200,
+                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
+                )
+            ],
+        },
+        expected_digest=forged_digest,
+        digest_headers={manifest_path: forged_digest},
+    )
+    assert result.returncode != 0
+    assert "raw manifest digest is" in result.stderr
+
+
+def test_release_image_assertion_selects_linux_amd64_from_an_index() -> None:
+    child_digests = (named_digest("manifest-amd64"), named_digest("manifest-arm64"))
+    config_digests = (named_digest("config-amd64"), named_digest("config-arm64"))
+    attestation_digest = named_digest("attestation")
     index = {
         "schemaVersion": 2,
         "mediaType": "application/vnd.oci.image.index.v1+json",
@@ -1224,189 +864,21 @@ def test_release_image_assertion_checks_every_platform_in_an_index() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert f"/v2/hew-lang/playground/manifests/{attestation_digest}" not in requests
+    assert f"/v2/hew-lang/playground/manifests/{child_digests[0]}" in requests
+    assert f"/v2/hew-lang/playground/manifests/{child_digests[1]}" not in requests
 
 
 def test_release_image_assertion_rejects_unclassified_platformless_child() -> None:
     index = {
         "schemaVersion": 2,
         "mediaType": "application/vnd.oci.image.index.v1+json",
-        "manifests": [{"digest": "sha256:unclassified"}],
+        "manifests": [{"digest": named_digest("unclassified")}],
     }
     result, _requests = run_canned_release_image_assertion(
         {"/v2/hew-lang/playground/manifests/v0.6.0-rc2": [(200, index)]}
     )
     assert result.returncode != 0
     assert "has no platform.os and is not marked as an attestation" in result.stderr
-
-
-def test_exact_workflow_shell_accepts_one_stable_matching_run() -> None:
-    result, calls, polls = run_playground("success")
-    assert result.returncode == 0, result.stderr
-    assert polls == 2
-    dispatches = [call for call in calls if call.startswith("gh workflow run")]
-    assert dispatches == [
-        "gh workflow run build.yml -R hew-lang/playground --ref main"
-        f" -f publish=true -f hew_sha={HEW_SHA}"
-        " -f version=0.6.0-rc1 -f correlation_id=hew-777-2"
-    ]
-    watches = [call for call in calls if call.startswith("gh run watch")]
-    assert watches == ["gh run watch 101 -R hew-lang/playground --exit-status"]
-    assert not any(call.startswith("gh api user") for call in calls)
-
-
-def test_moving_default_branch_does_not_break_dispatch_correlation() -> None:
-    result, calls, polls = run_playground("moving-head")
-    assert result.returncode == 0, result.stderr
-    assert polls == 2
-    assert not any("/commits/main" in call for call in calls)
-
-    stale_sha_job = (
-        playground_job()
-        .replace(
-            '                --arg actor "${DISPATCH_ACTOR}" \\\n',
-            '                --arg sha "sha-before" \\\n'
-            '                --arg actor "${DISPATCH_ACTOR}" \\\n',
-        )
-        .replace(
-            "                  | select(.actor.login == $actor)\n",
-            "                  | select(.head_sha == $sha)\n"
-            "                  | select(.actor.login == $actor)\n",
-        )
-        .replace(
-            "          for _ in $(seq 1 30); do",
-            "          for _ in $(seq 1 1); do",
-        )
-    )
-    stale_result, stale_calls, stale_polls = run_playground(
-        "moving-head", script=playground_script(stale_sha_job)
-    )
-    assert stale_result.returncode != 0
-    assert "could not correlate" in stale_result.stdout
-    assert stale_polls == 1
-    assert not any(call.startswith("gh run watch") for call in stale_calls)
-
-
-def test_malformed_release_commit_identity_is_terminal() -> None:
-    for bad_sha in ("", "not-a-sha", HEW_SHA[:39], HEW_SHA.upper()):
-        result, calls, polls = run_playground("success", hew_sha=bad_sha)
-        assert result.returncode != 0, repr(bad_sha)
-        assert "release commit identity is not an exact lowercase" in result.stdout, (
-            repr(bad_sha)
-        )
-        assert polls == 0, repr(bad_sha)
-        assert not any(call.startswith("gh workflow run") for call in calls), repr(
-            bad_sha
-        )
-
-
-def test_run_listing_api_failure_is_terminal() -> None:
-    result, calls, polls = run_playground("api-failure")
-    assert result.returncode != 0
-    assert "failed to list playground workflow runs" in result.stdout
-    assert polls == 0
-    assert not any(call.startswith("gh run watch") for call in calls)
-
-
-def test_run_listing_jq_failure_is_terminal() -> None:
-    result, calls, polls = run_playground("success", jq_failure=True)
-    assert result.returncode != 0
-    assert "failed to parse playground workflow runs" in result.stdout
-    assert polls == 1
-    assert not any(call.startswith("gh run watch") for call in calls)
-
-
-def test_successful_empty_polls_exhaust_the_bound() -> None:
-    result, calls, polls = run_playground("empty")
-    assert result.returncode != 0
-    assert "could not correlate" in result.stdout
-    assert polls == 30
-    assert not any(call.startswith("gh run watch") for call in calls)
-
-
-def test_ambiguous_correlation_fails_on_the_first_poll() -> None:
-    result, calls, polls = run_playground("ambiguous")
-    assert result.returncode != 0
-    assert "ambiguous playground workflow dispatch correlation" in result.stdout
-    assert polls == 1
-    assert not any(call.startswith("gh run watch") for call in calls)
-
-
-def test_each_exact_run_identity_dimension_is_mandatory() -> None:
-    for scenario in ("title", "actor", "floor"):
-        result, calls, polls = run_playground(scenario)
-        assert result.returncode != 0, scenario
-        assert "could not correlate" in result.stdout, scenario
-        assert polls == 30, scenario
-        assert not any(call.startswith("gh run watch") for call in calls), scenario
-
-
-def test_timeout_undercut_mutation_is_rejected() -> None:
-    mutated = playground_job().replace(
-        "    timeout-minutes: 120", "    timeout-minutes: 80"
-    )
-    try:
-        assert_wait_budget(mutated)
-    except AssertionError:
-        return
-    raise AssertionError(
-        "the upstream wait accepted the downstream maximum without margin"
-    )
-
-
-def test_publish_mode_downgrade_mutation_is_rejected() -> None:
-    mutated = playground_job().replace("-f publish=true", "-f publish=false")
-    mutated += "\n# -f publish=true\n"
-    try:
-        assert_exact_dispatch_correlation(mutated)
-    except (AssertionError, ValueError):
-        return
-    raise AssertionError("a publish-mode downgrade was hidden by padding")
-
-
-def test_correlation_swap_with_padding_is_rejected() -> None:
-    mutated = playground_job().replace(
-        "select(.display_title == $display_title)",
-        "select(.display_title == $actor)",
-    )
-    mutated += "\n# select(.display_title == $display_title)\n"
-    try:
-        assert_exact_dispatch_correlation(mutated)
-    except (AssertionError, ValueError):
-        return
-    raise AssertionError("a swapped selector was hidden by padding outside its query")
-
-
-def test_correlation_argument_swap_with_padding_is_rejected() -> None:
-    mutated = playground_job().replace(
-        '--arg actor "${DISPATCH_ACTOR}"',
-        '--arg actor "${EXPECTED_DISPLAY_TITLE}"',
-    )
-    mutated += '\n# --arg actor "${DISPATCH_ACTOR}"\n'
-    try:
-        assert_exact_dispatch_correlation(mutated)
-    except (AssertionError, ValueError):
-        return
-    raise AssertionError("a swapped argument was hidden by padding outside its query")
-
-
-def test_pipeline_status_masking_mutation_is_rejected() -> None:
-    mutated = playground_job().replace(
-        "            if ! RUNS_JSON=$(gh api -X GET \\",
-        "            RUNS_JSON=$(gh api -X GET \\",
-    )
-    mutated += "\n# if ! RUNS_JSON=$(gh api -X GET\n"
-    try:
-        assert_fail_closed_run_retrieval(mutated)
-    except (AssertionError, ValueError):
-        return
-    raise AssertionError("an unchecked API retrieval was hidden by padding")
-
-
-def test_required_downstream_failure_is_not_masked() -> None:
-    job = playground_job()
-    assert "gh run watch" in job
-    assert "continue-on-error" not in job
-    assert "skipping playground trigger" not in job
 
 
 def test_prerelease_policy_uses_selected_release_tag() -> None:

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -110,6 +110,14 @@ def acquisition_script() -> str:
     return textwrap.dedent(step[run:]).rstrip() + "\n"
 
 
+def local_publish_script(text: str | None = None) -> str:
+    """Extract the exact Bash program that reports the local publish command."""
+    job = playground_job() if text is None else text
+    step = step_of(job, "Report expected local release image publish")
+    run = step.index("        run: |\n") + len("        run: |\n")
+    return textwrap.dedent(step[run:]).rstrip() + "\n"
+
+
 def run_acquisition(mode: str | None) -> tuple:
     """Execute the acquisition-mode selection with a given repository variable."""
     with tempfile.TemporaryDirectory() as directory:
@@ -134,6 +142,28 @@ def run_acquisition(mode: str | None) -> tuple:
             if "=" in line
         )
         return result, outputs
+
+
+def run_local_publish_report(
+    release_ref: str = HEW_SHA, script: str | None = None
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env.update(
+        {
+            "HEW_EXAMPLES_REF": release_ref,
+            "RELEASE_TAG": "v0.6.0-rc1",
+            "DEADLINE_EPOCH": str(int(time()) + 60),
+        }
+    )
+    env.pop("HEW_SHA", None)
+    return subprocess.run(
+        ["bash", "-c", local_publish_script() if script is None else script],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 def run_release_image_assertion(env_overrides: dict) -> subprocess.CompletedProcess:
@@ -210,35 +240,42 @@ def image_manifest(config_digest: str) -> dict:
     }
 
 
-def image_config(revision: str) -> dict:
+def image_config(labels: dict[str, str] | None) -> dict:
+    config = {}
+    if labels is not None:
+        config["Labels"] = labels
     return {
         "architecture": "amd64",
         "os": "linux",
-        "config": {"Labels": {"org.opencontainers.image.revision": revision}},
+        "config": config,
     }
 
 
 def run_canned_release_image_assertion(
     responses: dict[str, list[tuple[int, dict]]],
+    *,
+    deadline_epoch: int | None = None,
 ) -> tuple[subprocess.CompletedProcess, list[str]]:
     responses = {
         "/token": [(200, {"token": "pull-token"})],
         **responses,
     }
     with canned_registry(responses) as (port, requests):
-        result = run_release_image_assertion(
-            {
-                "IMAGE_REPOSITORY": "hew-lang/playground",
-                "IMAGE_TAG": "v0.6.0-rc2",
-                "EXPECTED_REVISION": HEW_SHA,
-                "GHCR_TOKEN": "test-token",
-                "GHCR_USERNAME": "test-user",
-                "DEADLINE_MINUTES": "1",
-                "IMAGE_REGISTRY": f"127.0.0.1:{port}",
-                "IMAGE_REGISTRY_SCHEME": "http",
-                "POLL_INTERVAL_SECONDS": "1",
-            }
-        )
+        env = {
+            "IMAGE_REPOSITORY": "hew-lang/playground",
+            "IMAGE_TAG": "v0.6.0-rc2",
+            "EXPECTED_REVISION": HEW_SHA,
+            "GHCR_TOKEN": "test-token",
+            "GHCR_USERNAME": "test-user",
+            "IMAGE_REGISTRY": f"127.0.0.1:{port}",
+            "IMAGE_REGISTRY_SCHEME": "http",
+            "POLL_INTERVAL_SECONDS": "1",
+        }
+        if deadline_epoch is None:
+            env["DEADLINE_MINUTES"] = "1"
+        else:
+            env["DEADLINE_EPOCH"] = str(deadline_epoch)
+        result = run_release_image_assertion(env)
     return result, requests
 
 
@@ -639,6 +676,8 @@ def test_release_image_assertion_covers_every_acquisition_mode() -> None:
     local_step = step_of(job, "Report expected local release image publish")
     assert "if: steps.acquisition.outputs.mode == 'local'" in local_step
     assert "gh workflow run" not in local_step
+    assert "HEW_EXAMPLES_REF: ${{ steps.release-commit.outputs.hew_sha }}" in local_step
+    assert "HEW_SHA:" not in local_step
 
     assert_step = step_of(
         job, "Assert release image exists and binds the release commit"
@@ -669,6 +708,68 @@ def test_release_image_assertion_covers_every_acquisition_mode() -> None:
 
     assert RELEASE_IMAGE_ASSERTION.exists()
     assert RELEASE_IMAGE_ASSERTION.stat().st_mode & stat.S_IXUSR
+
+
+def test_local_publish_command_requires_pre_tag_candidate_publisher() -> None:
+    report = run_local_publish_report()
+    assert report.returncode == 0, report.stderr
+    commands = [
+        line.strip()
+        for line in report.stdout.splitlines()
+        if line.strip().startswith("make release-candidate-publish ")
+    ]
+    assert commands == [
+        f"make release-candidate-publish HEW_EXAMPLES_REF={HEW_SHA} HEW_VERSION=0.6.0-rc1"
+    ]
+    local_step = step_of(
+        playground_job(), "Report expected local release image publish"
+    )
+    assert "make release-publish " not in local_step
+    assert "HEW_SHA" not in local_step
+    assert "# external: hew-lang/playground" in local_step
+
+    runbook = RUNBOOK.read_text()
+    pre_tag = runbook[
+        runbook.index("## Phase 5") : runbook.index(
+            "```bash", runbook.index("## Phase 5")
+        )
+    ]
+    assert (
+        "`make release-candidate-publish HEW_EXAMPLES_REF=<sha> "
+        "HEW_VERSION=<version>`. <!-- external-target: hew-lang/playground -->"
+    ) in pre_tag
+    assert "org.opencontainers.image.revision" in pre_tag
+    assert "before\n   rc2" in pre_tag
+    assert "make release-publish HEW_SHA=" not in pre_tag
+    assert "make release-publish HEW_EXAMPLES_REF=" not in pre_tag
+
+    release_publish_mutation = local_publish_script().replace(
+        "release-candidate-publish", "release-publish"
+    )
+    mutated = run_local_publish_report(script=release_publish_mutation)
+    assert mutated.returncode == 0, mutated.stderr
+    mutated_commands = [
+        line.strip()
+        for line in mutated.stdout.splitlines()
+        if line.strip().startswith("make release-publish ")
+    ]
+    assert mutated_commands == [
+        f"make release-publish HEW_EXAMPLES_REF={HEW_SHA} HEW_VERSION=0.6.0-rc1"
+    ]
+    assert mutated_commands != commands
+
+
+def test_local_publish_report_rejects_mutated_or_malformed_authority() -> None:
+    for bad_sha in ("not-a-sha", HEW_SHA[:39], HEW_SHA.upper()):
+        result = run_local_publish_report(bad_sha)
+        assert result.returncode != 0, bad_sha
+        assert "release commit identity is not an exact lowercase" in result.stdout
+        assert "make release-candidate-publish" not in result.stdout
+
+    mutation = local_publish_script().replace("${HEW_EXAMPLES_REF}", "${HEW_SHA}")
+    result = run_local_publish_report(script=mutation)
+    assert result.returncode != 0
+    assert "HEW_SHA: unbound variable" in result.stderr
 
 
 def test_release_image_assertion_rejects_unusable_inputs() -> None:
@@ -722,7 +823,10 @@ def test_release_image_assertion_accepts_matching_single_manifest() -> None:
                 (200, image_manifest(config_digest))
             ],
             f"/v2/hew-lang/playground/blobs/{config_digest}": [
-                (200, image_config(HEW_SHA))
+                (
+                    200,
+                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
+                )
             ],
         }
     )
@@ -741,16 +845,63 @@ def test_release_image_assertion_polls_past_a_stale_tag() -> None:
                 (200, image_manifest(good_digest)),
             ],
             f"/v2/hew-lang/playground/blobs/{stale_digest}": [
-                (200, image_config("f" * 40))
+                (
+                    200,
+                    image_config({"org.opencontainers.image.revision": "f" * 40}),
+                )
             ],
             f"/v2/hew-lang/playground/blobs/{good_digest}": [
-                (200, image_config(HEW_SHA))
+                (
+                    200,
+                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
+                )
             ],
         }
     )
     assert result.returncode == 0, result.stderr
     assert requests.count(tag_path) == 2
     assert "still binds" in result.stderr
+
+
+def test_release_image_assertion_rejects_missing_revision_label() -> None:
+    config_digest = "sha256:config-missing-revision"
+    config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
+    result, requests = run_canned_release_image_assertion(
+        {
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [
+                (200, image_manifest(config_digest))
+            ],
+            config_path: [(200, image_config({}))],
+        }
+    )
+    assert result.returncode != 0
+    assert config_path in requests
+    assert "carries no org.opencontainers.image.revision label" in result.stderr
+    assert "publisher must stamp the hew release commit" in result.stderr
+
+
+def test_release_image_assertion_rejects_wrong_revision_label() -> None:
+    wrong_revision = "f" * 40
+    config_digest = "sha256:config-wrong-revision"
+    config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
+    result, requests = run_canned_release_image_assertion(
+        {
+            "/v2/hew-lang/playground/manifests/v0.6.0-rc2": [
+                (200, image_manifest(config_digest))
+            ],
+            config_path: [
+                (
+                    200,
+                    image_config({"org.opencontainers.image.revision": wrong_revision}),
+                )
+            ],
+        },
+        deadline_epoch=int(time()) + 2,
+    )
+    assert result.returncode != 0
+    assert config_path in requests
+    assert f"still binds {wrong_revision}; waiting for {HEW_SHA}" in result.stderr
+    assert f"did not bind {HEW_SHA}" in result.stderr
 
 
 def test_release_image_assertion_checks_every_platform_in_an_index() -> None:
@@ -785,10 +936,16 @@ def test_release_image_assertion_checks_every_platform_in_an_index() -> None:
                 (200, image_manifest(config_digests[1]))
             ],
             f"/v2/hew-lang/playground/blobs/{config_digests[0]}": [
-                (200, image_config(HEW_SHA))
+                (
+                    200,
+                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
+                )
             ],
             f"/v2/hew-lang/playground/blobs/{config_digests[1]}": [
-                (200, image_config(HEW_SHA))
+                (
+                    200,
+                    image_config({"org.opencontainers.image.revision": HEW_SHA}),
+                )
             ],
         }
     )
@@ -1523,7 +1680,7 @@ def test_release_record_is_durable_and_tag_ready() -> None:
     assert "every release bar and the final-candidate checklist are green" in runbook
     assert "Manually dispatch" in runbook
     assert "both independent publication arms" in runbook
-    assert "Only after both arms are green" in runbook
+    assert "Only after both independent publication arms are green" in runbook
     assert "Homebrew" in runbook and "prerelease" in runbook
     assert "publish-npm-packages.yml" in runbook
 

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -16,11 +16,14 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from threading import Thread
 from time import time
+from urllib.error import HTTPError
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 
 ROOT = Path(__file__).resolve().parents[2]
 HEW_SHA = "0123456789abcdef0123456789abcdef01234567"
+BEARER_SCHEME = "Bearer"
 WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
 SANDBOX_VM_MANIFEST = ROOT / "hew-sandbox-vm" / "package.json"
 SANDBOX_VM_LOCKFILE = ROOT / "hew-sandbox-vm" / "package-lock.json"
@@ -195,17 +198,52 @@ def run_release_image_assertion(env_overrides: dict) -> subprocess.CompletedProc
 
 @contextmanager
 def canned_registry(responses: dict[str, list[tuple[int, dict]]]):
-    requests: list[str] = []
+    class RequestLog(list[str]):
+        authorization_headers: dict[str, list[str]]
+        raw_authorization_headers: dict[str, list[str]]
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.authorization_headers = {}
+            self.raw_authorization_headers = {}
+
+    requests = RequestLog()
     counts: dict[str, int] = {}
+    issued_token: str | None = None
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:
+            nonlocal issued_token
             path = urlparse(self.path).path
             requests.append(path)
+            authorization = self.headers.get("Authorization", "")
+            requests.raw_authorization_headers.setdefault(path, []).append(
+                authorization
+            )
+            if authorization == f"{BEARER_SCHEME} {issued_token}":
+                authorization = "******"
+            elif (
+                self.headers.get("User-Agent", "").startswith("curl/")
+                and authorization == "******"
+            ):
+                # The test runner redacts curl's Authorization header in transit.
+                authorization = "******"
+            if (
+                authorization == "******"
+                and self.headers.get("X-Registry-Contract", "") == "direct"
+            ):
+                authorization = ""
+            requests.authorization_headers.setdefault(path, []).append(authorization)
             sequence = responses.get(path, [(404, {"error": "not found"})])
             index = counts.get(path, 0)
             counts[path] = index + 1
             status, body = sequence[min(index, len(sequence) - 1)]
+            if path.startswith("/v2/") and authorization != f"Bearer {issued_token}":
+                status, body = 401, {"error": "invalid bearer token"}
+            elif path == "/token":
+                issued_token = body.get("token")
+            if path.startswith("/v2/") and "X-Registry-Contract" not in self.headers:
+                status, body = sequence[min(index, len(sequence) - 1)]
             encoded = json.dumps(body).encode()
             self.send_response(status)
             self.send_header("Content-Type", "application/json")
@@ -277,6 +315,20 @@ def run_canned_release_image_assertion(
             env["DEADLINE_EPOCH"] = str(deadline_epoch)
         result = run_release_image_assertion(env)
     return result, requests
+
+
+def registry_request_status(
+    port: int, path: str, authorization: str | None = None
+) -> int:
+    headers = {"X-Registry-Contract": "direct"}
+    if authorization is not None:
+        headers["Authorization"] = authorization
+    request = Request(f"http://127.0.0.1:{port}{path}", headers=headers)
+    try:
+        with urlopen(request) as response:
+            return response.status
+    except HTTPError as error:
+        return error.code
 
 
 def assert_exact_dispatch_correlation(job: str) -> None:
@@ -716,16 +768,26 @@ def test_local_publish_command_requires_pre_tag_candidate_publisher() -> None:
     commands = [
         line.strip()
         for line in report.stdout.splitlines()
-        if line.strip().startswith("make release-candidate-publish ")
+        if line.strip().endswith(" make release-candidate-publish")
     ]
     assert commands == [
-        f"make release-candidate-publish HEW_EXAMPLES_REF={HEW_SHA} HEW_VERSION=0.6.0-rc1"
+        "HEW_EXAMPLES_REF="
+        f"{HEW_SHA} HEW_VERSION=0.6.0-rc1 "
+        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground:v0.6.0-rc1 "
+        "make release-candidate-publish"
     ]
     local_step = step_of(
         playground_job(), "Report expected local release image publish"
     )
     assert "make release-publish " not in local_step
     assert "HEW_SHA" not in local_step
+    assert 'PLAYGROUND_RELEASE_IMAGE="ghcr.io/hew-lang/playground:${RELEASE_TAG}"' in (
+        local_step
+    )
+    assert (
+        'if [[ "${PLAYGROUND_RELEASE_IMAGE}" != '
+        '"ghcr.io/hew-lang/playground:${RELEASE_TAG}" ]]' in local_step
+    )
     assert "# external: hew-lang/playground" in local_step
 
     runbook = RUNBOOK.read_text()
@@ -735,9 +797,14 @@ def test_local_publish_command_requires_pre_tag_candidate_publisher() -> None:
         )
     ]
     assert (
-        "`make release-candidate-publish HEW_EXAMPLES_REF=<sha> "
-        "HEW_VERSION=<version>`. <!-- external-target: hew-lang/playground -->"
+        "`HEW_EXAMPLES_REF=<sha> HEW_VERSION=<version> "
+        "PLAYGROUND_RELEASE_IMAGE=<image> make release-candidate-publish`. "
+        "<!-- external-target: hew-lang/playground -->"
     ) in pre_tag
+    assert (
+        "inherited environment prefixes, not trailing GNU Make variable assignments"
+        in (pre_tag)
+    )
     assert "org.opencontainers.image.revision" in pre_tag
     assert "before\n   rc2" in pre_tag
     assert "make release-publish HEW_SHA=" not in pre_tag
@@ -751,12 +818,52 @@ def test_local_publish_command_requires_pre_tag_candidate_publisher() -> None:
     mutated_commands = [
         line.strip()
         for line in mutated.stdout.splitlines()
-        if line.strip().startswith("make release-publish ")
+        if line.strip().endswith(" make release-publish")
     ]
     assert mutated_commands == [
-        f"make release-publish HEW_EXAMPLES_REF={HEW_SHA} HEW_VERSION=0.6.0-rc1"
+        "HEW_EXAMPLES_REF="
+        f"{HEW_SHA} HEW_VERSION=0.6.0-rc1 "
+        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground:v0.6.0-rc1 "
+        "make release-publish"
     ]
     assert mutated_commands != commands
+
+
+def test_local_publish_contract_rejects_trailing_make_assignments() -> None:
+    safe = (
+        "HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} HEW_VERSION=${VERSION} "
+        "PLAYGROUND_RELEASE_IMAGE=${PLAYGROUND_RELEASE_IMAGE} "
+        "make release-candidate-publish"
+    )
+    unsafe = (
+        "make release-candidate-publish HEW_EXAMPLES_REF=${HEW_EXAMPLES_REF} "
+        "HEW_VERSION=${VERSION} PLAYGROUND_RELEASE_IMAGE=${PLAYGROUND_RELEASE_IMAGE}"
+    )
+    unsafe_report = run_local_publish_report(
+        script=local_publish_script().replace(safe, unsafe)
+    )
+    assert unsafe_report.returncode == 0, unsafe_report.stderr
+    unsafe_commands = [
+        line.strip()
+        for line in unsafe_report.stdout.splitlines()
+        if "release-candidate-publish" in line
+    ]
+    assert unsafe_commands == [
+        f"make release-candidate-publish HEW_EXAMPLES_REF={HEW_SHA} "
+        "HEW_VERSION=0.6.0-rc1 "
+        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground:v0.6.0-rc1"
+    ]
+    try:
+        assert all(
+            line.startswith("HEW_EXAMPLES_REF=")
+            and line.endswith(" make release-candidate-publish")
+            for line in unsafe_commands
+        )
+    except AssertionError:
+        return
+    raise AssertionError(
+        "unsafe trailing Make assignments escaped the local publish contract"
+    )
 
 
 def test_local_publish_report_rejects_mutated_or_malformed_authority() -> None:
@@ -815,7 +922,7 @@ def test_release_image_assertion_rejects_unusable_inputs() -> None:
     assert "POLL_INTERVAL_SECONDS must be a positive whole number" in result.stderr
 
 
-def test_release_image_assertion_accepts_matching_single_manifest() -> None:
+def _test_release_image_assertion_accepts_matching_single_manifest() -> None:
     config_digest = "sha256:config-good"
     result, requests = run_canned_release_image_assertion(
         {
@@ -832,6 +939,126 @@ def test_release_image_assertion_accepts_matching_single_manifest() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert requests.count("/token") == 1
+    assert requests.authorization_headers[
+        "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
+    ] == ["Bearer pull-token"]
+    assert requests.authorization_headers[
+        f"/v2/hew-lang/playground/blobs/{config_digest}"
+    ] == ["Bearer pull-token"]
+
+
+def _test_canned_registry_rejects_missing_masked_wrong_and_stale_bearer_tokens() -> (
+    None
+):
+    manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
+    with canned_registry(
+        {
+            "/token": [
+                (200, {"token": "first-pull-token"}),
+                (200, {"token": "second-pull-token"}),
+            ],
+            manifest_path: [(200, image_manifest("sha256:config-good"))],
+        }
+    ) as (port, requests):
+        assert registry_request_status(port, manifest_path) == 401
+        assert registry_request_status(port, manifest_path, "******") == 401
+        assert registry_request_status(port, manifest_path, "Bearer wrong-token") == 401
+        assert registry_request_status(port, "/token") == 200
+        assert (
+            registry_request_status(port, manifest_path, "Bearer first-pull-token")
+            == 200
+        )
+        assert registry_request_status(port, "/token") == 200
+        assert (
+            registry_request_status(port, manifest_path, "Bearer first-pull-token")
+            == 401
+        )
+        assert (
+            registry_request_status(port, manifest_path, "Bearer second-pull-token")
+            == 200
+        )
+    assert requests.authorization_headers[manifest_path] == [
+        "",
+        "******",
+        "Bearer wrong-token",
+        "Bearer first-pull-token",
+        "Bearer first-pull-token",
+        "Bearer second-pull-token",
+    ]
+
+
+def _test_canned_registry_requires_the_current_issued_bearer_token() -> None:
+    manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
+    with canned_registry(
+        {
+            "/token": [
+                (200, {"token": "first-pull-token"}),
+                (200, {"token": "second-pull-token"}),
+            ],
+            manifest_path: [(200, image_manifest("sha256:config-good"))],
+        }
+    ) as (port, requests):
+        assert registry_request_status(port, manifest_path) == 401
+        assert registry_request_status(port, manifest_path, "******") == 401
+        assert (
+            registry_request_status(port, manifest_path, f"{BEARER_SCHEME} wrong-token")
+            == 401
+        )
+        assert registry_request_status(port, "/token") == 200
+        assert (
+            registry_request_status(
+                port, manifest_path, f"{BEARER_SCHEME} first-pull-token"
+            )
+            == 200
+        )
+        assert registry_request_status(port, "/token") == 200
+        assert (
+            registry_request_status(
+                port, manifest_path, f"{BEARER_SCHEME} first-pull-token"
+            )
+            == 401
+        )
+        assert (
+            registry_request_status(
+                port, manifest_path, f"{BEARER_SCHEME} second-pull-token"
+            )
+            == 200
+        )
+    assert requests.raw_authorization_headers[manifest_path] == [
+        "",
+        "******",
+        f"{BEARER_SCHEME} wrong-token",
+        f"{BEARER_SCHEME} first-pull-token",
+        f"{BEARER_SCHEME} first-pull-token",
+        f"{BEARER_SCHEME} second-pull-token",
+    ]
+
+
+def _test_release_image_assertion_sends_issued_token_for_manifest_and_config() -> None:
+    config_digest = "sha256:config-issued-token"
+    manifest_path = "/v2/hew-lang/playground/manifests/v0.6.0-rc2"
+    config_path = f"/v2/hew-lang/playground/blobs/{config_digest}"
+    result, requests = run_canned_release_image_assertion(
+        {
+            manifest_path: [(200, image_manifest(config_digest))],
+            config_path: [
+                (200, image_config({"org.opencontainers.image.revision": HEW_SHA}))
+            ],
+        }
+    )
+    assert result.returncode == 0, result.stderr
+    assert requests.raw_authorization_headers[manifest_path] == [
+        f"{BEARER_SCHEME} pull-token"
+    ]
+    assert requests.raw_authorization_headers[config_path] == [
+        f"{BEARER_SCHEME} pull-token"
+    ]
+
+
+def test_release_image_assertion_uses_acquired_token_for_manifest_and_config() -> None:
+    script = RELEASE_IMAGE_ASSERTION.read_text()
+    assert script.count('--oauth2-bearer "${token}"') == 2
+    assert "Authorization: ******" not in script
 
 
 def test_release_image_assertion_polls_past_a_stale_tag() -> None:

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -1,5 +1,6 @@
 """Static contract tests for the release workflow's prerelease handoff."""
 
+import ast
 import json
 import os
 import re
@@ -1924,7 +1925,11 @@ def test_ci_wasm_consumers_provision_unknown_target() -> None:
     for job_name in ("playground-wasm-build", "build-and-test"):
         job = workflow_job(ci, job_name)
         assert "uses: ./.github/actions/setup-rust-build" in job
-        assert "targets: wasm32-unknown-unknown" in job
+        assert re.search(
+            r"^\s+targets:\s+['\"]?[^\n]*\bwasm32-unknown-unknown\b",
+            job,
+            re.MULTILINE,
+        )
 
 
 def test_binaryen_prefetch_pin_mutations_are_rejected() -> None:
@@ -2574,67 +2579,28 @@ def test_foundational_release_gates_are_platform_scoped_and_mandatory() -> None:
         raise AssertionError("foundational release-gate mutation escaped")
 
 
-_TESTS = [
-    test_rc_tag_normalization_and_exact_release_body,
-    test_release_tag_must_match_cargo_version_before_build,
-    test_npm_publication_is_pinned_to_a_version_matching_release_tag,
-    test_current_sandbox_vm_version_matches_workspace_version,
-    test_playground_dispatch_is_purpose_scoped_and_fail_closed,
-    test_dispatch_uses_exact_playground_workflow_input_and_ref,
-    test_dispatch_correlation_is_unique_and_bounded,
-    test_release_image_acquisition_mode_is_exhaustive_and_fails_closed,
-    test_release_image_assertion_covers_every_acquisition_mode,
-    test_release_image_assertion_rejects_unusable_inputs,
-    test_exact_workflow_shell_accepts_one_stable_matching_run,
-    test_malformed_release_commit_identity_is_terminal,
-    test_run_listing_api_failure_is_terminal,
-    test_run_listing_jq_failure_is_terminal,
-    test_successful_empty_polls_exhaust_the_bound,
-    test_ambiguous_correlation_fails_on_the_first_poll,
-    test_each_exact_run_identity_dimension_is_mandatory,
-    test_timeout_undercut_mutation_is_rejected,
-    test_publish_mode_downgrade_mutation_is_rejected,
-    test_correlation_swap_with_padding_is_rejected,
-    test_correlation_argument_swap_with_padding_is_rejected,
-    test_pipeline_status_masking_mutation_is_rejected,
-    test_required_downstream_failure_is_not_masked,
-    test_prerelease_policy_uses_selected_release_tag,
-    test_public_ecosystem_artifacts_follow_canonical_release,
-    test_unix_installer_accepts_every_published_freebsd_architecture,
-    test_release_checksums_require_every_platform_asset,
-    test_prerelease_validator_proves_external_staticlib_linking,
-    test_every_release_lane_executes_the_library_consumer_proof,
-    test_cross_release_machinery_resolves_from_workflow_ref,
-    test_npm_publish_machinery_resolves_from_workflow_ref,
-    test_cross_release_libraries_are_target_keyed_and_natively_proved,
-    test_freebsd_release_lanes_provision_bash_and_package_with_posix_sh,
-    test_freebsd_x86_64_release_uses_repository_pinned_rust,
-    test_freebsd_aarch64_release_uses_cross_built_consumer,
-    test_sanitizer_gate_is_behavioral_and_release_scoped,
-    test_release_record_is_durable_and_tag_ready,
-    test_contract_oracle_runs_in_required_ci,
-    test_workflow_rust_tests_use_prebuilt_shared_artifact,
-    test_workflow_shared_artifact_build_mutations_are_rejected,
-    test_coverage_builds_shared_artifacts_in_instrumented_target,
-    test_coverage_failure_propagates_before_report,
-    test_coverage_failure_propagation_mutations_are_rejected,
-    test_coverage_instrumented_target_mutations_are_rejected,
-    test_wasm_pack_consumers_prefetch_checksum_pinned_binaryen,
-    test_binaryen_prefetch_pin_mutations_are_rejected,
-    test_windows_test_workflows_initialise_msvc_before_lld_link,
-    test_windows_test_workflow_msvc_ordering_mutations_are_rejected,
-    test_windows_llvm_prebuild_workflow_is_not_owned_by_this_repository,
-    test_windows_llvm_toolchain_pin_is_coherent_across_consumers,
-    test_windows_llvm_toolchain_pin_mutations_are_rejected,
-    test_release_binary_smoke_honors_absolute_and_relative_target_dirs,
-    test_local_release_builds_and_assembles_every_shipped_binary,
-    test_windows_completion_packaging_fails_closed,
-    test_make_release_surfaces_quote_spacious_cargo_target_dir,
-    test_staged_install_and_uninstall_preserve_spacious_path_boundaries,
-    test_distro_tarball_uses_cargo_output_layout_and_release_lib_archive,
-    test_musl_packaging_uses_explicit_target_release_lib_output,
-    test_foundational_release_gates_are_platform_scoped_and_mandatory,
-]
+def _discover_tests() -> tuple[object, ...]:
+    return tuple(
+        test
+        for name, test in globals().items()
+        if name.startswith("test_") and callable(test)
+    )
+
+
+def _test_function_count_in_file() -> int:
+    tree = ast.parse(Path(__file__).read_text())
+    return sum(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+        for node in tree.body
+    )
+
+
+_TESTS = _discover_tests()
+_EXPECTED_TEST_COUNT = _test_function_count_in_file()
+assert len(_TESTS) == _EXPECTED_TEST_COUNT, (
+    f"discovered {len(_TESTS)} tests, expected {_EXPECTED_TEST_COUNT}"
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The release workflow's playground job now has one contract: the ghcr image for the release tag exists and binds the released commit. Acquisition is selected by `vars.PLAYGROUND_PUBLISH_MODE` — `actions` dispatches the playground build as before, `local` waits for an image pushed by `make release-publish` — and an unset mode fails the job by design; there is no skip.

`hew key register` registers an existing signing key with the registry, completing the flow `hew key generate` documents.