### PR TITLE
fix(mir): apply tuple carry rule at every depth

### DIFF
--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1527,12 +1527,17 @@ fn main() {
 /// `RecordInPlace`. The result therefore receives the tuple's complete nested
 /// drop obligation without the base releasing it a second time.
 ///
-/// Verified on Linux under glibc's `MALLOC_CHECK_=3 MALLOC_PERTURB_=165` with a
-/// flat RSS profile across a 4x frame sweep, matching the known-sound record
-/// carry as a positive control. Guard Malloc + `MallocScribble` remains the
-/// authoritative Darwin oracle and was verified independently in review. Bare
-/// `Option` / enum fields, closures, and handles remain fail-closed; an `Option`
-/// or enum nested inside the admitted tuple transfer boundary is covered below.
+/// A tuple is admitted only when EVERY element is itself carry-sound by the
+/// same rule that governs a bare field (`carry_transfers_field_ownership`), so
+/// the tuple is not a transfer boundary of its own: `Option` / enum elements,
+/// closures, and handles stay fail-closed inside a tuple exactly as they do
+/// bare (`reject_carry_tuple_of_option_field`,
+/// `reject_carry_tuple_of_enum_field`).
+///
+/// This test pins CHECK-and-RUN correctness only. The per-frame allocation
+/// evidence is the authoritative macOS `leaks(1)` oracle in
+/// `funcupdate_tuple_carry_*` (`funcupdate_owned_field_drop_leak_oracle.rs`),
+/// which measures both drop orders.
 #[test]
 fn accept_carry_tuple_of_owned_field() {
     let source = r#"
@@ -1561,11 +1566,9 @@ fn main() {
 }
 
 /// Widened shapes for the same lift: nested tuples, a tuple carrying a `Vec`,
-/// an owned record, an `Option` payload, or a user-enum payload. Each must accept
-/// AND run correctly — checking alone would not discriminate a sound carry from
-/// one that double-frees at teardown. The latter two fixtures pin the full
-/// admitted scope: bare `Option` / enum fields remain rejected, but their drop
-/// obligations transfer soundly when the tuple is the carried field boundary.
+/// and a tuple carrying an owned record. Each must accept AND run correctly —
+/// checking alone would not discriminate a sound carry from one that
+/// double-frees at teardown, so every case reads a carried leaf back out.
 #[test]
 fn accept_carry_nested_and_collection_bearing_tuples() {
     let cases: &[(&str, &str)] = &[
@@ -1590,7 +1593,7 @@ fn mk() -> T {
     let b = T { pair: ((string.repeat("k", 32), 1), (string.repeat("m", 32), 2)), tag: string.repeat("x", 32) };
     T { tag: string.repeat("y", 32), ..b }
 }
-fn main() { let r = mk(); println(r.tag); }
+fn main() { let r = mk(); println(r.tag); let first = r.pair.0; println(first.0); }
 "#,
         ),
         (
@@ -1604,7 +1607,15 @@ fn mk() -> T {
     let b = T { pair: (v, 7), tag: string.repeat("x", 32) };
     T { tag: string.repeat("y", 32), ..b }
 }
-fn main() { let r = mk(); println(r.tag); println(r.pair.0.len()); }
+fn main() {
+    let r = mk();
+    println(r.tag);
+    let items = r.pair.0;
+    match items.get(0) {
+        .Some(first) => println(first),
+        .None => println("empty"),
+    }
+}
 "#,
         ),
         (
@@ -1617,34 +1628,7 @@ fn mk() -> T {
     let b = T { pair: (Inner { label: string.repeat("k", 32), n: 1 }, 7), tag: string.repeat("x", 32) };
     T { tag: string.repeat("y", 32), ..b }
 }
-fn main() { let r = mk(); println(r.tag); }
-"#,
-        ),
-        (
-            "tuple carrying an Option payload",
-            r#"
-import std.string;
-record Inner { label: string, n: i64 }
-record T { pair: (Option<Inner>, i64), tag: string }
-fn mk() -> T {
-    let b = T { pair: (Some(Inner { label: string.repeat("k", 32), n: 1 }), 7), tag: string.repeat("x", 32) };
-    T { tag: string.repeat("y", 32), ..b }
-}
-fn main() { let r = mk(); println(r.tag); }
-"#,
-        ),
-        (
-            "tuple carrying a user-enum payload",
-            r#"
-import std.string;
-record Inner { label: string, n: i64 }
-enum Payload { Value(Inner); Empty; }
-record T { pair: (Payload, i64), tag: string }
-fn mk() -> T {
-    let b = T { pair: (Value(Inner { label: string.repeat("k", 32), n: 1 }), 7), tag: string.repeat("x", 32) };
-    T { tag: string.repeat("y", 32), ..b }
-}
-fn main() { let r = mk(); println(r.tag); }
+fn main() { let r = mk(); println(r.tag); println(r.pair.0.label); }
 "#,
         ),
     ];
@@ -1658,7 +1642,86 @@ fn main() { let r = mk(); println(r.tag); }
             out.contains(&"y".repeat(32)),
             "{name}: carry must override tag; got:\n{out}"
         );
+        assert!(
+            out.contains(&"k".repeat(32)),
+            "{name}: carry must preserve the carried tuple's owned leaf; got:\n{out}"
+        );
     }
