### PR TITLE
fix(runtime): report registered send failures as connection drops

### DIFF
--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -5986,8 +5986,12 @@ fn setup_remote_ask(
         };
 
         if !send_ok {
-            reply_table().remove(request_id);
-            return RemoteAskSetupResult::Error(AskError::SendFailed);
+            // The ask is already bound to an authenticated, active connection.
+            // A transport failure from this point is a connection drop, and it
+            // must resolve through the same table authority as reader cleanup.
+            // Returning the registered slot also preserves the suspendable
+            // path's wake protocol when the drop wins before the caller parks.
+            reply_table().fail_connection(connection);
         }
 
         RemoteAskSetupResult::Ok((request_id, pending))
@@ -9741,37 +9745,41 @@ mod tests {
     }
 
     #[test]
-    fn send_failure_removes_pending_reply_slot_no_leak() {
+    fn send_failure_resolves_registered_reply_as_connection_dropped() {
         // `setup_remote_ask` registers a pending reply BEFORE the outbound send;
-        // on a fail-closed send (the SIGPIPE→EPIPE path that returns
-        // `AskError::SendFailed`) it must `remove` the slot so a failed ask
-        // cannot leak a pending entry. This pins that cleanup contract on a
-        // fresh table, isolated from the process-global one.
+        // on a fail-closed send (for example SIGPIPE→EPIPE), the connection
+        // fan-out must own the outcome so this path and reader cleanup cannot
+        // publish different failure codes. This pins that contract on a fresh
+        // table, isolated from the process-global one.
         let table = ReplyRoutingTable::new();
         assert_eq!(table.pending_len(), 0);
 
-        let (request_id, _pending) = table.register(ConnectionKey {
+        let connection = ConnectionKey {
             conn_mgr: 42,
             conn_id: 7,
-        });
+        };
+        let (_request_id, pending) = table.register(connection);
         assert_eq!(
             table.pending_len(),
             1,
             "register must install exactly one pending reply slot"
         );
 
-        // Mirror `setup_remote_ask`'s `!send_ok` branch: remove the slot the ask
-        // registered before the send that just failed.
-        let removed = table.remove(request_id);
-        assert!(
-            removed.is_some(),
-            "the fail-closed send path must find and remove the registered slot"
-        );
+        // Mirror `setup_remote_ask`'s `!send_ok` branch.
+        table.fail_connection(connection);
         assert_eq!(
             table.pending_len(),
             0,
-            "AskError::SendFailed cleanup must not leak the reply slot"
+            "connection-drop cleanup must not leak the reply slot"
         );
+        let guard = pending
+            .outcome
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let outcome = guard.as_ref().expect("send failure must resolve the ask");
+        assert_eq!(outcome.status, ReplyStatus::Failed);
+        assert_eq!(outcome.ask_error, AskError::ConnectionDropped);
+        assert!(outcome.data.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Route post-registration transport send failures through the reply table connection-drop fan-out.
- Keep `ConnectionDropped` authoritative when socket send failure races reader cleanup.
- Replace the slot-removal regression with coverage that asserts failure code 6 and no pending-entry leak.

## Context

Main is red at `cf0f3a414` on `hew_node::tests::connection_drop_wakes_pending_remote_ask`: Linux reported code 4 (`SendFailed`) instead of code 6 (`ConnectionDropped`). The send path registered the ask, then bypassed the reply-table authority when the socket write failed before reader cleanup won the race.

## Verification

- Targeted characterization: 200/200 before the fix across `--test-threads 1` and `16` on macOS; the Linux timing window did not reproduce locally.
- Targeted verification: 200/200 after the fix across `--test-threads 1` and `16`.
- `cargo test -p hew-runtime`
- Diff-routed preflight completed. Formatting, strict clippy, standard-library build and freshness, the ratcheted Hew suite, await coverage, MQTT, observe, and source/commit checks passed. The broad nextest, vertical-slice, and fuzz commands were terminated only by their configured 180s, 240s, and 210s watchdogs; no hotfix assertion failed.