### PR TITLE
fix(pkg): secure registry package resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,7 @@ dependencies = [
  "tiny_http",
  "toml",
  "ureq",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,6 +1934,8 @@ dependencies = [
  "base64",
  "clap",
  "ed25519-dalek",
+ "fd-lock",
+ "libc",
  "rand 0.10.1",
  "rand_core 0.10.1",
  "semver",

--- a/hew-cli/tests/pkg_path_dependency_e2e.rs
+++ b/hew-cli/tests/pkg_path_dependency_e2e.rs
@@ -1,0 +1,109 @@
+mod support;
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use support::{describe_output, hew_binary, repo_root, require_codegen, run_bounded_command};
+
+fn write_manifest(root: &Path, dependencies: &str) {
+    std::fs::write(
+        root.join("hew.toml"),
+        format!(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2026\"\n\n[dependencies]\n{dependencies}"
+        ),
+    )
+    .expect("write project manifest");
+}
+
+fn run_pkg(home: &Path, project: &Path, args: &[&str]) -> Output {
+    Command::new(hew_binary())
+        .args(args)
+        .current_dir(project)
+        .env("HOME", home)
+        .env_remove("USERPROFILE")
+        .output()
+        .expect("run hew package command")
+}
+
+#[test]
+fn pkg_path_dependency_adds_installs_and_builds() {
+    require_codegen();
+    let workspace = tempfile::Builder::new()
+        .prefix("pkg-path-e2e-")
+        .tempdir_in(repo_root())
+        .expect("create package workspace");
+    let home = workspace.path().join("home");
+    let project = workspace.path().join("app");
+    let dependency = workspace.path().join("foo");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&dependency).unwrap();
+    write_manifest(&project, "");
+    std::fs::write(
+        project.join("main.hew"),
+        "import foo;\nfn main() -> i64 { foo.answer() }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dependency.join("hew.toml"),
+        "[package]\nname = \"foo\"\nversion = \"1.4.0\"\nedition = \"2026\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dependency.join("foo.hew"),
+        "pub fn answer() -> i64 { 42 }\n",
+    )
+    .unwrap();
+
+    let add = run_pkg(&home, &project, &["add", "foo", "--path", "../foo"]);
+    assert!(
+        add.status.success(),
+        "hew add --path failed\n{}",
+        describe_output(&add)
+    );
+    let install = run_pkg(&home, &project, &["install"]);
+    assert!(
+        install.status.success(),
+        "path install failed\n{}",
+        describe_output(&install)
+    );
+    let lock = std::fs::read_to_string(project.join("hew.lock")).unwrap();
+    assert!(lock.contains("source = \"path\""), "{lock}");
+    assert!(lock.contains("path = \"../foo\""), "{lock}");
+
+    let mut build = Command::new(hew_binary());
+    build
+        .arg("build")
+        .current_dir(&project)
+        .env("HOME", &home)
+        .env_remove("USERPROFILE");
+    let output = run_bounded_command(build, "hew build path dependency");
+    assert!(
+        output.status.success(),
+        "path dependency build failed\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn pkg_missing_path_refuses_install() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    write_manifest(&project, "missing = { path = \"../missing\" }\n");
+
+    let output = run_pkg(&home, &project, &["install"]);
+    assert!(
+        !output.status.success(),
+        "missing path must fail\n{}",
+        describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("missing"), "{stderr}");
+    assert!(
+        stderr.contains("../missing") || stderr.contains("/missing"),
+        "{stderr}"
+    );
+}

--- a/hew-cli/tests/pkg_path_dependency_e2e.rs
+++ b/hew-cli/tests/pkg_path_dependency_e2e.rs
@@ -71,6 +71,19 @@ fn pkg_path_dependency_adds_installs_and_builds() {
     assert!(lock.contains("source = \"path\""), "{lock}");
     assert!(lock.contains("path = \"../foo\""), "{lock}");
 
+    let mut check = Command::new(hew_binary());
+    check
+        .arg("check")
+        .current_dir(&project)
+        .env("HOME", &home)
+        .env_remove("USERPROFILE");
+    let output = run_bounded_command(check, "hew check path dependency");
+    assert!(
+        output.status.success(),
+        "path dependency check failed\n{}",
+        describe_output(&output)
+    );
+
     let mut build = Command::new(hew_binary());
     build
         .arg("build")

--- a/hew-cli/tests/pkg_resolver_e2e.rs
+++ b/hew-cli/tests/pkg_resolver_e2e.rs
@@ -191,18 +191,38 @@ fn start_repair_registry(tarball: Vec<u8>, checksum: String) -> RepairRegistry {
 }
 
 fn package_tarball(root: &Path) -> hew_pkg::tarball::PackResult {
-    let package_source = root.join("foo-source");
+    package_tarball_variant(root, "default", "pub fn answer() -> i64 { 42 }\n", None)
+}
+
+fn package_tarball_variant(
+    root: &Path,
+    label: &str,
+    source: &str,
+    path_dependency: Option<&str>,
+) -> hew_pkg::tarball::PackResult {
+    let package_source = root.join(format!("foo-source-{label}"));
     std::fs::create_dir_all(&package_source).unwrap();
+    let dependency = path_dependency.map_or_else(String::new, |name| {
+        let dependency_root = package_source.join(name);
+        std::fs::create_dir_all(&dependency_root).unwrap();
+        std::fs::write(
+            dependency_root.join("hew.toml"),
+            format!("[package]\nname = \"{name}\"\nversion = \"1.0.0\"\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            dependency_root.join(format!("{name}.hew")),
+            format!("pub fn identity() -> str {{ \"{label}-{name}\" }}\n"),
+        )
+        .unwrap();
+        format!("\n[dependencies]\n{name} = {{ path = \"{name}\" }}\n")
+    });
     std::fs::write(
         package_source.join("hew.toml"),
-        "[package]\nname = \"foo\"\nversion = \"0.2.1\"\n",
+        format!("[package]\nname = \"foo\"\nversion = \"0.2.1\"\n{dependency}"),
     )
     .unwrap();
-    std::fs::write(
-        package_source.join("foo.hew"),
-        "pub fn answer() -> i64 { 42 }\n",
-    )
-    .unwrap();
+    std::fs::write(package_source.join("foo.hew"), source).unwrap();
     hew_pkg::tarball::pack(&package_source, &[], &[]).unwrap()
 }
 
@@ -475,6 +495,112 @@ fn pkg_concurrent_repair_downloads_and_publishes_once() {
         .unwrap(),
         "pub fn answer() -> i64 { 42 }\n"
     );
+}
+
+#[test]
+fn pkg_online_install_keeps_registry_confirmed_generation_after_pointer_swap() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let cache = root.path().join("cache");
+    let seed_project = root.path().join("seed-b");
+    let project = root.path().join("install-a");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&seed_project).unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    write_manifest(&seed_project, "foo = \"0.2.1\"\n");
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+
+    let packed_b = package_tarball_variant(
+        root.path(),
+        "b",
+        "pub fn answer() -> i64 { 222 }\n",
+        Some("poison"),
+    );
+    let checksum_b = packed_b.checksum.clone();
+    let registry_b = start_repair_registry(packed_b.data, packed_b.checksum);
+    write_config(&home, &cache, Some(&registry_b.api_url));
+    let seeded = run_pkg_bounded(
+        &home,
+        &seed_project,
+        &["install", "--registry", "mock"],
+        "seed adversarial generation B",
+    );
+    assert!(
+        seeded.status.success(),
+        "could not seed generation B\n{}",
+        describe_output(&seeded)
+    );
+    drop(registry_b);
+
+    let cache_registry = hew_pkg::registry::Registry::with_root(cache.clone());
+    let generation_b = cache_registry.package_dir("foo", "0.2.1");
+    assert_eq!(
+        std::fs::read_to_string(generation_b.join("foo.hew")).unwrap(),
+        "pub fn answer() -> i64 { 222 }\n"
+    );
+    let generation_b_name = generation_b
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let pointer = cache.join("foo/.0.2.1.current");
+
+    let packed_a = package_tarball_variant(
+        root.path(),
+        "a",
+        "pub fn answer() -> i64 { 111 }\n",
+        Some("slow"),
+    );
+    assert_ne!(packed_a.checksum, checksum_b);
+    let registry_a = start_repair_registry(packed_a.data, packed_a.checksum);
+    write_config(&home, &cache, Some(&registry_a.api_url));
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let writer_stop = Arc::clone(&stop);
+    let swaps = Arc::new(AtomicUsize::new(0));
+    let writer_swaps = Arc::clone(&swaps);
+    let writer = std::thread::spawn(move || {
+        let pointer_b = format!("{generation_b_name}\n");
+        while !writer_stop.load(Ordering::Acquire) {
+            if std::fs::read_to_string(&pointer)
+                .is_ok_and(|current| current.trim() != generation_b_name)
+            {
+                std::fs::write(&pointer, pointer_b.as_bytes()).unwrap();
+                writer_swaps.fetch_add(1, Ordering::Release);
+            }
+            std::thread::yield_now();
+        }
+    });
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--registry", "mock"],
+        "online verified-generation pointer swap",
+    );
+    stop.store(true, Ordering::Release);
+    writer.join().unwrap();
+    assert!(
+        output.status.success(),
+        "install of confirmed generation A failed\n{}",
+        describe_output(&output)
+    );
+    assert!(
+        swaps.load(Ordering::Acquire) > 0,
+        "counterfactual writer never replaced the A pointer with B"
+    );
+    assert_eq!(registry_a.package_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(registry_a.download_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        std::fs::read_to_string(project.join(".hew/packages/foo/foo.hew")).unwrap(),
+        "pub fn answer() -> i64 { 111 }\n",
+        "materialization must use the registry-confirmed A generation"
+    );
+    assert!(project.join(".hew/packages/slow/slow.hew").is_file());
+    assert!(!project.join(".hew/packages/poison").exists());
+    let lock = std::fs::read_to_string(project.join("hew.lock")).unwrap();
+    assert!(lock.contains("name = \"slow\""), "{lock}");
+    assert!(!lock.contains("name = \"poison\""), "{lock}");
 }
 
 #[test]

--- a/hew-cli/tests/pkg_resolver_e2e.rs
+++ b/hew-cli/tests/pkg_resolver_e2e.rs
@@ -2,9 +2,13 @@ mod support;
 
 use std::fmt::Write as _;
 use std::io::{Read as _, Write as _};
-use std::net::TcpListener;
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 use support::{describe_output, hew_binary};
 
@@ -76,6 +80,105 @@ fn start_404_registry() -> String {
     format!("http://{address}/api/v1")
 }
 
+struct RepairRegistry {
+    api_url: String,
+    package_requests: Arc<AtomicUsize>,
+    download_requests: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+    wake_address: SocketAddr,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for RepairRegistry {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = TcpStream::connect(self.wake_address);
+        if let Some(handle) = self.handle.take() {
+            let result = handle.join();
+            if !std::thread::panicking() {
+                result.expect("join mock registry");
+            }
+        }
+    }
+}
+
+fn start_repair_registry(tarball: Vec<u8>, checksum: String) -> RepairRegistry {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock registry");
+    let address = listener.local_addr().expect("mock registry address");
+    let api_url = format!("http://{address}/api/v1");
+    let download_url = format!("http://{address}/packages/foo/0.2.1.tar.zst");
+    let package_requests = Arc::new(AtomicUsize::new(0));
+    let download_requests = Arc::new(AtomicUsize::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_package_requests = Arc::clone(&package_requests);
+    let thread_download_requests = Arc::clone(&download_requests);
+    let thread_stop = Arc::clone(&stop);
+
+    let handle = std::thread::spawn(move || {
+        while !thread_stop.load(Ordering::Relaxed) {
+            let (mut stream, _) = listener.accept().expect("accept registry request");
+            if thread_stop.load(Ordering::Relaxed) {
+                break;
+            }
+            let mut request = [0_u8; 4096];
+            let bytes_read = stream.read(&mut request).expect("read registry request");
+            let request = String::from_utf8_lossy(&request[..bytes_read]);
+            let path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .expect("request path");
+
+            if path == "/api/v1/packages/foo" {
+                thread_package_requests.fetch_add(1, Ordering::Relaxed);
+                let body = serde_json::json!({
+                    "versions": [{
+                        "name": "foo",
+                        "vers": "0.2.1",
+                        "cksum": checksum,
+                        "sig": "",
+                        "key_fp": "",
+                        "dl": download_url,
+                    }]
+                })
+                .to_string();
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .expect("write package response");
+            } else if path == "/packages/foo/0.2.1.tar.zst" {
+                thread_download_requests.fetch_add(1, Ordering::Relaxed);
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    tarball.len()
+                )
+                .expect("write tarball headers");
+                stream.write_all(&tarball).expect("write tarball");
+            } else {
+                let body = r#"{"error":"not found"}"#;
+                write!(
+                    stream,
+                    "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .expect("write not-found response");
+            }
+        }
+    });
+
+    RepairRegistry {
+        api_url,
+        package_requests,
+        download_requests,
+        stop,
+        wake_address: address,
+        handle: Some(handle),
+    }
+}
+
 #[test]
 fn pkg_registry_404_refuses_stale_cache() {
     let root = support::tempdir();
@@ -135,5 +238,60 @@ fn pkg_offline_uses_cache_and_says_so() {
         stderr.contains(cache.to_string_lossy().as_ref()),
         "{stderr}"
     );
+    assert!(project.join(".hew/packages/foo/foo.hew").is_file());
+}
+
+#[test]
+fn pkg_online_repairs_incomplete_cache_without_loop() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    let package_source = root.path().join("foo-source");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&package_source).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    std::fs::write(
+        package_source.join("hew.toml"),
+        "[package]\nname = \"foo\"\nversion = \"0.2.1\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        package_source.join("foo.hew"),
+        "pub fn answer() -> i64 { 42 }\n",
+    )
+    .unwrap();
+    let packed = hew_pkg::tarball::pack(&package_source, &[], &[]).unwrap();
+    let registry = start_repair_registry(packed.data, packed.checksum);
+    write_config(&home, &cache, Some(&registry.api_url));
+
+    let incomplete = cache.join("foo").join("0.2.1");
+    std::fs::create_dir_all(&incomplete).unwrap();
+    std::fs::write(incomplete.join("partial.marker"), "incomplete").unwrap();
+
+    let mut command = Command::new(hew_binary());
+    command
+        .args(["install", "--registry", "mock"])
+        .current_dir(&project)
+        .env("HOME", &home)
+        .env_remove("USERPROFILE");
+    let output = support::try_run_bounded_command(
+        command,
+        "online install repairs incomplete cache",
+        Duration::from_secs(10),
+    )
+    .expect("online install must terminate");
+
+    assert!(
+        output.status.success(),
+        "online install should refetch an incomplete cache entry\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(registry.package_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(registry.download_requests.load(Ordering::Relaxed), 1);
+    assert!(incomplete.join("hew.toml").is_file());
+    assert!(incomplete.join("foo.hew").is_file());
+    assert!(!incomplete.join("partial.marker").exists());
     assert!(project.join(".hew/packages/foo/foo.hew").is_file());
 }

--- a/hew-cli/tests/pkg_resolver_e2e.rs
+++ b/hew-cli/tests/pkg_resolver_e2e.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::io::{Read as _, Write as _};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -71,6 +72,42 @@ fn run_pkg_bounded(home: &Path, project: &Path, args: &[&str], label: &str) -> O
         .env_remove("USERPROFILE");
     support::try_run_bounded_command(command, label, Duration::from_secs(30))
         .expect("package command must terminate")
+}
+
+fn snapshot_tree(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    fn visit(root: &Path, path: &Path, snapshot: &mut BTreeMap<PathBuf, Vec<u8>>) {
+        let mut entries = std::fs::read_dir(path)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let entry_path = entry.path();
+            let relative = entry_path.strip_prefix(root).unwrap().to_path_buf();
+            let metadata = std::fs::symlink_metadata(&entry_path).unwrap();
+            if metadata.file_type().is_symlink() {
+                snapshot.insert(
+                    relative,
+                    format!(
+                        "symlink:{}",
+                        std::fs::read_link(&entry_path).unwrap().display()
+                    )
+                    .into_bytes(),
+                );
+            } else if metadata.is_dir() {
+                snapshot.insert(relative.clone(), b"directory".to_vec());
+                visit(root, &entry_path, snapshot);
+            } else {
+                snapshot.insert(relative, std::fs::read(entry_path).unwrap());
+            }
+        }
+    }
+
+    let mut snapshot = BTreeMap::new();
+    if root.is_dir() {
+        visit(root, root, &mut snapshot);
+    }
+    snapshot
 }
 
 fn start_404_registry() -> String {
@@ -202,20 +239,8 @@ fn package_tarball_variant(
 ) -> hew_pkg::tarball::PackResult {
     let package_source = root.join(format!("foo-source-{label}"));
     std::fs::create_dir_all(&package_source).unwrap();
-    let dependency = path_dependency.map_or_else(String::new, |name| {
-        let dependency_root = package_source.join(name);
-        std::fs::create_dir_all(&dependency_root).unwrap();
-        std::fs::write(
-            dependency_root.join("hew.toml"),
-            format!("[package]\nname = \"{name}\"\nversion = \"1.0.0\"\n"),
-        )
-        .unwrap();
-        std::fs::write(
-            dependency_root.join(format!("{name}.hew")),
-            format!("pub fn identity() -> str {{ \"{label}-{name}\" }}\n"),
-        )
-        .unwrap();
-        format!("\n[dependencies]\n{name} = {{ path = \"{name}\" }}\n")
+    let dependency = path_dependency.map_or_else(String::new, |path| {
+        format!("\n[dependencies]\nevil = {{ path = {path:?} }}\n")
     });
     std::fs::write(
         package_source.join("hew.toml"),
@@ -226,15 +251,68 @@ fn package_tarball_variant(
     hew_pkg::tarball::pack(&package_source, &[], &[]).unwrap()
 }
 
+fn assert_registry_path_dependency_rejected(path: &str, label: &str) {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    let packed = package_tarball_variant(
+        root.path(),
+        label,
+        "pub fn answer() -> i64 { 42 }\n",
+        Some(path),
+    );
+    let registry = start_repair_registry(packed.data, packed.checksum);
+    write_config(&home, &cache, Some(&registry.api_url));
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--registry", "mock"],
+        "reject registry path dependency",
+    );
+    assert!(
+        !output.status.success(),
+        "registry path dependency must fail\n{}",
+        describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("forbidden path dependency"), "{stderr}");
+    assert!(stderr.contains(path), "{stderr}");
+    assert!(!project.join("hew.lock").exists());
+    assert!(!project.join(".hew").exists());
+    assert!(!cache.join(".registries").exists());
+    assert_eq!(registry.download_requests.load(Ordering::Relaxed), 1);
+}
+
 fn write_lockfile(project: &Path, version: &str, checksum: Option<&str>) {
     let checksum = checksum.map_or_else(String::new, |value| format!("checksum = {value:?}\n"));
+    let registry = hew_pkg::config::default_registry_identity();
     std::fs::write(
         project.join("hew.lock"),
         format!(
-            "[[package]]\nname = \"foo\"\nrequirement = \"0.2.1\"\nversion = {version:?}\n{checksum}"
+            "[[package]]\nname = \"foo\"\nrequirement = \"0.2.1\"\nversion = {version:?}\nregistry = {registry:?}\n{checksum}"
         ),
     )
     .unwrap();
+}
+
+#[test]
+fn pkg_rejects_relative_path_dependency_in_registry_archive_without_mutation() {
+    assert_registry_path_dependency_rejected("nested", "relative-path");
+}
+
+#[test]
+fn pkg_rejects_traversal_path_dependency_in_registry_archive_without_mutation() {
+    assert_registry_path_dependency_rejected("../../escape", "traversal-path");
+}
+
+#[test]
+fn pkg_rejects_absolute_path_dependency_in_registry_archive_without_mutation() {
+    assert_registry_path_dependency_rejected("/etc/hew-poison", "absolute-path");
 }
 
 #[test]
@@ -263,10 +341,7 @@ fn pkg_registry_404_refuses_stale_cache() {
         stderr.contains(&format!("{registry_api}/packages/foo")),
         "{stderr}"
     );
-    assert!(
-        stderr.contains(cached_path.to_string_lossy().as_ref()),
-        "{stderr}"
-    );
+    assert!(!stderr.contains(cached_path.to_string_lossy().as_ref()));
     assert!(stderr.contains("was not used"), "{stderr}");
     assert!(stderr.contains("--offline"), "{stderr}");
     assert!(!project.join(".hew/packages/foo").exists());
@@ -336,7 +411,11 @@ fn pkg_online_repairs_incomplete_cache_without_loop() {
     );
     assert_eq!(registry.package_requests.load(Ordering::Relaxed), 1);
     assert_eq!(registry.download_requests.load(Ordering::Relaxed), 1);
-    let active = hew_pkg::registry::Registry::with_root(cache.clone()).package_dir("foo", "0.2.1");
+    let active = hew_pkg::registry::Registry::with_root(cache.clone()).package_dir_for(
+        &hew_pkg::config::registry_identity(&registry.api_url),
+        "foo",
+        "0.2.1",
+    );
     assert!(active.join("hew.toml").is_file());
     assert!(active.join("foo.hew").is_file());
     assert!(incomplete.join("partial.marker").exists());
@@ -368,7 +447,8 @@ fn pkg_online_repairs_tampered_manifest_present_cache() {
         describe_output(&first)
     );
     let cache_registry = hew_pkg::registry::Registry::with_root(cache.clone());
-    let cached = cache_registry.package_dir("foo", "0.2.1");
+    let registry_id = hew_pkg::config::registry_identity(&registry.api_url);
+    let cached = cache_registry.package_dir_for(&registry_id, "foo", "0.2.1");
     std::fs::write(cached.join("foo.hew"), "pub fn answer() -> i64 { 7 }\n").unwrap();
 
     let output = run_pkg_bounded(
@@ -384,8 +464,12 @@ fn pkg_online_repairs_tampered_manifest_present_cache() {
     );
     assert_eq!(registry.download_requests.load(Ordering::Relaxed), 2);
     assert_eq!(
-        std::fs::read_to_string(cache_registry.package_dir("foo", "0.2.1").join("foo.hew"))
-            .unwrap(),
+        std::fs::read_to_string(
+            cache_registry
+                .package_dir_for(&registry_id, "foo", "0.2.1")
+                .join("foo.hew"),
+        )
+        .unwrap(),
         "pub fn answer() -> i64 { 42 }\n"
     );
     assert_eq!(
@@ -394,7 +478,7 @@ fn pkg_online_repairs_tampered_manifest_present_cache() {
         "published generations are immutable"
     );
     assert!(cache_registry
-        .package_dir("foo", "0.2.1")
+        .package_dir_for(&registry_id, "foo", "0.2.1")
         .join(".hew-registry-cache.toml")
         .is_file());
 }
@@ -485,11 +569,15 @@ fn pkg_concurrent_repair_downloads_and_publishes_once() {
         describe_output(&second_output)
     );
     assert_eq!(registry.package_requests.load(Ordering::Relaxed), 2);
-    assert_eq!(registry.download_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(registry.download_requests.load(Ordering::Relaxed), 2);
     assert_eq!(
         std::fs::read_to_string(
             hew_pkg::registry::Registry::with_root(cache)
-                .package_dir("foo", "0.2.1")
+                .package_dir_for(
+                    &hew_pkg::config::registry_identity(&registry.api_url),
+                    "foo",
+                    "0.2.1",
+                )
                 .join("foo.hew")
         )
         .unwrap(),
@@ -510,12 +598,8 @@ fn pkg_online_install_keeps_registry_confirmed_generation_after_pointer_swap() {
     write_manifest(&seed_project, "foo = \"0.2.1\"\n");
     write_manifest(&project, "foo = \"0.2.1\"\n");
 
-    let packed_b = package_tarball_variant(
-        root.path(),
-        "b",
-        "pub fn answer() -> i64 { 222 }\n",
-        Some("poison"),
-    );
+    let packed_b =
+        package_tarball_variant(root.path(), "b", "pub fn answer() -> i64 { 222 }\n", None);
     let checksum_b = packed_b.checksum.clone();
     let registry_b = start_repair_registry(packed_b.data, packed_b.checksum);
     write_config(&home, &cache, Some(&registry_b.api_url));
@@ -530,30 +614,39 @@ fn pkg_online_install_keeps_registry_confirmed_generation_after_pointer_swap() {
         "could not seed generation B\n{}",
         describe_output(&seeded)
     );
+    let adversarial_registry_id = hew_pkg::config::registry_identity(&registry_b.api_url);
     drop(registry_b);
 
     let cache_registry = hew_pkg::registry::Registry::with_root(cache.clone());
-    let generation_b = cache_registry.package_dir("foo", "0.2.1");
+    let generation_b = cache_registry.package_dir_for(&adversarial_registry_id, "foo", "0.2.1");
     assert_eq!(
         std::fs::read_to_string(generation_b.join("foo.hew")).unwrap(),
         "pub fn answer() -> i64 { 222 }\n"
     );
-    let generation_b_name = generation_b
+    let packed_a =
+        package_tarball_variant(root.path(), "a", "pub fn answer() -> i64 { 111 }\n", None);
+    assert_ne!(packed_a.checksum, checksum_b);
+    let registry_a = start_repair_registry(packed_a.data, packed_a.checksum);
+    write_config(&home, &cache, Some(&registry_a.api_url));
+    let verified_registry_id = hew_pkg::config::registry_identity(&registry_a.api_url);
+    let a_slot = cache_registry.package_dir_for(&verified_registry_id, "foo", "0.2.1");
+    let a_package_root = a_slot.parent().unwrap();
+    std::fs::create_dir_all(a_package_root).unwrap();
+    let adversarial_b = a_package_root.join(".0.2.1.generation-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    std::fs::create_dir_all(&adversarial_b).unwrap();
+    std::fs::copy(
+        generation_b.join("hew.toml"),
+        adversarial_b.join("hew.toml"),
+    )
+    .unwrap();
+    std::fs::copy(generation_b.join("foo.hew"), adversarial_b.join("foo.hew")).unwrap();
+    let generation_b_name = adversarial_b
         .file_name()
         .unwrap()
         .to_string_lossy()
         .into_owned();
-    let pointer = cache.join("foo/.0.2.1.current");
-
-    let packed_a = package_tarball_variant(
-        root.path(),
-        "a",
-        "pub fn answer() -> i64 { 111 }\n",
-        Some("slow"),
-    );
-    assert_ne!(packed_a.checksum, checksum_b);
-    let registry_a = start_repair_registry(packed_a.data, packed_a.checksum);
-    write_config(&home, &cache, Some(&registry_a.api_url));
+    let pointer = a_package_root.join(".0.2.1.current");
+    std::fs::write(&pointer, format!("{generation_b_name}\n")).unwrap();
 
     let stop = Arc::new(AtomicBool::new(false));
     let writer_stop = Arc::clone(&stop);
@@ -596,11 +689,6 @@ fn pkg_online_install_keeps_registry_confirmed_generation_after_pointer_swap() {
         "pub fn answer() -> i64 { 111 }\n",
         "materialization must use the registry-confirmed A generation"
     );
-    assert!(project.join(".hew/packages/slow/slow.hew").is_file());
-    assert!(!project.join(".hew/packages/poison").exists());
-    let lock = std::fs::read_to_string(project.join("hew.lock")).unwrap();
-    assert!(lock.contains("name = \"slow\""), "{lock}");
-    assert!(!lock.contains("name = \"poison\""), "{lock}");
 }
 
 #[test]
@@ -797,14 +885,21 @@ fn pkg_locked_uses_exact_version_and_never_rewrites_lockfile() {
 }
 
 #[test]
-fn pkg_locked_online_incomplete_graph_never_contacts_registry_or_mutates_cache() {
+#[expect(
+    clippy::too_many_lines,
+    reason = "one matrix shares setup and exact mutation snapshots across all invalid lock classes"
+)]
+fn pkg_locked_invalid_graphs_never_contact_registry_or_mutate_project_or_cache() {
     let root = support::tempdir();
     let home = root.path().join("home");
     let project = root.path().join("app");
+    let seed_project = root.path().join("seed");
     let cache = root.path().join("cache");
     std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&seed_project).unwrap();
     std::fs::create_dir_all(&home).unwrap();
     write_manifest(&project, "foo = \"0.2.1\"\n");
+    write_manifest(&seed_project, "baz = \"1.0.0\"\n");
     write_config(&home, &cache, None);
 
     let foo = write_cached_package(&cache, "foo", "0.2.1");
@@ -814,6 +909,7 @@ fn pkg_locked_online_incomplete_graph_never_contacts_registry_or_mutates_cache()
     )
     .unwrap();
     write_cached_package(&cache, "bar", "1.0.0");
+    write_cached_package(&cache, "baz", "1.0.0");
     let initial = run_pkg_bounded(
         &home,
         &project,
@@ -821,48 +917,105 @@ fn pkg_locked_online_incomplete_graph_never_contacts_registry_or_mutates_cache()
         "create complete lock",
     );
     assert!(initial.status.success(), "{}", describe_output(&initial));
+    let seed = run_pkg_bounded(
+        &home,
+        &seed_project,
+        &["install", "--offline"],
+        "create extra package lock entry",
+    );
+    assert!(seed.status.success(), "{}", describe_output(&seed));
 
     let complete_lock = std::fs::read_to_string(project.join("hew.lock")).unwrap();
-    let foo_entry = complete_lock
+    let entries = complete_lock
         .split("[[package]]")
         .skip(1)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let foo_entry = entries
+        .iter()
         .find(|entry| entry.contains("name = \"foo\""))
         .unwrap();
-    let incomplete_lock =
-        format!("# intentionally incomplete locked graph\n\n[[package]]{foo_entry}");
-    std::fs::write(project.join("hew.lock"), &incomplete_lock).unwrap();
-    std::fs::remove_dir_all(cache.join("bar")).unwrap();
+    let transitive_entry = entries
+        .iter()
+        .find(|entry| entry.contains("name = \"bar\""))
+        .unwrap();
+    let seed_lock = std::fs::read_to_string(seed_project.join("hew.lock")).unwrap();
+    let extra_entry = seed_lock
+        .split("[[package]]")
+        .skip(1)
+        .find(|entry| entry.contains("name = \"baz\""))
+        .unwrap();
+    let default_registry = hew_pkg::config::default_registry_identity();
+    let unsupported_entry = foo_entry.replacen(
+        "version = \"0.2.1\"",
+        "version = \"0.2.1\"\nsource = \"git\"",
+        1,
+    );
+    let wrong_registry_entry = foo_entry.replacen(
+        &format!("registry = {default_registry:?}"),
+        "registry = \"https://wrong.example/api/v1\"",
+        1,
+    );
+    let invalid_locks = [
+        (
+            "incomplete",
+            format!(
+                "# invalid locked graph\n\n[[package]]{foo_entry}[[package]]{transitive_entry}"
+            )
+            .replace(&format!("[[package]]{transitive_entry}"), ""),
+        ),
+        ("extra", format!("{complete_lock}\n[[package]]{extra_entry}")),
+        (
+            "duplicate",
+            format!("{complete_lock}\n[[package]]{foo_entry}"),
+        ),
+        (
+            "unsupported",
+            format!(
+                "# invalid locked graph\n\n[[package]]{unsupported_entry}[[package]]{transitive_entry}"
+            ),
+        ),
+        (
+            "wrong-registry",
+            format!(
+                "# invalid locked graph\n\n[[package]]{wrong_registry_entry}[[package]]{transitive_entry}"
+            ),
+        ),
+    ];
+
     std::fs::remove_dir_all(project.join(".hew")).unwrap();
+    std::fs::remove_dir_all(seed_project.join(".hew")).unwrap();
 
     let packed = package_tarball(root.path());
     let registry = start_repair_registry(packed.data, packed.checksum);
     write_config(&home, &cache, Some(&registry.api_url));
-    let foo_before = std::fs::read(foo.join("hew.toml")).unwrap();
+    for (case, invalid_lock) in invalid_locks {
+        std::fs::write(project.join("hew.lock"), invalid_lock).unwrap();
+        let project_before = snapshot_tree(&project);
+        let cache_before = snapshot_tree(&cache);
+        let output = run_pkg_bounded(
+            &home,
+            &project,
+            &["install", "--locked"],
+            &format!("invalid locked graph: {case}"),
+        );
+        assert!(
+            !output.status.success(),
+            "{case} locked graph must fail\n{}",
+            describe_output(&output)
+        );
+        assert_eq!(
+            snapshot_tree(&project),
+            project_before,
+            "{case} locked failure mutated the project"
+        );
+        assert_eq!(
+            snapshot_tree(&cache),
+            cache_before,
+            "{case} locked failure mutated the cache"
+        );
+    }
 
-    let output = run_pkg_bounded(
-        &home,
-        &project,
-        &["install", "--locked", "--registry", "mock"],
-        "online incomplete locked graph",
-    );
-    assert!(
-        !output.status.success(),
-        "incomplete locked graph must fail\n{}",
-        describe_output(&output)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("locked graph could not resolve"),
-        "{}",
-        describe_output(&output)
-    );
     assert_eq!(registry.package_requests.load(Ordering::Relaxed), 0);
     assert_eq!(registry.download_requests.load(Ordering::Relaxed), 0);
-    assert!(!cache.join(".locks").exists());
-    assert!(!cache.join("bar").exists());
-    assert_eq!(std::fs::read(foo.join("hew.toml")).unwrap(), foo_before);
-    assert_eq!(
-        std::fs::read_to_string(project.join("hew.lock")).unwrap(),
-        incomplete_lock
-    );
-    assert!(!project.join(".hew/packages/foo").exists());
 }

--- a/hew-cli/tests/pkg_resolver_e2e.rs
+++ b/hew-cli/tests/pkg_resolver_e2e.rs
@@ -1,0 +1,139 @@
+mod support;
+
+use std::fmt::Write as _;
+use std::io::{Read as _, Write as _};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use support::{describe_output, hew_binary};
+
+fn write_manifest(root: &Path, dependencies: &str) {
+    std::fs::write(
+        root.join("hew.toml"),
+        format!(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2026\"\n\n[dependencies]\n{dependencies}"
+        ),
+    )
+    .expect("write project manifest");
+}
+
+fn write_cached_package(cache: &Path, name: &str, version: &str) -> PathBuf {
+    let package = cache.join(name).join(version);
+    std::fs::create_dir_all(&package).expect("create cached package");
+    std::fs::write(
+        package.join("hew.toml"),
+        format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n"),
+    )
+    .expect("write cached package manifest");
+    std::fs::write(
+        package.join(format!("{name}.hew")),
+        "pub fn answer() -> i64 { 42 }\n",
+    )
+    .expect("write cached package source");
+    package
+}
+
+fn write_config(home: &Path, cache: &Path, registry_api: Option<&str>) {
+    let hew_home = home.join(".hew");
+    std::fs::create_dir_all(&hew_home).expect("create package-manager home");
+    let mut config = format!("[registry]\npath = {:?}\n", cache.to_string_lossy());
+    if let Some(api) = registry_api {
+        write!(
+            config,
+            "\n[registries.mock]\nindex = \"unused\"\napi = {api:?}\n"
+        )
+        .expect("format named registry config");
+    }
+    std::fs::write(hew_home.join("config.toml"), config).expect("write package config");
+}
+
+fn run_pkg(home: &Path, project: &Path, args: &[&str]) -> Output {
+    Command::new(hew_binary())
+        .args(args)
+        .current_dir(project)
+        .env("HOME", home)
+        .env_remove("USERPROFILE")
+        .output()
+        .expect("run hew package command")
+}
+
+fn start_404_registry() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock registry");
+    let address = listener.local_addr().expect("mock registry address");
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept registry request");
+        let mut request = [0_u8; 4096];
+        let _ = stream.read(&mut request);
+        let body = r#"{"error":"package not found"}"#;
+        write!(
+            stream,
+            "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+        .expect("write registry response");
+    });
+    format!("http://{address}/api/v1")
+}
+
+#[test]
+fn pkg_registry_404_refuses_stale_cache() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    let cached_path = write_cached_package(&cache, "foo", "0.2.1");
+    let registry_api = start_404_registry();
+    write_config(&home, &cache, Some(&registry_api));
+
+    let output = run_pkg(&home, &project, &["install", "--registry", "mock"]);
+    assert!(
+        !output.status.success(),
+        "registry miss must fail closed\n{}",
+        describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("foo"), "{stderr}");
+    assert!(stderr.contains("0.2.1"), "{stderr}");
+    assert!(
+        stderr.contains(&format!("{registry_api}/packages/foo")),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(cached_path.to_string_lossy().as_ref()),
+        "{stderr}"
+    );
+    assert!(stderr.contains("was not used"), "{stderr}");
+    assert!(stderr.contains("--offline"), "{stderr}");
+    assert!(!project.join(".hew/packages/foo").exists());
+}
+
+#[test]
+fn pkg_offline_uses_cache_and_says_so() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    write_cached_package(&cache, "foo", "0.2.1");
+    write_config(&home, &cache, None);
+
+    let output = run_pkg(&home, &project, &["install", "--offline"]);
+    assert!(
+        output.status.success(),
+        "offline install should use cache\n{}",
+        describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Offline mode"), "{stderr}");
+    assert!(
+        stderr.contains(cache.to_string_lossy().as_ref()),
+        "{stderr}"
+    );
+    assert!(project.join(".hew/packages/foo/foo.hew").is_file());
+}

--- a/hew-cli/tests/pkg_resolver_e2e.rs
+++ b/hew-cli/tests/pkg_resolver_e2e.rs
@@ -316,9 +316,10 @@ fn pkg_online_repairs_incomplete_cache_without_loop() {
     );
     assert_eq!(registry.package_requests.load(Ordering::Relaxed), 1);
     assert_eq!(registry.download_requests.load(Ordering::Relaxed), 1);
-    assert!(incomplete.join("hew.toml").is_file());
-    assert!(incomplete.join("foo.hew").is_file());
-    assert!(!incomplete.join("partial.marker").exists());
+    let active = hew_pkg::registry::Registry::with_root(cache.clone()).package_dir("foo", "0.2.1");
+    assert!(active.join("hew.toml").is_file());
+    assert!(active.join("foo.hew").is_file());
+    assert!(incomplete.join("partial.marker").exists());
     assert!(project.join(".hew/packages/foo/foo.hew").is_file());
 }
 
@@ -346,7 +347,8 @@ fn pkg_online_repairs_tampered_manifest_present_cache() {
         "initial online install failed\n{}",
         describe_output(&first)
     );
-    let cached = cache.join("foo/0.2.1");
+    let cache_registry = hew_pkg::registry::Registry::with_root(cache.clone());
+    let cached = cache_registry.package_dir("foo", "0.2.1");
     std::fs::write(cached.join("foo.hew"), "pub fn answer() -> i64 { 7 }\n").unwrap();
 
     let output = run_pkg_bounded(
@@ -362,10 +364,19 @@ fn pkg_online_repairs_tampered_manifest_present_cache() {
     );
     assert_eq!(registry.download_requests.load(Ordering::Relaxed), 2);
     assert_eq!(
-        std::fs::read_to_string(cached.join("foo.hew")).unwrap(),
+        std::fs::read_to_string(cache_registry.package_dir("foo", "0.2.1").join("foo.hew"))
+            .unwrap(),
         "pub fn answer() -> i64 { 42 }\n"
     );
-    assert!(cached.join(".hew-registry-cache.toml").is_file());
+    assert_eq!(
+        std::fs::read_to_string(cached.join("foo.hew")).unwrap(),
+        "pub fn answer() -> i64 { 7 }\n",
+        "published generations are immutable"
+    );
+    assert!(cache_registry
+        .package_dir("foo", "0.2.1")
+        .join(".hew-registry-cache.toml")
+        .is_file());
 }
 
 #[test]
@@ -456,7 +467,12 @@ fn pkg_concurrent_repair_downloads_and_publishes_once() {
     assert_eq!(registry.package_requests.load(Ordering::Relaxed), 2);
     assert_eq!(registry.download_requests.load(Ordering::Relaxed), 1);
     assert_eq!(
-        std::fs::read_to_string(cache.join("foo/0.2.1/foo.hew")).unwrap(),
+        std::fs::read_to_string(
+            hew_pkg::registry::Registry::with_root(cache)
+                .package_dir("foo", "0.2.1")
+                .join("foo.hew")
+        )
+        .unwrap(),
         "pub fn answer() -> i64 { 42 }\n"
     );
 }
@@ -554,5 +570,102 @@ fn pkg_locked_rejects_missing_cached_package() {
         String::from_utf8_lossy(&output.stderr).contains("is missing from cache"),
         "{}",
         describe_output(&output)
+    );
+}
+
+#[test]
+fn pkg_locked_uses_exact_version_and_never_rewrites_lockfile() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    write_config(&home, &cache, None);
+
+    let locked_package = write_cached_package(&cache, "foo", "0.2.1");
+    std::fs::write(
+        locked_package.join("foo.hew"),
+        "pub fn selected() -> i64 { 21 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        locked_package.join("hew.toml"),
+        "[package]\nname = \"foo\"\nversion = \"0.2.1\"\n\n[dependencies]\nbar = \"^1\"\n",
+    )
+    .unwrap();
+    let locked_bar = write_cached_package(&cache, "bar", "1.0.1");
+    std::fs::write(
+        locked_bar.join("bar.hew"),
+        "pub fn selected() -> i64 { 101 }\n",
+    )
+    .unwrap();
+    let initial = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--offline"],
+        "create initial lock",
+    );
+    assert!(initial.status.success(), "{}", describe_output(&initial));
+    let generated_lock = std::fs::read_to_string(project.join("hew.lock")).unwrap();
+    let lock_contents = generated_lock.replace(
+        "requirement = \"0.2.1\"",
+        "requirement = \"^0.2\" # retained verbatim by --locked",
+    );
+    assert_ne!(generated_lock, lock_contents);
+    std::fs::write(project.join("hew.lock"), &lock_contents).unwrap();
+    write_manifest(&project, "foo = \"^0.2\"\n");
+
+    let newer_package = write_cached_package(&cache, "foo", "0.2.2");
+    std::fs::write(
+        newer_package.join("foo.hew"),
+        "pub fn selected() -> i64 { 22 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        newer_package.join("hew.toml"),
+        "[package]\nname = \"foo\"\nversion = \"0.2.2\"\n\n[dependencies]\nbar = \"^1\"\n",
+    )
+    .unwrap();
+    let newer_bar = write_cached_package(&cache, "bar", "1.0.2");
+    std::fs::write(
+        newer_bar.join("bar.hew"),
+        "pub fn selected() -> i64 { 102 }\n",
+    )
+    .unwrap();
+    let materialized = project.join(".hew/packages/foo");
+    let metadata = std::fs::symlink_metadata(&materialized).unwrap();
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        std::fs::remove_file(&materialized).unwrap();
+    } else {
+        std::fs::remove_dir_all(&materialized).unwrap();
+    }
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--locked", "--offline"],
+        "locked exact version",
+    );
+    assert!(
+        output.status.success(),
+        "locked exact install failed\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        std::fs::read_to_string(project.join("hew.lock")).unwrap(),
+        lock_contents,
+        "--locked must not rewrite even formatting or comments"
+    );
+    assert_eq!(
+        std::fs::read_to_string(project.join(".hew/packages/foo/foo.hew")).unwrap(),
+        "pub fn selected() -> i64 { 21 }\n",
+        "a newer compatible cache entry must not supersede the locked version"
+    );
+    assert_eq!(
+        std::fs::read_to_string(project.join(".hew/packages/bar/bar.hew")).unwrap(),
+        "pub fn selected() -> i64 { 101 }\n",
+        "transitive packages must also use the exact locked graph"
     );
 }

--- a/hew-cli/tests/pkg_resolver_e2e.rs
+++ b/hew-cli/tests/pkg_resolver_e2e.rs
@@ -6,7 +6,7 @@ use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -60,6 +60,17 @@ fn run_pkg(home: &Path, project: &Path, args: &[&str]) -> Output {
         .env_remove("USERPROFILE")
         .output()
         .expect("run hew package command")
+}
+
+fn run_pkg_bounded(home: &Path, project: &Path, args: &[&str], label: &str) -> Output {
+    let mut command = Command::new(hew_binary());
+    command
+        .args(args)
+        .current_dir(project)
+        .env("HOME", home)
+        .env_remove("USERPROFILE");
+    support::try_run_bounded_command(command, label, Duration::from_secs(30))
+        .expect("package command must terminate")
 }
 
 fn start_404_registry() -> String {
@@ -179,6 +190,33 @@ fn start_repair_registry(tarball: Vec<u8>, checksum: String) -> RepairRegistry {
     }
 }
 
+fn package_tarball(root: &Path) -> hew_pkg::tarball::PackResult {
+    let package_source = root.join("foo-source");
+    std::fs::create_dir_all(&package_source).unwrap();
+    std::fs::write(
+        package_source.join("hew.toml"),
+        "[package]\nname = \"foo\"\nversion = \"0.2.1\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        package_source.join("foo.hew"),
+        "pub fn answer() -> i64 { 42 }\n",
+    )
+    .unwrap();
+    hew_pkg::tarball::pack(&package_source, &[], &[]).unwrap()
+}
+
+fn write_lockfile(project: &Path, version: &str, checksum: Option<&str>) {
+    let checksum = checksum.map_or_else(String::new, |value| format!("checksum = {value:?}\n"));
+    std::fs::write(
+        project.join("hew.lock"),
+        format!(
+            "[[package]]\nname = \"foo\"\nrequirement = \"0.2.1\"\nversion = {version:?}\n{checksum}"
+        ),
+    )
+    .unwrap();
+}
+
 #[test]
 fn pkg_registry_404_refuses_stale_cache() {
     let root = support::tempdir();
@@ -247,22 +285,10 @@ fn pkg_online_repairs_incomplete_cache_without_loop() {
     let home = root.path().join("home");
     let project = root.path().join("app");
     let cache = root.path().join("cache");
-    let package_source = root.path().join("foo-source");
     std::fs::create_dir_all(&project).unwrap();
     std::fs::create_dir_all(&home).unwrap();
-    std::fs::create_dir_all(&package_source).unwrap();
     write_manifest(&project, "foo = \"0.2.1\"\n");
-    std::fs::write(
-        package_source.join("hew.toml"),
-        "[package]\nname = \"foo\"\nversion = \"0.2.1\"\n",
-    )
-    .unwrap();
-    std::fs::write(
-        package_source.join("foo.hew"),
-        "pub fn answer() -> i64 { 42 }\n",
-    )
-    .unwrap();
-    let packed = hew_pkg::tarball::pack(&package_source, &[], &[]).unwrap();
+    let packed = package_tarball(root.path());
     let registry = start_repair_registry(packed.data, packed.checksum);
     write_config(&home, &cache, Some(&registry.api_url));
 
@@ -279,7 +305,7 @@ fn pkg_online_repairs_incomplete_cache_without_loop() {
     let output = support::try_run_bounded_command(
         command,
         "online install repairs incomplete cache",
-        Duration::from_secs(10),
+        Duration::from_secs(30),
     )
     .expect("online install must terminate");
 
@@ -294,4 +320,239 @@ fn pkg_online_repairs_incomplete_cache_without_loop() {
     assert!(incomplete.join("foo.hew").is_file());
     assert!(!incomplete.join("partial.marker").exists());
     assert!(project.join(".hew/packages/foo/foo.hew").is_file());
+}
+
+#[test]
+fn pkg_online_repairs_tampered_manifest_present_cache() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    let packed = package_tarball(root.path());
+    let registry = start_repair_registry(packed.data, packed.checksum);
+    write_config(&home, &cache, Some(&registry.api_url));
+
+    let first = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--registry", "mock"],
+        "initial verified cache install",
+    );
+    assert!(
+        first.status.success(),
+        "initial online install failed\n{}",
+        describe_output(&first)
+    );
+    let cached = cache.join("foo/0.2.1");
+    std::fs::write(cached.join("foo.hew"), "pub fn answer() -> i64 { 7 }\n").unwrap();
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--registry", "mock"],
+        "tampered cache repair",
+    );
+    assert!(
+        output.status.success(),
+        "online install should replace an unverified manifest-present cache\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(registry.download_requests.load(Ordering::Relaxed), 2);
+    assert_eq!(
+        std::fs::read_to_string(cached.join("foo.hew")).unwrap(),
+        "pub fn answer() -> i64 { 42 }\n"
+    );
+    assert!(cached.join(".hew-registry-cache.toml").is_file());
+}
+
+#[test]
+fn pkg_malformed_archive_preserves_untrusted_old_cache() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    let cached = write_cached_package(&cache, "foo", "0.2.1");
+    let old_source = std::fs::read(cached.join("foo.hew")).unwrap();
+    let malformed = b"not a zstd archive".to_vec();
+    let registry = start_repair_registry(
+        malformed.clone(),
+        hew_pkg::tarball::checksum_bytes(&malformed),
+    );
+    write_config(&home, &cache, Some(&registry.api_url));
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--registry", "mock"],
+        "malformed archive replacement",
+    );
+    assert!(
+        !output.status.success(),
+        "malformed replacement must fail\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(std::fs::read(cached.join("foo.hew")).unwrap(), old_source);
+    assert!(!cached.join(".hew-registry-cache.toml").exists());
+    assert!(!project.join(".hew/packages/foo").exists());
+}
+
+#[test]
+fn pkg_concurrent_repair_downloads_and_publishes_once() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let cache = root.path().join("cache");
+    let first_project = root.path().join("first");
+    let second_project = root.path().join("second");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&first_project).unwrap();
+    std::fs::create_dir_all(&second_project).unwrap();
+    write_manifest(&first_project, "foo = \"0.2.1\"\n");
+    write_manifest(&second_project, "foo = \"0.2.1\"\n");
+    write_cached_package(&cache, "foo", "0.2.1");
+    let packed = package_tarball(root.path());
+    let registry = start_repair_registry(packed.data, packed.checksum);
+    write_config(&home, &cache, Some(&registry.api_url));
+
+    let barrier = Arc::new(Barrier::new(2));
+    let run_install = |project: PathBuf, barrier: Arc<Barrier>| {
+        let home = home.clone();
+        std::thread::spawn(move || {
+            barrier.wait();
+            let mut command = Command::new(hew_binary());
+            command
+                .args(["install", "--registry", "mock"])
+                .current_dir(project)
+                .env("HOME", home)
+                .env_remove("USERPROFILE");
+            support::try_run_bounded_command(
+                command,
+                "concurrent package cache repair",
+                Duration::from_secs(30),
+            )
+            .expect("concurrent repair must terminate")
+        })
+    };
+    let first = run_install(first_project.clone(), Arc::clone(&barrier));
+    let second = run_install(second_project.clone(), barrier);
+    let first_output = first.join().unwrap();
+    let second_output = second.join().unwrap();
+
+    assert!(
+        first_output.status.success(),
+        "first concurrent install failed\n{}",
+        describe_output(&first_output)
+    );
+    assert!(
+        second_output.status.success(),
+        "second concurrent install failed\n{}",
+        describe_output(&second_output)
+    );
+    assert_eq!(registry.package_requests.load(Ordering::Relaxed), 2);
+    assert_eq!(registry.download_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        std::fs::read_to_string(cache.join("foo/0.2.1/foo.hew")).unwrap(),
+        "pub fn answer() -> i64 { 42 }\n"
+    );
+}
+
+#[test]
+fn pkg_locked_rejects_traversal_version_before_cache_lookup() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    write_config(&home, &cache, None);
+    write_lockfile(
+        &project,
+        "../../escape",
+        Some("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+    );
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--locked", "--offline"],
+        "traversal lock version",
+    );
+    assert!(
+        !output.status.success(),
+        "traversal lock version must fail\n{}",
+        describe_output(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid version"), "{stderr}");
+    assert!(!root.path().join("escape").exists());
+}
+
+#[test]
+fn pkg_locked_rejects_missing_registry_checksum() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    write_config(&home, &cache, None);
+    write_lockfile(&project, "0.2.1", None);
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--locked", "--offline"],
+        "missing locked checksum",
+    );
+    assert!(
+        !output.status.success(),
+        "missing locked checksum must fail\n{}",
+        describe_output(&output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("missing its locked checksum"),
+        "{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn pkg_locked_rejects_missing_cached_package() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    write_config(&home, &cache, None);
+    write_lockfile(
+        &project,
+        "0.2.1",
+        Some("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+    );
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--locked", "--offline"],
+        "missing locked cache",
+    );
+    assert!(
+        !output.status.success(),
+        "missing locked cache must fail\n{}",
+        describe_output(&output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("is missing from cache"),
+        "{}",
+        describe_output(&output)
+    );
 }

--- a/hew-cli/tests/pkg_resolver_e2e.rs
+++ b/hew-cli/tests/pkg_resolver_e2e.rs
@@ -669,3 +669,74 @@ fn pkg_locked_uses_exact_version_and_never_rewrites_lockfile() {
         "transitive packages must also use the exact locked graph"
     );
 }
+
+#[test]
+fn pkg_locked_online_incomplete_graph_never_contacts_registry_or_mutates_cache() {
+    let root = support::tempdir();
+    let home = root.path().join("home");
+    let project = root.path().join("app");
+    let cache = root.path().join("cache");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    write_manifest(&project, "foo = \"0.2.1\"\n");
+    write_config(&home, &cache, None);
+
+    let foo = write_cached_package(&cache, "foo", "0.2.1");
+    std::fs::write(
+        foo.join("hew.toml"),
+        "[package]\nname = \"foo\"\nversion = \"0.2.1\"\n\n[dependencies]\nbar = \"1.0.0\"\n",
+    )
+    .unwrap();
+    write_cached_package(&cache, "bar", "1.0.0");
+    let initial = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--offline"],
+        "create complete lock",
+    );
+    assert!(initial.status.success(), "{}", describe_output(&initial));
+
+    let complete_lock = std::fs::read_to_string(project.join("hew.lock")).unwrap();
+    let foo_entry = complete_lock
+        .split("[[package]]")
+        .skip(1)
+        .find(|entry| entry.contains("name = \"foo\""))
+        .unwrap();
+    let incomplete_lock =
+        format!("# intentionally incomplete locked graph\n\n[[package]]{foo_entry}");
+    std::fs::write(project.join("hew.lock"), &incomplete_lock).unwrap();
+    std::fs::remove_dir_all(cache.join("bar")).unwrap();
+    std::fs::remove_dir_all(project.join(".hew")).unwrap();
+
+    let packed = package_tarball(root.path());
+    let registry = start_repair_registry(packed.data, packed.checksum);
+    write_config(&home, &cache, Some(&registry.api_url));
+    let foo_before = std::fs::read(foo.join("hew.toml")).unwrap();
+
+    let output = run_pkg_bounded(
+        &home,
+        &project,
+        &["install", "--locked", "--registry", "mock"],
+        "online incomplete locked graph",
+    );
+    assert!(
+        !output.status.success(),
+        "incomplete locked graph must fail\n{}",
+        describe_output(&output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("locked graph could not resolve"),
+        "{}",
+        describe_output(&output)
+    );
+    assert_eq!(registry.package_requests.load(Ordering::Relaxed), 0);
+    assert_eq!(registry.download_requests.load(Ordering::Relaxed), 0);
+    assert!(!cache.join(".locks").exists());
+    assert!(!cache.join("bar").exists());
+    assert_eq!(std::fs::read(foo.join("hew.toml")).unwrap(), foo_before);
+    assert_eq!(
+        std::fs::read_to_string(project.join("hew.lock")).unwrap(),
+        incomplete_lock
+    );
+    assert!(!project.join(".hew/packages/foo").exists());
+}

--- a/hew-pkg/Cargo.toml
+++ b/hew-pkg/Cargo.toml
@@ -20,6 +20,8 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand = "0.10.1"
 rand_core = "0.10.1"
 base64.workspace = true
+fd-lock.workspace = true
+libc.workspace = true
 tar = "0.4"
 zstd = "0.13"
 ureq = { version = "3", features = ["json"] }

--- a/hew-pkg/Cargo.toml
+++ b/hew-pkg/Cargo.toml
@@ -27,7 +27,10 @@ zstd = "0.13"
 ureq = { version = "3", features = ["json"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/hew-pkg/Cargo.toml
+++ b/hew-pkg/Cargo.toml
@@ -30,6 +30,7 @@ ureq = { version = "3", features = ["json"] }
 windows-sys = { version = "0.61", features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
+  "Win32_System_IO",
 ] }
 
 [dev-dependencies]

--- a/hew-pkg/Cargo.toml
+++ b/hew-pkg/Cargo.toml
@@ -26,6 +26,9 @@ tar = "0.4"
 zstd = "0.13"
 ureq = { version = "3", features = ["json"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile.workspace = true
 tiny_http = "0.12"

--- a/hew-pkg/src/atomic_fs.rs
+++ b/hew-pkg/src/atomic_fs.rs
@@ -3,6 +3,8 @@ use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use rand::RngExt as _;
+
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub fn write_atomic(path: &Path, content: &[u8], mode: u32) -> io::Result<()> {
@@ -174,28 +176,53 @@ fn pointer_path_for(target: &Path) -> io::Result<PathBuf> {
 }
 
 fn generation_path_for(target: &Path) -> io::Result<PathBuf> {
+    let mut rng = rand::rng();
+    generation_path_for_with(target, || rng.random::<u128>())
+}
+
+fn generation_path_for_with<F>(target: &Path, mut nonce: F) -> io::Result<PathBuf>
+where
+    F: FnMut() -> u128,
+{
     let file_name = target
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?;
-    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    Ok(target.with_file_name(format!(
-        ".{file_name}.generation-{}-{counter}",
-        std::process::id()
-    )))
+    for _ in 0..100 {
+        let candidate = target.with_file_name(format!(".{file_name}.generation-{:032x}", nonce()));
+        match fs::symlink_metadata(&candidate) {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(candidate),
+            Ok(_) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate a unique generation name",
+    ))
 }
 
 /// Resolve a logical publication slot to its immutable active generation.
 /// A missing pointer denotes the legacy direct-directory representation.
-pub(crate) fn resolve_published_dir(target: &Path) -> PathBuf {
-    let Ok(pointer_path) = pointer_path_for(target) else {
-        return target.to_path_buf();
-    };
-    let Ok(pointer) = fs::read_to_string(pointer_path) else {
-        return target.to_path_buf();
+pub(crate) fn resolve_published_dir(target: &Path) -> io::Result<PathBuf> {
+    resolve_published_dir_with(target, |path| fs::read_to_string(path))
+}
+
+fn resolve_published_dir_with<F>(target: &Path, read_pointer: F) -> io::Result<PathBuf>
+where
+    F: FnOnce(&Path) -> io::Result<String>,
+{
+    let pointer_path = pointer_path_for(target)?;
+    let pointer = match read_pointer(&pointer_path) {
+        Ok(pointer) => pointer,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(target.to_path_buf()),
+        Err(error) => return Err(error),
     };
     let Some(target_name) = target.file_name().and_then(|name| name.to_str()) else {
-        return target.to_path_buf();
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path has no file name",
+        ));
     };
     let generation = pointer.trim();
     let expected_prefix = format!(".{target_name}.generation-");
@@ -203,11 +230,12 @@ pub(crate) fn resolve_published_dir(target: &Path) -> PathBuf {
         && !generation.contains('/')
         && !generation.contains('\\')
     {
-        target.with_file_name(generation)
+        Ok(target.with_file_name(generation))
     } else {
-        // Fail closed on a corrupt or attacker-controlled pointer rather than
-        // falling back to a potentially stale legacy directory.
-        target.with_file_name(format!(".{target_name}.invalid-generation-pointer"))
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid package generation pointer",
+        ))
     }
 }
 
@@ -340,7 +368,7 @@ mod tests {
         let reader_target = target.clone();
         let reader = std::thread::spawn(move || {
             while !reader_stop.load(Ordering::Relaxed) {
-                let active = resolve_published_dir(&reader_target);
+                let active = resolve_published_dir(&reader_target).unwrap();
                 if !matches!(
                     fs::read_to_string(active.join("state")).as_deref(),
                     Ok("old" | "new")
@@ -363,7 +391,7 @@ mod tests {
 
         assert!(!saw_partial.load(Ordering::Relaxed));
         assert!(matches!(
-            fs::read_to_string(resolve_published_dir(&target).join("state")).as_deref(),
+            fs::read_to_string(resolve_published_dir(&target).unwrap().join("state")).as_deref(),
             Ok("old" | "new")
         ));
     }
@@ -383,8 +411,54 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(
-            fs::read_to_string(resolve_published_dir(&target).join("state")).unwrap(),
+            fs::read_to_string(resolve_published_dir(&target).unwrap().join("state")).unwrap(),
             "old"
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_pointer_never_revives_stale_legacy_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("state"), "stale legacy").unwrap();
+        fs::write(pointer_path_for(&target).unwrap(), [0xff, 0xfe]).unwrap();
+
+        let error = resolve_published_dir(&target).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn unreadable_pointer_never_revives_stale_legacy_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("state"), "stale legacy").unwrap();
+
+        let error = resolve_published_dir_with(&target, |_| {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "simulated unreadable pointer",
+            ))
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn generation_name_retries_a_retained_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        let collision = target.with_file_name(format!(".package.generation-{:032x}", 7_u128));
+        fs::create_dir(&collision).unwrap();
+        let mut nonces = [7_u128, 8_u128].into_iter();
+
+        let generation = generation_path_for_with(&target, || nonces.next().unwrap()).unwrap();
+
+        assert_ne!(generation, collision);
+        assert_eq!(
+            generation.file_name().unwrap().to_string_lossy(),
+            format!(".package.generation-{:032x}", 8_u128)
         );
     }
 

--- a/hew-pkg/src/atomic_fs.rs
+++ b/hew-pkg/src/atomic_fs.rs
@@ -9,6 +9,67 @@ pub fn write_atomic(path: &Path, content: &[u8], mode: u32) -> io::Result<()> {
     write_atomic_with_hook(path, content, mode, |_| Ok(()))
 }
 
+#[derive(Debug)]
+pub struct StagedDir {
+    path: PathBuf,
+    active: bool,
+}
+
+impl StagedDir {
+    pub fn new(target: &Path) -> io::Result<Self> {
+        let parent = target.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "target has no parent directory",
+            )
+        })?;
+        fs::create_dir_all(parent)?;
+
+        for _ in 0..100 {
+            let path = temp_path_for(target)?;
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path, active: true }),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a unique staging directory",
+        ))
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn publish(mut self, target: &Path) -> io::Result<()> {
+        match fs::symlink_metadata(target) {
+            Ok(_) => {
+                exchange_paths(&self.path, target)?;
+                remove_path(&self.path)?;
+                self.active = false;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                fs::rename(&self.path, target)?;
+                self.active = false;
+            }
+            Err(error) => return Err(error),
+        }
+
+        sync_parent_dir(target)
+    }
+}
+
+impl Drop for StagedDir {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = remove_path(&self.path);
+        }
+    }
+}
+
 fn write_atomic_with_hook<F>(
     path: &Path,
     content: &[u8],
@@ -93,6 +154,85 @@ fn temp_path_for(path: &Path) -> io::Result<PathBuf> {
     Ok(path.with_file_name(format!(".{file_name}.tmp-{}-{counter}", std::process::id())))
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn exchange_paths(left: &Path, right: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let left = CString::new(left.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    let right = CString::new(right.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+
+    // SAFETY: both pointers remain valid for the duration of the syscall and
+    // identify existing paths on the same filesystem.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            libc::AT_FDCWD,
+            left.as_ptr(),
+            libc::AT_FDCWD,
+            right.as_ptr(),
+            libc::RENAME_EXCHANGE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn exchange_paths(left: &Path, right: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let left = CString::new(left.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+    let right = CString::new(right.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+
+    // SAFETY: both pointers remain valid for the duration of the call and
+    // identify existing paths on the same filesystem.
+    let result = unsafe { libc::renamex_np(left.as_ptr(), right.as_ptr(), libc::RENAME_SWAP) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "ios"
+)))]
+fn exchange_paths(left: &Path, right: &Path) -> io::Result<()> {
+    let backup = temp_path_for(right)?;
+    fs::rename(right, &backup)?;
+    if let Err(error) = fs::rename(left, right) {
+        let restore = fs::rename(&backup, right);
+        return match restore {
+            Ok(()) => Err(error),
+            Err(restore_error) => Err(io::Error::other(format!(
+                "publication failed: {error}; restoring previous content failed: {restore_error}"
+            ))),
+        };
+    }
+    fs::rename(backup, left)
+}
+
+fn remove_path(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+}
+
 fn sync_parent_dir(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
@@ -149,6 +289,46 @@ mod tests {
 
         assert_eq!(fs::read_to_string(&path).unwrap(), "old-token");
         assert_eq!(fs::read_to_string(&temp_path).unwrap(), "new-token");
+    }
+
+    #[test]
+    fn staged_directory_publication_never_exposes_partial_tree() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("state"), "old").unwrap();
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let saw_partial = Arc::new(AtomicBool::new(false));
+        let reader_stop = Arc::clone(&stop);
+        let reader_partial = Arc::clone(&saw_partial);
+        let reader_target = target.clone();
+        let reader = std::thread::spawn(move || {
+            while !reader_stop.load(Ordering::Relaxed) {
+                if !matches!(
+                    fs::read_to_string(reader_target.join("state")).as_deref(),
+                    Ok("old" | "new")
+                ) {
+                    reader_partial.store(true, Ordering::Relaxed);
+                    break;
+                }
+                std::thread::yield_now();
+            }
+        });
+
+        for index in 0..100 {
+            let staged = StagedDir::new(&target).unwrap();
+            let state = if index % 2 == 0 { "new" } else { "old" };
+            fs::write(staged.path().join("state"), state).unwrap();
+            staged.publish(&target).unwrap();
+        }
+        stop.store(true, Ordering::Relaxed);
+        reader.join().unwrap();
+
+        assert!(!saw_partial.load(Ordering::Relaxed));
     }
 
     #[cfg(unix)]

--- a/hew-pkg/src/atomic_fs.rs
+++ b/hew-pkg/src/atomic_fs.rs
@@ -1059,9 +1059,16 @@ mod tests {
         let reader = std::thread::spawn(move || {
             let mut first_read = true;
             while !reader_stop.load(Ordering::Relaxed) {
-                let active = resolve_published_dir(&reader_target).unwrap();
+                // Read through the same pinning authority used by package
+                // consumers.  Resolving the pointer alone neither serializes
+                // with pointer replacement nor leases the returned generation:
+                // Windows may report the former race as a sharing violation,
+                // and a collector may retire the generation before `state` is
+                // opened.  The pin couples the slot lock and generation lease
+                // for the entire tree read.
+                let active = pin_published_dir(&reader_target).unwrap();
                 if !matches!(
-                    fs::read_to_string(active.join("state")).as_deref(),
+                    fs::read_to_string(active.path().join("state")).as_deref(),
                     Ok("old" | "new")
                 ) {
                     reader_partial.store(true, Ordering::Relaxed);
@@ -1090,8 +1097,9 @@ mod tests {
 
         assert!(!saw_partial.load(Ordering::Relaxed));
         assert!(reads.load(Ordering::Relaxed) > 0);
+        let active = pin_published_dir(&target).unwrap();
         assert!(matches!(
-            fs::read_to_string(resolve_published_dir(&target).unwrap().join("state")).as_deref(),
+            fs::read_to_string(active.path().join("state")).as_deref(),
             Ok("old" | "new")
         ));
     }

--- a/hew-pkg/src/atomic_fs.rs
+++ b/hew-pkg/src/atomic_fs.rs
@@ -2,10 +2,12 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
 
 use rand::RngExt as _;
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+const RETAINED_SUPERSEDED_GENERATIONS: usize = 2;
 
 pub fn write_atomic(path: &Path, content: &[u8], mode: u32) -> io::Result<()> {
     write_atomic_with_hook(path, content, mode, |_| Ok(()))
@@ -46,10 +48,17 @@ impl StagedDir {
         &self.path
     }
 
+    #[cfg(test)]
     pub fn publish(mut self, target: &Path) -> io::Result<PathBuf> {
-        self.publish_with_hook(target, || Ok(()))
+        let pinned = self.publish_pinned_with_hooks(target, || Ok(()), || Ok(()))?;
+        Ok(pinned.path().to_path_buf())
     }
 
+    pub(crate) fn publish_pinned(mut self, target: &Path) -> io::Result<PinnedDir> {
+        self.publish_pinned_with_hooks(target, || Ok(()), || Ok(()))
+    }
+
+    #[cfg(test)]
     fn publish_with_hook<F>(
         &mut self,
         target: &Path,
@@ -58,25 +67,96 @@ impl StagedDir {
     where
         F: FnOnce() -> io::Result<()>,
     {
+        let pinned = self.publish_pinned_with_hooks(target, before_pointer_replace, || Ok(()))?;
+        Ok(pinned.path().to_path_buf())
+    }
+
+    #[cfg(test)]
+    fn publish_with_hooks<B, A>(
+        &mut self,
+        target: &Path,
+        before_pointer_replace: B,
+        after_pointer_replace: A,
+    ) -> io::Result<PathBuf>
+    where
+        B: FnOnce() -> io::Result<()>,
+        A: FnOnce() -> io::Result<()>,
+    {
+        let pinned =
+            self.publish_pinned_with_hooks(target, before_pointer_replace, after_pointer_replace)?;
+        Ok(pinned.path().to_path_buf())
+    }
+
+    fn publish_pinned_with_hooks<B, A>(
+        &mut self,
+        target: &Path,
+        before_pointer_replace: B,
+        after_pointer_replace: A,
+    ) -> io::Result<PinnedDir>
+    where
+        B: FnOnce() -> io::Result<()>,
+        A: FnOnce() -> io::Result<()>,
+    {
+        let _slot_lock = lock_slot(target, LockMode::Exclusive, false)?
+            .expect("a blocking lock acquisition always returns a guard");
         let generation = generation_path_for(target)?;
         fs::rename(&self.path, &generation)?;
         self.active = false;
-        sync_parent_dir(&generation)?;
+        let mut ownership = RenamedGeneration::new(generation.clone());
+        if let Err(error) = sync_parent_dir(&generation) {
+            return Err(ownership.reclaim_after(error));
+        }
 
-        before_pointer_replace()?;
+        if let Err(error) = before_pointer_replace() {
+            return Err(ownership.reclaim_after(error));
+        }
+        let lease_path = match generation_lease_path_for(&generation) {
+            Ok(path) => path,
+            Err(error) => return Err(ownership.reclaim_after(error)),
+        };
+        let generation_lock = match lock_file(&lease_path, LockMode::Shared, false) {
+            Ok(Some(lock)) => lock,
+            Ok(None) => unreachable!("a blocking lock acquisition always returns a guard"),
+            Err(error) => return Err(ownership.reclaim_after(error)),
+        };
 
-        let generation_name = generation
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "invalid generation name")
-            })?;
-        write_atomic(
-            &pointer_path_for(target)?,
+        let Some(generation_name) = generation.file_name().and_then(|name| name.to_str()) else {
+            return Err(ownership.reclaim_after(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid generation name",
+            )));
+        };
+        let pointer = pointer_path_for(target)?;
+        let publish_result = write_atomic_with_commit_hook(
+            &pointer,
             format!("{generation_name}\n").as_bytes(),
             0o644,
-        )?;
-        Ok(generation)
+            || {
+                ownership.release();
+                after_pointer_replace()
+            },
+        );
+        if let Err(error) = publish_result {
+            if ownership.owned {
+                match resolve_published_dir_with(target, read_pointer) {
+                    Ok(active) if active == generation => ownership.release(),
+                    Ok(_) => {}
+                    Err(_) => ownership.release(),
+                }
+            }
+            if ownership.owned {
+                return Err(ownership.reclaim_after(error));
+            }
+            return Err(error);
+        }
+        ownership.release();
+        cleanup_generations_locked(target);
+        Ok(PinnedDir {
+            path: generation,
+            lease: Some(GenerationLease {
+                lock: Some(generation_lock),
+            }),
+        })
     }
 }
 
@@ -97,6 +177,32 @@ fn write_atomic_with_hook<F>(
 where
     F: FnOnce(&Path) -> io::Result<()>,
 {
+    write_atomic_with_hooks(path, content, mode, before_rename, || Ok(()))
+}
+
+fn write_atomic_with_commit_hook<F>(
+    path: &Path,
+    content: &[u8],
+    mode: u32,
+    after_replace: F,
+) -> io::Result<()>
+where
+    F: FnOnce() -> io::Result<()>,
+{
+    write_atomic_with_hooks(path, content, mode, |_| Ok(()), after_replace)
+}
+
+fn write_atomic_with_hooks<B, A>(
+    path: &Path,
+    content: &[u8],
+    mode: u32,
+    before_rename: B,
+    after_replace: A,
+) -> io::Result<()>
+where
+    B: FnOnce(&Path) -> io::Result<()>,
+    A: FnOnce() -> io::Result<()>,
+{
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -115,8 +221,51 @@ where
     before_rename(&temp_path)?;
 
     replace_file(&temp_path, path)?;
+    after_replace()?;
     sync_parent_dir(path)?;
     Ok(())
+}
+
+#[derive(Debug)]
+struct RenamedGeneration {
+    path: PathBuf,
+    owned: bool,
+}
+
+impl RenamedGeneration {
+    fn new(path: PathBuf) -> Self {
+        Self { path, owned: true }
+    }
+
+    fn release(&mut self) {
+        self.owned = false;
+    }
+
+    fn reclaim_after(&mut self, publication_error: io::Error) -> io::Error {
+        match remove_path(&self.path) {
+            Ok(()) => {
+                self.owned = false;
+                if let Err(sync_error) = sync_parent_dir(&self.path) {
+                    return io::Error::other(format!(
+                        "{publication_error}; never-active generation was removed but its parent could not be synchronized: {sync_error}"
+                    ));
+                }
+                publication_error
+            }
+            Err(reclaim_error) => io::Error::other(format!(
+                "{publication_error}; could not reclaim never-active generation {}: {reclaim_error}",
+                self.path.display()
+            )),
+        }
+    }
+}
+
+impl Drop for RenamedGeneration {
+    fn drop(&mut self) {
+        if self.owned {
+            let _ = remove_path(&self.path);
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -180,6 +329,22 @@ fn pointer_path_for(target: &Path) -> io::Result<PathBuf> {
     Ok(target.with_file_name(format!(".{file_name}.current")))
 }
 
+fn slot_lock_path_for(target: &Path) -> io::Result<PathBuf> {
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?;
+    Ok(target.with_file_name(format!(".{file_name}.slot.lock")))
+}
+
+fn generation_lease_path_for(generation: &Path) -> io::Result<PathBuf> {
+    let file_name = generation
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?;
+    Ok(generation.with_file_name(format!("{file_name}.lease")))
+}
+
 fn generation_path_for(target: &Path) -> io::Result<PathBuf> {
     let mut rng = rand::rng();
     generation_path_for_with(target, || rng.random::<u128>())
@@ -211,6 +376,113 @@ where
 /// A missing pointer denotes the legacy direct-directory representation.
 pub(crate) fn resolve_published_dir(target: &Path) -> io::Result<PathBuf> {
     resolve_published_dir_with(target, read_pointer)
+}
+
+/// An immutable published directory held under a cross-process generation
+/// lease. Legacy direct directories are never generation-collected and carry
+/// no generation lease.
+#[derive(Debug)]
+pub(crate) struct PinnedDir {
+    path: PathBuf,
+    lease: Option<GenerationLease>,
+}
+
+impl PinnedDir {
+    pub(crate) fn legacy(path: PathBuf) -> Self {
+        Self { path, lease: None }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn canonicalize(mut self) -> io::Result<Self> {
+        self.path = self.path.canonicalize()?;
+        Ok(self)
+    }
+
+    pub(crate) fn is_generation(&self) -> bool {
+        self.lease.is_some()
+    }
+}
+
+#[derive(Debug)]
+struct GenerationLease {
+    lock: Option<FileLock>,
+}
+
+impl Drop for GenerationLease {
+    fn drop(&mut self) {
+        if let Some(mut lock) = self.lock.take() {
+            lock.unlock();
+        }
+    }
+}
+
+/// Pin the active immutable generation while holding the slot lock across the
+/// pointer read and lease acquisition.
+pub(crate) fn pin_published_dir(target: &Path) -> io::Result<PinnedDir> {
+    let pointer = pointer_path_for(target)?;
+    match fs::symlink_metadata(&pointer) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            validate_generation_directory(target)?;
+            return Ok(PinnedDir::legacy(target.to_path_buf()));
+        }
+        Err(error) => return Err(error),
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "published package pointer is not a regular file: {}",
+                    pointer.display()
+                ),
+            ));
+        }
+        Ok(_) => {}
+    }
+
+    let _slot_lock = lock_slot_existing(target, LockMode::Shared, false)?
+        .expect("a blocking lock acquisition always returns a guard");
+    let path = resolve_published_dir(target)?;
+    validate_generation_directory(&path)?;
+    let lease_path = generation_lease_path_for(&path)?;
+    let lock = lock_file_existing(&lease_path, LockMode::Shared, false)?
+        .expect("a blocking lock acquisition always returns a guard");
+    validate_generation_directory(&path)?;
+    Ok(PinnedDir {
+        path,
+        lease: Some(GenerationLease { lock: Some(lock) }),
+    })
+}
+
+pub(crate) fn pin_published_dir_if_present(target: &Path) -> io::Result<Option<PinnedDir>> {
+    let pointer = pointer_path_for(target)?;
+    let target_state = fs::symlink_metadata(target);
+    let pointer_state = fs::symlink_metadata(&pointer);
+    match (target_state, pointer_state) {
+        (Err(target_error), Err(pointer_error))
+            if target_error.kind() == io::ErrorKind::NotFound
+                && pointer_error.kind() == io::ErrorKind::NotFound =>
+        {
+            Ok(None)
+        }
+        (Err(error), _) | (_, Err(error)) if error.kind() != io::ErrorKind::NotFound => Err(error),
+        _ => pin_published_dir(target).map(Some),
+    }
+}
+
+fn validate_generation_directory(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "published package generation is not a directory: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(not(windows))]
@@ -264,16 +536,290 @@ where
     };
     let generation = pointer.trim();
     let expected_prefix = format!(".{target_name}.generation-");
-    if generation.starts_with(&expected_prefix)
-        && !generation.contains('/')
-        && !generation.contains('\\')
-    {
+    if is_generation_name(generation, &expected_prefix) {
         Ok(target.with_file_name(generation))
     } else {
         Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "invalid package generation pointer",
         ))
+    }
+}
+
+fn is_generation_name(name: &str, prefix: &str) -> bool {
+    name.strip_prefix(prefix).is_some_and(|nonce| {
+        nonce.len() == 32 && nonce.as_bytes().iter().all(u8::is_ascii_hexdigit)
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LockMode {
+    Shared,
+    Exclusive,
+}
+
+#[derive(Debug)]
+struct FileLock {
+    file: Option<File>,
+}
+
+impl FileLock {
+    fn unlock(&mut self) {
+        if let Some(file) = self.file.take() {
+            os_unlock(&file);
+        }
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        self.unlock();
+    }
+}
+
+fn lock_slot(target: &Path, mode: LockMode, nonblocking: bool) -> io::Result<Option<FileLock>> {
+    lock_file(&slot_lock_path_for(target)?, mode, nonblocking)
+}
+
+fn lock_slot_existing(
+    target: &Path,
+    mode: LockMode,
+    nonblocking: bool,
+) -> io::Result<Option<FileLock>> {
+    lock_file_existing(&slot_lock_path_for(target)?, mode, nonblocking)
+}
+
+fn lock_file(path: &Path, mode: LockMode, nonblocking: bool) -> io::Result<Option<FileLock>> {
+    lock_file_with_create(path, mode, nonblocking, true)
+}
+
+fn lock_file_existing(
+    path: &Path,
+    mode: LockMode,
+    nonblocking: bool,
+) -> io::Result<Option<FileLock>> {
+    lock_file_with_create(path, mode, nonblocking, false)
+}
+
+fn lock_file_with_create(
+    path: &Path,
+    mode: LockMode,
+    nonblocking: bool,
+    create: bool,
+) -> io::Result<Option<FileLock>> {
+    if let Some(parent) = path.parent() {
+        if create {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    if let Ok(metadata) = fs::symlink_metadata(path) {
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("lock path is not a regular file: {}", path.display()),
+            ));
+        }
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(create)
+        .truncate(false)
+        .open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("lock path is not a regular file: {}", path.display()),
+        ));
+    }
+    if os_lock(&file, mode, nonblocking)? {
+        Ok(Some(FileLock { file: Some(file) }))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(unix)]
+fn os_lock(file: &File, mode: LockMode, nonblocking: bool) -> io::Result<bool> {
+    use std::os::fd::AsRawFd as _;
+
+    let operation = match mode {
+        LockMode::Shared => libc::LOCK_SH,
+        LockMode::Exclusive => libc::LOCK_EX,
+    } | if nonblocking { libc::LOCK_NB } else { 0 };
+    loop {
+        // SAFETY: the descriptor belongs to `file` and remains open throughout
+        // the call.
+        if unsafe { libc::flock(file.as_raw_fd(), operation) } == 0 {
+            return Ok(true);
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() == io::ErrorKind::Interrupted {
+            continue;
+        }
+        if nonblocking && error.kind() == io::ErrorKind::WouldBlock {
+            return Ok(false);
+        }
+        return Err(error);
+    }
+}
+
+#[cfg(unix)]
+fn os_unlock(file: &File) {
+    use std::os::fd::AsRawFd as _;
+
+    // SAFETY: the descriptor belongs to `file` and remains open for this call.
+    let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+}
+
+#[cfg(windows)]
+fn os_lock(file: &File, mode: LockMode, nonblocking: bool) -> io::Result<bool> {
+    use std::mem::zeroed;
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+    };
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let mut flags = match mode {
+        LockMode::Shared => 0,
+        LockMode::Exclusive => LOCKFILE_EXCLUSIVE_LOCK,
+    };
+    if nonblocking {
+        flags |= LOCKFILE_FAIL_IMMEDIATELY;
+    }
+    // SAFETY: zero is a valid OVERLAPPED value for a synchronous whole-file
+    // lock, and the file handle remains open while the lock is held.
+    let mut overlapped: OVERLAPPED = unsafe { zeroed() };
+    let result = unsafe {
+        LockFileEx(
+            file.as_raw_handle(),
+            flags,
+            0,
+            u32::MAX,
+            u32::MAX,
+            &raw mut overlapped,
+        )
+    };
+    if result != 0 {
+        return Ok(true);
+    }
+    let error = io::Error::last_os_error();
+    if nonblocking && error.raw_os_error() == Some(ERROR_LOCK_VIOLATION.cast_signed()) {
+        Ok(false)
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(windows)]
+fn os_unlock(file: &File) {
+    use std::mem::zeroed;
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::UnlockFileEx;
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    // SAFETY: this unlocks the same whole-file byte range used by `os_lock`;
+    // the file handle remains open throughout the call.
+    let mut overlapped: OVERLAPPED = unsafe { zeroed() };
+    let _ = unsafe {
+        UnlockFileEx(
+            file.as_raw_handle(),
+            0,
+            u32::MAX,
+            u32::MAX,
+            &raw mut overlapped,
+        )
+    };
+}
+
+#[derive(Debug)]
+struct GenerationCandidate {
+    path: PathBuf,
+    modified: SystemTime,
+    name: String,
+}
+
+/// Collect only generations beyond the bounded recent-history allowance.
+/// Every uncertainty is handled by retaining the affected generation.
+fn cleanup_generations_locked(target: &Path) {
+    let Ok(active) = resolve_published_dir(target) else {
+        return;
+    };
+    if active == target {
+        return;
+    }
+    let Some(parent) = target.parent() else {
+        return;
+    };
+    let Some(target_name) = target.file_name().and_then(|name| name.to_str()) else {
+        return;
+    };
+    let prefix = format!(".{target_name}.generation-");
+    let Ok(entries) = fs::read_dir(parent) else {
+        return;
+    };
+    let mut candidates = Vec::new();
+    for entry in entries {
+        let Ok(entry) = entry else {
+            return;
+        };
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if !is_generation_name(&name, &prefix) {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if path == active {
+            continue;
+        }
+        let Ok(modified) = entry.metadata().and_then(|metadata| metadata.modified()) else {
+            continue;
+        };
+        candidates.push(GenerationCandidate {
+            path,
+            modified,
+            name,
+        });
+    }
+    candidates.sort_by(|left, right| {
+        right
+            .modified
+            .cmp(&left.modified)
+            .then_with(|| right.name.cmp(&left.name))
+    });
+
+    for candidate in candidates.into_iter().skip(RETAINED_SUPERSEDED_GENERATIONS) {
+        let Ok(lease_path) = generation_lease_path_for(&candidate.path) else {
+            continue;
+        };
+        let Ok(Some(collector_lease)) = lock_file_existing(&lease_path, LockMode::Exclusive, true)
+        else {
+            continue;
+        };
+        let Ok(current) = resolve_published_dir(target) else {
+            continue;
+        };
+        if current == candidate.path {
+            continue;
+        }
+        let Ok(metadata) = fs::symlink_metadata(&candidate.path) else {
+            continue;
+        };
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            continue;
+        }
+        if fs::remove_dir_all(&candidate.path).is_ok() {
+            drop(collector_lease);
+            let _ = fs::remove_file(lease_path);
+        }
     }
 }
 
@@ -456,6 +1002,29 @@ where
 mod tests {
     use super::*;
 
+    fn generation_dirs(target: &Path) -> Vec<PathBuf> {
+        let parent = target.parent().unwrap();
+        let prefix = format!(
+            ".{}.generation-",
+            target.file_name().unwrap().to_string_lossy()
+        );
+        fs::read_dir(parent)
+            .unwrap()
+            .map(Result::unwrap)
+            .filter(|entry| {
+                entry.file_name().to_string_lossy().starts_with(&prefix)
+                    && entry.file_type().unwrap().is_dir()
+            })
+            .map(|entry| entry.path())
+            .collect()
+    }
+
+    fn publish_state(target: &Path, state: &str) -> PathBuf {
+        let staged = StagedDir::new(target).unwrap();
+        fs::write(staged.path().join("state"), state).unwrap();
+        staged.publish(target).unwrap()
+    }
+
     #[test]
     fn interrupted_atomic_write_keeps_original_target() {
         let dir = tempfile::tempdir().unwrap();
@@ -545,6 +1114,138 @@ mod tests {
             fs::read_to_string(resolve_published_dir(&target).unwrap().join("state")).unwrap(),
             "old"
         );
+        assert!(
+            generation_dirs(&target).is_empty(),
+            "the renamed never-active generation must be reclaimed immediately"
+        );
+    }
+
+    #[test]
+    fn post_commit_failure_retains_potentially_active_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        let mut staged = StagedDir::new(&target).unwrap();
+        fs::write(staged.path().join("state"), "committed").unwrap();
+
+        let error = staged
+            .publish_with_hooks(
+                &target,
+                || Ok(()),
+                || Err(io::Error::other("simulated parent durability failure")),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        let active = resolve_published_dir(&target).unwrap();
+        assert_eq!(
+            fs::read_to_string(active.join("state")).unwrap(),
+            "committed"
+        );
+        assert_eq!(generation_dirs(&target), [active]);
+    }
+
+    #[test]
+    fn successful_swaps_have_bounded_generation_retention() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+
+        for index in 0..12 {
+            publish_state(&target, &index.to_string());
+        }
+
+        assert!(generation_dirs(&target).len() <= 3);
+        assert_eq!(
+            fs::read_to_string(resolve_published_dir(&target).unwrap().join("state")).unwrap(),
+            "11"
+        );
+    }
+
+    #[test]
+    fn pinned_old_generation_is_collected_by_later_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        let first = publish_state(&target, "first");
+        let pinned = pin_published_dir(&target).unwrap();
+        assert_eq!(pinned.path(), first);
+
+        for index in 0..6 {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            publish_state(&target, &format!("new-{index}"));
+        }
+
+        assert_eq!(
+            fs::read_to_string(pinned.path().join("state")).unwrap(),
+            "first"
+        );
+        assert!(first.is_dir());
+        assert!(generation_dirs(&target).len() > 3);
+
+        drop(pinned);
+
+        assert!(
+            first.exists(),
+            "releasing a read lease must not trigger collection"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        publish_state(&target, "cleanup-trigger");
+
+        assert!(!first.exists());
+        assert!(generation_dirs(&target).len() <= 3);
+    }
+
+    #[test]
+    fn a_recent_non_current_generation_is_not_deleted_merely_for_being_old() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        let first = publish_state(&target, "first");
+        publish_state(&target, "second");
+
+        assert!(first.is_dir());
+        assert_eq!(generation_dirs(&target).len(), 2);
+    }
+
+    #[test]
+    fn os_reader_lock_blocks_nonblocking_collector_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("generation.lease");
+        let reader = lock_file(&lock_path, LockMode::Shared, false)
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            lock_file(&lock_path, LockMode::Exclusive, true)
+                .unwrap()
+                .is_none(),
+            "an active OS reader lease must exclude collection"
+        );
+        drop(reader);
+        assert!(
+            lock_file(&lock_path, LockMode::Exclusive, true)
+                .unwrap()
+                .is_some(),
+            "releasing the reader lease must permit collection"
+        );
+    }
+
+    #[test]
+    fn uncertain_lease_metadata_retains_collection_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        let retained = publish_state(&target, "retained");
+        let lease_path = generation_lease_path_for(&retained).unwrap();
+        fs::remove_file(&lease_path).unwrap();
+        fs::create_dir(&lease_path).unwrap();
+
+        for index in 0..5 {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            publish_state(&target, &format!("new-{index}"));
+        }
+
+        assert!(
+            retained.is_dir(),
+            "invalid lock metadata must fail closed by retaining the generation"
+        );
+        assert!(generation_dirs(&target).len() > 3);
     }
 
     #[test]

--- a/hew-pkg/src/atomic_fs.rs
+++ b/hew-pkg/src/atomic_fs.rs
@@ -210,7 +210,40 @@ where
 /// Resolve a logical publication slot to its immutable active generation.
 /// A missing pointer denotes the legacy direct-directory representation.
 pub(crate) fn resolve_published_dir(target: &Path) -> io::Result<PathBuf> {
-    resolve_published_dir_with(target, |path| fs::read_to_string(path))
+    resolve_published_dir_with(target, read_pointer)
+}
+
+#[cfg(not(windows))]
+fn read_pointer(path: &Path) -> io::Result<String> {
+    fs::read_to_string(path)
+}
+
+#[cfg(windows)]
+fn read_pointer(path: &Path) -> io::Result<String> {
+    use std::io::Read as _;
+
+    let mut file = open_pointer_file(path)?;
+    let mut pointer = String::new();
+    file.read_to_string(&mut pointer)?;
+    Ok(pointer)
+}
+
+#[cfg(windows)]
+fn open_pointer_file(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+
+    let mut options = OpenOptions::new();
+    options.read(true).share_mode(windows_pointer_share_mode());
+    options.open(path)
+}
+
+#[cfg(windows)]
+fn windows_pointer_share_mode() -> u32 {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
 }
 
 fn resolve_published_dir_with<F>(target: &Path, read_pointer: F) -> io::Result<PathBuf>
@@ -250,15 +283,62 @@ fn replace_file(source: &Path, target: &Path) -> io::Result<()> {
     fs::rename(source, target)
 }
 
+#[cfg(any(test, windows))]
+const WINDOWS_REPLACE_MAX_ATTEMPTS: usize = 8;
+
+#[cfg(all(test, windows))]
+use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::{
+    ERROR_FILE_NOT_FOUND, ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION,
+};
+
+#[cfg(all(test, not(windows)))]
+const ERROR_ACCESS_DENIED: u32 = 5;
+#[cfg(all(test, not(windows)))]
+const ERROR_LOCK_VIOLATION: u32 = 33;
+#[cfg(all(test, not(windows)))]
+const ERROR_SHARING_VIOLATION: u32 = 32;
+
+#[cfg(any(test, windows))]
+fn is_windows_replace_contention(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(code)
+            if code == ERROR_SHARING_VIOLATION.cast_signed()
+                || code == ERROR_LOCK_VIOLATION.cast_signed()
+    )
+}
+
+#[cfg(any(test, windows))]
+fn retry_windows_replace_with<F, W>(mut replace: F, mut wait: W) -> io::Result<()>
+where
+    F: FnMut() -> io::Result<()>,
+    W: FnMut(usize),
+{
+    let mut original_error = None;
+    for attempt in 0..WINDOWS_REPLACE_MAX_ATTEMPTS {
+        match replace() {
+            Ok(()) => return Ok(()),
+            Err(error) if is_windows_replace_contention(&error) => {
+                if original_error.is_none() {
+                    original_error = Some(error);
+                }
+                if attempt + 1 == WINDOWS_REPLACE_MAX_ATTEMPTS {
+                    return Err(original_error.expect("a contention error was retained"));
+                }
+                wait(attempt);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("the finite replacement loop always returns")
+}
+
 #[cfg(windows)]
 fn replace_file(source: &Path, target: &Path) -> io::Result<()> {
     use std::iter;
     use std::os::windows::ffi::OsStrExt as _;
-    use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_WRITE_THROUGH};
-
-    if !target.exists() {
-        return fs::rename(source, target);
-    }
 
     let source_wide = source
         .as_os_str()
@@ -270,22 +350,54 @@ fn replace_file(source: &Path, target: &Path) -> io::Result<()> {
         .encode_wide()
         .chain(iter::once(0))
         .collect::<Vec<_>>();
+    retry_windows_replace_with(
+        || replace_file_once(&source_wide, &target_wide),
+        |attempt| std::thread::sleep(std::time::Duration::from_millis(1_u64 << attempt)),
+    )
+}
+
+#[cfg(windows)]
+fn replace_file_once(source: &[u16], target: &[u16]) -> io::Result<()> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, ReplaceFileW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        REPLACEFILE_WRITE_THROUGH,
+    };
+
     // SAFETY: both strings are NUL-terminated and remain alive for the call;
     // no backup or metadata exclusion buffers are supplied.
     let result = unsafe {
         ReplaceFileW(
-            target_wide.as_ptr(),
-            source_wide.as_ptr(),
+            target.as_ptr(),
+            source.as_ptr(),
             std::ptr::null(),
             REPLACEFILE_WRITE_THROUGH,
             std::ptr::null(),
             std::ptr::null(),
         )
     };
-    if result == 0 {
-        Err(io::Error::last_os_error())
-    } else {
+    if result != 0 {
+        return Ok(());
+    }
+
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() != Some(ERROR_FILE_NOT_FOUND.cast_signed()) {
+        return Err(error);
+    }
+
+    // ReplaceFileW requires an existing target. MoveFileExW provides the same
+    // write-through atomic rename when the target disappeared or never existed.
+    // SAFETY: both strings are NUL-terminated and remain alive for the call.
+    let result = unsafe {
+        MoveFileExW(
+            source.as_ptr(),
+            target.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result != 0 {
         Ok(())
+    } else {
+        Err(io::Error::last_os_error())
     }
 }
 
@@ -358,8 +470,9 @@ mod tests {
 
     #[test]
     fn staged_directory_publication_never_exposes_partial_tree() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::sync::{mpsc, Arc};
+        use std::time::Duration;
 
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("package");
@@ -368,10 +481,14 @@ mod tests {
 
         let stop = Arc::new(AtomicBool::new(false));
         let saw_partial = Arc::new(AtomicBool::new(false));
+        let reads = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = mpsc::sync_channel(0);
         let reader_stop = Arc::clone(&stop);
         let reader_partial = Arc::clone(&saw_partial);
+        let reader_reads = Arc::clone(&reads);
         let reader_target = target.clone();
         let reader = std::thread::spawn(move || {
+            let mut first_read = true;
             while !reader_stop.load(Ordering::Relaxed) {
                 let active = resolve_published_dir(&reader_target).unwrap();
                 if !matches!(
@@ -381,10 +498,18 @@ mod tests {
                     reader_partial.store(true, Ordering::Relaxed);
                     break;
                 }
+                reader_reads.fetch_add(1, Ordering::Relaxed);
+                if first_read {
+                    started_tx.send(()).unwrap();
+                    first_read = false;
+                }
                 std::thread::yield_now();
             }
         });
 
+        started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reader must observe the initial complete publication");
         for index in 0..100 {
             let staged = StagedDir::new(&target).unwrap();
             let state = if index % 2 == 0 { "new" } else { "old" };
@@ -395,6 +520,7 @@ mod tests {
         reader.join().unwrap();
 
         assert!(!saw_partial.load(Ordering::Relaxed));
+        assert!(reads.load(Ordering::Relaxed) > 0);
         assert!(matches!(
             fs::read_to_string(resolve_published_dir(&target).unwrap().join("state")).as_deref(),
             Ok("old" | "new")
@@ -448,6 +574,115 @@ mod tests {
         })
         .unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn windows_replace_retry_accepts_only_sharing_contention() {
+        assert!(is_windows_replace_contention(
+            &io::Error::from_raw_os_error(ERROR_SHARING_VIOLATION.cast_signed())
+        ));
+        assert!(is_windows_replace_contention(
+            &io::Error::from_raw_os_error(ERROR_LOCK_VIOLATION.cast_signed())
+        ));
+        assert!(!is_windows_replace_contention(
+            &io::Error::from_raw_os_error(ERROR_ACCESS_DENIED.cast_signed())
+        ));
+        assert!(!is_windows_replace_contention(&io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid pointer"
+        )));
+    }
+
+    #[test]
+    fn windows_replace_retry_stops_after_success() {
+        let mut attempts = 0;
+        let mut waits = Vec::new();
+
+        retry_windows_replace_with(
+            || {
+                attempts += 1;
+                if attempts < 3 {
+                    Err(io::Error::from_raw_os_error(
+                        ERROR_SHARING_VIOLATION.cast_signed(),
+                    ))
+                } else {
+                    Ok(())
+                }
+            },
+            |attempt| waits.push(attempt),
+        )
+        .unwrap();
+
+        assert_eq!(attempts, 3);
+        assert_eq!(waits, [0, 1]);
+    }
+
+    #[test]
+    fn windows_replace_retry_is_bounded_and_returns_original_error() {
+        let mut attempts = 0;
+        let error = retry_windows_replace_with(
+            || {
+                attempts += 1;
+                let code = if attempts == 1 {
+                    ERROR_SHARING_VIOLATION
+                } else {
+                    ERROR_LOCK_VIOLATION
+                };
+                Err(io::Error::from_raw_os_error(code.cast_signed()))
+            },
+            |_| {},
+        )
+        .unwrap_err();
+
+        assert_eq!(attempts, WINDOWS_REPLACE_MAX_ATTEMPTS);
+        assert_eq!(
+            error.raw_os_error(),
+            Some(ERROR_SHARING_VIOLATION.cast_signed())
+        );
+    }
+
+    #[test]
+    fn windows_replace_retry_does_not_retry_access_denied() {
+        let mut attempts = 0;
+        let error = retry_windows_replace_with(
+            || {
+                attempts += 1;
+                Err(io::Error::from_raw_os_error(
+                    ERROR_ACCESS_DENIED.cast_signed(),
+                ))
+            },
+            |_| panic!("non-contention errors must not wait"),
+        )
+        .unwrap_err();
+
+        assert_eq!(attempts, 1);
+        assert_eq!(
+            error.raw_os_error(),
+            Some(ERROR_ACCESS_DENIED.cast_signed())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_pointer_reader_allows_delete_compatible_replacement() {
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        };
+
+        assert_eq!(
+            windows_pointer_share_mode(),
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let pointer = dir.path().join(".package.current");
+        fs::write(&pointer, "old").unwrap();
+        let held_reader = open_pointer_file(&pointer).unwrap();
+
+        write_atomic(&pointer, b"new", 0o644).unwrap();
+
+        assert_eq!(read_pointer(&pointer).unwrap(), "new");
+        drop(held_reader);
     }
 
     #[test]

--- a/hew-pkg/src/atomic_fs.rs
+++ b/hew-pkg/src/atomic_fs.rs
@@ -46,11 +46,15 @@ impl StagedDir {
         &self.path
     }
 
-    pub fn publish(mut self, target: &Path) -> io::Result<()> {
+    pub fn publish(mut self, target: &Path) -> io::Result<PathBuf> {
         self.publish_with_hook(target, || Ok(()))
     }
 
-    fn publish_with_hook<F>(&mut self, target: &Path, before_pointer_replace: F) -> io::Result<()>
+    fn publish_with_hook<F>(
+        &mut self,
+        target: &Path,
+        before_pointer_replace: F,
+    ) -> io::Result<PathBuf>
     where
         F: FnOnce() -> io::Result<()>,
     {
@@ -71,7 +75,8 @@ impl StagedDir {
             &pointer_path_for(target)?,
             format!("{generation_name}\n").as_bytes(),
             0o644,
-        )
+        )?;
+        Ok(generation)
     }
 }
 

--- a/hew-pkg/src/atomic_fs.rs
+++ b/hew-pkg/src/atomic_fs.rs
@@ -45,20 +45,31 @@ impl StagedDir {
     }
 
     pub fn publish(mut self, target: &Path) -> io::Result<()> {
-        match fs::symlink_metadata(target) {
-            Ok(_) => {
-                exchange_paths(&self.path, target)?;
-                remove_path(&self.path)?;
-                self.active = false;
-            }
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                fs::rename(&self.path, target)?;
-                self.active = false;
-            }
-            Err(error) => return Err(error),
-        }
+        self.publish_with_hook(target, || Ok(()))
+    }
 
-        sync_parent_dir(target)
+    fn publish_with_hook<F>(&mut self, target: &Path, before_pointer_replace: F) -> io::Result<()>
+    where
+        F: FnOnce() -> io::Result<()>,
+    {
+        let generation = generation_path_for(target)?;
+        fs::rename(&self.path, &generation)?;
+        self.active = false;
+        sync_parent_dir(&generation)?;
+
+        before_pointer_replace()?;
+
+        let generation_name = generation
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "invalid generation name")
+            })?;
+        write_atomic(
+            &pointer_path_for(target)?,
+            format!("{generation_name}\n").as_bytes(),
+            0o644,
+        )
     }
 }
 
@@ -96,7 +107,7 @@ where
 
     before_rename(&temp_path)?;
 
-    fs::rename(&temp_path, path)?;
+    replace_file(&temp_path, path)?;
     sync_parent_dir(path)?;
     Ok(())
 }
@@ -154,74 +165,95 @@ fn temp_path_for(path: &Path) -> io::Result<PathBuf> {
     Ok(path.with_file_name(format!(".{file_name}.tmp-{}-{counter}", std::process::id())))
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
-fn exchange_paths(left: &Path, right: &Path) -> io::Result<()> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt as _;
+fn pointer_path_for(target: &Path) -> io::Result<PathBuf> {
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?;
+    Ok(target.with_file_name(format!(".{file_name}.current")))
+}
 
-    let left = CString::new(left.as_os_str().as_bytes())
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
-    let right = CString::new(right.as_os_str().as_bytes())
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
+fn generation_path_for(target: &Path) -> io::Result<PathBuf> {
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?;
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    Ok(target.with_file_name(format!(
+        ".{file_name}.generation-{}-{counter}",
+        std::process::id()
+    )))
+}
 
-    // SAFETY: both pointers remain valid for the duration of the syscall and
-    // identify existing paths on the same filesystem.
+/// Resolve a logical publication slot to its immutable active generation.
+/// A missing pointer denotes the legacy direct-directory representation.
+pub(crate) fn resolve_published_dir(target: &Path) -> PathBuf {
+    let Ok(pointer_path) = pointer_path_for(target) else {
+        return target.to_path_buf();
+    };
+    let Ok(pointer) = fs::read_to_string(pointer_path) else {
+        return target.to_path_buf();
+    };
+    let Some(target_name) = target.file_name().and_then(|name| name.to_str()) else {
+        return target.to_path_buf();
+    };
+    let generation = pointer.trim();
+    let expected_prefix = format!(".{target_name}.generation-");
+    if generation.starts_with(&expected_prefix)
+        && !generation.contains('/')
+        && !generation.contains('\\')
+    {
+        target.with_file_name(generation)
+    } else {
+        // Fail closed on a corrupt or attacker-controlled pointer rather than
+        // falling back to a potentially stale legacy directory.
+        target.with_file_name(format!(".{target_name}.invalid-generation-pointer"))
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, target: &Path) -> io::Result<()> {
+    // POSIX rename atomically replaces an existing directory entry.
+    fs::rename(source, target)
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, target: &Path) -> io::Result<()> {
+    use std::iter;
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_WRITE_THROUGH};
+
+    if !target.exists() {
+        return fs::rename(source, target);
+    }
+
+    let source_wide = source
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect::<Vec<_>>();
+    let target_wide = target
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect::<Vec<_>>();
+    // SAFETY: both strings are NUL-terminated and remain alive for the call;
+    // no backup or metadata exclusion buffers are supplied.
     let result = unsafe {
-        libc::syscall(
-            libc::SYS_renameat2,
-            libc::AT_FDCWD,
-            left.as_ptr(),
-            libc::AT_FDCWD,
-            right.as_ptr(),
-            libc::RENAME_EXCHANGE,
+        ReplaceFileW(
+            target_wide.as_ptr(),
+            source_wide.as_ptr(),
+            std::ptr::null(),
+            REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null(),
+            std::ptr::null(),
         )
     };
     if result == 0 {
-        Ok(())
-    } else {
         Err(io::Error::last_os_error())
-    }
-}
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-fn exchange_paths(left: &Path, right: &Path) -> io::Result<()> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt as _;
-
-    let left = CString::new(left.as_os_str().as_bytes())
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
-    let right = CString::new(right.as_os_str().as_bytes())
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains a NUL byte"))?;
-
-    // SAFETY: both pointers remain valid for the duration of the call and
-    // identify existing paths on the same filesystem.
-    let result = unsafe { libc::renamex_np(left.as_ptr(), right.as_ptr(), libc::RENAME_SWAP) };
-    if result == 0 {
-        Ok(())
     } else {
-        Err(io::Error::last_os_error())
+        Ok(())
     }
-}
-
-#[cfg(not(any(
-    target_os = "linux",
-    target_os = "android",
-    target_os = "macos",
-    target_os = "ios"
-)))]
-fn exchange_paths(left: &Path, right: &Path) -> io::Result<()> {
-    let backup = temp_path_for(right)?;
-    fs::rename(right, &backup)?;
-    if let Err(error) = fs::rename(left, right) {
-        let restore = fs::rename(&backup, right);
-        return match restore {
-            Ok(()) => Err(error),
-            Err(restore_error) => Err(io::Error::other(format!(
-                "publication failed: {error}; restoring previous content failed: {restore_error}"
-            ))),
-        };
-    }
-    fs::rename(backup, left)
 }
 
 fn remove_path(path: &Path) -> io::Result<()> {
@@ -308,8 +340,9 @@ mod tests {
         let reader_target = target.clone();
         let reader = std::thread::spawn(move || {
             while !reader_stop.load(Ordering::Relaxed) {
+                let active = resolve_published_dir(&reader_target);
                 if !matches!(
-                    fs::read_to_string(reader_target.join("state")).as_deref(),
+                    fs::read_to_string(active.join("state")).as_deref(),
                     Ok("old" | "new")
                 ) {
                     reader_partial.store(true, Ordering::Relaxed);
@@ -329,6 +362,30 @@ mod tests {
         reader.join().unwrap();
 
         assert!(!saw_partial.load(Ordering::Relaxed));
+        assert!(matches!(
+            fs::read_to_string(resolve_published_dir(&target).join("state")).as_deref(),
+            Ok("old" | "new")
+        ));
+    }
+
+    #[test]
+    fn interrupted_generation_publish_keeps_previous_generation_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("package");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("state"), "old").unwrap();
+
+        let mut staged = StagedDir::new(&target).unwrap();
+        fs::write(staged.path().join("state"), "new").unwrap();
+        let error = staged
+            .publish_with_hook(&target, || Err(io::Error::other("simulated power loss")))
+            .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(
+            fs::read_to_string(resolve_published_dir(&target).join("state")).unwrap(),
+            "old"
+        );
     }
 
     #[cfg(unix)]

--- a/hew-pkg/src/checksum.rs
+++ b/hew-pkg/src/checksum.rs
@@ -15,20 +15,13 @@ use std::path::Path;
 /// Returns an [`io::Error`] if any file cannot be read or the directory cannot
 /// be traversed.
 pub fn compute_dir_checksum(dir: &Path) -> Result<String, io::Error> {
-    use sha2::{Digest, Sha256};
-
-    let mut hasher = Sha256::new();
-    let mut files = crate::package_fs::collect_package_files(dir)?;
-    files.sort();
-
-    for rel_path in &files {
-        let abs_path = dir.join(rel_path);
-        hasher.update(rel_path.as_bytes());
-        let contents = std::fs::read(&abs_path)?;
-        hasher.update(&contents);
+    let mut digest = crate::package_fs::TreeDigest::new();
+    let files = crate::package_fs::collect_package_snapshot(dir)?;
+    for file in &files {
+        digest.add_file(&file.path, &file.contents);
     }
 
-    Ok(crate::package_fs::sha256_prefixed(&hasher.finalize()))
+    Ok(digest.finish())
 }
 
 /// Verify that a directory's checksum matches an expected value.
@@ -94,16 +87,49 @@ mod tests {
     }
 
     #[test]
-    fn checksum_skips_git_and_target() {
+    fn checksum_frames_path_and_content() {
+        let tree_a = tempfile::tempdir().unwrap();
+        std::fs::write(tree_a.path().join("a"), "bc").unwrap();
+
+        let tree_b = tempfile::tempdir().unwrap();
+        std::fs::write(tree_b.path().join("ab"), "c").unwrap();
+
+        assert_ne!(
+            compute_dir_checksum(tree_a.path()).unwrap(),
+            compute_dir_checksum(tree_b.path()).unwrap()
+        );
+    }
+
+    #[test]
+    fn checksum_has_stable_domain_version_golden() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a"), "bc").unwrap();
+        assert_eq!(
+            compute_dir_checksum(dir.path()).unwrap(),
+            "sha256:e76ce035ee455d973bbe1ab1636cb48437c085f1dab958efa6a25370db8073a8"
+        );
+    }
+
+    #[test]
+    fn checksum_skips_package_artifacts() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("main.hew"), "content").unwrap();
         let c1 = compute_dir_checksum(dir.path()).unwrap();
 
-        // Adding .git and target dirs should not change checksum.
-        std::fs::create_dir(dir.path().join(".git")).unwrap();
-        std::fs::write(dir.path().join(".git").join("HEAD"), "ref").unwrap();
-        std::fs::create_dir(dir.path().join("target")).unwrap();
-        std::fs::write(dir.path().join("target").join("out"), "bin").unwrap();
+        for (directory, file) in [(".git", "HEAD"), ("target", "out"), (".hew", "state")] {
+            std::fs::create_dir(dir.path().join(directory)).unwrap();
+            std::fs::write(dir.path().join(directory).join(file), "ignored").unwrap();
+        }
+        std::fs::write(
+            dir.path().join(crate::package_fs::CACHE_METADATA_FILE),
+            "mutable metadata",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join(crate::package_fs::CACHE_ARCHIVE_FILE),
+            "mutable archive",
+        )
+        .unwrap();
         let c2 = compute_dir_checksum(dir.path()).unwrap();
 
         assert_eq!(c1, c2);
@@ -147,5 +173,29 @@ mod tests {
         std::fs::write(dir.path().join("src").join("lib.hew"), "actor Lib2 {}").unwrap();
         let c2 = compute_dir_checksum(dir.path()).unwrap();
         assert_ne!(c1, c2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn checksum_rejects_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("outside"), "content").unwrap();
+        symlink(dir.path().join("outside"), dir.path().join("link")).unwrap();
+
+        assert!(compute_dir_checksum(dir.path()).is_err());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn checksum_rejects_non_utf8_names() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(OsStr::from_bytes(b"bad-\xff")), "content").unwrap();
+
+        assert!(compute_dir_checksum(dir.path()).is_err());
     }
 }

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -313,7 +313,7 @@ pub fn manifest_issues(root: &Path) -> Result<Vec<String>, String> {
     let manifest_path = root.join(crate::project::MANIFEST_FILE);
     let m = manifest::parse_manifest(&manifest_path)
         .map_err(|e| format!("cannot load {}: {e}", manifest_path.display()))?;
-    Ok(collect_manifest_issues(&m, &registry))
+    Ok(collect_manifest_issues(&m, root, &registry))
 }
 
 /// Scaffold a manifest-first Hew project in `dir` — the `hew init` back end.
@@ -946,8 +946,24 @@ fn fetch_missing_packages(
             }
         }
 
-        // Unpack into the global registry.
+        // Replace any incomplete cache entry only after the download has passed
+        // checksum and signature verification.
         let target = registry.package_dir(name, version);
+        match std::fs::symlink_metadata(&target) {
+            Ok(_) => remove_path_for_replacement(&target).map_err(|error| {
+                format!(
+                    "could not replace incomplete cache entry for {name}@{version} at {}: {error}",
+                    target.display()
+                )
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "could not inspect cache entry for {name}@{version} at {}: {error}",
+                    target.display()
+                ));
+            }
+        }
         if let Err(e) = tarball::unpack(&tarball_data, &target) {
             eprintln!("unpack failed");
             return Err(format!("could not unpack {name}@{version}: {e}"));
@@ -1563,6 +1579,7 @@ fn cmd_remove(package: &str) {
 /// dependency requirement the registry cannot satisfy.
 fn collect_manifest_issues(
     m: &manifest::HewManifest,
+    root: &Path,
     registry: &registry::Registry,
 ) -> Vec<String> {
     let mut issues = Vec::new();
@@ -1580,7 +1597,7 @@ fn collect_manifest_issues(
 
     for (name, spec) in &m.dependencies {
         let req = spec.version_req();
-        if let Err(e) = resolver::resolve_version(name, req, registry) {
+        if let Err(e) = resolver::resolve_dependency_from_root(name, spec, root, registry) {
             issues.push(format!("dependency {name}@{req}: {e}"));
         }
     }

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -1,7 +1,7 @@
 //! Package-manager command surface, flattened into the `hew` CLI as native
 //! top-level subcommands (`hew add`, `hew install`, `hew publish`, …).
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
@@ -668,7 +668,7 @@ fn cmd_install(
         .iter()
         .map(|(identity, package)| (identity.clone(), package.path.clone()))
         .collect();
-    let mut confirmed_versions = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut confirmed_registry = BTreeMap::<(String, String), VerifiedRegistryPackage>::new();
     let mut fetch_progress = FetchProgress::default();
     let resolved = loop {
         let result = if locked_lockfile.is_some() {
@@ -676,7 +676,8 @@ fn cmd_install(
         } else if offline {
             resolver::resolve_all_from_root(&m, &cwd, registry)
         } else {
-            resolver::resolve_all_confirmed(&m, &cwd, registry, &confirmed_versions)
+            let pinned_online_paths = pinned_registry_paths(&confirmed_registry);
+            resolver::resolve_all_pinned(&m, &cwd, registry, &pinned_online_paths)
         };
         match result {
             Ok(resolved) => break resolved,
@@ -704,17 +705,17 @@ fn cmd_install(
                     eprintln!("hew install: {error}");
                     std::process::exit(1);
                 }
-                let confirmed_before = confirmed_version_count(&confirmed_versions);
+                let confirmed_before = confirmed_registry.len();
                 if let Err(error) = fetch_missing_packages(
                     &failures,
                     registry,
                     registry_name,
-                    &mut confirmed_versions,
+                    &mut confirmed_registry,
                 ) {
                     eprintln!("hew install: {error}");
                     std::process::exit(1);
                 }
-                if confirmed_version_count(&confirmed_versions) <= confirmed_before {
+                if confirmed_registry.len() <= confirmed_before {
                     eprintln!("hew install: registry fetch completed without making progress");
                     std::process::exit(1);
                 }
@@ -754,7 +755,7 @@ fn cmd_install(
                         None,
                         Some(pinned.checksum.clone()),
                     )
-                } else {
+                } else if offline {
                     let target = registry.package_dir(name, version);
                     if !target.is_dir() {
                         eprintln!(
@@ -773,6 +774,16 @@ fn cmd_install(
                         }
                     };
                     (target, "registry", None, checksum)
+                } else {
+                    let pinned = confirmed_registry
+                        .get(&(name.clone(), version.clone()))
+                        .expect("online registry resolution must retain its verified path");
+                    (
+                        pinned.path.clone(),
+                        "registry",
+                        None,
+                        Some(pinned.checksum.clone()),
+                    )
                 }
             }
             resolver::PackageSource::Path(path) => (
@@ -837,15 +848,24 @@ fn cmd_install(
 }
 
 #[derive(Debug)]
-struct VerifiedLockedPackage {
+struct VerifiedRegistryPackage {
     path: PathBuf,
     checksum: String,
+}
+
+fn pinned_registry_paths(
+    packages: &BTreeMap<(String, String), VerifiedRegistryPackage>,
+) -> BTreeMap<(String, String), PathBuf> {
+    packages
+        .iter()
+        .map(|(identity, package)| (identity.clone(), package.path.clone()))
+        .collect()
 }
 
 fn verify_locked_registry_packages(
     lockfile: &lockfile::LockFile,
     registry: &registry::Registry,
-) -> Result<BTreeMap<(String, String), VerifiedLockedPackage>, String> {
+) -> Result<BTreeMap<(String, String), VerifiedRegistryPackage>, String> {
     let mut pinned = BTreeMap::new();
     for entry in &lockfile.packages {
         if entry.source != "registry" {
@@ -893,7 +913,7 @@ fn verify_locked_registry_packages(
         }
         pinned.insert(
             (entry.name.clone(), entry.version.clone()),
-            VerifiedLockedPackage {
+            VerifiedRegistryPackage {
                 path,
                 checksum: actual,
             },
@@ -967,7 +987,7 @@ fn fetch_missing_packages(
     failures: &[resolver::UnresolvedDep],
     registry: &registry::Registry,
     default_registry_name: Option<&str>,
-    confirmed_versions: &mut BTreeMap<String, BTreeSet<String>>,
+    confirmed_registry: &mut BTreeMap<(String, String), VerifiedRegistryPackage>,
 ) -> Result<(), String> {
     for failure in failures {
         let api_client = make_client(failure.registry.as_deref().or(default_registry_name));
@@ -1048,11 +1068,16 @@ fn fetch_missing_packages(
             )
         })?;
 
-        if registry.is_online_cache_verified(name, version, &resolved.checksum)? {
-            confirmed_versions
-                .entry(name.clone())
-                .or_default()
-                .insert(version.clone());
+        if let Some(verified) =
+            registry.verified_online_cache_entry(name, version, &resolved.checksum)?
+        {
+            confirmed_registry.insert(
+                (name.clone(), version.clone()),
+                VerifiedRegistryPackage {
+                    path: verified.path,
+                    checksum: verified.tree_checksum,
+                },
+            );
             eprintln!("confirmed cached {name}@{version}");
             continue;
         }
@@ -1144,17 +1169,28 @@ fn fetch_missing_packages(
             &resolved.checksum,
             &tarball_data,
         )?;
-        staged.publish(&target).map_err(|error| {
+        let generation = staged.publish(&target).map_err(|error| {
             format!(
                 "could not publish cache entry for {name}@{version} at {}: {error}",
                 target.display()
             )
         })?;
-
-        confirmed_versions
-            .entry(name.clone())
-            .or_default()
-            .insert(version.clone());
+        let generation = generation.canonicalize().map_err(|error| {
+            format!(
+                "could not pin published cache entry for {name}@{version} at {}: {error}",
+                generation.display()
+            )
+        })?;
+        let tree_checksum = checksum::compute_dir_checksum(&generation).map_err(|error| {
+            format!("could not verify published cache entry for {name}@{version}: {error}")
+        })?;
+        confirmed_registry.insert(
+            (name.clone(), version.clone()),
+            VerifiedRegistryPackage {
+                path: generation,
+                checksum: tree_checksum,
+            },
+        );
         eprintln!("{name}@{version}");
     }
 
@@ -1187,10 +1223,6 @@ impl FetchProgress {
         self.rounds += 1;
         Ok(())
     }
-}
-
-fn confirmed_version_count(confirmed: &BTreeMap<String, BTreeSet<String>>) -> usize {
-    confirmed.values().map(BTreeSet::len).sum()
 }
 
 fn validate_registry_identity(name: &str, version: &str) -> Result<(), String> {

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -599,7 +599,7 @@ fn cmd_install(
 
     let lock_path = cwd.join("hew.lock");
 
-    if locked {
+    let locked_lockfile = if locked {
         // --locked: read existing lock and validate against manifest.
         let lf = match lockfile::read_lockfile(&lock_path) {
             Ok(lf) => lf,
@@ -661,7 +661,10 @@ fn cmd_install(
                 _ => {}
             }
         }
-    }
+        Some(lf)
+    } else {
+        None
+    };
 
     let local_packages = project_packages_path(&cwd);
     if let Err(e) = std::fs::create_dir_all(&local_packages) {
@@ -671,7 +674,7 @@ fn cmd_install(
 
     ensure_gitignore_entry(&cwd, ".hew/");
 
-    if m.dependencies.is_empty() {
+    if m.dependencies.is_empty() && !locked {
         // Write an empty lockfile for consistency.
         let lf = lockfile::LockFile {
             packages: Vec::new(),
@@ -695,7 +698,15 @@ fn cmd_install(
     let mut confirmed_versions = BTreeMap::<String, BTreeSet<String>>::new();
     let mut fetch_progress = FetchProgress::default();
     let resolved = loop {
-        let result = if offline {
+        let result = if let Some(lockfile) = &locked_lockfile {
+            let locked_versions = lockfile
+                .packages
+                .iter()
+                .filter(|package| package.source == "registry")
+                .map(|package| (package.name.clone(), package.version.clone()))
+                .collect();
+            resolver::resolve_all_locked(&m, &cwd, registry, &locked_versions)
+        } else if offline {
             resolver::resolve_all_from_root(&m, &cwd, registry)
         } else {
             resolver::resolve_all_confirmed(&m, &cwd, registry, &confirmed_versions)
@@ -740,6 +751,13 @@ fn cmd_install(
             }
         }
     };
+
+    if let Some(lockfile) = &locked_lockfile {
+        if let Err(error) = validate_locked_resolution(lockfile, &resolved) {
+            eprintln!("hew install: {error}");
+            std::process::exit(1);
+        }
+    }
 
     // Build lockfile entries from resolved versions.
     let mut lock_packages: Vec<lockfile::LockedPackage> = Vec::new();
@@ -817,15 +835,71 @@ fn cmd_install(
         }
     }
 
-    // Write the lockfile.
-    let lf = lockfile::LockFile {
-        packages: lock_packages,
-    };
-    if let Err(e) = lockfile::write_lockfile(&lock_path, &lf) {
-        eprintln!("hew install: cannot write hew.lock: {e}");
-        std::process::exit(1);
+    if locked {
+        println!("Used locked dependency graph");
+    } else {
+        // Write the lockfile.
+        let lf = lockfile::LockFile {
+            packages: lock_packages,
+        };
+        if let Err(e) = lockfile::write_lockfile(&lock_path, &lf) {
+            eprintln!("hew install: cannot write hew.lock: {e}");
+            std::process::exit(1);
+        }
+        println!("Wrote hew.lock");
     }
-    println!("Wrote hew.lock");
+}
+
+fn validate_locked_resolution(
+    lockfile: &lockfile::LockFile,
+    resolved: &BTreeMap<String, resolver::ResolvedPackage>,
+) -> Result<(), String> {
+    let locked = lockfile
+        .packages
+        .iter()
+        .map(|package| (package.name.as_str(), package))
+        .collect::<BTreeMap<_, _>>();
+
+    for (name, package) in resolved {
+        let entry = locked
+            .get(name.as_str())
+            .ok_or_else(|| format!("locked dependency graph is missing `{name}`"))?;
+        let expected_source = match &package.source {
+            resolver::PackageSource::Registry => "registry",
+            resolver::PackageSource::Path(_) => "path",
+        };
+        if entry.version != package.version || entry.source != expected_source {
+            return Err(format!(
+                "locked dependency `{name}` is {}@{} but resolution requires {}@{}",
+                entry.source, entry.version, expected_source, package.version
+            ));
+        }
+        if let resolver::PackageSource::Path(resolved_path) = &package.source {
+            let path_matches = entry.path.as_deref().is_some_and(|locked_path| {
+                package.direct_path.as_deref() == Some(locked_path)
+                    || Path::new(locked_path)
+                        .canonicalize()
+                        .is_ok_and(|path| &path == resolved_path)
+            });
+            if !path_matches {
+                return Err(format!(
+                    "locked path for dependency `{name}` does not match the resolved graph"
+                ));
+            }
+        }
+    }
+
+    if let Some(extra) = lockfile
+        .packages
+        .iter()
+        .find(|entry| !resolved.contains_key(&entry.name))
+    {
+        return Err(format!(
+            "locked dependency graph contains unreachable package `{}`",
+            extra.name
+        ));
+    }
+    Ok(())
 }
 
 /// Fetch missing packages from the remote registry.
@@ -1000,7 +1074,7 @@ fn fetch_missing_packages(
             }
         }
 
-        let target = registry.package_dir(name, version);
+        let target = registry.package_slot(name, version);
         let staged = crate::atomic_fs::StagedDir::new(&target).map_err(|error| {
             format!(
                 "could not stage cache entry for {name}@{version} at {}: {error}",

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -1,7 +1,8 @@
 //! Package-manager command surface, flattened into the `hew` CLI as native
 //! top-level subcommands (`hew add`, `hew install`, `hew publish`, …).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Read as _;
 use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
@@ -230,7 +231,7 @@ pub fn dispatch(cmd: &PkgCommand) {
             locked,
             registry: reg,
             offline,
-        } => cmd_install(*locked, *offline, &registry, reg.as_deref()),
+        } => cmd_install(*locked, *offline, &registry, reg.as_deref(), &cfg),
         PkgCommand::Publish {
             registry: reg,
             local,
@@ -354,8 +355,34 @@ fn make_client(registry_name: Option<&str>) -> client::RegistryClient {
             }
             c
         }
+
         None => client::RegistryClient::new(),
     }
+}
+
+fn registry_sources_or_exit(
+    cfg: &config::PkgConfig,
+    registry_name: Option<&str>,
+) -> resolver::RegistrySources {
+    let (default_registry, default_selector) = match registry_name {
+        Some(name) => {
+            let remote = config::get_named_registry(cfg, name).unwrap_or_else(|| {
+                eprintln!("hew: unknown registry '{name}'");
+                eprintln!("Configure it in ~/.hew/config.toml under [registries.{name}]");
+                std::process::exit(1);
+            });
+            (
+                config::registry_identity(&remote.api),
+                Some(name.to_string()),
+            )
+        }
+        None => (config::default_registry_identity(), None),
+    };
+    resolver::RegistrySources::new(
+        default_registry,
+        default_selector,
+        config::named_registry_identities(cfg),
+    )
 }
 
 /// Resolve the API token required for an authenticated registry call.
@@ -582,6 +609,7 @@ fn cmd_install(
     offline: bool,
     registry: &registry::Registry,
     registry_name: Option<&str>,
+    cfg: &config::PkgConfig,
 ) {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let manifest_path = cwd.join("hew.toml");
@@ -596,6 +624,7 @@ fn cmd_install(
             std::process::exit(1);
         }
     };
+    let registry_sources = registry_sources_or_exit(cfg, registry_name);
 
     let lock_path = cwd.join("hew.lock");
 
@@ -616,7 +645,12 @@ fn cmd_install(
             eprintln!("hew install: {error}");
             std::process::exit(1);
         }
-        if lockfile::is_lock_stale(&lf, &m) {
+        if lockfile::is_lock_stale_for_registries(
+            &lf,
+            &m,
+            registry_sources.default_registry(),
+            registry_sources.named(),
+        ) {
             let err = lockfile::LockError::Stale;
             eprintln!("hew install: {err}");
             eprintln!("Run `hew install` without --locked to update it.");
@@ -633,14 +667,6 @@ fn cmd_install(
     } else {
         (None, BTreeMap::new())
     };
-
-    let local_packages = project_packages_path(&cwd);
-    if let Err(e) = std::fs::create_dir_all(&local_packages) {
-        eprintln!("hew install: cannot create .hew/packages/: {e}");
-        std::process::exit(1);
-    }
-
-    ensure_gitignore_entry(&cwd, ".hew/");
 
     if m.dependencies.is_empty() && !locked {
         // Write an empty lockfile for consistency.
@@ -666,18 +692,49 @@ fn cmd_install(
     // offline resolution explicitly admits the local cache.
     let pinned_locked_paths = pinned_locked_registry
         .iter()
-        .map(|(identity, package)| (identity.clone(), package.path.clone()))
+        .map(|(identity, package)| (identity.clone(), package.path().to_path_buf()))
         .collect();
-    let mut confirmed_registry = BTreeMap::<(String, String), VerifiedRegistryPackage>::new();
+    let offline_registry = if offline && locked_lockfile.is_none() {
+        match pin_offline_registry_packages(registry, &registry_sources, registry_name.is_none()) {
+            Ok(packages) => packages,
+            Err(error) => {
+                eprintln!("hew install: {error}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        BTreeMap::new()
+    };
+    let offline_paths = pinned_registry_paths(&offline_registry);
+    let mut confirmed_registry =
+        BTreeMap::<(String, String, String), VerifiedRegistryPackage>::new();
     let mut fetch_progress = FetchProgress::default();
     let resolved = loop {
         let result = if locked_lockfile.is_some() {
-            resolver::resolve_all_locked(&m, &cwd, registry, &pinned_locked_paths)
+            resolver::resolve_all_pinned_with_sources(
+                &m,
+                &cwd,
+                registry,
+                &registry_sources,
+                &pinned_locked_paths,
+            )
         } else if offline {
-            resolver::resolve_all_from_root(&m, &cwd, registry)
+            resolver::resolve_all_pinned_with_sources(
+                &m,
+                &cwd,
+                registry,
+                &registry_sources,
+                &offline_paths,
+            )
         } else {
             let pinned_online_paths = pinned_registry_paths(&confirmed_registry);
-            resolver::resolve_all_pinned(&m, &cwd, registry, &pinned_online_paths)
+            resolver::resolve_all_pinned_with_sources(
+                &m,
+                &cwd,
+                registry,
+                &registry_sources,
+                &pinned_online_paths,
+            )
         };
         match result {
             Ok(resolved) => break resolved,
@@ -706,12 +763,9 @@ fn cmd_install(
                     std::process::exit(1);
                 }
                 let confirmed_before = confirmed_registry.len();
-                if let Err(error) = fetch_missing_packages(
-                    &failures,
-                    registry,
-                    registry_name,
-                    &mut confirmed_registry,
-                ) {
+                if let Err(error) =
+                    fetch_missing_packages(&failures, registry, &mut confirmed_registry)
+                {
                     eprintln!("hew install: {error}");
                     std::process::exit(1);
                 }
@@ -733,6 +787,12 @@ fn cmd_install(
             std::process::exit(1);
         }
     }
+    let local_packages = project_packages_path(&cwd);
+    if let Err(e) = std::fs::create_dir_all(&local_packages) {
+        eprintln!("hew install: cannot create .hew/packages/: {e}");
+        std::process::exit(1);
+    }
+    ensure_gitignore_entry(&cwd, ".hew/");
 
     // Build lockfile entries from resolved versions.
     let mut lock_packages: Vec<lockfile::LockedPackage> = Vec::new();
@@ -743,45 +803,41 @@ fn cmd_install(
             std::process::exit(1);
         }
         let version = &package.version;
-        let (target, source, locked_path, pkg_checksum) = match &package.source {
-            resolver::PackageSource::Registry => {
+        let (target, source, locked_path, locked_registry, pkg_checksum) = match &package.source {
+            resolver::PackageSource::Registry {
+                registry: registry_id,
+            } => {
                 if locked {
                     let pinned = pinned_locked_registry
-                        .get(&(name.clone(), version.clone()))
+                        .get(&(registry_id.clone(), name.clone(), version.clone()))
                         .expect("locked registry resolution must retain its verified path");
                     (
-                        pinned.path.clone(),
+                        pinned.path().to_path_buf(),
                         "registry",
                         None,
+                        Some(registry_id.clone()),
                         Some(pinned.checksum.clone()),
                     )
                 } else if offline {
-                    let target = registry.package_dir(name, version);
-                    if !target.is_dir() {
-                        eprintln!(
-                            "hew install: confirmed package {name}@{version} is missing from cache at {}",
-                            target.display()
-                        );
-                        std::process::exit(1);
-                    }
-                    let checksum = match checksum::compute_dir_checksum(&target) {
-                        Ok(checksum) => Some(checksum),
-                        Err(error) => {
-                            eprintln!(
-                                "hew install: cannot compute checksum for {name}@{version}: {error}"
-                            );
-                            std::process::exit(1);
-                        }
-                    };
-                    (target, "registry", None, checksum)
-                } else {
-                    let pinned = confirmed_registry
-                        .get(&(name.clone(), version.clone()))
-                        .expect("online registry resolution must retain its verified path");
+                    let pinned = offline_registry
+                        .get(&(registry_id.clone(), name.clone(), version.clone()))
+                        .expect("offline registry resolution must retain its pinned path");
                     (
-                        pinned.path.clone(),
+                        pinned.path().to_path_buf(),
                         "registry",
                         None,
+                        Some(registry_id.clone()),
+                        Some(pinned.checksum.clone()),
+                    )
+                } else {
+                    let pinned = confirmed_registry
+                        .get(&(registry_id.clone(), name.clone(), version.clone()))
+                        .expect("online registry resolution must retain its verified path");
+                    (
+                        pinned.path().to_path_buf(),
+                        "registry",
+                        None,
+                        Some(registry_id.clone()),
                         Some(pinned.checksum.clone()),
                     )
                 }
@@ -796,6 +852,7 @@ fn cmd_install(
                         .unwrap_or_else(|| path.to_string_lossy().into_owned()),
                 ),
                 None,
+                None,
             ),
         };
 
@@ -803,9 +860,10 @@ fn cmd_install(
             name: name.clone(),
             requirement: package.direct_requirement.clone(),
             version: version.clone(),
-            checksum: pkg_checksum,
+            checksum: pkg_checksum.clone(),
             signature: None,
             source: source.to_string(),
+            registry: locked_registry,
             path: locked_path,
         });
 
@@ -823,7 +881,19 @@ fn cmd_install(
                 std::process::exit(1);
             }
         }
-        match replace_local_package_materialization(&link, &target) {
+        let materialization = match &package.source {
+            resolver::PackageSource::Registry { .. } => replace_registry_package_copy_verified(
+                &link,
+                &target,
+                pkg_checksum
+                    .as_deref()
+                    .expect("verified registry package has a checksum"),
+            ),
+            resolver::PackageSource::Path(_) => {
+                replace_local_package_materialization(&link, &target)
+            }
+        };
+        match materialization {
             Ok(materialization) => println!("  {} {name}@{version}", materialization.verb()),
             Err(e) => {
                 eprintln!("hew install: cannot materialize project package for {name}: {e}");
@@ -849,23 +919,117 @@ fn cmd_install(
 
 #[derive(Debug)]
 struct VerifiedRegistryPackage {
-    path: PathBuf,
+    pinned: crate::atomic_fs::PinnedDir,
     checksum: String,
 }
 
+impl VerifiedRegistryPackage {
+    fn path(&self) -> &Path {
+        self.pinned.path()
+    }
+}
+
 fn pinned_registry_paths(
-    packages: &BTreeMap<(String, String), VerifiedRegistryPackage>,
-) -> BTreeMap<(String, String), PathBuf> {
+    packages: &BTreeMap<(String, String, String), VerifiedRegistryPackage>,
+) -> BTreeMap<(String, String, String), PathBuf> {
     packages
         .iter()
-        .map(|(identity, package)| (identity.clone(), package.path.clone()))
+        .map(|(identity, package)| (identity.clone(), package.path().to_path_buf()))
         .collect()
+}
+
+fn pin_offline_registry_packages(
+    registry: &registry::Registry,
+    sources: &resolver::RegistrySources,
+    allow_legacy_default: bool,
+) -> Result<BTreeMap<(String, String, String), VerifiedRegistryPackage>, String> {
+    let mut identities = sources.named().values().cloned().collect::<BTreeSet<_>>();
+    identities.insert(sources.default_registry().to_string());
+    let mut pinned = BTreeMap::new();
+
+    for registry_id in identities {
+        let include_legacy = allow_legacy_default && registry_id == sources.default_registry();
+        let packages = registry
+            .try_list_packages_for(&registry_id, include_legacy)
+            .map_err(|error| {
+                format!("cannot enumerate offline cache for registry `{registry_id}`: {error}")
+            })?;
+        for package in packages {
+            let identity = (
+                registry_id.clone(),
+                package.name.clone(),
+                package.version.clone(),
+            );
+            if pinned.contains_key(&identity) {
+                continue;
+            }
+
+            let package_pin = if package.pin.is_generation() {
+                package.pin
+            } else {
+                let slot = registry.package_slot_for(&registry_id, &package.name, &package.version);
+                let staged = crate::atomic_fs::StagedDir::new(&slot).map_err(|error| {
+                    format!(
+                        "cannot stage legacy cache migration for {}@{}: {error}",
+                        package.name, package.version
+                    )
+                })?;
+                copy_dir(package.pin.path(), staged.path()).map_err(|error| {
+                    format!(
+                        "cannot copy legacy cache for {}@{}: {error}",
+                        package.name, package.version
+                    )
+                })?;
+                let staged_checksum =
+                    checksum::compute_dir_checksum(staged.path()).map_err(|error| {
+                        format!(
+                            "cannot verify legacy cache copy for {}@{}: {error}",
+                            package.name, package.version
+                        )
+                    })?;
+                let published = staged.publish_pinned(&slot).map_err(|error| {
+                    format!(
+                        "cannot publish migrated cache for {}@{}: {error}",
+                        package.name, package.version
+                    )
+                })?;
+                let published_checksum =
+                    checksum::compute_dir_checksum(published.path()).map_err(|error| {
+                        format!(
+                            "cannot verify migrated cache for {}@{}: {error}",
+                            package.name, package.version
+                        )
+                    })?;
+                if published_checksum != staged_checksum {
+                    return Err(format!(
+                        "migrated cache changed before pinning for {}@{}",
+                        package.name, package.version
+                    ));
+                }
+                published
+            };
+            let checksum = checksum::compute_dir_checksum(package_pin.path()).map_err(|error| {
+                format!(
+                    "cannot verify offline cache for {}@{}: {error}",
+                    package.name, package.version
+                )
+            })?;
+            pinned.insert(
+                identity,
+                VerifiedRegistryPackage {
+                    pinned: package_pin,
+                    checksum,
+                },
+            );
+        }
+    }
+    Ok(pinned)
 }
 
 fn verify_locked_registry_packages(
     lockfile: &lockfile::LockFile,
     registry: &registry::Registry,
-) -> Result<BTreeMap<(String, String), VerifiedRegistryPackage>, String> {
+) -> Result<BTreeMap<(String, String, String), VerifiedRegistryPackage>, String> {
     let mut pinned = BTreeMap::new();
     for entry in &lockfile.packages {
         if entry.source != "registry" {
@@ -875,22 +1039,32 @@ fn verify_locked_registry_packages(
             .checksum
             .as_deref()
             .expect("validated registry lock entry must have a checksum");
-        let resolved = registry
-            .package_dir_checked(&entry.name, &entry.version)
+        let registry_id = entry
+            .registry
+            .as_deref()
+            .expect("validated registry lock entry must have an identity");
+        let pin = registry
+            .pin_package_dir_for_if_present(registry_id, &entry.name, &entry.version)
             .map_err(|error| {
                 format!(
                     "cannot resolve locked package {}@{} generation: {error}",
                     entry.name, entry.version
                 )
+            })?
+            .ok_or_else(|| {
+                format!(
+                    "locked package {}@{} is missing from cache",
+                    entry.name, entry.version
+                )
             })?;
-        let path = resolved.canonicalize().map_err(|error| {
+        let unresolved_path = pin.path().display().to_string();
+        let pin = pin.canonicalize().map_err(|error| {
             format!(
                 "locked package {}@{} is missing from cache at {}: {error}",
-                entry.name,
-                entry.version,
-                resolved.display()
+                entry.name, entry.version, unresolved_path
             )
         })?;
+        let path = pin.path();
         if !path.join("hew.toml").is_file() {
             return Err(format!(
                 "locked package {}@{} is missing from cache at {}",
@@ -899,7 +1073,7 @@ fn verify_locked_registry_packages(
                 path.display()
             ));
         }
-        let actual = checksum::compute_dir_checksum(&path).map_err(|error| {
+        let actual = checksum::compute_dir_checksum(path).map_err(|error| {
             format!(
                 "cannot verify checksum for {}@{}: {error}",
                 entry.name, entry.version
@@ -912,9 +1086,13 @@ fn verify_locked_registry_packages(
             ));
         }
         pinned.insert(
-            (entry.name.clone(), entry.version.clone()),
+            (
+                registry_id.to_string(),
+                entry.name.clone(),
+                entry.version.clone(),
+            ),
             VerifiedRegistryPackage {
-                path,
+                pinned: pin,
                 checksum: actual,
             },
         );
@@ -937,7 +1115,7 @@ fn validate_locked_resolution(
             .get(name.as_str())
             .ok_or_else(|| format!("locked dependency graph is missing `{name}`"))?;
         let expected_source = match &package.source {
-            resolver::PackageSource::Registry => "registry",
+            resolver::PackageSource::Registry { .. } => "registry",
             resolver::PackageSource::Path(_) => "path",
         };
         if entry.version != package.version || entry.source != expected_source {
@@ -945,6 +1123,13 @@ fn validate_locked_resolution(
                 "locked dependency `{name}` is {}@{} but resolution requires {}@{}",
                 entry.source, entry.version, expected_source, package.version
             ));
+        }
+        if let resolver::PackageSource::Registry { registry } = &package.source {
+            if entry.registry.as_deref() != Some(registry) {
+                return Err(format!(
+                    "locked dependency `{name}` registry identity does not match the resolved graph"
+                ));
+            }
         }
         if let resolver::PackageSource::Path(resolved_path) = &package.source {
             let path_matches = entry.path.as_deref().is_some_and(|locked_path| {
@@ -986,11 +1171,19 @@ fn validate_locked_resolution(
 fn fetch_missing_packages(
     failures: &[resolver::UnresolvedDep],
     registry: &registry::Registry,
-    default_registry_name: Option<&str>,
-    confirmed_registry: &mut BTreeMap<(String, String), VerifiedRegistryPackage>,
+    confirmed_registry: &mut BTreeMap<(String, String, String), VerifiedRegistryPackage>,
 ) -> Result<(), String> {
     for failure in failures {
-        let api_client = make_client(failure.registry.as_deref().or(default_registry_name));
+        let api_client = make_client(failure.registry_selector.as_deref());
+        if api_client.registry_identity() != failure.registry {
+            return Err(format!(
+                "registry client identity mismatch for `{}`: resolver selected `{}`, client uses `{}`",
+                failure.package,
+                failure.registry,
+                api_client.registry_identity()
+            ));
+        }
+        let registry_id = &failure.registry;
         let name = &failure.package;
         let requirements = &failure.requirements;
         let requirement_summary = requirements.join(", ");
@@ -1003,13 +1196,7 @@ fn fetch_missing_packages(
             Ok(entries) => entries,
             Err(api_err) => {
                 eprintln!("failed");
-                let cache_path = resolver::resolve_cached_version(name, requirements, registry)
-                    .ok()
-                    .flatten()
-                    .map_or_else(
-                        || registry.root().join(name),
-                        |version| registry.package_dir(name, &version),
-                    );
+                let cache_path = registry.source_root(registry_id).join(name);
                 return Err(format!(
                     "registry request failed for package `{name}` version `{requirement_summary}` at `{}`: {api_err}; cached package path `{}` was not used (rerun with `hew install --offline` to use cached packages)",
                     api_client.package_url(name),
@@ -1034,47 +1221,19 @@ fn fetch_missing_packages(
             return Err(format!(
                 "registry `{}` has no version of package `{name}` matching [{requirement_summary}]; cached package path `{}` was not used",
                 api_client.package_url(name),
-                registry.root().join(name).display()
+                registry.source_root(registry_id).join(name).display()
             ));
         };
         let version = &resolved.version;
 
         validate_registry_identity(name, version)?;
-        let lock_dir = registry.root().join(".locks");
-        std::fs::create_dir_all(&lock_dir).map_err(|error| {
-            format!(
-                "could not create package cache lock directory {}: {error}",
-                lock_dir.display()
-            )
-        })?;
-        let lock_path = lock_dir.join(format!("{name}-{version}.lock"));
-        let lock_file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&lock_path)
-            .map_err(|error| {
-                format!(
-                    "could not open package cache lock {}: {error}",
-                    lock_path.display()
-                )
-            })?;
-        let mut package_lock = fd_lock::RwLock::new(lock_file);
-        let _package_guard = package_lock.write().map_err(|error| {
-            format!(
-                "could not acquire package cache lock {}: {error}",
-                lock_path.display()
-            )
-        })?;
-
         if let Some(verified) =
-            registry.verified_online_cache_entry(name, version, &resolved.checksum)?
+            registry.verified_online_cache_entry(registry_id, name, version, &resolved.checksum)?
         {
             confirmed_registry.insert(
-                (name.clone(), version.clone()),
+                (registry_id.clone(), name.clone(), version.clone()),
                 VerifiedRegistryPackage {
-                    path: verified.path,
+                    pinned: verified.pin,
                     checksum: verified.tree_checksum,
                 },
             );
@@ -1151,7 +1310,50 @@ fn fetch_missing_packages(
             }
         }
 
-        let target = registry.package_slot(name, version);
+        validate_downloaded_registry_manifest(&tarball_data, name)?;
+
+        let lock_dir = registry.source_root(registry_id).join(".locks");
+        std::fs::create_dir_all(&lock_dir).map_err(|error| {
+            format!(
+                "could not create package cache lock directory {}: {error}",
+                lock_dir.display()
+            )
+        })?;
+        let lock_path = lock_dir.join(format!("{name}-{version}.lock"));
+        let lock_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| {
+                format!(
+                    "could not open package cache lock {}: {error}",
+                    lock_path.display()
+                )
+            })?;
+        let mut package_lock = fd_lock::RwLock::new(lock_file);
+        let _package_guard = package_lock.write().map_err(|error| {
+            format!(
+                "could not acquire package cache lock {}: {error}",
+                lock_path.display()
+            )
+        })?;
+        if let Some(verified) =
+            registry.verified_online_cache_entry(registry_id, name, version, &resolved.checksum)?
+        {
+            confirmed_registry.insert(
+                (registry_id.clone(), name.clone(), version.clone()),
+                VerifiedRegistryPackage {
+                    pinned: verified.pin,
+                    checksum: verified.tree_checksum,
+                },
+            );
+            eprintln!("confirmed cached {name}@{version}");
+            continue;
+        }
+
+        let target = registry.package_slot_for(registry_id, name, version);
         let staged = crate::atomic_fs::StagedDir::new(&target).map_err(|error| {
             format!(
                 "could not stage cache entry for {name}@{version} at {}: {error}",
@@ -1164,30 +1366,28 @@ fn fetch_missing_packages(
         }
         registry::Registry::write_cache_metadata(
             staged.path(),
+            registry_id,
             name,
             version,
             &resolved.checksum,
             &tarball_data,
         )?;
-        let generation = staged.publish(&target).map_err(|error| {
+        let pinned = staged.publish_pinned(&target).map_err(|error| {
             format!(
                 "could not publish cache entry for {name}@{version} at {}: {error}",
                 target.display()
             )
         })?;
-        let generation = generation.canonicalize().map_err(|error| {
-            format!(
-                "could not pin published cache entry for {name}@{version} at {}: {error}",
-                generation.display()
-            )
+        let pinned = pinned.canonicalize().map_err(|error| {
+            format!("could not canonicalize published cache entry for {name}@{version}: {error}")
         })?;
-        let tree_checksum = checksum::compute_dir_checksum(&generation).map_err(|error| {
+        let tree_checksum = checksum::compute_dir_checksum(pinned.path()).map_err(|error| {
             format!("could not verify published cache entry for {name}@{version}: {error}")
         })?;
         confirmed_registry.insert(
-            (name.clone(), version.clone()),
+            (registry_id.clone(), name.clone(), version.clone()),
             VerifiedRegistryPackage {
-                path: generation,
+                pinned,
                 checksum: tree_checksum,
             },
         );
@@ -1202,7 +1402,7 @@ const MAX_FETCH_ROUNDS: usize = 1024;
 #[derive(Debug, Default)]
 struct FetchProgress {
     rounds: usize,
-    previous_failures: Option<Vec<(String, Vec<String>)>>,
+    previous_failures: Option<Vec<(String, String, Vec<String>)>>,
 }
 
 impl FetchProgress {
@@ -1214,7 +1414,13 @@ impl FetchProgress {
         }
         let signature = failures
             .iter()
-            .map(|failure| (failure.package.clone(), failure.requirements.clone()))
+            .map(|failure| {
+                (
+                    failure.registry.clone(),
+                    failure.package.clone(),
+                    failure.requirements.clone(),
+                )
+            })
             .collect::<Vec<_>>();
         if self.previous_failures.as_ref() == Some(&signature) {
             return Err("registry fetch repeated without making resolver progress".to_string());
@@ -1223,6 +1429,59 @@ impl FetchProgress {
         self.rounds += 1;
         Ok(())
     }
+}
+
+fn validate_downloaded_registry_manifest(data: &[u8], package: &str) -> Result<(), String> {
+    let decoder = zstd::Decoder::new(std::io::Cursor::new(data))
+        .map_err(|error| format!("cannot inspect archive manifest for `{package}`: {error}"))?;
+    let mut archive = tar::Archive::new(decoder);
+    let mut manifest_text = None;
+    for entry in archive
+        .entries()
+        .map_err(|error| format!("cannot inspect archive for `{package}`: {error}"))?
+    {
+        let mut entry =
+            entry.map_err(|error| format!("cannot inspect archive for `{package}`: {error}"))?;
+        let path = entry
+            .path()
+            .map_err(|error| format!("cannot inspect archive for `{package}`: {error}"))?;
+        let normalized = path
+            .components()
+            .filter_map(|component| match component {
+                std::path::Component::Normal(part) => Some(part),
+                std::path::Component::CurDir => None,
+                _ => Some(component.as_os_str()),
+            })
+            .collect::<PathBuf>();
+        if normalized != Path::new("hew.toml") {
+            continue;
+        }
+        if manifest_text.is_some() {
+            return Err(format!(
+                "registry archive for `{package}` contains multiple hew.toml entries"
+            ));
+        }
+        if !entry.header().entry_type().is_file() {
+            return Err(format!(
+                "registry archive for `{package}` has a non-file hew.toml entry"
+            ));
+        }
+        if entry.size() > 1024 * 1024 {
+            return Err(format!(
+                "registry archive manifest for `{package}` exceeds 1 MiB"
+            ));
+        }
+        let mut text = String::new();
+        entry
+            .read_to_string(&mut text)
+            .map_err(|error| format!("cannot read archive manifest for `{package}`: {error}"))?;
+        manifest_text = Some(text);
+    }
+    let text = manifest_text
+        .ok_or_else(|| format!("registry archive for `{package}` is missing hew.toml"))?;
+    let parsed: manifest::HewManifest = toml::from_str(&text)
+        .map_err(|error| format!("invalid registry manifest for `{package}`: {error}"))?;
+    resolver::validate_registry_manifest(package, &parsed).map_err(|error| error.to_string())
 }
 
 fn validate_registry_identity(name: &str, version: &str) -> Result<(), String> {
@@ -2431,7 +2690,6 @@ fn local_link_path(base: &Path, package_name: &str) -> Result<PathBuf, String> {
 enum LocalPackageMaterialization {
     #[cfg(unix)]
     Linked,
-    #[cfg(not(unix))]
     Copied,
 }
 
@@ -2440,7 +2698,6 @@ impl LocalPackageMaterialization {
         match self {
             #[cfg(unix)]
             Self::Linked => "linked",
-            #[cfg(not(unix))]
             Self::Copied => "copied",
         }
     }
@@ -2460,6 +2717,112 @@ fn replace_local_package_materialization(
         replace_local_package_copy(link, target)?;
         Ok(LocalPackageMaterialization::Copied)
     }
+}
+
+fn replace_registry_package_copy_verified(
+    destination: &Path,
+    source: &Path,
+    expected_checksum: &str,
+) -> std::io::Result<LocalPackageMaterialization> {
+    if !source.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("{} is not an installed package directory", source.display()),
+        ));
+    }
+    let parent = destination.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} has no parent directory", destination.display()),
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+    let file_name = destination.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} has no final path component", destination.display()),
+        )
+    })?;
+    let staged = unique_materialization_path(destination, "copy")?;
+    if let Err(error) = copy_dir(source, &staged) {
+        let _ = remove_path_for_replacement(&staged);
+        return Err(error);
+    }
+    let staged_checksum = checksum::compute_dir_checksum(&staged)?;
+    if staged_checksum != expected_checksum {
+        let _ = remove_path_for_replacement(&staged);
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "copied registry package checksum mismatch for {}",
+                file_name.to_string_lossy()
+            ),
+        ));
+    }
+    replace_directory_coherently(&staged, destination)?;
+    let installed_checksum = checksum::compute_dir_checksum(destination)?;
+    if installed_checksum != expected_checksum {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "materialized registry package checksum mismatch for {}",
+                destination.display()
+            ),
+        ));
+    }
+    Ok(LocalPackageMaterialization::Copied)
+}
+
+fn unique_materialization_path(path: &Path, purpose: &str) -> std::io::Result<PathBuf> {
+    let name = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} has no final path component", path.display()),
+        )
+    })?;
+    for counter in 0..100_u32 {
+        let candidate = path.with_file_name(format!(
+            ".{}.{}-{}-{counter}",
+            name.to_string_lossy(),
+            purpose,
+            std::process::id()
+        ));
+        match std::fs::symlink_metadata(&candidate) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(candidate);
+            }
+            Ok(_) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        format!("cannot allocate staging path for {}", path.display()),
+    ))
+}
+
+fn replace_directory_coherently(staged: &Path, destination: &Path) -> std::io::Result<()> {
+    match std::fs::symlink_metadata(destination) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return std::fs::rename(staged, destination);
+        }
+        Err(error) => return Err(error),
+        Ok(_) => {}
+    }
+
+    let backup = unique_materialization_path(destination, "previous")?;
+    std::fs::rename(destination, &backup)?;
+    if let Err(error) = std::fs::rename(staged, destination) {
+        let rollback = std::fs::rename(&backup, destination);
+        return match rollback {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(std::io::Error::other(format!(
+                "cannot install {}: {error}; rollback also failed: {rollback_error}",
+                destination.display()
+            ))),
+        };
+    }
+    remove_path_for_replacement(&backup)
 }
 
 #[cfg(unix)]
@@ -2593,7 +2956,8 @@ mod tests {
         let failures = vec![resolver::UnresolvedDep {
             package: "foo".to_string(),
             requirements: vec!["1.0.0".to_string()],
-            registry: None,
+            registry: config::default_registry_identity(),
+            registry_selector: None,
         }];
         let mut progress = FetchProgress::default();
 
@@ -2717,6 +3081,62 @@ mod tests {
     }
 
     #[test]
+    fn registry_materialization_is_a_verified_copy() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(
+            src.path().join("hew.toml"),
+            "[package]\nname=\"x\"\nversion=\"0.2.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(src.path().join("x.hew"), "verified").unwrap();
+        let expected = checksum::compute_dir_checksum(src.path()).unwrap();
+
+        let project = tempfile::tempdir().unwrap();
+        let destination = project.path().join(".hew/packages/x");
+        std::fs::create_dir_all(&destination).unwrap();
+        std::fs::write(destination.join("stale.hew"), "old").unwrap();
+
+        replace_registry_package_copy_verified(&destination, src.path(), &expected).unwrap();
+
+        assert!(!std::fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            checksum::compute_dir_checksum(&destination).unwrap(),
+            expected
+        );
+        assert!(!destination.join("stale.hew").exists());
+    }
+
+    #[test]
+    fn registry_copy_mismatch_does_not_mutate_project() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(
+            src.path().join("hew.toml"),
+            "[package]\nname=\"x\"\nversion=\"0.2.0\"\n",
+        )
+        .unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let destination = project.path().join(".hew/packages/x");
+        std::fs::create_dir_all(&destination).unwrap();
+        std::fs::write(destination.join("old.hew"), "old").unwrap();
+
+        let error = replace_registry_package_copy_verified(
+            &destination,
+            src.path(),
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(
+            std::fs::read_to_string(destination.join("old.hew")).unwrap(),
+            "old"
+        );
+    }
+
+    #[test]
     fn publish_copies_to_registry() {
         let src = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -2749,10 +3169,12 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let registry_root = root.path().join("registry");
         let registry = registry::Registry::with_root(registry_root.clone());
-        let package_root = registry_root.join("foo");
+        let registry_id = config::default_registry_identity();
+        let source_root = registry.source_root(&registry_id);
+        let package_root = source_root.join("foo");
         let generation_a = package_root.join(".1.0.0.generation-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let generation_b = package_root.join(".1.0.0.generation-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-        let bar = registry_root.join("bar/1.0.0");
+        let bar = source_root.join("bar/1.0.0");
         std::fs::create_dir_all(&generation_a).unwrap();
         std::fs::create_dir_all(&generation_b).unwrap();
         std::fs::create_dir_all(&bar).unwrap();
@@ -2778,6 +3200,12 @@ mod tests {
             format!("{}\n", generation_a.file_name().unwrap().to_string_lossy()),
         )
         .unwrap();
+        std::fs::write(
+            package_root.join(".1.0.0.generation-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.lease"),
+            [],
+        )
+        .unwrap();
+        std::fs::write(package_root.join(".1.0.0.slot.lock"), []).unwrap();
 
         let lockfile = lockfile::LockFile {
             packages: vec![
@@ -2788,6 +3216,7 @@ mod tests {
                     checksum: Some(checksum::compute_dir_checksum(&generation_a).unwrap()),
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(registry_id.clone()),
                     path: None,
                 },
                 lockfile::LockedPackage {
@@ -2797,6 +3226,7 @@ mod tests {
                     checksum: Some(checksum::compute_dir_checksum(&bar).unwrap()),
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(registry_id.clone()),
                     path: None,
                 },
             ],
@@ -2819,7 +3249,10 @@ mod tests {
             }
         });
         ready.wait();
-        assert_eq!(registry.package_dir("foo", "1.0.0"), generation_b);
+        assert_eq!(
+            registry.package_dir_for(&registry_id, "foo", "1.0.0"),
+            generation_b
+        );
 
         let project = root.path().join("project");
         std::fs::create_dir_all(&project).unwrap();
@@ -2831,28 +3264,62 @@ mod tests {
         let manifest = manifest::parse_manifest(&project.join("hew.toml")).unwrap();
         let pinned_paths = pinned
             .iter()
-            .map(|(identity, package)| (identity.clone(), package.path.clone()))
+            .map(|(identity, package)| (identity.clone(), package.path().to_path_buf()))
             .collect();
-        let resolved =
-            resolver::resolve_all_locked(&manifest, &project, &registry, &pinned_paths).unwrap();
+        let sources = resolver::RegistrySources::default_source();
+        let resolved = resolver::resolve_all_pinned_with_sources(
+            &manifest,
+            &project,
+            &registry,
+            &sources,
+            &pinned_paths,
+        )
+        .unwrap();
         assert!(resolved.contains_key("bar"));
         assert!(!resolved.contains_key("baz"));
 
         let link = project.join(".hew/packages/foo");
-        replace_local_package_materialization(
-            &link,
-            &pinned
-                .get(&("foo".to_string(), "1.0.0".to_string()))
-                .unwrap()
-                .path,
-        )
-        .unwrap();
+        let verified = pinned
+            .get(&(registry_id, "foo".to_string(), "1.0.0".to_string()))
+            .unwrap();
+        replace_registry_package_copy_verified(&link, verified.path(), &verified.checksum).unwrap();
         assert_eq!(
             std::fs::read_to_string(link.join("foo.hew")).unwrap(),
             "generation A"
         );
         stop.store(true, Ordering::Relaxed);
         writer.join().unwrap();
+    }
+
+    #[test]
+    fn locked_cache_from_wrong_registry_is_rejected() {
+        let root = tempfile::tempdir().unwrap();
+        let registry = registry::Registry::with_root(root.path().to_path_buf());
+        let first = "https://registry-a.example/api/v1";
+        let second = "https://registry-b.example/api/v1";
+        let package = registry.package_dir_for(first, "foo", "1.0.0");
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(
+            package.join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let checksum = checksum::compute_dir_checksum(&package).unwrap();
+        let lockfile = lockfile::LockFile {
+            packages: vec![lockfile::LockedPackage {
+                name: "foo".to_string(),
+                requirement: Some("1.0.0".to_string()),
+                version: "1.0.0".to_string(),
+                checksum: Some(checksum),
+                signature: None,
+                source: "registry".to_string(),
+                registry: Some(second.to_string()),
+                path: None,
+            }],
+        };
+
+        let error = verify_locked_registry_packages(&lockfile, &registry).unwrap_err();
+        assert!(error.contains("missing from cache"), "{error}");
     }
 
     #[test]

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -31,6 +31,9 @@ pub enum PkgCommand {
         /// Use a named registry from config
         #[arg(long, short = 'r')]
         registry: Option<String>,
+        /// Add a dependency from a local directory
+        #[arg(long, value_name = "DIR", conflicts_with = "registry")]
+        path: Option<PathBuf>,
     },
     /// Install dependencies into .hew/packages/
     Install {
@@ -221,7 +224,8 @@ pub fn dispatch(cmd: &PkgCommand) {
             package,
             version,
             registry: reg,
-        } => cmd_add(package, version, reg.as_deref()),
+            path,
+        } => cmd_add(package, version, reg.as_deref(), path.as_deref()),
         PkgCommand::Install {
             locked,
             registry: reg,
@@ -513,7 +517,7 @@ fn ensure_gitignore_entry(dir: &Path, entry: &str) {
     }
 }
 
-fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>) {
+fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>, dependency_path: Option<&Path>) {
     if !is_valid_package_name(pkg) {
         eprintln!("hew add: {}", invalid_package_name_message(pkg));
         std::process::exit(1);
@@ -530,7 +534,37 @@ fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>) {
         eprintln!("Run `hew init` to create one.");
         std::process::exit(1);
     }
-    match manifest::add_dependency(&manifest_path, pkg, version, registry_name) {
+    let result = if let Some(path) = dependency_path {
+        let resolved = cwd.join(path);
+        let dependency_manifest = resolved.join("hew.toml");
+        match manifest::parse_manifest(&dependency_manifest) {
+            Ok(dependency) if dependency.package.name == pkg => {
+                manifest::add_path_dependency(&manifest_path, pkg, version, path)
+            }
+            Ok(dependency) => {
+                eprintln!(
+                    "hew add: path dependency `{pkg}` at `{}` declares package name `{}`",
+                    resolved.display(),
+                    dependency.package.name
+                );
+                std::process::exit(1);
+            }
+            Err(error) => {
+                eprintln!(
+                    "hew add: cannot load path dependency `{pkg}` at `{}`: {error}",
+                    resolved.display()
+                );
+                std::process::exit(1);
+            }
+        }
+    } else {
+        manifest::add_dependency(&manifest_path, pkg, version, registry_name)
+    };
+    match result {
+        Ok(()) if dependency_path.is_some() => println!(
+            "Added {pkg} from {} to hew.toml",
+            dependency_path.expect("checked path dependency").display()
+        ),
         Ok(()) => println!("Added {pkg}@{version} to hew.toml"),
         Err(e) => {
             eprintln!("hew add: {e}");
@@ -693,20 +727,36 @@ fn cmd_install(
             std::process::exit(1);
         }
         let version = &package.version;
-        let target = registry.package_dir(name, version);
-        if !target.is_dir() {
-            eprintln!(
-                "hew install: confirmed package {name}@{version} is missing from cache at {}",
-                target.display()
-            );
-            std::process::exit(1);
-        }
-        let pkg_checksum = match checksum::compute_dir_checksum(&target) {
-            Ok(checksum) => Some(checksum),
-            Err(error) => {
-                eprintln!("warning: cannot compute checksum for {name}@{version}: {error}");
-                None
+        let (target, source, locked_path, pkg_checksum) = match &package.source {
+            resolver::PackageSource::Registry => {
+                let target = registry.package_dir(name, version);
+                if !target.is_dir() {
+                    eprintln!(
+                        "hew install: confirmed package {name}@{version} is missing from cache at {}",
+                        target.display()
+                    );
+                    std::process::exit(1);
+                }
+                let checksum = match checksum::compute_dir_checksum(&target) {
+                    Ok(checksum) => Some(checksum),
+                    Err(error) => {
+                        eprintln!("warning: cannot compute checksum for {name}@{version}: {error}");
+                        None
+                    }
+                };
+                (target, "registry", None, checksum)
             }
+            resolver::PackageSource::Path(path) => (
+                path.clone(),
+                "path",
+                Some(
+                    package
+                        .direct_path
+                        .clone()
+                        .unwrap_or_else(|| path.to_string_lossy().into_owned()),
+                ),
+                None,
+            ),
         };
 
         lock_packages.push(lockfile::LockedPackage {
@@ -715,8 +765,8 @@ fn cmd_install(
             version: version.clone(),
             checksum: pkg_checksum,
             signature: None,
-            source: "registry".to_string(),
-            path: None,
+            source: source.to_string(),
+            path: locked_path,
         });
 
         // Build the local symlink path: replace :: with / separators.

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -1,6 +1,7 @@
 //! Package-manager command surface, flattened into the `hew` CLI as native
 //! top-level subcommands (`hew add`, `hew install`, `hew publish`, …).
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
@@ -39,6 +40,9 @@ pub enum PkgCommand {
         /// Use a named registry from config
         #[arg(long, short = 'r')]
         registry: Option<String>,
+        /// Resolve exclusively from the local package cache
+        #[arg(long, conflicts_with = "registry")]
+        offline: bool,
     },
     /// Publish this package to the registry
     Publish {
@@ -221,7 +225,8 @@ pub fn dispatch(cmd: &PkgCommand) {
         PkgCommand::Install {
             locked,
             registry: reg,
-        } => cmd_install(*locked, &registry, reg.as_deref()),
+            offline,
+        } => cmd_install(*locked, *offline, &registry, reg.as_deref()),
         PkgCommand::Publish {
             registry: reg,
             local,
@@ -538,7 +543,12 @@ fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>) {
     clippy::too_many_lines,
     reason = "install has many sequential steps that are clearest in one function"
 )]
-fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Option<&str>) {
+fn cmd_install(
+    locked: bool,
+    offline: bool,
+    registry: &registry::Registry,
+    registry_name: Option<&str>,
+) {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let manifest_path = cwd.join("hew.toml");
     if !manifest_path.exists() {
@@ -626,14 +636,44 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
         return;
     }
 
-    // Resolve dependencies to exact versions, fetching any missing transitive
-    // packages until the graph resolves cleanly.
+    if offline {
+        eprintln!(
+            "Offline mode: using cached packages from {}; the registry will not be contacted.",
+            registry.root().display()
+        );
+    }
+
+    // Online resolution admits only versions confirmed by this registry
+    // session. Offline resolution explicitly admits the local cache.
+    let mut confirmed_versions = BTreeMap::<String, BTreeSet<String>>::new();
     let resolved = loop {
-        match resolver::resolve_all(&m, registry) {
+        let result = if offline {
+            resolver::resolve_all_from_root(&m, &cwd, registry)
+        } else {
+            resolver::resolve_all_confirmed(&m, &cwd, registry, &confirmed_versions)
+        };
+        match result {
             Ok(resolved) => break resolved,
+            Err(resolver::ResolveError::UnresolvableDeps { failures }) if offline => {
+                eprintln!("hew install: offline cache could not resolve:");
+                for failure in failures {
+                    eprintln!(
+                        "  {} [{}] in {}",
+                        failure.package,
+                        failure.requirements.join(", "),
+                        registry.root().display()
+                    );
+                }
+                std::process::exit(1);
+            }
             Err(resolver::ResolveError::UnresolvableDeps { failures }) => {
-                if !fetch_missing_packages(&failures, registry, registry_name) {
-                    eprintln!("hew install: could not resolve the dependency graph");
+                if let Err(error) = fetch_missing_packages(
+                    &failures,
+                    registry,
+                    registry_name,
+                    &mut confirmed_versions,
+                ) {
+                    eprintln!("hew install: {error}");
                     std::process::exit(1);
                 }
             }
@@ -654,21 +694,19 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
         }
         let version = &package.version;
         let target = registry.package_dir(name, version);
-        if !registry.is_installed(name, version) {
-            eprintln!("warning: {name}@{version} not found in global registry (~/.hew/packages/)");
+        if !target.is_dir() {
+            eprintln!(
+                "hew install: confirmed package {name}@{version} is missing from cache at {}",
+                target.display()
+            );
+            std::process::exit(1);
         }
-
-        // Compute checksum if the package directory exists.
-        let pkg_checksum = if target.is_dir() {
-            match checksum::compute_dir_checksum(&target) {
-                Ok(cs) => Some(cs),
-                Err(e) => {
-                    eprintln!("warning: cannot compute checksum for {name}@{version}: {e}");
-                    None
-                }
+        let pkg_checksum = match checksum::compute_dir_checksum(&target) {
+            Ok(checksum) => Some(checksum),
+            Err(error) => {
+                eprintln!("warning: cannot compute checksum for {name}@{version}: {error}");
+                None
             }
-        } else {
-            None
         };
 
         lock_packages.push(lockfile::LockedPackage {
@@ -678,6 +716,7 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
             checksum: pkg_checksum,
             signature: None,
             source: "registry".to_string(),
+            path: None,
         });
 
         // Build the local symlink path: replace :: with / separators.
@@ -727,9 +766,8 @@ fn fetch_missing_packages(
     failures: &[resolver::UnresolvedDep],
     registry: &registry::Registry,
     default_registry_name: Option<&str>,
-) -> bool {
-    let mut fetched_any = false;
-
+    confirmed_versions: &mut BTreeMap<String, BTreeSet<String>>,
+) -> Result<(), String> {
     for failure in failures {
         let api_client = make_client(failure.registry.as_deref().or(default_registry_name));
         let name = &failure.package;
@@ -738,23 +776,24 @@ fn fetch_missing_packages(
 
         eprint!("Fetching {name} from registry... ");
 
-        // Query the remote for available versions (fall back to local index).
+        // The registry is authoritative in online mode. A failed request must
+        // never admit an unconfirmed cache entry.
         let entries = match api_client.get_package(name) {
             Ok(entries) => entries,
             Err(api_err) => {
-                // Fallback: try local index if synced.
-                let index_root = config::local_index_path();
-                match index::read_index_entries(&index_root, name) {
-                    Ok(entries) if !entries.is_empty() => {
-                        eprintln!("(using local index fallback)");
-                        entries
-                    }
-                    _ => {
-                        eprintln!("failed");
-                        eprintln!("  warning: could not query registry for {name}: {api_err}");
-                        continue;
-                    }
-                }
+                eprintln!("failed");
+                let cache_path = resolver::resolve_cached_version(name, requirements, registry)
+                    .ok()
+                    .flatten()
+                    .map_or_else(
+                        || registry.root().join(name),
+                        |version| registry.package_dir(name, &version),
+                    );
+                return Err(format!(
+                    "registry request failed for package `{name}` version `{requirement_summary}` at `{}`: {api_err}; cached package path `{}` was not used (rerun with `hew install --offline` to use cached packages)",
+                    api_client.package_url(name),
+                    cache_path.display()
+                ));
             }
         };
 
@@ -766,22 +805,34 @@ fn fetch_missing_packages(
             Ok(result) => result,
             Err(e) => {
                 eprintln!("failed");
-                eprintln!("  warning: {e}");
-                continue;
+                return Err(e.to_string());
             }
         };
         let Some(resolved) = matched else {
             eprintln!("no matching version");
-            eprintln!("  warning: no version of {name} matches [{requirement_summary}]");
-            continue;
+            return Err(format!(
+                "registry `{}` has no version of package `{name}` matching [{requirement_summary}]; cached package path `{}` was not used",
+                api_client.package_url(name),
+                registry.root().join(name).display()
+            ));
         };
         let version = &resolved.version;
+
+        if registry.is_installed(name, version) {
+            confirmed_versions
+                .entry(name.clone())
+                .or_default()
+                .insert(version.clone());
+            eprintln!("confirmed cached {name}@{version}");
+            continue;
+        }
 
         // Get the download URL from the registry response.
         let Some(ref dl_url) = resolved.dl else {
             eprintln!("failed");
-            eprintln!("  warning: registry did not provide download URL for {name}@{version}");
-            continue;
+            return Err(format!(
+                "registry did not provide a download URL for package `{name}` version `{version}`"
+            ));
         };
 
         // Download the tarball.
@@ -789,8 +840,9 @@ fn fetch_missing_packages(
             Ok(data) => data,
             Err(e) => {
                 eprintln!("download failed");
-                eprintln!("  warning: could not download {name}@{version}: {e}");
-                continue;
+                return Err(format!(
+                    "could not download package `{name}` version `{version}`: {e}"
+                ));
             }
         };
 
@@ -801,7 +853,9 @@ fn fetch_missing_packages(
             eprintln!("  error: tarball integrity check failed for {name}@{version}");
             eprintln!("  expected: {}", resolved.checksum);
             eprintln!("  actual:   {actual_checksum}");
-            continue;
+            return Err(format!(
+                "tarball integrity check failed for {name}@{version}"
+            ));
         }
 
         // Verify Ed25519 signature over the checksum.
@@ -815,8 +869,7 @@ fn fetch_missing_packages(
                 Ok(()) => {}
                 Err(msg) => {
                     eprintln!("SIGNATURE VERIFICATION FAILED");
-                    eprintln!("  error: {msg}");
-                    continue;
+                    return Err(msg);
                 }
             }
         } else {
@@ -847,15 +900,17 @@ fn fetch_missing_packages(
         let target = registry.package_dir(name, version);
         if let Err(e) = tarball::unpack(&tarball_data, &target) {
             eprintln!("unpack failed");
-            eprintln!("  warning: could not unpack {name}@{version}: {e}");
-            continue;
+            return Err(format!("could not unpack {name}@{version}: {e}"));
         }
 
-        fetched_any = true;
+        confirmed_versions
+            .entry(name.clone())
+            .or_default()
+            .insert(version.clone());
         eprintln!("{name}@{version}");
     }
 
-    fetched_any
+    Ok(())
 }
 
 /// Verify an Ed25519 signature over a checksum by fetching the public key

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -612,40 +612,53 @@ fn cmd_install(
                 std::process::exit(1);
             }
         };
+        if let Err(error) = lockfile::validate_lockfile(&lf) {
+            eprintln!("hew install: {error}");
+            std::process::exit(1);
+        }
         if lockfile::is_lock_stale(&lf, &m) {
             let err = lockfile::LockError::Stale;
             eprintln!("hew install: {err}");
             eprintln!("Run `hew install` without --locked to update it.");
             std::process::exit(1);
         }
-        // Verify checksums of locked packages.
+        // Verify every locked registry package before resolution can reuse it.
         for entry in &lf.packages {
-            if !is_valid_package_name(&entry.name) {
-                eprintln!("hew install: {}", invalid_package_name_message(&entry.name));
+            if entry.source != "registry" {
+                continue;
+            }
+            let expected = entry
+                .checksum
+                .as_deref()
+                .expect("validated registry lock entry must have a checksum");
+            let pkg_dir = registry.package_dir(&entry.name, &entry.version);
+            if !registry.is_installed(&entry.name, &entry.version) {
+                eprintln!(
+                    "hew install: locked package {}@{} is missing from cache at {}",
+                    entry.name,
+                    entry.version,
+                    pkg_dir.display()
+                );
                 std::process::exit(1);
             }
-            if let Some(expected) = &entry.checksum {
-                let pkg_dir = registry.package_dir(&entry.name, &entry.version);
-                if pkg_dir.is_dir() {
-                    match checksum::compute_dir_checksum(&pkg_dir) {
-                        Ok(actual) if actual != *expected => {
-                            eprintln!(
-                                "hew install: checksum mismatch for {}@{}",
-                                entry.name, entry.version
-                            );
-                            eprintln!("  expected: {expected}");
-                            eprintln!("  actual:   {actual}");
-                            std::process::exit(1);
-                        }
-                        Err(e) => {
-                            eprintln!(
-                                "warning: cannot verify checksum for {}@{}: {e}",
-                                entry.name, entry.version
-                            );
-                        }
-                        _ => {}
-                    }
+            match checksum::compute_dir_checksum(&pkg_dir) {
+                Ok(actual) if actual != expected => {
+                    eprintln!(
+                        "hew install: checksum mismatch for {}@{}",
+                        entry.name, entry.version
+                    );
+                    eprintln!("  expected: {expected}");
+                    eprintln!("  actual:   {actual}");
+                    std::process::exit(1);
                 }
+                Err(error) => {
+                    eprintln!(
+                        "hew install: cannot verify checksum for {}@{}: {error}",
+                        entry.name, entry.version
+                    );
+                    std::process::exit(1);
+                }
+                _ => {}
             }
         }
     }
@@ -680,6 +693,7 @@ fn cmd_install(
     // Online resolution admits only versions confirmed by this registry
     // session. Offline resolution explicitly admits the local cache.
     let mut confirmed_versions = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut fetch_progress = FetchProgress::default();
     let resolved = loop {
         let result = if offline {
             resolver::resolve_all_from_root(&m, &cwd, registry)
@@ -701,6 +715,11 @@ fn cmd_install(
                 std::process::exit(1);
             }
             Err(resolver::ResolveError::UnresolvableDeps { failures }) => {
+                if let Err(error) = fetch_progress.begin_round(&failures) {
+                    eprintln!("hew install: {error}");
+                    std::process::exit(1);
+                }
+                let confirmed_before = confirmed_version_count(&confirmed_versions);
                 if let Err(error) = fetch_missing_packages(
                     &failures,
                     registry,
@@ -708,6 +727,10 @@ fn cmd_install(
                     &mut confirmed_versions,
                 ) {
                     eprintln!("hew install: {error}");
+                    std::process::exit(1);
+                }
+                if confirmed_version_count(&confirmed_versions) <= confirmed_before {
+                    eprintln!("hew install: registry fetch completed without making progress");
                     std::process::exit(1);
                 }
             }
@@ -740,8 +763,10 @@ fn cmd_install(
                 let checksum = match checksum::compute_dir_checksum(&target) {
                     Ok(checksum) => Some(checksum),
                     Err(error) => {
-                        eprintln!("warning: cannot compute checksum for {name}@{version}: {error}");
-                        None
+                        eprintln!(
+                            "hew install: cannot compute checksum for {name}@{version}: {error}"
+                        );
+                        std::process::exit(1);
                     }
                 };
                 (target, "registry", None, checksum)
@@ -868,7 +893,36 @@ fn fetch_missing_packages(
         };
         let version = &resolved.version;
 
-        if registry.is_installed(name, version) {
+        validate_registry_identity(name, version)?;
+        let lock_dir = registry.root().join(".locks");
+        std::fs::create_dir_all(&lock_dir).map_err(|error| {
+            format!(
+                "could not create package cache lock directory {}: {error}",
+                lock_dir.display()
+            )
+        })?;
+        let lock_path = lock_dir.join(format!("{name}-{version}.lock"));
+        let lock_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| {
+                format!(
+                    "could not open package cache lock {}: {error}",
+                    lock_path.display()
+                )
+            })?;
+        let mut package_lock = fd_lock::RwLock::new(lock_file);
+        let _package_guard = package_lock.write().map_err(|error| {
+            format!(
+                "could not acquire package cache lock {}: {error}",
+                lock_path.display()
+            )
+        })?;
+
+        if registry.is_online_cache_verified(name, version, &resolved.checksum)? {
             confirmed_versions
                 .entry(name.clone())
                 .or_default()
@@ -946,28 +1000,30 @@ fn fetch_missing_packages(
             }
         }
 
-        // Replace any incomplete cache entry only after the download has passed
-        // checksum and signature verification.
         let target = registry.package_dir(name, version);
-        match std::fs::symlink_metadata(&target) {
-            Ok(_) => remove_path_for_replacement(&target).map_err(|error| {
-                format!(
-                    "could not replace incomplete cache entry for {name}@{version} at {}: {error}",
-                    target.display()
-                )
-            })?,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(format!(
-                    "could not inspect cache entry for {name}@{version} at {}: {error}",
-                    target.display()
-                ));
-            }
-        }
-        if let Err(e) = tarball::unpack(&tarball_data, &target) {
+        let staged = crate::atomic_fs::StagedDir::new(&target).map_err(|error| {
+            format!(
+                "could not stage cache entry for {name}@{version} at {}: {error}",
+                target.display()
+            )
+        })?;
+        if let Err(e) = tarball::unpack(&tarball_data, staged.path()) {
             eprintln!("unpack failed");
             return Err(format!("could not unpack {name}@{version}: {e}"));
         }
+        registry::Registry::write_cache_metadata(
+            staged.path(),
+            name,
+            version,
+            &resolved.checksum,
+            &tarball_data,
+        )?;
+        staged.publish(&target).map_err(|error| {
+            format!(
+                "could not publish cache entry for {name}@{version} at {}: {error}",
+                target.display()
+            )
+        })?;
 
         confirmed_versions
             .entry(name.clone())
@@ -977,6 +1033,47 @@ fn fetch_missing_packages(
     }
 
     Ok(())
+}
+
+const MAX_FETCH_ROUNDS: usize = 1024;
+
+#[derive(Debug, Default)]
+struct FetchProgress {
+    rounds: usize,
+    previous_failures: Option<Vec<(String, Vec<String>)>>,
+}
+
+impl FetchProgress {
+    fn begin_round(&mut self, failures: &[resolver::UnresolvedDep]) -> Result<(), String> {
+        if self.rounds >= MAX_FETCH_ROUNDS {
+            return Err(format!(
+                "registry fetch exceeded the finite limit of {MAX_FETCH_ROUNDS} rounds"
+            ));
+        }
+        let signature = failures
+            .iter()
+            .map(|failure| (failure.package.clone(), failure.requirements.clone()))
+            .collect::<Vec<_>>();
+        if self.previous_failures.as_ref() == Some(&signature) {
+            return Err("registry fetch repeated without making resolver progress".to_string());
+        }
+        self.previous_failures = Some(signature);
+        self.rounds += 1;
+        Ok(())
+    }
+}
+
+fn confirmed_version_count(confirmed: &BTreeMap<String, BTreeSet<String>>) -> usize {
+    confirmed.values().map(BTreeSet::len).sum()
+}
+
+fn validate_registry_identity(name: &str, version: &str) -> Result<(), String> {
+    if !is_valid_package_name(name) {
+        return Err(invalid_package_name_message(name));
+    }
+    semver::Version::parse(version)
+        .map(|_| ())
+        .map_err(|error| format!("invalid registry version `{version}` for `{name}`: {error}"))
 }
 
 /// Verify an Ed25519 signature over a checksum by fetching the public key
@@ -2332,6 +2429,22 @@ fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fetch_progress_rejects_repeated_non_progress() {
+        let failures = vec![resolver::UnresolvedDep {
+            package: "foo".to_string(),
+            requirements: vec!["1.0.0".to_string()],
+            registry: None,
+        }];
+        let mut progress = FetchProgress::default();
+
+        progress.begin_round(&failures).unwrap();
+        let error = progress.begin_round(&failures).unwrap_err();
+
+        assert!(error.contains("repeated without making resolver progress"));
+        assert_eq!(progress.rounds, 1);
+    }
 
     #[test]
     fn ensure_gitignore_entry_creates_file() {

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -599,7 +599,7 @@ fn cmd_install(
 
     let lock_path = cwd.join("hew.lock");
 
-    let locked_lockfile = if locked {
+    let (locked_lockfile, pinned_locked_registry) = if locked {
         // --locked: read existing lock and validate against manifest.
         let lf = match lockfile::read_lockfile(&lock_path) {
             Ok(lf) => lf,
@@ -622,48 +622,16 @@ fn cmd_install(
             eprintln!("Run `hew install` without --locked to update it.");
             std::process::exit(1);
         }
-        // Verify every locked registry package before resolution can reuse it.
-        for entry in &lf.packages {
-            if entry.source != "registry" {
-                continue;
-            }
-            let expected = entry
-                .checksum
-                .as_deref()
-                .expect("validated registry lock entry must have a checksum");
-            let pkg_dir = registry.package_dir(&entry.name, &entry.version);
-            if !registry.is_installed(&entry.name, &entry.version) {
-                eprintln!(
-                    "hew install: locked package {}@{} is missing from cache at {}",
-                    entry.name,
-                    entry.version,
-                    pkg_dir.display()
-                );
+        let pinned = match verify_locked_registry_packages(&lf, registry) {
+            Ok(pinned) => pinned,
+            Err(error) => {
+                eprintln!("hew install: {error}");
                 std::process::exit(1);
             }
-            match checksum::compute_dir_checksum(&pkg_dir) {
-                Ok(actual) if actual != expected => {
-                    eprintln!(
-                        "hew install: checksum mismatch for {}@{}",
-                        entry.name, entry.version
-                    );
-                    eprintln!("  expected: {expected}");
-                    eprintln!("  actual:   {actual}");
-                    std::process::exit(1);
-                }
-                Err(error) => {
-                    eprintln!(
-                        "hew install: cannot verify checksum for {}@{}: {error}",
-                        entry.name, entry.version
-                    );
-                    std::process::exit(1);
-                }
-                _ => {}
-            }
-        }
-        Some(lf)
+        };
+        (Some(lf), pinned)
     } else {
-        None
+        (None, BTreeMap::new())
     };
 
     let local_packages = project_packages_path(&cwd);
@@ -693,19 +661,18 @@ fn cmd_install(
         );
     }
 
-    // Online resolution admits only versions confirmed by this registry
-    // session. Offline resolution explicitly admits the local cache.
+    // Locked resolution uses only the immutable paths verified above. Online
+    // resolution admits only versions confirmed by this registry session;
+    // offline resolution explicitly admits the local cache.
+    let pinned_locked_paths = pinned_locked_registry
+        .iter()
+        .map(|(identity, package)| (identity.clone(), package.path.clone()))
+        .collect();
     let mut confirmed_versions = BTreeMap::<String, BTreeSet<String>>::new();
     let mut fetch_progress = FetchProgress::default();
     let resolved = loop {
-        let result = if let Some(lockfile) = &locked_lockfile {
-            let locked_versions = lockfile
-                .packages
-                .iter()
-                .filter(|package| package.source == "registry")
-                .map(|package| (package.name.clone(), package.version.clone()))
-                .collect();
-            resolver::resolve_all_locked(&m, &cwd, registry, &locked_versions)
+        let result = if locked_lockfile.is_some() {
+            resolver::resolve_all_locked(&m, &cwd, registry, &pinned_locked_paths)
         } else if offline {
             resolver::resolve_all_from_root(&m, &cwd, registry)
         } else {
@@ -713,8 +680,15 @@ fn cmd_install(
         };
         match result {
             Ok(resolved) => break resolved,
-            Err(resolver::ResolveError::UnresolvableDeps { failures }) if offline => {
-                eprintln!("hew install: offline cache could not resolve:");
+            Err(resolver::ResolveError::UnresolvableDeps { failures })
+                if offline || locked_lockfile.is_some() =>
+            {
+                let mode = if locked {
+                    "locked graph"
+                } else {
+                    "offline cache"
+                };
+                eprintln!("hew install: {mode} could not resolve:");
                 for failure in failures {
                     eprintln!(
                         "  {} [{}] in {}",
@@ -770,24 +744,36 @@ fn cmd_install(
         let version = &package.version;
         let (target, source, locked_path, pkg_checksum) = match &package.source {
             resolver::PackageSource::Registry => {
-                let target = registry.package_dir(name, version);
-                if !target.is_dir() {
-                    eprintln!(
-                        "hew install: confirmed package {name}@{version} is missing from cache at {}",
-                        target.display()
-                    );
-                    std::process::exit(1);
-                }
-                let checksum = match checksum::compute_dir_checksum(&target) {
-                    Ok(checksum) => Some(checksum),
-                    Err(error) => {
+                if locked {
+                    let pinned = pinned_locked_registry
+                        .get(&(name.clone(), version.clone()))
+                        .expect("locked registry resolution must retain its verified path");
+                    (
+                        pinned.path.clone(),
+                        "registry",
+                        None,
+                        Some(pinned.checksum.clone()),
+                    )
+                } else {
+                    let target = registry.package_dir(name, version);
+                    if !target.is_dir() {
                         eprintln!(
-                            "hew install: cannot compute checksum for {name}@{version}: {error}"
+                            "hew install: confirmed package {name}@{version} is missing from cache at {}",
+                            target.display()
                         );
                         std::process::exit(1);
                     }
-                };
-                (target, "registry", None, checksum)
+                    let checksum = match checksum::compute_dir_checksum(&target) {
+                        Ok(checksum) => Some(checksum),
+                        Err(error) => {
+                            eprintln!(
+                                "hew install: cannot compute checksum for {name}@{version}: {error}"
+                            );
+                            std::process::exit(1);
+                        }
+                    };
+                    (target, "registry", None, checksum)
+                }
             }
             resolver::PackageSource::Path(path) => (
                 path.clone(),
@@ -848,6 +834,72 @@ fn cmd_install(
         }
         println!("Wrote hew.lock");
     }
+}
+
+#[derive(Debug)]
+struct VerifiedLockedPackage {
+    path: PathBuf,
+    checksum: String,
+}
+
+fn verify_locked_registry_packages(
+    lockfile: &lockfile::LockFile,
+    registry: &registry::Registry,
+) -> Result<BTreeMap<(String, String), VerifiedLockedPackage>, String> {
+    let mut pinned = BTreeMap::new();
+    for entry in &lockfile.packages {
+        if entry.source != "registry" {
+            continue;
+        }
+        let expected = entry
+            .checksum
+            .as_deref()
+            .expect("validated registry lock entry must have a checksum");
+        let resolved = registry
+            .package_dir_checked(&entry.name, &entry.version)
+            .map_err(|error| {
+                format!(
+                    "cannot resolve locked package {}@{} generation: {error}",
+                    entry.name, entry.version
+                )
+            })?;
+        let path = resolved.canonicalize().map_err(|error| {
+            format!(
+                "locked package {}@{} is missing from cache at {}: {error}",
+                entry.name,
+                entry.version,
+                resolved.display()
+            )
+        })?;
+        if !path.join("hew.toml").is_file() {
+            return Err(format!(
+                "locked package {}@{} is missing from cache at {}",
+                entry.name,
+                entry.version,
+                path.display()
+            ));
+        }
+        let actual = checksum::compute_dir_checksum(&path).map_err(|error| {
+            format!(
+                "cannot verify checksum for {}@{}: {error}",
+                entry.name, entry.version
+            )
+        })?;
+        if actual != expected {
+            return Err(format!(
+                "checksum mismatch for {}@{}\n  expected: {expected}\n  actual:   {actual}",
+                entry.name, entry.version
+            ));
+        }
+        pinned.insert(
+            (entry.name.clone(), entry.version.clone()),
+            VerifiedLockedPackage {
+                path,
+                checksum: actual,
+            },
+        );
+    }
+    Ok(pinned)
 }
 
 fn validate_locked_resolution(
@@ -2651,6 +2703,124 @@ mod tests {
 
         assert!(dest.join("hew.toml").exists());
         assert!(dest.join("main.hew").exists());
+    }
+
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "security regression keeps verification, concurrent swap, graph, and materialization in one proof"
+    )]
+    fn locked_resolution_and_materialization_keep_verified_generation_after_pointer_swap() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Arc, Barrier};
+
+        let root = tempfile::tempdir().unwrap();
+        let registry_root = root.path().join("registry");
+        let registry = registry::Registry::with_root(registry_root.clone());
+        let package_root = registry_root.join("foo");
+        let generation_a = package_root.join(".1.0.0.generation-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let generation_b = package_root.join(".1.0.0.generation-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let bar = registry_root.join("bar/1.0.0");
+        std::fs::create_dir_all(&generation_a).unwrap();
+        std::fs::create_dir_all(&generation_b).unwrap();
+        std::fs::create_dir_all(&bar).unwrap();
+        std::fs::write(
+            generation_a.join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\nbar = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(generation_a.join("foo.hew"), "generation A").unwrap();
+        std::fs::write(
+            generation_b.join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\nbaz = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(generation_b.join("foo.hew"), "generation B").unwrap();
+        std::fs::write(
+            bar.join("hew.toml"),
+            "[package]\nname = \"bar\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            package_root.join(".1.0.0.current"),
+            format!("{}\n", generation_a.file_name().unwrap().to_string_lossy()),
+        )
+        .unwrap();
+
+        let lockfile = lockfile::LockFile {
+            packages: vec![
+                lockfile::LockedPackage {
+                    name: "foo".to_string(),
+                    requirement: Some("1.0.0".to_string()),
+                    version: "1.0.0".to_string(),
+                    checksum: Some(checksum::compute_dir_checksum(&generation_a).unwrap()),
+                    signature: None,
+                    source: "registry".to_string(),
+                    path: None,
+                },
+                lockfile::LockedPackage {
+                    name: "bar".to_string(),
+                    requirement: None,
+                    version: "1.0.0".to_string(),
+                    checksum: Some(checksum::compute_dir_checksum(&bar).unwrap()),
+                    signature: None,
+                    source: "registry".to_string(),
+                    path: None,
+                },
+            ],
+        };
+        let pinned = verify_locked_registry_packages(&lockfile, &registry).unwrap();
+
+        let ready = Arc::new(Barrier::new(2));
+        let writer_ready = Arc::clone(&ready);
+        let stop = Arc::new(AtomicBool::new(false));
+        let writer_stop = Arc::clone(&stop);
+        let pointer = package_root.join(".1.0.0.current");
+        let generation_b_name = generation_b.file_name().unwrap().to_owned();
+        let writer = std::thread::spawn(move || {
+            let pointer_b = format!("{}\n", generation_b_name.to_string_lossy());
+            crate::atomic_fs::write_atomic(&pointer, pointer_b.as_bytes(), 0o644).unwrap();
+            writer_ready.wait();
+            while !writer_stop.load(Ordering::Relaxed) {
+                crate::atomic_fs::write_atomic(&pointer, pointer_b.as_bytes(), 0o644).unwrap();
+                std::thread::yield_now();
+            }
+        });
+        ready.wait();
+        assert_eq!(registry.package_dir("foo", "1.0.0"), generation_b);
+
+        let project = root.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(
+            project.join("hew.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\nfoo = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let manifest = manifest::parse_manifest(&project.join("hew.toml")).unwrap();
+        let pinned_paths = pinned
+            .iter()
+            .map(|(identity, package)| (identity.clone(), package.path.clone()))
+            .collect();
+        let resolved =
+            resolver::resolve_all_locked(&manifest, &project, &registry, &pinned_paths).unwrap();
+        assert!(resolved.contains_key("bar"));
+        assert!(!resolved.contains_key("baz"));
+
+        let link = project.join(".hew/packages/foo");
+        replace_local_package_materialization(
+            &link,
+            &pinned
+                .get(&("foo".to_string(), "1.0.0".to_string()))
+                .unwrap()
+                .path,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(link.join("foo.hew")).unwrap(),
+            "generation A"
+        );
+        stop.store(true, Ordering::Relaxed);
+        writer.join().unwrap();
     }
 
     #[test]

--- a/hew-pkg/src/client.rs
+++ b/hew-pkg/src/client.rs
@@ -202,9 +202,9 @@ impl RegistryClient {
 
     /// Create a client for a named registry.
     #[must_use]
-    pub fn with_url(api_url: String) -> Self {
+    pub fn with_url(api_url: impl AsRef<str>) -> Self {
         Self {
-            api_url,
+            api_url: config::registry_identity(api_url.as_ref()),
             fallback_urls: Vec::new(),
             cdn_url: None,
             token: None,
@@ -230,6 +230,12 @@ impl RegistryClient {
     #[must_use]
     pub fn package_url(&self, name: &str) -> String {
         format!("{}/packages/{name}", self.api_url)
+    }
+
+    /// Canonical source identity bound to this client's primary API URL.
+    #[must_use]
+    pub fn registry_identity(&self) -> &str {
+        &self.api_url
     }
 
     /// Start the GitHub OAuth device flow.
@@ -753,7 +759,7 @@ mod tests {
 
     #[test]
     fn package_urls_preserve_dotted_names() {
-        let client = RegistryClient::with_url("https://registry.example.com".to_string());
+        let client = RegistryClient::with_url("https://registry.example.com");
         assert_eq!(
             format!("{}/packages/{}", client.api_url, "alice.router"),
             "https://registry.example.com/packages/alice.router"
@@ -776,7 +782,7 @@ mod tests {
 
     #[test]
     fn client_custom_url() {
-        let client = RegistryClient::with_url("https://internal.example.com/api/v1".to_string());
+        let client = RegistryClient::with_url("https://internal.example.com/api/v1");
         assert_eq!(client.api_url, "https://internal.example.com/api/v1");
     }
 
@@ -849,7 +855,7 @@ mod tests {
 
     #[test]
     fn client_with_fallback() {
-        let client = RegistryClient::with_url("https://primary.example.com/api/v1".to_string())
+        let client = RegistryClient::with_url("https://primary.example.com/api/v1")
             .with_fallback("https://mirror.example.com/api/v1".to_string());
         assert_eq!(
             client.fallback_urls,

--- a/hew-pkg/src/client.rs
+++ b/hew-pkg/src/client.rs
@@ -226,6 +226,12 @@ impl RegistryClient {
         self
     }
 
+    /// Return the registry API URL used to query a package.
+    #[must_use]
+    pub fn package_url(&self, name: &str) -> String {
+        format!("{}/packages/{name}", self.api_url)
+    }
+
     /// Start the GitHub OAuth device flow.
     ///
     /// # Errors

--- a/hew-pkg/src/config.rs
+++ b/hew-pkg/src/config.rs
@@ -62,6 +62,58 @@ pub const DEFAULT_FALLBACK_API: Option<&str> = Some("https://mirror.hewpkg.com/a
 /// The default public registry index URL.
 pub const DEFAULT_REGISTRY_INDEX: &str = "https://github.com/hew-lang/registry-index";
 
+/// Canonical identity for a registry source.
+///
+/// The primary API URL is authoritative. Selector names and fallback URLs are
+/// deliberately excluded so aliases for the same source share an identity,
+/// while different default and named sources cannot collapse.
+#[must_use]
+pub fn registry_identity(api_url: &str) -> String {
+    let trimmed = api_url.trim().trim_end_matches('/');
+    let Some((scheme, remainder)) = trimmed.split_once("://") else {
+        return trimmed.to_string();
+    };
+    let (authority, path) = remainder
+        .split_once('/')
+        .map_or((remainder, ""), |(authority, path)| (authority, path));
+    let normalized_path = path.trim_end_matches('/');
+    if normalized_path.is_empty() {
+        format!(
+            "{}://{}",
+            scheme.to_ascii_lowercase(),
+            authority.to_ascii_lowercase()
+        )
+    } else {
+        format!(
+            "{}://{}/{}",
+            scheme.to_ascii_lowercase(),
+            authority.to_ascii_lowercase(),
+            normalized_path
+        )
+    }
+}
+
+/// Canonical identity of the compiled-in default registry.
+#[must_use]
+pub fn default_registry_identity() -> String {
+    registry_identity(DEFAULT_REGISTRY_API)
+}
+
+/// Return canonical identities for all configured named registries.
+#[must_use]
+pub fn named_registry_identities(config: &PkgConfig) -> std::collections::BTreeMap<String, String> {
+    config
+        .registries
+        .as_ref()
+        .map(|registries| {
+            registries
+                .iter()
+                .map(|(name, remote)| (name.clone(), registry_identity(&remote.api)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Errors that can occur when reading or parsing `~/.hew/config.toml`.
 #[derive(Debug)]
 pub enum ConfigError {
@@ -347,6 +399,14 @@ fallback-api = "https://mirror.example.com/api/v1"
         assert_eq!(
             reg.fallback_api.as_deref(),
             Some("https://mirror.example.com/api/v1")
+        );
+    }
+
+    #[test]
+    fn registry_identity_normalizes_primary_api_url() {
+        assert_eq!(
+            registry_identity(" HTTPS://Registry.Example.COM/api/v1/// "),
+            "https://registry.example.com/api/v1"
         );
     }
 }

--- a/hew-pkg/src/lockfile.rs
+++ b/hew-pkg/src/lockfile.rs
@@ -157,7 +157,14 @@ pub fn write_lockfile(path: &Path, lockfile: &LockFile) -> Result<(), LockError>
 /// Returns [`LockError::InvalidEntry`] for invalid names or versions, or when a
 /// registry package lacks the checksum required for a locked install.
 pub fn validate_lockfile(lockfile: &LockFile) -> Result<(), LockError> {
+    let mut names = std::collections::BTreeSet::new();
     for package in &lockfile.packages {
+        if !names.insert(package.name.as_str()) {
+            return Err(LockError::InvalidEntry {
+                package: package.name.clone(),
+                reason: "duplicate package identity".to_string(),
+            });
+        }
         if !crate::package_name::is_valid(&package.name) {
             return Err(LockError::InvalidEntry {
                 package: package.name.clone(),
@@ -168,6 +175,12 @@ pub fn validate_lockfile(lockfile: &LockFile) -> Result<(), LockError> {
             package: package.name.clone(),
             reason: format!("invalid version `{}`: {error}", package.version),
         })?;
+        if !matches!(package.source.as_str(), "registry" | "path") {
+            return Err(LockError::InvalidEntry {
+                package: package.name.clone(),
+                reason: format!("unsupported source `{}`", package.source),
+            });
+        }
         if package.source == "registry" {
             let checksum = package
                 .checksum
@@ -182,6 +195,11 @@ pub fn validate_lockfile(lockfile: &LockFile) -> Result<(), LockError> {
                     reason: format!("invalid checksum `{checksum}`"),
                 });
             }
+        } else if package.path.as_deref().is_none_or(str::is_empty) {
+            return Err(LockError::InvalidEntry {
+                package: package.name.clone(),
+                reason: "path package is missing its locked path".to_string(),
+            });
         }
     }
     Ok(())

--- a/hew-pkg/src/lockfile.rs
+++ b/hew-pkg/src/lockfile.rs
@@ -29,6 +29,9 @@ pub struct LockedPackage {
     /// Package source: `"registry"`, `"path"`, or `"local"`.
     #[serde(default = "default_source", skip_serializing_if = "is_default_source")]
     pub source: String,
+    /// Canonical registry identity when `source = "registry"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
     /// Local dependency path when `source = "path"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
@@ -182,6 +185,23 @@ pub fn validate_lockfile(lockfile: &LockFile) -> Result<(), LockError> {
             });
         }
         if package.source == "registry" {
+            let registry = package
+                .registry
+                .as_deref()
+                .ok_or_else(|| LockError::InvalidEntry {
+                    package: package.name.clone(),
+                    reason: "registry package is missing its canonical registry identity"
+                        .to_string(),
+                })?;
+            if registry.is_empty()
+                || crate::config::registry_identity(registry) != registry
+                || !(registry.starts_with("https://") || registry.starts_with("http://"))
+            {
+                return Err(LockError::InvalidEntry {
+                    package: package.name.clone(),
+                    reason: format!("invalid canonical registry identity `{registry}`"),
+                });
+            }
             let checksum = package
                 .checksum
                 .as_deref()
@@ -195,11 +215,25 @@ pub fn validate_lockfile(lockfile: &LockFile) -> Result<(), LockError> {
                     reason: format!("invalid checksum `{checksum}`"),
                 });
             }
-        } else if package.path.as_deref().is_none_or(str::is_empty) {
-            return Err(LockError::InvalidEntry {
-                package: package.name.clone(),
-                reason: "path package is missing its locked path".to_string(),
-            });
+            if package.path.is_some() {
+                return Err(LockError::InvalidEntry {
+                    package: package.name.clone(),
+                    reason: "registry package cannot contain a locked path".to_string(),
+                });
+            }
+        } else {
+            if package.registry.is_some() {
+                return Err(LockError::InvalidEntry {
+                    package: package.name.clone(),
+                    reason: "path package cannot contain a registry identity".to_string(),
+                });
+            }
+            if package.path.as_deref().is_none_or(str::is_empty) {
+                return Err(LockError::InvalidEntry {
+                    package: package.name.clone(),
+                    reason: "path package is missing its locked path".to_string(),
+                });
+            }
         }
     }
     Ok(())
@@ -216,32 +250,71 @@ fn is_sha256_checksum(checksum: &str) -> bool {
 /// A lockfile is stale when its recorded direct dependency requirements differ
 /// from the current manifest requirements.
 #[must_use]
+#[allow(
+    dead_code,
+    reason = "kept as the default-registry convenience API for library callers"
+)]
 pub fn is_lock_stale(lockfile: &LockFile, manifest: &HewManifest) -> bool {
-    let locked_requirements: std::collections::BTreeMap<&str, (&str, Option<&str>)> = lockfile
+    is_lock_stale_for_registries(
+        lockfile,
+        manifest,
+        &crate::config::default_registry_identity(),
+        &std::collections::BTreeMap::new(),
+    )
+}
+
+/// Compare direct requirements together with their canonical source identities.
+#[must_use]
+pub fn is_lock_stale_for_registries(
+    lockfile: &LockFile,
+    manifest: &HewManifest,
+    default_registry: &str,
+    named_registries: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    type RequirementIdentity<'a> = (&'a str, Option<&'a str>, Option<&'a str>);
+    type RequirementMap<'a> = std::collections::BTreeMap<&'a str, RequirementIdentity<'a>>;
+
+    let locked_requirements: RequirementMap<'_> = lockfile
         .packages
         .iter()
         .filter_map(|package| {
             package.requirement.as_deref().map(|requirement| {
                 (
                     package.name.as_str(),
-                    (requirement, package.path.as_deref()),
+                    (
+                        requirement,
+                        package.path.as_deref(),
+                        package.registry.as_deref(),
+                    ),
                 )
             })
         })
         .collect();
-    let manifest_requirements: std::collections::BTreeMap<&str, (&str, Option<&str>)> = manifest
+    let manifest_requirements: Option<RequirementMap<'_>> = manifest
         .dependencies
         .iter()
         .map(|(name, dep_spec)| {
-            let path = match dep_spec {
-                crate::manifest::DepSpec::Version(_) => None,
-                crate::manifest::DepSpec::Table(table) => table.path.as_deref(),
+            let (path, selector) = match dep_spec {
+                crate::manifest::DepSpec::Version(_) => (None, None),
+                crate::manifest::DepSpec::Table(table) => {
+                    (table.path.as_deref(), table.registry.as_deref())
+                }
             };
-            (name.as_str(), (dep_spec.version_req(), path))
+            if path.is_some() && selector.is_some() {
+                return None;
+            }
+            let registry = if path.is_some() {
+                None
+            } else if let Some(selector) = selector {
+                Some(named_registries.get(selector)?.as_str())
+            } else {
+                Some(default_registry)
+            };
+            Some((name.as_str(), (dep_spec.version_req(), path, registry)))
         })
         .collect();
 
-    locked_requirements != manifest_requirements
+    manifest_requirements.is_none_or(|requirements| locked_requirements != requirements)
 }
 
 #[cfg(test)]
@@ -300,6 +373,7 @@ mod tests {
                     checksum: Some("sha256:def456".to_string()),
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
                 LockedPackage {
@@ -309,6 +383,7 @@ mod tests {
                     checksum: Some("sha256:abc123".to_string()),
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
             ],
@@ -340,6 +415,7 @@ mod tests {
                 checksum: None,
                 signature: None,
                 source: "registry".to_string(),
+                registry: Some(crate::config::default_registry_identity()),
                 path: None,
             }],
         };
@@ -386,6 +462,7 @@ mod tests {
                 checksum: None,
                 signature: None,
                 source: "registry".to_string(),
+                registry: Some(crate::config::default_registry_identity()),
                 path: None,
             }],
         };
@@ -408,6 +485,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
                 LockedPackage {
@@ -417,6 +495,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
             ],
@@ -437,6 +516,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
                 LockedPackage {
@@ -446,6 +526,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
             ],
@@ -465,6 +546,7 @@ mod tests {
                 checksum: None,
                 signature: None,
                 source: "registry".to_string(),
+                registry: Some(crate::config::default_registry_identity()),
                 path: None,
             }],
         };
@@ -484,6 +566,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
                 LockedPackage {
@@ -493,6 +576,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
             ],
@@ -529,6 +613,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
                 LockedPackage {
@@ -538,6 +623,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    registry: Some(crate::config::default_registry_identity()),
                     path: None,
                 },
             ],
@@ -577,6 +663,7 @@ mod tests {
                 checksum: None,
                 signature: None,
                 source: "path".to_string(),
+                registry: None,
                 path: Some("../local".to_string()),
             }],
         };
@@ -630,6 +717,7 @@ mod tests {
                 checksum: Some(format!("sha256:{}", "0".repeat(64))),
                 signature: None,
                 source: "registry".to_string(),
+                registry: Some(crate::config::default_registry_identity()),
                 path: None,
             }],
         };
@@ -648,11 +736,65 @@ mod tests {
                 checksum: None,
                 signature: None,
                 source: "registry".to_string(),
+                registry: Some(crate::config::default_registry_identity()),
                 path: None,
             }],
         };
 
         let error = validate_lockfile(&lockfile).unwrap_err();
         assert!(error.to_string().contains("missing its locked checksum"));
+    }
+
+    #[test]
+    fn validation_rejects_legacy_registry_entry_without_identity() {
+        let lockfile = LockFile {
+            packages: vec![LockedPackage {
+                name: "foo".to_string(),
+                requirement: Some("1.0.0".to_string()),
+                version: "1.0.0".to_string(),
+                checksum: Some(format!("sha256:{}", "0".repeat(64))),
+                signature: None,
+                source: "registry".to_string(),
+                registry: None,
+                path: None,
+            }],
+        };
+
+        let error = validate_lockfile(&lockfile).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("missing its canonical registry identity"));
+    }
+
+    #[test]
+    fn changing_default_registry_identity_stales_lock() {
+        let first = "https://registry-a.example/api/v1";
+        let second = "https://registry-b.example/api/v1";
+        let lockfile = LockFile {
+            packages: vec![LockedPackage {
+                name: "foo".to_string(),
+                requirement: Some("1.0.0".to_string()),
+                version: "1.0.0".to_string(),
+                checksum: Some(format!("sha256:{}", "0".repeat(64))),
+                signature: None,
+                source: "registry".to_string(),
+                registry: Some(first.to_string()),
+                path: None,
+            }],
+        };
+        let manifest = make_manifest(&[("foo", "1.0.0")]);
+
+        assert!(!is_lock_stale_for_registries(
+            &lockfile,
+            &manifest,
+            first,
+            &std::collections::BTreeMap::new(),
+        ));
+        assert!(is_lock_stale_for_registries(
+            &lockfile,
+            &manifest,
+            second,
+            &std::collections::BTreeMap::new(),
+        ));
     }
 }

--- a/hew-pkg/src/lockfile.rs
+++ b/hew-pkg/src/lockfile.rs
@@ -29,6 +29,9 @@ pub struct LockedPackage {
     /// Package source: `"registry"`, `"path"`, or `"local"`.
     #[serde(default = "default_source", skip_serializing_if = "is_default_source")]
     pub source: String,
+    /// Local dependency path when `source = "path"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 fn default_source() -> String {
@@ -143,20 +146,28 @@ pub fn write_lockfile(path: &Path, lockfile: &LockFile) -> Result<(), LockError>
 /// from the current manifest requirements.
 #[must_use]
 pub fn is_lock_stale(lockfile: &LockFile, manifest: &HewManifest) -> bool {
-    let locked_requirements: std::collections::BTreeMap<&str, &str> = lockfile
+    let locked_requirements: std::collections::BTreeMap<&str, (&str, Option<&str>)> = lockfile
         .packages
         .iter()
         .filter_map(|package| {
-            package
-                .requirement
-                .as_deref()
-                .map(|requirement| (package.name.as_str(), requirement))
+            package.requirement.as_deref().map(|requirement| {
+                (
+                    package.name.as_str(),
+                    (requirement, package.path.as_deref()),
+                )
+            })
         })
         .collect();
-    let manifest_requirements: std::collections::BTreeMap<&str, &str> = manifest
+    let manifest_requirements: std::collections::BTreeMap<&str, (&str, Option<&str>)> = manifest
         .dependencies
         .iter()
-        .map(|(name, dep_spec)| (name.as_str(), dep_spec.version_req()))
+        .map(|(name, dep_spec)| {
+            let path = match dep_spec {
+                crate::manifest::DepSpec::Version(_) => None,
+                crate::manifest::DepSpec::Table(table) => table.path.as_deref(),
+            };
+            (name.as_str(), (dep_spec.version_req(), path))
+        })
         .collect();
 
     locked_requirements != manifest_requirements
@@ -218,6 +229,7 @@ mod tests {
                     checksum: Some("sha256:def456".to_string()),
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
                 LockedPackage {
                     name: "ecosystem::db::postgres".to_string(),
@@ -226,6 +238,7 @@ mod tests {
                     checksum: Some("sha256:abc123".to_string()),
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
             ],
         };
@@ -256,6 +269,7 @@ mod tests {
                 checksum: None,
                 signature: None,
                 source: "registry".to_string(),
+                path: None,
             }],
         };
 
@@ -301,6 +315,7 @@ mod tests {
                 checksum: None,
                 signature: None,
                 source: "registry".to_string(),
+                path: None,
             }],
         };
         let manifest = make_manifest(&[
@@ -322,6 +337,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
                 LockedPackage {
                     name: "ecosystem::db::postgres".to_string(),
@@ -330,6 +346,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
             ],
         };
@@ -349,6 +366,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
                 LockedPackage {
                     name: "ecosystem::db::tls".to_string(),
@@ -357,6 +375,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
             ],
         };
@@ -375,6 +394,7 @@ mod tests {
                 checksum: None,
                 signature: None,
                 source: "registry".to_string(),
+                path: None,
             }],
         };
         let manifest = make_manifest(&[("std::net::http", "^1.2")]);
@@ -393,6 +413,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
                 LockedPackage {
                     name: "std::net::http".to_string(),
@@ -401,6 +422,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
             ],
         };
@@ -436,6 +458,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
                 LockedPackage {
                     name: "aaa::first".to_string(),
@@ -444,6 +467,7 @@ mod tests {
                     checksum: None,
                     signature: None,
                     source: "registry".to_string(),
+                    path: None,
                 },
             ],
         };
@@ -468,6 +492,49 @@ mod tests {
 
         let content = std::fs::read_to_string(&lock_path).unwrap();
         assert!(content.starts_with("# This file is auto-generated by hew."));
+    }
+
+    #[test]
+    fn path_source_roundtrips_and_participates_in_freshness() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("hew.lock");
+        let lockfile = LockFile {
+            packages: vec![LockedPackage {
+                name: "local".to_string(),
+                requirement: Some("*".to_string()),
+                version: "1.2.3".to_string(),
+                checksum: None,
+                signature: None,
+                source: "path".to_string(),
+                path: Some("../local".to_string()),
+            }],
+        };
+        write_lockfile(&lock_path, &lockfile).unwrap();
+
+        let read = read_lockfile(&lock_path).unwrap();
+        assert_eq!(read.packages[0].source, "path");
+        assert_eq!(read.packages[0].path.as_deref(), Some("../local"));
+
+        let mut manifest = make_manifest(&[]);
+        manifest.dependencies.insert(
+            "local".to_string(),
+            manifest::DepSpec::Table(manifest::DepTable {
+                version: "*".to_string(),
+                optional: None,
+                features: None,
+                default_features: None,
+                registry: None,
+                path: Some("../local".to_string()),
+            }),
+        );
+        assert!(!is_lock_stale(&read, &manifest));
+
+        let manifest::DepSpec::Table(dependency) = manifest.dependencies.get_mut("local").unwrap()
+        else {
+            unreachable!();
+        };
+        dependency.path = Some("../other".to_string());
+        assert!(is_lock_stale(&read, &manifest));
     }
 
     #[test]

--- a/hew-pkg/src/lockfile.rs
+++ b/hew-pkg/src/lockfile.rs
@@ -63,6 +63,13 @@ pub enum LockError {
     Stale,
     /// The lockfile does not exist.
     Missing,
+    /// A package entry contains an unsafe or incomplete identity.
+    InvalidEntry {
+        /// Package name as written in the lockfile.
+        package: String,
+        /// Validation failure.
+        reason: String,
+    },
 }
 
 impl fmt::Display for LockError {
@@ -73,6 +80,9 @@ impl fmt::Display for LockError {
             Self::Serialize(e) => write!(f, "cannot serialize lockfile: {e}"),
             Self::Stale => write!(f, "lockfile is out of date with hew.toml"),
             Self::Missing => write!(f, "hew.lock not found"),
+            Self::InvalidEntry { package, reason } => {
+                write!(f, "invalid lockfile entry for `{package}`: {reason}")
+            }
         }
     }
 }
@@ -83,7 +93,7 @@ impl std::error::Error for LockError {
             Self::Io(e) => Some(e),
             Self::Parse(e) => Some(e),
             Self::Serialize(e) => Some(e),
-            Self::Stale | Self::Missing => None,
+            Self::Stale | Self::Missing | Self::InvalidEntry { .. } => None,
         }
     }
 }
@@ -138,6 +148,49 @@ pub fn write_lockfile(path: &Path, lockfile: &LockFile) -> Result<(), LockError>
     let content = format!("{LOCKFILE_HEADER}{body}");
     std::fs::write(path, content)?;
     Ok(())
+}
+
+/// Validate every package identity before callers compose cache paths from it.
+///
+/// # Errors
+///
+/// Returns [`LockError::InvalidEntry`] for invalid names or versions, or when a
+/// registry package lacks the checksum required for a locked install.
+pub fn validate_lockfile(lockfile: &LockFile) -> Result<(), LockError> {
+    for package in &lockfile.packages {
+        if !crate::package_name::is_valid(&package.name) {
+            return Err(LockError::InvalidEntry {
+                package: package.name.clone(),
+                reason: crate::package_name::invalid_message(&package.name),
+            });
+        }
+        semver::Version::parse(&package.version).map_err(|error| LockError::InvalidEntry {
+            package: package.name.clone(),
+            reason: format!("invalid version `{}`: {error}", package.version),
+        })?;
+        if package.source == "registry" {
+            let checksum = package
+                .checksum
+                .as_deref()
+                .ok_or_else(|| LockError::InvalidEntry {
+                    package: package.name.clone(),
+                    reason: "registry package is missing its locked checksum".to_string(),
+                })?;
+            if !is_sha256_checksum(checksum) {
+                return Err(LockError::InvalidEntry {
+                    package: package.name.clone(),
+                    reason: format!("invalid checksum `{checksum}`"),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_sha256_checksum(checksum: &str) -> bool {
+    checksum
+        .strip_prefix("sha256:")
+        .is_some_and(|hex| hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit()))
 }
 
 /// Returns `true` if the lockfile is stale relative to the manifest.
@@ -547,5 +600,41 @@ mod tests {
 
         let missing_err = LockError::Missing;
         assert!(missing_err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn validation_rejects_traversal_version() {
+        let lockfile = LockFile {
+            packages: vec![LockedPackage {
+                name: "foo".to_string(),
+                requirement: Some("1.0.0".to_string()),
+                version: "../../escape".to_string(),
+                checksum: Some(format!("sha256:{}", "0".repeat(64))),
+                signature: None,
+                source: "registry".to_string(),
+                path: None,
+            }],
+        };
+
+        let error = validate_lockfile(&lockfile).unwrap_err();
+        assert!(error.to_string().contains("invalid version"));
+    }
+
+    #[test]
+    fn validation_requires_registry_checksum() {
+        let lockfile = LockFile {
+            packages: vec![LockedPackage {
+                name: "foo".to_string(),
+                requirement: Some("1.0.0".to_string()),
+                version: "1.0.0".to_string(),
+                checksum: None,
+                signature: None,
+                source: "registry".to_string(),
+                path: None,
+            }],
+        };
+
+        let error = validate_lockfile(&lockfile).unwrap_err();
+        assert!(error.to_string().contains("missing its locked checksum"));
     }
 }

--- a/hew-pkg/src/manifest.rs
+++ b/hew-pkg/src/manifest.rs
@@ -68,7 +68,8 @@ impl fmt::Display for DepSpec {
 /// Table form of a dependency specification.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DepTable {
-    /// Semver version requirement (required).
+    /// Semver version requirement (defaults to `"*"` for path dependencies).
+    #[serde(default = "default_dependency_version")]
     pub version: String,
     /// If `true`, only included when a feature enables it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -85,6 +86,10 @@ pub struct DepTable {
     /// Local path dependency (not publishable).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+}
+
+fn default_dependency_version() -> String {
+    "*".to_string()
 }
 
 /// Errors that can occur when reading, parsing, or writing a `hew.toml` manifest.
@@ -429,6 +434,33 @@ pub fn add_dependency(
     save_manifest(path, &manifest)
 }
 
+/// Add or update a local path dependency in the `hew.toml` at `path`.
+///
+/// # Errors
+///
+/// Returns [`ManifestError`] when the manifest cannot be read, parsed,
+/// serialized, or written.
+pub fn add_path_dependency(
+    path: &Path,
+    name: &str,
+    version: &str,
+    dependency_path: &Path,
+) -> Result<(), ManifestError> {
+    let mut manifest = parse_manifest(path)?;
+    manifest.dependencies.insert(
+        name.to_string(),
+        DepSpec::Table(DepTable {
+            version: version.to_string(),
+            optional: None,
+            features: None,
+            default_features: None,
+            registry: None,
+            path: Some(dependency_path.to_string_lossy().into_owned()),
+        }),
+    );
+    save_manifest(path, &manifest)
+}
+
 /// Validate that a manifest has all required fields for publishing.
 ///
 /// Returns a list of missing field names. An empty list means the manifest is
@@ -638,6 +670,41 @@ mod tests {
             }
             DepSpec::Version(_) => panic!("expected table dependency"),
         }
+    }
+
+    #[test]
+    fn path_dependency_defaults_to_any_version() {
+        let file = write_temp(concat!(
+            "[package]\n",
+            "name = \"app\"\n",
+            "version = \"0.1.0\"\n",
+            "\n[dependencies]\n",
+            "local = { path = \"../local\" }\n",
+        ));
+
+        let manifest = parse_manifest(file.path()).unwrap();
+        let DepSpec::Table(dependency) = &manifest.dependencies["local"] else {
+            panic!("expected path dependency table");
+        };
+        assert_eq!(dependency.version, "*");
+        assert_eq!(dependency.path.as_deref(), Some("../local"));
+    }
+
+    #[test]
+    fn add_path_dependency_persists_local_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hew.toml");
+        write_default_manifest(&path, "myproject").unwrap();
+
+        add_path_dependency(&path, "local", "*", Path::new("../local")).unwrap();
+
+        let manifest = parse_manifest(&path).unwrap();
+        let DepSpec::Table(dependency) = &manifest.dependencies["local"] else {
+            panic!("expected path dependency table");
+        };
+        assert_eq!(dependency.version, "*");
+        assert_eq!(dependency.path.as_deref(), Some("../local"));
+        assert!(dependency.registry.is_none());
     }
 
     #[test]

--- a/hew-pkg/src/package_fs.rs
+++ b/hew-pkg/src/package_fs.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use sha2::{Digest, Sha256};
 
 const SKIPPED_PACKAGE_DIRS: &[&str] = &[".git", "target", ".hew"];
+pub const CACHE_METADATA_FILE: &str = ".hew-registry-cache.toml";
+pub const CACHE_ARCHIVE_FILE: &str = ".hew-registry-cache.tar.zst";
 
 /// Return true when a directory should be skipped for package traversal.
 #[must_use]
@@ -27,7 +29,10 @@ fn collect_package_files_inner(
         let entry = entry?;
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
-        if is_skipped_package_dir(&name_str) {
+        if is_skipped_package_dir(&name_str)
+            || name_str == CACHE_METADATA_FILE
+            || name_str == CACHE_ARCHIVE_FILE
+        {
             continue;
         }
         let path = entry.path();

--- a/hew-pkg/src/package_fs.rs
+++ b/hew-pkg/src/package_fs.rs
@@ -6,6 +6,43 @@ use sha2::{Digest, Sha256};
 const SKIPPED_PACKAGE_DIRS: &[&str] = &[".git", "target", ".hew"];
 pub const CACHE_METADATA_FILE: &str = ".hew-registry-cache.toml";
 pub const CACHE_ARCHIVE_FILE: &str = ".hew-registry-cache.tar.zst";
+const TREE_DIGEST_DOMAIN: &[u8; 23] = b"hew.package-tree-digest";
+const TREE_DIGEST_VERSION: [u8; 4] = 1_u32.to_be_bytes();
+const TREE_ENTRY_REGULAR_FILE: u8 = 1;
+
+/// One regular file captured from a package tree.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct PackageFile {
+    pub(crate) path: String,
+    pub(crate) contents: Vec<u8>,
+}
+
+/// Incremental canonical digest of a package's regular-file tree.
+pub(crate) struct TreeDigest {
+    hasher: Sha256,
+}
+
+impl TreeDigest {
+    pub(crate) fn new() -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(TREE_DIGEST_DOMAIN);
+        hasher.update(TREE_DIGEST_VERSION);
+        Self { hasher }
+    }
+
+    pub(crate) fn add_file(&mut self, canonical_path: &str, contents: &[u8]) {
+        self.hasher.update([TREE_ENTRY_REGULAR_FILE]);
+        self.hasher
+            .update((canonical_path.len() as u64).to_be_bytes());
+        self.hasher.update(canonical_path.as_bytes());
+        self.hasher.update((contents.len() as u64).to_be_bytes());
+        self.hasher.update(contents);
+    }
+
+    pub(crate) fn finish(self) -> String {
+        format_sha256(&self.hasher.finalize())
+    }
+}
 
 /// Return true when a directory should be skipped for package traversal.
 #[must_use]
@@ -13,53 +50,625 @@ pub fn is_skipped_package_dir(name: &str) -> bool {
     SKIPPED_PACKAGE_DIRS.contains(&name)
 }
 
-/// Recursively collect relative file paths under `root`, using `/` separators.
-pub fn collect_package_files(root: &Path) -> Result<Vec<String>, io::Error> {
-    let mut files = Vec::new();
-    collect_package_files_inner(root, root, &mut files)?;
+fn is_skipped_package_entry(name: &str) -> bool {
+    is_skipped_package_dir(name) || name == CACHE_METADATA_FILE || name == CACHE_ARCHIVE_FILE
+}
+
+/// Capture a package tree as sorted canonical `/`-separated paths and bytes.
+pub(crate) fn collect_package_snapshot(root: &Path) -> Result<Vec<PackageFile>, io::Error> {
+    let mut files = platform::collect(root)?;
+    files.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(files)
 }
 
-fn collect_package_files_inner(
-    root: &Path,
-    dir: &Path,
-    files: &mut Vec<String>,
-) -> Result<(), io::Error> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if is_skipped_package_dir(&name_str)
-            || name_str == CACHE_METADATA_FILE
-            || name_str == CACHE_ARCHIVE_FILE
-        {
-            continue;
+fn invalid_name(path: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("package path is not valid UTF-8: {path}"),
+    )
+}
+
+fn invalid_component(path: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("package path contains a traversal component: {path}"),
+    )
+}
+
+fn unsupported_file_type(path: &str, kind: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("unsupported {kind} in package tree: {path}"),
+    )
+}
+
+fn changed_during_snapshot(path: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("package entry changed while being read: {path}"),
+    )
+}
+
+fn canonical_child(prefix: &str, name: &str) -> Result<String, io::Error> {
+    if name.is_empty() || name == "." || name == ".." || name.contains('/') {
+        return Err(invalid_component(name));
+    }
+    Ok(if prefix.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{prefix}/{name}")
+    })
+}
+
+#[cfg(unix)]
+mod platform {
+    use std::ffi::{CStr, CString};
+    use std::fs::File;
+    use std::io::{self, Read as _};
+    use std::mem::MaybeUninit;
+    use std::os::fd::{AsRawFd as _, BorrowedFd, FromRawFd as _, IntoRawFd as _, OwnedFd, RawFd};
+    use std::os::unix::ffi::OsStrExt as _;
+    use std::os::unix::fs::MetadataExt as _;
+    use std::path::Path;
+    use std::ptr::NonNull;
+
+    use super::{
+        canonical_child, changed_during_snapshot, invalid_component, invalid_name,
+        is_skipped_package_entry, unsupported_file_type, PackageFile,
+    };
+
+    struct DirStream(NonNull<libc::DIR>);
+
+    impl DirStream {
+        fn open(fd: OwnedFd) -> io::Result<Self> {
+            let raw_fd = fd.into_raw_fd();
+            // SAFETY: `raw_fd` is a valid owned directory descriptor. On
+            // success, fdopendir takes ownership of it.
+            let stream = unsafe { libc::fdopendir(raw_fd) };
+            if let Some(stream) = NonNull::new(stream) {
+                Ok(Self(stream))
+            } else {
+                let error = io::Error::last_os_error();
+                // SAFETY: fdopendir failed, so ownership remained here.
+                unsafe {
+                    libc::close(raw_fd);
+                }
+                Err(error)
+            }
         }
-        let path = entry.path();
-        if path.is_dir() {
-            collect_package_files_inner(root, &path, files)?;
-        } else {
-            let rel = path.strip_prefix(root).map_err(io::Error::other)?;
-            let rel_str = rel
-                .components()
-                .map(|c| c.as_os_str().to_string_lossy().into_owned())
-                .collect::<Vec<_>>()
-                .join("/");
-            files.push(rel_str);
+
+        fn fd(&self) -> RawFd {
+            // SAFETY: the stream remains live for the duration of the call.
+            unsafe { libc::dirfd(self.0.as_ptr()) }
         }
     }
-    Ok(())
+
+    impl Drop for DirStream {
+        fn drop(&mut self) {
+            // SAFETY: fdopendir owns the descriptor and closedir releases both
+            // the stream and that descriptor exactly once.
+            unsafe {
+                libc::closedir(self.0.as_ptr());
+            }
+        }
+    }
+
+    pub(super) fn collect(root: &Path) -> io::Result<Vec<PackageFile>> {
+        collect_with_hook(root, &mut |_| {})
+    }
+
+    fn collect_with_hook<F>(root: &Path, hook: &mut F) -> io::Result<Vec<PackageFile>>
+    where
+        F: FnMut(&str),
+    {
+        let root = CString::new(root.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "package root contains an interior NUL",
+            )
+        })?;
+        let flags = libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW;
+        // SAFETY: `root` is a valid NUL-terminated pathname.
+        let raw_fd = unsafe { libc::open(root.as_ptr(), flags) };
+        if raw_fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: open returned a new owned descriptor.
+        let root_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        let root_stat = stat_fd(root_fd.as_raw_fd())?;
+        if file_kind(root_stat.st_mode) != libc::S_IFDIR {
+            return Err(unsupported_file_type(
+                &root.to_string_lossy(),
+                "non-directory package root",
+            ));
+        }
+
+        let mut files = Vec::new();
+        collect_dir(root_fd, "", &mut files, hook)?;
+        Ok(files)
+    }
+
+    fn collect_dir<F>(
+        dir_fd: OwnedFd,
+        prefix: &str,
+        files: &mut Vec<PackageFile>,
+        hook: &mut F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(&str),
+    {
+        let before = metadata_fd(dir_fd.as_raw_fd())?;
+        let stream = DirStream::open(dir_fd)?;
+
+        loop {
+            set_errno(0);
+            // SAFETY: `stream` is a valid directory stream and readdir's
+            // returned pointer is consumed before the next call.
+            let entry = unsafe { libc::readdir(stream.0.as_ptr()) };
+            if entry.is_null() {
+                let errno = get_errno();
+                if errno == 0 {
+                    break;
+                }
+                return Err(io::Error::from_raw_os_error(errno));
+            }
+
+            // SAFETY: d_name is NUL-terminated for a successful readdir call.
+            let name_bytes = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
+            if name_bytes == b"." || name_bytes == b".." {
+                continue;
+            }
+            let name = std::str::from_utf8(name_bytes)
+                .map_err(|_| invalid_name(&format!("{prefix}/<non-UTF-8>")))?;
+            let path = canonical_child(prefix, name)?;
+            let name = CString::new(name_bytes).map_err(|_| invalid_component(&path))?;
+            let expected = stat_at(stream.fd(), &name)?;
+            let expected_kind = file_kind(expected.st_mode);
+            if expected_kind == libc::S_IFLNK {
+                return Err(unsupported_file_type(&path, "symbolic link"));
+            }
+            if is_skipped_package_entry(name.to_str().expect("validated UTF-8 name")) {
+                continue;
+            }
+
+            hook(&path);
+            match expected_kind {
+                libc::S_IFDIR => {
+                    let child = open_at(
+                        stream.fd(),
+                        &name,
+                        libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
+                    )?;
+                    let opened = stat_fd(child.as_raw_fd())?;
+                    if !same_identity_and_type(&expected, &opened) {
+                        return Err(changed_during_snapshot(&path));
+                    }
+                    collect_dir(child, &path, files, hook)?;
+                }
+                libc::S_IFREG => {
+                    let file_fd = open_at(
+                        stream.fd(),
+                        &name,
+                        libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+                    )?;
+                    let opened = stat_fd(file_fd.as_raw_fd())?;
+                    if !same_identity_and_type(&expected, &opened) {
+                        return Err(changed_during_snapshot(&path));
+                    }
+
+                    // File::from owns the descriptor from this point onward.
+                    let mut file = File::from(file_fd);
+                    let before_read = file.metadata()?;
+                    if !before_read.is_file() {
+                        return Err(unsupported_file_type(&path, "non-regular file"));
+                    }
+                    let mut contents = Vec::new();
+                    file.read_to_end(&mut contents)?;
+                    let after_read = file.metadata()?;
+                    if !same_file_state(&before_read, &after_read) {
+                        return Err(changed_during_snapshot(&path));
+                    }
+                    files.push(PackageFile { path, contents });
+                }
+                _ => return Err(unsupported_file_type(&path, "non-regular file")),
+            }
+        }
+
+        let after = metadata_fd(stream.fd())?;
+        if !same_file_state(&before, &after) {
+            return Err(changed_during_snapshot(if prefix.is_empty() {
+                "."
+            } else {
+                prefix
+            }));
+        }
+        Ok(())
+    }
+
+    fn open_at(dir_fd: RawFd, name: &CStr, flags: libc::c_int) -> io::Result<OwnedFd> {
+        // SAFETY: `dir_fd` remains open, and `name` is a valid single-component
+        // NUL-terminated name.
+        let fd = unsafe { libc::openat(dir_fd, name.as_ptr(), flags) };
+        if fd < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            // SAFETY: openat returned a new owned descriptor.
+            Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+        }
+    }
+
+    fn stat_at(dir_fd: RawFd, name: &CStr) -> io::Result<libc::stat> {
+        let mut stat = MaybeUninit::uninit();
+        // SAFETY: all pointers are valid and stat points to writable storage.
+        let result = unsafe {
+            libc::fstatat(
+                dir_fd,
+                name.as_ptr(),
+                stat.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if result == 0 {
+            // SAFETY: successful fstatat initialized stat.
+            Ok(unsafe { stat.assume_init() })
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn stat_fd(fd: RawFd) -> io::Result<libc::stat> {
+        let mut stat = MaybeUninit::uninit();
+        // SAFETY: `fd` is open and stat points to writable storage.
+        let result = unsafe { libc::fstat(fd, stat.as_mut_ptr()) };
+        if result == 0 {
+            // SAFETY: successful fstat initialized stat.
+            Ok(unsafe { stat.assume_init() })
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn file_kind(mode: libc::mode_t) -> libc::mode_t {
+        mode & libc::S_IFMT
+    }
+
+    fn same_identity_and_type(left: &libc::stat, right: &libc::stat) -> bool {
+        left.st_dev == right.st_dev
+            && left.st_ino == right.st_ino
+            && file_kind(left.st_mode) == file_kind(right.st_mode)
+    }
+
+    fn metadata_fd(fd: RawFd) -> io::Result<std::fs::Metadata> {
+        // SAFETY: the borrowed descriptor remains owned by the caller and open
+        // for the duration of the clone.
+        let borrowed = unsafe { BorrowedFd::borrow_raw(fd) };
+        let duplicate = borrowed.try_clone_to_owned()?;
+        File::from(duplicate).metadata()
+    }
+
+    fn same_file_state(left: &std::fs::Metadata, right: &std::fs::Metadata) -> bool {
+        left.dev() == right.dev()
+            && left.ino() == right.ino()
+            && left.mode() == right.mode()
+            && left.size() == right.size()
+            && left.mtime() == right.mtime()
+            && left.mtime_nsec() == right.mtime_nsec()
+            && left.ctime() == right.ctime()
+            && left.ctime_nsec() == right.ctime_nsec()
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn errno_location() -> *mut libc::c_int {
+        // SAFETY: libc returns the calling thread's errno storage.
+        unsafe { libc::__errno_location() }
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    ))]
+    fn errno_location() -> *mut libc::c_int {
+        // SAFETY: libc returns the calling thread's errno storage.
+        unsafe { libc::__error() }
+    }
+
+    fn set_errno(value: libc::c_int) {
+        // SAFETY: errno_location returns writable thread-local errno storage.
+        unsafe {
+            *errno_location() = value;
+        }
+    }
+
+    fn get_errno() -> libc::c_int {
+        // SAFETY: errno_location returns readable thread-local errno storage.
+        unsafe { *errno_location() }
+    }
+
+    #[cfg(test)]
+    pub(super) fn collect_identity_counterfactual<F>(
+        root: &Path,
+        mut hook: F,
+    ) -> io::Result<Vec<PackageFile>>
+    where
+        F: FnMut(&str),
+    {
+        collect_with_hook(root, &mut hook)
+    }
+}
+
+#[cfg(windows)]
+mod platform {
+    use std::fs::{File, Metadata, OpenOptions};
+    use std::io::{self, Read as _};
+    use std::mem::MaybeUninit;
+    use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
+    use std::os::windows::io::AsRawHandle as _;
+    use std::path::Path;
+
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_DIRECTORY,
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    use super::{
+        canonical_child, changed_during_snapshot, invalid_name, is_skipped_package_entry,
+        unsupported_file_type, PackageFile,
+    };
+
+    struct OpenedEntry {
+        file: File,
+        metadata: Metadata,
+        identity: WindowsIdentity,
+    }
+
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    struct WindowsIdentity {
+        volume_serial: u32,
+        file_index: u64,
+        attributes: u32,
+    }
+
+    pub(super) fn collect(root: &Path) -> io::Result<Vec<PackageFile>> {
+        let root_handle = open_entry(root, true)?;
+        validate_metadata(&root_handle.metadata, ".", true)?;
+        let mut files = Vec::new();
+        collect_dir(root, "", root_handle, &mut files)?;
+        Ok(files)
+    }
+
+    fn collect_dir(
+        dir: &Path,
+        prefix: &str,
+        dir_handle: OpenedEntry,
+        files: &mut Vec<PackageFile>,
+    ) -> io::Result<()> {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let name = entry
+                .file_name()
+                .into_string()
+                .map_err(|_| invalid_name(&entry.path().display().to_string()))?;
+            let path = canonical_child(prefix, &name)?;
+            let entry_path = entry.path();
+            let expected = std::fs::symlink_metadata(&entry_path)?;
+            let is_dir = expected.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0;
+            validate_metadata(&expected, &path, is_dir)?;
+            if is_skipped_package_entry(&name) {
+                continue;
+            }
+
+            let mut opened = open_entry(&entry_path, is_dir)?;
+            validate_metadata(&opened.metadata, &path, is_dir)?;
+            if !same_metadata_state(&expected, &opened.metadata) {
+                return Err(changed_during_snapshot(&path));
+            }
+            if is_dir {
+                collect_dir(&entry_path, &path, opened, files)?;
+            } else {
+                let mut contents = Vec::new();
+                opened.file.read_to_end(&mut contents)?;
+                let after = opened.file.metadata()?;
+                if !same_metadata_state(&opened.metadata, &after) {
+                    return Err(changed_during_snapshot(&path));
+                }
+                files.push(PackageFile { path, contents });
+            }
+        }
+
+        let after = dir_handle.file.metadata()?;
+        let reopened = open_entry(dir, true)?;
+        if !same_metadata_state(&dir_handle.metadata, &after)
+            || dir_handle.identity != reopened.identity
+        {
+            return Err(changed_during_snapshot(if prefix.is_empty() {
+                "."
+            } else {
+                prefix
+            }));
+        }
+        Ok(())
+    }
+
+    fn open_entry(path: &Path, is_dir: bool) -> io::Result<OpenedEntry> {
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+            .custom_flags(
+                FILE_FLAG_OPEN_REPARSE_POINT
+                    | if is_dir {
+                        FILE_FLAG_BACKUP_SEMANTICS
+                    } else {
+                        0
+                    },
+            );
+        let file = options.open(path)?;
+        let metadata = file.metadata()?;
+        let identity = file_identity(&file)?;
+        Ok(OpenedEntry {
+            file,
+            metadata,
+            identity,
+        })
+    }
+
+    fn validate_metadata(metadata: &Metadata, path: &str, is_dir: bool) -> io::Result<()> {
+        let attributes = metadata.file_attributes();
+        if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(unsupported_file_type(path, "reparse point"));
+        }
+        let opened_is_dir = attributes & FILE_ATTRIBUTE_DIRECTORY != 0;
+        if opened_is_dir != is_dir {
+            return Err(changed_during_snapshot(path));
+        }
+        if !is_dir && !metadata.is_file() {
+            return Err(unsupported_file_type(path, "non-regular file"));
+        }
+        Ok(())
+    }
+
+    fn same_metadata_state(left: &Metadata, right: &Metadata) -> bool {
+        (left.file_attributes() & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT))
+            == (right.file_attributes() & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT))
+            && left.file_size() == right.file_size()
+            && left.last_write_time() == right.last_write_time()
+            && left.creation_time() == right.creation_time()
+    }
+
+    fn file_identity(file: &File) -> io::Result<WindowsIdentity> {
+        let mut information = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+        // SAFETY: the handle remains valid for the call and `information`
+        // points to writable storage of the required type.
+        let result =
+            unsafe { GetFileInformationByHandle(file.as_raw_handle(), information.as_mut_ptr()) };
+        if result == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: a successful call initialized the structure.
+        let information = unsafe { information.assume_init() };
+        Ok(WindowsIdentity {
+            volume_serial: information.dwVolumeSerialNumber,
+            file_index: (u64::from(information.nFileIndexHigh) << 32)
+                | u64::from(information.nFileIndexLow),
+            attributes: information.dwFileAttributes
+                & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT),
+        })
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+mod platform {
+    use std::fs::File;
+    use std::io::{self, Read as _};
+    use std::path::Path;
+
+    use super::{
+        canonical_child, changed_during_snapshot, invalid_name, is_skipped_package_entry,
+        unsupported_file_type, PackageFile,
+    };
+
+    pub(super) fn collect(root: &Path) -> io::Result<Vec<PackageFile>> {
+        let metadata = std::fs::symlink_metadata(root)?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err(unsupported_file_type(".", "non-directory package root"));
+        }
+        let mut files = Vec::new();
+        collect_dir(root, "", &mut files)?;
+        Ok(files)
+    }
+
+    fn collect_dir(dir: &Path, prefix: &str, files: &mut Vec<PackageFile>) -> io::Result<()> {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let name = entry
+                .file_name()
+                .into_string()
+                .map_err(|_| invalid_name(&entry.path().display().to_string()))?;
+            let path = canonical_child(prefix, &name)?;
+            let metadata = std::fs::symlink_metadata(entry.path())?;
+            if metadata.file_type().is_symlink() {
+                return Err(unsupported_file_type(&path, "symbolic link"));
+            }
+            if is_skipped_package_entry(&name) {
+                continue;
+            }
+            if metadata.is_dir() {
+                collect_dir(&entry.path(), &path, files)?;
+            } else if metadata.is_file() {
+                let mut file = File::open(entry.path())?;
+                let before = file.metadata()?;
+                let mut contents = Vec::new();
+                file.read_to_end(&mut contents)?;
+                let after = file.metadata()?;
+                if before.len() != after.len() || before.modified()? != after.modified()? {
+                    return Err(changed_during_snapshot(&path));
+                }
+                files.push(PackageFile { path, contents });
+            } else {
+                return Err(unsupported_file_type(&path, "non-regular file"));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Compute a `sha256:{hex}` digest string for raw bytes.
 #[must_use]
 pub fn sha256_prefixed(data: &[u8]) -> String {
+    format_sha256(&Sha256::digest(data))
+}
+
+fn format_sha256(hash: &[u8]) -> String {
     use std::fmt::Write as _;
 
-    let hash = Sha256::digest(data);
     let mut hex = String::with_capacity(hash.len() * 2);
     for byte in hash {
         write!(&mut hex, "{byte:02x}").expect("writing to a String cannot fail");
     }
     format!("sha256:{hex}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_paths_are_sorted_and_canonical() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("nested")).unwrap();
+        std::fs::write(dir.path().join("z"), b"z").unwrap();
+        std::fs::write(dir.path().join("nested").join("a"), b"a").unwrap();
+
+        let snapshot = collect_package_snapshot(dir.path()).unwrap();
+        assert_eq!(
+            snapshot
+                .iter()
+                .map(|entry| entry.path.as_str())
+                .collect::<Vec<_>>(),
+            ["nested/a", "z"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn snapshot_rejects_entry_identity_substitution() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file");
+        std::fs::write(&path, b"original").unwrap();
+        let replacement = dir.path().join("replacement");
+        std::fs::write(&replacement, b"replacement").unwrap();
+
+        let result = platform::collect_identity_counterfactual(dir.path(), |entry| {
+            if entry == "file" {
+                std::fs::rename(&replacement, &path).unwrap();
+            }
+        });
+
+        assert!(result.is_err());
+    }
 }

--- a/hew-pkg/src/registry.rs
+++ b/hew-pkg/src/registry.rs
@@ -25,6 +25,12 @@ pub struct InstalledPackage {
     pub path: PathBuf,
 }
 
+#[derive(Debug)]
+pub(crate) struct VerifiedCacheEntry {
+    pub(crate) path: PathBuf,
+    pub(crate) tree_checksum: String,
+}
+
 /// The global Hew package registry (`~/.hew/packages/`).
 ///
 /// Package layout on disk:
@@ -90,20 +96,25 @@ impl Registry {
             .is_ok_and(|path| is_package_dir(&path))
     }
 
-    pub(crate) fn is_online_cache_verified(
+    pub(crate) fn verified_online_cache_entry(
         &self,
         name: &str,
         version: &str,
         registry_checksum: &str,
-    ) -> Result<bool, String> {
-        let package_dir = self.package_dir(name, version);
+    ) -> Result<Option<VerifiedCacheEntry>, String> {
+        let package_dir = self
+            .package_dir_checked(name, version)
+            .map_err(|error| format!("cannot resolve cache for {name}@{version}: {error}"))?;
         if !is_package_dir(&package_dir) {
-            return Ok(false);
+            return Ok(None);
         }
+        let package_dir = package_dir
+            .canonicalize()
+            .map_err(|error| format!("cannot pin cache for {name}@{version}: {error}"))?;
 
         let metadata_text = match std::fs::read_to_string(package_dir.join(CACHE_METADATA_FILE)) {
             Ok(text) => text,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(error) => {
                 return Err(format!(
                     "cannot read cache metadata for {name}@{version}: {error}"
@@ -112,18 +123,18 @@ impl Registry {
         };
         let metadata: CacheMetadata = match toml::from_str(&metadata_text) {
             Ok(metadata) => metadata,
-            Err(_) => return Ok(false),
+            Err(_) => return Ok(None),
         };
         if metadata.name != name
             || metadata.version != version
             || metadata.registry_checksum != registry_checksum
         {
-            return Ok(false);
+            return Ok(None);
         }
 
         let archive = match std::fs::read(package_dir.join(CACHE_ARCHIVE_FILE)) {
             Ok(archive) => archive,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(error) => {
                 return Err(format!(
                     "cannot read cached archive for {name}@{version}: {error}"
@@ -131,25 +142,32 @@ impl Registry {
             }
         };
         if crate::tarball::checksum_bytes(&archive) != registry_checksum {
-            return Ok(false);
+            return Ok(None);
         }
         let Ok(archive_tree_checksum) = crate::tarball::unpacked_tree_checksum(&archive) else {
-            return Ok(false);
+            return Ok(None);
         };
         if archive_tree_checksum != metadata.tree_checksum {
-            return Ok(false);
+            return Ok(None);
         }
 
         let Ok(manifest) = crate::manifest::parse_manifest(&package_dir.join("hew.toml")) else {
-            return Ok(false);
+            return Ok(None);
         };
         if manifest.package.name != name || manifest.package.version != version {
-            return Ok(false);
+            return Ok(None);
         }
 
         let actual = crate::checksum::compute_dir_checksum(&package_dir)
             .map_err(|error| format!("cannot verify cache for {name}@{version}: {error}"))?;
-        Ok(actual == metadata.tree_checksum)
+        if actual == metadata.tree_checksum {
+            Ok(Some(VerifiedCacheEntry {
+                path: package_dir,
+                tree_checksum: actual,
+            }))
+        } else {
+            Ok(None)
+        }
     }
 
     pub(crate) fn write_cache_metadata(
@@ -487,12 +505,14 @@ mod tests {
         Registry::write_cache_metadata(&pkg_dir, "foo", "1.0.0", &archive.checksum, &archive.data)
             .unwrap();
         assert!(reg
-            .is_online_cache_verified("foo", "1.0.0", &archive.checksum)
-            .unwrap());
+            .verified_online_cache_entry("foo", "1.0.0", &archive.checksum)
+            .unwrap()
+            .is_some());
 
         std::fs::write(pkg_dir.join("foo.hew"), "pub fn value() -> i64 { 2 }\n").unwrap();
-        assert!(!reg
-            .is_online_cache_verified("foo", "1.0.0", &archive.checksum)
-            .unwrap());
+        assert!(reg
+            .verified_online_cache_entry("foo", "1.0.0", &archive.checksum)
+            .unwrap()
+            .is_none());
     }
 }

--- a/hew-pkg/src/registry.rs
+++ b/hew-pkg/src/registry.rs
@@ -62,6 +62,18 @@ impl Registry {
     /// `<root>/ecosystem.db.postgres/1.0.0`.
     #[must_use]
     pub fn package_dir(&self, name: &str, version: &str) -> PathBuf {
+        self.package_dir_checked(name, version).unwrap_or_else(|_| {
+            self.root
+                .join(name)
+                .join(format!(".{version}.invalid-generation-pointer"))
+        })
+    }
+
+    pub(crate) fn package_dir_checked(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> std::io::Result<PathBuf> {
         crate::atomic_fs::resolve_published_dir(&self.package_slot(name, version))
     }
 
@@ -74,7 +86,8 @@ impl Registry {
     /// Return `true` if `name@version` is present in the registry.
     #[must_use]
     pub fn is_installed(&self, name: &str, version: &str) -> bool {
-        is_package_dir(&self.package_dir(name, version))
+        self.package_dir_checked(name, version)
+            .is_ok_and(|path| is_package_dir(&path))
     }
 
     pub(crate) fn is_online_cache_verified(
@@ -246,7 +259,9 @@ fn collect_packages(
         // missing generation must not revive a stale legacy directory.
         published_versions.insert(version.to_string());
         let logical_slot = dir.join(version);
-        let active = crate::atomic_fs::resolve_published_dir(&logical_slot);
+        let Ok(active) = crate::atomic_fs::resolve_published_dir(&logical_slot) else {
+            continue;
+        };
         if !is_package_dir(&active) {
             continue;
         }
@@ -404,6 +419,24 @@ mod tests {
         assert_eq!(packages[0].name, "foo");
         assert_eq!(packages[0].version, "1.0.0");
         assert_eq!(packages[0].path, reg.package_dir("foo", "1.0.0"));
+    }
+
+    #[test]
+    fn corrupt_pointer_does_not_revive_valid_legacy_package() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = Registry::with_root(dir.path().to_path_buf());
+        let legacy = reg.package_slot("foo", "1.0.0");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(
+            legacy.join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(legacy.with_file_name(".1.0.0.current"), [0xff, 0xfe]).unwrap();
+
+        assert!(!reg.is_installed("foo", "1.0.0"));
+        assert_ne!(reg.package_dir("foo", "1.0.0"), legacy);
+        assert!(reg.list_packages().is_empty());
     }
 
     #[test]

--- a/hew-pkg/src/registry.rs
+++ b/hew-pkg/src/registry.rs
@@ -62,6 +62,12 @@ impl Registry {
     /// `<root>/ecosystem.db.postgres/1.0.0`.
     #[must_use]
     pub fn package_dir(&self, name: &str, version: &str) -> PathBuf {
+        crate::atomic_fs::resolve_published_dir(&self.package_slot(name, version))
+    }
+
+    /// Return the stable logical slot used to publish a package generation.
+    #[must_use]
+    pub(crate) fn package_slot(&self, name: &str, version: &str) -> PathBuf {
         self.root.join(name).join(version)
     }
 
@@ -221,11 +227,51 @@ fn collect_packages(
         return;
     };
 
+    let entries = entries.flatten().collect::<Vec<_>>();
+    let mut published_versions = std::collections::BTreeSet::new();
     let mut subdirs = Vec::new();
 
-    for entry in entries.flatten() {
+    for entry in &entries {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let Some(version) = name
+            .strip_prefix('.')
+            .and_then(|name| name.strip_suffix(".current"))
+        else {
+            continue;
+        };
+        // Once a generation pointer exists it is authoritative. A corrupt or
+        // missing generation must not revive a stale legacy directory.
+        published_versions.insert(version.to_string());
+        let logical_slot = dir.join(version);
+        let active = crate::atomic_fs::resolve_published_dir(&logical_slot);
+        if !is_package_dir(&active) {
+            continue;
+        }
+        let Ok(rel) = dir.strip_prefix(root) else {
+            continue;
+        };
+        let name_parts = rel
+            .components()
+            .filter_map(|component| component.as_os_str().to_str())
+            .collect::<Vec<_>>();
+        if name_parts.is_empty() {
+            continue;
+        }
+        packages.push(InstalledPackage {
+            name: name_parts.join("."),
+            version: version.to_string(),
+            path: active,
+        });
+    }
+
+    for entry in entries {
         let path = entry.path();
-        if path.is_dir() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() && !name.starts_with('.') && !published_versions.contains(name.as_ref()) {
             subdirs.push(path);
         }
     }
@@ -326,6 +372,38 @@ mod tests {
         assert_eq!(pkgs.len(), 2);
         assert_eq!(pkgs[0].name, "ecosystem.db.postgres");
         assert_eq!(pkgs[1].name, "std.net.http");
+    }
+
+    #[test]
+    fn list_packages_reports_only_active_published_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = Registry::with_root(dir.path().to_path_buf());
+        let slot = reg.package_slot("foo", "1.0.0");
+        std::fs::create_dir_all(&slot).unwrap();
+        std::fs::write(
+            slot.join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let staged = crate::atomic_fs::StagedDir::new(&slot).unwrap();
+        std::fs::write(
+            staged.path().join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(staged.path().join("generation"), "new").unwrap();
+        staged.publish(&slot).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(reg.package_dir("foo", "1.0.0").join("generation")).unwrap(),
+            "new"
+        );
+        let packages = reg.list_packages();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "foo");
+        assert_eq!(packages[0].version, "1.0.0");
+        assert_eq!(packages[0].path, reg.package_dir("foo", "1.0.0"));
     }
 
     #[test]

--- a/hew-pkg/src/registry.rs
+++ b/hew-pkg/src/registry.rs
@@ -2,6 +2,18 @@
 
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
+
+use crate::package_fs::{CACHE_ARCHIVE_FILE, CACHE_METADATA_FILE};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct CacheMetadata {
+    name: String,
+    version: String,
+    registry_checksum: String,
+    tree_checksum: String,
+}
+
 /// An installed package discovered in the global registry.
 #[derive(Debug)]
 pub struct InstalledPackage {
@@ -57,6 +69,118 @@ impl Registry {
     #[must_use]
     pub fn is_installed(&self, name: &str, version: &str) -> bool {
         is_package_dir(&self.package_dir(name, version))
+    }
+
+    pub(crate) fn is_online_cache_verified(
+        &self,
+        name: &str,
+        version: &str,
+        registry_checksum: &str,
+    ) -> Result<bool, String> {
+        let package_dir = self.package_dir(name, version);
+        if !is_package_dir(&package_dir) {
+            return Ok(false);
+        }
+
+        let metadata_text = match std::fs::read_to_string(package_dir.join(CACHE_METADATA_FILE)) {
+            Ok(text) => text,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => {
+                return Err(format!(
+                    "cannot read cache metadata for {name}@{version}: {error}"
+                ));
+            }
+        };
+        let metadata: CacheMetadata = match toml::from_str(&metadata_text) {
+            Ok(metadata) => metadata,
+            Err(_) => return Ok(false),
+        };
+        if metadata.name != name
+            || metadata.version != version
+            || metadata.registry_checksum != registry_checksum
+        {
+            return Ok(false);
+        }
+
+        let archive = match std::fs::read(package_dir.join(CACHE_ARCHIVE_FILE)) {
+            Ok(archive) => archive,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => {
+                return Err(format!(
+                    "cannot read cached archive for {name}@{version}: {error}"
+                ));
+            }
+        };
+        if crate::tarball::checksum_bytes(&archive) != registry_checksum {
+            return Ok(false);
+        }
+        let Ok(archive_tree_checksum) = crate::tarball::unpacked_tree_checksum(&archive) else {
+            return Ok(false);
+        };
+        if archive_tree_checksum != metadata.tree_checksum {
+            return Ok(false);
+        }
+
+        let Ok(manifest) = crate::manifest::parse_manifest(&package_dir.join("hew.toml")) else {
+            return Ok(false);
+        };
+        if manifest.package.name != name || manifest.package.version != version {
+            return Ok(false);
+        }
+
+        let actual = crate::checksum::compute_dir_checksum(&package_dir)
+            .map_err(|error| format!("cannot verify cache for {name}@{version}: {error}"))?;
+        Ok(actual == metadata.tree_checksum)
+    }
+
+    pub(crate) fn write_cache_metadata(
+        package_dir: &Path,
+        name: &str,
+        version: &str,
+        registry_checksum: &str,
+        archive: &[u8],
+    ) -> Result<(), String> {
+        let manifest = crate::manifest::parse_manifest(&package_dir.join("hew.toml"))
+            .map_err(|error| format!("cannot validate unpacked {name}@{version}: {error}"))?;
+        if manifest.package.name != name || manifest.package.version != version {
+            return Err(format!(
+                "unpacked package identity mismatch for {name}@{version}: manifest declares {}@{}",
+                manifest.package.name, manifest.package.version
+            ));
+        }
+
+        if crate::tarball::checksum_bytes(archive) != registry_checksum {
+            return Err(format!(
+                "cached archive checksum changed before publication for {name}@{version}"
+            ));
+        }
+        let tree_checksum = crate::tarball::unpacked_tree_checksum(archive)
+            .map_err(|error| format!("cannot verify unpacked {name}@{version}: {error}"))?;
+        let actual_tree_checksum = crate::checksum::compute_dir_checksum(package_dir)
+            .map_err(|error| format!("cannot checksum unpacked {name}@{version}: {error}"))?;
+        if actual_tree_checksum != tree_checksum {
+            return Err(format!(
+                "unpacked tree checksum mismatch for {name}@{version}"
+            ));
+        }
+        let metadata = CacheMetadata {
+            name: name.to_string(),
+            version: version.to_string(),
+            registry_checksum: registry_checksum.to_string(),
+            tree_checksum,
+        };
+        let content = toml::to_string(&metadata)
+            .map_err(|error| format!("cannot serialize cache metadata: {error}"))?;
+        crate::atomic_fs::write_atomic(&package_dir.join(CACHE_ARCHIVE_FILE), archive, 0o644)
+            .map_err(|error| {
+                format!("cannot retain verified archive for {name}@{version}: {error}")
+            })?;
+        crate::atomic_fs::write_atomic(
+            &package_dir.join(CACHE_METADATA_FILE),
+            content.as_bytes(),
+            0o644,
+        )
+        .map_err(|error| format!("cannot write cache metadata for {name}@{version}: {error}"))
     }
 
     /// Return the root path of this registry.
@@ -234,5 +358,30 @@ mod tests {
         std::fs::write(pkg_dir.join("partial.marker"), "incomplete").unwrap();
         assert!(!reg.is_installed("std.net.http", "1.0.0"));
         assert!(reg.list_packages().is_empty());
+    }
+
+    #[test]
+    fn online_cache_verification_detects_tampering() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = Registry::with_root(dir.path().to_path_buf());
+        let pkg_dir = reg.package_dir("foo", "1.0.0");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(
+            pkg_dir.join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(pkg_dir.join("foo.hew"), "pub fn value() -> i64 { 1 }\n").unwrap();
+        let archive = crate::tarball::pack(&pkg_dir, &[], &[]).unwrap();
+        Registry::write_cache_metadata(&pkg_dir, "foo", "1.0.0", &archive.checksum, &archive.data)
+            .unwrap();
+        assert!(reg
+            .is_online_cache_verified("foo", "1.0.0", &archive.checksum)
+            .unwrap());
+
+        std::fs::write(pkg_dir.join("foo.hew"), "pub fn value() -> i64 { 2 }\n").unwrap();
+        assert!(!reg
+            .is_online_cache_verified("foo", "1.0.0", &archive.checksum)
+            .unwrap());
     }
 }

--- a/hew-pkg/src/registry.rs
+++ b/hew-pkg/src/registry.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::package_fs::{CACHE_ARCHIVE_FILE, CACHE_METADATA_FILE};
 
@@ -10,6 +11,7 @@ use crate::package_fs::{CACHE_ARCHIVE_FILE, CACHE_METADATA_FILE};
 struct CacheMetadata {
     name: String,
     version: String,
+    registry: String,
     registry_checksum: String,
     tree_checksum: String,
 }
@@ -26,8 +28,26 @@ pub struct InstalledPackage {
 }
 
 #[derive(Debug)]
-pub(crate) struct VerifiedCacheEntry {
+pub(crate) struct PinnedInstalledPackage {
+    pub(crate) name: String,
+    pub(crate) version: String,
     pub(crate) path: PathBuf,
+    pub(crate) pin: crate::atomic_fs::PinnedDir,
+}
+
+impl PinnedInstalledPackage {
+    fn into_installed(self) -> InstalledPackage {
+        InstalledPackage {
+            name: self.name,
+            version: self.version,
+            path: self.path,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct VerifiedCacheEntry {
+    pub(crate) pin: crate::atomic_fs::PinnedDir,
     pub(crate) tree_checksum: String,
 }
 
@@ -35,10 +55,10 @@ pub(crate) struct VerifiedCacheEntry {
 ///
 /// Package layout on disk:
 /// ```text
-/// ~/.hew/packages/{package}/{version}/hew.toml
+/// ~/.hew/packages/.registries/{sha256(registry-id)}/{package}/{version}/hew.toml
 /// ```
-/// e.g. `~/.hew/packages/std.net.http/1.0.0/hew.toml`
-/// corresponds to the package `std.net.http` at version `1.0.0`.
+/// The legacy unnamespaced layout is consulted only by explicit offline
+/// default-registry resolution and is migrated before a new lockfile is used.
 #[derive(Debug)]
 pub struct Registry {
     root: PathBuf,
@@ -75,6 +95,37 @@ impl Registry {
         })
     }
 
+    /// Return the active package generation for a canonical registry identity.
+    #[must_use]
+    pub fn package_dir_for(&self, registry: &str, name: &str, version: &str) -> PathBuf {
+        self.package_dir_for_checked(registry, name, version)
+            .unwrap_or_else(|_| {
+                self.source_root(registry)
+                    .join(name)
+                    .join(format!(".{version}.invalid-generation-pointer"))
+            })
+    }
+
+    pub(crate) fn package_dir_for_checked(
+        &self,
+        registry: &str,
+        name: &str,
+        version: &str,
+    ) -> std::io::Result<PathBuf> {
+        crate::atomic_fs::resolve_published_dir(&self.package_slot_for(registry, name, version))
+    }
+
+    pub(crate) fn pin_package_dir_for_if_present(
+        &self,
+        registry: &str,
+        name: &str,
+        version: &str,
+    ) -> std::io::Result<Option<crate::atomic_fs::PinnedDir>> {
+        crate::atomic_fs::pin_published_dir_if_present(
+            &self.package_slot_for(registry, name, version),
+        )
+    }
+
     pub(crate) fn package_dir_checked(
         &self,
         name: &str,
@@ -89,6 +140,25 @@ impl Registry {
         self.root.join(name).join(version)
     }
 
+    /// Return the source-namespaced logical package slot.
+    #[must_use]
+    pub(crate) fn package_slot_for(&self, registry: &str, name: &str, version: &str) -> PathBuf {
+        self.source_root(registry).join(name).join(version)
+    }
+
+    /// Return the cache root dedicated to one canonical registry identity.
+    #[must_use]
+    pub(crate) fn source_root(&self, registry: &str) -> PathBuf {
+        use std::fmt::Write as _;
+
+        let digest = Sha256::digest(registry.as_bytes());
+        let mut namespace = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            write!(&mut namespace, "{byte:02x}").expect("writing to a String cannot fail");
+        }
+        self.root.join(".registries").join(namespace)
+    }
+
     /// Return `true` if `name@version` is present in the registry.
     #[must_use]
     pub fn is_installed(&self, name: &str, version: &str) -> bool {
@@ -98,19 +168,38 @@ impl Registry {
 
     pub(crate) fn verified_online_cache_entry(
         &self,
+        registry: &str,
         name: &str,
         version: &str,
         registry_checksum: &str,
     ) -> Result<Option<VerifiedCacheEntry>, String> {
-        let package_dir = self
-            .package_dir_checked(name, version)
-            .map_err(|error| format!("cannot resolve cache for {name}@{version}: {error}"))?;
-        if !is_package_dir(&package_dir) {
+        let pin = match self.pin_package_dir_for_if_present(registry, name, version) {
+            Ok(pin) => pin,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::InvalidData
+                ) =>
+            {
+                return Ok(None);
+            }
+            Err(error) => {
+                return Err(format!(
+                    "cannot resolve cache for {name}@{version}: {error}"
+                ));
+            }
+        };
+        let Some(pin) = pin else {
+            return Ok(None);
+        };
+        let package_dir = pin.path();
+        if !is_package_dir(package_dir) {
             return Ok(None);
         }
-        let package_dir = package_dir
+        let pin = pin
             .canonicalize()
             .map_err(|error| format!("cannot pin cache for {name}@{version}: {error}"))?;
+        let package_dir = pin.path();
 
         let metadata_text = match std::fs::read_to_string(package_dir.join(CACHE_METADATA_FILE)) {
             Ok(text) => text,
@@ -127,6 +216,7 @@ impl Registry {
         };
         if metadata.name != name
             || metadata.version != version
+            || metadata.registry != registry
             || metadata.registry_checksum != registry_checksum
         {
             return Ok(None);
@@ -157,12 +247,15 @@ impl Registry {
         if manifest.package.name != name || manifest.package.version != version {
             return Ok(None);
         }
+        if crate::resolver::validate_registry_manifest(name, &manifest).is_err() {
+            return Ok(None);
+        }
 
-        let actual = crate::checksum::compute_dir_checksum(&package_dir)
+        let actual = crate::checksum::compute_dir_checksum(package_dir)
             .map_err(|error| format!("cannot verify cache for {name}@{version}: {error}"))?;
         if actual == metadata.tree_checksum {
             Ok(Some(VerifiedCacheEntry {
-                path: package_dir,
+                pin,
                 tree_checksum: actual,
             }))
         } else {
@@ -172,6 +265,7 @@ impl Registry {
 
     pub(crate) fn write_cache_metadata(
         package_dir: &Path,
+        registry: &str,
         name: &str,
         version: &str,
         registry_checksum: &str,
@@ -203,6 +297,7 @@ impl Registry {
         let metadata = CacheMetadata {
             name: name.to_string(),
             version: version.to_string(),
+            registry: registry.to_string(),
             registry_checksum: registry_checksum.to_string(),
             tree_checksum,
         };
@@ -235,8 +330,55 @@ impl Registry {
     #[must_use]
     pub fn list_packages(&self) -> Vec<InstalledPackage> {
         let mut packages = Vec::new();
-        collect_packages(&self.root, &self.root, &mut packages);
+        let _ = collect_packages(&self.root, &self.root, &mut packages);
         packages
+            .into_iter()
+            .map(PinnedInstalledPackage::into_installed)
+            .collect()
+    }
+
+    /// List packages cached for one canonical registry identity.
+    ///
+    /// `include_legacy` is reserved for explicit offline compatibility with the
+    /// default registry. Online, named, and locked callers must pass `false`.
+    #[must_use]
+    pub fn list_packages_for(&self, registry: &str, include_legacy: bool) -> Vec<InstalledPackage> {
+        let source_root = self.source_root(registry);
+        let mut packages = Vec::new();
+        let _ = collect_packages(&source_root, &source_root, &mut packages);
+        if include_legacy {
+            let _ = collect_packages(&self.root, &self.root, &mut packages);
+            packages.retain(|package| {
+                package
+                    .path
+                    .strip_prefix(self.root.join(".registries"))
+                    .is_err()
+            });
+        }
+        packages
+            .into_iter()
+            .map(PinnedInstalledPackage::into_installed)
+            .collect()
+    }
+
+    pub(crate) fn try_list_packages_for(
+        &self,
+        registry: &str,
+        include_legacy: bool,
+    ) -> std::io::Result<Vec<PinnedInstalledPackage>> {
+        let source_root = self.source_root(registry);
+        let mut packages = Vec::new();
+        collect_packages(&source_root, &source_root, &mut packages)?;
+        if include_legacy {
+            collect_packages(&self.root, &self.root, &mut packages)?;
+            packages.retain(|package| {
+                package
+                    .path
+                    .strip_prefix(self.root.join(".registries"))
+                    .is_err()
+            });
+        }
+        Ok(packages)
     }
 }
 
@@ -252,13 +394,15 @@ impl Default for Registry {
 fn collect_packages(
     root: &std::path::Path,
     dir: &std::path::Path,
-    packages: &mut Vec<InstalledPackage>,
-) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+    packages: &mut Vec<PinnedInstalledPackage>,
+) -> std::io::Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
     };
 
-    let entries = entries.flatten().collect::<Vec<_>>();
+    let entries = entries.collect::<Result<Vec<_>, _>>()?;
     let mut published_versions = std::collections::BTreeSet::new();
     let mut subdirs = Vec::new();
 
@@ -277,9 +421,8 @@ fn collect_packages(
         // missing generation must not revive a stale legacy directory.
         published_versions.insert(version.to_string());
         let logical_slot = dir.join(version);
-        let Ok(active) = crate::atomic_fs::resolve_published_dir(&logical_slot) else {
-            continue;
-        };
+        let pin = crate::atomic_fs::pin_published_dir(&logical_slot)?;
+        let active = pin.path().to_path_buf();
         if !is_package_dir(&active) {
             continue;
         }
@@ -293,10 +436,11 @@ fn collect_packages(
         if name_parts.is_empty() {
             continue;
         }
-        packages.push(InstalledPackage {
+        packages.push(PinnedInstalledPackage {
             name: name_parts.join("."),
             version: version.to_string(),
             path: active,
+            pin,
         });
     }
 
@@ -317,10 +461,11 @@ fn collect_packages(
                 .collect();
             if let Some((version, name_parts)) = parts.split_last() {
                 if !name_parts.is_empty() {
-                    packages.push(InstalledPackage {
+                    packages.push(PinnedInstalledPackage {
                         name: name_parts.join("."),
                         version: (*version).to_string(),
                         path: dir.to_path_buf(),
+                        pin: crate::atomic_fs::PinnedDir::legacy(dir.to_path_buf()),
                     });
                 }
             }
@@ -328,8 +473,9 @@ fn collect_packages(
     }
 
     for subdir in subdirs {
-        collect_packages(root, &subdir, packages);
+        collect_packages(root, &subdir, packages)?;
     }
+    Ok(())
 }
 
 fn is_package_dir(path: &Path) -> bool {
@@ -354,6 +500,28 @@ mod tests {
         let reg = Registry::with_root(dir.path().to_path_buf());
         let p = reg.package_dir("ecosystem.db.postgres", "1.0.0");
         assert_eq!(p, dir.path().join("ecosystem.db.postgres").join("1.0.0"));
+    }
+
+    #[test]
+    fn registry_identities_have_disjoint_cache_slots() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = Registry::with_root(dir.path().to_path_buf());
+        let first = "https://registry-a.example/api/v1";
+        let second = "https://registry-b.example/api/v1";
+        assert_ne!(
+            reg.package_slot_for(first, "foo", "1.0.0"),
+            reg.package_slot_for(second, "foo", "1.0.0")
+        );
+
+        let package = reg.package_dir_for(first, "foo", "1.0.0");
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(
+            package.join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        assert_eq!(reg.list_packages_for(first, false).len(), 1);
+        assert!(reg.list_packages_for(second, false).is_empty());
     }
 
     #[test]
@@ -493,7 +661,8 @@ mod tests {
     fn online_cache_verification_detects_tampering() {
         let dir = tempfile::tempdir().unwrap();
         let reg = Registry::with_root(dir.path().to_path_buf());
-        let pkg_dir = reg.package_dir("foo", "1.0.0");
+        let registry_id = crate::config::default_registry_identity();
+        let pkg_dir = reg.package_dir_for(&registry_id, "foo", "1.0.0");
         std::fs::create_dir_all(&pkg_dir).unwrap();
         std::fs::write(
             pkg_dir.join("hew.toml"),
@@ -502,16 +671,102 @@ mod tests {
         .unwrap();
         std::fs::write(pkg_dir.join("foo.hew"), "pub fn value() -> i64 { 1 }\n").unwrap();
         let archive = crate::tarball::pack(&pkg_dir, &[], &[]).unwrap();
-        Registry::write_cache_metadata(&pkg_dir, "foo", "1.0.0", &archive.checksum, &archive.data)
-            .unwrap();
+        Registry::write_cache_metadata(
+            &pkg_dir,
+            &registry_id,
+            "foo",
+            "1.0.0",
+            &archive.checksum,
+            &archive.data,
+        )
+        .unwrap();
         assert!(reg
-            .verified_online_cache_entry("foo", "1.0.0", &archive.checksum)
+            .verified_online_cache_entry(&registry_id, "foo", "1.0.0", &archive.checksum)
             .unwrap()
             .is_some());
 
         std::fs::write(pkg_dir.join("foo.hew"), "pub fn value() -> i64 { 2 }\n").unwrap();
         assert!(reg
-            .verified_online_cache_entry("foo", "1.0.0", &archive.checksum)
+            .verified_online_cache_entry(&registry_id, "foo", "1.0.0", &archive.checksum)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn online_cache_treats_missing_or_invalid_generation_lease_as_untrusted() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = Registry::with_root(dir.path().to_path_buf());
+        let registry_id = crate::config::default_registry_identity();
+        let slot = reg.package_slot_for(&registry_id, "foo", "1.0.0");
+        let staged = crate::atomic_fs::StagedDir::new(&slot).unwrap();
+        std::fs::write(
+            staged.path().join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let generation = staged.publish(&slot).unwrap();
+        let generation_name = generation.file_name().unwrap().to_string_lossy();
+        let lease = generation.with_file_name(format!("{generation_name}.lease"));
+        std::fs::remove_file(&lease).unwrap();
+
+        assert!(reg
+            .verified_online_cache_entry(&registry_id, "foo", "1.0.0", "sha256:unused")
+            .unwrap()
+            .is_none());
+        assert!(
+            generation.is_dir(),
+            "uncertain published generation must be retained for repair"
+        );
+        assert!(!lease.exists());
+
+        std::fs::create_dir(&lease).unwrap();
+        assert!(reg
+            .verified_online_cache_entry(&registry_id, "foo", "1.0.0", "sha256:unused")
+            .unwrap()
+            .is_none());
+        assert!(
+            generation.is_dir(),
+            "invalid lease metadata must not consume the published generation"
+        );
+    }
+
+    #[test]
+    fn cache_metadata_cannot_confirm_a_different_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = Registry::with_root(dir.path().to_path_buf());
+        let first = "https://registry-a.example/api/v1";
+        let second = "https://registry-b.example/api/v1";
+        let first_dir = reg.package_dir_for(first, "foo", "1.0.0");
+        std::fs::create_dir_all(&first_dir).unwrap();
+        std::fs::write(
+            first_dir.join("hew.toml"),
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(first_dir.join("foo.hew"), "pub fn value() -> i64 { 1 }\n").unwrap();
+        let archive = crate::tarball::pack(&first_dir, &[], &[]).unwrap();
+        Registry::write_cache_metadata(
+            &first_dir,
+            first,
+            "foo",
+            "1.0.0",
+            &archive.checksum,
+            &archive.data,
+        )
+        .unwrap();
+
+        let second_dir = reg.package_dir_for(second, "foo", "1.0.0");
+        std::fs::create_dir_all(&second_dir).unwrap();
+        for file in [
+            "hew.toml",
+            "foo.hew",
+            CACHE_ARCHIVE_FILE,
+            CACHE_METADATA_FILE,
+        ] {
+            std::fs::copy(first_dir.join(file), second_dir.join(file)).unwrap();
+        }
+        assert!(reg
+            .verified_online_cache_entry(second, "foo", "1.0.0", &archive.checksum)
             .unwrap()
             .is_none());
     }

--- a/hew-pkg/src/registry.rs
+++ b/hew-pkg/src/registry.rs
@@ -56,7 +56,7 @@ impl Registry {
     /// Return `true` if `name@version` is present in the registry.
     #[must_use]
     pub fn is_installed(&self, name: &str, version: &str) -> bool {
-        self.package_dir(name, version).is_dir()
+        is_package_dir(&self.package_dir(name, version))
     }
 
     /// Return the root path of this registry.
@@ -97,19 +97,16 @@ fn collect_packages(
         return;
     };
 
-    let mut has_toml = false;
     let mut subdirs = Vec::new();
 
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
             subdirs.push(path);
-        } else if entry.file_name() == "hew.toml" {
-            has_toml = true;
         }
     }
 
-    if has_toml {
+    if is_package_dir(dir) {
         if let Ok(rel) = dir.strip_prefix(root) {
             let parts: Vec<&str> = rel
                 .components()
@@ -130,6 +127,10 @@ fn collect_packages(
     for subdir in subdirs {
         collect_packages(root, &subdir, packages);
     }
+}
+
+fn is_package_dir(path: &Path) -> bool {
+    path.join("hew.toml").is_file()
 }
 
 #[cfg(test)]
@@ -216,6 +217,22 @@ mod tests {
         let reg = Registry::with_root(dir.path().to_path_buf());
         let pkg_dir = reg.package_dir("std.net.http", "1.0.0");
         std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(
+            pkg_dir.join("hew.toml"),
+            "[package]\nname = \"std.net.http\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
         assert!(reg.is_installed("std.net.http", "1.0.0"));
+    }
+
+    #[test]
+    fn is_installed_returns_false_for_incomplete_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg = Registry::with_root(dir.path().to_path_buf());
+        let pkg_dir = reg.package_dir("std.net.http", "1.0.0");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("partial.marker"), "incomplete").unwrap();
+        assert!(!reg.is_installed("std.net.http", "1.0.0"));
+        assert!(reg.list_packages().is_empty());
     }
 }

--- a/hew-pkg/src/resolver.rs
+++ b/hew-pkg/src/resolver.rs
@@ -901,6 +901,33 @@ pub fn resolve_version(
     })
 }
 
+/// Resolve one direct dependency from the manifest that declares it.
+///
+/// Registry dependencies are selected from the installed package registry.
+/// Path dependencies are resolved relative to `root` and validated against
+/// their local manifest.
+///
+/// # Errors
+///
+/// Returns [`ResolveError`] when the dependency requirement is invalid, no
+/// registry version matches, or a path dependency is missing or malformed.
+pub fn resolve_dependency_from_root(
+    package_name: &str,
+    spec: &DepSpec,
+    root: &Path,
+    registry: &Registry,
+) -> Result<String, ResolveError> {
+    validate_package_name(package_name)?;
+    let source = dependency_source(package_name, spec, root)?;
+    match source {
+        PackageSource::Registry => resolve_version(package_name, spec.version_req(), registry),
+        PackageSource::Path(path) => {
+            let mut resolver = ResolverPass::with_seed(registry, root, None, BTreeMap::new());
+            resolver.load_path_manifest(package_name, &path, &[spec.version_req().to_string()])
+        }
+    }
+}
+
 /// Find the highest cached version satisfying all active requirements.
 ///
 /// # Errors

--- a/hew-pkg/src/resolver.rs
+++ b/hew-pkg/src/resolver.rs
@@ -13,6 +13,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::path::{Path, PathBuf};
 
 use crate::index::IndexEntry;
 use crate::manifest::{self, DepSpec, HewManifest};
@@ -39,6 +40,19 @@ pub struct ResolvedPackage {
     pub requirements: Vec<String>,
     /// The root manifest's direct requirement, if this is a direct dependency.
     pub direct_requirement: Option<String>,
+    /// Location from which this package is materialized.
+    pub source: PackageSource,
+    /// Manifest spelling of a direct path dependency, for lockfile freshness.
+    pub direct_path: Option<String>,
+}
+
+/// Source selected for a resolved package.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackageSource {
+    /// A package version in the global registry cache.
+    Registry,
+    /// A package rooted at the given local directory.
+    Path(PathBuf),
 }
 
 /// Errors that can occur during version resolution.
@@ -71,6 +85,47 @@ pub enum ResolveError {
         version: String,
         /// The underlying manifest error.
         source: manifest::ManifestError,
+    },
+    /// A local dependency path does not exist or is not a directory.
+    PathDependencyNotFound {
+        /// Dependency name from the parent manifest.
+        package: String,
+        /// Fully resolved local path.
+        path: PathBuf,
+    },
+    /// A local dependency manifest could not be read.
+    PathManifestRead {
+        /// Dependency name from the parent manifest.
+        package: String,
+        /// Fully resolved local path.
+        path: PathBuf,
+        /// Underlying manifest error.
+        source: manifest::ManifestError,
+    },
+    /// A local package's declared name differs from its dependency key.
+    PathPackageNameMismatch {
+        /// Dependency name from the parent manifest.
+        package: String,
+        /// Name declared by the local package.
+        declared: String,
+        /// Fully resolved local path.
+        path: PathBuf,
+    },
+    /// A local package version does not satisfy all active requirements.
+    PathVersionMismatch {
+        /// Dependency name from the parent manifest.
+        package: String,
+        /// Version declared by the local package.
+        version: String,
+        /// Active version requirements.
+        requirements: Vec<String>,
+        /// Fully resolved local path.
+        path: PathBuf,
+    },
+    /// The graph refers to one package name through incompatible sources.
+    ConflictingSources {
+        /// Conflicting package name.
+        package: String,
     },
     /// The selected dependency graph contains a cycle.
     CircularDependency {
@@ -112,6 +167,43 @@ impl fmt::Display for ResolveError {
                     "cannot read installed manifest for `{package}@{version}`: {source}"
                 )
             }
+            Self::PathDependencyNotFound { package, path } => write!(
+                f,
+                "path dependency `{package}` was not found at `{}`",
+                path.display()
+            ),
+            Self::PathManifestRead {
+                package,
+                path,
+                source,
+            } => write!(
+                f,
+                "cannot read path dependency `{package}` at `{}`: {source}",
+                path.display()
+            ),
+            Self::PathPackageNameMismatch {
+                package,
+                declared,
+                path,
+            } => write!(
+                f,
+                "path dependency `{package}` at `{}` declares package name `{declared}`",
+                path.display()
+            ),
+            Self::PathVersionMismatch {
+                package,
+                version,
+                requirements,
+                path,
+            } => write!(
+                f,
+                "path dependency `{package}` at `{}` has version `{version}`, which does not match [{}]",
+                path.display(),
+                requirements.join(", ")
+            ),
+            Self::ConflictingSources { package } => {
+                write!(f, "dependency `{package}` is requested from conflicting sources")
+            }
             Self::CircularDependency { cycle } => {
                 write!(f, "circular dependency detected: {}", cycle.join(" -> "))
             }
@@ -135,9 +227,15 @@ impl std::error::Error for ResolveError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::InvalidVersionReq { source, .. } => Some(source),
-            Self::ManifestRead { source, .. } => Some(source),
+            Self::ManifestRead { source, .. } | Self::PathManifestRead { source, .. } => {
+                Some(source)
+            }
             Self::NoMatchingVersion { .. }
             | Self::InvalidPackageName { .. }
+            | Self::PathDependencyNotFound { .. }
+            | Self::PathPackageNameMismatch { .. }
+            | Self::PathVersionMismatch { .. }
+            | Self::ConflictingSources { .. }
             | Self::CircularDependency { .. }
             | Self::UnresolvableDeps { .. } => None,
         }
@@ -210,6 +308,8 @@ struct PackageState {
     requested_features: BTreeSet<String>,
     use_default_features: bool,
     registry: Option<String>,
+    source: Option<PackageSource>,
+    direct_path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -227,6 +327,8 @@ struct DepRequest {
     features: BTreeSet<String>,
     use_default_features: bool,
     registry: Option<String>,
+    source: PackageSource,
+    direct_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -238,6 +340,11 @@ struct FailureState {
 #[derive(Debug, Clone, Default)]
 struct ActiveFeatures {
     enabled_optional_dependencies: BTreeSet<String>,
+}
+
+struct CachedManifest {
+    manifest: HewManifest,
+    root: PathBuf,
 }
 
 enum VisitControl {
@@ -253,19 +360,26 @@ enum PassOutcome {
 
 struct ResolverPass<'a> {
     registry: &'a Registry,
+    root: &'a Path,
     available_versions: BTreeMap<String, Vec<semver::Version>>,
     package_states: BTreeMap<String, PackageState>,
     selected_versions: BTreeMap<String, String>,
     expanded_states: BTreeMap<String, ExpandedState>,
     failures: BTreeMap<String, FailureState>,
-    manifest_cache: BTreeMap<(String, String), HewManifest>,
+    manifest_cache: BTreeMap<(String, String), CachedManifest>,
 }
 
 impl<'a> ResolverPass<'a> {
-    fn with_seed(registry: &'a Registry, package_states: BTreeMap<String, PackageState>) -> Self {
+    fn with_seed(
+        registry: &'a Registry,
+        root: &'a Path,
+        confirmed_versions: Option<&'a BTreeMap<String, BTreeSet<String>>>,
+        package_states: BTreeMap<String, PackageState>,
+    ) -> Self {
         Self {
             registry,
-            available_versions: available_versions(registry),
+            root,
+            available_versions: available_versions(registry, confirmed_versions),
             package_states,
             selected_versions: BTreeMap::new(),
             expanded_states: BTreeMap::new(),
@@ -275,7 +389,7 @@ impl<'a> ResolverPass<'a> {
     }
 
     fn resolve_manifest(mut self, manifest: &HewManifest) -> Result<PassOutcome, ResolveError> {
-        for request in root_requests(manifest) {
+        for request in root_requests(manifest, self.root)? {
             match self.visit_request(request, &[])? {
                 VisitControl::Continue => {}
                 VisitControl::Restart => return Ok(PassOutcome::Restart(self.package_states)),
@@ -297,6 +411,11 @@ impl<'a> ResolverPass<'a> {
                             version: version.clone(),
                             requirements: state.requirements.iter().cloned().collect(),
                             direct_requirement: state.direct_requirement.clone(),
+                            source: state
+                                .source
+                                .clone()
+                                .expect("selected package must have a source"),
+                            direct_path: state.direct_path.clone(),
                         },
                     )
                 })
@@ -329,8 +448,19 @@ impl<'a> ResolverPass<'a> {
             return Err(ResolveError::CircularDependency { cycle });
         }
 
+        let request_source = request.source.clone();
         let (requirements, requested_features, use_default_features) = {
             let state = self.package_states.entry(request.name.clone()).or_default();
+            if state
+                .source
+                .as_ref()
+                .is_some_and(|source| source != &request_source)
+            {
+                return Err(ResolveError::ConflictingSources {
+                    package: request.name,
+                });
+            }
+            state.source.get_or_insert_with(|| request_source.clone());
             state.requirements.insert(request.requirement.clone());
             if state.direct_requirement.is_none() {
                 state
@@ -340,7 +470,12 @@ impl<'a> ResolverPass<'a> {
             if state.registry.is_none() {
                 state.registry.clone_from(&request.registry);
             }
-            state.requested_features.extend(request.features);
+            if state.direct_path.is_none() {
+                state.direct_path.clone_from(&request.direct_path);
+            }
+            state
+                .requested_features
+                .extend(request.features.iter().cloned());
             state.use_default_features |= request.use_default_features;
             (
                 state.requirements.iter().cloned().collect::<Vec<_>>(),
@@ -349,24 +484,7 @@ impl<'a> ResolverPass<'a> {
             )
         };
 
-        let Some(version) = select_highest_matching_version(
-            &request.name,
-            &requirements,
-            &self.available_versions,
-        )?
-        else {
-            self.failures
-                .entry(request.name)
-                .and_modify(|failure| {
-                    failure.requirements.extend(requirements.iter().cloned());
-                    if failure.registry.is_none() {
-                        failure.registry.clone_from(&request.registry);
-                    }
-                })
-                .or_insert_with(|| FailureState {
-                    requirements: requirements.iter().cloned().collect(),
-                    registry: request.registry.clone(),
-                });
+        let Some(version) = self.select_version(&request, &request_source, &requirements)? else {
             return Ok(VisitControl::Continue);
         };
 
@@ -395,8 +513,8 @@ impl<'a> ResolverPass<'a> {
             .expect("package state must exist after merging request")
             .clone();
         let dependency_requests = {
-            let manifest = self.load_manifest(&request.name, &version)?;
-            dependency_requests_from_manifest(manifest, &state_snapshot)
+            let cached = self.load_manifest(&request.name, &version, &request_source)?;
+            dependency_requests_from_manifest(&cached.manifest, &state_snapshot, &cached.root)?
         };
 
         self.expanded_states.insert(request.name.clone(), expanded);
@@ -414,27 +532,127 @@ impl<'a> ResolverPass<'a> {
         Ok(VisitControl::Continue)
     }
 
+    fn select_version(
+        &mut self,
+        request: &DepRequest,
+        source: &PackageSource,
+        requirements: &[String],
+    ) -> Result<Option<String>, ResolveError> {
+        match source {
+            PackageSource::Registry => {
+                let version = select_highest_matching_version(
+                    &request.name,
+                    requirements,
+                    &self.available_versions,
+                )?;
+                if version.is_none() {
+                    self.failures
+                        .entry(request.name.clone())
+                        .and_modify(|failure| {
+                            failure.requirements.extend(requirements.iter().cloned());
+                            if failure.registry.is_none() {
+                                failure.registry.clone_from(&request.registry);
+                            }
+                        })
+                        .or_insert_with(|| FailureState {
+                            requirements: requirements.iter().cloned().collect(),
+                            registry: request.registry.clone(),
+                        });
+                }
+                Ok(version)
+            }
+            PackageSource::Path(path) => self
+                .load_path_manifest(&request.name, path, requirements)
+                .map(Some),
+        }
+    }
+
     fn load_manifest(
         &mut self,
         package: &str,
         version: &str,
-    ) -> Result<&HewManifest, ResolveError> {
+        source: &PackageSource,
+    ) -> Result<&CachedManifest, ResolveError> {
         let key = (package.to_string(), version.to_string());
         if !self.manifest_cache.contains_key(&key) {
-            let manifest_path = self.registry.package_dir(package, version).join("hew.toml");
-            let manifest = manifest::parse_manifest(&manifest_path).map_err(|source| {
-                ResolveError::ManifestRead {
-                    package: package.to_string(),
-                    version: version.to_string(),
-                    source,
+            match source {
+                PackageSource::Registry => {
+                    let root = self.registry.package_dir(package, version);
+                    let manifest =
+                        manifest::parse_manifest(&root.join("hew.toml")).map_err(|source| {
+                            ResolveError::ManifestRead {
+                                package: package.to_string(),
+                                version: version.to_string(),
+                                source,
+                            }
+                        })?;
+                    self.manifest_cache
+                        .insert(key.clone(), CachedManifest { manifest, root });
                 }
-            })?;
-            self.manifest_cache.insert(key.clone(), manifest);
+                PackageSource::Path(path) => {
+                    self.load_path_manifest(package, path, &[version.to_string()])?;
+                }
+            }
         }
         Ok(self
             .manifest_cache
             .get(&key)
             .expect("manifest cache entry must exist after insertion"))
+    }
+
+    fn load_path_manifest(
+        &mut self,
+        package: &str,
+        path: &Path,
+        requirements: &[String],
+    ) -> Result<String, ResolveError> {
+        if !path.is_dir() {
+            return Err(ResolveError::PathDependencyNotFound {
+                package: package.to_string(),
+                path: path.to_path_buf(),
+            });
+        }
+        let manifest = manifest::parse_manifest(&path.join("hew.toml")).map_err(|source| {
+            ResolveError::PathManifestRead {
+                package: package.to_string(),
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+        if manifest.package.name != package {
+            return Err(ResolveError::PathPackageNameMismatch {
+                package: package.to_string(),
+                declared: manifest.package.name,
+                path: path.to_path_buf(),
+            });
+        }
+        let version = semver::Version::parse(&manifest.package.version).map_err(|source| {
+            ResolveError::InvalidVersionReq {
+                input: manifest.package.version.clone(),
+                source,
+            }
+        })?;
+        let parsed_requirements = parse_requirements(requirements)?;
+        if !parsed_requirements
+            .iter()
+            .all(|requirement| requirement.matches(&version))
+        {
+            return Err(ResolveError::PathVersionMismatch {
+                package: package.to_string(),
+                version: version.to_string(),
+                requirements: requirements.to_vec(),
+                path: path.to_path_buf(),
+            });
+        }
+        let version = version.to_string();
+        self.manifest_cache.insert(
+            (package.to_string(), version.clone()),
+            CachedManifest {
+                manifest,
+                root: path.to_path_buf(),
+            },
+        );
+        Ok(version)
     }
 }
 
@@ -460,9 +678,19 @@ fn normalize_version(v: &str) -> String {
     }
 }
 
-fn available_versions(registry: &Registry) -> BTreeMap<String, Vec<semver::Version>> {
+fn available_versions(
+    registry: &Registry,
+    confirmed_versions: Option<&BTreeMap<String, BTreeSet<String>>>,
+) -> BTreeMap<String, Vec<semver::Version>> {
     let mut versions = BTreeMap::<String, Vec<semver::Version>>::new();
     for package in registry.list_packages() {
+        if confirmed_versions.is_some_and(|confirmed| {
+            !confirmed
+                .get(&package.name)
+                .is_some_and(|versions| versions.contains(&package.version))
+        }) {
+            continue;
+        }
         if let Ok(version) = semver::Version::parse(&package.version) {
             versions.entry(package.name).or_default().push(version);
         }
@@ -498,19 +726,54 @@ fn select_highest_matching_version(
         .map(ToString::to_string))
 }
 
-fn root_requests(manifest: &HewManifest) -> Vec<DepRequest> {
+fn root_requests(manifest: &HewManifest, root: &Path) -> Result<Vec<DepRequest>, ResolveError> {
     manifest
         .dependencies
         .iter()
-        .map(|(name, dep_spec)| DepRequest {
-            name: name.clone(),
-            requirement: dep_spec.version_req().to_string(),
-            direct_requirement: Some(dep_spec.version_req().to_string()),
-            features: requested_features(dep_spec),
-            use_default_features: uses_default_features(dep_spec),
-            registry: dependency_registry(dep_spec),
+        .map(|(name, dep_spec)| {
+            Ok(DepRequest {
+                name: name.clone(),
+                requirement: dep_spec.version_req().to_string(),
+                direct_requirement: Some(dep_spec.version_req().to_string()),
+                features: requested_features(dep_spec),
+                use_default_features: uses_default_features(dep_spec),
+                registry: dependency_registry(dep_spec),
+                source: dependency_source(name, dep_spec, root)?,
+                direct_path: dependency_path(dep_spec).map(ToString::to_string),
+            })
         })
         .collect()
+}
+
+fn dependency_path(dep_spec: &DepSpec) -> Option<&str> {
+    match dep_spec {
+        DepSpec::Version(_) => None,
+        DepSpec::Table(table) => table.path.as_deref(),
+    }
+}
+
+fn dependency_source(
+    package: &str,
+    dep_spec: &DepSpec,
+    root: &Path,
+) -> Result<PackageSource, ResolveError> {
+    let Some(path) = dependency_path(dep_spec) else {
+        return Ok(PackageSource::Registry);
+    };
+    let resolved = root.join(path);
+    let canonical = resolved
+        .canonicalize()
+        .map_err(|_| ResolveError::PathDependencyNotFound {
+            package: package.to_string(),
+            path: resolved.clone(),
+        })?;
+    if !canonical.is_dir() {
+        return Err(ResolveError::PathDependencyNotFound {
+            package: package.to_string(),
+            path: canonical,
+        });
+    }
+    Ok(PackageSource::Path(canonical))
 }
 
 fn requested_features(dep_spec: &DepSpec) -> BTreeSet<String> {
@@ -542,29 +805,29 @@ fn dependency_registry(dep_spec: &DepSpec) -> Option<String> {
 fn dependency_requests_from_manifest(
     manifest: &HewManifest,
     state: &PackageState,
-) -> Vec<DepRequest> {
+    root: &Path,
+) -> Result<Vec<DepRequest>, ResolveError> {
     let active_features = resolve_active_features(manifest, state);
+    let mut requests = Vec::new();
+    for (name, dep_spec) in &manifest.dependencies {
+        if dependency_is_optional(dep_spec)
+            && !active_features.enabled_optional_dependencies.contains(name)
+        {
+            continue;
+        }
 
-    manifest
-        .dependencies
-        .iter()
-        .filter_map(|(name, dep_spec)| {
-            if dependency_is_optional(dep_spec)
-                && !active_features.enabled_optional_dependencies.contains(name)
-            {
-                return None;
-            }
-
-            Some(DepRequest {
-                name: name.clone(),
-                requirement: dep_spec.version_req().to_string(),
-                direct_requirement: None,
-                features: requested_features(dep_spec),
-                use_default_features: uses_default_features(dep_spec),
-                registry: dependency_registry(dep_spec),
-            })
-        })
-        .collect()
+        requests.push(DepRequest {
+            name: name.clone(),
+            requirement: dep_spec.version_req().to_string(),
+            direct_requirement: None,
+            features: requested_features(dep_spec),
+            use_default_features: uses_default_features(dep_spec),
+            registry: dependency_registry(dep_spec),
+            source: dependency_source(name, dep_spec, root)?,
+            direct_path: None,
+        });
+    }
+    Ok(requests)
 }
 
 fn dependency_is_optional(dep_spec: &DepSpec) -> bool {
@@ -627,11 +890,33 @@ pub fn resolve_version(
     validate_package_name(package_name)?;
 
     let requirements = vec![requirement.to_string()];
-    select_highest_matching_version(package_name, &requirements, &available_versions(registry))?
-        .ok_or_else(|| ResolveError::NoMatchingVersion {
-            package: package_name.to_string(),
-            requirement: requirement.to_string(),
-        })
+    select_highest_matching_version(
+        package_name,
+        &requirements,
+        &available_versions(registry, None),
+    )?
+    .ok_or_else(|| ResolveError::NoMatchingVersion {
+        package: package_name.to_string(),
+        requirement: requirement.to_string(),
+    })
+}
+
+/// Find the highest cached version satisfying all active requirements.
+///
+/// # Errors
+///
+/// Returns [`ResolveError::InvalidVersionReq`] if any requirement is invalid.
+pub fn resolve_cached_version(
+    package_name: &str,
+    requirements: &[String],
+    registry: &Registry,
+) -> Result<Option<String>, ResolveError> {
+    validate_package_name(package_name)?;
+    select_highest_matching_version(
+        package_name,
+        requirements,
+        &available_versions(registry, None),
+    )
 }
 
 fn validate_package_name(package: &str) -> Result<(), ResolveError> {
@@ -739,9 +1024,47 @@ pub fn resolve_all(
     manifest: &HewManifest,
     registry: &Registry,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
+    resolve_all_from_root(manifest, Path::new("."), registry)
+}
+
+/// Resolve dependencies from the cache, interpreting path dependencies
+/// relative to `root`.
+///
+/// # Errors
+///
+/// Returns [`ResolveError`] when the graph cannot be resolved.
+pub fn resolve_all_from_root(
+    manifest: &HewManifest,
+    root: &Path,
+    registry: &Registry,
+) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
+    resolve_all_inner(manifest, root, registry, None)
+}
+
+/// Resolve dependencies using only registry versions confirmed by the current
+/// online install operation. Path dependencies remain available from disk.
+///
+/// # Errors
+///
+/// Returns [`ResolveError`] when the graph cannot be resolved.
+pub fn resolve_all_confirmed(
+    manifest: &HewManifest,
+    root: &Path,
+    registry: &Registry,
+    confirmed_versions: &BTreeMap<String, BTreeSet<String>>,
+) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
+    resolve_all_inner(manifest, root, registry, Some(confirmed_versions))
+}
+
+fn resolve_all_inner(
+    manifest: &HewManifest,
+    root: &Path,
+    registry: &Registry,
+    confirmed_versions: Option<&BTreeMap<String, BTreeSet<String>>>,
+) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
     let mut seed_states = BTreeMap::new();
     loop {
-        let pass = ResolverPass::with_seed(registry, seed_states);
+        let pass = ResolverPass::with_seed(registry, root, confirmed_versions, seed_states);
         match pass.resolve_manifest(manifest)? {
             PassOutcome::Resolved(resolved) => return Ok(resolved),
             PassOutcome::Restart(next_seed_states) => {
@@ -1499,6 +1822,91 @@ mod tests {
         let resolved = resolve_all(&manifest, &reg).unwrap();
         assert_eq!(resolved["feature.core"].version, "1.0.0");
         assert_eq!(resolved["feature.tls"].version, "1.1.0");
+    }
+
+    #[test]
+    fn confirmed_resolution_refuses_unconfirmed_cached_version() {
+        let (_dir, registry) = test_registry();
+        install_fake(&registry, "cached.pkg", "1.0.0");
+        let manifest = test_manifest(BTreeMap::from([(
+            "cached.pkg".to_string(),
+            DepSpec::Version("1.0.0".to_string()),
+        )]));
+        let confirmed = BTreeMap::new();
+
+        let error = resolve_all_confirmed(&manifest, Path::new("."), &registry, &confirmed)
+            .expect_err("unconfirmed cache entry must be unavailable");
+        assert!(matches!(error, ResolveError::UnresolvableDeps { .. }));
+
+        let confirmed = BTreeMap::from([(
+            "cached.pkg".to_string(),
+            BTreeSet::from(["1.0.0".to_string()]),
+        )]);
+        let resolved = resolve_all_confirmed(&manifest, Path::new("."), &registry, &confirmed)
+            .expect("confirmed cache entry should resolve");
+        assert_eq!(resolved["cached.pkg"].version, "1.0.0");
+    }
+
+    #[test]
+    fn path_dependency_resolves_with_transitive_registry_dependency() {
+        let (registry_dir, registry) = test_registry();
+        install_fake(&registry, "registry.leaf", "2.0.0");
+        let project = tempfile::tempdir().unwrap();
+        let local = project.path().join("local");
+        std::fs::create_dir(&local).unwrap();
+        std::fs::write(
+            local.join("hew.toml"),
+            concat!(
+                "[package]\n",
+                "name = \"local\"\n",
+                "version = \"1.2.3\"\n",
+                "\n[dependencies]\n",
+                "\"registry.leaf\" = \"2.0.0\"\n",
+            ),
+        )
+        .unwrap();
+        let manifest = test_manifest(BTreeMap::from([(
+            "local".to_string(),
+            DepSpec::Table(DepTable {
+                version: "*".to_string(),
+                optional: None,
+                features: None,
+                default_features: None,
+                registry: None,
+                path: Some("local".to_string()),
+            }),
+        )]));
+
+        let resolved = resolve_all_from_root(&manifest, project.path(), &registry).unwrap();
+        assert_eq!(resolved["local"].version, "1.2.3");
+        assert_eq!(resolved["registry.leaf"].version, "2.0.0");
+        assert_eq!(
+            resolved["local"].source,
+            PackageSource::Path(local.canonicalize().unwrap())
+        );
+        drop(registry_dir);
+    }
+
+    #[test]
+    fn missing_path_dependency_is_named() {
+        let (_registry_dir, registry) = test_registry();
+        let project = tempfile::tempdir().unwrap();
+        let manifest = test_manifest(BTreeMap::from([(
+            "missing".to_string(),
+            DepSpec::Table(DepTable {
+                version: "*".to_string(),
+                optional: None,
+                features: None,
+                default_features: None,
+                registry: None,
+                path: Some("does-not-exist".to_string()),
+            }),
+        )]));
+
+        let error = resolve_all_from_root(&manifest, project.path(), &registry).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("missing"));
+        assert!(message.contains("does-not-exist"));
     }
 
     // ── Display / Error impls ───────────────────────────────────────────

--- a/hew-pkg/src/resolver.rs
+++ b/hew-pkg/src/resolver.rs
@@ -137,6 +137,13 @@ pub enum ResolveError {
         /// Each unresolved package along with all active requirements.
         failures: Vec<UnresolvedDep>,
     },
+    /// A resolver pass repeated without changing its accumulated state.
+    NoProgress,
+    /// Resolution exceeded its finite pass limit.
+    ProgressLimitExceeded {
+        /// Maximum number of passes attempted.
+        limit: usize,
+    },
 }
 
 impl fmt::Display for ResolveError {
@@ -219,6 +226,13 @@ impl fmt::Display for ResolveError {
                 }
                 Ok(())
             }
+            Self::NoProgress => {
+                f.write_str("dependency resolution repeated without making progress")
+            }
+            Self::ProgressLimitExceeded { limit } => write!(
+                f,
+                "dependency resolution exceeded the finite limit of {limit} passes"
+            ),
         }
     }
 }
@@ -237,7 +251,9 @@ impl std::error::Error for ResolveError {
             | Self::PathVersionMismatch { .. }
             | Self::ConflictingSources { .. }
             | Self::CircularDependency { .. }
-            | Self::UnresolvableDeps { .. } => None,
+            | Self::UnresolvableDeps { .. }
+            | Self::NoProgress
+            | Self::ProgressLimitExceeded { .. } => None,
         }
     }
 }
@@ -301,7 +317,7 @@ impl VersionReq {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct PackageState {
     requirements: BTreeSet<String>,
     direct_requirement: Option<String>,
@@ -1089,12 +1105,18 @@ fn resolve_all_inner(
     registry: &Registry,
     confirmed_versions: Option<&BTreeMap<String, BTreeSet<String>>>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
+    const MAX_RESOLUTION_PASSES: usize = 1024;
+
     let mut seed_states = BTreeMap::new();
-    loop {
+    for _ in 0..MAX_RESOLUTION_PASSES {
+        let previous_seed_states = seed_states.clone();
         let pass = ResolverPass::with_seed(registry, root, confirmed_versions, seed_states);
         match pass.resolve_manifest(manifest)? {
             PassOutcome::Resolved(resolved) => return Ok(resolved),
             PassOutcome::Restart(next_seed_states) => {
+                if next_seed_states == previous_seed_states {
+                    return Err(ResolveError::NoProgress);
+                }
                 seed_states = next_seed_states;
             }
             PassOutcome::Unresolved(failures) => {
@@ -1102,6 +1124,9 @@ fn resolve_all_inner(
             }
         }
     }
+    Err(ResolveError::ProgressLimitExceeded {
+        limit: MAX_RESOLUTION_PASSES,
+    })
 }
 
 #[cfg(test)]

--- a/hew-pkg/src/resolver.rs
+++ b/hew-pkg/src/resolver.rs
@@ -27,8 +27,10 @@ pub struct UnresolvedDep {
     pub package: String,
     /// Every version requirement currently imposed on the package.
     pub requirements: Vec<String>,
-    /// The named registry required for this package, if any.
-    pub registry: Option<String>,
+    /// Canonical identity of the registry required for this package.
+    pub registry: String,
+    /// Config selector used to construct the client, if this is a named source.
+    pub registry_selector: Option<String>,
 }
 
 /// A resolved package in the dependency graph.
@@ -47,10 +49,13 @@ pub struct ResolvedPackage {
 }
 
 /// Source selected for a resolved package.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PackageSource {
     /// A package version in the global registry cache.
-    Registry,
+    Registry {
+        /// Canonical source identity.
+        registry: String,
+    },
     /// A package rooted at the given local directory.
     Path(PathBuf),
 }
@@ -126,6 +131,29 @@ pub enum ResolveError {
     ConflictingSources {
         /// Conflicting package name.
         package: String,
+        /// First source identity.
+        first: PackageSource,
+        /// Conflicting source identity.
+        second: PackageSource,
+    },
+    /// A registry-origin manifest contains a forbidden path dependency.
+    RegistryPathDependency {
+        /// Registry package declaring the dependency.
+        package: String,
+        /// Dependency key.
+        dependency: String,
+        /// Untrusted path spelling from the manifest.
+        path: String,
+    },
+    /// A dependency table combines mutually exclusive path and registry fields.
+    PathAndRegistry {
+        /// Dependency key.
+        package: String,
+    },
+    /// A manifest refers to an unconfigured named registry.
+    UnknownRegistry {
+        /// Unknown selector.
+        registry: String,
     },
     /// The selected dependency graph contains a cycle.
     CircularDependency {
@@ -146,6 +174,10 @@ pub enum ResolveError {
     },
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "the exhaustive diagnostic mapping keeps every resolver error precise"
+)]
 impl fmt::Display for ResolveError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -208,8 +240,30 @@ impl fmt::Display for ResolveError {
                 path.display(),
                 requirements.join(", ")
             ),
-            Self::ConflictingSources { package } => {
-                write!(f, "dependency `{package}` is requested from conflicting sources")
+            Self::ConflictingSources {
+                package,
+                first,
+                second,
+            } => {
+                write!(
+                    f,
+                    "dependency `{package}` is requested from conflicting sources ({first:?} and {second:?})"
+                )
+            }
+            Self::RegistryPathDependency {
+                package,
+                dependency,
+                path,
+            } => write!(
+                f,
+                "registry package `{package}` contains forbidden path dependency `{dependency}` with path `{path}`"
+            ),
+            Self::PathAndRegistry { package } => write!(
+                f,
+                "dependency `{package}` cannot specify both `path` and `registry`"
+            ),
+            Self::UnknownRegistry { registry } => {
+                write!(f, "dependency refers to unknown registry `{registry}`")
             }
             Self::CircularDependency { cycle } => {
                 write!(f, "circular dependency detected: {}", cycle.join(" -> "))
@@ -250,6 +304,9 @@ impl std::error::Error for ResolveError {
             | Self::PathPackageNameMismatch { .. }
             | Self::PathVersionMismatch { .. }
             | Self::ConflictingSources { .. }
+            | Self::RegistryPathDependency { .. }
+            | Self::PathAndRegistry { .. }
+            | Self::UnknownRegistry { .. }
             | Self::CircularDependency { .. }
             | Self::UnresolvableDeps { .. }
             | Self::NoProgress
@@ -323,7 +380,7 @@ struct PackageState {
     direct_requirement: Option<String>,
     requested_features: BTreeSet<String>,
     use_default_features: bool,
-    registry: Option<String>,
+    registry_selector: Option<String>,
     source: Option<PackageSource>,
     direct_path: Option<String>,
 }
@@ -342,7 +399,7 @@ struct DepRequest {
     direct_requirement: Option<String>,
     features: BTreeSet<String>,
     use_default_features: bool,
-    registry: Option<String>,
+    registry_selector: Option<String>,
     source: PackageSource,
     direct_path: Option<String>,
 }
@@ -350,7 +407,8 @@ struct DepRequest {
 #[derive(Debug, Clone, Default)]
 struct FailureState {
     requirements: BTreeSet<String>,
-    registry: Option<String>,
+    registry: String,
+    registry_selector: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -361,6 +419,82 @@ struct ActiveFeatures {
 struct CachedManifest {
     manifest: HewManifest,
     root: PathBuf,
+}
+
+/// Registry identities available while resolving one dependency graph.
+#[derive(Debug, Clone)]
+pub struct RegistrySources {
+    default_registry: String,
+    default_selector: Option<String>,
+    named: BTreeMap<String, String>,
+}
+
+impl RegistrySources {
+    /// Construct source identities for the CLI-selected default and all named
+    /// registries configured for explicit dependency selectors.
+    #[must_use]
+    pub fn new(
+        default_registry: String,
+        default_selector: Option<String>,
+        named: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            default_registry,
+            default_selector,
+            named,
+        }
+    }
+
+    /// Construct the compiled-in default source without named registries.
+    #[must_use]
+    pub fn default_source() -> Self {
+        Self::new(
+            crate::config::default_registry_identity(),
+            None,
+            BTreeMap::new(),
+        )
+    }
+
+    /// Canonical identity used for root and local dependencies without a selector.
+    #[must_use]
+    pub fn default_registry(&self) -> &str {
+        &self.default_registry
+    }
+
+    /// Configured selector used for the default source, if named.
+    #[must_use]
+    pub fn default_selector(&self) -> Option<&str> {
+        self.default_selector.as_deref()
+    }
+
+    /// Configured named source identities.
+    #[must_use]
+    pub fn named(&self) -> &BTreeMap<String, String> {
+        &self.named
+    }
+
+    fn resolve(
+        &self,
+        selector: Option<&str>,
+        inherited: Option<(&str, Option<&str>)>,
+    ) -> Result<(String, Option<String>), ResolveError> {
+        if let Some(selector) = selector {
+            let identity =
+                self.named
+                    .get(selector)
+                    .ok_or_else(|| ResolveError::UnknownRegistry {
+                        registry: selector.to_string(),
+                    })?;
+            return Ok((identity.clone(), Some(selector.to_string())));
+        }
+        if let Some((identity, selector)) = inherited {
+            return Ok((
+                identity.to_string(),
+                selector.map(std::string::ToString::to_string),
+            ));
+        }
+        Ok((self.default_registry.clone(), self.default_selector.clone()))
+    }
 }
 
 enum VisitControl {
@@ -376,31 +510,45 @@ enum PassOutcome {
 
 struct ResolverPass<'a> {
     registry: &'a Registry,
+    registry_sources: &'a RegistrySources,
     root: &'a Path,
-    pinned_registry_paths: Option<&'a BTreeMap<(String, String), PathBuf>>,
-    available_versions: BTreeMap<String, Vec<semver::Version>>,
+    allow_legacy_default: bool,
+    pinned_registry_paths: Option<&'a BTreeMap<(String, String, String), PathBuf>>,
+    available_versions: BTreeMap<(String, String), Vec<semver::Version>>,
     package_states: BTreeMap<String, PackageState>,
     selected_versions: BTreeMap<String, String>,
     expanded_states: BTreeMap<String, ExpandedState>,
     failures: BTreeMap<String, FailureState>,
-    manifest_cache: BTreeMap<(String, String), CachedManifest>,
+    manifest_cache: BTreeMap<(PackageSource, String, String), CachedManifest>,
 }
 
 impl<'a> ResolverPass<'a> {
     fn with_seed(
         registry: &'a Registry,
+        registry_sources: &'a RegistrySources,
         root: &'a Path,
-        confirmed_versions: Option<&'a BTreeMap<String, BTreeSet<String>>>,
-        pinned_registry_paths: Option<&'a BTreeMap<(String, String), PathBuf>>,
+        allow_legacy_default: bool,
+        confirmed_versions: Option<&'a BTreeMap<(String, String), BTreeSet<String>>>,
+        pinned_registry_paths: Option<&'a BTreeMap<(String, String, String), PathBuf>>,
         package_states: BTreeMap<String, PackageState>,
     ) -> Self {
         let available_versions = pinned_registry_paths.map_or_else(
-            || available_versions(registry, confirmed_versions),
+            || {
+                available_versions(
+                    registry,
+                    registry_sources,
+                    allow_legacy_default,
+                    confirmed_versions,
+                )
+            },
             |paths| {
-                let mut versions = BTreeMap::<String, Vec<semver::Version>>::new();
-                for (name, version) in paths.keys() {
+                let mut versions = BTreeMap::<(String, String), Vec<semver::Version>>::new();
+                for (registry, name, version) in paths.keys() {
                     if let Ok(version) = semver::Version::parse(version) {
-                        versions.entry(name.clone()).or_default().push(version);
+                        versions
+                            .entry((registry.clone(), name.clone()))
+                            .or_default()
+                            .push(version);
                     }
                 }
                 versions
@@ -408,7 +556,9 @@ impl<'a> ResolverPass<'a> {
         );
         Self {
             registry,
+            registry_sources,
             root,
+            allow_legacy_default,
             pinned_registry_paths,
             available_versions,
             package_states,
@@ -420,7 +570,7 @@ impl<'a> ResolverPass<'a> {
     }
 
     fn resolve_manifest(mut self, manifest: &HewManifest) -> Result<PassOutcome, ResolveError> {
-        for request in root_requests(manifest, self.root)? {
+        for request in root_requests(manifest, self.root, self.registry_sources)? {
             match self.visit_request(request, &[])? {
                 VisitControl::Continue => {}
                 VisitControl::Restart => return Ok(PassOutcome::Restart(self.package_states)),
@@ -460,6 +610,7 @@ impl<'a> ResolverPass<'a> {
                     package,
                     requirements: failure.requirements.into_iter().collect(),
                     registry: failure.registry,
+                    registry_selector: failure.registry_selector,
                 })
                 .collect();
             Ok(PassOutcome::Unresolved(failures))
@@ -489,6 +640,8 @@ impl<'a> ResolverPass<'a> {
             {
                 return Err(ResolveError::ConflictingSources {
                     package: request.name,
+                    first: state.source.clone().expect("checked existing source"),
+                    second: request_source,
                 });
             }
             state.source.get_or_insert_with(|| request_source.clone());
@@ -498,8 +651,10 @@ impl<'a> ResolverPass<'a> {
                     .direct_requirement
                     .clone_from(&request.direct_requirement);
             }
-            if state.registry.is_none() {
-                state.registry.clone_from(&request.registry);
+            if state.registry_selector.is_none() {
+                state
+                    .registry_selector
+                    .clone_from(&request.registry_selector);
             }
             if state.direct_path.is_none() {
                 state.direct_path.clone_from(&request.direct_path);
@@ -544,8 +699,15 @@ impl<'a> ResolverPass<'a> {
             .expect("package state must exist after merging request")
             .clone();
         let dependency_requests = {
+            let registry_sources = self.registry_sources.clone();
             let cached = self.load_manifest(&request.name, &version, &request_source)?;
-            dependency_requests_from_manifest(&cached.manifest, &state_snapshot, &cached.root)?
+            dependency_requests_from_manifest(
+                &cached.manifest,
+                &state_snapshot,
+                &cached.root,
+                &request_source,
+                &registry_sources,
+            )?
         };
 
         self.expanded_states.insert(request.name.clone(), expanded);
@@ -570,8 +732,9 @@ impl<'a> ResolverPass<'a> {
         requirements: &[String],
     ) -> Result<Option<String>, ResolveError> {
         match source {
-            PackageSource::Registry => {
+            PackageSource::Registry { registry } => {
                 let version = select_highest_matching_version(
+                    registry,
                     &request.name,
                     requirements,
                     &self.available_versions,
@@ -581,13 +744,16 @@ impl<'a> ResolverPass<'a> {
                         .entry(request.name.clone())
                         .and_modify(|failure| {
                             failure.requirements.extend(requirements.iter().cloned());
-                            if failure.registry.is_none() {
-                                failure.registry.clone_from(&request.registry);
+                            if failure.registry_selector.is_none() {
+                                failure
+                                    .registry_selector
+                                    .clone_from(&request.registry_selector);
                             }
                         })
                         .or_insert_with(|| FailureState {
                             requirements: requirements.iter().cloned().collect(),
-                            registry: request.registry.clone(),
+                            registry: registry.clone(),
+                            registry_selector: request.registry_selector.clone(),
                         });
                 }
                 Ok(version)
@@ -604,15 +770,27 @@ impl<'a> ResolverPass<'a> {
         version: &str,
         source: &PackageSource,
     ) -> Result<&CachedManifest, ResolveError> {
-        let key = (package.to_string(), version.to_string());
+        let key = (source.clone(), package.to_string(), version.to_string());
         if !self.manifest_cache.contains_key(&key) {
             match source {
-                PackageSource::Registry => {
+                PackageSource::Registry { registry } => {
                     let root = self.pinned_registry_paths.map_or_else(
-                        || self.registry.package_dir(package, version),
+                        || {
+                            let namespaced =
+                                self.registry.package_dir_for(registry, package, version);
+                            if namespaced.is_dir() {
+                                namespaced
+                            } else if self.allow_legacy_default
+                                && registry == self.registry_sources.default_registry()
+                            {
+                                self.registry.package_dir(package, version)
+                            } else {
+                                namespaced
+                            }
+                        },
                         |paths| {
                             paths
-                                .get(&(package.to_string(), version.to_string()))
+                                .get(&(registry.clone(), package.to_string(), version.to_string()))
                                 .expect("locked available versions must have a pinned path")
                                 .clone()
                         },
@@ -625,6 +803,7 @@ impl<'a> ResolverPass<'a> {
                                 source,
                             }
                         })?;
+                    validate_registry_manifest(package, &manifest)?;
                     self.manifest_cache
                         .insert(key.clone(), CachedManifest { manifest, root });
                 }
@@ -685,7 +864,11 @@ impl<'a> ResolverPass<'a> {
         }
         let version = version.to_string();
         self.manifest_cache.insert(
-            (package.to_string(), version.clone()),
+            (
+                PackageSource::Path(path.to_path_buf()),
+                package.to_string(),
+                version.clone(),
+            ),
             CachedManifest {
                 manifest,
                 root: path.to_path_buf(),
@@ -719,19 +902,27 @@ fn normalize_version(v: &str) -> String {
 
 fn available_versions(
     registry: &Registry,
-    confirmed_versions: Option<&BTreeMap<String, BTreeSet<String>>>,
-) -> BTreeMap<String, Vec<semver::Version>> {
-    let mut versions = BTreeMap::<String, Vec<semver::Version>>::new();
-    for package in registry.list_packages() {
-        if confirmed_versions.is_some_and(|confirmed| {
-            !confirmed
-                .get(&package.name)
-                .is_some_and(|versions| versions.contains(&package.version))
-        }) {
-            continue;
-        }
-        if let Ok(version) = semver::Version::parse(&package.version) {
-            versions.entry(package.name).or_default().push(version);
+    sources: &RegistrySources,
+    allow_legacy_default: bool,
+    confirmed_versions: Option<&BTreeMap<(String, String), BTreeSet<String>>>,
+) -> BTreeMap<(String, String), Vec<semver::Version>> {
+    let mut versions = BTreeMap::<(String, String), Vec<semver::Version>>::new();
+    let mut identities = sources.named.values().cloned().collect::<BTreeSet<_>>();
+    identities.insert(sources.default_registry.clone());
+    for identity in identities {
+        let include_legacy = allow_legacy_default && identity == sources.default_registry;
+        for package in registry.list_packages_for(&identity, include_legacy) {
+            let package_key = (identity.clone(), package.name.clone());
+            if confirmed_versions.is_some_and(|confirmed| {
+                !confirmed
+                    .get(&package_key)
+                    .is_some_and(|versions| versions.contains(&package.version))
+            }) {
+                continue;
+            }
+            if let Ok(version) = semver::Version::parse(&package.version) {
+                versions.entry(package_key).or_default().push(version);
+            }
         }
     }
     for package_versions in versions.values_mut() {
@@ -749,13 +940,14 @@ fn parse_requirements(requirements: &[String]) -> Result<Vec<VersionReq>, Resolv
 }
 
 fn select_highest_matching_version(
+    registry: &str,
     package_name: &str,
     requirements: &[String],
-    versions_by_package: &BTreeMap<String, Vec<semver::Version>>,
+    versions_by_package: &BTreeMap<(String, String), Vec<semver::Version>>,
 ) -> Result<Option<String>, ResolveError> {
     let reqs = parse_requirements(requirements)?;
     Ok(versions_by_package
-        .get(package_name)
+        .get(&(registry.to_string(), package_name.to_string()))
         .and_then(|versions| {
             versions
                 .iter()
@@ -765,19 +957,25 @@ fn select_highest_matching_version(
         .map(ToString::to_string))
 }
 
-fn root_requests(manifest: &HewManifest, root: &Path) -> Result<Vec<DepRequest>, ResolveError> {
+fn root_requests(
+    manifest: &HewManifest,
+    root: &Path,
+    sources: &RegistrySources,
+) -> Result<Vec<DepRequest>, ResolveError> {
     manifest
         .dependencies
         .iter()
         .map(|(name, dep_spec)| {
+            let (source, registry_selector) =
+                dependency_source(name, dep_spec, root, None, sources, None)?;
             Ok(DepRequest {
                 name: name.clone(),
                 requirement: dep_spec.version_req().to_string(),
                 direct_requirement: Some(dep_spec.version_req().to_string()),
                 features: requested_features(dep_spec),
                 use_default_features: uses_default_features(dep_spec),
-                registry: dependency_registry(dep_spec),
-                source: dependency_source(name, dep_spec, root)?,
+                registry_selector,
+                source,
                 direct_path: dependency_path(dep_spec).map(ToString::to_string),
             })
         })
@@ -795,9 +993,29 @@ fn dependency_source(
     package: &str,
     dep_spec: &DepSpec,
     root: &Path,
-) -> Result<PackageSource, ResolveError> {
-    let Some(path) = dependency_path(dep_spec) else {
-        return Ok(PackageSource::Registry);
+    inherited: Option<(&str, Option<&str>)>,
+    sources: &RegistrySources,
+    registry_origin: Option<&str>,
+) -> Result<(PackageSource, Option<String>), ResolveError> {
+    let path = dependency_path(dep_spec);
+    let selector = dependency_registry(dep_spec);
+    if let Some(parent) = registry_origin {
+        if let Some(path) = path {
+            return Err(ResolveError::RegistryPathDependency {
+                package: parent.to_string(),
+                dependency: package.to_string(),
+                path: path.to_string(),
+            });
+        }
+    }
+    if path.is_some() && selector.is_some() {
+        return Err(ResolveError::PathAndRegistry {
+            package: package.to_string(),
+        });
+    }
+    let Some(path) = path else {
+        let (registry, registry_selector) = sources.resolve(selector.as_deref(), inherited)?;
+        return Ok((PackageSource::Registry { registry }, registry_selector));
     };
     let resolved = root.join(path);
     let canonical = resolved
@@ -812,7 +1030,7 @@ fn dependency_source(
             path: canonical,
         });
     }
-    Ok(PackageSource::Path(canonical))
+    Ok((PackageSource::Path(canonical), None))
 }
 
 fn requested_features(dep_spec: &DepSpec) -> BTreeSet<String> {
@@ -845,7 +1063,12 @@ fn dependency_requests_from_manifest(
     manifest: &HewManifest,
     state: &PackageState,
     root: &Path,
+    parent_source: &PackageSource,
+    sources: &RegistrySources,
 ) -> Result<Vec<DepRequest>, ResolveError> {
+    if let PackageSource::Registry { .. } = parent_source {
+        validate_registry_manifest(&manifest.package.name, manifest)?;
+    }
     let active_features = resolve_active_features(manifest, state);
     let mut requests = Vec::new();
     for (name, dep_spec) in &manifest.dependencies {
@@ -855,18 +1078,58 @@ fn dependency_requests_from_manifest(
             continue;
         }
 
+        let inherited = match parent_source {
+            PackageSource::Registry { registry } => {
+                Some((registry.as_str(), state.registry_selector.as_deref()))
+            }
+            PackageSource::Path(_) => None,
+        };
+        let (source, registry_selector) = dependency_source(
+            name,
+            dep_spec,
+            root,
+            inherited,
+            sources,
+            matches!(parent_source, PackageSource::Registry { .. })
+                .then_some(manifest.package.name.as_str()),
+        )?;
         requests.push(DepRequest {
             name: name.clone(),
             requirement: dep_spec.version_req().to_string(),
             direct_requirement: None,
             features: requested_features(dep_spec),
             use_default_features: uses_default_features(dep_spec),
-            registry: dependency_registry(dep_spec),
-            source: dependency_source(name, dep_spec, root)?,
+            registry_selector,
+            source,
             direct_path: None,
         });
     }
+
     Ok(requests)
+}
+
+/// Reject path dependencies in a manifest obtained from a registry.
+///
+/// This checks normal and development dependencies so cached or downloaded
+/// registry content cannot smuggle any local filesystem dependency.
+pub(crate) fn validate_registry_manifest(
+    package: &str,
+    manifest: &HewManifest,
+) -> Result<(), ResolveError> {
+    for (dependency, spec) in manifest
+        .dependencies
+        .iter()
+        .chain(manifest.dev_dependencies.iter())
+    {
+        if let Some(path) = dependency_path(spec) {
+            return Err(ResolveError::RegistryPathDependency {
+                package: package.to_string(),
+                dependency: dependency.clone(),
+                path: path.to_string(),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn dependency_is_optional(dep_spec: &DepSpec) -> bool {
@@ -929,10 +1192,12 @@ pub fn resolve_version(
     validate_package_name(package_name)?;
 
     let requirements = vec![requirement.to_string()];
+    let sources = RegistrySources::default_source();
     select_highest_matching_version(
+        sources.default_registry(),
         package_name,
         &requirements,
-        &available_versions(registry, None),
+        &available_versions(registry, &sources, true, None),
     )?
     .ok_or_else(|| ResolveError::NoMatchingVersion {
         package: package_name.to_string(),
@@ -957,11 +1222,22 @@ pub fn resolve_dependency_from_root(
     registry: &Registry,
 ) -> Result<String, ResolveError> {
     validate_package_name(package_name)?;
-    let source = dependency_source(package_name, spec, root)?;
+    let sources = RegistrySources::default_source();
+    let (source, _) = dependency_source(package_name, spec, root, None, &sources, None)?;
     match source {
-        PackageSource::Registry => resolve_version(package_name, spec.version_req(), registry),
+        PackageSource::Registry { .. } => {
+            resolve_version(package_name, spec.version_req(), registry)
+        }
         PackageSource::Path(path) => {
-            let mut resolver = ResolverPass::with_seed(registry, root, None, None, BTreeMap::new());
+            let mut resolver = ResolverPass::with_seed(
+                registry,
+                &sources,
+                root,
+                true,
+                None,
+                None,
+                BTreeMap::new(),
+            );
             resolver.load_path_manifest(package_name, &path, &[spec.version_req().to_string()])
         }
     }
@@ -978,10 +1254,12 @@ pub fn resolve_cached_version(
     registry: &Registry,
 ) -> Result<Option<String>, ResolveError> {
     validate_package_name(package_name)?;
+    let sources = RegistrySources::default_source();
     select_highest_matching_version(
+        sources.default_registry(),
         package_name,
         requirements,
-        &available_versions(registry, None),
+        &available_versions(registry, &sources, true, None),
     )
 }
 
@@ -1104,7 +1382,32 @@ pub fn resolve_all_from_root(
     root: &Path,
     registry: &Registry,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
-    resolve_all_inner(manifest, root, registry, None, None)
+    let sources = RegistrySources::default_source();
+    resolve_all_inner(manifest, root, registry, &sources, true, None, None)
+}
+
+/// Resolve from source-namespaced cache slots, optionally admitting the legacy
+/// default-registry layout for explicit offline compatibility.
+///
+/// # Errors
+///
+/// Returns [`ResolveError`] when the source-bound graph cannot be resolved.
+pub fn resolve_all_from_root_with_sources(
+    manifest: &HewManifest,
+    root: &Path,
+    registry: &Registry,
+    sources: &RegistrySources,
+    allow_legacy_default: bool,
+) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
+    resolve_all_inner(
+        manifest,
+        root,
+        registry,
+        sources,
+        allow_legacy_default,
+        None,
+        None,
+    )
 }
 
 /// Resolve dependencies using only registry versions confirmed by the current
@@ -1117,9 +1420,18 @@ pub fn resolve_all_confirmed(
     manifest: &HewManifest,
     root: &Path,
     registry: &Registry,
-    confirmed_versions: &BTreeMap<String, BTreeSet<String>>,
+    confirmed_versions: &BTreeMap<(String, String), BTreeSet<String>>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
-    resolve_all_inner(manifest, root, registry, Some(confirmed_versions), None)
+    let sources = RegistrySources::default_source();
+    resolve_all_inner(
+        manifest,
+        root,
+        registry,
+        &sources,
+        false,
+        Some(confirmed_versions),
+        None,
+    )
 }
 
 /// Resolve a dependency graph using the exact registry versions recorded in a
@@ -1134,7 +1446,7 @@ pub fn resolve_all_locked(
     manifest: &HewManifest,
     root: &Path,
     registry: &Registry,
-    pinned_registry_paths: &BTreeMap<(String, String), PathBuf>,
+    pinned_registry_paths: &BTreeMap<(String, String, String), PathBuf>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
     resolve_all_pinned(manifest, root, registry, pinned_registry_paths)
 }
@@ -1151,17 +1463,52 @@ pub fn resolve_all_pinned(
     manifest: &HewManifest,
     root: &Path,
     registry: &Registry,
-    pinned_registry_paths: &BTreeMap<(String, String), PathBuf>,
+    pinned_registry_paths: &BTreeMap<(String, String, String), PathBuf>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
-    resolve_all_inner(manifest, root, registry, None, Some(pinned_registry_paths))
+    let sources = RegistrySources::default_source();
+    resolve_all_inner(
+        manifest,
+        root,
+        registry,
+        &sources,
+        false,
+        None,
+        Some(pinned_registry_paths),
+    )
+}
+
+/// Resolve using exact source-bound immutable registry generations.
+///
+/// # Errors
+///
+/// Returns [`ResolveError`] when the pinned source-bound graph cannot be
+/// resolved.
+pub fn resolve_all_pinned_with_sources(
+    manifest: &HewManifest,
+    root: &Path,
+    registry: &Registry,
+    sources: &RegistrySources,
+    pinned_registry_paths: &BTreeMap<(String, String, String), PathBuf>,
+) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
+    resolve_all_inner(
+        manifest,
+        root,
+        registry,
+        sources,
+        false,
+        None,
+        Some(pinned_registry_paths),
+    )
 }
 
 fn resolve_all_inner(
     manifest: &HewManifest,
     root: &Path,
     registry: &Registry,
-    confirmed_versions: Option<&BTreeMap<String, BTreeSet<String>>>,
-    pinned_registry_paths: Option<&BTreeMap<(String, String), PathBuf>>,
+    registry_sources: &RegistrySources,
+    allow_legacy_default: bool,
+    confirmed_versions: Option<&BTreeMap<(String, String), BTreeSet<String>>>,
+    pinned_registry_paths: Option<&BTreeMap<(String, String, String), PathBuf>>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
     const MAX_RESOLUTION_PASSES: usize = 1024;
 
@@ -1170,7 +1517,9 @@ fn resolve_all_inner(
         let previous_seed_states = seed_states.clone();
         let pass = ResolverPass::with_seed(
             registry,
+            registry_sources,
             root,
+            allow_legacy_default,
             confirmed_versions,
             pinned_registry_paths,
             seed_states,
@@ -1944,6 +2293,14 @@ mod tests {
     fn confirmed_resolution_refuses_unconfirmed_cached_version() {
         let (_dir, registry) = test_registry();
         install_fake(&registry, "cached.pkg", "1.0.0");
+        let registry_id = crate::config::default_registry_identity();
+        let namespaced = registry.package_dir_for(&registry_id, "cached.pkg", "1.0.0");
+        std::fs::create_dir_all(&namespaced).unwrap();
+        std::fs::copy(
+            registry.package_dir("cached.pkg", "1.0.0").join("hew.toml"),
+            namespaced.join("hew.toml"),
+        )
+        .unwrap();
         let manifest = test_manifest(BTreeMap::from([(
             "cached.pkg".to_string(),
             DepSpec::Version("1.0.0".to_string()),
@@ -1955,7 +2312,7 @@ mod tests {
         assert!(matches!(error, ResolveError::UnresolvableDeps { .. }));
 
         let confirmed = BTreeMap::from([(
-            "cached.pkg".to_string(),
+            (registry_id, "cached.pkg".to_string()),
             BTreeSet::from(["1.0.0".to_string()]),
         )]);
         let resolved = resolve_all_confirmed(&manifest, Path::new("."), &registry, &confirmed)
@@ -2004,6 +2361,96 @@ mod tests {
     }
 
     #[test]
+    fn registry_manifest_rejects_every_path_dependency_spelling() {
+        for (index, path) in ["relative", "../../escape", "/absolute/escape"]
+            .into_iter()
+            .enumerate()
+        {
+            let (_dir, registry) = test_registry();
+            let package = registry.package_dir("registry.parent", "1.0.0");
+            std::fs::create_dir_all(&package).unwrap();
+            std::fs::write(
+                package.join("hew.toml"),
+                format!(
+                    "[package]\nname = \"registry.parent\"\nversion = \"1.0.0\"\n\n[dependencies]\nevil = {{ path = {path:?} }}\n"
+                ),
+            )
+            .unwrap();
+            let manifest = test_manifest(BTreeMap::from([(
+                "registry.parent".to_string(),
+                DepSpec::Version("1.0.0".to_string()),
+            )]));
+
+            let error = resolve_all(&manifest, &registry)
+                .expect_err(&format!("path spelling {index} must be rejected"));
+            assert!(matches!(
+                error,
+                ResolveError::RegistryPathDependency { ref path, .. } if path
+                    == ["relative", "../../escape", "/absolute/escape"][index]
+            ));
+        }
+    }
+
+    #[test]
+    fn same_package_from_different_registry_identities_conflicts() {
+        let (_dir, registry) = test_registry();
+        let registry_a = "https://a.example/api/v1".to_string();
+        let registry_b = "https://b.example/api/v1".to_string();
+        for (identity, parent) in [(&registry_a, "left"), (&registry_b, "right")] {
+            let package = registry.package_dir_for(identity, parent, "1.0.0");
+            std::fs::create_dir_all(&package).unwrap();
+            std::fs::write(
+                package.join("hew.toml"),
+                format!(
+                    "[package]\nname = \"{parent}\"\nversion = \"1.0.0\"\n\n[dependencies]\nshared = \"1.0.0\"\n"
+                ),
+            )
+            .unwrap();
+        }
+        let table = |registry: &str| {
+            DepSpec::Table(DepTable {
+                version: "1.0.0".to_string(),
+                optional: None,
+                features: None,
+                default_features: None,
+                registry: Some(registry.to_string()),
+                path: None,
+            })
+        };
+        let manifest = test_manifest(BTreeMap::from([
+            ("left".to_string(), table("a")),
+            ("right".to_string(), table("b")),
+        ]));
+        let sources = RegistrySources::new(
+            crate::config::default_registry_identity(),
+            None,
+            BTreeMap::from([
+                ("a".to_string(), registry_a.clone()),
+                ("b".to_string(), registry_b.clone()),
+            ]),
+        );
+
+        let error = resolve_all_from_root_with_sources(
+            &manifest,
+            Path::new("."),
+            &registry,
+            &sources,
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            ResolveError::ConflictingSources {
+                package,
+                first: PackageSource::Registry { registry: first },
+                second: PackageSource::Registry { registry: second },
+            } if package == "shared"
+                && BTreeSet::from([first.clone(), second.clone()])
+                    == BTreeSet::from([registry_a, registry_b])
+        ));
+    }
+
+    #[test]
     fn missing_path_dependency_is_named() {
         let (_registry_dir, registry) = test_registry();
         let project = tempfile::tempdir().unwrap();
@@ -2023,6 +2470,31 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("missing"));
         assert!(message.contains("does-not-exist"));
+    }
+
+    #[test]
+    fn dependency_cannot_combine_path_and_registry() {
+        let (_dir, registry) = test_registry();
+        let project = tempfile::tempdir().unwrap();
+        let local = project.path().join("local");
+        std::fs::create_dir(&local).unwrap();
+        let manifest = test_manifest(BTreeMap::from([(
+            "local".to_string(),
+            DepSpec::Table(DepTable {
+                version: "*".to_string(),
+                optional: None,
+                features: None,
+                default_features: None,
+                registry: Some("internal".to_string()),
+                path: Some("local".to_string()),
+            }),
+        )]));
+
+        let error = resolve_all_from_root(&manifest, project.path(), &registry).unwrap_err();
+        assert!(matches!(
+            error,
+            ResolveError::PathAndRegistry { package } if package == "local"
+        ));
     }
 
     // ── Display / Error impls ───────────────────────────────────────────
@@ -2052,7 +2524,8 @@ mod tests {
             failures: vec![UnresolvedDep {
                 package: "a".to_string(),
                 requirements: vec!["1.0".to_string(), "^1.2".to_string()],
-                registry: None,
+                registry: crate::config::default_registry_identity(),
+                registry_selector: None,
             }],
         };
         let msg = err.to_string();
@@ -2102,13 +2575,22 @@ mod tests {
             native: None,
         };
 
-        let err = resolve_all(&manifest, &reg).unwrap_err();
+        let internal = "https://registry.internal.example/api/v1".to_string();
+        let sources = RegistrySources::new(
+            crate::config::default_registry_identity(),
+            None,
+            BTreeMap::from([("internal".to_string(), internal.clone())]),
+        );
+        let err =
+            resolve_all_from_root_with_sources(&manifest, Path::new("."), &reg, &sources, true)
+                .unwrap_err();
         let ResolveError::UnresolvableDeps { failures } = err else {
             panic!("expected unresolved dependency");
         };
         assert_eq!(failures.len(), 1);
         assert_eq!(failures[0].package, "corp.auth");
-        assert_eq!(failures[0].registry.as_deref(), Some("internal"));
+        assert_eq!(failures[0].registry, internal);
+        assert_eq!(failures[0].registry_selector.as_deref(), Some("internal"));
     }
 
     // ── resolve_version_from_entries ─────────────────────────────────

--- a/hew-pkg/src/resolver.rs
+++ b/hew-pkg/src/resolver.rs
@@ -1136,6 +1136,23 @@ pub fn resolve_all_locked(
     registry: &Registry,
     pinned_registry_paths: &BTreeMap<(String, String), PathBuf>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
+    resolve_all_pinned(manifest, root, registry, pinned_registry_paths)
+}
+
+/// Resolve dependencies using only the exact immutable registry generations
+/// verified by the current install operation. Path dependencies remain
+/// available from disk.
+///
+/// # Errors
+///
+/// Returns [`ResolveError`] when the pinned graph cannot satisfy all dependency
+/// requirements or a pinned manifest cannot be loaded.
+pub fn resolve_all_pinned(
+    manifest: &HewManifest,
+    root: &Path,
+    registry: &Registry,
+    pinned_registry_paths: &BTreeMap<(String, String), PathBuf>,
+) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
     resolve_all_inner(manifest, root, registry, None, Some(pinned_registry_paths))
 }
 

--- a/hew-pkg/src/resolver.rs
+++ b/hew-pkg/src/resolver.rs
@@ -1099,6 +1099,32 @@ pub fn resolve_all_confirmed(
     resolve_all_inner(manifest, root, registry, Some(confirmed_versions))
 }
 
+/// Resolve a dependency graph using the exact registry versions recorded in a
+/// lockfile. Path dependencies continue to be resolved from their declared
+/// paths, but no registry version outside `locked_versions` is eligible.
+///
+/// # Errors
+///
+/// Returns [`ResolveError`] when an exact locked version is missing,
+/// incompatible with the graph, or otherwise cannot be resolved.
+pub fn resolve_all_locked(
+    manifest: &HewManifest,
+    root: &Path,
+    registry: &Registry,
+    locked_versions: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
+    let exact_versions = locked_versions
+        .iter()
+        .map(|(name, version)| {
+            (
+                name.clone(),
+                std::iter::once(version.clone()).collect::<BTreeSet<_>>(),
+            )
+        })
+        .collect();
+    resolve_all_inner(manifest, root, registry, Some(&exact_versions))
+}
+
 fn resolve_all_inner(
     manifest: &HewManifest,
     root: &Path,

--- a/hew-pkg/src/resolver.rs
+++ b/hew-pkg/src/resolver.rs
@@ -377,6 +377,7 @@ enum PassOutcome {
 struct ResolverPass<'a> {
     registry: &'a Registry,
     root: &'a Path,
+    pinned_registry_paths: Option<&'a BTreeMap<(String, String), PathBuf>>,
     available_versions: BTreeMap<String, Vec<semver::Version>>,
     package_states: BTreeMap<String, PackageState>,
     selected_versions: BTreeMap<String, String>,
@@ -390,12 +391,26 @@ impl<'a> ResolverPass<'a> {
         registry: &'a Registry,
         root: &'a Path,
         confirmed_versions: Option<&'a BTreeMap<String, BTreeSet<String>>>,
+        pinned_registry_paths: Option<&'a BTreeMap<(String, String), PathBuf>>,
         package_states: BTreeMap<String, PackageState>,
     ) -> Self {
+        let available_versions = pinned_registry_paths.map_or_else(
+            || available_versions(registry, confirmed_versions),
+            |paths| {
+                let mut versions = BTreeMap::<String, Vec<semver::Version>>::new();
+                for (name, version) in paths.keys() {
+                    if let Ok(version) = semver::Version::parse(version) {
+                        versions.entry(name.clone()).or_default().push(version);
+                    }
+                }
+                versions
+            },
+        );
         Self {
             registry,
             root,
-            available_versions: available_versions(registry, confirmed_versions),
+            pinned_registry_paths,
+            available_versions,
             package_states,
             selected_versions: BTreeMap::new(),
             expanded_states: BTreeMap::new(),
@@ -593,7 +608,15 @@ impl<'a> ResolverPass<'a> {
         if !self.manifest_cache.contains_key(&key) {
             match source {
                 PackageSource::Registry => {
-                    let root = self.registry.package_dir(package, version);
+                    let root = self.pinned_registry_paths.map_or_else(
+                        || self.registry.package_dir(package, version),
+                        |paths| {
+                            paths
+                                .get(&(package.to_string(), version.to_string()))
+                                .expect("locked available versions must have a pinned path")
+                                .clone()
+                        },
+                    );
                     let manifest =
                         manifest::parse_manifest(&root.join("hew.toml")).map_err(|source| {
                             ResolveError::ManifestRead {
@@ -938,7 +961,7 @@ pub fn resolve_dependency_from_root(
     match source {
         PackageSource::Registry => resolve_version(package_name, spec.version_req(), registry),
         PackageSource::Path(path) => {
-            let mut resolver = ResolverPass::with_seed(registry, root, None, BTreeMap::new());
+            let mut resolver = ResolverPass::with_seed(registry, root, None, None, BTreeMap::new());
             resolver.load_path_manifest(package_name, &path, &[spec.version_req().to_string()])
         }
     }
@@ -1081,7 +1104,7 @@ pub fn resolve_all_from_root(
     root: &Path,
     registry: &Registry,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
-    resolve_all_inner(manifest, root, registry, None)
+    resolve_all_inner(manifest, root, registry, None, None)
 }
 
 /// Resolve dependencies using only registry versions confirmed by the current
@@ -1096,12 +1119,12 @@ pub fn resolve_all_confirmed(
     registry: &Registry,
     confirmed_versions: &BTreeMap<String, BTreeSet<String>>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
-    resolve_all_inner(manifest, root, registry, Some(confirmed_versions))
+    resolve_all_inner(manifest, root, registry, Some(confirmed_versions), None)
 }
 
 /// Resolve a dependency graph using the exact registry versions recorded in a
 /// lockfile. Path dependencies continue to be resolved from their declared
-/// paths, but no registry version outside `locked_versions` is eligible.
+/// paths, but no registry version outside `pinned_registry_paths` is eligible.
 ///
 /// # Errors
 ///
@@ -1111,18 +1134,9 @@ pub fn resolve_all_locked(
     manifest: &HewManifest,
     root: &Path,
     registry: &Registry,
-    locked_versions: &BTreeMap<String, String>,
+    pinned_registry_paths: &BTreeMap<(String, String), PathBuf>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
-    let exact_versions = locked_versions
-        .iter()
-        .map(|(name, version)| {
-            (
-                name.clone(),
-                std::iter::once(version.clone()).collect::<BTreeSet<_>>(),
-            )
-        })
-        .collect();
-    resolve_all_inner(manifest, root, registry, Some(&exact_versions))
+    resolve_all_inner(manifest, root, registry, None, Some(pinned_registry_paths))
 }
 
 fn resolve_all_inner(
@@ -1130,13 +1144,20 @@ fn resolve_all_inner(
     root: &Path,
     registry: &Registry,
     confirmed_versions: Option<&BTreeMap<String, BTreeSet<String>>>,
+    pinned_registry_paths: Option<&BTreeMap<(String, String), PathBuf>>,
 ) -> Result<BTreeMap<String, ResolvedPackage>, ResolveError> {
     const MAX_RESOLUTION_PASSES: usize = 1024;
 
     let mut seed_states = BTreeMap::new();
     for _ in 0..MAX_RESOLUTION_PASSES {
         let previous_seed_states = seed_states.clone();
-        let pass = ResolverPass::with_seed(registry, root, confirmed_versions, seed_states);
+        let pass = ResolverPass::with_seed(
+            registry,
+            root,
+            confirmed_versions,
+            pinned_registry_paths,
+            seed_states,
+        );
         match pass.resolve_manifest(manifest)? {
             PassOutcome::Resolved(resolved) => return Ok(resolved),
             PassOutcome::Restart(next_seed_states) => {

--- a/hew-pkg/src/tarball.rs
+++ b/hew-pkg/src/tarball.rs
@@ -8,6 +8,8 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
 
+use crate::package_fs::{CACHE_ARCHIVE_FILE, CACHE_METADATA_FILE};
+
 /// Maximum compressed tarball size (10 MB).
 pub const MAX_TARBALL_SIZE: usize = 10 * 1024 * 1024;
 
@@ -189,6 +191,7 @@ fn unpack_with_limit(data: &[u8], target: &Path, max_bytes: u64) -> Result<(), T
         let mut entry = entry?;
         let original_path = entry.path()?.into_owned();
         let normalized_path = normalize_unpack_path(&original_path)?;
+        reject_reserved_cache_path(&normalized_path)?;
         let target_path = target.join(&normalized_path);
         let entry_type = entry.header().entry_type();
 
@@ -237,6 +240,72 @@ fn unpack_with_limit(data: &[u8], target: &Path, max_bytes: u64) -> Result<(), T
 
     cleanup.active = false;
     Ok(())
+}
+
+pub(crate) fn unpacked_tree_checksum(data: &[u8]) -> Result<String, TarballError> {
+    use sha2::{Digest as _, Sha256};
+    use std::collections::BTreeMap;
+
+    let decoder = zstd::Decoder::new(std::io::Cursor::new(data))
+        .map_err(|e| TarballError::Io(io::Error::new(io::ErrorKind::InvalidData, e)))?;
+    let mut archive = tar::Archive::new(decoder);
+    let mut files = BTreeMap::<String, Vec<u8>>::new();
+    let mut total_bytes = 0_u64;
+    let mut found_manifest = false;
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let original_path = entry.path()?.into_owned();
+        let normalized_path = normalize_unpack_path(&original_path)?;
+        reject_reserved_cache_path(&normalized_path)?;
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_dir() {
+            continue;
+        }
+        if !entry_type.is_file() {
+            return Err(TarballError::UnsupportedEntryType {
+                path: normalized_path,
+                kind: format!("{entry_type:?}"),
+            });
+        }
+        if normalized_path == Path::new("hew.toml") {
+            found_manifest = true;
+        }
+        let path = normalized_path
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join("/");
+        let mut contents = Vec::new();
+        entry.read_to_end(&mut contents)?;
+        total_bytes = total_bytes.saturating_add(contents.len() as u64);
+        if total_bytes > MAX_UNPACKED_TARBALL_BYTES {
+            return Err(TarballError::TooLarge {
+                size: total_bytes,
+                max: MAX_UNPACKED_TARBALL_BYTES,
+            });
+        }
+        files.insert(path, contents);
+    }
+
+    if !found_manifest {
+        return Err(TarballError::MissingManifest);
+    }
+
+    let mut hasher = Sha256::new();
+    for (path, contents) in files {
+        hasher.update(path.as_bytes());
+        hasher.update(contents);
+    }
+    Ok(crate::package_fs::sha256_prefixed(&hasher.finalize()))
+}
+
+fn reject_reserved_cache_path(path: &Path) -> Result<(), TarballError> {
+    if path == Path::new(CACHE_METADATA_FILE) || path == Path::new(CACHE_ARCHIVE_FILE) {
+        Err(TarballError::InvalidPath(path.to_path_buf()))
+    } else {
+        Ok(())
+    }
 }
 
 fn normalize_unpack_path(path: &Path) -> Result<PathBuf, TarballError> {

--- a/hew-pkg/src/tarball.rs
+++ b/hew-pkg/src/tarball.rs
@@ -3,6 +3,7 @@
 //! Produces reproducible `.tar.zst` archives with sorted entries and zeroed
 //! timestamps. Respects `include`/`exclude` globs from the manifest.
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Read, Write};
@@ -105,31 +106,27 @@ pub fn pack(
     exclude: &[String],
     include: &[String],
 ) -> Result<PackResult, TarballError> {
-    let mut files = crate::package_fs::collect_package_files(dir)?;
-    files.retain(|path| include.is_empty() || matches_any_glob(path, include));
-    files.retain(|path| !matches_any_glob(path, exclude));
-    files.sort();
+    let mut files = crate::package_fs::collect_package_snapshot(dir)?;
+    files.retain(|file| include.is_empty() || matches_any_glob(&file.path, include));
+    files.retain(|file| !matches_any_glob(&file.path, exclude));
 
-    if !files.iter().any(|f| f == "hew.toml") {
+    if !files.iter().any(|file| file.path == "hew.toml") {
         return Err(TarballError::MissingManifest);
     }
 
     let mut tar_data = Vec::new();
     {
         let mut builder = tar::Builder::new(&mut tar_data);
-        for rel_path in &files {
-            let abs_path = dir.join(rel_path);
-            let metadata = std::fs::metadata(&abs_path)?;
+        for file in &files {
             let mut header = tar::Header::new_gnu();
-            header.set_size(metadata.len());
+            header.set_size(file.contents.len() as u64);
             header.set_mode(0o644);
             header.set_uid(0);
             header.set_gid(0);
             header.set_mtime(0);
             header.set_cksum();
 
-            let file_data = std::fs::read(&abs_path)?;
-            builder.append_data(&mut header, rel_path, file_data.as_slice())?;
+            builder.append_data(&mut header, &file.path, file.contents.as_slice())?;
         }
         builder.finish()?;
     }
@@ -186,20 +183,18 @@ fn unpack_with_limit(data: &[u8], target: &Path, max_bytes: u64) -> Result<(), T
     let mut archive = tar::Archive::new(decoder);
     let mut total_bytes = 0_u64;
     let mut found_manifest = false;
+    let mut paths = ArchivePaths::default();
 
     for entry in archive.entries()? {
         let mut entry = entry?;
         let original_path = entry.path()?.into_owned();
-        let normalized_path = normalize_unpack_path(&original_path)?;
-        reject_reserved_cache_path(&normalized_path)?;
+        let (normalized_path, _) = normalize_archive_path(&original_path)?;
+        reject_reserved_package_path(&normalized_path)?;
         let target_path = target.join(&normalized_path);
         let entry_type = entry.header().entry_type();
 
-        if normalized_path == Path::new("hew.toml") {
-            found_manifest = true;
-        }
-
         if entry_type.is_dir() {
+            paths.register(&normalized_path, true)?;
             std::fs::create_dir_all(&target_path)?;
             continue;
         }
@@ -209,6 +204,10 @@ fn unpack_with_limit(data: &[u8], target: &Path, max_bytes: u64) -> Result<(), T
                 path: normalized_path,
                 kind: format!("{entry_type:?}"),
             });
+        }
+        paths.register(&normalized_path, false)?;
+        if normalized_path == Path::new("hew.toml") {
+            found_manifest = true;
         }
 
         if let Some(parent) = target_path.parent() {
@@ -243,7 +242,6 @@ fn unpack_with_limit(data: &[u8], target: &Path, max_bytes: u64) -> Result<(), T
 }
 
 pub(crate) fn unpacked_tree_checksum(data: &[u8]) -> Result<String, TarballError> {
-    use sha2::{Digest as _, Sha256};
     use std::collections::BTreeMap;
 
     let decoder = zstd::Decoder::new(std::io::Cursor::new(data))
@@ -252,14 +250,16 @@ pub(crate) fn unpacked_tree_checksum(data: &[u8]) -> Result<String, TarballError
     let mut files = BTreeMap::<String, Vec<u8>>::new();
     let mut total_bytes = 0_u64;
     let mut found_manifest = false;
+    let mut paths = ArchivePaths::default();
 
     for entry in archive.entries()? {
         let mut entry = entry?;
         let original_path = entry.path()?.into_owned();
-        let normalized_path = normalize_unpack_path(&original_path)?;
-        reject_reserved_cache_path(&normalized_path)?;
+        let (normalized_path, canonical_path) = normalize_archive_path(&original_path)?;
+        reject_reserved_package_path(&normalized_path)?;
         let entry_type = entry.header().entry_type();
         if entry_type.is_dir() {
+            paths.register(&normalized_path, true)?;
             continue;
         }
         if !entry_type.is_file() {
@@ -268,14 +268,10 @@ pub(crate) fn unpacked_tree_checksum(data: &[u8]) -> Result<String, TarballError
                 kind: format!("{entry_type:?}"),
             });
         }
+        paths.register(&normalized_path, false)?;
         if normalized_path == Path::new("hew.toml") {
             found_manifest = true;
         }
-        let path = normalized_path
-            .components()
-            .map(|component| component.as_os_str().to_string_lossy().into_owned())
-            .collect::<Vec<_>>()
-            .join("/");
         let mut contents = Vec::new();
         entry.read_to_end(&mut contents)?;
         total_bytes = total_bytes.saturating_add(contents.len() as u64);
@@ -285,34 +281,50 @@ pub(crate) fn unpacked_tree_checksum(data: &[u8]) -> Result<String, TarballError
                 max: MAX_UNPACKED_TARBALL_BYTES,
             });
         }
-        files.insert(path, contents);
+        files.insert(canonical_path, contents);
     }
 
     if !found_manifest {
         return Err(TarballError::MissingManifest);
     }
 
-    let mut hasher = Sha256::new();
+    let mut digest = crate::package_fs::TreeDigest::new();
     for (path, contents) in files {
-        hasher.update(path.as_bytes());
-        hasher.update(contents);
+        digest.add_file(&path, &contents);
     }
-    Ok(crate::package_fs::sha256_prefixed(&hasher.finalize()))
+    Ok(digest.finish())
 }
 
-fn reject_reserved_cache_path(path: &Path) -> Result<(), TarballError> {
-    if path == Path::new(CACHE_METADATA_FILE) || path == Path::new(CACHE_ARCHIVE_FILE) {
+fn reject_reserved_package_path(path: &Path) -> Result<(), TarballError> {
+    let has_skipped_directory = path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .is_some_and(crate::package_fs::is_skipped_package_dir)
+    });
+    let is_cache_file = path.file_name().is_some_and(|name| {
+        name == std::ffi::OsStr::new(CACHE_METADATA_FILE)
+            || name == std::ffi::OsStr::new(CACHE_ARCHIVE_FILE)
+    });
+    if has_skipped_directory || is_cache_file {
         Err(TarballError::InvalidPath(path.to_path_buf()))
     } else {
         Ok(())
     }
 }
 
-fn normalize_unpack_path(path: &Path) -> Result<PathBuf, TarballError> {
+fn normalize_archive_path(path: &Path) -> Result<(PathBuf, String), TarballError> {
     let mut normalized = PathBuf::new();
+    let mut canonical_components = Vec::new();
     for component in path.components() {
         match component {
-            Component::Normal(part) => normalized.push(part),
+            Component::Normal(part) => {
+                let utf8 = part
+                    .to_str()
+                    .ok_or_else(|| TarballError::InvalidPath(path.to_path_buf()))?;
+                normalized.push(part);
+                canonical_components.push(utf8);
+            }
             Component::CurDir => {}
             Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
                 return Err(TarballError::InvalidPath(path.to_path_buf()));
@@ -324,7 +336,45 @@ fn normalize_unpack_path(path: &Path) -> Result<PathBuf, TarballError> {
         return Err(TarballError::InvalidPath(path.to_path_buf()));
     }
 
-    Ok(normalized)
+    Ok((normalized, canonical_components.join("/")))
+}
+
+#[derive(Default)]
+struct ArchivePaths {
+    explicit: BTreeSet<PathBuf>,
+    files: BTreeSet<PathBuf>,
+    directories: BTreeSet<PathBuf>,
+}
+
+impl ArchivePaths {
+    fn register(&mut self, path: &Path, is_directory: bool) -> Result<(), TarballError> {
+        if !self.explicit.insert(path.to_path_buf()) {
+            return Err(TarballError::InvalidPath(path.to_path_buf()));
+        }
+
+        for ancestor in path.ancestors().skip(1) {
+            if ancestor.as_os_str().is_empty() {
+                break;
+            }
+            if self.files.contains(ancestor) {
+                return Err(TarballError::InvalidPath(path.to_path_buf()));
+            }
+            self.directories.insert(ancestor.to_path_buf());
+        }
+
+        if is_directory {
+            if self.files.contains(path) {
+                return Err(TarballError::InvalidPath(path.to_path_buf()));
+            }
+            self.directories.insert(path.to_path_buf());
+        } else {
+            if self.directories.contains(path) {
+                return Err(TarballError::InvalidPath(path.to_path_buf()));
+            }
+            self.files.insert(path.to_path_buf());
+        }
+        Ok(())
+    }
 }
 
 /// Compute the SHA-256 checksum of raw bytes.
@@ -433,6 +483,14 @@ mod tests {
     }
 
     fn compressed_raw_tar(entries: &[(&[u8], &[u8])]) -> Vec<u8> {
+        let entries = entries
+            .iter()
+            .map(|(path, contents)| (*path, *contents, b'0'))
+            .collect::<Vec<_>>();
+        compressed_raw_tar_with_types(&entries)
+    }
+
+    fn compressed_raw_tar_with_types(entries: &[(&[u8], &[u8], u8)]) -> Vec<u8> {
         fn write_octal(field: &mut [u8], value: u64) {
             let width = field.len();
             let formatted = format!("{value:0width$o}\0", width = width - 1);
@@ -440,7 +498,7 @@ mod tests {
         }
 
         let mut tar_data = Vec::new();
-        for (path, contents) in entries {
+        for (path, contents, entry_type) in entries {
             let mut header = [0_u8; 512];
             header[..path.len()].copy_from_slice(path);
             write_octal(&mut header[100..108], 0o644);
@@ -449,7 +507,7 @@ mod tests {
             write_octal(&mut header[124..136], contents.len() as u64);
             write_octal(&mut header[136..148], 0);
             header[148..156].fill(b' ');
-            header[156] = b'0';
+            header[156] = *entry_type;
             header[257..263].copy_from_slice(b"ustar\0");
             header[263..265].copy_from_slice(b"00");
             let checksum: u32 = header.iter().map(|byte| u32::from(*byte)).sum();
@@ -490,6 +548,17 @@ mod tests {
         let r2 = pack(src.path(), &[], &[]).unwrap();
         assert_eq!(r1.checksum, r2.checksum);
         assert_eq!(r1.data, r2.data);
+    }
+
+    #[test]
+    fn packed_archive_tree_checksum_matches_directory_checksum() {
+        let src = setup_package_dir();
+        let packed = pack(src.path(), &[], &[]).unwrap();
+
+        assert_eq!(
+            unpacked_tree_checksum(&packed.data).unwrap(),
+            crate::checksum::compute_dir_checksum(src.path()).unwrap()
+        );
     }
 
     #[test]
@@ -566,6 +635,45 @@ mod tests {
     }
 
     #[test]
+    fn archive_checksum_rejects_duplicate_normalized_paths() {
+        let manifest = b"[package]\nname=\"x\"\nversion=\"1.0.0\"\n";
+        let tarball =
+            compressed_tar(&[("hew.toml", manifest), ("a", b"first"), ("./a", b"second")]);
+
+        assert!(matches!(
+            unpacked_tree_checksum(&tarball),
+            Err(TarballError::InvalidPath(path)) if path == Path::new("a")
+        ));
+    }
+
+    #[test]
+    fn archive_checksum_rejects_file_directory_collision() {
+        let manifest = b"[package]\nname=\"x\"\nversion=\"1.0.0\"\n";
+        let tarball = compressed_raw_tar_with_types(&[
+            (b"hew.toml", manifest, b'0'),
+            (b"collision", b"", b'5'),
+            (b"collision", b"file", b'0'),
+        ]);
+
+        assert!(matches!(
+            unpacked_tree_checksum(&tarball),
+            Err(TarballError::InvalidPath(path)) if path == Path::new("collision")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn archive_checksum_rejects_non_utf8_path() {
+        let manifest = b"[package]\nname=\"x\"\nversion=\"1.0.0\"\n";
+        let tarball = compressed_raw_tar(&[(b"hew.toml", manifest), (b"bad-\xff", b"content")]);
+
+        assert!(matches!(
+            unpacked_tree_checksum(&tarball),
+            Err(TarballError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
     fn unpack_rejects_cumulative_size_over_limit() {
         let large = vec![b'a'; 4096];
         let tarball = compressed_tar(&[
@@ -594,6 +702,20 @@ mod tests {
 
         assert!(!dst.path().join(".git").exists());
         assert!(!dst.path().join("target").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pack_rejects_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let src = setup_package_dir();
+        symlink(src.path().join("main.hew"), src.path().join("linked.hew")).unwrap();
+
+        assert!(matches!(
+            pack(src.path(), &[], &[]),
+            Err(TarballError::Io(_))
+        ));
     }
 
     #[test]

--- a/tests/package-install/run.sh
+++ b/tests/package-install/run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # End-to-end package-manager consumer proof: explicit local publish setup ->
-# user-facing `hew install` -> lock/materialization -> compiler check/run.
+# user-facing `hew install --offline` -> lock/materialization -> compiler
+# check/run. Locally published packages are cache entries, so consuming them
+# must opt into cache-only resolution rather than treating a registry miss as
+# permission to fall back online.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -146,8 +149,9 @@ expect_install_failure() {
   local dir="$1"
   local name="$2"
   local needle="$3"
+  shift 3
   local output
-  if output="$(cd "${dir}" && "${HEW}" install 2>&1)"; then
+  if output="$(cd "${dir}" && "${HEW}" install "$@" 2>&1)"; then
     echo "${output}" >&2
     fail "${name}: hew install unexpectedly succeeded"
   fi
@@ -174,7 +178,7 @@ run_in "${adder_pkg}" publish-adder "${HEW}" publish --local
 
 consumer="${TMP}/consumer"
 write_consumer "${consumer}" "acme.adder" "0.1.0"
-run_in "${consumer}" install-adder "${HEW}" install
+run_in "${consumer}" install-adder "${HEW}" install --offline
 test -f "${consumer}/hew.lock" || fail "hew.lock was not written"
 assert_contains "${consumer}/hew.lock" 'name = "acme.adder"'
 assert_contains "${consumer}/hew.lock" 'version = "0.1.0"'
@@ -216,7 +220,8 @@ write_consumer "${broken_consumer}" "acme.broken" "0.1.0"
 expect_install_failure \
   "${broken_consumer}" \
   "malformed package" \
-  "cannot read installed manifest for \`acme.broken@0.1.0\`"
+  "cannot read installed manifest for \`acme.broken@0.1.0\`" \
+  --offline
 echo "PASS package-install malformed rejection"
 
 versioned_v1="${TMP}/pkgs/versioned-0.1.0"
@@ -228,14 +233,14 @@ run_in "${versioned_v2}" publish-versioned-v2 "${HEW}" publish --local
 
 versioned_consumer="${TMP}/versioned-consumer"
 write_consumer "${versioned_consumer}" "acme.versioned" "0.1.0"
-run_in "${versioned_consumer}" install-versioned-v1 "${HEW}" install
+run_in "${versioned_consumer}" install-versioned-v1 "${HEW}" install --offline
 assert_contains "${versioned_consumer}/hew.lock" 'name = "acme.versioned"'
 assert_contains "${versioned_consumer}/hew.lock" 'version = "0.1.0"'
 run_in "${versioned_consumer}" check-versioned-v1 "${HEW}" check main.hew
 assert_output "${versioned_consumer}" "101" "run-versioned-v1"
 
 write_consumer "${versioned_consumer}" "acme.versioned" "0.2.0"
-run_in "${versioned_consumer}" install-versioned-v2 "${HEW}" install
+run_in "${versioned_consumer}" install-versioned-v2 "${HEW}" install --offline
 assert_contains "${versioned_consumer}/hew.lock" 'name = "acme.versioned"'
 assert_contains "${versioned_consumer}/hew.lock" 'version = "0.2.0"'
 run_in "${versioned_consumer}" check-versioned-v2 "${HEW}" check main.hew


### PR DESCRIPTION
fix(pkg): secure registry package resolution

## Summary

- frame canonical package tree digests with an explicit domain, version, entry type, path length, path bytes, content length, and content bytes
- collect package snapshots through no-follow, descriptor-relative traversal so archive and directory checksums share exact bytes and reject path substitution
- reject every path dependency declared by a registry package before cache publication or project mutation
- bind dependency resolution, cache namespaces, immutable generations, lock entries, checksums, and materialization to canonical registry identities
- validate complete locked graphs before project mutation and preserve exact project/cache bytes on terminal locked failures
- pin immutable generations with cross-process leases through verification, resolution, and verified-copy materialization
- reclaim never-active generations immediately and retain a bounded set of superseded unleased generations without deleting active readers
- preserve Windows pointer sharing and finite replacement retry behavior

## Validation

- `cargo test -p hew-pkg --all-targets`
- `cargo test -p hew-cli --test pkg_resolver_e2e --test pkg_path_dependency_e2e`
- `make test-package-install`
- `cargo clippy -p hew-pkg -p hew-cli --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- atomic publication stress test repeated 50 times
- exact `atomic_fs.rs` and `package_fs.rs` production cfg paths compiled for `x86_64-pc-windows-gnu`, `x86_64-pc-windows-msvc`, and `x86_64-unknown-freebsd`

## Platform limits

- full Windows GNU package compilation stops in native dependencies because `x86_64-w64-mingw32-gcc` is unavailable
- full Windows MSVC package compilation stops in `zstd-sys` because Windows C SDK headers are unavailable
- full FreeBSD package compilation stops in `zstd-sys` because FreeBSD C sysroot headers are unavailable
