### PR TITLE
docs(release): prepare v0.6.0-rc2 records

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,12 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
 
+      - name: Checkout release machinery
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: release-machinery
+
       - name: Download cross-built release library (Windows)
         if: startsWith(matrix.target, 'windows')
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -436,7 +442,7 @@ jobs:
       - name: Prove release library consumer linking (Unix)
         if: "!startsWith(matrix.target, 'windows')"
         run: |
-          scripts/test-release-lib-link.sh \
+          release-machinery/scripts/test-release-lib-link.sh \
             --hew "target/${{ matrix.rust_target }}/release/hew" \
             --archive "target/${{ matrix.rust_target }}/release-lib/libhew.a"
 
@@ -444,7 +450,7 @@ jobs:
         if: startsWith(matrix.target, 'windows')
         shell: pwsh
         run: |
-          ./scripts/test-release-lib-link.ps1 `
+          ./release-machinery/scripts/test-release-lib-link.ps1 `
             -Hew "target/${{ matrix.rust_target }}/release/hew.exe" `
             -Archive "cross-release-libs/${{ matrix.rust_target }}/hew.lib"
 
@@ -519,7 +525,7 @@ jobs:
         if: startsWith(matrix.target, 'darwin')
         run: |
           for bin in "${ARCHIVE_NAME}"/bin/*; do
-            scripts/verify-macos-binary.sh "${bin}"
+            release-machinery/scripts/verify-macos-binary.sh "${bin}"
           done
 
       - name: Smoke test packaged hew before macOS signing
@@ -827,6 +833,12 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
 
+      - name: Checkout release machinery
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: release-machinery
+
       - name: Trust the workspace checkout
         # The container user differs from the checkout owner; without this
         # the hew-cli build script cannot read git metadata and the shipped
@@ -871,7 +883,7 @@ jobs:
 
       - name: Prove release library consumer linking
         run: |
-          scripts/test-release-lib-link.sh \
+          release-machinery/scripts/test-release-lib-link.sh \
             --hew "target/${{ matrix.rust_target }}/release/hew" \
             --archive "target/${{ matrix.rust_target }}/release-lib/libhew.a"
 
@@ -983,6 +995,12 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
 
+      - name: Checkout release machinery
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          path: release-machinery
+
       - name: Compute archive name
         id: archive
         run: |
@@ -1035,7 +1053,7 @@ jobs:
 
             # ── Rust builds (release) ──────────────────────────────────────
             cargo build -p hew-cli -p hew-lsp -p hew-observe --release
-            bash scripts/test-release-lib-link.sh \
+            bash release-machinery/scripts/test-release-lib-link.sh \
               --hew target/release/hew \
               --archive cross-release-libs/x86_64-unknown-freebsd/libhew.a
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.6.0-rc2] - 2026-08-23
+
+Hew v0.6.0-rc2 is the second release candidate for v0.6. It completes the
+dotted-path language cutover, hardens ownership and actor shutdown behavior,
+adds manifest-first package commands, and makes the release and CI gates more
+deterministic. It remains a candidate: the mandatory rc3 pass will retire the
+remaining ownership advisories and exercise the final promotion path.
+
 ### Changed (breaking)
 
 - **We have adopted one dotted path surface throughout Hew.** `::` path
@@ -17,6 +25,60 @@
   name such as `Option`, `Result`, or `Iterator` now fails with
   `E_PRELUDE_DECL_COLLISION`. Rename the user declaration; importing it under
   another module does not create a separate authority for the protected name.
+
+### Added
+
+- **Manifest-first package commands.** `hew build`, `hew run`, and `hew check`
+  resolve a project from its manifest, including test imports and native FFI
+  dependencies, and fail closed when registry publication fails.
+- **More composable language surfaces.** Top-level type aliases, trait objects
+  in return position and `Vec` storage, multi-statement `fork` bodies, fluent
+  `Vec` iterator methods, and structural aggregate formatting are now covered
+  by end-to-end compiler tests.
+- **Generated language reference pages.** Actors, supervision, machines,
+  concurrency, and resources are generated from executable Hew sources and
+  deployed with the standard-library reference.
+
+### Fixed — ownership and compiler correctness
+
+- **Owned aggregates keep one release authority through control flow.** Nested
+  tuple carries, projected record reads, divergent selections, call-result
+  matches, temporary receivers, closure environments, resource matches, and
+  collection ingress no longer lose or duplicate their drop obligation.
+- **Imported and generic identities remain canonical.** Qualified calls,
+  imported machines and wire types, dyn traits, generic layouts, structural
+  clone/equality, and opaque `try` payloads retain their defining identity
+  through checking, HIR, MIR, and code generation.
+- **Diagnostics and lints are fail-closed.** Checker state resets between
+  compilations, direct-iteration suggestions require proven clone support,
+  and deprecated path spellings are rejected by the stdlib ratchet.
+
+### Fixed — runtime and concurrency
+
+- **Faults produce an observable failed process.** Actor and supervised-child
+  failures converge on the runtime exit status, while failed registered sends
+  are reported as connection drops rather than successful delivery.
+- **Shutdown settles outstanding work before reclamation.** Cancelled restart
+  records, abandoned asks, timer ticks, parked asks, worker joins, and scheduler
+  cleanup use bounded, ordered hand-offs that do not publish drained state or
+  free runtime state prematurely.
+- **Actor scheduling tests use explicit happens-before edges.** Mailbox,
+  periodic-timer, restart, ask, and link-race coverage no longer relies on
+  incidental wall-clock ordering.
+
+### Changed — build, CI, and release trust
+
+- **Preflight is derived from declared gate inputs.** Gate routing follows the
+  artifact graph, shared test artifacts build once before execution, Linux CI
+  is split into balanced shards, and generated baselines have one registry and
+  regeneration target.
+- **Release validation covers the shipped layouts.** Windows and FreeBSD
+  candidates exercise the external static-library consumer, packaged archives
+  run clean-room smoke tests, npm publication is pinned to an immutable tag,
+  and documentation deployment validates its generated page set.
+- **Nightly sanitizer and coverage signals are executable again.** ASan keeps
+  timed-out runtime workers alive until bounded reclamation, and the coverage
+  workflow proves that test failures and missing reports cannot be masked.
 
 ## [0.6.0-rc1] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [0.6.0-rc2] - 2026-08-23
+## [0.6.0-rc2] - 2026-08-24
 
 Hew v0.6.0-rc2 is the second release candidate for v0.6. It completes the
 dotted-path language cutover, hardens ownership and actor shutdown behavior,
@@ -51,7 +51,10 @@ remaining ownership advisories and exercise the final promotion path.
   through checking, HIR, MIR, and code generation.
 - **Diagnostics and lints are fail-closed.** Checker state resets between
   compilations, direct-iteration suggestions require proven clone support,
-  and deprecated path spellings are rejected by the stdlib ratchet.
+  and deprecated path spellings are rejected by the stdlib ratchet. MIR
+  ownership findings are consolidated by function and root with source spans
+  and concrete local types; a real multi-module project that previously
+  produced 279 `E_MIR_CHECK` warnings now produces none.
 
 ### Fixed — runtime and concurrency
 
@@ -68,6 +71,9 @@ remaining ownership advisories and exercise the final promotion path.
 
 ### Changed — build, CI, and release trust
 
+- **Dogfood compiler build time fell from 113 seconds to 12 seconds.** LLVM IR
+  is emitted only when requested, the requested LLVM optimization level is
+  honored, and an IR-shape gate catches accidental compiler growth.
 - **Preflight is derived from declared gate inputs.** Gate routing follows the
   artifact graph, shared test artifacts build once before execution, Linux CI
   is split into balanced shards, and generated baselines have one registry and

--- a/Makefile
+++ b/Makefile
@@ -2074,6 +2074,7 @@ test-sandbox-parity-coverage-check-build:
 # inputs: scripts/tests/test_target_dir_gate_wiring.py scripts/pre-release-validate.sh
 # inputs: scripts/windows-release-build.ps1 scripts/ci-preflight-dispatcher.sh
 # inputs: scripts/lib/cargo-output-dir.sh
+# inputs: scripts/workspace-version.py
 # inputs: scripts/build-npm-packages.mjs scripts/cargo-output-dir.py
 # inputs: scripts/tests/test_rust_dependency_cache_contract.py
 # inputs: CHANGELOG.md docs/releases/*.md docs/release-runbook.md

--- a/Makefile
+++ b/Makefile
@@ -2077,6 +2077,7 @@ test-sandbox-parity-coverage-check-build:
 # inputs: scripts/workspace-version.py
 # inputs: scripts/build-npm-packages.mjs scripts/cargo-output-dir.py
 # inputs: scripts/tests/test_rust_dependency_cache_contract.py
+# inputs: hew-parser/fuzz/Cargo.lock
 # inputs: CHANGELOG.md docs/releases/*.md docs/release-runbook.md
 # inputs: docs/cross-platform-build-guide.md
 test-release-workflow-contract:

--- a/Makefile
+++ b/Makefile
@@ -2076,7 +2076,7 @@ test-sandbox-parity-coverage-check-build:
 # inputs: scripts/lib/cargo-output-dir.sh
 # inputs: scripts/build-npm-packages.mjs scripts/cargo-output-dir.py
 # inputs: scripts/tests/test_rust_dependency_cache_contract.py
-# inputs: CHANGELOG.md docs/releases/v0.6.0-rc1.md docs/release-runbook.md
+# inputs: CHANGELOG.md docs/releases/*.md docs/release-runbook.md
 # inputs: docs/cross-platform-build-guide.md
 test-release-workflow-contract:
 	python3 scripts/tests/test_release_workflow_contract.py

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -12,7 +12,9 @@ This is the concrete expansion of the `ci-full-run-pre-tag` todo.
 - [ ] CHANGELOG.md has either a populated `[Unreleased]` section or the dated
       `[X.Y.Z]` section for the intended release
 - [ ] Curated GitHub release notes are drafted at `docs/releases/vX.Y.Z.md`
-- [ ] Version in workspace `Cargo.toml` is still the *previous* release (bump happens below)
+- [ ] `workspace.package.version` in `Cargo.toml`, `Cargo.lock`, the intended
+      changelog record, and `docs/releases/vX.Y.Z.md` all name the candidate
+      that will be tagged
 
 ## Phase 1 — Assemble the candidate
 
@@ -51,36 +53,45 @@ git log --oneline -5  # confirm expected HEAD
 
 **Rationale:** pre-1.0, breaking changes allow rapid stdlib refinement without long deprecation cycles. All in-tree code must be updated in the same PR so the break is visible at a glance. `#[non_exhaustive]` protects downstream code from silent miscompilation.
 
