### PR TITLE
fix(mir): keep record drops authoritative across projection reads

### DIFF
--- a/hew-cli/tests/record_projection_drop_leak_oracle.rs
+++ b/hew-cli/tests/record_projection_drop_leak_oracle.rs
@@ -8,16 +8,84 @@ mod support;
 use support::leak_slope::{compile_to_native, measure_leaks_exact, run_under_malloc_scribble};
 use support::{describe_output, require_codegen};
 
-const TUPLE_SCALAR_SOURCE: &str =
-    include_str!("../../tests/vertical-slice/accept/record_tuple_scalar_projection_drop.hew");
+const CASES: &[(&str, &str)] = &[
+    (
+        "array_heap_move",
+        include_str!("../../tests/vertical-slice/accept/record_array_heap_projection_move.hew"),
+    ),
+    (
+        "array_heap_read",
+        include_str!("../../tests/vertical-slice/accept/record_array_heap_projection_read.hew"),
+    ),
+    (
+        "array_scalar_move",
+        include_str!("../../tests/vertical-slice/accept/record_array_scalar_projection_move.hew"),
+    ),
+    (
+        "array_scalar_read",
+        include_str!("../../tests/vertical-slice/accept/record_array_scalar_projection_read.hew"),
+    ),
+    (
+        "enum_heap_move",
+        include_str!("../../tests/vertical-slice/accept/record_enum_heap_projection_move.hew"),
+    ),
+    (
+        "enum_heap_read",
+        include_str!("../../tests/vertical-slice/accept/record_enum_heap_projection_read.hew"),
+    ),
+    (
+        "enum_scalar_move",
+        include_str!("../../tests/vertical-slice/accept/record_enum_scalar_projection_move.hew"),
+    ),
+    (
+        "enum_scalar_read",
+        include_str!("../../tests/vertical-slice/accept/record_enum_scalar_projection_read.hew"),
+    ),
+    (
+        "nested_heap_move",
+        include_str!("../../tests/vertical-slice/accept/record_nested_heap_projection_move.hew"),
+    ),
+    (
+        "nested_heap_read",
+        include_str!("../../tests/vertical-slice/accept/record_nested_heap_projection_read.hew"),
+    ),
+    (
+        "nested_scalar_move",
+        include_str!("../../tests/vertical-slice/accept/record_nested_scalar_projection_move.hew"),
+    ),
+    (
+        "nested_scalar_read",
+        include_str!("../../tests/vertical-slice/accept/record_nested_scalar_projection_read.hew"),
+    ),
+    (
+        "tuple_heap_move",
+        include_str!("../../tests/vertical-slice/accept/record_tuple_heap_projection_move.hew"),
+    ),
+    (
+        "tuple_heap_read",
+        include_str!("../../tests/vertical-slice/accept/record_tuple_heap_projection_read.hew"),
+    ),
+    (
+        "tuple_scalar_move",
+        include_str!("../../tests/vertical-slice/accept/record_tuple_scalar_projection_move.hew"),
+    ),
+    (
+        "tuple_scalar_read",
+        include_str!("../../tests/vertical-slice/accept/record_tuple_scalar_projection_drop.hew"),
+    ),
+];
 
-fn compile_fixture(prefix: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+fn compile_fixture(
+    prefix: &str,
+    name: &str,
+    source: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
     require_codegen();
     let dir = tempfile::Builder::new()
         .prefix(prefix)
         .tempdir()
         .expect("tempdir");
-    let bin = compile_to_native(TUPLE_SCALAR_SOURCE, dir.path(), "tuple_scalar_projection");
+    let bin = compile_to_native(source, dir.path(), name);
     (dir, bin)
 }
 
@@ -26,13 +94,15 @@ fn compile_fixture(prefix: &str) -> (tempfile::TempDir, std::path::PathBuf) {
     ignore = "exact leak oracle needs macOS leaks(1); absent capability must be a counted skip"
 )]
 #[test]
-fn tuple_scalar_projection_is_exactly_leak_clean() {
-    let (_dir, bin) = compile_fixture("record-tuple-scalar-leaks-");
-    assert_eq!(
-        measure_leaks_exact(&bin),
-        (0, 0),
-        "a scalar tuple projection must leave zero leaked nodes and bytes"
-    );
+fn projection_matrix_is_exactly_leak_clean() {
+    for &(name, source) in CASES {
+        let (_dir, bin) = compile_fixture("record-projection-leaks-", name, source);
+        assert_eq!(
+            measure_leaks_exact(&bin),
+            (0, 0),
+            "{name} must leave zero leaked nodes and bytes"
+        );
+    }
 }
 
 #[cfg_attr(
@@ -40,12 +110,14 @@ fn tuple_scalar_projection_is_exactly_leak_clean() {
     ignore = "the deterministic poisoned-allocator contract is macOS-only"
 )]
 #[test]