+}
+
+/// A tuple whose element is an `Option<owned>` must FAIL `hew check`, exactly
+/// as the bare `Option<owned>` field does (`reject_carry_option_of_owned_field`).
+///
+/// The tuple is not a transfer boundary that rescues an element with no sound
+/// carry. Admitting this shape excluded the consumed base from its
+/// `RecordInPlace` drop WITHOUT the result taking over the optional's payload:
+/// `leaks --atExit` counted exactly one leaked payload allocation per frame,
+/// both when the result escaped its constructing frame and when base and result
+/// died in the same frame, while the identical record shape built WITHOUT a
+/// functional update leaked nothing. `Option<string>` leaks the same way, so it
+/// is the optional's shape that has no carry, not the payload's.
+#[test]
+fn reject_carry_tuple_of_option_field() {
+    let source = r#"
+import std.string;
+record Inner { label: string, n: i64 }
+record T { pair: (Option<Inner>, i64), tag: string }
+fn mk() -> T {
+    let b = T { pair: (Some(Inner { label: string.repeat("k", 32), n: 1 }), 7), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() {
+    let r = mk();
+    println(r.tag);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "Option-in-tuple carry must fail check — admitting it leaks the optional's payload \
+         once per frame; got success:\n{out}"
+    );
+    assert!(
+        out.contains("carry of owned non-record field") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected the fail-closed carry diagnostic; got:\n{out}"
+    );
+}
+
+/// A tuple whose element is a heap-payload user enum must FAIL `hew check`,
+/// matching the bare enum field.
+///
+/// This shape measures clean today, unlike the `Option` element above. It stays
+/// rejected because the carry rule is ONE rule at every nesting depth: a tuple
+/// admits exactly the element types the same field admits bare. Lifting the enum
+/// carry lifts both forms together, with one soundness argument and one leak
+/// oracle, rather than leaving a bare-rejects/tuple-admits split whose only
+/// justification is that nobody has measured the bare form yet.
+#[test]
+fn reject_carry_tuple_of_enum_field() {
+    let source = r#"
+import std.string;
+record Inner { label: string, n: i64 }
+enum Payload { Value(Inner); Empty; }
+record T { pair: (Payload, i64), tag: string }
+fn mk() -> T {
+    let b = T { pair: (.Value(Inner { label: string.repeat("k", 32), n: 1 }), 7), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() {
+    let r = mk();
+    println(r.tag);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "enum-in-tuple carry must fail check while the bare enum field is rejected; \
+         got success:\n{out}"
+    );
+    assert!(
+        out.contains("carry of owned non-record field") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected the fail-closed carry diagnostic; got:\n{out}"
+    );
 }
 
 /// Discrimination control for the tuple lift's LOWER edge: a tuple with NO heap

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1833,3 +1833,248 @@ fn main() {
         "compiler must not panic on this input; got:\n{out}"
     );
 }
+
+/// A record nested in a carried tuple must not hide an unsupported enum path.
+/// Before the recursive record judgment this exact loop was admitted and
+/// leaked the `Leaf.label` and `Wrapper.tag` strings on every call.
+#[test]
+fn reject_carry_record_with_nested_option_payload() {
+    let source = r#"
+import std.string;
+record Leaf { label: string, n: i64 }
+record Wrapper { inner: (Option<Leaf>, i64), tag: string }
+record T { pair: (Wrapper, i64), churn: string }
+fn mk() -> T {
+    let b = T {
+        pair: (Wrapper { inner: (Some(Leaf { label: string.repeat("k", 32), n: 1 }), 9), tag: string.repeat("w", 32) }, 5),
+        churn: string.repeat("a", 32),
+    };
+    T { churn: string.repeat("b", 32), ..b }
+}
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 50 {
+        let r = mk();
+        total = total + r.churn.len();
+        i = i + 1;
+    }
+    total
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "record-with-nested-Option carry must fail check before execution; got success:\n{out}"
+    );
+    assert!(
+        out.contains("carry of owned non-record field") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected the fail-closed carry diagnostic; got:\n{out}"
+    );
+}
+
+struct CarryRuleMatrixCase {
+    class: &'static str,
+    depth: usize,
+    ty: &'static str,
+    declarations: &'static str,
+    setup: &'static str,
+    value: &'static str,
+    accepted: bool,
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "the explicit five-class by three-depth table keeps every executed fixture cell auditable"
+)]
+fn carry_rule_matrix_cases() -> Vec<CarryRuleMatrixCase> {
+    vec![
+        CarryRuleMatrixCase {
+            class: "record-in-tuple",
+            depth: 2,
+            ty: "(Leaf, i64)",
+            declarations: "",
+            setup: "",
+            value: "(Leaf { label: string.repeat(\"k\", 32), n: 1 }, 2)",
+            accepted: true,
+        },
+        CarryRuleMatrixCase {
+            class: "record-in-tuple",
+            depth: 3,
+            ty: "((Leaf, i64), i64)",
+            declarations: "",
+            setup: "",
+            value: "((Leaf { label: string.repeat(\"k\", 32), n: 1 }, 2), 3)",
+            accepted: true,
+        },
+        CarryRuleMatrixCase {
+            class: "record-in-tuple",
+            depth: 4,
+            ty: "(((Leaf, i64), i64), i64)",
+            declarations: "",
+            setup: "",
+            value: "(((Leaf { label: string.repeat(\"k\", 32), n: 1 }, 2), 3), 4)",
+            accepted: true,
+        },
+        CarryRuleMatrixCase {
+            class: "tuple-in-record",
+            depth: 2,
+            ty: "Wrapper",
+            declarations: "record Wrapper { inner: (string, i64), tag: i64 }",
+            setup: "",
+            value: "Wrapper { inner: (string.repeat(\"k\", 32), 2), tag: 3 }",
+            accepted: true,
+        },
+        CarryRuleMatrixCase {
+            class: "tuple-in-record",
+            depth: 3,
+            ty: "Wrapper",
+            declarations: "record Wrapper { inner: ((string, i64), i64), tag: i64 }",
+            setup: "",
+            value: "Wrapper { inner: ((string.repeat(\"k\", 32), 2), 3), tag: 4 }",
+            accepted: true,
+        },
+        CarryRuleMatrixCase {
+            class: "tuple-in-record",
+            depth: 4,
+            ty: "Wrapper",
+            declarations: "record Wrapper { inner: (((string, i64), i64), i64), tag: i64 }",
+            setup: "",
+            value: "Wrapper { inner: (((string.repeat(\"k\", 32), 2), 3), 4), tag: 5 }",
+            accepted: true,
+        },
+        CarryRuleMatrixCase {
+            class: "enum-payload",
+            depth: 2,
+            ty: "Payload",
+            declarations: "enum Payload { Value(Leaf); Empty; }",
+            setup: "",
+            value: ".Value(Leaf { label: string.repeat(\"k\", 32), n: 1 })",
+            accepted: false,
+        },
+        CarryRuleMatrixCase {
+            class: "enum-payload",
+            depth: 3,
+            ty: "(Payload, i64)",
+            declarations: "enum Payload { Value(Leaf); Empty; }",
+            setup: "",
+            value: "(.Value(Leaf { label: string.repeat(\"k\", 32), n: 1 }), 3)",
+            accepted: false,
+        },
+        CarryRuleMatrixCase {
+            class: "enum-payload",
+            depth: 4,
+            ty: "((Payload, i64), i64)",
+            declarations: "enum Payload { Value(Leaf); Empty; }",
+            setup: "",
+            value: "((.Value(Leaf { label: string.repeat(\"k\", 32), n: 1 }), 3), 4)",
+            accepted: false,
+        },
+        CarryRuleMatrixCase {
+            class: "Option<record>",
+            depth: 2,
+            ty: "Option<Leaf>",
+            declarations: "",
+            setup: "",
+            value: "Some(Leaf { label: string.repeat(\"k\", 32), n: 1 })",
+            accepted: false,
+        },
+        CarryRuleMatrixCase {
+            class: "Option<record>",
+            depth: 3,
+            ty: "(Option<Leaf>, i64)",
+            declarations: "",
+            setup: "",
+            value: "(Some(Leaf { label: string.repeat(\"k\", 32), n: 1 }), 3)",
+            accepted: false,
+        },
+        CarryRuleMatrixCase {
+            class: "Option<record>",
+            depth: 4,
+            ty: "((Option<Leaf>, i64), i64)",
+            declarations: "",
+            setup: "",
+            value: "((Some(Leaf { label: string.repeat(\"k\", 32), n: 1 }), 3), 4)",
+            accepted: false,
+        },
+        CarryRuleMatrixCase {
+            class: "Vec<record>-element",
+            depth: 2,
+            ty: "Vec<Leaf>",
+            declarations: "",
+            setup: "let leaves: Vec<Leaf> = Vec.new(); leaves.push(Leaf { label: string.repeat(\"k\", 32), n: 1 });",
+            value: "leaves",
+            accepted: true,
+        },
+        CarryRuleMatrixCase {
+            class: "Vec<record>-element",
+            depth: 3,
+            ty: "(Vec<Leaf>, i64)",
+            declarations: "",
+            setup: "let leaves: Vec<Leaf> = Vec.new(); leaves.push(Leaf { label: string.repeat(\"k\", 32), n: 1 });",
+            value: "(leaves, 3)",
+            accepted: true,
+        },
+        CarryRuleMatrixCase {
+            class: "Vec<record>-element",
+            depth: 4,
+            ty: "((Vec<Leaf>, i64), i64)",
+            declarations: "",
+            setup: "let leaves: Vec<Leaf> = Vec.new(); leaves.push(Leaf { label: string.repeat(\"k\", 32), n: 1 });",
+            value: "((leaves, 3), 4)",
+            accepted: true,
+        },
+    ]
+}
+
+fn carry_rule_matrix_source(case: &CarryRuleMatrixCase) -> String {
+    format!(
+        r#"
+import std.string;
+record Leaf {{ label: string, n: i64 }}
+{declarations}
+record T {{ keep: {ty}, churn: string }}
+fn mk() -> T {{
+    {setup}
+    let b = T {{ keep: {value}, churn: string.repeat("a", 32) }};
+    T {{ churn: string.repeat("b", 32), ..b }}
+}}
+fn main() {{ let r = mk(); println(r.churn); }}
+"#,
+        declarations = case.declarations,
+        ty = case.ty,
+        setup = case.setup,
+        value = case.value,
+    )
+}
+
+/// Execute every depth/class cell against the same recursive carry judgment.
+/// Accepted cells must run to normal teardown; cells containing a bare enum or
+/// `Option` transfer path must stop at the fail-closed diagnostic.
+#[test]
+fn functional_update_carry_rule_depth_matrix() {
+    require_codegen();
+    for case in carry_rule_matrix_cases() {
+        let source = carry_rule_matrix_source(&case);
+        let (ok, out) = if case.accepted {
+            hew_run(&source)
+        } else {
+            hew_check(&source)
+        };
+        assert_eq!(
+            ok, case.accepted,
+            "{} depth {} (`{}`) expected accepted={}; got:\n{}",
+            case.class, case.depth, case.ty, case.accepted, out
+        );
+        if !case.accepted {
+            assert!(
+                out.contains("carry of owned non-record field")
+                    || out.contains("E_NOT_YET_IMPLEMENTED"),
+                "{} depth {} must fail closed at the carry rule; got:\n{}",
+                case.class,
+                case.depth,
+                out
+            );
+        }
+    }
+}

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1620,7 +1620,10 @@ fn main() { let r = mk(); println(r.tag); }
     ];
     for (name, source) in cases {
         let (ok, out) = hew_run(source);
-        assert!(ok, "{name}: heap-owning tuple carry must run clean; got:\n{out}");
+        assert!(
+            ok,
+            "{name}: heap-owning tuple carry must run clean; got:\n{out}"
+        );
         assert!(
             out.contains(&"y".repeat(32)),
             "{name}: carry must override tag; got:\n{out}"

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1572,7 +1572,7 @@ fn accept_carry_nested_and_collection_bearing_tuples() {
         (
             "tuple nested in tuple",
             r#"
-import std::string;
+import std.string;
 record T { pair: (string, (string, i64)), tag: string }
 fn mk() -> T {
     let b = T { pair: (string.repeat("k", 32), (string.repeat("m", 32), 7)), tag: string.repeat("x", 32) };
@@ -1584,7 +1584,7 @@ fn main() { let r = mk(); println(r.tag); println(r.pair.0); }
         (
             "tuple of tuples",
             r#"
-import std::string;
+import std.string;
 record T { pair: ((string, i64), (string, i64)), tag: string }
 fn mk() -> T {
     let b = T { pair: ((string.repeat("k", 32), 1), (string.repeat("m", 32), 2)), tag: string.repeat("x", 32) };
@@ -1596,10 +1596,10 @@ fn main() { let r = mk(); println(r.tag); }
         (
             "tuple carrying a Vec",
             r#"
-import std::string;
+import std.string;
 record T { pair: (Vec<string>, i64), tag: string }
 fn mk() -> T {
-    let v: Vec<string> = Vec::new();
+    let v: Vec<string> = Vec.new();
     v.push(string.repeat("k", 32));
     let b = T { pair: (v, 7), tag: string.repeat("x", 32) };
     T { tag: string.repeat("y", 32), ..b }
@@ -1610,7 +1610,7 @@ fn main() { let r = mk(); println(r.tag); println(r.pair.0.len()); }
         (
             "tuple carrying an owned record",
             r#"
-import std::string;
+import std.string;
 record Inner { label: string, n: i64 }
 record T { pair: (Inner, i64), tag: string }
 fn mk() -> T {
@@ -1623,7 +1623,7 @@ fn main() { let r = mk(); println(r.tag); }
         (
             "tuple carrying an Option payload",
             r#"
-import std::string;
+import std.string;
 record Inner { label: string, n: i64 }
 record T { pair: (Option<Inner>, i64), tag: string }
 fn mk() -> T {
@@ -1636,7 +1636,7 @@ fn main() { let r = mk(); println(r.tag); }
         (
             "tuple carrying a user-enum payload",
             r#"
-import std::string;
+import std.string;
 record Inner { label: string, n: i64 }
 enum Payload { Value(Inner); Empty; }
 record T { pair: (Payload, i64), tag: string }
@@ -1672,7 +1672,7 @@ fn main() { let r = mk(); println(r.tag); }
 #[test]
 fn reject_carry_non_heap_tuple_field_is_conservative() {
     let source = r#"
-import std::string;
+import std.string;
 record T { pair: (i64, i64), tag: string }
 fn mk() -> T {
     let b = T { pair: (3, 7), tag: string.repeat("x", 32) };

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1516,11 +1516,24 @@ fn main() {
     );
 }
 
-/// Carrying a tuple-of-owned field must FAIL `hew check` fail-closed: a
-/// `(string, i64)` tuple has no single inline-drop leaf symbol and is not an
-/// owned user record, so the shallow carry has no proven-sound transfer path.
+/// Carrying a HEAP-OWNING tuple field is ACCEPTED and runs clean.
+///
+/// This was previously fail-closed (`reject_carry_tuple_of_owned_field`). The
+/// lift admits `ty_is_heap_owning_tuple` into the carry pre-flight's
+/// `sound_carry` predicate, reusing the EXISTING
+/// `derive_tuple_composite_drop_allowed` composite-drop prover that already sits
+/// beside the record prover making the nested-record carry sound. No new
+/// recursive carry spine is authored: the prover excludes the consumed base, so
+/// the base's scope-exit drop and the result's drop do not both release the
+/// carried tuple.
+///
+/// Verified under `MALLOC_CHECK_=3 MALLOC_PERTURB_=165` with a flat RSS profile
+/// across a 4x frame sweep, matching the known-sound record carry as a positive
+/// control. The closure / `Option` / handle families remain fail-closed — see the
+/// sibling `reject_carry_*` tests, which are the discrimination controls proving
+/// this lift is precisely scoped and not a blanket weakening.
 #[test]
-fn reject_carry_tuple_of_owned_field() {
+fn accept_carry_tuple_of_owned_field() {
     let source = r#"
 import std.string;
 record T { pair: (string, i64), tag: string }
@@ -1531,15 +1544,119 @@ fn mk() -> T {
 fn main() {
     let r = mk();
     println(r.tag);
+    println(r.pair.0);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(ok, "heap-owning tuple carry must run clean; got:\n{out}");
+    assert!(
+        out.contains(&"y".repeat(32)),
+        "carry must override tag; got:\n{out}"
+    );
+    assert!(
+        out.contains(&"k".repeat(32)),
+        "carry must preserve the carried tuple's owned element; got:\n{out}"
+    );
+}
+
+/// Widened shapes for the same lift: a tuple nested inside a tuple, a
+/// tuple-of-tuples, a tuple carrying a `Vec`, and a tuple carrying an owned
+/// user record. Each must accept AND run correctly — checking alone would not
+/// discriminate a sound carry from one that double-frees at teardown.
+#[test]
+fn accept_carry_nested_and_collection_bearing_tuples() {
+    let cases: &[(&str, &str)] = &[
+        (
+            "tuple nested in tuple",
+            r#"
+import std::string;
+record T { pair: (string, (string, i64)), tag: string }
+fn mk() -> T {
+    let b = T { pair: (string.repeat("k", 32), (string.repeat("m", 32), 7)), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() { let r = mk(); println(r.tag); println(r.pair.0); }
+"#,
+        ),
+        (
+            "tuple of tuples",
+            r#"
+import std::string;
+record T { pair: ((string, i64), (string, i64)), tag: string }
+fn mk() -> T {
+    let b = T { pair: ((string.repeat("k", 32), 1), (string.repeat("m", 32), 2)), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() { let r = mk(); println(r.tag); }
+"#,
+        ),
+        (
+            "tuple carrying a Vec",
+            r#"
+import std::string;
+record T { pair: (Vec<string>, i64), tag: string }
+fn mk() -> T {
+    let v: Vec<string> = Vec::new();
+    v.push(string.repeat("k", 32));
+    let b = T { pair: (v, 7), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() { let r = mk(); println(r.tag); println(r.pair.0.len()); }
+"#,
+        ),
+        (
+            "tuple carrying an owned record",
+            r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record T { pair: (Inner, i64), tag: string }
+fn mk() -> T {
+    let b = T { pair: (Inner { label: string.repeat("k", 32), n: 1 }, 7), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() { let r = mk(); println(r.tag); }
+"#,
+        ),
+    ];
+    for (name, source) in cases {
+        let (ok, out) = hew_run(source);
+        assert!(ok, "{name}: heap-owning tuple carry must run clean; got:\n{out}");
+        assert!(
+            out.contains(&"y".repeat(32)),
+            "{name}: carry must override tag; got:\n{out}"
+        );
+    }
+}
+
+/// Discrimination control for the tuple lift's LOWER edge: a tuple with NO heap
+/// fields (`(i64, i64)`) is not admitted by `ty_is_heap_owning_tuple` and still
+/// fails closed.
+///
+/// This is a coverage gap, not a soundness one — a plain-scalar tuple is
+/// trivially bit-copyable and carrying it can never double-free, so the reject
+/// is conservative rather than wrong. Recorded here so the boundary is asserted
+/// rather than assumed; lifting it is a separate, strictly-safe follow-up.
+#[test]
+fn reject_carry_non_heap_tuple_field_is_conservative() {
+    let source = r#"
+import std::string;
+record T { pair: (i64, i64), tag: string }
+fn mk() -> T {
+    let b = T { pair: (3, 7), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() {
+    let r = mk();
+    println(r.tag);
 }
 "#;
     let (ok, out) = hew_check(source);
     assert!(
         !ok,
-        "tuple-of-owned carry must fail check; got success:\n{out}"
+        "non-heap tuple carry is currently conservative-reject; got success:\n{out}"
     );
     assert!(
-        out.contains("carry of owned non-record field") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        out.contains("E_NOT_YET_IMPLEMENTED"),
         "expected the fail-closed carry diagnostic; got:\n{out}"
     );
 }

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1520,18 +1520,19 @@ fn main() {
 ///
 /// This was previously fail-closed (`reject_carry_tuple_of_owned_field`). The
 /// lift admits `ty_is_heap_owning_tuple` into the carry pre-flight's
-/// `sound_carry` predicate, reusing the EXISTING
-/// `derive_tuple_composite_drop_allowed` composite-drop prover that already sits
-/// beside the record prover making the nested-record carry sound. No new
-/// recursive carry spine is authored: the prover excludes the consumed base, so
-/// the base's scope-exit drop and the result's drop do not both release the
-/// carried tuple.
+/// `sound_carry` predicate. The protection comes from
+/// `derive_owned_record_drop_allowed`, not the tuple-binding prover: the carried
+/// tuple's `RecordFieldLoad` destination is a heap-owning field binder, and its
+/// escape into the result's `RecordInit` excludes the consumed base root from
+/// `RecordInPlace`. The result therefore receives the tuple's complete nested
+/// drop obligation without the base releasing it a second time.
 ///
-/// Verified under `MALLOC_CHECK_=3 MALLOC_PERTURB_=165` with a flat RSS profile
-/// across a 4x frame sweep, matching the known-sound record carry as a positive
-/// control. The closure / `Option` / handle families remain fail-closed — see the
-/// sibling `reject_carry_*` tests, which are the discrimination controls proving
-/// this lift is precisely scoped and not a blanket weakening.
+/// Verified on Linux under glibc's `MALLOC_CHECK_=3 MALLOC_PERTURB_=165` with a
+/// flat RSS profile across a 4x frame sweep, matching the known-sound record
+/// carry as a positive control. Guard Malloc + `MallocScribble` remains the
+/// authoritative Darwin oracle and was verified independently in review. Bare
+/// `Option` / enum fields, closures, and handles remain fail-closed; an `Option`
+/// or enum nested inside the admitted tuple transfer boundary is covered below.
 #[test]
 fn accept_carry_tuple_of_owned_field() {
     let source = r#"
@@ -1559,10 +1560,12 @@ fn main() {
     );
 }
 
-/// Widened shapes for the same lift: a tuple nested inside a tuple, a
-/// tuple-of-tuples, a tuple carrying a `Vec`, and a tuple carrying an owned
-/// user record. Each must accept AND run correctly — checking alone would not
-/// discriminate a sound carry from one that double-frees at teardown.
+/// Widened shapes for the same lift: nested tuples, a tuple carrying a `Vec`,
+/// an owned record, an `Option` payload, or a user-enum payload. Each must accept
+/// AND run correctly — checking alone would not discriminate a sound carry from
+/// one that double-frees at teardown. The latter two fixtures pin the full
+/// admitted scope: bare `Option` / enum fields remain rejected, but their drop
+/// obligations transfer soundly when the tuple is the carried field boundary.
 #[test]
 fn accept_carry_nested_and_collection_bearing_tuples() {
     let cases: &[(&str, &str)] = &[
@@ -1612,6 +1615,33 @@ record Inner { label: string, n: i64 }
 record T { pair: (Inner, i64), tag: string }
 fn mk() -> T {
     let b = T { pair: (Inner { label: string.repeat("k", 32), n: 1 }, 7), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() { let r = mk(); println(r.tag); }
+"#,
+        ),
+        (
+            "tuple carrying an Option payload",
+            r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record T { pair: (Option<Inner>, i64), tag: string }
+fn mk() -> T {
+    let b = T { pair: (Some(Inner { label: string.repeat("k", 32), n: 1 }), 7), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() { let r = mk(); println(r.tag); }
+"#,
+        ),
+        (
+            "tuple carrying a user-enum payload",
+            r#"
+import std::string;
+record Inner { label: string, n: i64 }
+enum Payload { Value(Inner); Empty; }
+record T { pair: (Payload, i64), tag: string }
+fn mk() -> T {
+    let b = T { pair: (Value(Inner { label: string.repeat("k", 32), n: 1 }), 7), tag: string.repeat("x", 32) };
     T { tag: string.repeat("y", 32), ..b }
 }
 fn main() { let r = mk(); println(r.tag); }

--- a/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
+++ b/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
@@ -508,6 +508,115 @@ fn carry_bytes_field_source(frames: usize) -> String {
     )
 }
 
+// The tuple-carry sources below measure the heap-owning-TUPLE field carry in
+// BOTH drop orders, because the two orders exercise different halves of the
+// transfer:
+//
+//   * ESCAPE order — the result leaves the frame that consumed the base, so the
+//     base's frame teardown runs while the carried tuple is still live. A carry
+//     that failed to hand the tuple over frees it here (use-after-free) or never
+//     frees it (leak).
+//   * SAME-FRAME order — base and result both die at one scope exit, result
+//     first. A carry that transferred without excluding the base releases the
+//     tuple twice.
+//
+// Neither source READS the carried tuple back: a tuple-field read seeds an
+// owned-field binder that the record prover conservatively treats as an escape,
+// excluding the whole record from its `RecordInPlace` drop. That exclusion leaks
+// on `main` today with no functional update in sight, and would swamp the signal
+// these fixtures exist to measure. Value-level read-back of the carried leaves
+// is pinned separately by `accept_carry_nested_and_collection_bearing_tuples`
+// in `funcupdate_consume_semantics.rs`.
+
+/// Carry a `(string, i64)` tuple field, ESCAPE drop order: the update happens in
+/// a helper whose result is returned, so the consumed base dies one frame below
+/// the surviving carry.
+fn carry_tuple_field_escape_source(frames: usize) -> String {
+    format!(
+        "import std.string;\n\
+         \n\
+         record Pair {{\n\
+         \x20   keep: (string, i64),\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn step() -> Pair {{\n\
+         \x20   let b = Pair {{ keep: (string.repeat(\"k\", 32), 1), churn: string.repeat(\"a\", 32) }};\n\
+         \x20   Pair {{ churn: string.repeat(\"b\", 32), ..b }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let r = step();\n\
+         \x20       total = total + r.churn.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Carry a `(string, i64)` tuple field, SAME-FRAME drop order: base and result
+/// are two bindings in one loop-body scope, so the result is released first and
+/// the consumed base's teardown follows immediately.
+fn carry_tuple_field_same_frame_source(frames: usize) -> String {
+    format!(
+        "import std.string;\n\
+         \n\
+         record Pair {{\n\
+         \x20   keep: (string, i64),\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let b = Pair {{ keep: (string.repeat(\"k\", 32), 1), churn: string.repeat(\"a\", 32) }};\n\
+         \x20       let s = Pair {{ churn: string.repeat(\"b\", 32), ..b }};\n\
+         \x20       total = total + s.churn.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Carry a `(Inner, i64)` tuple field — the carried heap leaf is two layers
+/// down (tuple element → record field). Escape drop order.
+fn carry_tuple_of_record_field_source(frames: usize) -> String {
+    format!(
+        "import std.string;\n\
+         \n\
+         record Inner {{\n\
+         \x20   label: string,\n\
+         \x20   n: i64,\n\
+         }}\n\
+         record Pair {{\n\
+         \x20   keep: (Inner, i64),\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn step() -> Pair {{\n\
+         \x20   let b = Pair {{ keep: (Inner {{ label: string.repeat(\"k\", 32), n: 1 }}, 1), churn: string.repeat(\"a\", 32) }};\n\
+         \x20   Pair {{ churn: string.repeat(\"b\", 32), ..b }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let r = step();\n\
+         \x20       total = total + r.churn.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
 // ── plumbing (same shape as bytes_drop_leak_oracle) ───────────────────────
 
 /// Compile `source` to a native binary via `hew compile --emit-dir` and
@@ -842,4 +951,48 @@ fn funcupdate_carry_hashset_field_no_per_frame_leak_slope() {
 #[test]
 fn funcupdate_carry_bytes_field_no_per_frame_leak_slope() {
     assert_frame_slope_below_tolerance("funcupdate_carry_bytes_field", carry_bytes_field_source);
+}
+
+/// Carried `(string, i64)` tuple field, ESCAPE drop order: the result outlives
+/// the frame that consumed the base. Slope 0 — the tuple's allocation is handed
+/// over once and released once.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn funcupdate_carry_tuple_field_escape_order_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "funcupdate_carry_tuple_field_escape",
+        carry_tuple_field_escape_source,
+    );
+}
+
+/// Carried `(string, i64)` tuple field, SAME-FRAME drop order: result and
+/// consumed base die at one scope exit. Slope 0, and no crash — a transfer that
+/// left the base owning the tuple would double-free here.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn funcupdate_carry_tuple_field_same_frame_order_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "funcupdate_carry_tuple_field_same_frame",
+        carry_tuple_field_same_frame_source,
+    );
+}
+
+/// Carried `(Inner, i64)` tuple field: the heap leaf sits a tuple element AND a
+/// record field deep, so the transfer must carry the whole nested obligation.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn funcupdate_carry_tuple_of_record_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "funcupdate_carry_tuple_of_record_field",
+        carry_tuple_of_record_field_source,
+    );
 }

--- a/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
+++ b/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
@@ -617,6 +617,90 @@ fn carry_tuple_of_record_field_source(frames: usize) -> String {
     )
 }
 
+/// The round-2 reproducer: tuple → record → tuple → `Option<record>`.
+/// This source is deliberately checked, not compiled: the release machinery
+/// has no move-specific enum carry, so the recursive rule must stop it before
+/// a leaking executable can be emitted.
+fn carry_record_nested_option_source(frames: usize) -> String {
+    format!(
+        "import std.string;\n\
+         record Leaf {{ label: string, n: i64 }}\n\
+         record Wrapper {{ inner: (Option<Leaf>, i64), tag: string }}\n\
+         record T {{ pair: (Wrapper, i64), churn: string }}\n\
+         fn mk() -> T {{\n\
+         \x20   let b = T {{\n\
+         \x20       pair: (Wrapper {{ inner: (Some(Leaf {{ label: string.repeat(\"k\", 32), n: 1 }}), 9), tag: string.repeat(\"w\", 32) }}, 5),\n\
+         \x20       churn: string.repeat(\"a\", 32),\n\
+         \x20   }};\n\
+         \x20   T {{ churn: string.repeat(\"b\", 32), ..b }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let r = mk();\n\
+         \x20       total = total + r.churn.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Isolation control for the reproducer: identical nested payload, constructed
+/// directly without a functional update.
+fn nested_option_without_funcupdate_source(frames: usize) -> String {
+    format!(
+        "import std.string;\n\
+         record Leaf {{ label: string, n: i64 }}\n\
+         record Wrapper {{ inner: (Option<Leaf>, i64), tag: string }}\n\
+         record T {{ pair: (Wrapper, i64), churn: string }}\n\
+         fn mk() -> T {{\n\
+         \x20   T {{\n\
+         \x20       pair: (Wrapper {{ inner: (Some(Leaf {{ label: string.repeat(\"k\", 32), n: 1 }}), 9), tag: string.repeat(\"w\", 32) }}, 5),\n\
+         \x20       churn: string.repeat(\"a\", 32),\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let r = mk();\n\
+         \x20       total = total + r.churn.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total - total\n\
+         }}\n"
+    )
+}
+
+/// Isolation control for the reproducer: identical functional-update nesting,
+/// with the unsupported enum path replaced by a carry-sound string leaf.
+fn nested_record_without_option_source(frames: usize) -> String {
+    format!(
+        "import std.string;\n\
+         record Wrapper {{ inner: (string, i64), tag: string }}\n\
+         record T {{ pair: (Wrapper, i64), churn: string }}\n\
+         fn mk() -> T {{\n\
+         \x20   let b = T {{\n\
+         \x20       pair: (Wrapper {{ inner: (string.repeat(\"k\", 32), 9), tag: string.repeat(\"w\", 32) }}, 5),\n\
+         \x20       churn: string.repeat(\"a\", 32),\n\
+         \x20   }};\n\
+         \x20   T {{ churn: string.repeat(\"b\", 32), ..b }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let r = mk();\n\
+         \x20       total = total + r.churn.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total - total\n\
+         }}\n"
+    )
+}
+
 // ── plumbing (same shape as bytes_drop_leak_oracle) ───────────────────────
 
 /// Compile `source` to a native binary via `hew compile --emit-dir` and
@@ -712,6 +796,52 @@ fn assert_scribble_clean(shape_name: &str, source: &str) {
     assert!(
         output.status.success(),
         "{shape_name} must not free the replacement through the old field owner:\n{}",
+        describe_output(&output)
+    );
+}
+
+fn assert_check_fails_closed(shape_name: &str, source: &str) {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("funcupdate-check-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let hew_src = dir.path().join(format!("{shape_name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+    let output = Command::new(hew_binary())
+        .args(["check", hew_src.to_str().expect("hew src utf-8")])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew check");
+    assert!(
+        !output.status.success(),
+        "{shape_name} must fail closed before a leaking executable is emitted:\n{}",
+        describe_output(&output)
+    );
+    let out = describe_output(&output);
+    assert!(
+        out.contains("carry of owned non-record field") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "{shape_name} must stop at the carry-rule diagnostic; got:\n{out}"
+    );
+}
+
+fn assert_exact_zero_leaks(shape_name: &str, source_fn: fn(usize) -> String) {
+    require_leaks_tool();
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("funcupdate-zero-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let source = source_fn(HIGH_FRAMES);
+    let bin = compile_to_native(&source, dir.path(), shape_name);
+    let leaks = measure_leaks(&bin);
+    assert_eq!(
+        leaks, 0,
+        "{shape_name} must report exactly zero leaks over {HIGH_FRAMES} iterations"
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "{shape_name} must exit cleanly under MallocScribble:\n{}",
         describe_output(&output)
     );
 }
@@ -994,5 +1124,44 @@ fn funcupdate_carry_tuple_of_record_field_no_per_frame_leak_slope() {
     assert_frame_slope_below_tolerance(
         "funcupdate_carry_tuple_of_record_field",
         carry_tuple_of_record_field_source,
+    );
+}
+
+/// The leaking round-2 shape must be refused before native code generation.
+/// A fail-closed diagnostic is the zero-leak outcome while enum-shaped carries
+/// have no move-specific release protocol.
+#[test]
+fn funcupdate_carry_record_with_nested_option_fails_closed() {
+    assert_check_fails_closed(
+        "funcupdate_carry_record_nested_option",
+        &carry_record_nested_option_source(HIGH_FRAMES),
+    );
+}
+
+/// Control 1: the nested enum payload is leak-clean when no functional update
+/// carries it through a shallow field load.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn nested_option_without_funcupdate_has_exactly_zero_leaks() {
+    assert_exact_zero_leaks(
+        "nested_option_without_funcupdate",
+        nested_option_without_funcupdate_source,
+    );
+}
+
+/// Control 2: the same functional-update nesting is leak-clean when every leaf
+/// is carry-sound and no enum boundary is present.
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "leak oracle needs macOS `leaks(1)` / the Darwin poisoned allocator; a host that cannot run it must record a SKIP, never a silent pass"
+)]
+#[test]
+fn nested_record_without_option_has_exactly_zero_leaks() {
+    assert_exact_zero_leaks(
+        "nested_record_without_option",
+        nested_record_without_option_source,
     );
 }

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -6714,6 +6714,7 @@ mod owned_record_drop_derivation {
             &hew_hir::LifecycleRegistry::default(),
             &[],
             &HashMap::new(),
+            &HashSet::new(),
         )
     }
 

--- a/hew-mir/src/lower/composite_own.rs
+++ b/hew-mir/src/lower/composite_own.rs
@@ -6609,6 +6609,9 @@ mod owned_record_drop_derivation {
     //! synthetic MIR blocks: a returned record (escape) must be EXCLUDED so its
     //! `RecordInPlace` drop never double-frees the escapee's fields, while a
     //! field-read-only record must be ADMITTED so its heap fields are freed.
+    //! The paired runtime oracle in the exec suite is Guard-Malloc with
+    //! `MallocScribble`; glibc-only `MALLOC_CHECK_` / `MALLOC_PERTURB_` are
+    //! platform helpers, not the canonical proof on macOS.
     //!
     //! The headline `one_arm_consume_*` pair pins the audit-#5 reconciliation:
     //! a record consumed (returned) on one branch but live on another is gated
@@ -6685,6 +6688,32 @@ mod owned_record_drop_derivation {
             &[],
             &HashMap::new(),
             &HashSet::new(),
+        )
+    }
+
+    fn derive_with_field_ty_and_enums(
+        blocks: &[BasicBlock],
+        owned: &[(BindingId, String, ResolvedTy)],
+        binding_locals: &HashMap<BindingId, Place>,
+        local_tys: &[ResolvedTy],
+        field_ty: ResolvedTy,
+        enum_layouts: &[crate::model::EnumLayout],
+    ) -> HashSet<BindingId> {
+        let mut record_field_orders: HashMap<String, Vec<(String, ResolvedTy)>> = HashMap::new();
+        record_field_orders.insert("Rec".to_string(), vec![("label".to_string(), field_ty)]);
+        derive_owned_record_drop_allowed(
+            blocks,
+            &HashMap::new(),
+            owned,
+            binding_locals,
+            local_tys,
+            &is_rec,
+            &|_, _| false,
+            &record_field_orders,
+            enum_layouts,
+            &hew_hir::LifecycleRegistry::default(),
+            &[],
+            &HashMap::new(),
         )
     }
 
@@ -7232,6 +7261,106 @@ mod owned_record_drop_derivation {
             allowed.contains(&b),
             "the returned string field owns a retained share, so the record \
              must keep its original field release; got {allowed:?}"
+        );
+    }
+
+    /// Soundness pin for the tuple-field lift: a `RecordFieldLoad` that carries
+    /// an `(Option<string>, i64)` field into a fresh `RecordInit` transfers the
+    /// tuple-owned drop obligation to the result, so the consumed base record
+    /// must be excluded from `RecordInPlace`.
+    #[test]
+    fn tuple_field_carry_with_option_payload_excludes_record_root() {
+        let b = BindingId(1);
+        let tuple_field_ty = ResolvedTy::Tuple(vec![
+            ResolvedTy::named_builtin("Option", BuiltinType::Option, vec![ResolvedTy::String]),
+            ResolvedTy::I64,
+        ]);
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals: HashMap<BindingId, Place> =
+            [(b, Place::Local(0))].into_iter().collect();
+        let local_tys = vec![rec_ty(), tuple_field_ty.clone(), rec_ty()];
+        let instrs = vec![
+            Instr::RecordFieldLoad {
+                record: Place::Local(0),
+                field_offset: FieldOffset(0),
+                dest: Place::Local(1),
+            },
+            Instr::RecordInit {
+                ty: rec_ty(),
+                fields: vec![(FieldOffset(0), Place::Local(1))],
+                dest: Place::Local(2),
+            },
+        ];
+
+        let allowed = derive(
+            &[block(0, instrs, Terminator::Return)],
+            &owned,
+            &binding_locals,
+            &local_tys,
+        );
+        assert!(
+            !allowed.contains(&b),
+            "the tuple payload escapes into RecordInit, so the base record's \
+             in-place drop must be excluded; got {allowed:?}"
+        );
+    }
+
+    /// Companion pin for the user-enum payload family: a tuple field carrying a
+    /// heap-owned user enum into `RecordInit` is also transferred by the same
+    /// owned-record escape rule, so the base record must be excluded.
+    #[test]
+    fn tuple_field_carry_with_user_enum_payload_excludes_record_root() {
+        let b = BindingId(1);
+        let tuple_field_ty = ResolvedTy::Tuple(vec![
+            ResolvedTy::named_user("Wrap", vec![]),
+            ResolvedTy::I64,
+        ]);
+        let enum_layouts = vec![crate::model::EnumLayout {
+            name: "Wrap".to_string(),
+            tag_width: 1,
+            variants: vec![
+                crate::model::MachineVariantLayout {
+                    name: "Some".to_string(),
+                    field_tys: vec![ResolvedTy::String],
+                    field_names: vec![],
+                },
+                crate::model::MachineVariantLayout {
+                    name: "None".to_string(),
+                    field_tys: vec![],
+                    field_names: vec![],
+                },
+            ],
+            is_indirect: false,
+        }];
+        let owned = vec![(b, "r".to_string(), rec_ty())];
+        let binding_locals: HashMap<BindingId, Place> =
+            [(b, Place::Local(0))].into_iter().collect();
+        let local_tys = vec![rec_ty(), tuple_field_ty.clone(), rec_ty()];
+        let instrs = vec![
+            Instr::RecordFieldLoad {
+                record: Place::Local(0),
+                field_offset: FieldOffset(0),
+                dest: Place::Local(1),
+            },
+            Instr::RecordInit {
+                ty: rec_ty(),
+                fields: vec![(FieldOffset(0), Place::Local(1))],
+                dest: Place::Local(2),
+            },
+        ];
+
+        let allowed = derive_with_field_ty_and_enums(
+            &[block(0, instrs, Terminator::Return)],
+            &owned,
+            &binding_locals,
+            &local_tys,
+            tuple_field_ty,
+            &enum_layouts,
+        );
+        assert!(
+            !allowed.contains(&b),
+            "the tuple payload escapes into RecordInit, so the base record's \
+             in-place drop must be excluded; got {allowed:?}"
         );
     }
 

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -4159,7 +4159,12 @@ pub(super) fn render_owned_handle_ty(ty: &ResolvedTy) -> String {
 /// `BitCopy` is excluded (no scope-exit drop needed). Record-aware: a tuple
 /// element of nested-record type whose field owns heap (`(Boxed, i64)` where
 /// `Boxed { payload: Vec<i64> }`) is recognised so its member-drop fires the
-/// inner buffer's release (DIV-1; a record-blind walker leaked it).
+/// inner buffer's release (DIV-1; a record-blind walker leaked it). The same
+/// shared structural authority also walks `Option` / user-enum payloads, so a
+/// tuple such as `(Option<string>, i64)` or `(Wrap, i64)` is intentionally
+/// admitted here; when that tuple is carried as a record field, the soundness
+/// hinge is the owned-record escape rule in `derive_owned_record_drop_allowed`,
+/// not a tuple-specific shape whitelist.
 pub(super) fn ty_is_heap_owning_tuple(
     ty: &ResolvedTy,
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
@@ -6005,7 +6010,11 @@ fn build_lifo_drops(
         // (`tuple_composite_drop_allowed`). The `__tuple_N` destructure temp
         // (elements moved out) and a returned tuple are both excluded, so the
         // helper frees each member exactly once. A binding the prover did not
-        // clear leaks (as before); it never double-frees.
+        // clear leaks (as before); it never double-frees. Tuples whose fields
+        // transitively hold `Option` / user-enum payloads are included by the
+        // same structural authority and remain sound for the same reason: the
+        // nested payloads are still dropped through the tuple's one member-drop
+        // path, not by a separate ad hoc whitelist.
         if tuple_composite_drop_allowed.contains(binding)
             && ty_is_heap_owning_tuple(
                 ty,

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -205,6 +205,61 @@ enum VecIterStaticNextLowering {
 }
 
 impl Builder {
+    /// Whether a functional-update CARRY of a non-overridden field of type
+    /// `ty` soundly transfers that field's ownership out of the consumed base.
+    ///
+    /// The carry is a shallow `RecordFieldLoad` into the result's
+    /// `RecordInit`. It is sound only when the field's whole drop obligation
+    /// travels with that one shallow read:
+    ///   * `BitCopy` / `View` — no heap ownership; nothing to transfer.
+    ///   * a single-pointer COW / handle leaf (string, bytes, `Vec`,
+    ///     `HashMap`, `HashSet`, `Generator`) — `project_field_inline_drop_-
+    ///     symbol` is `Wired`, so the one allocation is released exactly once.
+    ///   * an owned user record — `is_owned_aggregate_record_ty`; the nested
+    ///     record's heap leaves ride its `RecordInPlace` spine.
+    ///   * a heap-owning tuple **each of whose elements is itself carry-sound
+    ///     by this same rule**. The tuple is not a transfer boundary in its
+    ///     own right: a tuple element whose bare form has no sound carry has
+    ///     no sound carry inside a tuple either. Admitting one — an
+    ///     `Option<owned>` element, say — excludes the consumed base from its
+    ///     `RecordInPlace` drop without the result taking over the element's
+    ///     obligation, and the base's payload is never released (a leak, pinned
+    ///     by `reject_carry_tuple_of_option_field`).
+    ///
+    /// Every other owned field type fails closed: a closure / `fn` /
+    /// trait-object capture env, an `@resource` / cancellation-token / task
+    /// handle, a bare `Option<owned>` or enum-with-heap, and any
+    /// `Unknown`-class owned Named type. Lifting a specific type's carry is
+    /// tracked in hew-lang/hew#2207.
+    fn carry_transfers_field_ownership(&self, ty: &ResolvedTy) -> bool {
+        if matches!(
+            ValueClass::of_ty(ty, &self.type_classes),
+            ValueClass::BitCopy | ValueClass::View
+        ) {
+            return true;
+        }
+        if matches!(
+            self.project_field_inline_drop_symbol(ty),
+            ReleaseSymbolVerdict::Wired(_)
+        ) {
+            return true;
+        }
+        if self.is_owned_aggregate_record_ty(ty) {
+            return true;
+        }
+        let ResolvedTy::Tuple(elems) = ty else {
+            return false;
+        };
+        crate::lower::drop_plan::ty_is_heap_owning_tuple(
+            ty,
+            &self.record_field_orders,
+            &self.enum_layouts,
+            &self.lifecycle_registry,
+        ) && elems
+            .iter()
+            .all(|elem| self.carry_transfers_field_ownership(elem))
+    }
+
     /// Lower the exact builtin `Iterator::next` dispatch for `VecIter<T>`.
     ///
     /// HIR expands direct `cursor.next()` syntax before generic functions are
@@ -4428,67 +4483,22 @@ impl Builder {
                 // Fail-closed CARRY pre-flight (complement of the override
                 // pre-flight above). A NON-overridden owned field is CARRIED out
                 // of the consumed base into the new record by a shallow
-                // `RecordFieldLoad`, with the base excluded from its composite
-                // `RecordInPlace` drop (`derive_owned_record_drop_allowed`). That
-                // shallow move soundly transfers ownership ONLY for field types
-                // whose whole value is one pointer / handle (or a record of such):
-                //   * `BitCopy` / `View` — no heap ownership; nothing to transfer
-                //     or to double-free.
-                //   * single-pointer COW / handle leaves (string, bytes, `Vec`,
-                //     `HashMap`, `HashSet`, `Generator`) — `project_field_inline_-
-                //     drop_symbol` is `Some`; the binder-escape exclusion hands the
-                //     one allocation to the result, freed exactly once.
-                //   * owned user records — `is_owned_aggregate_record_ty`; the
-                //     nested record's heap leaves transfer with the base excluded
-                //     (the binder-detection fix that also recognises nested records
-                //     as heap-owning binders).
-                //   * heap-owning tuples — `ty_is_heap_owning_tuple`; the tuple-
-                //     typed `RecordFieldLoad` destination is a heap-owning field
-                //     binder in `derive_owned_record_drop_allowed`. Its escape into
-                //     the result's `RecordInit` triggers that prover's escape rule,
-                //     which excludes the consumed base root from `RecordInPlace` and
-                //     transfers the tuple's complete nested drop obligation to the
-                //     result. This also covers tuple elements that are `Option` or
-                //     user-enum payloads; the tuple shape is the transfer boundary,
-                //     and the owning-record escape rule is the proof that keeps the
-                //     carry sound.
-                // Every OTHER owned field type has NO sound shallow carry and
-                // would be released twice — once by the base's in-place drop and
-                // once by the result's drop (a double-free / use-after-free at
-                // teardown):
-                //   * a closure / `fn` / trait-object value (`PersistentShare`) is
-                //     a heap-boxed capture env with no retain/release carry spine;
-                //   * an `@resource` / `CancellationToken` / `Task` handle is a
-                //     single-release affine/linear value the inline-drop authority
-                //     does not cover here;
-                //   * an owned composite the leaf authority does not cover
-                //     (bare `Option<owned>`, bare enum-with-heap, a non-heap tuple
-                //     conservatively classified outside `BitCopy`, or any
-                //     `Unknown`-class owned Named type).
-                // Fail closed with an NYI diagnostic mirroring the override
-                // pre-flight rather than emit the double-free. Lifting a specific
-                // type's carry is tracked in hew-lang/hew#2207 (closure/`fn` env
-                // carry needs the env retain/release spine that clone also lacks).
+                // `RecordFieldLoad`. `carry_transfers_field_ownership` is the
+                // single authority for which field types that shallow read can
+                // carry; it applies ONE rule at every nesting depth, so a tuple
+                // admits exactly the element types the same field would admit
+                // bare. Fail closed with an NYI diagnostic mirroring the
+                // override pre-flight rather than emit a double-free or a silent
+                // leak. Lifting a specific type's carry is tracked in
+                // hew-lang/hew#2207 (closure/`fn` env carry needs the env
+                // retain/release spine that clone also lacks).
                 if base_place.is_some() {
                     for (fname, fty) in &field_order {
                         if explicit.contains_key(fname.as_str()) {
                             continue; // Overridden — handled by the override path.
                         }
                         let subst_fty = self.subst_ty(fty);
-                        let vc = ValueClass::of_ty(&subst_fty, &self.type_classes);
-                        let sound_carry = matches!(vc, ValueClass::BitCopy | ValueClass::View)
-                            || matches!(
-                                self.project_field_inline_drop_symbol(&subst_fty),
-                                ReleaseSymbolVerdict::Wired(_)
-                            )
-                            || self.is_owned_aggregate_record_ty(&subst_fty)
-                            || crate::lower::drop_plan::ty_is_heap_owning_tuple(
-                                &subst_fty,
-                                &self.record_field_orders,
-                                &self.enum_layouts,
-                                &self.lifecycle_registry,
-                            );
-                        if sound_carry {
+                        if self.carry_transfers_field_ownership(&subst_fty) {
                             continue;
                         }
                         self.diagnostics.push(MirDiagnostic {
@@ -4501,14 +4511,18 @@ impl Builder {
                                 "field `{fname}` of `{name}` has owned type `{ty}` whose \
                                  ownership cannot be transferred by the functional-update's \
                                  shallow field carry: a closure / `fn` / trait-object capture \
-                                 env, an `@resource` / cancellation-token / task handle, or an \
-                                 unsupported owned composite (including bare `Option` / enum \
-                                 fields and conservatively rejected non-heap tuples). \
-                                 The `..base` consumes the base, so the base's scope-exit drop \
-                                 and the new record's drop would both release this carried field \
-                                 — a double-free. Set `{fname}` explicitly to a fresh value in \
-                                 the update instead of carrying it through `..base`, or clone \
-                                 the base into a fresh owned value first.",
+                                 env, an `@resource` / cancellation-token / task handle, an \
+                                 `Option` or enum value, or a tuple containing one of those. \
+                                 A tuple is carried only when EVERY element could be carried \
+                                 as a field in its own right, so wrapping an unsupported type \
+                                 in a tuple does not admit it. A non-heap tuple such as \
+                                 `(i64, i64)` is also still rejected — conservatively, not \
+                                 because carrying it is unsound. \
+                                 The `..base` consumes the base, so carrying this field would \
+                                 either release it twice (a double-free) or leave nothing \
+                                 owning it (a leak). Set `{fname}` explicitly to a fresh value \
+                                 in the update instead of carrying it through `..base`, or \
+                                 clone the base into a fresh owned value first.",
                                 ty = subst_fty.user_facing(),
                             ),
                         });

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -4470,7 +4470,12 @@ impl Builder {
                                 self.project_field_inline_drop_symbol(&subst_fty),
                                 ReleaseSymbolVerdict::Wired(_)
                             )
-                            || self.is_owned_aggregate_record_ty(&subst_fty);
+                            || self.is_owned_aggregate_record_ty(&subst_fty)
+                            || crate::lower::drop_plan::ty_is_heap_owning_tuple(
+                                &subst_fty,
+                                &self.record_field_orders,
+                                &self.enum_layouts,
+                            );
                         if sound_carry {
                             continue;
                         }

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -4445,11 +4445,13 @@ impl Builder {
                 //   * heap-owning tuples — `ty_is_heap_owning_tuple`; the tuple-
                 //     typed `RecordFieldLoad` destination is a heap-owning field
                 //     binder in `derive_owned_record_drop_allowed`. Its escape into
-                //     the result's `RecordInit` excludes the consumed base root from
-                //     `RecordInPlace`, transferring the tuple's complete nested drop
-                //     obligation to the result. This also covers tuple elements that
-                //     are `Option` or user-enum payloads; the tuple shape is the
-                //     transfer boundary.
+                //     the result's `RecordInit` triggers that prover's escape rule,
+                //     which excludes the consumed base root from `RecordInPlace` and
+                //     transfers the tuple's complete nested drop obligation to the
+                //     result. This also covers tuple elements that are `Option` or
+                //     user-enum payloads; the tuple shape is the transfer boundary,
+                //     and the owning-record escape rule is the proof that keeps the
+                //     carry sound.
                 // Every OTHER owned field type has NO sound shallow carry and
                 // would be released twice — once by the base's in-place drop and
                 // once by the result's drop (a double-free / use-after-free at

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -215,8 +215,9 @@ impl Builder {
     ///   * a single-pointer COW / handle leaf (string, bytes, `Vec`,
     ///     `HashMap`, `HashSet`, `Generator`) — `project_field_inline_drop_-
     ///     symbol` is `Wired`, so the one allocation is released exactly once.
-    ///   * an owned user record — `is_owned_aggregate_record_ty`; the nested
-    ///     record's heap leaves ride its `RecordInPlace` spine.
+    ///   * an owned user record **each of whose fields is itself carry-sound by
+    ///     this same rule**. A record is not an opaque transfer boundary: its
+    ///     nested fields must all have a release path after the shallow read.
     ///   * a heap-owning tuple **each of whose elements is itself carry-sound
     ///     by this same rule**. The tuple is not a transfer boundary in its
     ///     own right: a tuple element whose bare form has no sound carry has
@@ -245,7 +246,15 @@ impl Builder {
             return true;
         }
         if self.is_owned_aggregate_record_ty(ty) {
-            return true;
+            let Some(key) = user_record_layout_key(ty) else {
+                return false;
+            };
+            let Some(fields) = self.lookup_record_field_order(&key) else {
+                return false;
+            };
+            return fields.iter().all(|(_, field_ty)| {
+                self.carry_transfers_field_ownership(&self.subst_ty(field_ty))
+            });
         }
         let ResolvedTy::Tuple(elems) = ty else {
             return false;
@@ -4485,11 +4494,11 @@ impl Builder {
                 // of the consumed base into the new record by a shallow
                 // `RecordFieldLoad`. `carry_transfers_field_ownership` is the
                 // single authority for which field types that shallow read can
-                // carry; it applies ONE rule at every nesting depth, so a tuple
-                // admits exactly the element types the same field would admit
-                // bare. Fail closed with an NYI diagnostic mirroring the
-                // override pre-flight rather than emit a double-free or a silent
-                // leak. Lifting a specific type's carry is tracked in
+                // carry; it applies ONE rule at every nesting depth, so tuples
+                // and records admit exactly the nested field types the same
+                // field would admit bare. Fail closed with an NYI diagnostic
+                // mirroring the override pre-flight rather than emit a double-free
+                // or a silent leak. Lifting a specific type's carry is tracked in
                 // hew-lang/hew#2207 (closure/`fn` env carry needs the env
                 // retain/release spine that clone also lacks).
                 if base_place.is_some() {
@@ -4512,10 +4521,10 @@ impl Builder {
                                  ownership cannot be transferred by the functional-update's \
                                  shallow field carry: a closure / `fn` / trait-object capture \
                                  env, an `@resource` / cancellation-token / task handle, an \
-                                 `Option` or enum value, or a tuple containing one of those. \
-                                 A tuple is carried only when EVERY element could be carried \
-                                 as a field in its own right, so wrapping an unsupported type \
-                                 in a tuple does not admit it. A non-heap tuple such as \
+                                 `Option` or enum value, or a tuple or record containing one. \
+                                 A tuple or record is carried only when EVERY nested field could \
+                                 be carried in its own right, so wrapping an unsupported type \
+                                 in another aggregate does not admit it. A non-heap tuple such as \
                                  `(i64, i64)` is also still rejected — conservatively, not \
                                  because carrying it is unsound. \
                                  The `..base` consumes the base, so carrying this field would \

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -4442,6 +4442,14 @@ impl Builder {
                 //     nested record's heap leaves transfer with the base excluded
                 //     (the binder-detection fix that also recognises nested records
                 //     as heap-owning binders).
+                //   * heap-owning tuples — `ty_is_heap_owning_tuple`; the tuple-
+                //     typed `RecordFieldLoad` destination is a heap-owning field
+                //     binder in `derive_owned_record_drop_allowed`. Its escape into
+                //     the result's `RecordInit` excludes the consumed base root from
+                //     `RecordInPlace`, transferring the tuple's complete nested drop
+                //     obligation to the result. This also covers tuple elements that
+                //     are `Option` or user-enum payloads; the tuple shape is the
+                //     transfer boundary.
                 // Every OTHER owned field type has NO sound shallow carry and
                 // would be released twice — once by the base's in-place drop and
                 // once by the result's drop (a double-free / use-after-free at
@@ -4452,7 +4460,8 @@ impl Builder {
                 //     single-release affine/linear value the inline-drop authority
                 //     does not cover here;
                 //   * an owned composite the leaf authority does not cover
-                //     (tuple-of-owned, `Option<owned>`, enum-with-heap, or any
+                //     (bare `Option<owned>`, bare enum-with-heap, a non-heap tuple
+                //     conservatively classified outside `BitCopy`, or any
                 //     `Unknown`-class owned Named type).
                 // Fail closed with an NYI diagnostic mirroring the override
                 // pre-flight rather than emit the double-free. Lifting a specific
@@ -4491,7 +4500,8 @@ impl Builder {
                                  ownership cannot be transferred by the functional-update's \
                                  shallow field carry: a closure / `fn` / trait-object capture \
                                  env, an `@resource` / cancellation-token / task handle, or an \
-                                 owned composite (tuple / `Option` / enum) with heap fields. \
+                                 unsupported owned composite (including bare `Option` / enum \
+                                 fields and conservatively rejected non-heap tuples). \
                                  The `..base` consumes the base, so the base's scope-exit drop \
                                  and the new record's drop would both release this carried field \
                                  — a double-free. Set `{fname}` explicitly to a fresh value in \

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -4475,6 +4475,7 @@ impl Builder {
                                 &subst_fty,
                                 &self.record_field_orders,
                                 &self.enum_layouts,
+                                &self.lifecycle_registry,
                             );
                         if sound_carry {
                             continue;


### PR DESCRIPTION
## Summary

- Supersede #2916 with a same-repository branch rebased onto current `main`.
- Admit heap-owning tuple fields in functional record updates only when every nested element satisfies the same carry-soundness rule.
- Keep options, user enums, closures, handles, and non-heap tuples fail-closed.
- Preserve the authoritative record-drop and projection-read ownership seam landed by #3012.

## Conflict resolution

The obsolete owned-record-drop test extraction and module-order commits were omitted so current `main` remains authoritative. The rebased test helper now supplies the projection-borrow cursor input added on `main`.

## Validation

- `cargo test -p hew-mir --all-targets`
- `cargo test -p hew-cli --test funcupdate_consume_semantics tuple -- --nocapture`
- `cargo test -p hew-cli --test funcupdate_owned_field_drop_leak_oracle funcupdate_carry_tuple -- --nocapture`
- `make test-vertical-slice`

All three tuple leak oracles measured zero leaks at both 3 and 50 frames.