-## Phase 2 — Version bump
+## Phase 2 — Establish the release identity
 
-> **Prerequisite:** The version bump must be a single commit that updates
-> `Cargo.toml`'s workspace version AND the matching `[Unreleased]` →
-> `[X.Y.Z]` rename in `CHANGELOG.md`. Tagging a commit where `Cargo.toml`
-> still reports the prior version produces binaries that self-report the
-> wrong version.
+> **Prerequisite:** Any required version bump must update `Cargo.toml`'s
+> workspace version, every lockfile, the dated changelog record, and the exact
+> `docs/releases/vX.Y.Z.md` file together. Tagging a commit where any one of
+> those identities differs produces a split release record.
 
 ```bash
-# Bump workspace version in Cargo.toml
-# (currently: edit `version = "X.Y.Z"` in the root [workspace.package])
+# Set the intended version in the root [workspace.package], if needed.
 $EDITOR Cargo.toml
 
-# Stamp CHANGELOG.md — move [Unreleased] contents under new version header
+# Keep a fresh [Unreleased] heading and stamp its completed entries under the
+# dated [X.Y.Z] heading. Create docs/releases/vX.Y.Z.md at the same time.
 $EDITOR CHANGELOG.md
+$EDITOR docs/releases/vX.Y.Z.md
 
-# Update lockfile
+# Update and verify every committed lockfile through Cargo.
 cargo check --workspace
+cargo check --workspace --locked
+cargo update --manifest-path hew-parser/fuzz/Cargo.toml \
+  -p hew-parser --precise X.Y.Z --offline
 
-# Commit the version bump
-# Note: all crates use version.workspace = true, so only root Cargo.toml needs editing.
-git add Cargo.toml Cargo.lock CHANGELOG.md
-git commit -m "chore: bump version to v0.4.0"
+# Confirm the identity that all later commands derive.
+release_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
+release_tag="v${release_version}"
+test -f "docs/releases/${release_tag}.md"
+
+git add Cargo.toml Cargo.lock hew-parser/fuzz/Cargo.lock CHANGELOG.md \
+  "docs/releases/${release_tag}.md"
+git commit -m "chore(release): prepare ${release_tag}"
 ```
 
 ## Phase 3 — Push release branch (triggers release-gate CI)
 
 ```bash
-git checkout -b release/v0.4
-git push origin release/v0.4
+release_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
+release_tag="v${release_version}"
+git checkout -b "release/${release_tag}"
+git push origin "release/${release_tag}"
 ```
 
 This triggers `.github/workflows/release-gate.yml`, which runs:
@@ -210,6 +221,13 @@ The publication sequence is a fail-closed dependency graph. Do not advance
 past a failed or missing result; items grouped in braces may run independently,
 but every arm must succeed before the graph rejoins:
 
+All identities below are derived from the checked-out candidate:
+
+```bash
+release_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
+release_tag="v${release_version}"
+```
+
 1. Confirm every release bar and the final-candidate checklist are green on
    the exact candidate commit, including sanitizer evidence, required secrets,
    and branch protection.
@@ -272,8 +290,8 @@ but every arm must succeed before the graph rejoins:
    `docs/releases/<tag>.md` file for that tag.
 5. After the assets exist, complete the npm publication arm:
    - Manually dispatch `.github/workflows/publish-npm-packages.yml` with
-     `release_tag=v0.6.0-rc1` for
-     `@hew-lang/{wasm,sandbox-wasm,sandbox-vm}@0.6.0-rc1`, and wait for each
+     `release_tag="${release_tag}"` for
+     `@hew-lang/{wasm,sandbox-wasm,sandbox-vm}@${release_version}`, and wait for each
      result. The workflow checks out that immutable tag and rejects a workspace
      or sandbox package version mismatch. A tag does not publish these packages.
 6. The tag-push release workflow only observes the pre-tag candidate image; it
@@ -306,8 +324,10 @@ branch. In particular, `gate-sanitizers` must have executed ASan successfully
 and accepted the bounded TSan/Miri behavioral ledger for the release version.
 
 ```bash
-git tag -s v0.6.0-rc1 -m "Hew v0.6.0-rc1"
-git push origin v0.6.0-rc1
+release_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
+release_tag="v${release_version}"
+git tag -s "$release_tag" -m "Hew $release_tag"
+git push origin "$release_tag"
 ```
 
 This triggers `.github/workflows/release.yml`, which:
@@ -316,7 +336,11 @@ This triggers `.github/workflows/release.yml`, which:
 - Runs `scripts/verify-macos-binary.sh` on macOS artifacts before signing
 - Runs package-layout smoke inside the FreeBSD VM after the tarball is assembled
 - Runs Ubuntu clean-room tarball smoke for linux-x86_64 and linux-aarch64
-- Builds Linux distro packages and smoke-tests the installable `.deb` / `.rpm` / `.pkg.tar.zst` outputs in Docker (Arch remains x86_64-only)
+- For final tags, builds Linux distro packages and smoke-tests the installable
+  `.deb` / `.rpm` / `.pkg.tar.zst` outputs in Docker (Arch remains x86_64-only).
+  Release-candidate tags deliberately skip this job because the current distro
+  version mapping does not encode `-rcN`; RCs are validated through the Linux
+  tarballs and clean-room archive smoke tests instead.
 - Signs and notarizes macOS binaries on tag releases
 - Creates a GitHub Release with checksums and the curated notes from
   `docs/releases/<tag>.md`
@@ -338,9 +362,10 @@ macOS release notes:
 
 ## Phase 6 — Docs publish (after release tag)
 
-- [ ] Confirm `secrets.CLOUDFLARE_API_TOKEN` is set in repository settings
-      (one-time setup — then remove the `if: false` guard in
-      `.github/workflows/deploy-docs.yml` and this checkbox).
+- [ ] Confirm `secrets.CLOUDFLARE_API_TOKEN` and
+      `secrets.CLOUDFLARE_ACCOUNT_ID` are set in repository settings. The docs
+      workflow has no disabled guard: every `v*` tag invokes it and a missing
+      credential fails the deployment.
 - [ ] Confirm the token can edit Pages projects in the target account.
       The production project is
       `hew-docs`, and its custom domain is `docs.hew.sh`.
@@ -400,7 +425,7 @@ cause keyword-highlighting gaps that are invisible from this repo's CI.
 | Packaged archive smoke (Linux/macOS) | release.yml (Unix matrix) | Yes    |
 | Packaged archive smoke (Windows zip) | release.yml (Windows job) | Yes |
 | FreeBSD packaged archive smoke | release.yml (FreeBSD VM, x86_64 + aarch64) | Yes |
-| Linux package install smoke  | release.yml (`linux-packages`) | Yes    |
+| Linux package install smoke  | release.yml (`linux-packages`) | Yes for final tags; skipped for RCs |
 | Linux Docker clean-room tarball smoke | release.yml (`docker-clean-room-test`) | Yes |
 | macOS build + tests          | ci.yml + release-gate.yml    | Yes       |
 | Windows build + tests        | ci.yml + release-gate.yml    | Yes       |
@@ -440,7 +465,7 @@ one `[[waiver]]` row per non-executed axis:
 ```toml
 [[waiver]]
 axis = "tsan"
-release = "0.6.0-rc1"
+release = "<workspace release version>"
 behavior = "the concrete observed lane or toolchain behavior"
 reason = "why the behavior is not an authoritative release failure"
 tracking = "https://github.com/hew-lang/hew/issues/<issue>"

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -76,7 +76,7 @@ cargo update --manifest-path hew-parser/fuzz/Cargo.toml \
   -p hew-parser --precise X.Y.Z --offline
 
 # Confirm the identity that all later commands derive.
-release_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
+release_version="$(scripts/workspace-version.py)"
 release_tag="v${release_version}"
 test -f "docs/releases/${release_tag}.md"
 
@@ -88,7 +88,7 @@ git commit -m "chore(release): prepare ${release_tag}"
 ## Phase 3 — Push release branch (triggers release-gate CI)
 
 ```bash
-release_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
+release_version="$(scripts/workspace-version.py)"
 release_tag="v${release_version}"
 git checkout -b "release/${release_tag}"
 git push origin "release/${release_tag}"
@@ -98,10 +98,13 @@ This triggers `.github/workflows/release-gate.yml`, which runs:
 
 | Platform       | Build scope                              | Test scope                          |
 |----------------|------------------------------------------|-------------------------------------|
-| Linux x86_64   | hew-cli, hew-lsp, hew-lib, WASM runtime | Rust workspace, codegen E2E (native + WASM) |
-| Linux aarch64  | hew-cli, hew-lsp, hew-lib, WASM runtime | Rust workspace, codegen E2E (native + WASM) |
-| macOS arm64    | hew-cli, hew-lsp, hew-lib     | Rust workspace, codegen E2E (native) |
+| Linux x86_64   | hew-cli, hew-lsp, hew-observe, hew-lib, WASM runtime | Rust workspace, codegen E2E (native + WASM) |
+| Linux aarch64  | hew-cli, hew-lsp, hew-observe, hew-lib, WASM runtime | Rust workspace, codegen E2E (native + WASM) |
+| macOS arm64    | hew-cli, hew-lsp, hew-observe, hew-lib | Rust workspace, codegen E2E (native) |
+| macOS x86_64 (`macos-15-intel`) | hew-cli, hew-lsp, hew-observe, hew-lib | Rust workspace, codegen E2E (native) |
 | Windows x86_64 | hew-cli, hew-lsp, hew-observe, hew-lib | Rust workspace + C-ABI + executable release-library consumer |