-fn tuple_scalar_projection_drops_each_owner_once() {
-    let (_dir, bin) = compile_fixture("record-tuple-scalar-scribble-");
-    let output = run_under_malloc_scribble(&bin);
-    assert!(
-        output.status.success(),
-        "tuple scalar projection double-freed or read poisoned memory:\n{}",
-        describe_output(&output)
-    );
+fn projection_matrix_drops_each_owner_once() {
+    for &(name, source) in CASES {
+        let (_dir, bin) = compile_fixture("record-projection-scribble-", name, source);
+        let output = run_under_malloc_scribble(&bin);
+        assert!(
+            output.status.success(),
+            "{name} double-freed or read poisoned memory:\n{}",
+            describe_output(&output)
+        );
+    }
 }

--- a/hew-cli/tests/record_projection_drop_leak_oracle.rs
+++ b/hew-cli/tests/record_projection_drop_leak_oracle.rs
@@ -1,0 +1,51 @@
+//! Exact leak and poisoned-allocator oracle for projection reads through a
+//! heap-owning record field.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{compile_to_native, measure_leaks_exact, run_under_malloc_scribble};
+use support::{describe_output, require_codegen};
+
+const TUPLE_SCALAR_SOURCE: &str =
+    include_str!("../../tests/vertical-slice/accept/record_tuple_scalar_projection_drop.hew");
+
+fn compile_fixture(prefix: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(TUPLE_SCALAR_SOURCE, dir.path(), "tuple_scalar_projection");
+    (dir, bin)
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "exact leak oracle needs macOS leaks(1); absent capability must be a counted skip"
+)]
+#[test]
+fn tuple_scalar_projection_is_exactly_leak_clean() {
+    let (_dir, bin) = compile_fixture("record-tuple-scalar-leaks-");
+    assert_eq!(
+        measure_leaks_exact(&bin),
+        (0, 0),
+        "a scalar tuple projection must leave zero leaked nodes and bytes"
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the deterministic poisoned-allocator contract is macOS-only"
+)]
+#[test]
+fn tuple_scalar_projection_drops_each_owner_once() {
+    let (_dir, bin) = compile_fixture("record-tuple-scalar-scribble-");
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "tuple scalar projection double-freed or read poisoned memory:\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -294,6 +294,16 @@ pub(super) fn apply_escaped_record_sibling_field_drops(
                         poison!(root);
                     }
                 }
