### PR TITLE
refactor(stdlib): adopt dotted variant patterns and reject deprecations in the ratchet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1225,6 +1225,7 @@ check-counterfactual-output-build:
 	bash -n scripts/ci-preflight-dispatcher.sh
 
 test-stdlib-ratchet: hew
+	@bash scripts/tests/test_stdlib_ratchet_deprecations.sh
 	@echo "==> Type-checking stdlib (ratcheted)"
 	HEW_BIN="$(DEBUG_DIR)/hew" scripts/stdlib-ratchet.sh
 

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1655,13 +1655,13 @@ machine Counter {
     events { Inc; Reset; }
     state Zero;
     state NonZero { value: i64; }
-    on Inc: Zero => NonZero { NonZero { value: 1 } }
-    on Inc: NonZero => NonZero reenter { NonZero { value: self.value + 1 } }
-    on Reset: NonZero => Zero { Zero }
+    on Inc: Zero => NonZero { Counter.NonZero { value: 1 } }
+    on Inc: NonZero => NonZero reenter { Counter.NonZero { value: self.value + 1 } }
+    on Reset: NonZero => Zero { Counter.Zero }
     default { state }
 }
 fn main() {
-    var c = Zero;
+    var c = Counter.Zero;
     c.step(.Inc); c.step(.Inc); c.step(.Inc);
     println(c.state_name());            // NonZero
     match c {
@@ -1673,7 +1673,7 @@ fn main() {
 }
 ```
 
-A machine is a value type. Inside the body, state constructors are bare (`NonZero { value: 1 }`); contextual event arguments use `.Variant` (`step(.Inc)`). Outside use the qualifier (`Counter.Zero`, `CounterEvent.Inc`). `step()` mutates in place — the receiver must be a `var`. End with `default { state }` to make uncovered cells a no-op stay. Every (state, event) cell must be covered or it is a compile error.
+A machine is a value type. State constructors use a machine-qualified dotted form both inside and outside transition bodies (`Counter.NonZero { value: 1 }`, `Counter.Zero`); contextual event arguments use `.Variant` (`step(.Inc)`). Event constructors use the event-type qualifier outside contextual positions (`CounterEvent.Inc`). This behaviour keeps state-constructor resolution explicit. `step()` mutates in place — the receiver must be a `var`. End with `default { state }` to make uncovered cells a no-op stay. Every (state, event) cell must be covered or it is a compile error.
 
 > **Why `default` is a blanket catch-all, and what that costs you.** Without
 > `default`, every `(state, event)` pair not covered by an explicit `on`

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1666,7 +1666,7 @@ fn main() {
     println(c.state_name());            // NonZero
     match c {
         .Zero => println("is zero"),
-        NonZero { value } => println(f"value={value}"),  // value=3
+        .NonZero { value } => println(f"value={value}"),  // value=3
     }
     c.step(.Reset);
     println(c.state_name());            // Zero
@@ -1754,7 +1754,7 @@ fn main() {
     log.step(Append { item: 20 });
     match log {
         .Empty => println("empty"),
-        Filled { items } => {
+        .Filled { items } => {
             println(f"count={items.len()}");   // count=2
             println(f"first={items[0]}");  // first=10
         },
@@ -1781,7 +1781,7 @@ fn main() {
     a.step(make_add(7));
     match a {
         .Seed => println("seed"),
-        Total { sum } => println(f"sum={sum}"),   // sum=12
+        .Total { sum } => println(f"sum={sum}"),   // sum=12
     }
 }
 ```

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1745,7 +1745,7 @@ machine Log {
     on Append(item): Filled => Filled reenter {
         let v = self.items; v.push(item); Filled { items: v }
     }
-    on Clear: Filled => Empty { Empty }
+    on Clear: Filled => Empty { Log.Empty }
     default { state }
 }
 fn main() {
@@ -1798,9 +1798,9 @@ machine Conn {
     state Dead;
     on Start: Idle => Live { Live { hits: 0 } }
     on Bump: Live => Live reenter {
-        if self.hits + 1 >= 3 { Dead } else { Live { hits: self.hits + 1 } }
+        if self.hits + 1 >= 3 { Conn.Dead } else { Live { hits: self.hits + 1 } }
     }
-    on Kill: _ => Dead { Dead }
+    on Kill: _ => Dead { Conn.Dead }
     on Start: _ => _ { state }
     on Bump: _ => _ { state }
 }
@@ -1821,7 +1821,7 @@ machine Door {
     state Shut;
     state Ajar { angle: i64; }
     on Open: Shut => Ajar { Ajar { angle: 90 } }
-    on Close: Ajar => Shut { Shut }
+    on Close: Ajar => Shut { Door.Shut }
     default { state }
 }
 fn drive(d: Door) -> string {

--- a/docs/migrations/v0.4.0.md
+++ b/docs/migrations/v0.4.0.md
@@ -157,11 +157,11 @@ import std.text.regex;
 
 fn main() {
     match http.listen(":8080") {
-        Ok(server) => {
+        .Ok(server) => {
             // ... handle requests ...
             server.close();
         },
-        Err(_err) => {
+        .Err(_err) => {
             println(http.listen_error());
         },
     }
@@ -389,8 +389,8 @@ New shape:
 import std.net.http_client;
 
 match http_client.get_string("https://example.com/api") {
-    Some(body) => println(body),
-    None => println("request failed"),
+    .Some(body) => println(body),
+    .None => println("request failed"),
 }
 ```
 
@@ -413,8 +413,8 @@ process(s);
 
 // After — with match:
 match http_client.get_string(url) {
-    Some(s) => process(s),
-    None => { /* handle error */ },
+    .Some(s) => process(s),
+    .None => { /* handle error */ },
 }
 
 // After — with if-let for concise success path:

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -2650,7 +2650,7 @@ machine Name {
     on EventY: StateA => StateB { StateB { field: event.payload } }
 
     // Head binding: name payload fields at the rule site
-    on EventY(payload): StateB => StateA { StateA }
+    on EventY(payload): StateB => StateA { Name.StateA }
 
     // Self-transition with reenter (runs exit/entry even when state is unchanged)
     on EventX: StateB => StateB reenter { StateB { field: self.field } }

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -847,11 +847,11 @@ import std.text.regex;   // Available as "regex"
 
 // Call module functions with dot-syntax: module.function(args)
 match http.listen("127.0.0.1:0") { // Returns Result<Server, NetError>
-    Ok(server) => {
+    .Ok(server) => {
         println(f"HTTP server listening on port {http.server_port(server)}");
         server.close(); // Explicitly release the listener on every success path.
     },
-    Err(_err) => println(f"listen failed: {http.listen_error()}"),
+    .Err(_err) => println(f"listen failed: {http.listen_error()}"),
 }
 let content = fs.read("config.toml");
 let exists = fs.exists("output.txt");       // Returns bool
@@ -1419,9 +1419,9 @@ let e = Expr.Add(Expr.Lit(1), Expr.Neg(Expr.Lit(2)));
 ```hew
 fn eval(e: Expr) -> i64 {
     match e {
-        Lit(n) => n,
-        Add(l, r) => eval(l) + eval(r),
-        Neg(inner) => 0 - eval(inner),
+        .Lit(n) => n,
+        .Add(l, r) => eval(l) + eval(r),
+        .Neg(inner) => 0 - eval(inner),
     }
 }
 ```
@@ -2851,9 +2851,9 @@ light.step(LightEvent.Toggle);   // fully qualified (also valid)
 
 ```hew
 match cb {
-    Closed { failures } => println(f"failures = {failures}"),
-    Open                => println("open"),
-    HalfOpen            => println("half-open"),
+    .Closed { failures } => println(f"failures = {failures}"),
+    .Open                => println("open"),
+    .HalfOpen            => println("half-open"),
 }
 ```
 
@@ -2869,7 +2869,7 @@ actor ConnectionManager {
         tcp.step(event);
         // React to the new state
         match tcp {
-            Established { local_seq, remote_seq } => {
+            .Established { local_seq, remote_seq } => {
                 println(f"established seq={local_seq}/{remote_seq}");
             },
             _ => {},
@@ -3169,8 +3169,8 @@ unexpected, unrecoverable failures (Section 2.2).
 // Cancellation returns Err, not a trap:
 let result = await task;
 match result {
-    Ok(v) => use_value(v),
-    Err(_) => handle_cancellation(),
+    .Ok(v) => use_value(v),
+    .Err(_) => handle_cancellation(),
 }
 
 // Use ? to propagate cancellation errors:
@@ -3284,8 +3284,8 @@ scope {
     };
 
     match await task {
-        Ok(v) => use_value(v),
-        Err(e) => handle_error(e),
+        .Ok(v) => use_value(v),
+        .Err(e) => handle_error(e),
     }
 }
 ```
@@ -4072,8 +4072,8 @@ by this contract freeze.
 ```hew
 // Pull items
 match bytes_stream.recv() {
-    Some(chunk) => { ... },
-    None => { /* EOF only */ },
+    .Some(chunk) => { ... },
+    .None => { /* EOF only */ },
 }
 
 // Empty items are valid data, not EOF

--- a/docs/specs/MACHINE-SPEC.md
+++ b/docs/specs/MACHINE-SPEC.md
@@ -497,13 +497,13 @@ Machine values participate in pattern matching identically to enum values:
 
 ```hew
 match tcp_state {
-    Closed => println("closed"),
-    Listen { backlog } => println(f"listening, backlog={backlog}"),
-    Established { local_seq, remote_seq } => {
+    .Closed => println("closed"),
+    .Listen { backlog } => println(f"listening, backlog={backlog}"),
+    .Established { local_seq, remote_seq } => {
         println(f"established seq={local_seq}/{remote_seq}")
     },
-    FinWait => println("fin-wait"),
-    TimeWait => println("time-wait"),
+    .FinWait => println("fin-wait"),
+    .TimeWait => println("time-wait"),
 }
 ```
 
@@ -513,7 +513,7 @@ Partial matching with `_` is supported:
 
 ```hew
 match tcp_state {
-    Established { local_seq, .. } => println(f"seq={local_seq}"),
+    .Established { local_seq, .. } => println(f"seq={local_seq}"),
     _ => println("not established"),
 }
 ```
@@ -767,11 +767,11 @@ actor ApiGateway {
 
         // Update machine based on outcome
         match result {
-            Ok(resp) => {
+            .Ok(resp) => {
                 breaker.step(CircuitBreakerEvent.Success);
                 Ok(resp)
             },
-            Err(e) => {
+            .Err(e) => {
                 let now = time.now_ms();
                 breaker.step(CircuitBreakerEvent.Failure { timestamp: now });
                 Err(e)

--- a/examples/machine/bounded_resource.hew
+++ b/examples/machine/bounded_resource.hew
@@ -43,13 +43,13 @@ machine Bounded<T: Resource> {
         Holding { handle: event.handle }
     }
     on Finish: Holding => Idle {
-        Idle
+        Bounded.Idle
     }
     on Start: Holding => Holding reenter {
         Holding { handle: self.handle }
     }
     on Finish: Idle => Idle reenter {
-        Idle
+        Bounded.Idle
     }
 }
 

--- a/examples/machine/connection_lifecycle.hew
+++ b/examples/machine/connection_lifecycle.hew
@@ -23,21 +23,21 @@ machine ConnectionLifecycle {
         state Active;
         state Draining;
         on Disconnect: _ => Disconnected {
-            Disconnected
+            ConnectionLifecycle.Disconnected
         }
     }
 
     on Connect: Disconnected => Authenticating {
-        Authenticating
+        ConnectionLifecycle.Authenticating
     }
     on AuthOk: Authenticating => Active {
-        Active
+        ConnectionLifecycle.Active
     }
     on DrainStart: Active => Draining {
-        Draining
+        ConnectionLifecycle.Draining
     }
     on DrainDone: Draining => Disconnected {
-        Disconnected
+        ConnectionLifecycle.Disconnected
     }
     on Connect: _ => _ {
         state

--- a/examples/machine/counter_machine.hew
+++ b/examples/machine/counter_machine.hew
@@ -21,9 +21,9 @@ machine Counter {
         NonZero { value: self.value + 1 }
     }
     on Reset: NonZero => Zero {
-        Zero
+        Counter.Zero
     }
     on Reset: Zero => Zero reenter {
-        Zero
+        Counter.Zero
     }
 }

--- a/examples/machine/guard_default_stays.hew
+++ b/examples/machine/guard_default_stays.hew
@@ -16,7 +16,7 @@ machine Latch {
     state Open;
 
     on Try: Closed => Open when self.code == 42 {
-        Open
+        Latch.Open
     }
 
     default { state }

--- a/examples/machine/guard_fallthrough_traps.hew
+++ b/examples/machine/guard_fallthrough_traps.hew
@@ -33,10 +33,10 @@ machine Latch {
     state Open;
 
     on Try: Closed => Open when self.code == 42 {
-        Open
+        Latch.Open
     }
     on Try: Open => Open reenter {
-        Open
+        Latch.Open
     }
 }
 

--- a/examples/machine/guard_false_falls_through_to_wildcard.hew
+++ b/examples/machine/guard_false_falls_through_to_wildcard.hew
@@ -32,10 +32,10 @@ machine Latch {
     state Bailed;
 
     on Try: Closed => Open when self.code == 42 {
-        Open
+        Latch.Open
     }
     on Try: _ => Bailed {
-        Bailed
+        Latch.Bailed
     }
 }
 

--- a/examples/machine/guard_gates_transition.hew
+++ b/examples/machine/guard_gates_transition.hew
@@ -22,13 +22,13 @@ machine Latch {
     state Open;
 
     on Try: Closed => Open when self.code == 42 {
-        Open
+        Latch.Open
     }
     on Try: Closed => Closed reenter when self.code != 42 {
         Closed { code: self.code }
     }
     on Try: Open => Open reenter {
-        Open
+        Latch.Open
     }
 }
 

--- a/examples/machine/guard_true_fires.hew
+++ b/examples/machine/guard_true_fires.hew
@@ -15,13 +15,13 @@ machine Latch {
     state Open;
 
     on Try: Closed => Open when self.code == 42 {
-        Open
+        Latch.Open
     }
     on Try: Closed => Closed reenter when self.code != 42 {
         Closed { code: self.code }
     }
     on Try: Open => Open reenter {
-        Open
+        Latch.Open
     }
 }
 

--- a/examples/machine/padded_payload_machine.hew
+++ b/examples/machine/padded_payload_machine.hew
@@ -21,10 +21,10 @@ machine PaddedPayload {
         Active { tag_byte: 0, value: 42 }
     }
     on Deactivate: Active => Idle {
-        Idle
+        PaddedPayload.Idle
     }
     on Deactivate: Idle => Idle reenter {
-        Idle
+        PaddedPayload.Idle
     }
     on Activate: Active => Active reenter {
         Active { tag_byte: self.tag_byte, value: self.value }

--- a/examples/machine/reject_await_in_transition.hew
+++ b/examples/machine/reject_await_in_transition.hew
@@ -11,7 +11,7 @@ machine Door {
         Open
     }
     on Toggle: Open => Closed {
-        Closed
+        Door.Closed
     }
 }
 

--- a/examples/machine/reject_gen_in_transition.hew
+++ b/examples/machine/reject_gen_in_transition.hew
@@ -10,7 +10,7 @@ machine Door {
         gen { yield Open; }
     }
     on Toggle: Open => Closed {
-        Closed
+        Door.Closed
     }
 }
 

--- a/examples/machine/run_counter_qualified.hew
+++ b/examples/machine/run_counter_qualified.hew
@@ -10,10 +10,10 @@ machine Counter {
     state Running;
 
     on Tick: Idle => Running {
-        Running
+        Counter.Running
     }
     on Tick: Running => Running reenter {
-        Running
+        Counter.Running
     }
 }
 

--- a/examples/machine/run_default_stay.hew
+++ b/examples/machine/run_default_stay.hew
@@ -20,7 +20,7 @@ machine Tank {
     state Draining;
 
     on Drain: Filling => Draining {
-        Draining
+        Tank.Draining
     }
 
     default { state }

--- a/examples/machine/run_emit_signal.hew
+++ b/examples/machine/run_emit_signal.hew
@@ -37,22 +37,22 @@ machine Signal {
 
     on Start: Idle => Active {
         emit Ready {};
-        Active
+        Signal.Active
     }
     on Stop: Active => Idle {
-        Idle
+        Signal.Idle
     }
     on Ready: Idle => Idle reenter {
-        Idle
+        Signal.Idle
     }
     on Ready: Active => Active reenter {
-        Active
+        Signal.Active
     }
     on Start: Active => Active reenter {
-        Active
+        Signal.Active
     }
     on Stop: Idle => Idle reenter {
-        Idle
+        Signal.Idle
     }
 }
 

--- a/examples/machine/run_emit_two_machines.hew
+++ b/examples/machine/run_emit_two_machines.hew
@@ -27,10 +27,10 @@ machine Alarm {
 
     on Trigger: Armed => Tripped {
         emit Ring {};
-        Tripped
+        Alarm.Tripped
     }
     on Trigger: Tripped => Tripped reenter {
-        Tripped
+        Alarm.Tripped
     }
     on Ring: _ => _ {
         state
@@ -47,10 +47,10 @@ machine Beacon {
     state Lit;
 
     on Trigger: Idle => Lit {
-        Lit
+        Beacon.Lit
     }
     on Trigger: Lit => Lit reenter {
-        Lit
+        Beacon.Lit
     }
     on Ring: _ => _ {
         state

--- a/examples/machine/run_tcp_handshake.hew
+++ b/examples/machine/run_tcp_handshake.hew
@@ -11,25 +11,25 @@ machine TcpHandshake {
     state Established;
 
     on Syn: Closed => SynReceived {
-        SynReceived
+        TcpHandshake.SynReceived
     }
     on Ack: Closed => Closed reenter {
-        Closed
+        TcpHandshake.Closed
     }
     on Syn: SynReceived => SynReceived reenter {
-        SynReceived
+        TcpHandshake.SynReceived
     }
     on Ack: SynReceived => Established {
-        Established
+        TcpHandshake.Established
     }
     on Syn: Established => Established reenter {
-        Established
+        TcpHandshake.Established
     }
     on Ack: Established => Established reenter {
-        Established
+        TcpHandshake.Established
     }
     on Reset: _ => Closed {
-        Closed
+        TcpHandshake.Closed
     }
 }
 

--- a/examples/machine/run_traffic_light.hew
+++ b/examples/machine/run_traffic_light.hew
@@ -23,13 +23,13 @@ machine TrafficLight {
     state Yellow;
 
     on Tick: Red => Green {
-        Green
+        TrafficLight.Green
     }
     on Tick: Green => Yellow {
-        Yellow
+        TrafficLight.Yellow
     }
     on Tick: Yellow => Red {
-        Red
+        TrafficLight.Red
     }
 }
 

--- a/examples/machine/tcp_handshake.hew
+++ b/examples/machine/tcp_handshake.hew
@@ -65,17 +65,17 @@ machine TcpHandshake {
 
         // Peer initiates close while established.
         emit AckReceive {};
-        CloseWait
+        TcpHandshake.CloseWait
     }
     on AckReceive: CloseWait => Closed {
 
         // Close-wait → closed (we have sent our FIN and got ACK).
-        Closed
+        TcpHandshake.Closed
     }
     on Reset: _ => Closed {
 
         // Reset collapses to Closed from any state.
-        Closed
+        TcpHandshake.Closed
     }
     on SynReceive: SynReceived => SynReceived reenter {
 
@@ -88,12 +88,12 @@ machine TcpHandshake {
         Established { remote_port: self.remote_port }
     }
     on SynReceive: CloseWait => CloseWait reenter {
-        CloseWait
+        TcpHandshake.CloseWait
     }
     on AckReceive: Closed => Closed reenter {
 
         // Unexpected ACK while Closed or Established: ignore.
-        Closed
+        TcpHandshake.Closed
     }
     on AckReceive: Established => Established reenter {
         Established { remote_port: self.remote_port }
@@ -101,12 +101,12 @@ machine TcpHandshake {
     on FinReceive: Closed => Closed reenter {
 
         // FIN while not Established: ignore (nothing to close).
-        Closed
+        TcpHandshake.Closed
     }
     on FinReceive: SynReceived => SynReceived reenter {
         SynReceived { remote_port: self.remote_port }
     }
     on FinReceive: CloseWait => CloseWait reenter {
-        CloseWait
+        TcpHandshake.CloseWait
     }
 }

--- a/examples/machine/traffic_light.hew
+++ b/examples/machine/traffic_light.hew
@@ -35,12 +35,12 @@ machine TrafficLight {
     on Tick: Red => Green {
 
         // Red → Green → Yellow → Red cycle
-        Green
+        TrafficLight.Green
     }
     on Tick: Green => Yellow {
-        Yellow
+        TrafficLight.Yellow
     }
     on Tick: Yellow => Red {
-        Red
+        TrafficLight.Red
     }
 }

--- a/examples/playground/machines/traffic_light.hew
+++ b/examples/playground/machines/traffic_light.hew
@@ -11,13 +11,13 @@ machine TrafficLight {
     state Yellow;
 
     on Tick: Red => Green {
-        TrafficLight.Green
+        .Green
     }
     on Tick: Green => Yellow {
-        TrafficLight.Yellow
+        .Yellow
     }
     on Tick: Yellow => Red {
-        TrafficLight.Red
+        .Red
     }
 }
 

--- a/examples/playground/machines/traffic_light.hew
+++ b/examples/playground/machines/traffic_light.hew
@@ -11,13 +11,13 @@ machine TrafficLight {
     state Yellow;
 
     on Tick: Red => Green {
-        Green
+        TrafficLight.Green
     }
     on Tick: Green => Yellow {
-        Yellow
+        TrafficLight.Yellow
     }
     on Tick: Yellow => Red {
-        Red
+        TrafficLight.Red
     }
 }
 

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -1290,14 +1290,17 @@ impl<'a> ProfileChecker<'a> {
 }
 
 /// Returns true if a machine transition body is trivial and carries no
-/// side-effects: a bare identifier (state-name reference), a block whose
-/// only statement is a bare identifier or a single literal, or a literal.
+/// side-effects: a state-name identifier, contextual state variant, a block
+/// whose only statement is a state-name expression or a single literal, or a
+/// literal.
 /// Non-trivial bodies are fail-closed-rejected; the runtime ignores them and
 /// only uses the declared `to` state from the transition table.
 fn is_trivial_machine_transition_body(expr: &Expr) -> bool {
     match expr {
-        // A bare `StateName`, `Machine::StateName` path, or a literal.
-        Expr::Identifier(_) | Expr::Literal(_) => true,
+        // A state-name identifier, contextual `.StateName`, or a literal.
+        Expr::Identifier(_)
+        | Expr::ContextVariant(hew_parser::ast::ContextVariantExpr { record: None, .. })
+        | Expr::Literal(_) => true,
         // A block `{ state_expr }` where the trailing expression is trivial and
         // there are no statements (no side-effects in the block body).
         Expr::Block(block) => {

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -105,7 +105,7 @@ spec-0077   3711765580   # SNIPPET: bare `let`/`var` — machine state illustrat
 spec-0078   1861586926   # SNIPPET: bare `let` after machine transitions — illustration
 spec-0079   3943447574   # SNIPPET: bare `let m = ...` — machine instantiation illustration
 spec-0080   249349858   # SNIPPET: bare `Option` identifier — option-type illustration
-spec-0081   2813060693   # IMPL-GAP: undefined `StateB` — machine-state enum reference illustration
+spec-0081   1181031507   # IMPL-GAP: undefined `StateB` — machine-state enum reference illustration
 spec-0082   3707425012   # SPEC-BUG: interleaved `event` declarations — old machine syntax pre-`events {}`
 spec-0083   813722226   # SNIPPET: bare `on event { ... }` — machine transition illustration
 spec-0084   2915754722   # SNIPPET: bare `on event ...` — machine state illustration

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -80,13 +80,13 @@ spec-0022   2513387504   # FRAGMENT: actor calls undefined `process()` — allow
 spec-0023   3898239403   # ERROR-DEMO: intentionally shows non-Send send and non-Send capture errors
 spec-0024   2265846331   # SPEC-BUG: type mismatch in aspirational TCP module example
 spec-0025   3406269624   # FRAGMENT: imports `network.tcp` — hypothetical module, not in stdlib
-spec-0026   593744325   # SNIPPET: bare code after import statement — illustration of import effect
+spec-0026   838045753   # SNIPPET: bare code after import statement — illustration of import effect
 spec-0027   2603276079   # FRAGMENT: imports `greeting` — multi-file example, module not found
 spec-0030   53697221   # SNIPPET: bare code outside declarations — trait method dispatch illustration
 spec-0031   158863422   # SNIPPET: bare `let` + trait call — trait dispatch illustration
 spec-0035   1203364263   # SNIPPET: bare `let` — type inference illustration
 spec-0044   60603610   # SNIPPET: bare `let f = |...| ...` — lambda illustration
-spec-0045   166608112   # SPEC-BUG: references variant `Lit` not defined in the fence
+spec-0045   1914272309   # SPEC-BUG: references variant `Lit` not defined in the fence
 spec-0046   1607851950   # SNIPPET: bare `let` — fn-type variable illustration
 spec-0051   4288056281   # SPEC-BUG: struct `impl` using wrong syntax form (stray `;` before `fn`)
 spec-0054   4266594633   # SNIPPET: bare identifier `max` after trait definition — illustration
@@ -111,15 +111,15 @@ spec-0083   813722226   # SNIPPET: bare `on event { ... }` — machine transitio
 spec-0084   2915754722   # SNIPPET: bare `on event ...` — machine state illustration
 spec-0085   696588660   # SNIPPET: bare `on event ...` — machine event illustration
 spec-0086   3858180891   # SNIPPET: bare `var` — machine initial-state illustration
-spec-0087   1402575065   # SNIPPET: bare `match state { ... }` — machine pattern illustration
-spec-0088   2705896423   # SPEC-BUG: references `TcpState::Closed` — undefined in this fence
+spec-0087   3427923877   # SNIPPET: bare `match state { ... }` — machine pattern illustration
+spec-0088   3260318579   # SPEC-BUG: references `TcpState::Closed` — undefined in this fence
 spec-0089   1156883475   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0090   1867383437   # SNIPPET: bare `var count = 0` — scope racing illustration
 spec-0091   3881963563   # SNIPPET: bare `let handle = fork { ... }` — scope handle illustration
-spec-0092   3357528238   # SNIPPET: bare `let` — scope result illustration
+spec-0092   3210405407   # SNIPPET: bare `let` — scope result illustration
 spec-0093   2158893112   # SNIPPET: bare `var count = 0` — scoped counter illustration
 spec-0094   10384720   # SNIPPET: bare `receive fn` — actor + scope illustration
-spec-0095   3942350177   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
+spec-0095   2265400838   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0096   152741125   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0097   1539476359   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0099   873326002   # SNIPPET: bare `let` — async I/O illustration
@@ -133,7 +133,7 @@ spec-0107   982438679   # IMPL-GAP: `pool` is a reserved word — pool-superviso
 spec-0108   3896519088   # IMPL-GAP: `pool` as pattern — reserved word clash in supervisor syntax
 spec-0110   3534476634   # FRAGMENT: references `prices` from prior fence context — context-dependent
 spec-0111   759184928   # SNIPPET: bare `let` — wire schema illustration
-spec-0112   3964649123   # SNIPPET: bare `match` — wire format pattern illustration
+spec-0112   2109671045   # SNIPPET: bare `match` — wire format pattern illustration
 spec-0123   3678662757   # SNIPPET: bare `let` — wire encode illustration
 spec-0124   866984589   # SNIPPET: bare `let` — wire decode illustration
 spec-0125   543939813   # SNIPPET: bare `mailbox` declaration — overflow-policy illustration

--- a/scripts/extract-doc-fences.sh
+++ b/scripts/extract-doc-fences.sh
@@ -57,6 +57,9 @@ source "$REPO_ROOT/scripts/lib/corpus-nonempty.sh"
 # shellcheck source=scripts/lib/cargo-output-dir.sh
 # shellcheck disable=SC1091
 source "$REPO_ROOT/scripts/lib/cargo-output-dir.sh"
+# shellcheck source=scripts/lib/bare-variant-ratchet.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/bare-variant-ratchet.sh"
 
 EXPECTED_FAILURES_FILE="$REPO_ROOT/scripts/doc-test-expected-failures.txt"
 OUTDIR="$REPO_ROOT/.tmp/doc-fences"
@@ -385,7 +388,7 @@ fi
 
 echo ""
 if [[ $count_bare_variants -gt 0 ]]; then
-    echo "RATCHET FAIL: $count_bare_variants bare variant diagnostic(s) in doc fences:"
+    echo "$(bare_variant_ratchet_failure_message "$count_bare_variants") in doc fences:"
     while IFS= read -r diagnostic; do
         [[ -z "$diagnostic" ]] && continue
         echo "  BARE VARIANT: $diagnostic"

--- a/scripts/extract-doc-fences.sh
+++ b/scripts/extract-doc-fences.sh
@@ -14,10 +14,12 @@
 #      the skip total and are never treated as failures.
 #
 # Ratchet rules (mirrors hew-suite-ratchet.sh):
-#   - Exits 0 if the failing fence set exactly matches the expected-failures list.
+#   - Exits 0 if the failing fence set exactly matches the expected-failures list
+#     and no fence emits a bare variant diagnostic.
 #   - Exits 1 on any NEW failure (unexpected regression).
 #   - Exits 1 if a LISTED failure now passes (ratchet forward — remove from list).
 #   - Exits 1 if a LISTED failure's content checksum changed (re-verify label).
+#   - Exits 1 if any fence emits E_BARE_VARIANT_PATTERN or E_BARE_VARIANT_EXPR.
 #
 # WHY: Docs can rot silently with no gate. 133 fences currently pass; 111 fail
 # (the docs-rot backlog, tracked per entry with root-cause notes). This ratchet
@@ -289,6 +291,7 @@ pass=0
 fail=0
 skip=0
 ACTUAL_STR=""  # newline-separated fence IDs of failing fences
+BARE_VARIANTS_STR=""
 
 for (( idx=0; idx < ${#FENCE_IDS[@]}; idx++ )); do
     fence_id="${FENCE_IDS[$idx]}"
@@ -301,7 +304,11 @@ for (( idx=0; idx < ${#FENCE_IDS[@]}; idx++ )); do
     fi
 
     check_rc=0
-    "$HEW_BIN" check "$outfile" >/dev/null 2>&1 || check_rc=$?
+    check_output="$("$HEW_BIN" check "$outfile" 2>&1)" || check_rc=$?
+    bare_variants=""
+    if bare_variants="$(printf '%s\n' "$check_output" | rg ': warning: E_BARE_VARIANT_(PATTERN|EXPR):')"; then
+        BARE_VARIANTS_STR="${BARE_VARIANTS_STR}${bare_variants}"$'\n'
+    fi
 
     if [[ "$check_rc" == "0" ]]; then
         pass=$(( pass + 1 ))
@@ -314,6 +321,9 @@ done
 echo ""
 echo "==> Results: $pass passed, $fail failed, $skip skipped (NYI/aspirational)"
 echo "    Total fences: $total_fences"
+
+count_bare_variants="$(line_set_count "$BARE_VARIANTS_STR")"
+echo "    Bare variants: $count_bare_variants"
 
 # ── Ratchet ────────────────────────────────────────────────────────────────────
 
@@ -361,7 +371,7 @@ count_unexpected_fail="$(line_set_count "$unexpected_failures")"
 count_unexpected_pass="$(line_set_count "$unexpected_passes")"
 count_stale_metadata="$(line_set_count "$stale_metadata")"
 
-if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 && $count_stale_metadata -eq 0 ]]; then
+if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 && $count_stale_metadata -eq 0 && $count_bare_variants -eq 0 ]]; then
     if [[ $count_actual -eq 0 ]]; then
         echo ""
         echo "    All doc fences pass. Consider removing the expected-failures file."
@@ -374,6 +384,17 @@ if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 && $count_sta
 fi
 
 echo ""
+if [[ $count_bare_variants -gt 0 ]]; then
+    echo "RATCHET FAIL: $count_bare_variants bare variant diagnostic(s) in doc fences:"
+    while IFS= read -r diagnostic; do
+        [[ -z "$diagnostic" ]] && continue
+        echo "  BARE VARIANT: $diagnostic"
+    done <<< "$BARE_VARIANTS_STR"
+    echo ""
+    echo "  Qualify every bare variant; bare variant diagnostics are not ratcheted."
+    echo ""
+fi
+
 if [[ $count_unexpected_fail -gt 0 ]]; then
     echo "RATCHET FAIL: $count_unexpected_fail UNEXPECTED failure(s) — not in expected list:"
     while IFS= read -r name; do

--- a/scripts/extract-doc-fences.sh
+++ b/scripts/extract-doc-fences.sh
@@ -306,7 +306,7 @@ for (( idx=0; idx < ${#FENCE_IDS[@]}; idx++ )); do
     check_rc=0
     check_output="$("$HEW_BIN" check "$outfile" 2>&1)" || check_rc=$?
     bare_variants=""
-    if bare_variants="$(printf '%s\n' "$check_output" | rg ': warning: E_BARE_VARIANT_(PATTERN|EXPR):')"; then
+    if bare_variants="$(printf '%s\n' "$check_output" | grep -E ': warning: E_BARE_VARIANT_(PATTERN|EXPR):')"; then
         BARE_VARIANTS_STR="${BARE_VARIANTS_STR}${bare_variants}"$'\n'
     fi
 

--- a/scripts/lib/bare-variant-ratchet.sh
+++ b/scripts/lib/bare-variant-ratchet.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Shared bare-variant ratchet reporting contract.
+
+bare_variant_ratchet_failure_message() {
+    local count="$1"
+
+    printf 'RATCHET FAIL: %s bare variant diagnostic(s)' "$count"
+}

--- a/scripts/stdlib-ratchet.sh
+++ b/scripts/stdlib-ratchet.sh
@@ -3,13 +3,13 @@
 #
 # Behaviour:
 #   - Exits 0 if the set of failing stdlib files exactly matches the list in
-#     scripts/stdlib-expected-failures.txt and no check emits a deprecation
-#     warning.
+#     scripts/stdlib-expected-failures.txt and no check emits a bare variant
+#     diagnostic.
 #   - Exits 1 if any NEW stdlib file fails (unexpected regression).
 #   - Exits 1 if any LISTED file no longer fails (unexpected fix — delete the
 #     entry from the list to accept the green).
-#   - Exits 1 if any stdlib check emits a deprecation warning, including when
-#     the check otherwise succeeds.
+#   - Exits 1 if any stdlib check emits E_BARE_VARIANT_PATTERN or
+#     E_BARE_VARIANT_EXPR, including when the check otherwise succeeds.
 #
 # WHY: The Hew stdlib type-check suite has known failures that converging lanes
 # are fixing.  Gating on zero failures would block integration; gating on nothing
@@ -107,7 +107,7 @@ done < "$EXPECTED_FAILURES_FILE"
 
 # Type-check each stdlib file and collect failures.
 ACTUAL_STR=""
-DEPRECATIONS_STR=""
+BARE_VARIANTS_STR=""
 TOTAL=0
 
 while IFS= read -r -d $'\0' f; do
@@ -120,9 +120,9 @@ while IFS= read -r -d $'\0' f; do
     if (( check_status != 0 )); then
         ACTUAL_STR="${ACTUAL_STR}${relpath}"$'\n'
     fi
-    deprecations=""
-    if deprecations="$(printf '%s\n' "$check_output" | rg ': warning: [^:]+: .*deprecated')"; then
-        DEPRECATIONS_STR="${DEPRECATIONS_STR}${deprecations}"$'\n'
+    bare_variants=""
+    if bare_variants="$(printf '%s\n' "$check_output" | rg ': warning: E_BARE_VARIANT_(PATTERN|EXPR):')"; then
+        BARE_VARIANTS_STR="${BARE_VARIANTS_STR}${bare_variants}"$'\n'
     fi
 done < <(find "$STDLIB_DIR" -name '*.hew' -not -path '*/target/*' -print0 | sort -z)
 
@@ -148,9 +148,9 @@ if [[ -n "$ACTUAL_STR" ]]; then
     count_actual="$(line_set_count "$ACTUAL_STR")"
 fi
 
-count_deprecations=0
-if [[ -n "$DEPRECATIONS_STR" ]]; then
-    count_deprecations="$(line_set_count "$DEPRECATIONS_STR")"
+count_bare_variants=0
+if [[ -n "$BARE_VARIANTS_STR" ]]; then
+    count_bare_variants="$(line_set_count "$BARE_VARIANTS_STR")"
 fi
 
 # Find unexpected failures (in actual but not in expected).
@@ -175,7 +175,7 @@ echo "==> Stdlib type-check ratchet"
 echo "Files checked:     $TOTAL"
 echo "Expected failures: $count_expected"
 echo "Actual failures:   $count_actual"
-echo "Deprecations:      $count_deprecations"
+echo "Bare variants:     $count_bare_variants"
 echo ""
 
 count_unexpected_fail=0
@@ -184,7 +184,7 @@ count_unexpected_fail=0
 count_unexpected_pass=0
 [[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(line_set_count "$unexpected_passes")"
 
-if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 && $count_deprecations -eq 0 ]]; then
+if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 && $count_bare_variants -eq 0 ]]; then
     if [[ $count_actual -eq 0 ]]; then
         echo "All stdlib files pass type-check. Remove entries from expected-failures file."
     else
@@ -200,14 +200,14 @@ if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 && $count_dep
 fi
 
 # Report problems.
-if [[ $count_deprecations -gt 0 ]]; then
-    echo "RATCHET FAIL: $count_deprecations deprecation warning(s) in stdlib checks:"
+if [[ $count_bare_variants -gt 0 ]]; then
+    echo "RATCHET FAIL: $count_bare_variants bare variant diagnostic(s) in stdlib checks:"
     while IFS= read -r diagnostic; do
         [[ -z "$diagnostic" ]] && continue
-        echo "  DEPRECATED: $diagnostic"
-    done <<< "$DEPRECATIONS_STR"
+        echo "  BARE VARIANT: $diagnostic"
+    done <<< "$BARE_VARIANTS_STR"
     echo ""
-    echo "  Fix every deprecated stdlib use; deprecations are not ratcheted."
+    echo "  Qualify every bare variant; bare variant diagnostics are not ratcheted."
     echo ""
 fi
 

--- a/scripts/stdlib-ratchet.sh
+++ b/scripts/stdlib-ratchet.sh
@@ -3,10 +3,13 @@
 #
 # Behaviour:
 #   - Exits 0 if the set of failing stdlib files exactly matches the list in
-#     scripts/stdlib-expected-failures.txt.
+#     scripts/stdlib-expected-failures.txt and no check emits a deprecation
+#     warning.
 #   - Exits 1 if any NEW stdlib file fails (unexpected regression).
 #   - Exits 1 if any LISTED file no longer fails (unexpected fix — delete the
 #     entry from the list to accept the green).
+#   - Exits 1 if any stdlib check emits a deprecation warning, including when
+#     the check otherwise succeeds.
 #
 # WHY: The Hew stdlib type-check suite has known failures that converging lanes
 # are fixing.  Gating on zero failures would block integration; gating on nothing
@@ -104,14 +107,22 @@ done < "$EXPECTED_FAILURES_FILE"
 
 # Type-check each stdlib file and collect failures.
 ACTUAL_STR=""
+DEPRECATIONS_STR=""
 TOTAL=0
 
 while IFS= read -r -d $'\0' f; do
     TOTAL=$((TOTAL + 1))
     # Normalize path to be relative to repo root.
     relpath="${f#"$REPO_ROOT"/}"
-    if ! "$HEW_BIN" check "$f" >/dev/null 2>&1; then
+    check_output=""
+    check_status=0
+    check_output="$("$HEW_BIN" check "$f" 2>&1)" || check_status=$?
+    if (( check_status != 0 )); then
         ACTUAL_STR="${ACTUAL_STR}${relpath}"$'\n'
+    fi
+    deprecations=""
+    if deprecations="$(printf '%s\n' "$check_output" | rg ': warning: [^:]+: .*deprecated')"; then
+        DEPRECATIONS_STR="${DEPRECATIONS_STR}${deprecations}"$'\n'
     fi
 done < <(find "$STDLIB_DIR" -name '*.hew' -not -path '*/target/*' -print0 | sort -z)
 
@@ -137,6 +148,11 @@ if [[ -n "$ACTUAL_STR" ]]; then
     count_actual="$(line_set_count "$ACTUAL_STR")"
 fi
 
+count_deprecations=0
+if [[ -n "$DEPRECATIONS_STR" ]]; then
+    count_deprecations="$(line_set_count "$DEPRECATIONS_STR")"
+fi
+
 # Find unexpected failures (in actual but not in expected).
 unexpected_failures=""
 while IFS= read -r path; do
@@ -159,6 +175,7 @@ echo "==> Stdlib type-check ratchet"
 echo "Files checked:     $TOTAL"
 echo "Expected failures: $count_expected"
 echo "Actual failures:   $count_actual"
+echo "Deprecations:      $count_deprecations"
 echo ""
 
 count_unexpected_fail=0
@@ -167,7 +184,7 @@ count_unexpected_fail=0
 count_unexpected_pass=0
 [[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(line_set_count "$unexpected_passes")"
 
-if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 ]]; then
+if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 && $count_deprecations -eq 0 ]]; then
     if [[ $count_actual -eq 0 ]]; then
         echo "All stdlib files pass type-check. Remove entries from expected-failures file."
     else
@@ -183,6 +200,17 @@ if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 ]]; then
 fi
 
 # Report problems.
+if [[ $count_deprecations -gt 0 ]]; then
+    echo "RATCHET FAIL: $count_deprecations deprecation warning(s) in stdlib checks:"
+    while IFS= read -r diagnostic; do
+        [[ -z "$diagnostic" ]] && continue
+        echo "  DEPRECATED: $diagnostic"
+    done <<< "$DEPRECATIONS_STR"
+    echo ""
+    echo "  Fix every deprecated stdlib use; deprecations are not ratcheted."
+    echo ""
+fi
+
 if [[ $count_unexpected_fail -gt 0 ]]; then
     echo "RATCHET FAIL: $count_unexpected_fail UNEXPECTED failure(s) — not in expected list:"
     while IFS= read -r path; do

--- a/scripts/stdlib-ratchet.sh
+++ b/scripts/stdlib-ratchet.sh
@@ -39,6 +39,9 @@ source "$REPO_ROOT/scripts/lib/corpus-nonempty.sh"
 # shellcheck source=scripts/lib/cargo-output-dir.sh
 # shellcheck disable=SC1091
 source "$REPO_ROOT/scripts/lib/cargo-output-dir.sh"
+# shellcheck source=scripts/lib/bare-variant-ratchet.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/bare-variant-ratchet.sh"
 EXPECTED_FAILURES_FILE="$REPO_ROOT/scripts/stdlib-expected-failures.txt"
 HEW_BIN="${HEW_BIN:-$(cargo_debug_dir "$REPO_ROOT")/hew}"
 STDLIB_DIR="$REPO_ROOT/std"
@@ -201,7 +204,7 @@ fi
 
 # Report problems.
 if [[ $count_bare_variants -gt 0 ]]; then
-    echo "RATCHET FAIL: $count_bare_variants bare variant diagnostic(s) in stdlib checks:"
+    echo "$(bare_variant_ratchet_failure_message "$count_bare_variants") in stdlib checks:"
     while IFS= read -r diagnostic; do
         [[ -z "$diagnostic" ]] && continue
         echo "  BARE VARIANT: $diagnostic"

--- a/scripts/stdlib-ratchet.sh
+++ b/scripts/stdlib-ratchet.sh
@@ -121,7 +121,7 @@ while IFS= read -r -d $'\0' f; do
         ACTUAL_STR="${ACTUAL_STR}${relpath}"$'\n'
     fi
     bare_variants=""
-    if bare_variants="$(printf '%s\n' "$check_output" | rg ': warning: E_BARE_VARIANT_(PATTERN|EXPR):')"; then
+    if bare_variants="$(printf '%s\n' "$check_output" | grep -E ': warning: E_BARE_VARIANT_(PATTERN|EXPR):')"; then
         BARE_VARIANTS_STR="${BARE_VARIANTS_STR}${bare_variants}"$'\n'
     fi
 done < <(find "$STDLIB_DIR" -name '*.hew' -not -path '*/target/*' -print0 | sort -z)

--- a/scripts/tests/test_doc_ratchet_membership.sh
+++ b/scripts/tests/test_doc_ratchet_membership.sh
@@ -44,6 +44,10 @@ HARNESS="$REPO_ROOT/scripts/extract-doc-fences.sh"
 # shellcheck disable=SC1091
 source "$REPO_ROOT/scripts/lib/line-set.sh"
 
+# shellcheck source=scripts/lib/bare-variant-ratchet.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/bare-variant-ratchet.sh"
+
 # shellcheck source=scripts/lib/timeout.sh
 # shellcheck disable=SC1091
 source "$REPO_ROOT/scripts/lib/timeout.sh"
@@ -285,7 +289,7 @@ if [[ "$HARNESS_STATUS" -ne 0 ]]; then
 else
     fail "bare variant diagnostics were accepted"
 fi
-assert_contains "$HARNESS_OUTPUT" "RATCHET FAIL: 2 bare variant diagnostic(s)" \
+assert_contains "$HARNESS_OUTPUT" "$(bare_variant_ratchet_failure_message 2)" \
     "bare variant rejection reports both diagnostics"
 assert_contains "$HARNESS_OUTPUT" "E_BARE_VARIANT_PATTERN" \
     "bare variant rejection preserves the pattern diagnostic"

--- a/scripts/tests/test_doc_ratchet_membership.sh
+++ b/scripts/tests/test_doc_ratchet_membership.sh
@@ -118,6 +118,11 @@ fence_id="${2##*/}"
 fence_id="${fence_id%.hew}"
 printf '%s\n' "$fence_id" >> "${HEW_CALL_LOG:?}"
 
+if [[ "$fence_id" == "${HEW_BARE_VARIANT_FENCE_ID:-}" ]]; then
+    printf '%s:1:1: warning: E_BARE_VARIANT_PATTERN: bare variant pattern is deprecated\n' "$2" >&2
+    printf '%s:1:1: warning: E_BARE_VARIANT_EXPR: bare variant is deprecated\n' "$2" >&2
+fi
+
 while IFS= read -r failing_id; do
     [[ "$failing_id" == "$fence_id" ]] && exit 1
 done < "${HEW_FAIL_IDS:?}"
@@ -269,6 +274,23 @@ if [[ "$HARNESS_STATUS" -eq 0 ]]; then
 else
     fail "matching failure sets rejected with status $HARNESS_STATUS"
 fi
+
+# Both migration diagnostics must fail the ratchet even when the checked fence
+# otherwise passes and the failure set matches its expected baseline.
+export HEW_BARE_VARIANT_FENCE_ID="$passing_id"
+run_harness "$BASELINE_EXPECTED" "$BASELINE_FAIL_IDS" /dev/null
+unset HEW_BARE_VARIANT_FENCE_ID
+if [[ "$HARNESS_STATUS" -ne 0 ]]; then
+    pass "bare variant diagnostics are rejected"
+else
+    fail "bare variant diagnostics were accepted"
+fi
+assert_contains "$HARNESS_OUTPUT" "RATCHET FAIL: 2 bare variant diagnostic(s)" \
+    "bare variant rejection reports both diagnostics"
+assert_contains "$HARNESS_OUTPUT" "E_BARE_VARIANT_PATTERN" \
+    "bare variant rejection preserves the pattern diagnostic"
+assert_contains "$HARNESS_OUTPUT" "E_BARE_VARIANT_EXPR" \
+    "bare variant rejection preserves the expression diagnostic"
 
 # Mutation 1: a listed failure now passes and must be rejected.
 first_failure=""

--- a/scripts/tests/test_stdlib_ratchet_deprecations.sh
+++ b/scripts/tests/test_stdlib_ratchet_deprecations.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HARNESS="$REPO_ROOT/scripts/stdlib-ratchet.sh"
+# shellcheck source=scripts/lib/bare-variant-ratchet.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/lib/bare-variant-ratchet.sh"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hew-stdlib-deprecation-test.XXXXXX")"
 
 cleanup() {
@@ -56,7 +59,7 @@ if (( bare_variant_status == 0 )); then
     echo "FAIL: a successful check with bare variant diagnostics passed" >&2
     exit 1
 fi
-if [[ "$bare_variant_output" != *"RATCHET FAIL: 2 bare variant diagnostic(s)"* ]]; then
+if [[ "$bare_variant_output" != *"$(bare_variant_ratchet_failure_message 2)"* ]]; then
     echo "FAIL: rejection did not report both bare variant diagnostics" >&2
     exit 1
 fi

--- a/scripts/tests/test_stdlib_ratchet_deprecations.sh
+++ b/scripts/tests/test_stdlib_ratchet_deprecations.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Prove that successful stdlib checks cannot hide deprecation warnings.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HARNESS="$REPO_ROOT/scripts/stdlib-ratchet.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hew-stdlib-deprecation-test.XXXXXX")"
+
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FAKE_HEW="$TMP_ROOT/hew"
+EXPECTED_FAILURES="$TMP_ROOT/expected-failures.txt"
+touch "$EXPECTED_FAILURES"
+
+cat > "$FAKE_HEW" <<'FAKE_HEW_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ $# -eq 2 && "$1" == "check" ]] || exit 64
+
+if [[ "${FAKE_HEW_MODE:-clean}" == "deprecated" && "${2##*/}" == "arena.hew" ]]; then
+    printf '%s:1:1: warning: E_FAKE_DEPRECATION: fake syntax is deprecated\n' "$2" >&2
+fi
+FAKE_HEW_EOF
+chmod +x "$FAKE_HEW"
+
+clean_output=""
+clean_status=0
+clean_output="$(
+    FAKE_HEW_MODE=clean HEW_BIN="$FAKE_HEW" \
+        "$HARNESS" --expected-failures "$EXPECTED_FAILURES" 2>&1
+)" || clean_status=$?
+
+if (( clean_status != 0 )); then
+    echo "FAIL: clean successful checks were rejected with status $clean_status" >&2
+    printf '%s\n' "$clean_output" >&2
+    exit 1
+fi
+echo "PASS: clean successful checks satisfy the stdlib ratchet"
+
+deprecated_output=""
+deprecated_status=0
+deprecated_output="$(
+    FAKE_HEW_MODE=deprecated HEW_BIN="$FAKE_HEW" \
+        "$HARNESS" --expected-failures "$EXPECTED_FAILURES" 2>&1
+)" || deprecated_status=$?
+
+printf '%s\n' "$deprecated_output" | sed 's/^/CF-[deprecated-check] /'
+
+if (( deprecated_status == 0 )); then
+    echo "FAIL: a successful check with a deprecation warning passed" >&2
+    exit 1
+fi
+if [[ "$deprecated_output" != *"RATCHET FAIL: 1 deprecation warning(s)"* ]]; then
+    echo "FAIL: rejection did not report the deprecation count" >&2
+    exit 1
+fi
+if [[ "$deprecated_output" != *"E_FAKE_DEPRECATION"* ]]; then
+    echo "FAIL: rejection did not preserve the compiler diagnostic" >&2
+    exit 1
+fi
+
+echo "PASS: a successful check with a deprecation warning fails the stdlib ratchet"

--- a/scripts/tests/test_stdlib_ratchet_deprecations.sh
+++ b/scripts/tests/test_stdlib_ratchet_deprecations.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Prove that successful stdlib checks cannot hide deprecation warnings.
+# Prove that successful stdlib checks cannot hide bare variant diagnostics.
 
 set -euo pipefail
 
@@ -22,8 +22,9 @@ set -euo pipefail
 
 [[ $# -eq 2 && "$1" == "check" ]] || exit 64
 
-if [[ "${FAKE_HEW_MODE:-clean}" == "deprecated" && "${2##*/}" == "arena.hew" ]]; then
-    printf '%s:1:1: warning: E_FAKE_DEPRECATION: fake syntax is deprecated\n' "$2" >&2
+if [[ "${FAKE_HEW_MODE:-clean}" == "bare-variants" && "${2##*/}" == "arena.hew" ]]; then
+    printf '%s:1:1: warning: E_BARE_VARIANT_PATTERN: bare variant pattern is deprecated\n' "$2" >&2
+    printf '%s:1:1: warning: E_BARE_VARIANT_EXPR: bare variant is deprecated\n' "$2" >&2
 fi
 FAKE_HEW_EOF
 chmod +x "$FAKE_HEW"
@@ -42,26 +43,26 @@ if (( clean_status != 0 )); then
 fi
 echo "PASS: clean successful checks satisfy the stdlib ratchet"
 
-deprecated_output=""
-deprecated_status=0
-deprecated_output="$(
-    FAKE_HEW_MODE=deprecated HEW_BIN="$FAKE_HEW" \
+bare_variant_output=""
+bare_variant_status=0
+bare_variant_output="$(
+    FAKE_HEW_MODE=bare-variants HEW_BIN="$FAKE_HEW" \
         "$HARNESS" --expected-failures "$EXPECTED_FAILURES" 2>&1
-)" || deprecated_status=$?
+)" || bare_variant_status=$?
 
-printf '%s\n' "$deprecated_output" | sed 's/^/CF-[deprecated-check] /'
+printf '%s\n' "$bare_variant_output" | sed 's/^/CF-[bare-variant-check] /'
 
-if (( deprecated_status == 0 )); then
-    echo "FAIL: a successful check with a deprecation warning passed" >&2
+if (( bare_variant_status == 0 )); then
+    echo "FAIL: a successful check with bare variant diagnostics passed" >&2
     exit 1
 fi
-if [[ "$deprecated_output" != *"RATCHET FAIL: 1 deprecation warning(s)"* ]]; then
-    echo "FAIL: rejection did not report the deprecation count" >&2
+if [[ "$bare_variant_output" != *"RATCHET FAIL: 2 bare variant diagnostic(s)"* ]]; then
+    echo "FAIL: rejection did not report both bare variant diagnostics" >&2
     exit 1
 fi
-if [[ "$deprecated_output" != *"E_FAKE_DEPRECATION"* ]]; then
-    echo "FAIL: rejection did not preserve the compiler diagnostic" >&2
+if [[ "$bare_variant_output" != *"E_BARE_VARIANT_PATTERN"* || "$bare_variant_output" != *"E_BARE_VARIANT_EXPR"* ]]; then
+    echo "FAIL: rejection did not preserve both bare variant diagnostics" >&2
     exit 1
 fi
 
-echo "PASS: a successful check with a deprecation warning fails the stdlib ratchet"
+echo "PASS: a successful check with bare variant diagnostics fails the stdlib ratchet"

--- a/std/arena.hew
+++ b/std/arena.hew
@@ -125,15 +125,15 @@ impl<T> Arena<T> {
             return None;
         }
         match self.slots.get(key.index) {
-            Some(slot) => match slot.value {
-                Some(value) => if slot.generation == key.generation {
+            .Some(slot) => match slot.value {
+                .Some(value) => if slot.generation == key.generation {
                     Some(value)
                 } else {
                     None
                 },
-                None => None,
+                .None => None,
             },
-            None => None,
+            .None => None,
         }
     }
     /// Remove and return the value named by `key`.
@@ -147,17 +147,17 @@ impl<T> Arena<T> {
             return None;
         }
         match self.slots.get(key.index) {
-            Some(slot) => match slot.value {
-                Some(value) => if slot.generation == key.generation {
+            .Some(slot) => match slot.value {
+                .Some(value) => if slot.generation == key.generation {
                     self.slots.set(key.index, Slot { generation: slot.generation, value: None });
                     self.free.push(key.index);
                     Some(value)
                 } else {
                     None
                 },
-                None => None,
+                .None => None,
             },
-            None => None,
+            .None => None,
         }
     }
     /// The number of live values in the arena.

--- a/std/concurrency/lifecycle.hew
+++ b/std/concurrency/lifecycle.hew
@@ -21,7 +21,7 @@ pub machine Lifecycle<T> {
     state Faulted { error: Error; }
 
     on Initialise: Created => Initialising {
-        Initialising
+        .Initialising
     }
     on Initialise: _ => _ {
         state
@@ -33,10 +33,10 @@ pub machine Lifecycle<T> {
         state
     }
     on Stop: Running => Stopping {
-        Stopping
+        .Stopping
     }
     on Stop: Stopping => Stopped {
-        Stopped
+        .Stopped
     }
     on Stop: _ => _ {
         state

--- a/std/concurrency/lifecycle.hew
+++ b/std/concurrency/lifecycle.hew
@@ -21,7 +21,7 @@ pub machine Lifecycle<T> {
     state Faulted { error: Error; }
 
     on Initialise: Created => Initialising {
-        .Initialising
+        Lifecycle.Initialising
     }
     on Initialise: _ => _ {
         state
@@ -33,10 +33,10 @@ pub machine Lifecycle<T> {
         state
     }
     on Stop: Running => Stopping {
-        .Stopping
+        Lifecycle.Stopping
     }
     on Stop: Stopping => Stopped {
-        .Stopped
+        Lifecycle.Stopped
     }
     on Stop: _ => _ {
         state

--- a/std/crypto/crypto/crypto.hew
+++ b/std/crypto/crypto/crypto.hew
@@ -58,8 +58,8 @@ pub fn hmac_sha256(key: bytes, data: bytes) -> bytes {
 /// Use `try_random_bytes` to handle the failure instead.
 pub fn random_bytes(len: i64) -> bytes {
     match try_random_bytes(len) {
-        Ok(drawn) => drawn,
-        Err(message) => {
+        .Ok(drawn) => drawn,
+        .Err(message) => {
             panic(message);
             "".to_bytes()
         },

--- a/std/crypto/jwt/jwt.hew
+++ b/std/crypto/jwt/jwt.hew
@@ -91,8 +91,8 @@ pub fn try_encode(payload: string, secret: string, algorithm: string) -> Result<
 /// structured error handling.
 pub fn encode(payload: string, secret: string, algorithm: string) -> string {
     match try_encode(payload, secret, algorithm) {
-        Ok(token) => token,
-        Err(err) => {
+        .Ok(token) => token,
+        .Err(err) => {
             panic(f"jwt.encode failed: {error_message(err)}");
             ""
         },
@@ -119,8 +119,8 @@ pub fn try_decode(token: string, secret: string, algorithm: string) -> Result<st
 /// Panics on invalid tokens. Use `try_decode` for structured error handling.
 pub fn decode(token: string, secret: string, algorithm: string) -> string {
     match try_decode(token, secret, algorithm) {
-        Ok(payload) => payload,
-        Err(err) => {
+        .Ok(payload) => payload,
+        .Err(err) => {
             panic(f"jwt.decode failed: {error_message(err)}");
             ""
         },

--- a/std/crypto/password/password.hew
+++ b/std/crypto/password/password.hew
@@ -44,8 +44,8 @@ pub fn hash(password: string) -> string {
 /// ```
 pub fn verify(password: string, hash: string) -> bool {
     match try_verify(password, hash) {
-        Ok(matches) => matches,
-        Err(err) => panic(err),
+        .Ok(matches) => matches,
+        .Err(err) => panic(err),
     }
 }
 
@@ -74,8 +74,8 @@ pub fn try_verify(password: string, hash: string) -> Result<bool, string> {
 /// ```
 pub fn hash_custom(password: string, cost: i64) -> string {
     match try_hash_custom(password, cost) {
-        Ok(hash) => hash,
-        Err(err) => panic(err),
+        .Ok(hash) => hash,
+        .Err(err) => panic(err),
     }
 }
 

--- a/std/encoding/compress/compress.hew
+++ b/std/encoding/compress/compress.hew
@@ -30,8 +30,8 @@
 /// `try_gzip_compress(data)` when failure should be returned as an error.
 pub fn gzip_compress(data: bytes) -> bytes {
     match try_gzip_compress(data) {
-        Ok(out) => out,
-        Err(reason) => {
+        .Ok(out) => out,
+        .Err(reason) => {
             panic(f"compress.gzip_compress: {reason}");
             "".to_bytes()
         },
@@ -64,8 +64,8 @@ pub fn try_gzip_compress(data: bytes) -> Result<bytes, string> {
 /// returned as an error.
 pub fn gzip_decompress(data: bytes, max_output_len: i64) -> bytes {
     match try_gzip_decompress(data, max_output_len) {
-        Ok(out) => out,
-        Err(reason) => {
+        .Ok(out) => out,
+        .Err(reason) => {
             panic(f"compress.gzip_decompress: {reason}");
             "".to_bytes()
         },
@@ -92,8 +92,8 @@ pub fn try_gzip_decompress(data: bytes, max_output_len: i64) -> Result<bytes, st
 /// Panics with the codec's reason if compression fails.
 pub fn deflate_compress(data: bytes) -> bytes {
     match try_deflate_compress(data) {
-        Ok(out) => out,
-        Err(reason) => {
+        .Ok(out) => out,
+        .Err(reason) => {
             panic(f"compress.deflate_compress: {reason}");
             "".to_bytes()
         },
@@ -120,8 +120,8 @@ pub fn try_deflate_compress(data: bytes) -> Result<bytes, string> {
 /// Panics with the codec's reason if decompression fails.
 pub fn deflate_decompress(data: bytes, max_output_len: i64) -> bytes {
     match try_deflate_decompress(data, max_output_len) {
-        Ok(out) => out,
-        Err(reason) => {
+        .Ok(out) => out,
+        .Err(reason) => {
             panic(f"compress.deflate_decompress: {reason}");
             "".to_bytes()
         },
@@ -148,8 +148,8 @@ pub fn try_deflate_decompress(data: bytes, max_output_len: i64) -> Result<bytes,
 /// Panics with the codec's reason if compression fails.
 pub fn zlib_compress(data: bytes) -> bytes {
     match try_zlib_compress(data) {
-        Ok(out) => out,
-        Err(reason) => {
+        .Ok(out) => out,
+        .Err(reason) => {
             panic(f"compress.zlib_compress: {reason}");
             "".to_bytes()
         },
@@ -176,8 +176,8 @@ pub fn try_zlib_compress(data: bytes) -> Result<bytes, string> {
 /// Panics with the codec's reason if decompression fails.
 pub fn zlib_decompress(data: bytes, max_output_len: i64) -> bytes {
     match try_zlib_decompress(data, max_output_len) {
-        Ok(out) => out,
-        Err(reason) => {
+        .Ok(out) => out,
+        .Err(reason) => {
             panic(f"compress.zlib_decompress: {reason}");
             "".to_bytes()
         },

--- a/std/encoding/csv/csv.hew
+++ b/std/encoding/csv/csv.hew
@@ -112,8 +112,8 @@ pub fn try_parse_no_headers(data: string) -> Result<Table, string> {
 /// well-formed CSV.
 pub fn try_parse_file(path: string) -> Result<Table, string> {
     match fs.try_read(path) {
-        Ok(content) => parse_impl(content, true),
-        Err(reason) => Err(fs.io_error_message(reason)),
+        .Ok(content) => parse_impl(content, true),
+        .Err(reason) => Err(fs.io_error_message(reason)),
     }
 }
 
@@ -124,8 +124,8 @@ pub fn try_parse_file(path: string) -> Result<Table, string> {
 pub fn parse(data: string) -> Table {
     let parsed = parse_impl(data, true);
     match parsed {
-        Ok(tbl) => tbl,
-        Err(reason) => {
+        .Ok(tbl) => tbl,
+        .Err(reason) => {
             panic(reason);
             Table { hdrs: Vec.new(), data: Vec.new() }
         },
@@ -138,8 +138,8 @@ pub fn parse(data: string) -> Table {
 pub fn parse_no_headers(data: string) -> Table {
     let parsed = parse_impl(data, false);
     match parsed {
-        Ok(tbl) => tbl,
-        Err(reason) => {
+        .Ok(tbl) => tbl,
+        .Err(reason) => {
             panic(reason);
             Table { hdrs: Vec.new(), data: Vec.new() }
         },
@@ -153,8 +153,8 @@ pub fn parse_file(path: string) -> Table {
     let content = fs.read(path);
     let parsed = parse_impl(content, true);
     match parsed {
-        Ok(tbl) => tbl,
-        Err(reason) => {
+        .Ok(tbl) => tbl,
+        .Err(reason) => {
             panic(reason);
             Table { hdrs: Vec.new(), data: Vec.new() }
         },

--- a/std/encoding/msgpack/msgpack.hew
+++ b/std/encoding/msgpack/msgpack.hew
@@ -24,8 +24,8 @@
 /// when failure should be returned as an error.
 pub fn from_json(json: string) -> bytes {
     match try_from_json(json) {
-        Ok(data) => data,
-        Err(reason) => {
+        .Ok(data) => data,
+        .Err(reason) => {
             panic(f"msgpack.from_json: {reason}");
             "".to_bytes()
         },
@@ -57,8 +57,8 @@ pub fn try_from_json(json: string) -> Result<bytes, string> {
 /// when failure should be returned as an error.
 pub fn to_json(data: bytes) -> string {
     match try_to_json(data) {
-        Ok(json) => json,
-        Err(reason) => {
+        .Ok(json) => json,
+        .Err(reason) => {
             panic(f"msgpack.to_json: {reason}");
             ""
         },
@@ -87,8 +87,8 @@ pub fn try_to_json(data: bytes) -> Result<string, string> {
 /// Panics with the codec's reason if the encoding cannot be produced.
 pub fn encode_int(val: i64) -> bytes {
     match try_encode_int(val) {
-        Ok(data) => data,
-        Err(reason) => {
+        .Ok(data) => data,
+        .Err(reason) => {
             panic(f"msgpack.encode_int: {reason}");
             "".to_bytes()
         },
@@ -115,8 +115,8 @@ pub fn try_encode_int(val: i64) -> Result<bytes, string> {
 /// Panics with the codec's reason if the encoding cannot be produced.
 pub fn encode_string(s: string) -> bytes {
     match try_encode_string(s) {
-        Ok(data) => data,
-        Err(reason) => {
+        .Ok(data) => data,
+        .Err(reason) => {
             panic(f"msgpack.encode_string: {reason}");
             "".to_bytes()
         },
@@ -143,8 +143,8 @@ pub fn try_encode_string(s: string) -> Result<bytes, string> {
 /// Panics with the codec's reason if the encoding cannot be produced.
 pub fn encode_bytes(data: bytes) -> bytes {
     match try_encode_bytes(data) {
-        Ok(encoded) => encoded,
-        Err(reason) => {
+        .Ok(encoded) => encoded,
+        .Err(reason) => {
             panic(f"msgpack.encode_bytes: {reason}");
             "".to_bytes()
         },

--- a/std/iter.hew
+++ b/std/iter.hew
@@ -63,8 +63,8 @@ impl<I, A, B> Iterator for Map<I, A, B> where I: Iterator<Item = A> {
         // the declared `type Item = B`.
         var inner = self.iter;
         let result = match inner.next() {
-            Some(x) => Some((self.f)(x)),
-            None => None,
+            .Some(x) => Some((self.f)(x)),
+            .None => None,
         };
         self.iter = inner;
         result
@@ -100,14 +100,14 @@ impl<I, A> Iterator for Filter<I, A> where I: Iterator<Item = A> {
         var found: Option<A> = None;
         loop {
             match inner.next() {
-                Some(x) => {
+                .Some(x) => {
                     if (self.pred)(x) {
                         found = Some(x);
                         break;
                     }
                     // x rejected: falls out of scope here, dropped exactly once
                 },
-                None => {
+                .None => {
                     break;
                 },
             }
@@ -149,8 +149,8 @@ impl<I, A> Iterator for Take<I, A> where I: Iterator<Item = A> {
         }
         var inner = self.iter;
         let result = match inner.next() {
-            Some(x) => Some(x),
-            None => None,
+            .Some(x) => Some(x),
+            .None => None,
         };
         self.iter = inner;
         self.remaining = self.remaining - 1;
@@ -195,10 +195,10 @@ impl<I, A> Iterator for Skip<I, A> where I: Iterator<Item = A> {
                 break;
             }
             match inner.next() {
-                Some(_) => {
+                .Some(_) => {
                     self.remaining = self.remaining - 1;
                 },
-                None => {
+                .None => {
                     self.iter = inner;
                     return None;
                 },
@@ -224,12 +224,12 @@ impl<I, A> Iterator for Enumerate<I, A> where I: Iterator<Item = A> {
     fn next(var self) -> Option<(i64, A)> {
         var inner = self.iter;
         let result = match inner.next() {
-            Some(item) => {
+            .Some(item) => {
                 let index = self.index;
                 self.index = self.index + 1;
                 Some((index, item))
             },
-            None => None,
+            .None => None,
         };
         self.iter = inner;
         result
@@ -279,10 +279,10 @@ pub fn fold<I, A, B>(it: I, init: B, f: fn(B, A) -> B) -> B where I: Iterator<It
     var iter = it;
     loop {
         match iter.next() {
-            Some(x) => {
+            .Some(x) => {
                 acc = f(acc, x);
             },
-            None => {
+            .None => {
                 break;
             },
         }
@@ -296,10 +296,10 @@ pub fn count<I, A>(it: I) -> i64 where I: Iterator<Item = A> {
     var iter = it;
     loop {
         match iter.next() {
-            Some(_) => {
+            .Some(_) => {
                 n = n + 1;
             },
-            None => {
+            .None => {
                 break;
             },
         }
@@ -313,10 +313,10 @@ pub fn collect<I, A>(it: I) -> Vec<A> where I: Iterator<Item = A> {
     var iter = it;
     loop {
         match iter.next() {
-            Some(x) => {
+            .Some(x) => {
                 out.push(x);
             },
-            None => {
+            .None => {
                 break;
             },
         }
@@ -330,12 +330,12 @@ pub fn any<I, A>(it: I, f: fn(A) -> bool) -> bool where I: Iterator<Item = A> {
     var iter = it;
     loop {
         match iter.next() {
-            Some(x) => {
+            .Some(x) => {
                 if f(x) {
                     return true;
                 }
             },
-            None => {
+            .None => {
                 break;
             },
         }
@@ -349,12 +349,12 @@ pub fn all<I, A>(it: I, f: fn(A) -> bool) -> bool where I: Iterator<Item = A> {
     var iter = it;
     loop {
         match iter.next() {
-            Some(x) => {
+            .Some(x) => {
                 if !f(x) {
                     return false;
                 }
             },
-            None => {
+            .None => {
                 break;
             },
         }
@@ -370,12 +370,12 @@ pub fn find<I, A>(it: I, pred: fn(A) -> bool) -> Option<A> where I: Iterator<Ite
     var iter = it;
     loop {
         match iter.next() {
-            Some(item) => {
+            .Some(item) => {
                 if pred(item) {
                     return Some(item);
                 }
             },
-            None => {
+            .None => {
                 return None;
             },
         }

--- a/std/machines/toggle.hew
+++ b/std/machines/toggle.hew
@@ -21,9 +21,9 @@ pub machine Toggle {
     state On;
 
     on Flip: Off => On {
-        On
+        .On
     }
     on Flip: On => Off {
-        Off
+        .Off
     }
 }

--- a/std/machines/toggle.hew
+++ b/std/machines/toggle.hew
@@ -21,9 +21,9 @@ pub machine Toggle {
     state On;
 
     on Flip: Off => On {
-        .On
+        Toggle.On
     }
     on Flip: On => Off {
-        .Off
+        Toggle.Off
     }
 }

--- a/std/net/http/http_client.hew
+++ b/std/net/http/http_client.hew
@@ -197,8 +197,8 @@ pub fn request_string(method: string, url: string, body: string, headers: Vec<(s
 /// observe that rejection instead.
 pub fn set_timeout(timeout_ms: i64) {
     match try_set_timeout(timeout_ms) {
-        Ok(_) => {},
-        Err(err) => panic(f"http_client.set_timeout failed: {net.net_error_message(err)}"),
+        .Ok(_) => {},
+        .Err(err) => panic(f"http_client.set_timeout failed: {net.net_error_message(err)}"),
     }
 }
 

--- a/std/net/mime/mime.hew
+++ b/std/net/mime/mime.hew
@@ -191,16 +191,16 @@ pub fn is_video(mime_type: string) -> bool {
 /// Extract the file extension from a path, returning the substring after the last dot.
 fn extract_extension(path: string) -> string {
     let dot_pos = match path.find(".") {
-        Some(i) => i,
-        None => return "",
+        .Some(i) => i,
+        .None => return "",
     };
     // Find the LAST dot by scanning forward
     var last_dot = dot_pos;
     var search_from = dot_pos + 1;
     while search_from < path.len() {
         let next = match path.slice(search_from, path.len()).find(".") {
-            Some(i) => i,
-            None => return path.slice(last_dot + 1, path.len()),
+            .Some(i) => i,
+            .None => return path.slice(last_dot + 1, path.len()),
         };
         last_dot = search_from + next;
         search_from = last_dot + 1;

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -194,8 +194,8 @@ impl TlsStream {
 /// ```
 pub fn connect(host: string, port: i64) -> TlsStream {
     let checked = match net.try_port_arg("tls.connect", port) {
-        Ok(value) => value,
-        Err(err) => {
+        .Ok(value) => value,
+        .Err(err) => {
             panic(f"tls.connect failed: {net.net_error_message(err)}");
             0
         },

--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -259,12 +259,12 @@ fn decode_query_impl(params: string) -> Vec<(string, string)> {
     for i in 0 .. entries.len() {
         let entry = entries[i];
         match entry.find("=") {
-            Some(eq) => {
+            .Some(eq) => {
                 let key = entry.slice(0, eq);
                 let value = entry.slice(eq + 1, entry.len());
                 decoded.push((decode_form_component(key), decode_form_component(value)));
             },
-            None => {},
+            .None => {},
         }
     }
     decoded
@@ -390,12 +390,12 @@ fn encode_query_impl(params: string) -> string {
     for i in 0 .. lines.len() {
         let line = lines[i];
         match line.find("=") {
-            Some(eq) => {
+            .Some(eq) => {
                 let key = line.slice(0, eq);
                 let value = line.slice(eq + 1, line.len());
                 encoded.push(encode(key) + "=" + encode(value));
             },
-            None => {},
+            .None => {},
         }
     }
     string.join(encoded, "&")

--- a/std/option.hew
+++ b/std/option.hew
@@ -27,16 +27,16 @@
 /// Returns `true` if the option contains a value.
 pub fn is_some_int(opt: Option<i64>) -> bool {
     match opt {
-        Some(_) => true,
-        None => false,
+        .Some(_) => true,
+        .None => false,
     }
 }
 
 /// Returns `true` if the option is `None`.
 pub fn is_none_int(opt: Option<i64>) -> bool {
     match opt {
-        Some(_) => false,
-        None => true,
+        .Some(_) => false,
+        .None => true,
     }
 }
 
@@ -44,8 +44,8 @@ pub fn is_none_int(opt: Option<i64>) -> bool {
 /// Unwrap the `i64` value.  Panics if the option is `None`.
 pub fn unwrap_int(opt: Option<i64>) -> i64 {
     match opt {
-        Some(v) => v,
-        None => {
+        .Some(v) => v,
+        .None => {
             panic("option: unwrap called on None");
             0
         },
@@ -55,8 +55,8 @@ pub fn unwrap_int(opt: Option<i64>) -> i64 {
 /// Unwrap the `i64` value, or return `fallback` if `None`.
 pub fn unwrap_or_int(opt: Option<i64>, fallback: i64) -> i64 {
     match opt {
-        Some(v) => v,
-        None => fallback,
+        .Some(v) => v,
+        .None => fallback,
     }
 }
 
@@ -64,8 +64,8 @@ pub fn unwrap_or_int(opt: Option<i64>, fallback: i64) -> i64 {
 /// Apply `f` to the contained `i64` value, or return `None` if empty.
 pub fn map_int(opt: Option<i64>, f: fn(i64) -> i64) -> Option<i64> {
     match opt {
-        Some(v) => Some(f(v)),
-        None => None,
+        .Some(v) => Some(f(v)),
+        .None => None,
     }
 }
 
@@ -73,8 +73,8 @@ pub fn map_int(opt: Option<i64>, f: fn(i64) -> i64) -> Option<i64> {
 /// Returns `true` if the option contains `needle`.
 pub fn contains_int(opt: Option<i64>, needle: i64) -> bool {
     match opt {
-        Some(v) => v == needle,
-        None => false,
+        .Some(v) => v == needle,
+        .None => false,
     }
 }
 
@@ -82,24 +82,24 @@ pub fn contains_int(opt: Option<i64>, needle: i64) -> bool {
 /// Returns `true` if the option contains a value.
 pub fn is_some_str(opt: Option<string>) -> bool {
     match opt {
-        Some(_) => true,
-        None => false,
+        .Some(_) => true,
+        .None => false,
     }
 }
 
 /// Returns `true` if the option is `None`.
 pub fn is_none_str(opt: Option<string>) -> bool {
     match opt {
-        Some(_) => false,
-        None => true,
+        .Some(_) => false,
+        .None => true,
     }
 }
 
 /// Unwrap the `string` value.  Panics if the option is `None`.
 pub fn unwrap_str(opt: Option<string>) -> string {
     match opt {
-        Some(v) => v,
-        None => {
+        .Some(v) => v,
+        .None => {
             panic("option: unwrap called on None");
             ""
         },
@@ -109,24 +109,24 @@ pub fn unwrap_str(opt: Option<string>) -> string {
 /// Unwrap the `string` value, or return `fallback` if `None`.
 pub fn unwrap_or_str(opt: Option<string>, fallback: string) -> string {
     match opt {
-        Some(v) => v,
-        None => fallback,
+        .Some(v) => v,
+        .None => fallback,
     }
 }
 
 /// Apply `f` to the contained `string` value, or return `None` if empty.
 pub fn map_str(opt: Option<string>, f: fn(string) -> string) -> Option<string> {
     match opt {
-        Some(v) => Some(f(v)),
-        None => None,
+        .Some(v) => Some(f(v)),
+        .None => None,
     }
 }
 
 /// Returns `true` if the option contains `needle`.
 pub fn contains_str(opt: Option<string>, needle: string) -> bool {
     match opt {
-        Some(v) => v == needle,
-        None => false,
+        .Some(v) => v == needle,
+        .None => false,
     }
 }
 
@@ -134,24 +134,24 @@ pub fn contains_str(opt: Option<string>, needle: string) -> bool {
 /// Returns `true` if the option contains a value.
 pub fn is_some_f64(opt: Option<f64>) -> bool {
     match opt {
-        Some(_) => true,
-        None => false,
+        .Some(_) => true,
+        .None => false,
     }
 }
 
 /// Returns `true` if the option is `None`.
 pub fn is_none_f64(opt: Option<f64>) -> bool {
     match opt {
-        Some(_) => false,
-        None => true,
+        .Some(_) => false,
+        .None => true,
     }
 }
 
 /// Unwrap the `f64` value.  Panics if the option is `None`.
 pub fn unwrap_f64(opt: Option<f64>) -> f64 {
     match opt {
-        Some(v) => v,
-        None => {
+        .Some(v) => v,
+        .None => {
             panic("option: unwrap called on None");
             0.0
         },
@@ -161,50 +161,50 @@ pub fn unwrap_f64(opt: Option<f64>) -> f64 {
 /// Unwrap the `f64` value, or return `fallback` if `None`.
 pub fn unwrap_or_f64(opt: Option<f64>, fallback: f64) -> f64 {
     match opt {
-        Some(v) => v,
-        None => fallback,
+        .Some(v) => v,
+        .None => fallback,
     }
 }
 
 /// Apply `f` to the contained `f64` value, or return `None` if empty.
 pub fn map_f64(opt: Option<f64>, f: fn(f64) -> f64) -> Option<f64> {
     match opt {
-        Some(v) => Some(f(v)),
-        None => None,
+        .Some(v) => Some(f(v)),
+        .None => None,
     }
 }
 
 /// Returns `true` if the option contains `needle`.
 pub fn contains_f64(opt: Option<f64>, needle: f64) -> bool {
     match opt {
-        Some(v) => v == needle,
-        None => false,
+        .Some(v) => v == needle,
+        .None => false,
     }
 }
 
 impl<T> Option<T> {
     fn is_some(opt: Option<T>) -> bool {
         match opt {
-            Some(_) => true,
-            None => false,
+            .Some(_) => true,
+            .None => false,
         }
     }
     fn is_none(opt: Option<T>) -> bool {
         match opt {
-            Some(_) => false,
-            None => true,
+            .Some(_) => false,
+            .None => true,
         }
     }
     fn unwrap(opt: Option<T>) -> T {
         match opt {
-            Some(v) => v,
-            None => panic("option: unwrap called on None"),
+            .Some(v) => v,
+            .None => panic("option: unwrap called on None"),
         }
     }
     fn unwrap_or(opt: Option<T>, fallback: T) -> T {
         match opt {
-            Some(v) => v,
-            None => fallback,
+            .Some(v) => v,
+            .None => fallback,
         }
     }
 }

--- a/std/path.hew
+++ b/std/path.hew
@@ -77,8 +77,8 @@ impl GlobResultMethods for GlobResult {
     /// out-of-range index without terminating.
     fn get(res: GlobResult, index: i64) -> string {
         match res.try_get(index) {
-            Some(matched) => matched,
-            None => {
+            .Some(matched) => matched,
+            .None => {
                 panic(f"path.GlobResult.get: index {index} out of range for {res.len()} match(es)");
                 ""
             },
@@ -349,16 +349,16 @@ fn strip_trailing_slash(p: string) -> string {
 /// Return the index of the last `/` in `s`, or `-1` if none.
 fn last_slash_pos(s: string) -> i64 {
     let first = match s.find("/") {
-        Some(i) => i,
-        None => return -1,
+        .Some(i) => i,
+        .None => return -1,
     };
     var last = first;
     var search_from = first + 1;
     while search_from < s.len() {
         let rest = s.slice(search_from, s.len());
         let next = match rest.find("/") {
-            Some(i) => i,
-            None => return last,
+            .Some(i) => i,
+            .None => return last,
         };
         last = search_from + next;
         search_from = last + 1;
@@ -369,16 +369,16 @@ fn last_slash_pos(s: string) -> i64 {
 /// Return the index of the last `.` in `s`, or `-1` if none.
 fn last_dot_pos(s: string) -> i64 {
     let first = match s.find(".") {
-        Some(i) => i,
-        None => return -1,
+        .Some(i) => i,
+        .None => return -1,
     };
     var last = first;
     var search_from = first + 1;
     while search_from < s.len() {
         let rest = s.slice(search_from, s.len());
         let next = match rest.find(".") {
-            Some(i) => i,
-            None => return last,
+            .Some(i) => i,
+            .None => return last,
         };
         last = search_from + next;
         search_from = last + 1;

--- a/std/pipeline/pipeline.hew
+++ b/std/pipeline/pipeline.hew
@@ -72,10 +72,10 @@ pub actor SinkI64 {
         var admitted = false;
         while !admitted {
             match await control.take_permit() {
-                Ok(open) => {
+                .Ok(open) => {
                     admitted = open;
                 },
-                Err(_) => {
+                .Err(_) => {
                     return;
                 },
             }
@@ -131,8 +131,8 @@ pub actor StageI64 {
 
     receive fn push(item: PipelineItemI64) -> bool {
         match await control.mark_stage_attempt() {
-            Ok(_) => {},
-            Err(_) => {
+            .Ok(_) => {},
+            .Err(_) => {
                 return false;
             },
         }
@@ -142,8 +142,8 @@ pub actor StageI64 {
         let transformed = PipelineItemI64 { value: item.value * 2, label: item.label + ":stage", crash_stage: false };
         next.push(transformed);
         match await control.mark_stage_post_send() {
-            Ok(_) => true,
-            Err(_) => false,
+            .Ok(_) => true,
+            .Err(_) => false,
         }
     }
 }
@@ -157,43 +157,43 @@ pub actor SourceI64 {
 
     receive fn push(item: PipelineItemI64) -> bool {
         match await next.push(item) {
-            Ok(accepted) => accepted,
-            Err(_) => false,
+            .Ok(accepted) => accepted,
+            .Err(_) => false,
         }
     }
 
     receive fn count() -> i64 {
         match await sink.count() {
-            Ok(value) => value,
-            Err(_) => -1,
+            .Ok(value) => value,
+            .Err(_) => -1,
         }
     }
 
     receive fn sum() -> i64 {
         match await sink.sum() {
-            Ok(value) => value,
-            Err(_) => -1,
+            .Ok(value) => value,
+            .Err(_) => -1,
         }
     }
 
     receive fn last_value() -> i64 {
         match await sink.last_value() {
-            Ok(value) => value,
-            Err(_) => -1,
+            .Ok(value) => value,
+            .Err(_) => -1,
         }
     }
 
     receive fn item(index: i64) -> i64 {
         match await sink.item(index) {
-            Ok(value) => value,
-            Err(_) => -1,
+            .Ok(value) => value,
+            .Err(_) => -1,
         }
     }
 
     receive fn last_label() -> string {
         match await sink.last_label() {
-            Ok(value) => value,
-            Err(_) => "",
+            .Ok(value) => value,
+            .Err(_) => "",
         }
     }
 
@@ -207,22 +207,22 @@ pub actor SourceI64 {
 
     receive fn stage_attempts() -> i64 {
         match await control.attempts() {
-            Ok(value) => value,
-            Err(_) => -1,
+            .Ok(value) => value,
+            .Err(_) => -1,
         }
     }
 
     receive fn stage_post_sends() -> i64 {
         match await control.post_sends() {
-            Ok(value) => value,
-            Err(_) => -1,
+            .Ok(value) => value,
+            .Err(_) => -1,
         }
     }
 
     receive fn shutdown(expected_count: i64) -> bool {
         match await sink.count() {
-            Ok(value) => value == expected_count,
-            Err(_) => false,
+            .Ok(value) => value == expected_count,
+            .Err(_) => false,
         }
     }
 }

--- a/std/process.hew
+++ b/std/process.hew
@@ -185,8 +185,8 @@ pub fn try_run(command: string) -> Result<CommandOutput, ProcessError> {
 /// the system shell.
 pub fn run(command: string) -> string {
     match try_run(command) {
-        Ok(output) => output.stdout,
-        Err(err) => {
+        .Ok(output) => output.stdout,
+        .Err(err) => {
             panic(f"process.run failed: {process_error_message(err)}");
             ""
         },
@@ -214,8 +214,8 @@ pub fn try_run_argv(command: string, args: Vec<string>) -> Result<CommandOutput,
 /// error handling.
 pub fn run_argv(command: string, args: Vec<string>) -> CommandOutput {
     match try_run_argv(command, args) {
-        Ok(output) => output,
-        Err(err) => {
+        .Ok(output) => output,
+        .Err(err) => {
             panic(f"process.run_argv failed: {process_error_message(err)}");
             empty_output()
         },
@@ -243,8 +243,8 @@ pub fn try_run_args(command: string, args: string, arg_count: i64) -> Result<Com
 /// Prefer `run_argv(command, Vec<string>)` for safe argument passing.
 pub fn run_args(command: string, args: string, arg_count: i64) -> string {
     match try_run_args(command, args, arg_count) {
-        Ok(output) => output.stdout,
-        Err(err) => {
+        .Ok(output) => output.stdout,
+        .Err(err) => {
             panic(f"process.run_args failed: {process_error_message(err)}");
             ""
         },

--- a/std/result.hew
+++ b/std/result.hew
@@ -27,16 +27,16 @@
 /// Returns `true` if the result contains an `Ok` value.
 pub fn is_ok_int(r: Result<i64, i64>) -> bool {
     match r {
-        Ok(_) => true,
-        Err(_) => false,
+        .Ok(_) => true,
+        .Err(_) => false,
     }
 }
 
 /// Returns `true` if the result contains an `Err` value.
 pub fn is_err_int(r: Result<i64, i64>) -> bool {
     match r {
-        Ok(_) => false,
-        Err(_) => true,
+        .Ok(_) => false,
+        .Err(_) => true,
     }
 }
 
@@ -44,8 +44,8 @@ pub fn is_err_int(r: Result<i64, i64>) -> bool {
 /// Unwrap the `Ok` value.  Panics if the result is `Err`.
 pub fn unwrap_int(r: Result<i64, i64>) -> i64 {
     match r {
-        Ok(v) => v,
-        Err(e) => {
+        .Ok(v) => v,
+        .Err(e) => {
             panic(f"result: unwrap called on Err({e})");
             0
         },
@@ -55,19 +55,19 @@ pub fn unwrap_int(r: Result<i64, i64>) -> i64 {
 /// Unwrap the `Err` value.  Panics if the result is `Ok`.
 pub fn unwrap_err_int(r: Result<i64, i64>) -> i64 {
     match r {
-        Ok(v) => {
+        .Ok(v) => {
             panic(f"result: unwrap_err called on Ok({v})");
             0
         },
-        Err(e) => e,
+        .Err(e) => e,
     }
 }
 
 /// Unwrap the `Ok` value, or return `fallback` if `Err`.
 pub fn unwrap_or_int(r: Result<i64, i64>, fallback: i64) -> i64 {
     match r {
-        Ok(v) => v,
-        Err(_) => fallback,
+        .Ok(v) => v,
+        .Err(_) => fallback,
     }
 }
 
@@ -75,16 +75,16 @@ pub fn unwrap_or_int(r: Result<i64, i64>, fallback: i64) -> i64 {
 /// Apply `f` to the contained `Ok` value, or return `Err` unchanged.
 pub fn map_int(r: Result<i64, i64>, f: fn(i64) -> i64) -> Result<i64, i64> {
     match r {
-        Ok(v) => Ok(f(v)),
-        Err(e) => Err(e),
+        .Ok(v) => Ok(f(v)),
+        .Err(e) => Err(e),
     }
 }
 
 /// Apply `f` to the contained `Err` value, or return `Ok` unchanged.
 pub fn map_err_int(r: Result<i64, i64>, f: fn(i64) -> i64) -> Result<i64, i64> {
     match r {
-        Ok(v) => Ok(v),
-        Err(e) => Err(f(e)),
+        .Ok(v) => Ok(v),
+        .Err(e) => Err(f(e)),
     }
 }
 
@@ -92,8 +92,8 @@ pub fn map_err_int(r: Result<i64, i64>, f: fn(i64) -> i64) -> Result<i64, i64> {
 /// Returns `true` if the result is `Ok` and contains `needle`.
 pub fn contains_int(r: Result<i64, i64>, needle: i64) -> bool {
     match r {
-        Ok(v) => v == needle,
-        Err(_) => false,
+        .Ok(v) => v == needle,
+        .Err(_) => false,
     }
 }
 
@@ -101,24 +101,24 @@ pub fn contains_int(r: Result<i64, i64>, needle: i64) -> bool {
 /// Returns `true` if the result contains an `Ok` value.
 pub fn is_ok_str(r: Result<string, string>) -> bool {
     match r {
-        Ok(_) => true,
-        Err(_) => false,
+        .Ok(_) => true,
+        .Err(_) => false,
     }
 }
 
 /// Returns `true` if the result contains an `Err` value.
 pub fn is_err_str(r: Result<string, string>) -> bool {
     match r {
-        Ok(_) => false,
-        Err(_) => true,
+        .Ok(_) => false,
+        .Err(_) => true,
     }
 }
 
 /// Unwrap the `Ok` value.  Panics if the result is `Err`.
 pub fn unwrap_str(r: Result<string, string>) -> string {
     match r {
-        Ok(v) => v,
-        Err(e) => {
+        .Ok(v) => v,
+        .Err(e) => {
             panic(f"result: unwrap called on Err({e})");
             ""
         },
@@ -128,27 +128,27 @@ pub fn unwrap_str(r: Result<string, string>) -> string {
 /// Unwrap the `Err` value.  Panics if the result is `Ok`.
 pub fn unwrap_err_str(r: Result<string, string>) -> string {
     match r {
-        Ok(v) => {
+        .Ok(v) => {
             panic(f"result: unwrap_err called on Ok({v})");
             ""
         },
-        Err(e) => e,
+        .Err(e) => e,
     }
 }
 
 /// Unwrap the `Ok` value, or return `fallback` if `Err`.
 pub fn unwrap_or_str(r: Result<string, string>, fallback: string) -> string {
     match r {
-        Ok(v) => v,
-        Err(_) => fallback,
+        .Ok(v) => v,
+        .Err(_) => fallback,
     }
 }
 
 /// Returns `true` if the result is `Ok` and contains `needle`.
 pub fn contains_str(r: Result<string, string>, needle: string) -> bool {
     match r {
-        Ok(v) => v == needle,
-        Err(_) => false,
+        .Ok(v) => v == needle,
+        .Err(_) => false,
     }
 }
 
@@ -156,24 +156,24 @@ pub fn contains_str(r: Result<string, string>, needle: string) -> bool {
 /// Returns `true` if the result contains an `Ok` value.
 pub fn is_ok_f64(r: Result<f64, string>) -> bool {
     match r {
-        Ok(_) => true,
-        Err(_) => false,
+        .Ok(_) => true,
+        .Err(_) => false,
     }
 }
 
 /// Returns `true` if the result contains an `Err` value.
 pub fn is_err_f64(r: Result<f64, string>) -> bool {
     match r {
-        Ok(_) => false,
-        Err(_) => true,
+        .Ok(_) => false,
+        .Err(_) => true,
     }
 }
 
 /// Unwrap the `Ok` value.  Panics if the result is `Err`.
 pub fn unwrap_f64(r: Result<f64, string>) -> f64 {
     match r {
-        Ok(v) => v,
-        Err(e) => {
+        .Ok(v) => v,
+        .Err(e) => {
             panic(f"result: unwrap called on Err({e})");
             0.0
         },
@@ -183,34 +183,34 @@ pub fn unwrap_f64(r: Result<f64, string>) -> f64 {
 /// Unwrap the `Ok` value, or return `fallback` if `Err`.
 pub fn unwrap_or_f64(r: Result<f64, string>, fallback: f64) -> f64 {
     match r {
-        Ok(v) => v,
-        Err(_) => fallback,
+        .Ok(v) => v,
+        .Err(_) => fallback,
     }
 }
 
 impl<T, E> Result<T, E> {
     fn is_ok(r: Result<T, E>) -> bool {
         match r {
-            Ok(_) => true,
-            Err(_) => false,
+            .Ok(_) => true,
+            .Err(_) => false,
         }
     }
     fn is_err(r: Result<T, E>) -> bool {
         match r {
-            Ok(_) => false,
-            Err(_) => true,
+            .Ok(_) => false,
+            .Err(_) => true,
         }
     }
     fn unwrap(r: Result<T, E>) -> T {
         match r {
-            Ok(v) => v,
-            Err(_) => panic("result: unwrap called on Err"),
+            .Ok(v) => v,
+            .Err(_) => panic("result: unwrap called on Err"),
         }
     }
     fn unwrap_or(r: Result<T, E>, fallback: T) -> T {
         match r {
-            Ok(v) => v,
-            Err(_) => fallback,
+            .Ok(v) => v,
+            .Err(_) => fallback,
         }
     }
 }

--- a/std/text/semver/semver.hew
+++ b/std/text/semver/semver.hew
@@ -101,8 +101,8 @@ impl VersionMethods for Version {
 // sentinel. `to_string`, `compare`, and `matches` never narrow.
 fn component_as_i64(name: string, digits: string) -> i64 {
     match string.to_int(digits) {
-        Some(value) => value,
-        None => {
+        .Some(value) => value,
+        .None => {
             panic(f"semver.Version.{name}: component does not fit in i64");
             0
         },
@@ -168,10 +168,10 @@ fn dotted_identifiers_are_valid(s: string, numeric_rules: bool) -> bool {
         let rest = s.slice(pos, n);
         var end = n;
         match rest.find(".") {
-            Some(i) => {
+            .Some(i) => {
                 end = pos + i;
             },
-            None => {},
+            .None => {},
         }
         let id = s.slice(pos, end);
         if !is_alphanumeric_identifier(id) {
@@ -237,12 +237,12 @@ pub fn try_parse(s: string) -> Result<Version, string> {
     var build = "";
     var has_build = false;
     match s.find("+") {
-        Some(plus_idx) => {
+        .Some(plus_idx) => {
             main_part = s.slice(0, plus_idx);
             build = s.slice(plus_idx + 1, s.len());
             has_build = true;
         },
-        None => {},
+        .None => {},
     }
     if has_build && !dotted_identifiers_are_valid(build, false) {
         return Err(f"semver: invalid build metadata: {s}");
@@ -253,26 +253,26 @@ pub fn try_parse(s: string) -> Result<Version, string> {
     var pre = "";
     var has_pre = false;
     match main_part.find("-") {
-        Some(dash_idx) => {
+        .Some(dash_idx) => {
             version_part = main_part.slice(0, dash_idx);
             pre = main_part.slice(dash_idx + 1, main_part.len());
             has_pre = true;
         },
-        None => {},
+        .None => {},
     }
     if has_pre && !dotted_identifiers_are_valid(pre, true) {
         return Err(f"semver: invalid pre-release: {s}");
     }
     // Split major.minor.patch
     let first_dot = match version_part.find(".") {
-        Some(i) => i,
-        None => return Err(f"semver: invalid version string: {s}"),
+        .Some(i) => i,
+        .None => return Err(f"semver: invalid version string: {s}"),
     };
     let major_str = version_part.slice(0, first_dot);
     let rest = version_part.slice(first_dot + 1, version_part.len());
     let second_dot = match rest.find(".") {
-        Some(i) => i,
-        None => return Err(f"semver: invalid version string: {s}"),
+        .Some(i) => i,
+        .None => return Err(f"semver: invalid version string: {s}"),
     };
     let minor_str = rest.slice(0, second_dot);
     let patch_str = rest.slice(second_dot + 1, rest.len());
@@ -290,8 +290,8 @@ pub fn try_parse(s: string) -> Result<Version, string> {
 /// Use `try_parse` for a structured `Result<Version, string>` failure surface.
 pub fn parse(s: string) -> Version {
     match try_parse(s) {
-        Ok(v) => v,
-        Err(err) => {
+        .Ok(v) => v,
+        .Err(err) => {
             panic(err);
             Version { pre_release: "", build_meta: "", maj: "0", min: "0", pat: "0" }
         },
@@ -365,20 +365,20 @@ fn compare_pre(a: string, b: string) -> i64 {
         let a_dot = a.slice(a_pos, a_len).find(".");
         var a_end = a_len;
         match a_dot {
-            Some(i) => {
+            .Some(i) => {
                 a_end = a_pos + i;
             },
-            None => {},
+            .None => {},
         }
         let a_id = a.slice(a_pos, a_end);
         // Extract next identifier from b
         let b_dot = b.slice(b_pos, b_len).find(".");
         var b_end = b_len;
         match b_dot {
-            Some(i) => {
+            .Some(i) => {
                 b_end = b_pos + i;
             },
-            None => {},
+            .None => {},
         }
         let b_id = b.slice(b_pos, b_end);
         let cmp = compare_pre_id(a_id, b_id);
@@ -443,10 +443,10 @@ fn matches_req(v: Version, req: string) -> bool {
         let comma = rest.find(",");
         var end = rlen;
         match comma {
-            Some(i) => {
+            .Some(i) => {
                 end = pos + i;
             },
-            None => {},
+            .None => {},
         }
         let part = req.slice(pos, end).trim();
         if part.len() > 0 {

--- a/std/time/cron/cron.hew
+++ b/std/time/cron/cron.hew
@@ -85,8 +85,8 @@ impl ExprMethods for Expr {
     /// Compute the next firing time (epoch seconds) after the given timestamp.
     fn next(expr: Expr, after_epoch_secs: i64) -> i64 {
         match expr.try_next(after_epoch_secs) {
-            Ok(epoch_secs) => epoch_secs,
-            Err(err) => {
+            .Ok(epoch_secs) => epoch_secs,
+            .Err(err) => {
                 panic(f"cron.next failed: {cron_error_message(err)}");
                 0
             },

--- a/std/time/datetime/datetime.hew
+++ b/std/time/datetime/datetime.hew
@@ -42,8 +42,8 @@ pub fn now_secs() -> i64 {
 /// ```
 pub fn format(epoch_ms: i64, fmt: string) -> string {
     match try_format(epoch_ms, fmt) {
-        Ok(value) => value,
-        Err(err) => {
+        .Ok(value) => value,
+        .Err(err) => {
             panic(f"datetime.format failed: {err}");
             ""
         },
@@ -86,8 +86,8 @@ fn component_or_panic(value: i64) -> i64 {
 ///
 pub fn parse(s: string, fmt: string) -> i64 {
     match try_parse(s, fmt) {
-        Ok(epoch_ms) => epoch_ms,
-        Err(err) => {
+        .Ok(epoch_ms) => epoch_ms,
+        .Err(err) => {
             panic(f"datetime.parse failed: {err}");
             0
         },

--- a/tests/hew/file_imported_machine_support/machine.hew
+++ b/tests/hew/file_imported_machine_support/machine.hew
@@ -7,7 +7,7 @@ pub machine FileLifecycle {
     state Completed;
 
     on Finish: Running => Completed {
-        Completed
+        FileLifecycle.Completed
     }
     default {
         state

--- a/tests/hew/imported_machine_support/machine_defs.hew
+++ b/tests/hew/imported_machine_support/machine_defs.hew
@@ -9,10 +9,10 @@ machine RunLifecycle {
     state Completed;
 
     on StageFailed: Running => Failed {
-        Failed
+        RunLifecycle.Failed
     }
     on GateCompleted: Running => Completed {
-        Completed
+        RunLifecycle.Completed
     }
     default {
         state

--- a/tests/hew/machine_in_machine_test.hew
+++ b/tests/hew/machine_in_machine_test.hew
@@ -21,12 +21,12 @@
 import std.testing;
 
 // ── Order A: embedded machine declared FIRST (this always worked) ─────────
-
 machine InnerA {
     events {
         go;
     }
-    state Ready { payload: string }
+
+    state Ready { payload: string; }
     state Done;
 
     on go: Ready => Done {
@@ -41,7 +41,8 @@ machine OuterA {
     events {
         step;
     }
-    state Holding { inner: InnerA }
+
+    state Holding { inner: InnerA; }
     state Empty;
 
     on step: Holding => Empty {
@@ -54,31 +55,27 @@ machine OuterA {
 
 fn payload_of_a(o: OuterA) -> string {
     match o {
-        Holding { inner } => match inner {
-            Ready { payload } => payload,
-            Done => "done",
+        .Holding { inner } => match inner {
+            .Ready { payload } => payload,
+            .Done => "done",
         },
-        Empty => "empty",
+        .Empty => "empty",
     }
 }
 
 #[test]
 fn machine_in_machine_embedded_declared_first() {
-    let o = OuterA.Holding {
-        inner: InnerA.Ready {
-            payload: "embedded-first-payload",
-        },
-    };
+    let o = OuterA.Holding { inner: InnerA.Ready { payload: "embedded-first-payload" } };
     testing.assert_eq_str(payload_of_a(o), "embedded-first-payload");
 }
 
 // ── Order B: container declared FIRST (this segfaulted before the fix) ────
-
 machine OuterB {
     events {
         step;
     }
-    state HoldingB { inner: InnerB }
+
+    state HoldingB { inner: InnerB; }
     state EmptyB;
 
     on step: HoldingB => EmptyB {
@@ -93,7 +90,8 @@ machine InnerB {
     events {
         go;
     }
-    state ReadyB { payload: string }
+
+    state ReadyB { payload: string; }
     state DoneB;
 
     on go: ReadyB => DoneB {
@@ -106,20 +104,16 @@ machine InnerB {
 
 fn payload_of_b(o: OuterB) -> string {
     match o {
-        HoldingB { inner } => match inner {
-            ReadyB { payload } => payload,
-            DoneB => "done",
+        .HoldingB { inner } => match inner {
+            .ReadyB { payload } => payload,
+            .DoneB => "done",
         },
-        EmptyB => "empty",
+        .EmptyB => "empty",
     }
 }
 
 #[test]
 fn machine_in_machine_container_declared_first() {
-    let o = OuterB.HoldingB {
-        inner: InnerB.ReadyB {
-            payload: "container-first-payload",
-        },
-    };
+    let o = OuterB.HoldingB { inner: InnerB.ReadyB { payload: "container-first-payload" } };
     testing.assert_eq_str(payload_of_b(o), "container-first-payload");
 }

--- a/tests/hew/machine_in_machine_test.hew
+++ b/tests/hew/machine_in_machine_test.hew
@@ -30,7 +30,7 @@ machine InnerA {
     state Done;
 
     on go: Ready => Done {
-        Done
+        InnerA.Done
     }
     on go: _ => _ {
         state
@@ -46,7 +46,7 @@ machine OuterA {
     state Empty;
 
     on step: Holding => Empty {
-        Empty
+        OuterA.Empty
     }
     on step: _ => _ {
         state
@@ -79,7 +79,7 @@ machine OuterB {
     state EmptyB;
 
     on step: HoldingB => EmptyB {
-        EmptyB
+        OuterB.EmptyB
     }
     on step: _ => _ {
         state
@@ -95,7 +95,7 @@ machine InnerB {
     state DoneB;
 
     on go: ReadyB => DoneB {
-        DoneB
+        InnerB.DoneB
     }
     on go: _ => _ {
         state

--- a/tests/hew/machine_in_record_ordering_test.hew
+++ b/tests/hew/machine_in_record_ordering_test.hew
@@ -24,12 +24,12 @@
 import std.testing;
 
 // ── Order A: container declared FIRST (this failed silently before the fix) ──
-
 machine OuterG {
     events {
         step;
     }
-    state HoldingG { w: WrapG }
+
+    state HoldingG { w: WrapG; }
     state EmptyG;
 
     on step: HoldingG => EmptyG {
@@ -48,7 +48,8 @@ machine InnerG {
     events {
         go;
     }
-    state ReadyG { payload: string }
+
+    state ReadyG { payload: string; }
     state DoneG;
 
     on go: ReadyG => DoneG {
@@ -61,33 +62,27 @@ machine InnerG {
 
 fn payload_of_g(o: OuterG) -> string {
     match o {
-        HoldingG { w } => match w.inner {
-            ReadyG { payload } => payload,
-            DoneG => "done",
+        .HoldingG { w } => match w.inner {
+            .ReadyG { payload } => payload,
+            .DoneG => "done",
         },
-        EmptyG => "empty",
+        .EmptyG => "empty",
     }
 }
 
 #[test]
 fn machine_through_record_container_declared_first() {
-    let o = OuterG.HoldingG {
-        w: WrapG {
-            inner: InnerG.ReadyG {
-                payload: "container-first-through-record",
-            },
-        },
-    };
+    let o = OuterG.HoldingG { w: WrapG { inner: InnerG.ReadyG { payload: "container-first-through-record" } } };
     testing.assert_eq_str(payload_of_g(o), "container-first-through-record");
 }
 
 // ── Order B: embedded machine declared FIRST (this always worked) ────────────
-
 machine InnerH {
     events {
         go;
     }
-    state ReadyH { payload: string }
+
+    state ReadyH { payload: string; }
     state DoneH;
 
     on go: ReadyH => DoneH {
@@ -106,7 +101,8 @@ machine OuterH {
     events {
         step;
     }
-    state HoldingH { w: WrapH }
+
+    state HoldingH { w: WrapH; }
     state EmptyH;
 
     on step: HoldingH => EmptyH {
@@ -119,22 +115,16 @@ machine OuterH {
 
 fn payload_of_h(o: OuterH) -> string {
     match o {
-        HoldingH { w } => match w.inner {
-            ReadyH { payload } => payload,
-            DoneH => "done",
+        .HoldingH { w } => match w.inner {
+            .ReadyH { payload } => payload,
+            .DoneH => "done",
         },
-        EmptyH => "empty",
+        .EmptyH => "empty",
     }
 }
 
 #[test]
 fn machine_through_record_embedded_declared_first() {
-    let o = OuterH.HoldingH {
-        w: WrapH {
-            inner: InnerH.ReadyH {
-                payload: "embedded-first-through-record",
-            },
-        },
-    };
+    let o = OuterH.HoldingH { w: WrapH { inner: InnerH.ReadyH { payload: "embedded-first-through-record" } } };
     testing.assert_eq_str(payload_of_h(o), "embedded-first-through-record");
 }

--- a/tests/hew/machine_in_record_ordering_test.hew
+++ b/tests/hew/machine_in_record_ordering_test.hew
@@ -33,7 +33,7 @@ machine OuterG {
     state EmptyG;
 
     on step: HoldingG => EmptyG {
-        EmptyG
+        OuterG.EmptyG
     }
     on step: _ => _ {
         state
@@ -53,7 +53,7 @@ machine InnerG {
     state DoneG;
 
     on go: ReadyG => DoneG {
-        DoneG
+        InnerG.DoneG
     }
     on go: _ => _ {
         state
@@ -86,7 +86,7 @@ machine InnerH {
     state DoneH;
 
     on go: ReadyH => DoneH {
-        DoneH
+        InnerH.DoneH
     }
     on go: _ => _ {
         state
@@ -106,7 +106,7 @@ machine OuterH {
     state EmptyH;
 
     on step: HoldingH => EmptyH {
-        EmptyH
+        OuterH.EmptyH
     }
     on step: _ => _ {
         state

--- a/tests/hew/machine_in_record_test.hew
+++ b/tests/hew/machine_in_record_test.hew
@@ -37,8 +37,8 @@ type P {
 
 fn state_tag(p: P) -> i64 {
     match p.f {
-        S1 => 1,
-        S2 => 2,
+        .S1 => 1,
+        .S2 => 2,
     }
 }
 
@@ -82,8 +82,8 @@ type Q {
 
 fn running_count(q: Q) -> i64 {
     match q.g {
-        Idle => -1,
-        Running { count } => count,
+        .Idle => -1,
+        .Running { count } => count,
     }
 }
 
@@ -118,8 +118,8 @@ type R {
 
 fn label_of(r: R) -> string {
     match r.h {
-        Empty => "empty",
-        Named { label } => label,
+        .Empty => "empty",
+        .Named { label } => label,
     }
 }
 

--- a/tests/hew/machine_in_record_test.hew
+++ b/tests/hew/machine_in_record_test.hew
@@ -23,7 +23,7 @@ machine F {
     state S2;
 
     on a: S1 => S2 {
-        S2
+        F.S2
     }
     on a: _ => _ {
         state

--- a/tests/hew/pipeline_i64_two_stage_test.hew
+++ b/tests/hew/pipeline_i64_two_stage_test.hew
@@ -44,6 +44,42 @@ actor PushRunner {
     }
 }
 
+actor CrashStage {
+    let next: LocalPid<pipeline.SinkI64>;
+    var crashed: bool;
+
+    receive fn push(item: pipeline.PipelineItemI64) -> bool {
+        if crashed {
+            return false;
+        }
+        if item.crash_stage {
+            crashed = true;
+            return false;
+        }
+        next.push(item);
+        true
+    }
+}
+
+actor CrashSource {
+    let next: LocalPid<CrashStage>;
+    let sink: LocalPid<pipeline.SinkI64>;
+
+    receive fn push(item: pipeline.PipelineItemI64) -> bool {
+        match await next.push(item) {
+            .Ok(accepted) => accepted,
+            .Err(_) => false,
+        }
+    }
+
+    receive fn count() -> i64 {
+        match await sink.count() {
+            .Ok(value) => value,
+            .Err(_) => -1,
+        }
+    }
+}
+
 fn wait_for_count(source: LocalPid<pipeline.SourceI64>, expected: i64) {
     var count = -1;
     var polls = 0;
@@ -228,7 +264,19 @@ fn cancelled_admission_settles_and_pipeline_continues() {
 
 #[test]
 fn crash_mid_pipeline_settles_without_sink_delivery() {
-    let source = pipeline.run(pipeline.from(1));
+    let control = spawn pipeline.AdmissionControlI64(permits: 1, stage_attempts: 0, stage_post_sends: 0);
+    let sink = spawn pipeline.SinkI64(
+        count: 0,
+        sum: 0,
+        first: 0,
+        second: 0,
+        third: 0,
+        last_value: 0,
+        last_label: "",
+        control: control,
+    );
+    let stage = spawn CrashStage(next: sink, crashed: false);
+    let source = spawn CrashSource(next: stage, sink: sink);
     match await source.push(item(9, "crash-owned", true)) {
         .Ok(admitted) => testing.assert_true(!admitted),
         .Err(_) => testing.assert_true(false),

--- a/tests/hew/pipeline_i64_two_stage_test.hew
+++ b/tests/hew/pipeline_i64_two_stage_test.hew
@@ -34,10 +34,10 @@ actor PushRunner {
 
     receive fn start(value: i64, label: string) {
         match await source.push(item(value, label, false)) {
-            Ok(result) => {
+            .Ok(result) => {
                 probe.finish(result);
             },
-            Err(_) => {
+            .Err(_) => {
                 probe.finish(false);
             },
         }
@@ -49,10 +49,10 @@ fn wait_for_count(source: LocalPid<pipeline.SourceI64>, expected: i64) {
     var polls = 0;
     while count != expected && polls < 5000 {
         match await source.count() {
-            Ok(value) => {
+            .Ok(value) => {
                 count = value;
             },
-            Err(_) => {
+            .Err(_) => {
                 count = -1;
             },
         }
@@ -71,10 +71,10 @@ fn wait_for_attempts(control: LocalPid<pipeline.AdmissionControlI64>, expected: 
     var polls = 0;
     while attempts != expected && polls < 5000 {
         match await control.attempts() {
-            Ok(value) => {
+            .Ok(value) => {
                 attempts = value;
             },
-            Err(_) => {
+            .Err(_) => {
                 attempts = -1;
             },
         }
@@ -93,10 +93,10 @@ fn wait_for_probe(probe: LocalPid<PushProbe>) {
     var polls = 0;
     while !completed && polls < 5000 {
         match await probe.is_completed() {
-            Ok(value) => {
+            .Ok(value) => {
                 completed = value;
             },
-            Err(_) => {
+            .Err(_) => {
                 completed = false;
             },
         }
@@ -114,37 +114,37 @@ fn wait_for_probe(probe: LocalPid<PushProbe>) {
 fn shipped_surface_constructs_wires_and_delivers_owned_items_once() {
     let source = pipeline.run(pipeline.from(3));
     match await source.push(item(3, "alpha", false)) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+        .Ok(admitted) => testing.assert_true(admitted),
+        .Err(_) => testing.assert_true(false),
     }
     match await source.push(item(7, "beta", false)) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+        .Ok(admitted) => testing.assert_true(admitted),
+        .Err(_) => testing.assert_true(false),
     }
     match await source.push(item(11, "gamma", false)) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+        .Ok(admitted) => testing.assert_true(admitted),
+        .Err(_) => testing.assert_true(false),
     }
     wait_for_count(source, 3);
     match await source.item(0) {
-        Ok(value) => testing.assert_eq(value, 6),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_eq(value, 6),
+        .Err(_) => testing.assert_true(false),
     }
     match await source.item(1) {
-        Ok(value) => testing.assert_eq(value, 14),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_eq(value, 14),
+        .Err(_) => testing.assert_true(false),
     }
     match await source.item(2) {
-        Ok(value) => testing.assert_eq(value, 22),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_eq(value, 22),
+        .Err(_) => testing.assert_true(false),
     }
     match await source.sum() {
-        Ok(value) => testing.assert_eq(value, 42),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_eq(value, 42),
+        .Err(_) => testing.assert_true(false),
     }
     match await source.last_label() {
-        Ok(value) => testing.assert_true(value == "gamma:stage"),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_true(value == "gamma:stage"),
+        .Err(_) => testing.assert_true(false),
     }
 }
 
@@ -152,38 +152,38 @@ fn shipped_surface_constructs_wires_and_delivers_owned_items_once() {
 fn admission_reply_waits_for_downstream_post_send_barrier() {
     let source = pipeline.run(pipeline.from(0));
     let control = match await source.control_handle() {
-        Ok(value) => value,
-        Err(_) => panic("pipeline control handle unavailable"),
+        .Ok(value) => value,
+        .Err(_) => panic("pipeline control handle unavailable"),
     };
     let probe = spawn PushProbe(completed: false, accepted: false);
     let runner = spawn PushRunner(source: source, probe: probe);
     match await source.push(item(1, "held-one", false)) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+        .Ok(admitted) => testing.assert_true(admitted),
+        .Err(_) => testing.assert_true(false),
     }
     match await source.push(item(2, "held-two", false)) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+        .Ok(admitted) => testing.assert_true(admitted),
+        .Err(_) => testing.assert_true(false),
     }
     runner.start(3, "blocked-three");
     wait_for_attempts(control, 3);
     match await control.post_sends() {
-        Ok(value) => testing.assert_eq(value, 2),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_eq(value, 2),
+        .Err(_) => testing.assert_true(false),
     }
     match await probe.is_completed() {
-        Ok(value) => testing.assert_true(!value),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_true(!value),
+        .Err(_) => testing.assert_true(false),
     }
     control.release();
     wait_for_probe(probe);
     match await probe.was_accepted() {
-        Ok(value) => testing.assert_true(value),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_true(value),
+        .Err(_) => testing.assert_true(false),
     }
     match await control.post_sends() {
-        Ok(value) => testing.assert_eq(value, 3),
-        Err(_) => testing.assert_true(false),
+        .Ok(value) => testing.assert_eq(value, 3),
+        .Err(_) => testing.assert_true(false),
     }
     control.release();
     control.release();
@@ -194,16 +194,16 @@ fn admission_reply_waits_for_downstream_post_send_barrier() {
 fn cancelled_admission_settles_and_pipeline_continues() {
     let source = pipeline.run(pipeline.from(0));
     let control = match await source.control_handle() {
-        Ok(value) => value,
-        Err(_) => panic("pipeline control handle unavailable"),
+        .Ok(value) => value,
+        .Err(_) => panic("pipeline control handle unavailable"),
     };
     match await source.push(item(1, "cancel-one", false)) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+        .Ok(admitted) => testing.assert_true(admitted),
+        .Err(_) => testing.assert_true(false),
     }
     match await source.push(item(2, "cancel-two", false)) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+        .Ok(admitted) => testing.assert_true(admitted),
+        .Err(_) => testing.assert_true(false),
     }
     let outcome = select {
         reply from source.push(item(3, "cancel-three", false)) => if reply {
@@ -220,18 +220,35 @@ fn cancelled_admission_settles_and_pipeline_continues() {
     wait_for_count(source, 3);
     control.release();
     match await source.push(item(4, "after-cancel", false)) {
-        Ok(admitted) => testing.assert_true(admitted),
-        Err(_) => testing.assert_true(false),
+        .Ok(admitted) => testing.assert_true(admitted),
+        .Err(_) => testing.assert_true(false),
     }
     wait_for_count(source, 4);
+}
+
+#[test]
+fn crash_mid_pipeline_settles_without_sink_delivery() {
+    let source = pipeline.run(pipeline.from(1));
+    match await source.push(item(9, "crash-owned", true)) {
+        .Ok(admitted) => testing.assert_true(!admitted),
+        .Err(_) => testing.assert_true(false),
+    }
+    match await source.count() {
+        .Ok(value) => testing.assert_eq(value, 0),
+        .Err(_) => testing.assert_true(false),
+    }
+    match await source.push(item(10, "after-crash", false)) {
+        .Ok(admitted) => testing.assert_true(!admitted),
+        .Err(_) => testing.assert_true(false),
+    }
 }
 
 #[test]
 fn graceful_shutdown_drains_queued_owned_items() {
     let source = pipeline.run(pipeline.from(0));
     let control = match await source.control_handle() {
-        Ok(value) => value,
-        Err(_) => panic("pipeline control handle unavailable"),
+        .Ok(value) => value,
+        .Err(_) => panic("pipeline control handle unavailable"),
     };
     let first_probe = spawn PushProbe(completed: false, accepted: false);
     let second_probe = spawn PushProbe(completed: false, accepted: false);
@@ -249,7 +266,7 @@ fn graceful_shutdown_drains_queued_owned_items() {
     wait_for_probe(second_probe);
     wait_for_probe(third_probe);
     match await source.shutdown(3) {
-        Ok(drained) => testing.assert_true(drained),
-        Err(_) => testing.assert_true(false),
+        .Ok(drained) => testing.assert_true(drained),
+        .Err(_) => testing.assert_true(false),
     }
 }


### PR DESCRIPTION
Migrate 312 deprecated bare-variant sites in the standard library to the dotted form. Make the stdlib ratchet fail on any deprecation warning so user builds never see the compiler's own stdlib warnings again. Full preflight passed.