+| FreeBSD x86_64 | hew-cli, hew-lsp, hew-observe, hew-lib | Rust workspace + C-ABI + executable release-library consumer |
+| FreeBSD aarch64 | hew-cli | Native compiler build + compiled-program smoke under QEMU |
 
 **Wait for all release gate jobs to go green, including `gate-sanitizers`.**
 The sanitizer job executes ASan and rejects missing, ambiguous, expired, vague,
@@ -224,8 +227,11 @@ but every arm must succeed before the graph rejoins:
 All identities below are derived from the checked-out candidate:
 
 ```bash
-release_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
+release_version="$(scripts/workspace-version.py)"
 release_tag="v${release_version}"
+release_sha="$(git rev-parse HEAD)"
+test "$(git status --porcelain)" = ""
+test "$(git rev-parse HEAD)" = "$(git rev-parse "origin/release/${release_tag}")"
 ```
 
 1. Confirm every release bar and the final-candidate checklist are green on
@@ -284,9 +290,15 @@ release_tag="v${release_version}"
    pre-tag handoff: it records the immutable raw manifest/index digest without
    requiring another Hew or playground commit. Do not use a Make target or the
    `publish` mode before tagging: publish authority requires the remote signed tag.
-3. Create the signed tag only after the preceding evidence is recorded.
-4. Let the release workflow build and publish the signed platform assets and
-   checksums. Its curated body must be the exact
+3. Create the signed tag and push it only after the preceding evidence is recorded:
+
+   ```bash
+   git tag -s "$release_tag" -m "Hew $release_tag"
+   git push origin "$release_tag"
+   ```
+
+4. Let the release workflow build and publish seven platform archives and one
+   checksum manifest from the signed tag. Its curated body must be the exact
    `docs/releases/<tag>.md` file for that tag.
 5. After the assets exist, complete the npm publication arm:
    - Manually dispatch `.github/workflows/publish-npm-packages.yml` with
@@ -323,17 +335,15 @@ Do not tag until `.github/workflows/release-gate.yml` is green on the release
 branch. In particular, `gate-sanitizers` must have executed ASan successfully
 and accepted the bounded TSan/Miri behavioral ledger for the release version.
 
-```bash
-release_version="$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')"
-release_tag="v${release_version}"
-git tag -s "$release_tag" -m "Hew $release_tag"
-git push origin "$release_tag"
-```
-
 This triggers `.github/workflows/release.yml`, which:
-- Builds release tarballs for linux-x86_64, linux-aarch64, darwin-x86_64, darwin-aarch64, windows-x86_64
+- Builds seven platform archives: six `.tar.gz` Unix archives for linux-x86_64,
+  linux-aarch64, darwin-x86_64, darwin-aarch64, freebsd-x86_64, and
+  freebsd-aarch64, plus one `windows-x86_64.zip`, with the complete
+  `hew-v<version>-checksums.txt` manifest
 - Extracts staged release archives and runs `hew run` from the packaged layout on Unix targets, with `HEW_STD` pointed at the extracted `std/`
-- Runs `scripts/verify-macos-binary.sh` on macOS artifacts before signing
+- Runs the workflow-ref
+  `release-machinery/scripts/verify-macos-binary.sh` on macOS artifacts before
+  signing
 - Runs package-layout smoke inside the FreeBSD VM after the tarball is assembled
 - Runs Ubuntu clean-room tarball smoke for linux-x86_64 and linux-aarch64
 - For final tags, builds Linux distro packages and smoke-tests the installable
@@ -349,7 +359,8 @@ This triggers `.github/workflows/release.yml`, which:
 
 macOS release notes:
 
-- arm64 release builds run on `macos-15`; Intel release builds stay on `macos-13`
+- arm64 release builds run on `macos-15`; Intel release builds run on
+  `macos-15-intel`
 - `MACOSX_DEPLOYMENT_TARGET=13.0` is exported in the release workflow so the
   shipped binaries remain compatible with macOS 13+
 - Tag releases require all of:
@@ -382,8 +393,8 @@ macOS release notes:
 
 ## Phase 7 — Post-release verification
 
-- [ ] GitHub Release page has all platform tarballs
-- [ ] Download and smoke-test at least one tarball
+- [ ] GitHub Release page has all seven platform archives and the checksum manifest
+- [ ] Download and smoke-test at least one platform archive
 - [ ] Homebrew formula updated (if applicable): `brew install hew-lang/hew/hew`
 - [ ] VS Code extension published (if applicable)
 - [ ] Author blog post at `hew-lang/hew.sh/src/content/blog/<YYYY>/<MM>/release-v<XYZ>.md` — required for any release with breaking changes; recommended for all minor releases.
@@ -431,8 +442,8 @@ cause keyword-highlighting gaps that are invisible from this repo's CI.
 | Windows build + tests        | ci.yml + release-gate.yml    | Yes       |
 | FreeBSD build + tests        | release-gate.yml (x86_64 + aarch64), freebsd.yml (nightly) | Yes for release branches |
 | ASan                         | release-gate.yml (`gate-sanitizers`) + nightly-sanitizers.yml | Yes for release branches |
-| TSan (Rust runtime)          | nightly-sanitizers.yml + `release-sanitizer-waiver.toml` | Bounded behavioral ledger for releases |
-| Miri                         | `release-sanitizer-waiver.toml` | Bounded behavioral ledger for releases |
+| TSan (Rust runtime)          | nightly-sanitizers.yml + `release-sanitizer-waiver.toml` | Bounded recurring advisory lane and behavioral ledger for releases |
+| Miri                         | nightly-sanitizers.yml + `release-sanitizer-waiver.toml` | Bounded recurring advisory lane and behavioral ledger for releases |
 | Codegen silent-failure lint  | codegen-lint.yml (PR)        | Advisory  |
 | Local cross-platform build   | `make pre-release`           | Recommended |
 
@@ -447,12 +458,16 @@ The release branch gate is the release-time authority for sanitizer evidence:
   `make asan`, records the result, and invokes
   `scripts/check-sanitizer-gate.sh "${RELEASE_VERSION}" ...`. The validator
   fails closed when ASan is absent, red, skipped, or ambiguous.
-- **TSan has a bounded release-version behavioral ledger while the upstream
-  `build-std`/TSan link failure remains unresolved.** The nightly lane still
-  provides signal, but a release needs an explicit `axis = "tsan"` row that
+- **TSan is a recurring executed advisory lane with a bounded release-version
+  behavioral ledger while the upstream `build-std`/TSan link failure remains
+  unresolved.** Its uninstrumented standard library prevents authoritative
+  race classification, so a release needs an explicit `axis = "tsan"` row that
   records observed behavior, rationale, owner, tracking issue, and expiry.
-- **Miri is not yet a recurring gate.** It uses the same bounded behavioral
-  ledger until a representative recurring FFI subset exists.
+- **Miri is a recurring executed advisory lane over the curated pure-Rust unsafe
+  subset.** A green run is positive evidence for that subset, while FFI,
+  syscall, socket, and subprocess paths remain outside Miri and prevent it from
+  being authoritative whole-runtime coverage. It uses the same bounded
+  behavioral ledger for release decisions.
 - **ASan coverage is only as broad as `make asan`.** Today that command runs
   the `hew-runtime --lib` ASan suite. It does not prove integration-only free
   sites, thread-reachable handle leaks, or every packaged binary path are
@@ -460,7 +475,7 @@ The release branch gate is the release-time authority for sanitizer evidence:
   `make asan` grows, the release gate inherits that coverage automatically.
 
 To record a limitation, edit `release-sanitizer-waiver.toml` and add exactly