+                Instr::TupleFieldLoad { tuple, dest, .. } => {
+                    if let Some(local) = base_local(*tuple) {
+                        if field_binders.contains(&local) {
+                            site!(binder_root(local), Some(idx));
+                        }
+                    }
+                    if let Some(&root) = base_local(*dest).and_then(|dl| alias_of.get(&dl)) {
+                        poison!(root);
+                    }
+                }
                 Instr::RecordInit { fields, dest, .. } => {
                     // A live-root field-projection cursor init BORROWS its
                     // `vec`-field binder (`vec_iter_projection_borrow_inits`):
@@ -795,8 +805,13 @@ fn compute_escaped_chain_sibling_drops(
     aggregate_clone_sites: &HashSet<(u32, usize, Place)>,
 ) -> Vec<(u32, usize, Vec<Instr>)> {
     // Immediate-parent map: alias_local -> (parent_local, field ordinal it reads).
+    // A retained string field load is a fresh co-owner, so it terminates the
+    // byte-alias chain rather than transferring the parent's original field.
+    let retained_string_aliases =
+        uniquely_defined_retained_string_field_load_aliases(blocks, local_tys);
     let parent_of: HashMap<u32, (u32, u32)> = alias_chain
         .iter()
+        .filter(|(alias, _, _)| !retained_string_aliases.contains(alias))
         .copied()
         .map(|(alias, parent, field)| (alias, (parent, field)))
         .collect();
@@ -2256,8 +2271,95 @@ pub(super) fn derive_owned_record_drop_allowed(
             .entry(binder)
             .or_insert(FieldBinderProvenance::RootOnly { root: owner_local });
     }
-    let is_escape_binder =
-        |l: u32| field_binders.contains(&l) || match_hop_binders.contains_key(&l);
+    let retained_string_moves = corroborated_retained_string_move_sites(blocks, local_tys);
+    let retained_bytes_moves = corroborated_retained_bytes_move_sites(blocks, local_tys);
+
+    // A heap-owning enum payload projected from a record field remains tied to
+    // the same record root until value flow proves an owning transfer. Carry
+    // the field provenance through the interior projection and ordinary local
+    // moves so the escape scan can distinguish a retained return (the caller
+    // receives an independent share) from an unretained hand-off. This is the
+    // record-field analogue of the payload-binder closure in the enum
+    // composite prover.
+    let mut nested_payload_binders: HashSet<u32> = HashSet::new();
+    loop {
+        let mut changed = false;
+        for block in blocks {
+            for (instr_index, instr) in block.instructions.iter().enumerate() {
+                let Instr::Move { dest, src } = instr else {
+                    continue;
+                };
+                let Some(dest_local) = base_local(*dest) else {
+                    continue;
+                };
+                if !matches!(dest, Place::Local(_)) || !local_is_heap_owning(dest_local) {
+                    continue;
+                }
+                if retained_string_moves.contains(&(block.id, instr_index))
+                    || retained_bytes_moves.contains(&(block.id, instr_index))
+                {
+                    continue;
+                }
+                let source_local = base_local(*src);
+                let source_is_binder = source_local.is_some_and(|local| {
+                    nested_payload_binders.contains(&local)
+                        || field_binders.contains(&local)
+                        || match_hop_binders.contains_key(&local)
+                });
+                let projection_seed = place_is_interior_projection(*src) && source_is_binder;
+                let local_handoff = matches!(src, Place::Local(_)) && source_is_binder;
+                if !projection_seed && !local_handoff {
+                    continue;
+                }
+                if nested_payload_binders.insert(dest_local) {
+                    changed = true;
+                }
+                let incoming = source_local
+                    .and_then(|local| binder_provenance.get(&local).copied())
+                    .unwrap_or(FieldBinderProvenance::Ambiguous);
+                match binder_provenance.entry(dest_local) {
+                    std::collections::hash_map::Entry::Vacant(slot) => {
+                        slot.insert(incoming);
+                        changed = true;
+                    }
+                    std::collections::hash_map::Entry::Occupied(mut slot) => {
+                        let current = *slot.get();
+                        let merged = match (current, incoming) {
+                            (a, b) if a == b => a,
+                            (FieldBinderProvenance::Ambiguous, _)
+                            | (_, FieldBinderProvenance::Ambiguous) => {
+                                FieldBinderProvenance::Ambiguous
+                            }
+                            (
+                                FieldBinderProvenance::Unique { root: r1, .. }
+                                | FieldBinderProvenance::RootOnly { root: r1 },
+                                FieldBinderProvenance::Unique { root: r2, .. }
+                                | FieldBinderProvenance::RootOnly { root: r2 },
+                            ) => {
+                                if r1 == r2 {
+                                    FieldBinderProvenance::RootOnly { root: r1 }
+                                } else {
+                                    FieldBinderProvenance::Ambiguous
+                                }
+                            }
+                        };
+                        if merged != current {
+                            slot.insert(merged);
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    let is_escape_binder = |l: u32| {
+        field_binders.contains(&l)
+            || match_hop_binders.contains_key(&l)
+            || nested_payload_binders.contains(&l)
+    };
 
     let mut excluded_roots: HashSet<u32> = HashSet::new();
     let generator_env_inits = generator_env_snapshot_init_locals(blocks);
@@ -2511,6 +2613,10 @@ pub(super) fn derive_owned_record_drop_allowed(
             // another alias member) from a real whole-record escape.
             if let Instr::Move { dest, src } = instr {
                 let src_local = base_local(*src);
+                let retained_projection_move = retained_string_moves
+                    .contains(&(block.id, instr_index))
+                    || retained_bytes_moves.contains(&(block.id, instr_index))
+                    || is_retained_return_move(block, instr_index, *dest, *src);
                 let dest_local = base_local(*dest);
                 if let Some(sl) = src_local {
                     let src_is_member = alias_of.contains_key(&sl)
@@ -2523,10 +2629,18 @@ pub(super) fn derive_owned_record_drop_allowed(
                     if src_is_member && !dest_is_member {
                         note_alias_escape(sl, &mut excluded_roots);
                     }
+                    // A tag read or scalar payload projection copies only
+                    // BitCopy data out of an aggregate field binder. The
+                    // record still owns every heap leaf, so this is an
+                    // interior read, not a field escape. A heap-owning payload
+                    // destination stays on the fail-closed escape path below.
                     if is_escape_binder(sl) {
                         let benign = dest_local.is_some_and(is_escape_binder)
                             && matches!(dest, Place::Local(_));
-                        if !benign {
+                        let benign_projection_read = place_is_tag_read(*src)
+                            || (place_is_interior_projection(*src)
+                                && dest_local.is_some_and(|dl| !local_is_heap_owning(dl)));
+                        if !benign && !benign_projection_read && !retained_projection_move {
                             note_field_escape(sl, &mut excluded_roots);
                         }
                     }
@@ -2548,6 +2662,7 @@ pub(super) fn derive_owned_record_drop_allowed(
                 Instr::Move { .. }
                     | Instr::Drop { .. }
                     | Instr::RecordFieldLoad { .. }
+                    | Instr::TupleFieldLoad { .. }
                     // `RecordFieldDrop` is an interior operation (GEP+drop on one
                     // field slot) and does not transfer ownership of the whole
                     // record out of the scope, so it must not count as an escape
@@ -6592,6 +6707,254 @@ mod owned_record_drop_derivation {
         assert!(
             allowed.contains(&b),
             "an untouched owned record is its own sole owner and must be admitted"
+        );
+    }
+
+    #[test]
+    fn scalar_tuple_projection_through_owned_field_is_admitted() {
+        let b = BindingId(1);
+        let tuple_ty = ResolvedTy::Tuple(vec![ResolvedTy::String, ResolvedTy::I64]);
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals = HashMap::from([(b, Place::Local(0))]);
+        let local_tys = vec![rec_ty(), tuple_ty.clone(), ResolvedTy::I64];
+        let instructions = vec![
+            Instr::RecordFieldLoad {
+                record: Place::Local(0),
+                field_offset: FieldOffset(0),
+                dest: Place::Local(1),
+            },
+            Instr::TupleFieldLoad {
+                tuple: Place::Local(1),
+                field_index: 1,
+                dest: Place::Local(2),
+            },
+        ];
+
+        let allowed = derive_with_field_ty(
+            &[block(0, instructions, Terminator::Return)],
+            &owned,
+            &binding_locals,
+            &local_tys,
+            tuple_ty,
+        );
+        assert!(
+            allowed.contains(&b),
+            "a scalar tuple projection is an interior read; the record must keep its drop"
+        );
+    }
+
+    #[test]
+    fn retained_string_tuple_projection_through_owned_field_is_admitted() {
+        let b = BindingId(1);
+        let tuple_ty = ResolvedTy::Tuple(vec![ResolvedTy::String, ResolvedTy::I64]);
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals = HashMap::from([(b, Place::Local(0))]);
+        let local_tys = vec![rec_ty(), tuple_ty.clone(), ResolvedTy::String];
+        let instructions = vec![
+            Instr::RecordFieldLoad {
+                record: Place::Local(0),
+                field_offset: FieldOffset(0),
+                dest: Place::Local(1),
+            },
+            Instr::TupleFieldLoad {
+                tuple: Place::Local(1),
+                field_index: 0,
+                dest: Place::Local(2),
+            },
+        ];
+
+        let allowed = derive_with_field_ty(
+            &[block(0, instructions, Terminator::Return)],
+            &owned,
+            &binding_locals,
+            &local_tys,
+            tuple_ty,
+        );
+        assert!(
+            allowed.contains(&b),
+            "a retained string tuple load mints its own share; the record keeps its drop"
+        );
+    }
+
+    #[test]
+    fn scalar_enum_payload_projection_through_owned_field_is_admitted() {
+        let b = BindingId(1);
+        let enum_ty = ResolvedTy::named_user("Choice", vec![]);
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals = HashMap::from([(b, Place::Local(0))]);
+        let local_tys = vec![rec_ty(), enum_ty.clone(), ResolvedTy::I64, ResolvedTy::I64];
+        let instructions = vec![
+            Instr::RecordFieldLoad {
+                record: Place::Local(0),
+                field_offset: FieldOffset(0),
+                dest: Place::Local(1),
+            },
+            Instr::Move {
+                dest: Place::Local(2),
+                src: Place::EnumTag(1),
+            },
+            Instr::Move {
+                dest: Place::Local(3),
+                src: Place::EnumVariant {
+                    local: 1,
+                    variant_idx: 0,
+                    field_idx: 0,
+                },
+            },
+        ];
+
+        let allowed = derive_with_field_ty(
+            &[block(0, instructions, Terminator::Return)],
+            &owned,
+            &binding_locals,
+            &local_tys,
+            enum_ty,
+        );
+        assert!(
+            allowed.contains(&b),
+            "enum tag and scalar payload reads transfer no heap ownership"
+        );
+    }
+
+    #[test]
+    fn heap_enum_payload_projection_through_owned_field_is_excluded() {
+        let b = BindingId(1);
+        let enum_ty = ResolvedTy::named_user("Choice", vec![]);
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals = HashMap::from([(b, Place::Local(0))]);
+        let local_tys = vec![rec_ty(), enum_ty.clone(), ResolvedTy::String];
+        let instructions = vec![
+            Instr::RecordFieldLoad {
+                record: Place::Local(0),
+                field_offset: FieldOffset(0),
+                dest: Place::Local(1),
+            },
+            Instr::Move {
+                dest: Place::Local(2),
+                src: Place::EnumVariant {
+                    local: 1,
+                    variant_idx: 1,
+                    field_idx: 0,
+                },
+            },
+            Instr::Move {
+                dest: Place::ReturnSlot,
+                src: Place::Local(2),
+            },
+        ];
+
+        let record_field_orders = HashMap::from([(
+            "Rec".to_string(),
+            vec![("choice".to_string(), enum_ty.clone())],
+        )]);
+        let enum_layouts = vec![crate::model::EnumLayout {
+            name: "Choice".to_string(),
+            tag_width: 1,
+            variants: vec![
+                crate::model::MachineVariantLayout {
+                    name: "Number".to_string(),
+                    field_tys: vec![ResolvedTy::I64],
+                    field_names: vec![],
+                },
+                crate::model::MachineVariantLayout {
+                    name: "Text".to_string(),
+                    field_tys: vec![ResolvedTy::String],
+                    field_names: vec![],
+                },
+            ],
+            is_indirect: false,
+        }];
+        let allowed = derive_owned_record_drop_allowed(
+            &[block(0, instructions, Terminator::Return)],
+            &HashMap::new(),
+            &owned,
+            &binding_locals,
+            &local_tys,
+            &is_rec,
+            &|_, _| false,
+            &record_field_orders,
+            &enum_layouts,
+            &hew_hir::LifecycleRegistry::default(),
+            &[],
+            &HashMap::new(),
+            &HashSet::new(),
+        );
+        assert!(
+            !allowed.contains(&b),
+            "a heap payload projection transfers ownership and must exclude the record"
+        );
+    }
+
+    #[test]
+    fn retained_heap_enum_payload_projection_through_owned_field_is_admitted() {
+        let b = BindingId(1);
+        let enum_ty = ResolvedTy::named_user("Choice", vec![]);
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals = HashMap::from([(b, Place::Local(0))]);
+        let local_tys = vec![rec_ty(), enum_ty.clone(), ResolvedTy::String];
+        let instructions = vec![
+            Instr::RecordFieldLoad {
+                record: Place::Local(0),
+                field_offset: FieldOffset(0),
+                dest: Place::Local(1),
+            },
+            Instr::Move {
+                dest: Place::Local(2),
+                src: Place::EnumVariant {
+                    local: 1,
+                    variant_idx: 1,
+                    field_idx: 0,
+                },
+            },
+            Instr::StringRetain {
+                value: Place::Local(2),
+                condition: StringRetainCondition::Always,
+            },
+            Instr::Move {
+                dest: Place::ReturnSlot,
+                src: Place::Local(2),
+            },
+        ];
+
+        let record_field_orders = HashMap::from([(
+            "Rec".to_string(),
+            vec![("choice".to_string(), enum_ty.clone())],
+        )]);
+        let enum_layouts = vec![crate::model::EnumLayout {
+            name: "Choice".to_string(),
+            tag_width: 1,
+            variants: vec![
+                crate::model::MachineVariantLayout {
+                    name: "Number".to_string(),
+                    field_tys: vec![ResolvedTy::I64],
+                    field_names: vec![],
+                },
+                crate::model::MachineVariantLayout {
+                    name: "Text".to_string(),
+                    field_tys: vec![ResolvedTy::String],
+                    field_names: vec![],
+                },
+            ],
+            is_indirect: false,
+        }];
+        let allowed = derive_owned_record_drop_allowed(
+            &[block(0, instructions, Terminator::Return)],
+            &HashMap::new(),
+            &owned,
+            &binding_locals,
+            &local_tys,
+            &is_rec,
+            &|_, _| false,
+            &record_field_orders,
+            &enum_layouts,
+            &hew_hir::LifecycleRegistry::default(),
+            &[],
+            &HashMap::new(),
+            &HashSet::new(),
+        );
+        assert!(
+            allowed.contains(&b),
+            "a retained payload return leaves the record as the original owner"
         );
     }
 

--- a/hew-mir/src/lower/composite_own/escaped_sibling_field_discharge.rs
+++ b/hew-mir/src/lower/composite_own/escaped_sibling_field_discharge.rs
@@ -828,6 +828,55 @@ fn match_bound_retained_string_load_is_not_attributed() {
     );
 }
 
+#[test]
+fn retained_string_tuple_chain_is_not_discharged_as_a_transfer() {
+    let b = BindingId(1);
+    let tuple_ty = ResolvedTy::Tuple(vec![ResolvedTy::String, ResolvedTy::I64]);
+    let owned = vec![(b, "r".to_string(), rec_ty())];
+    let binding_locals = HashMap::from([(b, Place::Local(0))]);
+    let local_tys = vec![rec_ty(), tuple_ty, ResolvedTy::String];
+    let mut blocks = vec![
+        block(0, vec![], Terminator::Goto { target: 1 }),
+        block(
+            1,
+            vec![
+                Instr::RecordFieldLoad {
+                    record: Place::Local(0),
+                    field_offset: FieldOffset(0),
+                    dest: Place::Local(1),
+                },
+                Instr::TupleFieldLoad {
+                    tuple: Place::Local(1),
+                    field_index: 0,
+                    dest: Place::Local(2),
+                },
+                Instr::Move {
+                    dest: Place::ReturnSlot,
+                    src: Place::Local(2),
+                },
+            ],
+            Terminator::Return,
+        ),
+    ];
+
+    apply_with(
+        &mut blocks,
+        &owned,
+        &binding_locals,
+        &local_tys,
+        &[(1, 0, 0), (2, 1, 0)],
+        &is_rec,
+        &owned_fields,
+    );
+    assert!(
+        !blocks
+            .iter()
+            .flat_map(|block| &block.instructions)
+            .any(|instr| matches!(instr, Instr::FieldDropInPlace { .. })),
+        "a retained tuple string is an independent share, so the record keeps its full drop"
+    );
+}
+
 /// Handle-transfer fields are also not byte-copy aggregate aliases. The
 /// helper must keep `local_is_byte_copy_aggregate` as the gate and leave the
 /// pre-existing fail-closed posture unchanged.

--- a/hew-mir/src/lower/split_consume.rs
+++ b/hew-mir/src/lower/split_consume.rs
@@ -1070,11 +1070,16 @@ pub(super) fn collect_record_field_binders(
         let mut changed = false;
         for block in blocks {
             for instr in &block.instructions {
-                if let Instr::Move { dest, src } = instr {
-                    if let (Some(sl), Some(dl)) = (base_local(*src), base_local(*dest)) {
-                        if field_binders.contains(&sl) && field_binders.insert(dl) {
-                            changed = true;
-                        }
+                if let Instr::Move {
+                    dest: Place::Local(dest),
+                    src: Place::Local(src),
+                } = instr
+                {
+                    if local_is_heap_owning(*dest)
+                        && field_binders.contains(src)
+                        && field_binders.insert(*dest)
+                    {
+                        changed = true;
                     }
                 }
             }

--- a/tests/vertical-slice/accept/record_array_heap_projection_move.hew
+++ b/tests/vertical-slice/accept/record_array_heap_projection_move.hew
@@ -1,0 +1,24 @@
+record ArrayHeapMoveCarrier { items: Vec<string>, sibling: string }
+
+fn project(i: i64) -> string {
+    let values: Vec<string> = Vec.new();
+    values.push(string_concat("array-", "payload"));
+    let r = ArrayHeapMoveCarrier {
+        items: values,
+        sibling: string_concat("sibling-", "payload"),
+    };
+    let moved = r.items[0];
+    let _ = i;
+    moved
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        let moved = project(i);
+        total = total + moved.len();
+        i = i + 1;
+    }
+    if total > 0 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_array_heap_projection_read.hew
+++ b/tests/vertical-slice/accept/record_array_heap_projection_read.hew
@@ -1,0 +1,21 @@
+record ArrayHeapReadCarrier { items: Vec<string>, sibling: string }
+
+fn project(i: i64) -> i64 {
+    let values: Vec<string> = Vec.new();
+    values.push(string_concat("array-", "payload"));
+    let r = ArrayHeapReadCarrier {
+        items: values,
+        sibling: string_concat("sibling-", "payload"),
+    };
+    r.items[0].len() + i - i
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total > 0 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_array_scalar_projection_move.hew
+++ b/tests/vertical-slice/accept/record_array_scalar_projection_move.hew
@@ -1,0 +1,22 @@
+record ArrayScalarMoveCarrier { items: Vec<i64>, sibling: string }
+
+fn project(i: i64) -> i64 {
+    let values: Vec<i64> = Vec.new();
+    values.push(i);
+    let r = ArrayScalarMoveCarrier {
+        items: values,
+        sibling: string_concat("sibling-", "payload"),
+    };
+    let moved = r.items[0];
+    moved
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total == 2016 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_array_scalar_projection_read.hew
+++ b/tests/vertical-slice/accept/record_array_scalar_projection_read.hew
@@ -1,0 +1,21 @@
+record ArrayScalarReadCarrier { items: Vec<i64>, sibling: string }
+
+fn project(i: i64) -> i64 {
+    let values: Vec<i64> = Vec.new();
+    values.push(i);
+    let r = ArrayScalarReadCarrier {
+        items: values,
+        sibling: string_concat("sibling-", "payload"),
+    };
+    r.items[0]
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total == 2016 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_enum_heap_projection_move.hew
+++ b/tests/vertical-slice/accept/record_enum_heap_projection_move.hew
@@ -1,0 +1,26 @@
+enum EnumHeapMoveChoice { Pair(string, i64); }
+record EnumHeapMoveCarrier {
+    choice: EnumHeapMoveChoice,
+    sibling: string,
+}
+
+fn project(i: i64) -> string {
+    let r = EnumHeapMoveCarrier {
+        choice: EnumHeapMoveChoice.Pair(string_concat("enum-", "payload"), i),
+        sibling: string_concat("sibling-", "payload"),
+    };
+    match r.choice {
+        EnumHeapMoveChoice.Pair(text, _) => text,
+    }
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        let moved = project(i);
+        total = total + moved.len();
+        i = i + 1;
+    }
+    if total > 0 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_enum_heap_projection_read.hew
+++ b/tests/vertical-slice/accept/record_enum_heap_projection_read.hew
@@ -1,0 +1,25 @@
+enum EnumHeapReadChoice { Pair(string, i64); }
+record EnumHeapReadCarrier {
+    choice: EnumHeapReadChoice,
+    sibling: string,
+}
+
+fn project(i: i64) -> i64 {
+    let r = EnumHeapReadCarrier {
+        choice: EnumHeapReadChoice.Pair(string_concat("enum-", "payload"), i),
+        sibling: string_concat("sibling-", "payload"),
+    };
+    match r.choice {
+        EnumHeapReadChoice.Pair(text, _) => text.len(),
+    }
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total > 0 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_enum_scalar_projection_move.hew
+++ b/tests/vertical-slice/accept/record_enum_scalar_projection_move.hew
@@ -1,0 +1,26 @@
+enum EnumScalarMoveChoice { Pair(string, i64); }
+record EnumScalarMoveCarrier {
+    choice: EnumScalarMoveChoice,
+    sibling: string,
+}
+
+fn project(i: i64) -> i64 {
+    let r = EnumScalarMoveCarrier {
+        choice: EnumScalarMoveChoice.Pair(string_concat("enum-", "payload"), i),
+        sibling: string_concat("sibling-", "payload"),
+    };
+    let moved = match r.choice {
+        EnumScalarMoveChoice.Pair(_, value) => value,
+    };
+    moved
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total == 2016 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_enum_scalar_projection_read.hew
+++ b/tests/vertical-slice/accept/record_enum_scalar_projection_read.hew
@@ -1,0 +1,25 @@
+enum EnumScalarReadChoice { Pair(string, i64); }
+record EnumScalarReadCarrier {
+    choice: EnumScalarReadChoice,
+    sibling: string,
+}
+
+fn project(i: i64) -> i64 {
+    let r = EnumScalarReadCarrier {
+        choice: EnumScalarReadChoice.Pair(string_concat("enum-", "payload"), i),
+        sibling: string_concat("sibling-", "payload"),
+    };
+    match r.choice {
+        EnumScalarReadChoice.Pair(_, value) => value,
+    }
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total == 2016 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_nested_heap_projection_move.hew
+++ b/tests/vertical-slice/accept/record_nested_heap_projection_move.hew
@@ -1,0 +1,27 @@
+record NestedHeapMoveInner { text: string, value: i64 }
+record NestedHeapMoveCarrier {
+    inner: NestedHeapMoveInner,
+    sibling: string,
+}
+
+fn project(i: i64) -> string {
+    let r = NestedHeapMoveCarrier {
+        inner: NestedHeapMoveInner {
+            text: string_concat("inner-", "payload"),
+            value: i,
+        },
+        sibling: string_concat("sibling-", "payload"),
+    };
+    r.inner.text
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        let moved = project(i);
+        total = total + moved.len();
+        i = i + 1;
+    }
+    if total > 0 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_nested_heap_projection_read.hew
+++ b/tests/vertical-slice/accept/record_nested_heap_projection_read.hew
@@ -1,0 +1,26 @@
+record NestedHeapReadInner { text: string, value: i64 }
+record NestedHeapReadCarrier {
+    inner: NestedHeapReadInner,
+    sibling: string,
+}
+
+fn project(i: i64) -> i64 {
+    let r = NestedHeapReadCarrier {
+        inner: NestedHeapReadInner {
+            text: string_concat("inner-", "payload"),
+            value: i,
+        },
+        sibling: string_concat("sibling-", "payload"),
+    };
+    r.inner.text.len()
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total > 0 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_nested_scalar_projection_move.hew
+++ b/tests/vertical-slice/accept/record_nested_scalar_projection_move.hew
@@ -1,0 +1,27 @@
+record NestedScalarMoveInner { text: string, value: i64 }
+record NestedScalarMoveCarrier {
+    inner: NestedScalarMoveInner,
+    sibling: string,
+}
+
+fn project(i: i64) -> i64 {
+    let r = NestedScalarMoveCarrier {
+        inner: NestedScalarMoveInner {
+            text: string_concat("inner-", "payload"),
+            value: i,
+        },
+        sibling: string_concat("sibling-", "payload"),
+    };
+    let moved = r.inner.value;
+    moved
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total == 2016 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_nested_scalar_projection_read.hew
+++ b/tests/vertical-slice/accept/record_nested_scalar_projection_read.hew
@@ -1,0 +1,26 @@
+record NestedScalarReadInner { text: string, value: i64 }
+record NestedScalarReadCarrier {
+    inner: NestedScalarReadInner,
+    sibling: string,
+}
+
+fn project(i: i64) -> i64 {
+    let r = NestedScalarReadCarrier {
+        inner: NestedScalarReadInner {
+            text: string_concat("inner-", "payload"),
+            value: i,
+        },
+        sibling: string_concat("sibling-", "payload"),
+    };
+    r.inner.value
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total == 2016 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_tuple_heap_projection_move.hew
+++ b/tests/vertical-slice/accept/record_tuple_heap_projection_move.hew
@@ -1,0 +1,23 @@
+record TupleHeapMoveCarrier {
+    pair: (string, i64),
+    sibling: string,
+}
+
+fn project(i: i64) -> string {
+    let r = TupleHeapMoveCarrier {
+        pair: (string_concat("tuple-", "payload"), i),
+        sibling: string_concat("sibling-", "payload"),
+    };
+    r.pair.0
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        let moved = project(i);
+        total = total + moved.len();
+        i = i + 1;
+    }
+    if total > 0 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_tuple_heap_projection_read.hew
+++ b/tests/vertical-slice/accept/record_tuple_heap_projection_read.hew
@@ -1,0 +1,22 @@
+record TupleHeapReadCarrier {
+    pair: (string, i64),
+    sibling: string,
+}
+
+fn project(i: i64) -> i64 {
+    let r = TupleHeapReadCarrier {
+        pair: (string_concat("tuple-", "payload"), i),
+        sibling: string_concat("sibling-", "payload"),
+    };
+    r.pair.0.len()
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total > 0 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_tuple_scalar_projection_drop.hew
+++ b/tests/vertical-slice/accept/record_tuple_scalar_projection_drop.hew
@@ -1,0 +1,26 @@
+//! Reading a scalar through a heap-owning tuple field keeps the record's
+//! recursive scope drop. Each helper frame owns two strings; a projection read
+//! must release both exactly once when the frame returns.
+
+record Carrier {
+    pair: (string, i64),
+    sibling: string,
+}
+
+fn read_scalar(i: i64) -> i64 {
+    let r = Carrier {
+        pair: (string_concat("pair-", "payload"), i),
+        sibling: string_concat("sibling-", "payload"),
+    };
+    r.pair.1
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 2000 {
+        total = total + read_scalar(i);
+        i = i + 1;
+    }
+    if total == 1999000 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/accept/record_tuple_scalar_projection_move.hew
+++ b/tests/vertical-slice/accept/record_tuple_scalar_projection_move.hew
@@ -1,0 +1,23 @@
+record TupleScalarMoveCarrier {
+    pair: (string, i64),
+    sibling: string,
+}
+
+fn project(i: i64) -> i64 {
+    let r = TupleScalarMoveCarrier {
+        pair: (string_concat("tuple-", "owner"), i),
+        sibling: string_concat("sibling-", "owner"),
+    };
+    let moved = r.pair.1;
+    moved
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 64 {
+        total = total + project(i);
+        i = i + 1;
+    }
+    if total == 2016 { 0 } else { 1 }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -5404,6 +5404,7 @@ run_accept_expect_status "let_record_destructure_multi_fields" 155
 # Accept: record with an owned string field destructures without double-free.
 # tag=7 is returned; run under MallocScribble=1 to catch use-after-free.
 run_accept_expect_status "let_record_destructure_owned_field" 7
+run_accept_expect_status "record_tuple_scalar_projection_drop" 0
 
 # Accept: destructure inside a called function and again at the call site.
 # dot(Vec2{3,4}) = 25; norm_sq desugar + outer desugar both fire.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -5404,6 +5404,21 @@ run_accept_expect_status "let_record_destructure_multi_fields" 155
 # Accept: record with an owned string field destructures without double-free.
 # tag=7 is returned; run under MallocScribble=1 to catch use-after-free.
 run_accept_expect_status "let_record_destructure_owned_field" 7
+run_accept_expect_status "record_array_heap_projection_move" 0
+run_accept_expect_status "record_array_heap_projection_read" 0
+run_accept_expect_status "record_array_scalar_projection_move" 0
+run_accept_expect_status "record_array_scalar_projection_read" 0
+run_accept_expect_status "record_enum_heap_projection_move" 0
+run_accept_expect_status "record_enum_heap_projection_read" 0
+run_accept_expect_status "record_enum_scalar_projection_move" 0
+run_accept_expect_status "record_enum_scalar_projection_read" 0
+run_accept_expect_status "record_nested_heap_projection_move" 0
+run_accept_expect_status "record_nested_heap_projection_read" 0
+run_accept_expect_status "record_nested_scalar_projection_move" 0
+run_accept_expect_status "record_nested_scalar_projection_read" 0
+run_accept_expect_status "record_tuple_heap_projection_move" 0
+run_accept_expect_status "record_tuple_heap_projection_read" 0
+run_accept_expect_status "record_tuple_scalar_projection_move" 0
 run_accept_expect_status "record_tuple_scalar_projection_drop" 0
 
 # Accept: destructure inside a called function and again at the call site.


### PR DESCRIPTION
Preserve record drop ownership across projection reads. Interior reads of tuple elements, nested record fields, enum payloads, and array indices no longer mark the record as escaped, so record drops remain authoritative. Add a 16-cell projection x access matrix of fixtures covering these cases and proving zero leaks with no double-free.