### PR TITLE
fix(types): unify call-graph declaration identities for qualified calls

### DIFF
--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -999,7 +999,7 @@ impl Checker {
         // the import table before consulting declaration/export authority so
         // nested modules and aliases retain their exact source identity.
         let canonical_owner = self.canonical_module_import_owner(module_name);
-        let key = format!("{canonical_owner}.{method}");
+        let key = self.canonical_fn_identity(Some(&canonical_owner), method);
         if !self.fn_sigs.contains_key(&key) {
             return None;
         }
@@ -1058,12 +1058,7 @@ impl Checker {
             self.reject_wasm_feature(span, WasmUnsupportedFeature::CryptoRandom);
         }
         let sig = self.fn_sigs.get(&key).cloned()?;
-        if let Some(caller) = &self.current_function {
-            self.call_graph
-                .entry(caller.clone())
-                .or_default()
-                .insert(key.clone());
-        }
+        self.record_call_edge(&key);
         self.record_module_qualified_stdlib_call_rewrite_if_any(module_name, method, span);
         self.record_module_qualified_user_call_rewrite_if_any(module_name, method, span);
         let assoc_bindings = self
@@ -2043,9 +2038,12 @@ impl Checker {
         // produces; the contains_key filter keeps bare registrations
         // (builtins, externs) resolving unchanged (the bare rung is the
         // builtin/extern floor, not a root fallback).
-        let resolved_fn_name = scoped_module_item_name(self.canonical_fn_owner(), &func_name)
-            .filter(|qualified| self.fn_sigs.contains_key(qualified))
-            .unwrap_or_else(|| func_name.clone());
+        let canonical_fn_name = self.canonical_fn_identity(self.canonical_fn_owner(), &func_name);
+        let resolved_fn_name = if self.fn_sigs.contains_key(&canonical_fn_name) {
+            canonical_fn_name
+        } else {
+            func_name.clone()
+        };
         if let Some(sig) = self.fn_sigs.get(&resolved_fn_name).cloned() {
             // Visibility enforcement: check that the caller's module is allowed
             // to reference this function.  We only check when the resolved key
@@ -2083,12 +2081,7 @@ impl Checker {
                 }
             }
 
-            if let Some(caller) = &self.current_function {
-                self.call_graph
-                    .entry(caller.clone())
-                    .or_default()
-                    .insert(resolved_fn_name.clone());
-            }
+            self.record_call_edge(&resolved_fn_name);
             // Mark the originating module as used for unqualified imports
             if let Some(module) = self
                 .unqualified_to_module

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1655,14 +1655,7 @@ impl Checker {
                     self.mark_module_owner_bindings_used(source_owner);
                 }
             }
-            if let Some(caller) = &self.current_function {
-                // The callee edge records the RESOLVED key so dead-code
-                // reachability stays aligned with canonical `fn_def_spans`.
-                self.call_graph
-                    .entry(caller.clone())
-                    .or_default()
-                    .insert(fn_sig_key.clone());
-            }
+            self.record_call_edge(&fn_sig_key);
             let sig = self.fn_sigs[&fn_sig_key].clone();
             // local-shadows-global: when the fn_sig slot was won by a builtin enum
             // variant, prefer any user-declared enum that has a variant with the

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -870,8 +870,7 @@ impl Checker {
         // rc1-F1 stage A: body checking resolves the same canonical key
         // `register_fn_sig_with_name` minted — root items included — so
         // `current_function` (a `fn_sigs`-family key) is always canonical.
-        let fn_name = scoped_module_item_name(self.canonical_fn_owner(), &fd.name)
-            .unwrap_or_else(|| fd.name.clone());
+        let fn_name = self.canonical_fn_identity(self.canonical_fn_owner(), &fd.name);
         self.check_function_as(fd, &fn_name);
     }
 

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -8063,7 +8063,7 @@ impl Checker {
             // lookup. Never recover the owner from the final path segment: two
             // nested stdlib modules may share both a leaf and a function name.
             let canonical_owner = self.canonical_module_import_owner(name);
-            let key = format!("{canonical_owner}.{method}");
+            let key = self.canonical_fn_identity(Some(&canonical_owner), method);
             let looks_like_module_call = !receiver_is_binding
                 && !receiver_is_known_type
                 && (self.module_binding_in_current_file(name)
@@ -8210,12 +8210,7 @@ impl Checker {
                     self.reject_wasm_feature(span, WasmUnsupportedFeature::CryptoRandom);
                 }
                 if let Some(sig) = self.fn_sigs.get(&key).cloned() {
-                    if let Some(caller) = &self.current_function {
-                        self.call_graph
-                            .entry(caller.clone())
-                            .or_default()
-                            .insert(key.clone());
-                    }
+                    self.record_call_edge(&key);
                     self.record_module_qualified_stdlib_call_rewrite_if_any(name, method, span);
                     self.record_module_qualified_user_call_rewrite_if_any(name, method, span);
                     let assoc_bindings = self

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -341,6 +341,48 @@ impl Checker {
         self.fn_sigs.contains_key(&scoped).then_some(scoped)
     }
 
+    /// Return the declaration-table identity for a free function.
+    ///
+    /// `owner` is supplied while minting a declaration or resolving a known
+    /// lexical owner. Without an owner, an already-resolved signature key is
+    /// re-anchored through named-import aliases or its declaration record.
+    /// Actor and method identities use `::` and remain unchanged.
+    pub(super) fn canonical_fn_identity(&self, owner: Option<&str>, name: &str) -> String {
+        if name.contains("::") {
+            return name.to_string();
+        }
+        if let Some(owner) = owner {
+            return scoped_module_item_name(Some(owner), name).unwrap_or_else(|| name.to_string());
+        }
+        if let Some(source) = self.import_fn_name_aliases.get(&(
+            self.current_module.clone(),
+            self.current_module_idx,
+            name.to_string(),
+        )) {
+            return source.clone();
+        }
+        if let Some((_, Some(declaring_module))) = self.fn_def_spans.get(name) {
+            let leaf = name.rsplit('.').next().unwrap_or(name);
+            return scoped_module_item_name(Some(declaring_module), leaf)
+                .unwrap_or_else(|| name.to_string());
+        }
+        name.to_string()
+    }
+
+    /// Record one call edge after canonicalizing both endpoints through the
+    /// declaration identity authority.
+    pub(super) fn record_call_edge(&mut self, target: &str) {
+        let Some(source) = self.current_function.clone() else {
+            return;
+        };
+        let source_identity = self.canonical_fn_identity(None, &source);
+        let target_identity = self.canonical_fn_identity(None, target);
+        self.call_graph
+            .entry(source_identity)
+            .or_default()
+            .insert(target_identity);
+    }
+
     /// When `key` is a ROOT-owned canonical free-fn key (`{root}.{leaf}`),
     /// return its bare leaf; with no minted root identity, a bare free-fn key
     /// IS root-owned and returns itself. `None` for module/method keys.

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -341,6 +341,16 @@ impl Checker {
         self.fn_sigs.contains_key(&scoped).then_some(scoped)
     }
 
+    /// Mint the declaration-table identity for a free function owned by a
+    /// known lexical scope. A source-less root deliberately keeps its bare
+    /// key; imported bindings are resolution facts and must never rename the
+    /// declaration that shadows them.
+    pub(super) fn declared_fn_identity(owner: Option<&str>, name: &str) -> String {
+        owner
+            .and_then(|owner| scoped_module_item_name(Some(owner), name))
+            .unwrap_or_else(|| name.to_string())
+    }
+
     /// Return the declaration-table identity for a free function.
     ///
     /// `owner` is supplied while minting a declaration or resolving a known
@@ -352,7 +362,10 @@ impl Checker {
             return name.to_string();
         }
         if let Some(owner) = owner {
-            return scoped_module_item_name(Some(owner), name).unwrap_or_else(|| name.to_string());
+            return Self::declared_fn_identity(Some(owner), name);
+        }
+        if let Some((_, declaring_module)) = self.fn_def_spans.get(name) {
+            return Self::declared_fn_identity(declaring_module.as_deref(), name);
         }
         if let Some(source) = self.import_fn_name_aliases.get(&(
             self.current_module.clone(),
@@ -360,11 +373,6 @@ impl Checker {
             name.to_string(),
         )) {
             return source.clone();
-        }
-        if let Some((_, Some(declaring_module))) = self.fn_def_spans.get(name) {
-            let leaf = name.rsplit('.').next().unwrap_or(name);
-            return scoped_module_item_name(Some(declaring_module), leaf)
-                .unwrap_or_else(|| name.to_string());
         }
         name.to_string()
     }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6076,7 +6076,7 @@ impl Checker {
                 // `current_module` (None = root): it is the display/provenance
                 // axis, and the legacy root render at publication boundaries
                 // derives from it.
-                let scoped_name = self.canonical_fn_identity(self.canonical_fn_owner(), &fd.name);
+                let scoped_name = Self::declared_fn_identity(self.canonical_fn_owner(), &fd.name);
                 if let Some((prev_span, _)) = self.fn_def_spans.get(&scoped_name) {
                     // Root diagnostics render the bare leaf, exactly as the
                     // declaration is spelled in source.

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6076,8 +6076,7 @@ impl Checker {
                 // `current_module` (None = root): it is the display/provenance
                 // axis, and the legacy root render at publication boundaries
                 // derives from it.
-                let scoped_name = scoped_module_item_name(self.canonical_fn_owner(), &fd.name)
-                    .unwrap_or_else(|| fd.name.clone());
+                let scoped_name = self.canonical_fn_identity(self.canonical_fn_owner(), &fd.name);
                 if let Some((prev_span, _)) = self.fn_def_spans.get(&scoped_name) {
                     // Root diagnostics render the bare leaf, exactly as the
                     // declaration is spelled in source.
@@ -11335,7 +11334,7 @@ impl Checker {
                     }
                 }
                 Item::Function(fd) => {
-                    let qualified = format!("{module_full_path}.{}", fd.name);
+                    let qualified = self.canonical_fn_identity(Some(module_full_path), &fd.name);
                     let surface_qualified = format!("{module_short}.{}", fd.name);
                     // Record visibility for all functions in the visibility table.
                     self.fn_visibility
@@ -11346,9 +11345,6 @@ impl Checker {
                         .or_insert(fd.visibility);
                     self.fn_def_spans
                         .entry(qualified.clone())
-                        .or_insert_with(|| (span.clone(), Some(module_full_path.to_string())));
-                    self.fn_def_spans
-                        .entry(surface_qualified)
                         .or_insert_with(|| (span.clone(), Some(module_full_path.to_string())));
                     // The parsed Hew declaration is the canonical signature
                     // authority.  A registry import may have installed an ABI
@@ -12171,7 +12167,7 @@ impl Checker {
                 .unwrap_or(importer_file_idx);
             match item {
                 Item::Function(fd) => {
-                    let qualified = format!("{module_full_path}.{}", fd.name);
+                    let qualified = self.canonical_fn_identity(Some(module_full_path), &fd.name);
                     let surface_qualified = format!("{module_short}.{}", fd.name);
                     // Record visibility for all functions in the visibility table.
                     self.fn_visibility
@@ -12180,16 +12176,8 @@ impl Checker {
                     self.fn_visibility
                         .entry(surface_qualified.clone())
                         .or_insert(fd.visibility);
-                    // Record fn_def_spans under the SHORT-NAME key so the access-
-                    // allowed check in methods.rs can look up the declaring module's
-                    // FULL path.  `collect_function_item` stores the same span under
-                    // the full-path key (e.g. "subpkg.helper.secret"); we mirror it
-                    // under the short-name key ("helper.secret") used at call sites.
                     self.fn_def_spans
                         .entry(qualified.clone())
-                        .or_insert_with(|| (span.clone(), Some(module_full_path.to_string())));
-                    self.fn_def_spans
-                        .entry(surface_qualified.clone())
                         .or_insert_with(|| (span.clone(), Some(module_full_path.to_string())));
 
                     // The signature is a source declaration fact even though

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -3266,12 +3266,9 @@ pub struct Checker {
         HashMap<ImportBindingKey, std::collections::BTreeSet<String>>,
     /// Call graph: maps caller function name → set of callee function names.
     ///
-    /// rc1-F1 stage A classification: CANONICALIZED with `fn_sigs` — caller
-    /// keys are `current_function` (a canonical fn-sig key) and callee keys
-    /// are the resolved fn-sig keys, so dead-code reachability joins against
-    /// canonical `fn_def_spans` without a bare/scoped rewrite. Bare callee
-    /// entries remain for builtins/externs, which have no declaration span
-    /// and never participate in dead-code findings.
+    /// Every endpoint passes through `record_call_edge`, which resolves the
+    /// same canonical identity used by `fn_def_spans`. Bare builtin and extern
+    /// callees have no declaration span and never participate in findings.
     pub(super) call_graph: HashMap<String, HashSet<String>>,
     /// Name of the function currently being checked (for call graph tracking).
     pub(super) current_function: Option<String>,

--- a/tests/vertical-slice/accept/qualified_call_reachability/hew.toml
+++ b/tests/vertical-slice/accept/qualified_call_reachability/hew.toml
@@ -1,0 +1,6 @@
+[package]
+name = "callgraph_reach_fixture"
+edition = "2026"
+version = "0.1.0"
+
+[dependencies]

--- a/tests/vertical-slice/accept/qualified_call_reachability/ops/native-loop.hew
+++ b/tests/vertical-slice/accept/qualified_call_reachability/ops/native-loop.hew
@@ -2,6 +2,10 @@ import callgraph_reach_fixture.runner.native_loop;
 
 import callgraph_reach_fixture.runner.native_loop.{NativeConfig};
 
+fn genuinely_uncalled() -> i64 {
+    7
+}
+
 fn main() -> i64 {
     native_loop.run_once(NativeConfig { value: 20 })
 }

--- a/tests/vertical-slice/accept/qualified_call_reachability/ops/native-loop.hew
+++ b/tests/vertical-slice/accept/qualified_call_reachability/ops/native-loop.hew
@@ -1,0 +1,7 @@
+import callgraph_reach_fixture.runner.native_loop;
+
+import callgraph_reach_fixture.runner.native_loop.{NativeConfig};
+
+fn main() -> i64 {
+    native_loop.run_once(NativeConfig { value: 20 })
+}

--- a/tests/vertical-slice/accept/qualified_call_reachability/src/runner/math.hew
+++ b/tests/vertical-slice/accept/qualified_call_reachability/src/runner/math.hew
@@ -1,0 +1,3 @@
+pub fn double(value: i64) -> i64 {
+    value * 2
+}

--- a/tests/vertical-slice/accept/qualified_call_reachability/src/runner/native_loop.hew
+++ b/tests/vertical-slice/accept/qualified_call_reachability/src/runner/native_loop.hew
@@ -1,0 +1,17 @@
+import callgraph_reach_fixture.runner.math;
+
+pub type NativeConfig {
+    value: i64;
+}
+
+fn reachable_helper(value: i64) -> i64 {
+    math.double(value)
+}
+
+fn genuinely_uncalled() -> i64 {
+    7
+}
+
+pub fn run_once(config: NativeConfig) -> i64 {
+    reachable_helper(config.value) + 2
+}

--- a/tests/vertical-slice/accept/qualified_call_reachability/src/runner/native_loop.hew
+++ b/tests/vertical-slice/accept/qualified_call_reachability/src/runner/native_loop.hew
@@ -8,10 +8,6 @@ fn reachable_helper(value: i64) -> i64 {
     math.double(value)
 }
 
-fn genuinely_uncalled() -> i64 {
-    7
-}
-
 pub fn run_once(config: NativeConfig) -> i64 {
     reachable_helper(config.value) + 2
 }

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4226,6 +4226,39 @@ run_accept_expect_status "w2006_scope_spawn" 0
 # Layout: accept/sibling_module_call.hew imports accept/arith.hew
 run_accept_expect_status "sibling_module_call" 42
 
+# A package-qualified call reaches its imported declaration and the private
+# helper below it. The uncalled private function proves the dead-code lint is
+# still active rather than suppressed for the fixture.
+qualified_call_reachability="${ROOT}/tests/vertical-slice/accept/qualified_call_reachability"
+if ! (
+  cd "${qualified_call_reachability}"
+  "${HEW}" build ops/native-loop.hew
+) >"${accept_output}" 2>&1; then
+  echo "qualified_call_reachability: expected package build to succeed" >&2
+  cat "${accept_output}" >&2
+  exit 1
+fi
+for reachable_function in run_once reachable_helper; do
+  if grep -qF "function \`${reachable_function}\` is never called" "${accept_output}"; then
+    echo "qualified_call_reachability: ${reachable_function} must be reachable" >&2
+    cat "${accept_output}" >&2
+    exit 1
+  fi
+done
+# shellcheck disable=SC2016  # Backticks are literal Hew diagnostic syntax.
+grep -qF 'function `genuinely_uncalled` is never called' "${accept_output}" || {
+  echo "qualified_call_reachability: expected the negative control warning" >&2
+  cat "${accept_output}" >&2
+  exit 1
+}
+# shellcheck disable=SC2016  # Backticks are literal Hew diagnostic syntax.
+qualified_dead_count="$(grep -c 'function `[^`]*` is never called' "${accept_output}")"
+if [[ "${qualified_dead_count}" -ne 1 ]]; then
+  echo "qualified_call_reachability: expected one dead-code warning, got ${qualified_dead_count}" >&2
+  cat "${accept_output}" >&2
+  exit 1
+fi
+
 # Accept: a flat file import publishes a pub free function into the importing
 # file's bare namespace, and the selected call target survives through native
 # lowering and execution.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4230,9 +4230,13 @@ run_accept_expect_status "sibling_module_call" 42
 # helper below it. The uncalled private function proves the dead-code lint is
 # still active rather than suppressed for the fixture.
 qualified_call_reachability="${ROOT}/tests/vertical-slice/accept/qualified_call_reachability"
+qualified_call_hew="${HEW}"
+if [[ "${qualified_call_hew}" != /* ]]; then
+  qualified_call_hew="${ROOT}/${qualified_call_hew}"
+fi
 if ! (
   cd "${qualified_call_reachability}"
-  "${HEW}" build ops/native-loop.hew
+  "${qualified_call_hew}" build ops/native-loop.hew
 ) >"${accept_output}" 2>&1; then
   echo "qualified_call_reachability: expected package build to succeed" >&2
   cat "${accept_output}" >&2


### PR DESCRIPTION
Qualified imported-function calls now record the same canonical declaration identity the dead-code prover keys on.

An imported public function and its private helpers are proven reachable. A package/module fixture pins it with a negative control. A real multi-module project went from 44 false never-called warnings to 0.