-one `[[waiver]]` row per non-executed axis:
+one `[[waiver]]` row per bounded advisory axis:
 
 ```toml
 [[waiver]]
@@ -502,9 +517,11 @@ rows fail the gate.
   as of 2026-04. Keep the nightly signal and record bounded release-version
   behavior only via `release-sanitizer-waiver.toml`; re-evaluate when upstream
   resolves.
-- **WASM capability gaps**: Channels and I/O streams are rejected at compile
-  time when targeting wasm32-wasi.  Timers (`sleep`/`sleep_until`) now have
-  cooperative semantics on WASM (actor parks at message boundary) and emit a
-  warning rather than an error.  See
+- **WASM capability gaps**: The bounded nonblocking channel slice
+  (`channel.new`, sender `send`/clone/close, receiver `try_recv`/close) is
+  supported on wasm32-wasi. Blocking receive and unsupported I/O paths remain
+  compile-time refusals. Timers (`sleep`/`sleep_until`) have cooperative
+  semantics on WASM (actor parks at message boundary) and emit a warning rather
+  than an error. See
   [`docs/wasm-capability-matrix.md`](wasm-capability-matrix.md) for the full
   Tier 1 / Tier 2 disposition table and the WASM-TODO backlog.

--- a/docs/releases/v0.6.0-rc2.md
+++ b/docs/releases/v0.6.0-rc2.md
@@ -16,6 +16,9 @@ package commands, and release gates that exercise the layouts users receive.
   package from its manifest, including tests and native FFI dependencies.
   Registry publication errors are terminal instead of being reported as a
   successful publish.
+- **Explicit package signing-key registration.** `hew key register` adds a
+  signing key to the configured registry through the same authenticated,
+  redaction-safe package client used by publication.
 - **Composed values retain ownership through lowering.** Nested tuples,
   projected records, match results, divergent selections, temporary receivers,
   closures, resource matches, and collection ingress retain exactly one release
@@ -46,25 +49,43 @@ platform-dependent result.
 - A borrowed element of a live collection cannot be returned, explicitly
   closed, or transferred into another owner. Read through the borrow or move an
   independently owned value instead.
-- Channels and I/O streams remain unavailable on `wasm32-wasi`; those
-  capabilities are rejected at compile time rather than silently emulated.
+- The bounded nonblocking channel slice remains available on `wasm32-wasi`:
+  `channel.new`, sender `send`/clone/close, and receiver `try_recv`/close.
+  Blocking receiver operations and unsupported I/O streams remain compile-time
+  refusals rather than silently emulated capabilities.
 
 ## Required rc3 work before v0.6.0
 
-The release sequence requires an exercised rc3 before the final release. That
-pass must drive the remaining ownership advisory corpus to zero, finish the
-crash-cleanup/quarantine protocol, repeat dogfood without unexplained warnings
-or internal errors, and rerun release qualification on the exact candidate.
-The final v0.6.0 tag is promoted from that exercised rc3 line; rc2 is not
-silently relabelled as final.
+The release sequence requires an exercised rc3 before the final release:
+
+- Drive the ownership advisory corpus to zero and quarantine every compiler
+  pipeline crash so a failed pipeline cannot continue with partial state.
+- Complete and prove crash-cleanup frame protocol stages 1–3: establish the
+  frame authority, settle its release obligations, and reclaim it only after
+  cleanup is complete.
+- Lift the accepted set for functional record updates carrying nested enum and
+  `Option` payloads, closing the remaining fail-closed boundary formerly tracked
+  in `TODO.md`, and drain every other remaining `TODO.md` release item.
+- Run the zero-surprise walkthrough, fresh dogfood, and full release
+  qualification on the exact rc3 candidate, then publish and exercise rc3
+  against real programs before promotion.
+
+The final v0.6.0 line may take defect-only fixes that do not materially change
+the accepted program set or the meaning of accepted programs. Any accepted-set
+change after rc3 forces rc4; it cannot be folded into final. The final tag is
+promoted from the exercised candidate line, never silently relabelled from rc2.
 
 ## Candidate limits and staged publication
 
 Publication for this RC is deliberately staged. The signed tag publishes the
 platform assets and checksums first. npm consumers are then published manually
 through `.github/workflows/publish-npm-packages.yml`; npm publication is not
-inferred from the tag. The playground image must identify the exact Hew commit
-used for this candidate before live cutover.
+inferred from the tag. Before tagging, the playground candidate is published
+from the exact clean Hew and playground identities and recorded as the
+version-scoped immutable lock `v<tag>@sha256:<raw-manifest-or-index-digest>`.
+The release workflow hashes the raw registry response, requires exactly one
+runnable `linux/amd64` image, and verifies that its revision label is the exact
+Hew candidate commit before live cutover.
 
 Hosted Actions billing for the ecosystem and playground repositories is an
 accepted rc2 infrastructure limitation and does not hold the rc2 tag. The

--- a/docs/releases/v0.6.0-rc2.md
+++ b/docs/releases/v0.6.0-rc2.md
@@ -1,0 +1,74 @@
+# Hew v0.6.0-rc2
+
+Hew v0.6.0-rc2 is the second release candidate for v0.6.0. It is not the final
+v0.6.0 release. This candidate concentrates the changes since rc1 into a
+coherent dotted-path language, a safer ownership/runtime core, manifest-first
+package commands, and release gates that exercise the layouts users receive.
+
+## Supported in this candidate
+
+- **One dotted path surface.** Modules, types, traits, variants, and imported
+  declarations use dotted paths. Explicit selections use
+  `module.{ Name, Other }`, generic calls use Hew's ordinary `name<T>(...)`
+  spelling, and contextual variants use `.Variant`. `hew fmt --migrate --root
+  .` performs the mechanical source migration.
+- **Manifest-first projects.** `hew build`, `hew run`, and `hew check` resolve a
+  package from its manifest, including tests and native FFI dependencies.
+  Registry publication errors are terminal instead of being reported as a
+  successful publish.
+- **Composed values retain ownership through lowering.** Nested tuples,
+  projected records, match results, divergent selections, temporary receivers,
+  closures, resource matches, and collection ingress retain exactly one release
+  obligation through HIR and MIR.
+- **Runtime failures are observable.** Actor and supervised-child faults affect
+  the process exit status. Restart, ask, timer, mailbox, and worker shutdown
+  paths settle their outstanding state before reclamation.
+- **Broader language composition.** Top-level type aliases, trait objects in
+  return position and `Vec` storage, multi-statement `fork` bodies, fluent
+  `Vec` iteration, and structural aggregate formatting have executable
+  compiler coverage.
+- **Candidate-shaped release validation.** The release gates smoke packaged
+  Unix and Windows layouts, cross-built FreeBSD consumers, immutable-tag npm
+  inputs, generated documentation, and the ASan/coverage execution paths.
+
+## Deliberate refusals
+
+These cases fail with a diagnostic rather than compiling to an unowned or
+platform-dependent result.
+
+- Retired `::`, turbofish, glob-import, and bare-variant spellings are rejected;
+  migrate them to the dotted forms above.
+- User declarations cannot shadow protected prelude names such as `Option`,
+  `Result`, or `Iterator`; rename the declaration.
+- `#[resource]` and `#[linear]` values cannot be stored in machine-state
+  payloads until machine lifecycle release is wired. Keep the resource outside
+  the machine and pass a handle through transitions.
+- A borrowed element of a live collection cannot be returned, explicitly
+  closed, or transferred into another owner. Read through the borrow or move an
+  independently owned value instead.
+- Channels and I/O streams remain unavailable on `wasm32-wasi`; those
+  capabilities are rejected at compile time rather than silently emulated.
+
+## Required rc3 work before v0.6.0
+
+The release sequence requires an exercised rc3 before the final release. That
+pass must drive the remaining ownership advisory corpus to zero, finish the
+crash-cleanup/quarantine protocol, repeat dogfood without unexplained warnings
+or internal errors, and rerun release qualification on the exact candidate.
+The final v0.6.0 tag is promoted from that exercised rc3 line; rc2 is not
+silently relabelled as final.
+
+## Candidate limits and staged publication
+
+Publication for this RC is deliberately staged. The signed tag publishes the
+platform assets and checksums first. npm consumers are then published manually
+through `.github/workflows/publish-npm-packages.yml`; npm publication is not
+inferred from the tag. The playground image must identify the exact Hew commit
+used for this candidate before live cutover.
+
+Hosted Actions billing for the ecosystem and playground repositories is an
+accepted rc2 infrastructure limitation and does not hold the rc2 tag. The
+authorized local publication path must execute the same version-pinned scripts
+and record the resulting image and package identities; this exception does not
+waive Hew's own release gates, platform assets, checksums, or post-publication
+verification.

--- a/docs/releases/v0.6.0-rc2.md
+++ b/docs/releases/v0.6.0-rc2.md
@@ -22,7 +22,13 @@ package commands, and release gates that exercise the layouts users receive.
 - **Composed values retain ownership through lowering.** Nested tuples,
   projected records, match results, divergent selections, temporary receivers,
   closures, resource matches, and collection ingress retain exactly one release
-  obligation through HIR and MIR.
+  obligation through HIR and MIR. Ownership diagnostics are consolidated into
+  actionable source findings; a multi-module project that previously produced
+  279 `E_MIR_CHECK` warnings now produces none.
+- **The compiler builds itself much faster.** Dogfood project build time fell
+  from 113 seconds to 12 seconds by emitting LLVM IR only when requested and
+  honoring the requested optimization level. A compact IR-shape gate guards
+  that improvement against accidental regression.
 - **Runtime failures are observable.** Actor and supervised-child faults affect
   the process exit status. Restart, ask, timer, mailbox, and worker shutdown
   paths settle their outstanding state before reclamation.
@@ -80,16 +86,7 @@ promoted from the exercised candidate line, never silently relabelled from rc2.
 Publication for this RC is deliberately staged. The signed tag publishes the
 platform assets and checksums first. npm consumers are then published manually
 through `.github/workflows/publish-npm-packages.yml`; npm publication is not
-inferred from the tag. Before tagging, the playground candidate is published
-from the exact clean Hew and playground identities and recorded as the
-version-scoped immutable lock `v<tag>@sha256:<raw-manifest-or-index-digest>`.
-The release workflow hashes the raw registry response, requires exactly one
-runnable `linux/amd64` image, and verifies that its revision label is the exact
-Hew candidate commit before live cutover.
-
-Hosted Actions billing for the ecosystem and playground repositories is an
-accepted rc2 infrastructure limitation and does not hold the rc2 tag. The
-authorized local publication path must execute the same version-pinned scripts
-and record the resulting image and package identities; this exception does not
-waive Hew's own release gates, platform assets, checksums, or post-publication
-verification.
+inferred from the tag. The playground image is published and consumed as
+`v0.6.0-rc2`. Before tagging, the release process validates that versioned image
+against the clean Hew candidate and records its registry digest as release
+evidence.

--- a/hew-parser/fuzz/Cargo.lock
+++ b/hew-parser/fuzz/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hew-hir"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -105,14 +105,14 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "logos",
 ]
 
 [[package]]
 name = "hew-mir"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "hew-hir",
  "hew-parser",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "finl_unicode",
  "hew-lexer",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "hew-types"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "hew-parser",
  "regex",

--- a/release-sanitizer-waiver.toml
+++ b/release-sanitizer-waiver.toml
@@ -31,3 +31,23 @@ reason = "A representative Miri model for the runtime FFI boundary is not yet av
 tracking = "https://github.com/hew-lang/hew/issues/1826"
 owner = "Hew runtime maintainers"
 expires = "2026-09-10"
+
+[[waiver]]
+axis = "tsan"
+release = "0.6.0-rc2"
+behavior = "The scheduled Linux TSan lane executes and reports a false race in libtest's mpmc CompletedTest handoff because the prebuilt standard library is uninstrumented; the same report is outside Hew runtime code."
+reason = "The observed CompletedTest report cannot distinguish instrumented Hew accesses from synchronization hidden inside uninstrumented std, so it is not an authoritative Hew race failure. ASan remains mandatory and executed."
+tracking = "https://github.com/hew-lang/hew/issues/1825"
+owner = "Hew runtime maintainers"
+expires = "2026-09-10"
+
+# Issue #1826 is closed after establishing the curated lane. It remains the
+# evidence record for this bounded rc2 scope; no replacement issue is invented.
+[[waiver]]
+axis = "miri"
+release = "0.6.0-rc2"
+behavior = "The curated runtime Miri lane reports 134 passed, 0 failed, 28 ignored, and 2270 filtered tests; FFI, syscall, socket, and subprocess paths are deliberately outside the interpreted set."
+reason = "The executed subset is green but cannot represent the runtime's foreign and operating-system boundaries, so it is evidence for the curated unsafe core rather than an authoritative whole-runtime gate."
+tracking = "https://github.com/hew-lang/hew/issues/1826"
+owner = "Hew runtime maintainers"
+expires = "2026-09-10"

--- a/release-sanitizer-waiver.toml
+++ b/release-sanitizer-waiver.toml
@@ -46,7 +46,7 @@ expires = "2026-09-10"
 [[waiver]]
 axis = "miri"
 release = "0.6.0-rc2"
-behavior = "The curated runtime Miri lane reports 134 passed, 0 failed, 28 ignored, and 2270 filtered tests; FFI, syscall, socket, and subprocess paths are deliberately outside the interpreted set."
+behavior = "The curated runtime Miri lane reports 134 passed, 0 failed, 28 ignored, and 2274 filtered tests; FFI, syscall, socket, and subprocess paths are deliberately outside the interpreted set."
 reason = "The executed subset is green but cannot represent the runtime's foreign and operating-system boundaries, so it is evidence for the curated unsafe core rather than an authoritative whole-runtime gate."
 tracking = "https://github.com/hew-lang/hew/issues/1826"
 owner = "Hew runtime maintainers"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -2944,6 +2944,7 @@ def test_generated_and_release_markdown_routes_to_its_consumers() -> None:
         *release_notes,
         "docs/release-runbook.md",
         "docs/cross-platform-build-guide.md",
+        "scripts/workspace-version.py",
     ):
         assert_gates(run_dispatcher(path), "test-release-workflow-contract")
 

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -2934,9 +2934,14 @@ def test_generated_and_release_markdown_routes_to_its_consumers() -> None:
         run_dispatcher("docs/wasm-capability-matrix.md"),
         "wasm-capability-check",
     )
+    release_notes = tuple(
+        str(path.relative_to(ROOT))
+        for path in sorted((ROOT / "docs" / "releases").glob("*.md"))
+    )
+    assert release_notes
     for path in (
         "CHANGELOG.md",
-        "docs/releases/v0.6.0-rc1.md",
+        *release_notes,
         "docs/release-runbook.md",
         "docs/cross-platform-build-guide.md",
     ):

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import stat
 import subprocess
+import sys
 import tarfile
 import tempfile
 import textwrap
@@ -37,7 +38,10 @@ COVERAGE_NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "coverage-nightly.y
 DEPLOY_DOCS_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-docs.yml"
 WORKFLOW_DIRECTORY = ROOT / ".github" / "workflows"
 RUNBOOK = ROOT / "docs" / "release-runbook.md"
+WASM_CAPABILITY_MATRIX = ROOT / "docs" / "wasm-capability-matrix.md"
 CHANGELOG = ROOT / "CHANGELOG.md"
+WORKSPACE_VERSION_HELPER = ROOT / "scripts" / "workspace-version.py"
+NIGHTLY_SANITIZERS = ROOT / ".github" / "workflows" / "nightly-sanitizers.yml"
 UNIX_INSTALLER = ROOT / "installers" / "install.sh"
 PRE_RELEASE_VALIDATOR = ROOT / "scripts" / "pre-release-validate.sh"
 RELEASE_LINK_PROBE = ROOT / "scripts" / "test-release-lib-link.sh"
@@ -408,6 +412,31 @@ def test_current_sandbox_vm_version_matches_workspace_version() -> None:
     )
     assert lockfile["version"] == workspace_version
     assert lockfile["packages"][""]["version"] == workspace_version
+
+
+def test_workspace_version_command_is_python310_compatible() -> None:
+    source = WORKSPACE_VERSION_HELPER.read_text()
+    ast.parse(source, filename=str(WORKSPACE_VERSION_HELPER), feature_version=(3, 10))
+    assert "import tomllib" not in source
+    assert "import toml_compat" in source
+
+    env = os.environ.copy()
+    env["HEW_FORCE_TOML_FALLBACK"] = "1"
+    result = subprocess.run(
+        [sys.executable, str(WORKSPACE_VERSION_HELPER)],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == WORKSPACE_VERSION
+
+    runbook = RUNBOOK.read_text()
+    assert "import tomllib" not in runbook
+    assert runbook.count('release_version="$(scripts/workspace-version.py)"') == 3
 
 
 def test_playground_release_uses_only_an_immutable_pretag_handoff() -> None:
@@ -1048,6 +1077,241 @@ def test_release_checksums_require_every_platform_asset() -> None:
     assert 'sha256sum "${assets[@]}"' in release
 
 
+def assert_release_platform_document_contract(
+    release: str, gate: str, runbook: str
+) -> None:
+    phase_three = runbook[runbook.index("## Phase 3") : runbook.index("## Phase 4")]
+    for platform in (
+        "Linux x86_64",
+        "Linux aarch64",
+        "macOS arm64",
+        "macOS x86_64 (`macos-15-intel`)",
+        "Windows x86_64",
+        "FreeBSD x86_64",
+        "FreeBSD aarch64",
+    ):
+        assert platform in phase_three
+
+    release_job = workflow_job(release, "release")
+    required_block = re.search(
+        r"required_assets=\(\n(?P<assets>.*?)\n\s*\)", release_job, re.DOTALL
+    )
+    assert required_block is not None
+    assets = re.findall(r'"hew-v\$\{VERSION\}-([^"]+)"', required_block.group("assets"))
+    assert assets == [
+        "darwin-aarch64.tar.gz",
+        "darwin-x86_64.tar.gz",
+        "windows-x86_64.zip",
+        "linux-x86_64.tar.gz",
+        "linux-aarch64.tar.gz",
+        "freebsd-x86_64.tar.gz",
+        "freebsd-aarch64.tar.gz",
+    ]
+    assert "seven platform archives and one\n   checksum manifest" in runbook
+    assert "six `.tar.gz` Unix archives" in runbook
+    assert "one `windows-x86_64.zip`" in runbook
+    assert "`hew-v<version>-checksums.txt`" in runbook
+    assert "macos-13" not in runbook
+    assert "os: macos-15-intel" in gate
+    assert "target: darwin-x86_64\n            os: macos-15-intel" in release
+
+
+def test_release_platform_and_archive_documentation_matches_workflows() -> None:
+    release = workflow()
+    gate = RELEASE_GATE.read_text()
+    runbook = RUNBOOK.read_text()
+    assert_release_platform_document_contract(release, gate, runbook)
+
+    mutations = (
+        (
+            release.replace(
+                '"hew-v${VERSION}-freebsd-aarch64.tar.gz"',
+                '"hew-v${VERSION}-linux-aarch64.tar.gz"',
+                1,
+            ),
+            gate,
+            runbook,
+        ),
+        (release, gate, runbook.replace("| FreeBSD aarch64", "| Removed", 1)),
+        (release, gate, runbook.replace("seven platform archives", "five tarballs", 1)),
+        (release, gate.replace("os: macos-15-intel", "os: macos-13", 1), runbook),
+    )
+    for mutated in mutations:
+        try:
+            assert_release_platform_document_contract(*mutated)
+        except AssertionError:
+            continue
+        raise AssertionError("a platform/archive truth mutation escaped")
+
+
+def assert_wasm_release_document_contract(
+    runbook: str, notes: str, matrix: str
+) -> None:
+    assert "`channel.new`" in matrix
+    assert "`Receiver<T>.try_recv/close`" in matrix
+    assert "Blocking channel receive operations" in matrix
+    assert "I/O streams require the OS threading and networking stack" in matrix
+    for document in (runbook, notes):
+        assert "bounded nonblocking channel" in document
+        assert "Blocking receive" in document or "Blocking receiver" in document
+        assert "unsupported I/O" in document
+    assert "Channels and I/O streams are rejected" not in runbook
+    assert "Channels and I/O streams remain unavailable" not in notes
+
+
+def test_release_docs_match_wasm_capability_authority() -> None:
+    runbook = RUNBOOK.read_text()
+    notes = RELEASE_NOTES.read_text()
+    matrix = WASM_CAPABILITY_MATRIX.read_text()
+    assert_wasm_release_document_contract(runbook, notes, matrix)
+
+    for mutated_runbook, mutated_notes in (
+        (
+            runbook.replace("The bounded nonblocking channel slice", "All channels", 1),
+            notes,
+        ),
+        (
+            runbook,
+            notes.replace(
+                "The bounded nonblocking channel slice remains available",
+                "Channels and I/O streams remain unavailable",
+                1,
+            ),
+        ),
+    ):
+        try:
+            assert_wasm_release_document_contract(
+                mutated_runbook, mutated_notes, matrix
+            )
+        except AssertionError:
+            continue
+        raise AssertionError("a blanket WASM channel refusal escaped")
+
+
+def assert_sanitizer_workflow_document_contract(
+    nightly: str, gate: str, runbook: str
+) -> None:
+    assert 'cron: "0 6 * * *"' in nightly
+    tsan = workflow_job(nightly, "rust-runtime-tsan")
+    miri = workflow_job(nightly, "rust-runtime-miri")
+    for job, command in ((tsan, "make tsan"), (miri, "make miri")):
+        assert "continue-on-error: true" in job
+        assert command in job
+    gate_asan = workflow_job(gate, "gate-sanitizers")
+    assert "make asan" in gate_asan
+    assert "continue-on-error" not in gate_asan
+    assert "TSan is a recurring executed advisory lane" in runbook
+    assert "Miri is a recurring executed advisory lane" in runbook
+    assert "not yet a recurring gate" not in runbook
+    assert "non-executed axis" not in runbook
+    assert (
+        "FFI,\n  syscall, socket, and subprocess paths remain outside Miri" in runbook
+    )
+
+
+def test_sanitizer_docs_match_recurring_workflow_contract() -> None:
+    nightly = NIGHTLY_SANITIZERS.read_text()
+    gate = RELEASE_GATE.read_text()
+    runbook = RUNBOOK.read_text()
+    assert_sanitizer_workflow_document_contract(nightly, gate, runbook)
+
+    mutations = (
+        (
+            nightly,
+            gate,
+            runbook.replace("Miri is a recurring", "Miri is not recurring", 1),
+        ),
+        (
+            nightly.replace("continue-on-error: true", "continue-on-error: false", 1),
+            gate,
+            runbook,
+        ),
+        (nightly, gate.replace("if make asan; then", "if true; then", 1), runbook),
+    )
+    for mutated in mutations:
+        try:
+            assert_sanitizer_workflow_document_contract(*mutated)
+        except AssertionError:
+            continue
+        raise AssertionError("a sanitizer workflow/document mutation escaped")
+
+
+def assert_candidate_publication_order(runbook: str) -> None:
+    phase = runbook[runbook.index("## Phase 5") : runbook.index("## Phase 6")]
+    clean_identity = 'test "$(git status --porcelain)" = ""'
+    candidate = "scripts/publish-release-image.sh candidate"
+    digest_inspection = "docker buildx imagetools inspect"
+    version_lock = "gh variable set PLAYGROUND_RELEASE_IMAGE_LOCK"
+    signed_tag = 'git tag -s "$release_tag" -m "Hew $release_tag"'
+    tag_push = 'git push origin "$release_tag"'
+    image_assertion = "scripts/assert-playground-release-image.sh"
+    publish = "scripts/publish-release-image.sh publish"
+    positions = [
+        phase.index(clean_identity),
+        phase.index(candidate),
+        phase.index(digest_inspection),
+        phase.index(version_lock),
+        phase.index(signed_tag),
+        phase.index(tag_push),
+        phase.index(image_assertion),
+        phase.index(publish),
+    ]
+    assert positions == sorted(positions)
+    assert phase.count(candidate) == 1
+    assert phase.count(publish) == 1
+    assert (
+        phase.count(
+            "env -u MAKEFLAGS -u MFLAGS -u MAKEOVERRIDES -u MAKEFILES -u GNUMAKEFLAGS"
+        )
+        == 1
+    )
+    assert 'HEW_EXAMPLES_REF="${HEW_RELEASE_SHA}"' in phase
+    assert "PLAYGROUND_PLATFORM=linux/amd64" in phase
+    assert "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground" in phase
+    assert (
+        "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground:v${VERSION}" not in phase
+    )
+    assert '--body "v${VERSION}@${PLAYGROUND_IMAGE_DIGEST}"' in phase
+    assert "version-scoped `PLAYGROUND_RELEASE_IMAGE_LOCK`" in phase
+    assert "raw manifest/index digest" in phase
+    assert "same exact clean\n   playground checkout" in phase
+    assert "Reconfirm the new digest and update the version-scoped\n   lock" in phase
+    assert "make release-candidate-publish" not in phase
+    assert "make release-publish" not in phase
+    assert "gh workflow run build.yml" not in phase
+    assert "mutable remote branch" in phase
+    assert "--body actions" not in phase
+
+
+def test_candidate_image_is_published_and_selected_before_tagging() -> None:
+    runbook = RUNBOOK.read_text()
+    assert_candidate_publication_order(runbook)
+
+    lock_line = "gh variable set PLAYGROUND_RELEASE_IMAGE_LOCK"
+    tag_line = 'git push origin "$release_tag"'
+    mutations = (
+        runbook.replace(
+            "scripts/publish-release-image.sh candidate",
+            "make release-candidate-publish",
+            1,
+        ),
+        runbook.replace(
+            "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground",
+            "PLAYGROUND_RELEASE_IMAGE=ghcr.io/hew-lang/playground:v${VERSION}",
+            1,
+        ),
+        runbook.replace(lock_line, "", 1).replace(
+            tag_line, f"{tag_line}\n   {lock_line}", 1
+        ),
+    )
+    for mutated in mutations:
+        try:
+            assert_candidate_publication_order(mutated)
+        except (AssertionError, ValueError):
+            continue
+        raise AssertionError("a candidate publication order/mode mutation escaped")
+
+
 def test_prerelease_validator_proves_external_staticlib_linking() -> None:
     validator = PRE_RELEASE_VALIDATOR.read_text()
     windows_build = WINDOWS_RELEASE_BUILD.read_text()
@@ -1265,8 +1529,8 @@ def test_freebsd_release_lanes_provision_bash_and_package_with_posix_sh() -> Non
     assert gate.count("git gmake bash pkgconf") == 2
     assert release.count("command -v bash") == 2
     assert gate.count("command -v bash") == 2
-    assert release.count("bash scripts/test-release-lib-link.sh") == 1
-    assert release.count("bash release-machinery/scripts/test-release-lib-link.sh") == 1
+    assert release.count("bash scripts/test-release-lib-link.sh") == 0
+    assert release.count("bash release-machinery/scripts/test-release-lib-link.sh") == 2
     # Gate: FreeBSD x86_64 only — the aarch64 gate leg is intentionally
     # scoped to build+smoke (coverage retained on freebsd-x86_64/linux-aarch64).
     assert gate.count("bash scripts/test-release-lib-link.sh") == 1
@@ -1467,18 +1731,28 @@ def test_sanitizer_gate_is_behavioral_and_release_scoped() -> None:
         "expires =",
     ):
         assert ledger.count(field) >= 2
+    assert "134 passed, 0 failed, 28 ignored, and 2274 filtered tests" in ledger
+    assert "2270 filtered" not in ledger
+    assert "https://github.com/hew-lang/hew/issues/1826" in ledger
+    assert "Issue #1826 is closed" in ledger
 
 
 def assert_release_record(
-    changelog: str, notes: str, runbook: str, *, notes_exist: bool = True
+    changelog: str,
+    notes: str,
+    runbook: str,
+    *,
+    version: str = WORKSPACE_VERSION,
+    notes_exist: bool = True,
 ) -> None:
     assert notes_exist
+    release_tag = f"v{version}"
     notes_words = " ".join(notes.split())
     runbook_words = " ".join(runbook.split())
 
     unreleased_start = changelog.index("## [Unreleased]")
     current_header = re.search(
-        rf"^## \[{re.escape(WORKSPACE_VERSION)}\] - \d{{4}}-\d{{2}}-\d{{2}}$",
+        rf"^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}$",
         changelog,
         re.MULTILINE,
     )
@@ -1486,7 +1760,7 @@ def assert_release_record(
     current_start = current_header.start()
     assert unreleased_start < current_start
     unreleased = changelog[unreleased_start:current_start]
-    assert WORKSPACE_VERSION not in unreleased
+    assert version not in unreleased
 
     next_release = changelog.find("\n## [", current_start + 1)
     current_record = (
@@ -1504,18 +1778,32 @@ def assert_release_record(
     ):
         assert provisional not in current_record.lower()
 
-    assert notes.startswith(f"# Hew {RELEASE_TAG}\n")
-    assert RELEASE_TAG in notes_words
-    if "-rc" in WORKSPACE_VERSION:
-        base_version = WORKSPACE_VERSION.split("-", 1)[0]
+    assert notes.startswith(f"# Hew {release_tag}\n")
+    assert release_tag in notes_words
+    if re.fullmatch(r"\d+\.\d+\.\d+-rc\d+", version):
+        base_version = version.split("-", 1)[0]
         assert f"release candidate for v{base_version}" in notes_words
         assert f"not the final v{base_version} release" in notes_words
-    assert "Publication for this RC is deliberately staged" in notes_words
-    assert (
-        "The signed tag publishes the platform assets and checksums first"
-        in notes_words
-    )
-    assert "npm publication is not inferred from the tag" in notes_words
+        assert "Publication for this RC is deliberately staged" in notes_words
+        assert (
+            "The signed tag publishes the platform assets and checksums first"
+            in notes_words
+        )
+        assert "npm publication is not inferred from the tag" in notes_words
+    else:
+        assert re.fullmatch(r"\d+\.\d+\.\d+", version)
+        assert "release candidate" not in notes_words.lower()
+        assert "Publication for this RC" not in notes_words
+        assert (
+            "Publication for this final release is complete only after" in notes_words
+        )
+        assert (
+            "The signed tag publishes the platform assets and checksums" in notes_words
+        )
+        assert (
+            "npm packages and the playground image are verified before live cutover"
+            in notes_words
+        )
     for pre_tag_only in (
         "tag and final changelog date remain intentionally unset",
         "This candidate does not claim",
@@ -1551,6 +1839,29 @@ def test_release_record_is_durable_and_tag_ready() -> None:
     )
 
 
+def test_rc2_notes_record_key_registration_and_raw_image_identity() -> None:
+    notes = RELEASE_NOTES.read_text()
+
+    def assert_rc2_authority(text: str) -> None:
+        assert "`hew key register`" in text
+        assert "`v<tag>@sha256:<raw-manifest-or-index-digest>`" in text
+        assert "hashes the raw registry response" in text
+        assert "exactly one\nrunnable `linux/amd64` image" in text
+        assert "exact\nHew candidate commit" in text
+
+    assert_rc2_authority(notes)
+    for old, new in (
+        ("`hew key register`", "key registration"),
+        ("raw registry response", "registry metadata"),
+        ("exactly one\nrunnable `linux/amd64` image", "a runnable image"),
+    ):
+        try:
+            assert_rc2_authority(notes.replace(old, new, 1))
+        except AssertionError:
+            continue
+        raise AssertionError("an rc2 authority mutation escaped")
+
+
 def test_release_record_rejects_missing_or_wrong_current_files() -> None:
     changelog = CHANGELOG.read_text()
     notes = RELEASE_NOTES.read_text()
@@ -1579,6 +1890,115 @@ def test_release_record_rejects_missing_or_wrong_current_files() -> None:
         except AssertionError:
             continue
         raise AssertionError("missing or wrong current release record escaped")
+
+
+def test_release_record_publication_prose_is_semver_stage_aware() -> None:
+    runbook = RUNBOOK.read_text()
+    changelog_template = """# Changelog
+
+## [Unreleased]
+
+## [{version}] - 2026-08-23
+
+### Fixed
+
+- Qualified the release.
+"""
+    rc_version = "0.6.0-rc9"
+    rc_notes = """# Hew v0.6.0-rc9
+
+Hew v0.6.0-rc9 is a release candidate for v0.6.0 and is not the final v0.6.0 release.
+Publication for this RC is deliberately staged. The signed tag publishes the
+platform assets and checksums first. npm publication is not inferred from the tag.
+"""
+    final_version = "0.6.0"
+    final_notes = """# Hew v0.6.0
+
+Publication for this final release is complete only after all follow-through is green.
+The signed tag publishes the platform assets and checksums. npm packages and the
+playground image are verified before live cutover.
+"""
+
+    assert_release_record(
+        changelog_template.format(version=rc_version),
+        rc_notes,
+        runbook,
+        version=rc_version,
+    )
+    assert_release_record(
+        changelog_template.format(version=final_version),
+        final_notes,
+        runbook,
+        version=final_version,
+    )
+
+    counterfactuals = (
+        (rc_version, final_notes.replace("v0.6.0", "v0.6.0-rc9", 1)),
+        (
+            final_version,
+            rc_notes.replace("v0.6.0-rc9", "v0.6.0", 1).replace(
+                "release candidate for v0.6.0 and is not the final v0.6.0 release.",
+                "",
+                1,
+            ),
+        ),
+    )
+    for version, notes in counterfactuals:
+        try:
+            assert_release_record(
+                changelog_template.format(version=version),
+                notes,
+                runbook,
+                version=version,
+            )
+        except AssertionError:
+            continue
+        raise AssertionError(
+            f"{version} accepted publication prose for the wrong stage"
+        )
+
+
+def assert_rc3_to_final_contract(notes: str, versioning: str) -> None:
+    notes_words = " ".join(notes.split())
+    for requirement in (
+        "ownership advisory corpus to zero",
+        "compiler pipeline crash",
+        "crash-cleanup frame protocol stages 1–3",
+        "nested enum and `Option` payloads",
+        "drain every other remaining `TODO.md` release item",
+        "zero-surprise walkthrough",
+        "fresh dogfood",
+        "full release qualification",
+        "publish and exercise rc3",
+        "defect-only fixes",
+        "Any accepted-set change after rc3 forces rc4",
+    ):
+        assert requirement in notes_words
+    assert (
+        "If a fix taken during promotion changes the accepted program set" in versioning
+    )
+    assert "promotion stops and a new candidate is cut" in versioning
+
+
+def test_rc3_to_final_release_boundary_is_complete() -> None:
+    notes = RELEASE_NOTES.read_text()
+    versioning = (ROOT / "docs" / "versioning.md").read_text()
+    assert_rc3_to_final_contract(notes, versioning)
+
+    mutations = (
+        notes.replace(
+            "change after rc3 forces rc4",
+            "change after rc3 may ship in final",
+            1,
+        ),
+        notes.replace("publish and exercise rc3", "tag rc3", 1),
+    )
+    for mutated in mutations:
+        try:
+            assert_rc3_to_final_contract(mutated, versioning)
+        except AssertionError:
+            continue
+        raise AssertionError("an incomplete rc3-to-final boundary escaped")
 
 
 def test_contract_oracle_runs_in_required_ci() -> None:
@@ -1693,6 +2113,99 @@ def workflow_steps(job: str) -> list[str]:
         ]
         for index, start in enumerate(starts)
     ]
+
+
+RELEASE_HELPER_REFERENCE = re.compile(
+    r"(?<![A-Za-z0-9_.-])(?P<path>(?:\./)?(?:release-machinery/)?"
+    r"scripts/[A-Za-z0-9_./-]+)"
+)
+
+
+def tag_checkout_jobs(text: str) -> dict[str, str]:
+    """Discover every job that checks out the immutable release tag."""
+    return {
+        name: job
+        for name, job in workflow_jobs_section(text).items()
+        if any(
+            "uses: actions/checkout@" in step and "ref: ${{ env.RELEASE_TAG }}" in step
+            for step in workflow_steps(job)
+        )
+    }
+
+
+def assert_tag_checkout_release_helpers_use_machinery(text: str) -> None:
+    """Bind all release helper execution to the workflow-ref checkout."""
+    tagged_jobs = tag_checkout_jobs(text)
+    assert tagged_jobs, "release workflow has no tag-checkout jobs"
+    helper_jobs = 0
+    for name, job in tagged_jobs.items():
+        references = list(RELEASE_HELPER_REFERENCE.finditer(job))
+        if not references:
+            continue
+        helper_jobs += 1
+        machinery_steps = [
+            step
+            for step in workflow_steps(job)
+            if "uses: actions/checkout@" in step
+            and "ref: ${{ github.sha }}" in step
+            and "path: release-machinery" in step
+        ]
+        assert len(machinery_steps) == 1, (
+            f"{name} executes release helpers without one release-machinery checkout"
+        )
+        machinery_position = job.index(machinery_steps[0])
+        for reference in references:
+            path = reference.group("path").removeprefix("./")
+            assert path.startswith("release-machinery/scripts/"), (
+                f"{name} executes a release helper from the tag checkout: {path}"
+            )
+            assert machinery_position < reference.start(), (
+                f"{name} executes {path} before copying release machinery"
+            )
+    assert helper_jobs, "release workflow has no helper-using tag-checkout jobs"
+
+
+def test_tag_checkout_release_helpers_use_workflow_ref_machinery() -> None:
+    assert_tag_checkout_release_helpers_use_machinery(workflow())
+
+
+def test_tag_checkout_release_helper_mutations_are_rejected() -> None:
+    text = workflow()
+    helper_jobs = {
+        name: job
+        for name, job in tag_checkout_jobs(text).items()
+        if RELEASE_HELPER_REFERENCE.search(job)
+    }
+    assert helper_jobs
+    first_job = next(iter(helper_jobs.values()))
+    machinery_step = next(
+        step
+        for step in workflow_steps(first_job)
+        if "ref: ${{ github.sha }}" in step and "path: release-machinery" in step
+    )
+    missing_copy = text.replace(machinery_step, "", 1)
+    direct_path = text.replace("release-machinery/scripts/", "scripts/", 1)
+    reordered_job = first_job.replace(machinery_step, "", 1) + machinery_step
+    copy_after_use = text.replace(first_job, reordered_job, 1)
+    undiscovered_job = (
+        text
+        + """
+  added-tag-builder:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+      - run: scripts/test-release-lib-link.sh
+"""
+    )
+
+    for mutation in (missing_copy, direct_path, copy_after_use, undiscovered_job):
+        try:
+            assert_tag_checkout_release_helpers_use_machinery(mutation)
+        except AssertionError:
+            continue
+        raise AssertionError("a tag-checkout release helper mutation escaped")
 
 
 def workflow_jobs_section(text: str) -> dict[str, str]:
@@ -2756,6 +3269,8 @@ def test_direct_runner_discovery_rejects_an_omitted_test() -> None:
         assert "test_omitted" in str(exc)
         return
     raise AssertionError("an omitted test escaped direct runner discovery parity")
+
+
 if __name__ == "__main__":
     failures = 0
     discovered = _discover_tests()

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -1839,21 +1839,21 @@ def test_release_record_is_durable_and_tag_ready() -> None:
     )
 
 
-def test_rc2_notes_record_key_registration_and_raw_image_identity() -> None:
+def test_rc2_notes_record_key_registration_and_versioned_image() -> None:
     notes = RELEASE_NOTES.read_text()
 
     def assert_rc2_authority(text: str) -> None:
         assert "`hew key register`" in text
-        assert "`v<tag>@sha256:<raw-manifest-or-index-digest>`" in text
-        assert "hashes the raw registry response" in text
-        assert "exactly one\nrunnable `linux/amd64` image" in text
-        assert "exact\nHew candidate commit" in text
+        assert "playground image is published and consumed as\n`v0.6.0-rc2`" in text
+        assert "registry digest as release\nevidence" in text
+        assert "Hosted Actions billing" not in text
+        assert "`v<tag>@sha256:<raw-manifest-or-index-digest>`" not in text
 
     assert_rc2_authority(notes)
     for old, new in (
         ("`hew key register`", "key registration"),
-        ("raw registry response", "registry metadata"),
-        ("exactly one\nrunnable `linux/amd64` image", "a runnable image"),
+        ("published and consumed", "available"),
+        ("registry digest as release\nevidence", "registry metadata"),
     ):
         try:
             assert_rc2_authority(notes.replace(old, new, 1))

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -36,7 +36,6 @@ CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 COVERAGE_NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "coverage-nightly.yml"
 DEPLOY_DOCS_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-docs.yml"
 WORKFLOW_DIRECTORY = ROOT / ".github" / "workflows"
-RELEASE_NOTES = ROOT / "docs" / "releases" / "v0.6.0-rc1.md"
 RUNBOOK = ROOT / "docs" / "release-runbook.md"
 CHANGELOG = ROOT / "CHANGELOG.md"
 UNIX_INSTALLER = ROOT / "installers" / "install.sh"
@@ -67,6 +66,20 @@ WINDOWS_LLVM_TOOLCHAIN_TAG = f"llvm-{WINDOWS_LLVM_TOOLCHAIN_VERSION}"
 WINDOWS_LLVM_TOOLCHAIN_ASSET = f"hew-llvm-{WINDOWS_LLVM_TOOLCHAIN_VERSION}.tar.gz"
 BINARYEN_SHA256 = "3dc677006555b355ea2da5e82602065a161d5e83eaefd3f759afa00b96e83212"
 PLAYGROUND_CONTRACT_REF = "21be84bb97436436b640f2acd09fb6dd2e0fbf94"
+
+
+def workspace_version() -> str:
+    manifest = tomllib.loads(WORKSPACE_MANIFEST.read_text())
+    version = manifest["workspace"]["package"]["version"]
+    assert isinstance(version, str) and re.fullmatch(
+        r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?", version
+    ), version
+    return version
+
+
+WORKSPACE_VERSION = workspace_version()
+RELEASE_TAG = f"v{WORKSPACE_VERSION}"
+RELEASE_NOTES = ROOT / "docs" / "releases" / f"{RELEASE_TAG}.md"
 
 
 def workflow() -> str:
@@ -1456,37 +1469,48 @@ def test_sanitizer_gate_is_behavioral_and_release_scoped() -> None:
         assert ledger.count(field) >= 2
 
 
-def test_release_record_is_durable_and_tag_ready() -> None:
-    changelog = CHANGELOG.read_text()
-    notes = RELEASE_NOTES.read_text()
-    runbook = RUNBOOK.read_text()
+def assert_release_record(
+    changelog: str, notes: str, runbook: str, *, notes_exist: bool = True
+) -> None:
+    assert notes_exist
     notes_words = " ".join(notes.split())
     runbook_words = " ".join(runbook.split())
 
     unreleased_start = changelog.index("## [Unreleased]")
-    rc1_start = changelog.index("## [0.6.0-rc1] - 2026-07-29")
-    unreleased = changelog[unreleased_start:rc1_start]
-    assert "### Changed" in unreleased
-    assert "- " in unreleased
-
-    next_release = changelog.find("\n## [", rc1_start + 1)
-    rc1_record = (
-        changelog[rc1_start:]
-        if next_release == -1
-        else changelog[rc1_start:next_release]
+    current_header = re.search(
+        rf"^## \[{re.escape(WORKSPACE_VERSION)}\] - \d{{4}}-\d{{2}}-\d{{2}}$",
+        changelog,
+        re.MULTILINE,
     )
+    assert current_header is not None
+    current_start = current_header.start()
+    assert unreleased_start < current_start
+    unreleased = changelog[unreleased_start:current_start]
+    assert WORKSPACE_VERSION not in unreleased
+
+    next_release = changelog.find("\n## [", current_start + 1)
+    current_record = (
+        changelog[current_start:]
+        if next_release == -1
+        else changelog[current_start:next_release]
+    )
+    assert "### " in current_record
+    assert "- " in current_record
     for provisional in (
         "unreleased",
         "tag is not cut",
         "will be finalized when",
         "in preparation",
     ):
-        assert provisional not in rc1_record.lower()
+        assert provisional not in current_record.lower()
 
-    assert "v0.6.0-rc1" in notes_words
-    assert "first release candidate for v0.6.0" in notes_words
-    assert "not the final v0.6.0 release" in notes_words
-    assert "Publication for this first RC is deliberately staged" in notes_words
+    assert notes.startswith(f"# Hew {RELEASE_TAG}\n")
+    assert RELEASE_TAG in notes_words
+    if "-rc" in WORKSPACE_VERSION:
+        base_version = WORKSPACE_VERSION.split("-", 1)[0]
+        assert f"release candidate for v{base_version}" in notes_words
+        assert f"not the final v{base_version} release" in notes_words
+    assert "Publication for this RC is deliberately staged" in notes_words
     assert (
         "The signed tag publishes the platform assets and checksums first"
         in notes_words
@@ -1502,8 +1526,11 @@ def test_release_record_is_durable_and_tag_ready() -> None:
         "CHANGELOG.md has either a populated `[Unreleased]` section or the dated "
         "`[X.Y.Z]` section for the intended release"
     ) in runbook_words
-    assert 'git tag -s v0.6.0-rc1 -m "Hew v0.6.0-rc1"' in runbook
-    assert "git push origin v0.6.0-rc1" in runbook
+    assert 'git tag -s "$release_tag" -m "Hew $release_tag"' in runbook
+    assert 'git push origin "$release_tag"' in runbook
+    assert "workspace.package.version" in runbook
+    assert "v0.6.0-rc1" not in runbook
+    assert "v0.4" not in runbook
     assert "git tag v0.4.0" not in runbook
     assert "git push origin v0.4.0" not in runbook
     assert "every release bar and the final-candidate checklist are green" in runbook
@@ -1512,6 +1539,46 @@ def test_release_record_is_durable_and_tag_ready() -> None:
     assert "Only after both independent publication arms are green" in runbook
     assert "Homebrew" in runbook and "prerelease" in runbook
     assert "publish-npm-packages.yml" in runbook
+
+
+def test_release_record_is_durable_and_tag_ready() -> None:
+    notes_exist = RELEASE_NOTES.exists()
+    assert_release_record(
+        CHANGELOG.read_text(),
+        RELEASE_NOTES.read_text() if notes_exist else "",
+        RUNBOOK.read_text(),
+        notes_exist=notes_exist,
+    )
+
+
+def test_release_record_rejects_missing_or_wrong_current_files() -> None:
+    changelog = CHANGELOG.read_text()
+    notes = RELEASE_NOTES.read_text()
+    runbook = RUNBOOK.read_text()
+    mutations = (
+        (changelog, notes, False),
+        (
+            changelog,
+            notes.replace(f"# Hew {RELEASE_TAG}", "# Hew v9.9.9", 1),
+            True,
+        ),
+        (
+            changelog.replace(f"## [{WORKSPACE_VERSION}]", "## [9.9.9]", 1),
+            notes,
+            True,
+        ),
+    )
+    for mutated_changelog, mutated_notes, notes_exist in mutations:
+        try:
+            assert_release_record(
+                mutated_changelog,
+                mutated_notes,
+                runbook,
+                notes_exist=notes_exist,
+            )
+        except AssertionError:
+            continue
+        raise AssertionError("missing or wrong current release record escaped")
 
 
 def test_contract_oracle_runs_in_required_ci() -> None:
@@ -2689,8 +2756,6 @@ def test_direct_runner_discovery_rejects_an_omitted_test() -> None:
         assert "test_omitted" in str(exc)
         return
     raise AssertionError("an omitted test escaped direct runner discovery parity")
-
-
 if __name__ == "__main__":
     failures = 0
     discovered = _discover_tests()

--- a/scripts/workspace-version.py
+++ b/scripts/workspace-version.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Print the repository workspace version from Cargo.toml."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+import toml_compat  # noqa: E402
+
+
+def main() -> int:
+    manifest_path = SCRIPT_DIR.parent / "Cargo.toml"
+    with manifest_path.open("rb") as manifest_file:
+        manifest = toml_compat.load(manifest_file)
+    version = manifest.get("workspace", {}).get("package", {}).get("version")
+    if (
+        not isinstance(version, str)
+        or re.fullmatch(
+            r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?", version
+        )
+        is None
+    ):
+        raise SystemExit(
+            f"{manifest_path}: workspace.package.version is missing or invalid"
+        )
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add the dated 2026-08-24 v0.6.0-rc2 changelog and curated release notes while preserving a fresh Unreleased section and the mandatory rc3 boundary
- derive the release-record contract from workspace.package.version and route every docs/releases/*.md file through it, with missing and wrong-version counterfactuals
- record rc2 TSan and Miri evidence, refresh the parser fuzz lock through Cargo, and align the runbook with the current package, docs, and seven-archive release flow
- preserve the pre-tag playground verification and release-workflow helper discovery while keeping public integration version-oriented at v0.6.0-rc2
- include the final #3015 ownership-diagnostic result (279 E_MIR_CHECK findings to zero) and #3014 dogfood compiler result (113 seconds to 12 seconds)

## Rebase and focused qualification

Rebased onto main 6ec58b7c819b86d74d4e4bdf4196249968fc435b after #3014. Exact signed candidate head: 8c44f88dba9076a6678ee2d74c9823b46613e90a.

- release workflow contract: 79/79
- pre-release validator: 32/32
- cargo output and target-dir contracts: 11/11 and 2/2
- preflight dispatcher and timeout counterfactuals: 162/162 and 13/13
- gate reachability: 74/74 self-tests and live A0-A12 green
- vertical compile routing counterfactuals: green
- rc2 sanitizer ledger validation: green
- parser fuzz manifest: cargo check --locked --offline green
- cargo fmt, shell lint, orchestration-leak checks, and diff check: green
- independent exact-range review: ACCEPT, no findings

The first hosted exact-head run identified one selector annotation: the changed parser fuzz lock had no declared gate input and fell back to comprehensive. The follow-up commit adds it to the existing release-workflow contract; focused dry-run now selects the release contract plus the two tree-wide scanners with no undeclared fallback. Independent incremental review: ACCEPT.

Broad and platform qualification is intentionally delegated to the hosted PR CI for this exact head; no duplicate comprehensive local preflight was run.

## Tracking note

The rc2 Miri row accurately points to #1826, which is closed after the curated lane was established. No replacement active issue was invented; if policy requires an active follow-up, it must be created separately by an authorized maintainer before changing that field.