### PR TITLE
fix(mir): balance returned projected string ownership

### DIFF
--- a/hew-cli/tests/returned_record_projected_string_payload.rs
+++ b/hew-cli/tests/returned_record_projected_string_payload.rs
@@ -79,6 +79,16 @@ fn source(detail: &str) -> String {
 }
 
 fn repeated_source(frames: usize) -> String {
+    repeated_source_with_alias(frames, false)
+}
+
+fn aliased_repeated_source(frames: usize) -> String {
+    repeated_source_with_alias(frames, true)
+}
+
+fn repeated_source_with_alias(frames: usize, alias: bool) -> String {
+    let alias_binding = if alias { "let alias = message;" } else { "" };
+    let second = if alias { "alias" } else { "message" };
     format!(
         r#"
 enum CleanupError {{
@@ -98,7 +108,8 @@ fn build() -> Result<Pair, string> {{
     match cleanup() {{
         .Ok(_) => Ok(Pair {{ first: "", second: "" }}),
         .Err(CleanupError.Dirty(message)) => {{
-            Ok(Pair {{ first: message, second: message }})
+            {alias_binding}
+            Ok(Pair {{ first: message, second: {second} }})
         }},
     }}
 }}
@@ -203,6 +214,15 @@ fn nested_payload_return_mints_only_the_missing_owner() {
         "two returned fields sharing one borrowed nested payload need exactly two owners:\n\
          {repeated_build}"
     );
+
+    let aliased_raw = dump_raw_mir(&aliased_repeated_source(1), "aliased_repeated_source");
+    let aliased_build = function_section(&aliased_raw, "build");
+    assert_eq!(
+        aliased_build.match_indices("string.retain").count(),
+        2,
+        "distinct locals in one projected-owner family still need exactly two returned owners:\n\
+         {aliased_build}"
+    );
 }
 
 #[test]
@@ -222,6 +242,20 @@ fn repeated_nested_payload_return_has_no_per_iteration_leak() {
     assert_frame_slope_below_tolerance_exact_lines(
         "repeated_returned_nested_string_payload",
         repeated_source,
+        |frames| frames,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the low/high leak-slope oracle requires macOS leaks(1)"
+)]
+#[test]
+fn aliased_repeated_nested_payload_return_has_no_per_iteration_leak() {
+    require_codegen();
+    assert_frame_slope_below_tolerance_exact_lines(
+        "aliased_repeated_returned_nested_string_payload",
+        aliased_repeated_source,
         |frames| frames,
     );
 }

--- a/hew-cli/tests/returned_record_projected_string_payload.rs
+++ b/hew-cli/tests/returned_record_projected_string_payload.rs
@@ -1,0 +1,162 @@
+//! Exact ownership oracle for a nested enum payload stored in a returned record.
+//!
+//! A nested-pattern binder is an alias of storage still owned by the matched
+//! call-result carrier. Returning that alias inside a record must mint one
+//! independent string owner before the carrier is dropped. The control puts an
+//! explicit `clone()` at that one boundary and therefore needs no implicit
+//! retain.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::process::Command;
+
+use support::leak_slope::compile_to_native;
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+const SOURCE_TEMPLATE: &str = r#"
+enum CleanupError {
+    Dirty(string);
+}
+
+type Retirement {
+    blocked: bool;
+    detail: string;
+}
+
+type Outcome {
+    status: string;
+}
+
+fn persist(value: string) {
+    if value.len() == 0 {
+        panic("empty");
+    }
+}
+
+fn cleanup() -> Result<(), CleanupError> {
+    Err(CleanupError.Dirty("dirty worktree " + f"{42}"))
+}
+
+fn retire() -> Result<Retirement, string> {
+    match cleanup() {
+        .Ok(_) => Ok(Retirement { blocked: false, detail: "" }),
+        .Err(CleanupError.Dirty(message)) => {
+            persist(message.clone());
+            Ok(Retirement { blocked: true, detail: __DETAIL__ })
+        },
+    }
+}
+
+fn lifecycle() -> Result<Outcome, string> {
+    let retirement = match retire() {
+        .Err(message) => return Err(message),
+        .Ok(value) => value,
+    };
+    Ok(Outcome {
+        status: if retirement.blocked { "blocked" } else { "merged" },
+    })
+}
+
+fn main() {
+    for _ in 0..64 {
+        match lifecycle() {
+            .Err(message) => panic(message),
+            .Ok(outcome) => {
+                if outcome.status != "blocked" {
+                    panic("wrong outcome");
+                }
+            },
+        }
+    }
+    println("ok");
+}
+"#;
+
+fn source(detail: &str) -> String {
+    SOURCE_TEMPLATE.replace("__DETAIL__", detail)
+}
+
+fn dump_raw_mir(source: &str, name: &str) -> String {
+    let dir = tempfile::Builder::new()
+        .prefix("returned-record-projected-string-mir-")
+        .tempdir()
+        .expect("tempdir");
+    let path = dir.path().join(format!("{name}.hew"));
+    std::fs::write(&path, source).expect("write Hew source");
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--dump-mir",
+            "raw",
+            path.to_str().expect("Hew source path is UTF-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile --dump-mir raw");
+    assert!(
+        output.status.success(),
+        "raw MIR dump failed for {name}:\n{}",
+        describe_output(&output)
+    );
+    String::from_utf8(output.stdout).expect("MIR dump is UTF-8")
+}
+
+fn function_section<'a>(dump: &'a str, name: &str) -> &'a str {
+    let marker = format!("fn {name}");
+    let start = dump
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing `{marker}` in MIR dump:\n{dump}"));
+    let tail = &dump[start..];
+    tail.find("\nfn ").map_or(tail, |next| &tail[..next])
+}
+
+fn compile_and_run(source: &str, name: &str) {
+    let dir = tempfile::Builder::new()
+        .prefix("returned-record-projected-string-run-")
+        .tempdir()
+        .expect("tempdir");
+    let binary = compile_to_native(source, dir.path(), name);
+    let output = Command::new(&binary)
+        .output()
+        .unwrap_or_else(|error| panic!("run {}: {error}", binary.display()));
+    assert!(
+        output.status.success(),
+        "{name} must release the carrier and returned record exactly once:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "ok\n");
+}
+
+#[test]
+fn nested_payload_return_mints_only_the_missing_owner() {
+    require_codegen();
+
+    let implicit = source("message");
+    let explicit_control = source("message.clone()");
+
+    let implicit_raw = dump_raw_mir(&implicit, "implicit_retain");
+    let implicit_retire = function_section(&implicit_raw, "retire");
+    assert_eq!(
+        implicit_retire.match_indices("string.retain").count(),
+        1,
+        "the borrowed nested payload needs exactly one owner for the returned record:\n\
+         {implicit_retire}"
+    );
+
+    let control_raw = dump_raw_mir(&explicit_control, "explicit_clone");
+    let control_retire = function_section(&control_raw, "retire");
+    assert_eq!(
+        control_retire.match_indices("string.retain").count(),
+        0,
+        "the explicit one-boundary clone already owns the returned field:\n{control_retire}"
+    );
+}
+
+#[test]
+fn nested_payload_return_and_explicit_clone_control_release_exactly_once() {
+    require_codegen();
+    compile_and_run(&source("message"), "implicit_retain");
+    compile_and_run(&source("message.clone()"), "explicit_clone");
+}

--- a/hew-cli/tests/returned_record_projected_string_payload.rs
+++ b/hew-cli/tests/returned_record_projected_string_payload.rs
@@ -131,6 +131,51 @@ fn main() {{
     )
 }
 
+fn overwritten_alias_source(frames: usize) -> String {
+    format!(
+        r#"
+enum CleanupError {{
+    Dirty(string);
+}}
+
+type Pair {{
+    first: string;
+    second: string;
+}}
+
+fn cleanup() -> Result<(), CleanupError> {{
+    Err(CleanupError.Dirty("dirty worktree " + f"{{42}}"))
+}}
+
+fn build(i: i64) -> Result<Pair, string> {{
+    match cleanup() {{
+        .Ok(_) => Ok(Pair {{ first: "", second: "" }}),
+        .Err(CleanupError.Dirty(message)) => {{
+            var current = message;
+            let alias = current;
+            current = "replacement " + f"{{i}}";
+            Ok(Pair {{ first: current, second: alias }})
+        }},
+    }}
+}}
+
+fn main() {{
+    for i in 0..{frames} {{
+        match build(i) {{
+            .Err(message) => panic(message),
+            .Ok(pair) => {{
+                if pair.first == pair.second {{
+                    panic("wrong generations");
+                }}
+            }},
+        }}
+        println("frame");
+    }}
+}}
+"#
+    )
+}
+
 fn dump_raw_mir(source: &str, name: &str) -> String {
     let dir = tempfile::Builder::new()
         .prefix("returned-record-projected-string-mir-")
@@ -223,6 +268,15 @@ fn nested_payload_return_mints_only_the_missing_owner() {
         "distinct locals in one projected-owner family still need exactly two returned owners:\n\
          {aliased_build}"
     );
+
+    let overwritten_raw = dump_raw_mir(&overwritten_alias_source(1), "overwritten_alias");
+    let overwritten_build = function_section(&overwritten_raw, "build");
+    assert_eq!(
+        overwritten_build.match_indices("string.retain").count(),
+        2,
+        "an overwritten binding must not join its replacement generation to a historical alias:\n\
+         {overwritten_build}"
+    );
 }
 
 #[test]
@@ -256,6 +310,20 @@ fn aliased_repeated_nested_payload_return_has_no_per_iteration_leak() {
     assert_frame_slope_below_tolerance_exact_lines(
         "aliased_repeated_returned_nested_string_payload",
         aliased_repeated_source,
+        |frames| frames,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the low/high leak-slope oracle requires macOS leaks(1)"
+)]
+#[test]
+fn overwritten_alias_generations_have_no_per_iteration_leak() {
+    require_codegen();
+    assert_frame_slope_below_tolerance_exact_lines(
+        "overwritten_returned_string_alias_generations",
+        overwritten_alias_source,
         |frames| frames,
     );
 }

--- a/hew-cli/tests/returned_record_projected_string_payload.rs
+++ b/hew-cli/tests/returned_record_projected_string_payload.rs
@@ -12,7 +12,9 @@ mod support;
 
 use std::process::Command;
 
-use support::leak_slope::{assert_frame_slope_below_tolerance_exact_lines, compile_to_native};
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance_exact_lines, compile_to_native, run_under_malloc_scribble,
+};
 use support::{describe_output, hew_binary, repo_root, require_codegen};
 
 const SOURCE_TEMPLATE: &str = r#"
@@ -273,6 +275,32 @@ fn main() {{
     )
 }
 
+fn reused_non_returned_alias_source(frames: usize) -> String {
+    format!(
+        r#"
+type Pair {{
+    first: string;
+    second: string;
+}}
+
+fn main() {{
+    let source = "reused fork " + f"{{42}}";
+    let alias = source;
+    for _ in 0..{frames} {{
+        let pair = Pair {{ first: source, second: alias }};
+        if pair.first != pair.second {{
+            panic("mismatch");
+        }}
+        println("frame");
+    }}
+    if source != alias {{
+        panic("source damaged");
+    }}
+}}
+"#
+    )
+}
+
 fn dump_raw_mir(source: &str, name: &str) -> String {
     let dir = tempfile::Builder::new()
         .prefix("returned-record-projected-string-mir-")
@@ -395,6 +423,18 @@ fn nested_payload_return_mints_only_the_missing_owner() {
         "the fresh replacement base owner and its retained fork are sufficient:\n\
          {before_fork_build}"
     );
+
+    let reused_raw = dump_raw_mir(
+        &reused_non_returned_alias_source(1),
+        "reused_non_returned_alias",
+    );
+    let reused_main = function_section(&reused_raw, "main");
+    assert_eq!(
+        reused_main.match_indices("string.retain").count(),
+        3,
+        "a non-returned Pair needs two aggregate retains in addition to the fork owner:\n\
+         {reused_main}"
+    );
 }
 
 #[test]
@@ -470,6 +510,45 @@ fn fresh_overwrite_before_fork_has_no_per_iteration_leak() {
     assert_frame_slope_below_tolerance_exact_lines(
         "fresh_overwrite_before_fork",
         overwritten_before_fork_source,
+        |frames| frames,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the poisoned allocator is a macOS ownership oracle"
+)]
+#[test]
+fn reused_non_returned_alias_is_clean_under_poisoned_allocator() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("reused-non-returned-alias-poison-")
+        .tempdir()
+        .expect("tempdir");
+    let binary = compile_to_native(
+        &reused_non_returned_alias_source(64),
+        dir.path(),
+        "reused_non_returned_alias_poison",
+    );
+    let output = run_under_malloc_scribble(&binary);
+    assert!(
+        output.status.success(),
+        "reused source and alias must survive each temporary Pair:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).lines().count(), 64);
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the low/high leak-slope oracle requires macOS leaks(1)"
+)]
+#[test]
+fn reused_non_returned_alias_has_no_per_iteration_leak() {
+    require_codegen();
+    assert_frame_slope_below_tolerance_exact_lines(
+        "reused_non_returned_alias",
+        reused_non_returned_alias_source,
         |frames| frames,
     );
 }

--- a/hew-cli/tests/returned_record_projected_string_payload.rs
+++ b/hew-cli/tests/returned_record_projected_string_payload.rs
@@ -12,7 +12,7 @@ mod support;
 
 use std::process::Command;
 
-use support::leak_slope::compile_to_native;
+use support::leak_slope::{assert_frame_slope_below_tolerance_exact_lines, compile_to_native};
 use support::{describe_output, hew_binary, repo_root, require_codegen};
 
 const SOURCE_TEMPLATE: &str = r#"
@@ -76,6 +76,48 @@ fn main() {
 
 fn source(detail: &str) -> String {
     SOURCE_TEMPLATE.replace("__DETAIL__", detail)
+}
+
+fn repeated_source(frames: usize) -> String {
+    format!(
+        r#"
+enum CleanupError {{
+    Dirty(string);
+}}
+
+type Pair {{
+    first: string;
+    second: string;
+}}
+
+fn cleanup() -> Result<(), CleanupError> {{
+    Err(CleanupError.Dirty("dirty worktree " + f"{{42}}"))
+}}
+
+fn build() -> Result<Pair, string> {{
+    match cleanup() {{
+        .Ok(_) => Ok(Pair {{ first: "", second: "" }}),
+        .Err(CleanupError.Dirty(message)) => {{
+            Ok(Pair {{ first: message, second: message }})
+        }},
+    }}
+}}
+
+fn main() {{
+    for _ in 0..{frames} {{
+        match build() {{
+            .Err(message) => panic(message),
+            .Ok(pair) => {{
+                if pair.first != pair.second {{
+                    panic("wrong pair");
+                }}
+            }},
+        }}
+        println("frame");
+    }}
+}}
+"#
+    )
 }
 
 fn dump_raw_mir(source: &str, name: &str) -> String {
@@ -152,6 +194,15 @@ fn nested_payload_return_mints_only_the_missing_owner() {
         0,
         "the explicit one-boundary clone already owns the returned field:\n{control_retire}"
     );
+
+    let repeated_raw = dump_raw_mir(&repeated_source(1), "repeated_source");
+    let repeated_build = function_section(&repeated_raw, "build");
+    assert_eq!(
+        repeated_build.match_indices("string.retain").count(),
+        2,
+        "two returned fields sharing one borrowed nested payload need exactly two owners:\n\
+         {repeated_build}"
+    );
 }
 
 #[test]
@@ -159,4 +210,18 @@ fn nested_payload_return_and_explicit_clone_control_release_exactly_once() {
     require_codegen();
     compile_and_run(&source("message"), "implicit_retain");
     compile_and_run(&source("message.clone()"), "explicit_clone");
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the low/high leak-slope oracle requires macOS leaks(1)"
+)]
+#[test]
+fn repeated_nested_payload_return_has_no_per_iteration_leak() {
+    require_codegen();
+    assert_frame_slope_below_tolerance_exact_lines(
+        "repeated_returned_nested_string_payload",
+        repeated_source,
+        |frames| frames,
+    );
 }

--- a/hew-cli/tests/returned_record_projected_string_payload.rs
+++ b/hew-cli/tests/returned_record_projected_string_payload.rs
@@ -176,6 +176,103 @@ fn main() {{
     )
 }
 
+fn stable_loop_alias_source(frames: usize) -> String {
+    format!(
+        r#"
+enum CleanupError {{
+    Dirty(string);
+}}
+
+type Pair {{
+    first: string;
+    second: string;
+}}
+
+fn persist(value: string) {{
+    if value.is_empty() {{
+        panic("empty");
+    }}
+}}
+
+fn cleanup() -> Result<(), CleanupError> {{
+    Err(CleanupError.Dirty("dirty worktree " + f"{{42}}"))
+}}
+
+fn build() -> Result<Pair, string> {{
+    match cleanup() {{
+        .Ok(_) => Ok(Pair {{ first: "", second: "" }}),
+        .Err(CleanupError.Dirty(message)) => {{
+            let alias = message;
+            for _ in 0..1 {{
+                persist(alias.clone());
+            }}
+            Ok(Pair {{ first: message, second: alias }})
+        }},
+    }}
+}}
+
+fn main() {{
+    for _ in 0..{frames} {{
+        match build() {{
+            .Err(message) => panic(message),
+            .Ok(pair) => {{
+                if pair.first != pair.second {{
+                    panic("wrong pair");
+                }}
+            }},
+        }}
+        println("frame");
+    }}
+}}
+"#
+    )
+}
+
+fn overwritten_before_fork_source(frames: usize) -> String {
+    format!(
+        r#"
+enum CleanupError {{
+    Dirty(string);
+}}
+
+type Pair {{
+    first: string;
+    second: string;
+}}
+
+fn cleanup() -> Result<(), CleanupError> {{
+    Err(CleanupError.Dirty("dirty worktree " + f"{{42}}"))
+}}
+
+fn build(i: i64) -> Result<Pair, string> {{
+    match cleanup() {{
+        .Ok(_) => Ok(Pair {{ first: "", second: "" }}),
+        .Err(CleanupError.Dirty(message)) => {{
+            var current = message;
+            current = "replacement " + f"{{i}}";
+            let alias = current;
+            Ok(Pair {{ first: current, second: alias }})
+        }},
+    }}
+}}
+
+fn main() {{
+    for i in 0..{frames} {{
+        match build(i) {{
+            .Err(message) => panic(message),
+            .Ok(pair) => {{
+                if pair.first != pair.second {{
+                    panic("wrong pair");
+                }}
+            }},
+        }}
+        println("frame");
+    }}
+}}
+"#
+    )
+}
+
 fn dump_raw_mir(source: &str, name: &str) -> String {
     let dir = tempfile::Builder::new()
         .prefix("returned-record-projected-string-mir-")
@@ -277,6 +374,27 @@ fn nested_payload_return_mints_only_the_missing_owner() {
         "an overwritten binding must not join its replacement generation to a historical alias:\n\
          {overwritten_build}"
     );
+
+    let looped_raw = dump_raw_mir(&stable_loop_alias_source(1), "stable_loop_alias");
+    let looped_build = function_section(&looped_raw, "build");
+    assert_eq!(
+        looped_build.match_indices("string.retain").count(),
+        2,
+        "a read-only loop preserves the forked generation and needs no extra owner:\n\
+         {looped_build}"
+    );
+
+    let before_fork_raw = dump_raw_mir(
+        &overwritten_before_fork_source(1),
+        "overwritten_before_fork",
+    );
+    let before_fork_build = function_section(&before_fork_raw, "build");
+    assert_eq!(
+        before_fork_build.match_indices("string.retain").count(),
+        2,
+        "the fresh replacement base owner and its retained fork are sufficient:\n\
+         {before_fork_build}"
+    );
 }
 
 #[test]
@@ -324,6 +442,34 @@ fn overwritten_alias_generations_have_no_per_iteration_leak() {
     assert_frame_slope_below_tolerance_exact_lines(
         "overwritten_returned_string_alias_generations",
         overwritten_alias_source,
+        |frames| frames,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the low/high leak-slope oracle requires macOS leaks(1)"
+)]
+#[test]
+fn stable_alias_across_read_only_loop_has_no_per_iteration_leak() {
+    require_codegen();
+    assert_frame_slope_below_tolerance_exact_lines(
+        "stable_alias_across_read_only_loop",
+        stable_loop_alias_source,
+        |frames| frames,
+    );
+}
+
+#[cfg_attr(
+    not(target_os = "macos"),
+    ignore = "the low/high leak-slope oracle requires macOS leaks(1)"
+)]
+#[test]
+fn fresh_overwrite_before_fork_has_no_per_iteration_leak() {
+    require_codegen();
+    assert_frame_slope_below_tolerance_exact_lines(
+        "fresh_overwrite_before_fork",
+        overwritten_before_fork_source,
         |frames| frames,
     );
 }

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -6271,12 +6271,38 @@ fn retain_nested_projected_returned_strings(
     index: &mut usize,
     builder: &mut Builder,
 ) {
+    let share_alias_edges: HashMap<Place, Vec<Place>> = builder
+        .string_local_share_sites
+        .values()
+        .filter_map(|(source, destination)| {
+            Some((
+                *builder.binding_locals.get(source)?,
+                *builder.binding_locals.get(destination)?,
+            ))
+        })
+        .fold(HashMap::new(), |mut edges, (source, destination)| {
+            edges.entry(source).or_default().push(destination);
+            edges
+        });
+    let returned_sources: HashSet<Place> = sources.iter().copied().collect();
     let mut retained = HashSet::new();
     for source in sources.iter().copied() {
+        let mut family = vec![source];
+        let mut seen = HashSet::from([source]);
+        let mut returned_share_descendant = false;
+        while let Some(member) = family.pop() {
+            for destination in share_alias_edges.get(&member).into_iter().flatten() {
+                if seen.insert(*destination) {
+                    returned_share_descendant |= returned_sources.contains(destination);
+                    family.push(*destination);
+                }
+            }
+        }
         if !retained.insert(source)
             || !nested_projected_strings.contains(&source)
             || share_reuse_exclusions.contains(&source)
             || already_neutralized.contains(&source)
+            || returned_share_descendant
         {
             continue;
         }
@@ -6478,8 +6504,11 @@ fn neutralize_returned_aggregate_member_sources(blocks: &mut [BasicBlock], build
             // this a SHARE handled by `finalize_string_ownership`. Retains are
             // once per distinct nested alias. `finalize_string_ownership`
             // supplies the ordinary N-1 shares when one source appears in N
-            // fields; this bridge retain supplies the otherwise-missing first
-            // returned owner because the carrier keeps the original.
+            // fields. A returned descendant in the same local-share family
+            // already has that family's retained fork owner, so it also
+            // suppresses the bridge. Otherwise this bridge retain supplies the
+            // missing first returned owner because the carrier keeps the
+            // original.
             retain_nested_projected_returned_strings(
                 block,
                 &sources,

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -6262,11 +6262,11 @@ fn nested_projected_returned_string_sources(
         .collect()
 }
 
-fn retained_string_share_owners_at_aggregate_sites(
+fn retained_string_share_edges(
     blocks: &[BasicBlock],
     builder: &Builder,
-) -> HashSet<(u32, Place, Place)> {
-    let retained_edges: Vec<(Place, Place)> = builder
+) -> Vec<(Place, Place, u32, usize)> {
+    builder
         .string_local_share_sites
         .iter()
         .filter_map(|(_site, (source_binding, destination_binding))| {
@@ -6303,10 +6303,19 @@ fn retained_string_share_owners_at_aggregate_sites(
                 }
                 _ => true,
             };
-            retained.then_some((source, destination))
+            let [(move_block, move_index)] = move_sites.as_slice() else {
+                return None;
+            };
+            retained.then_some((source, destination, *move_block, *move_index))
         })
-        .collect();
+        .collect()
+}
 
+fn retained_string_share_owners_at_aggregate_sites(
+    blocks: &[BasicBlock],
+    builder: &Builder,
+) -> HashSet<(u32, Place, Place)> {
+    let retained_edges = retained_string_share_edges(blocks, builder);
     let mut owners = HashSet::new();
     for block in blocks {
         for (index, instruction) in block.instructions.iter().enumerate() {
@@ -6318,21 +6327,48 @@ fn retained_string_share_owners_at_aggregate_sites(
                 ),
                 _ => continue,
             };
+            let mut owner_sources = HashSet::new();
+            let mut stable_links = HashMap::<Place, Vec<Place>>::new();
+            for (fork_source, fork_destination, move_block, move_index) in &retained_edges {
+                if !temp_drop::unique_move_generation_reaches_site(
+                    blocks,
+                    &builder.suspend_kinds,
+                    *fork_source,
+                    *fork_destination,
+                    block.id,
+                    index,
+                ) {
+                    continue;
+                }
+                owner_sources.insert(*fork_destination);
+                if temp_drop::local_generation_survives_to_site(
+                    blocks,
+                    &builder.suspend_kinds,
+                    *fork_source,
+                    *move_block,
+                    *move_index,
+                    block.id,
+                    index,
+                ) {
+                    stable_links
+                        .entry(*fork_source)
+                        .or_default()
+                        .push(*fork_destination);
+                }
+            }
             for source in sources {
-                if retained_edges
-                    .iter()
-                    .any(|(fork_source, fork_destination)| {
-                        *fork_destination == source
-                            && temp_drop::unique_move_generation_reaches_site(
-                                blocks,
-                                &builder.suspend_kinds,
-                                *fork_source,
-                                *fork_destination,
-                                block.id,
-                                index,
-                            )
-                    })
-                {
+                let mut family = vec![source];
+                let mut seen = HashSet::from([source]);
+                let mut has_owner = false;
+                while let Some(member) = family.pop() {
+                    has_owner |= owner_sources.contains(&member);
+                    for next in stable_links.get(&member).into_iter().flatten() {
+                        if seen.insert(*next) {
+                            family.push(*next);
+                        }
+                    }
+                }
+                if has_owner {
                     owners.insert((block.id, destination, source));
                 }
             }

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -6271,11 +6271,15 @@ fn retain_nested_projected_returned_strings(
     index: &mut usize,
     builder: &mut Builder,
 ) {
-    for source in sources.iter().copied().filter(|source| {
-        nested_projected_strings.contains(source)
-            && !share_reuse_exclusions.contains(source)
-            && !already_neutralized.contains(source)
-    }) {
+    let mut retained = HashSet::new();
+    for source in sources.iter().copied() {
+        if !retained.insert(source)
+            || !nested_projected_strings.contains(&source)
+            || share_reuse_exclusions.contains(&source)
+            || already_neutralized.contains(&source)
+        {
+            continue;
+        }
         shift_instr_spans_on_insert(
             &mut builder.instr_spans,
             block.id,
@@ -6472,8 +6476,10 @@ fn neutralize_returned_aggregate_member_sources(blocks: &mut [BasicBlock], build
             // local cannot neutralize. Mint the returned field's owner before
             // the byte-copying constructor, unless a later use already makes
             // this a SHARE handled by `finalize_string_ownership`. Retains are
-            // per field occurrence: two returned fields need two independent
-            // owner counts even when they read the same alias.
+            // once per distinct nested alias. `finalize_string_ownership`
+            // supplies the ordinary N-1 shares when one source appears in N
+            // fields; this bridge retain supplies the otherwise-missing first
+            // returned owner because the carrier keeps the original.
             retain_nested_projected_returned_strings(
                 block,
                 &sources,

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -6223,6 +6223,75 @@ fn returned_aggregate_member_source_targets(
         .collect()
 }
 
+/// String binders from an unneutralizable projected payload that flow into a
+/// returned aggregate.
+///
+/// A nested destructure first byte-copies its parent payload into a transient
+/// carrier, then byte-copies the leaf into the binder local. Neither local is
+/// the matched call result's owning slot, so clearing the binder after record
+/// construction cannot transfer the carrier's owner. The returned record must
+/// instead gain an independent `+1` before the carrier's recursive drop.
+///
+/// Keep this authority string-only: `CoW` strings have an explicit retain
+/// primitive. Other heap-owning projected payloads remain under the existing
+/// fail-closed transfer rules rather than acquiring an invented ownership
+/// protocol here.
+fn nested_projected_returned_string_sources(
+    candidates: &[(BindingId, String, ResolvedTy)],
+    returned_members: &HashSet<BindingId>,
+    builder: &Builder,
+) -> HashSet<Place> {
+    candidates
+        .iter()
+        .filter(|(binding, _name, ty)| {
+            returned_members.contains(binding) && matches!(ty, ResolvedTy::String)
+        })
+        .filter_map(|(binding, _name, _ty)| {
+            matches!(
+                builder
+                    .projected_payload_provenance
+                    .get(binding)
+                    .map(|provenance| &provenance.origin),
+                Some(ProjectedPayloadOrigin::Reject(
+                    ProjectedPayloadRejectReason::NestedDestructure
+                ))
+            )
+            .then(|| builder.binding_locals.get(binding).copied())
+            .flatten()
+        })
+        .collect()
+}
+
+fn retain_nested_projected_returned_strings(
+    block: &mut BasicBlock,
+    sources: &[Place],
+    nested_projected_strings: &HashSet<Place>,
+    share_reuse_exclusions: &HashSet<Place>,
+    already_neutralized: &HashSet<Place>,
+    index: &mut usize,
+    builder: &mut Builder,
+) {
+    for source in sources.iter().copied().filter(|source| {
+        nested_projected_strings.contains(source)
+            && !share_reuse_exclusions.contains(source)
+            && !already_neutralized.contains(source)
+    }) {
+        shift_instr_spans_on_insert(
+            &mut builder.instr_spans,
+            block.id,
+            u32::try_from(*index).unwrap_or(u32::MAX),
+        );
+        block.instructions.insert(
+            *index,
+            Instr::StringRetain {
+                value: source,
+                condition: StringRetainCondition::Always,
+            },
+        );
+        *index += 1;
+    }
+}
+
 fn aggregate_member_consumed_sources(blocks: &[BasicBlock]) -> HashSet<Place> {
     blocks
         .iter()
@@ -6320,23 +6389,8 @@ fn returned_member_share_reuse_exclusions(
     excluded
 }
 
-fn neutralize_returned_aggregate_member_sources(blocks: &mut [BasicBlock], builder: &mut Builder) {
-    let candidates = builder.owned_locals_exit_candidates();
-    let returned_members =
-        derive_returned_aggregate_member_bindings(blocks, &candidates, &builder.binding_locals);
-    if returned_members.is_empty() {
-        return;
-    }
-
-    let candidate_places =
-        returned_aggregate_member_source_targets(&candidates, &returned_members, builder);
-    let already_neutralized = aggregate_member_consumed_sources(blocks);
-
-    // Reverse the exact whole-value move graph from the return slot. A
-    // constructor qualifies only when its own destination is in this closure;
-    // another aggregate built from the same source in the same block cannot
-    // trigger an early neutralize.
-    let mut returned_value_locals: HashSet<u32> = blocks
+fn returned_aggregate_value_locals(blocks: &[BasicBlock]) -> HashSet<u32> {
+    let mut returned: HashSet<u32> = blocks
         .iter()
         .flat_map(|block| &block.instructions)
         .filter_map(|instr| match instr {
@@ -6353,16 +6407,37 @@ fn neutralize_returned_aggregate_member_sources(blocks: &mut [BasicBlock], build
             let Instr::Move { dest, src } = instr else {
                 continue;
             };
-            if base_local(*dest).is_some_and(|dest| returned_value_locals.contains(&dest)) {
+            if base_local(*dest).is_some_and(|dest| returned.contains(&dest)) {
                 if let Some(source) = base_local(*src) {
-                    changed |= returned_value_locals.insert(source);
+                    changed |= returned.insert(source);
                 }
             }
         }
         if !changed {
-            break;
+            return returned;
         }
     }
+}
+
+fn neutralize_returned_aggregate_member_sources(blocks: &mut [BasicBlock], builder: &mut Builder) {
+    let candidates = builder.owned_locals_exit_candidates();
+    let returned_members =
+        derive_returned_aggregate_member_bindings(blocks, &candidates, &builder.binding_locals);
+    if returned_members.is_empty() {
+        return;
+    }
+
+    let candidate_places =
+        returned_aggregate_member_source_targets(&candidates, &returned_members, builder);
+    let nested_projected_returned_strings =
+        nested_projected_returned_string_sources(&candidates, &returned_members, builder);
+    let already_neutralized = aggregate_member_consumed_sources(blocks);
+
+    // Reverse the exact whole-value move graph from the return slot. A
+    // constructor qualifies only when its own destination is in this closure;
+    // another aggregate built from the same source in the same block cannot
+    // trigger an early neutralize.
+    let returned_value_locals = returned_aggregate_value_locals(blocks);
 
     // A member source that is read after its aggregate construction is a
     // retained co-owner (a SHARE), not a transfer, and must keep its scope-exit
@@ -6392,6 +6467,22 @@ fn neutralize_returned_aggregate_member_sources(blocks: &mut [BasicBlock], build
                 index += 1;
                 continue;
             }
+
+            // A rejected projected string source aliases an owner that this
+            // local cannot neutralize. Mint the returned field's owner before
+            // the byte-copying constructor, unless a later use already makes
+            // this a SHARE handled by `finalize_string_ownership`. Retains are
+            // per field occurrence: two returned fields need two independent
+            // owner counts even when they read the same alias.
+            retain_nested_projected_returned_strings(
+                block,
+                &sources,
+                &nested_projected_returned_strings,
+                &share_reuse_exclusions,
+                &already_neutralized,
+                &mut index,
+                builder,
+            );
 
             let mut neutralized = HashSet::new();
             let sources: Vec<Place> = sources

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -6269,27 +6269,41 @@ fn retained_string_share_owners_at_aggregate_sites(
     let retained_edges: Vec<(Place, Place)> = builder
         .string_local_share_sites
         .iter()
-        .filter(|(site, (source, _destination))| {
-            blocks
-                .iter()
-                .flat_map(|block| &block.statements)
-                .any(|statement| {
-                    matches!(
-                        statement,
-                        MirStatement::Use {
-                            binding,
-                            site: use_site,
-                            intent: IntentKind::Read,
-                            ..
-                        } if binding == source && use_site == *site
-                    )
-                })
-        })
-        .filter_map(|(_site, (source, destination))| {
-            Some((
-                *builder.binding_locals.get(source)?,
-                *builder.binding_locals.get(destination)?,
-            ))
+        .filter_map(|(_site, (source_binding, destination_binding))| {
+            let source = *builder.binding_locals.get(source_binding)?;
+            let destination = *builder.binding_locals.get(destination_binding)?;
+            let move_sites: Vec<(u32, usize)> =
+                blocks
+                    .iter()
+                    .flat_map(|block| {
+                        block.instructions.iter().enumerate().filter_map(
+                            move |(index, instruction)| {
+                                matches!(
+                                    instruction,
+                                    Instr::Move { dest, src }
+                                        if *dest == destination && *src == source
+                                )
+                                .then_some((block.id, index))
+                            },
+                        )
+                    })
+                    .collect();
+            let retained = match move_sites.as_slice() {
+                [(block, index)] => {
+                    blocks.first().map(|entry| entry.id) != Some(*block)
+                        || base_local(source).is_some_and(|local| {
+                            local_is_used_after(
+                                blocks,
+                                &builder.suspend_kinds,
+                                local,
+                                *block,
+                                *index,
+                            )
+                        })
+                }
+                _ => true,
+            };
+            retained.then_some((source, destination))
         })
         .collect();
 

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -6262,47 +6262,95 @@ fn nested_projected_returned_string_sources(
         .collect()
 }
 
-fn retain_nested_projected_returned_strings(
-    block: &mut BasicBlock,
-    sources: &[Place],
-    nested_projected_strings: &HashSet<Place>,
-    share_reuse_exclusions: &HashSet<Place>,
-    already_neutralized: &HashSet<Place>,
-    index: &mut usize,
-    builder: &mut Builder,
-) {
-    let share_alias_edges: HashMap<Place, Vec<Place>> = builder
+fn retained_string_share_owners_at_aggregate_sites(
+    blocks: &[BasicBlock],
+    builder: &Builder,
+) -> HashSet<(u32, Place, Place)> {
+    let retained_edges: Vec<(Place, Place)> = builder
         .string_local_share_sites
-        .values()
-        .filter_map(|(source, destination)| {
+        .iter()
+        .filter(|(site, (source, _destination))| {
+            blocks
+                .iter()
+                .flat_map(|block| &block.statements)
+                .any(|statement| {
+                    matches!(
+                        statement,
+                        MirStatement::Use {
+                            binding,
+                            site: use_site,
+                            intent: IntentKind::Read,
+                            ..
+                        } if binding == source && use_site == *site
+                    )
+                })
+        })
+        .filter_map(|(_site, (source, destination))| {
             Some((
                 *builder.binding_locals.get(source)?,
                 *builder.binding_locals.get(destination)?,
             ))
         })
-        .fold(HashMap::new(), |mut edges, (source, destination)| {
-            edges.entry(source).or_default().push(destination);
-            edges
-        });
-    let returned_sources: HashSet<Place> = sources.iter().copied().collect();
-    let mut retained = HashSet::new();
-    for source in sources.iter().copied() {
-        let mut family = vec![source];
-        let mut seen = HashSet::from([source]);
-        let mut returned_share_descendant = false;
-        while let Some(member) = family.pop() {
-            for destination in share_alias_edges.get(&member).into_iter().flatten() {
-                if seen.insert(*destination) {
-                    returned_share_descendant |= returned_sources.contains(destination);
-                    family.push(*destination);
+        .collect();
+
+    let mut owners = HashSet::new();
+    for block in blocks {
+        for (index, instruction) in block.instructions.iter().enumerate() {
+            let (destination, sources): (Place, Vec<Place>) = match instruction {
+                Instr::TupleConstruct { elements, dest } => (*dest, elements.clone()),
+                Instr::RecordInit { fields, dest, .. } => (
+                    *dest,
+                    fields.iter().map(|(_offset, source)| *source).collect(),
+                ),
+                _ => continue,
+            };
+            for source in sources {
+                if retained_edges
+                    .iter()
+                    .any(|(fork_source, fork_destination)| {
+                        *fork_destination == source
+                            && temp_drop::unique_move_generation_reaches_site(
+                                blocks,
+                                &builder.suspend_kinds,
+                                *fork_source,
+                                *fork_destination,
+                                block.id,
+                                index,
+                            )
+                    })
+                {
+                    owners.insert((block.id, destination, source));
                 }
             }
         }
+    }
+    owners
+}
+
+struct ReturnedStringRetainProof<'a> {
+    nested_projected_strings: &'a HashSet<Place>,
+    share_reuse_exclusions: &'a HashSet<Place>,
+    already_neutralized: &'a HashSet<Place>,
+    retained_share_owners: &'a HashSet<(u32, Place, Place)>,
+}
+
+fn retain_nested_projected_returned_strings(
+    block: &mut BasicBlock,
+    destination: Place,
+    sources: &[Place],
+    proof: &ReturnedStringRetainProof<'_>,
+    index: &mut usize,
+    builder: &mut Builder,
+) {
+    let mut retained = HashSet::new();
+    for source in sources.iter().copied() {
         if !retained.insert(source)
-            || !nested_projected_strings.contains(&source)
-            || share_reuse_exclusions.contains(&source)
-            || already_neutralized.contains(&source)
-            || returned_share_descendant
+            || !proof.nested_projected_strings.contains(&source)
+            || proof.share_reuse_exclusions.contains(&source)
+            || proof.already_neutralized.contains(&source)
+            || proof
+                .retained_share_owners
+                .contains(&(block.id, destination, source))
         {
             continue;
         }
@@ -6474,6 +6522,13 @@ fn neutralize_returned_aggregate_member_sources(blocks: &mut [BasicBlock], build
     // release (see `returned_member_share_reuse_exclusions`).
     let share_reuse_exclusions =
         returned_member_share_reuse_exclusions(blocks, builder, &returned_value_locals);
+    let retained_share_owners = retained_string_share_owners_at_aggregate_sites(blocks, builder);
+    let retain_proof = ReturnedStringRetainProof {
+        nested_projected_strings: &nested_projected_returned_strings,
+        share_reuse_exclusions: &share_reuse_exclusions,
+        already_neutralized: &already_neutralized,
+        retained_share_owners: &retained_share_owners,
+    };
 
     for block in blocks {
         let mut index = 0;
@@ -6504,17 +6559,16 @@ fn neutralize_returned_aggregate_member_sources(blocks: &mut [BasicBlock], build
             // this a SHARE handled by `finalize_string_ownership`. Retains are
             // once per distinct nested alias. `finalize_string_ownership`
             // supplies the ordinary N-1 shares when one source appears in N
-            // fields. A returned descendant in the same local-share family
-            // already has that family's retained fork owner, so it also
-            // suppresses the bridge. Otherwise this bridge retain supplies the
-            // missing first returned owner because the carrier keeps the
-            // original.
+            // fields. A proven retained-share destination whose exact
+            // generation reaches this constructor already owns its fork, so
+            // it also suppresses the bridge. Otherwise this bridge retain
+            // supplies the missing first returned owner because the carrier
+            // keeps the original.
             retain_nested_projected_returned_strings(
                 block,
+                dest,
                 &sources,
-                &nested_projected_returned_strings,
-                &share_reuse_exclusions,
-                &already_neutralized,
+                &retain_proof,
                 &mut index,
                 builder,
             );

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -122,6 +122,29 @@ impl crate::return_provenance::LeafPolicy for ClosureStringReturnPolicy<'_> {
     }
 }
 
+pub(super) fn returned_aggregate_consumes_source(
+    block: &BasicBlock,
+    constructor_index: usize,
+    source: Place,
+    destination: Place,
+) -> bool {
+    block
+        .instructions
+        .iter()
+        .skip(constructor_index.saturating_add(1))
+        .take_while(|instruction| matches!(instruction, Instr::NeutralizePayloadSlot { .. }))
+        .any(|instruction| {
+            matches!(
+                instruction,
+                Instr::NeutralizePayloadSlot {
+                    place,
+                    transferee: Some(transferee),
+                    authority: crate::model::NeutralizeAuthority::ReturnedAggregateMemberConsume,
+                } if *place == source && *transferee == destination
+            )
+        })
+}
+
 impl Builder {
     /// Emit the handoff immediately. Correct wherever the destructure itself
     /// only runs on the path that selected the pattern (`if let` / `while let`

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -1,3 +1,4 @@
+use super::ownership::returned_aggregate_consumes_source;
 #[cfg(test)]
 use super::*;
 #[cfg(not(test))]
@@ -1770,29 +1771,6 @@ fn fresh_transferable_string_owner_reaches_site(
         target_index,
         &mut HashSet::new(),
     )
-}
-
-fn returned_aggregate_consumes_source(
-    block: &BasicBlock,
-    constructor_index: usize,
-    source: Place,
-    destination: Place,
-) -> bool {
-    block
-        .instructions
-        .iter()
-        .skip(constructor_index.saturating_add(1))
-        .take_while(|instruction| matches!(instruction, Instr::NeutralizePayloadSlot { .. }))
-        .any(|instruction| {
-            matches!(
-                instruction,
-                Instr::NeutralizePayloadSlot {
-                    place,
-                    transferee: Some(transferee),
-                    authority: crate::model::NeutralizeAuthority::ReturnedAggregateMemberConsume,
-                } if *place == source && *transferee == destination
-            )
-        })
 }
 
 fn remove_counted_string_retain_sites(

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -239,9 +239,6 @@ pub(super) fn local_generation_survives_to_site(
         if !reaches_target || !reached_from_definition {
             continue;
         }
-        if blocks_reachable_from(blocks, block.id).contains(&block.id) {
-            return false;
-        }
         let start = if block.id == definition_block {
             definition_index.saturating_add(1)
         } else {
@@ -1681,9 +1678,128 @@ fn stable_string_fork_families_at_site(
     (owner_destinations, stable_family)
 }
 
+struct FreshTransferableStringOwnerProof<'a> {
+    blocks: &'a [BasicBlock],
+    suspend_kinds: &'a HashMap<u32, SuspendKind>,
+    locals: &'a [ResolvedTy],
+    owned_string_return_carrier_symbols: &'a HashSet<String>,
+}
+
+fn fresh_transferable_string_owner_reaches_site(
+    blocks: &[BasicBlock],
+    suspend_kinds: &HashMap<u32, SuspendKind>,
+    locals: &[ResolvedTy],
+    owned_string_return_carrier_symbols: &HashSet<String>,
+    value: Place,
+    target_block: u32,
+    target_index: usize,
+) -> bool {
+    fn reaches(
+        proof: &FreshTransferableStringOwnerProof<'_>,
+        value: Place,
+        target_block: u32,
+        target_index: usize,
+        visiting: &mut HashSet<(Place, u32, usize)>,
+    ) -> bool {
+        let Place::Local(local) = value else {
+            return false;
+        };
+        if !visiting.insert((value, target_block, target_index)) {
+            return false;
+        }
+        let definitions: Vec<(u32, usize, &Instr)> = proof
+            .blocks
+            .iter()
+            .flat_map(|block| {
+                block
+                    .instructions
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(index, instruction)| {
+                        crate::dataflow::instr_reads_writes(instruction)
+                            .1
+                            .contains(&value)
+                            .then_some((block.id, index, instruction))
+                    })
+            })
+            .filter(|(block, index, _instruction)| {
+                local_generation_survives_to_site(
+                    proof.blocks,
+                    proof.suspend_kinds,
+                    value,
+                    *block,
+                    *index,
+                    target_block,
+                    target_index,
+                )
+            })
+            .collect();
+        let [(_block, _index, definition)] = definitions.as_slice() else {
+            return false;
+        };
+        let producer =
+            fresh_string_producer_dest(definition, proof.owned_string_return_carrier_symbols)
+                .or_else(|| string_field_load_producer_dest(definition, proof.locals))
+                .or_else(|| wire_codec_string_producer_dest(definition, proof.locals));
+        if producer == Some(value) {
+            return true;
+        }
+        let Instr::Move { dest, src } = definition else {
+            return false;
+        };
+        if *dest != Place::Local(local) {
+            return false;
+        }
+        let (definition_block, definition_index, _) = definitions[0];
+        reaches(proof, *src, definition_block, definition_index, visiting)
+    }
+
+    if base_local(value).is_none() {
+        return false;
+    }
+    let proof = FreshTransferableStringOwnerProof {
+        blocks,
+        suspend_kinds,
+        locals,
+        owned_string_return_carrier_symbols,
+    };
+    reaches(
+        &proof,
+        value,
+        target_block,
+        target_index,
+        &mut HashSet::new(),
+    )
+}
+
+fn returned_aggregate_consumes_source(
+    block: &BasicBlock,
+    constructor_index: usize,
+    source: Place,
+    destination: Place,
+) -> bool {
+    block
+        .instructions
+        .iter()
+        .skip(constructor_index.saturating_add(1))
+        .take_while(|instruction| matches!(instruction, Instr::NeutralizePayloadSlot { .. }))
+        .any(|instruction| {
+            matches!(
+                instruction,
+                Instr::NeutralizePayloadSlot {
+                    place,
+                    transferee: Some(transferee),
+                    authority: crate::model::NeutralizeAuthority::ReturnedAggregateMemberConsume,
+                } if *place == source && *transferee == destination
+            )
+        })
+}
+
 fn suppress_aggregate_retains_covered_by_stable_forks(
     blocks: &[BasicBlock],
     suspend_kinds: &HashMap<u32, SuspendKind>,
+    locals: &[ResolvedTy],
+    owned_string_return_carrier_symbols: &HashSet<String>,
     retain_sites: &mut Vec<StringRetainSite>,
 ) {
     let forks: Vec<(Place, Place, u32, usize)> = retain_sites
@@ -1702,11 +1818,12 @@ fn suppress_aggregate_retains_covered_by_stable_forks(
     let mut remove = HashMap::<(u32, usize, Place), usize>::new();
     for block in blocks {
         for (index, instruction) in block.instructions.iter().enumerate() {
-            let sources: Vec<Place> = match instruction {
-                Instr::TupleConstruct { elements, .. } => elements.clone(),
-                Instr::RecordInit { fields, .. } => {
-                    fields.iter().map(|(_offset, source)| *source).collect()
-                }
+            let (destination, sources): (Place, Vec<Place>) = match instruction {
+                Instr::TupleConstruct { elements, dest } => (*dest, elements.clone()),
+                Instr::RecordInit { fields, dest, .. } => (
+                    *dest,
+                    fields.iter().map(|(_offset, source)| *source).collect(),
+                ),
                 _ => continue,
             };
             let aggregate_sites: Vec<&StringRetainSite> = retain_sites
@@ -1743,7 +1860,22 @@ fn suppress_aggregate_retains_covered_by_stable_forks(
                     .iter()
                     .filter(|owner| family.contains(owner))
                     .count();
-                let required = occurrences.saturating_sub(preminted);
+                let transferable_base = family.iter().any(|member| {
+                    sources.contains(member)
+                        && returned_aggregate_consumes_source(block, index, *member, destination)
+                        && fresh_transferable_string_owner_reaches_site(
+                            blocks,
+                            suspend_kinds,
+                            locals,
+                            owned_string_return_carrier_symbols,
+                            *member,
+                            block.id,
+                            index,
+                        )
+                });
+                let required = occurrences
+                    .saturating_sub(preminted)
+                    .saturating_sub(usize::from(transferable_base));
                 let family_sites: Vec<&StringRetainSite> = aggregate_sites
                     .iter()
                     .copied()
@@ -5101,6 +5233,10 @@ pub(super) fn finalize_string_ownership(
     suppress_aggregate_retains_covered_by_stable_forks(
         &raw.blocks,
         &builder.suspend_kinds,
+        &builder.locals,
+        &builder
+            .call_scrutinee_provenance
+            .owned_string_return_carrier_symbols,
         &mut derivation.retain_sites,
     );
     apply_string_retain_sites(

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -1795,6 +1795,23 @@ fn returned_aggregate_consumes_source(
         })
 }
 
+fn remove_counted_string_retain_sites(
+    retain_sites: &mut Vec<StringRetainSite>,
+    mut remove: HashMap<(u32, usize, Place), usize>,
+) {
+    retain_sites.retain(|site| {
+        let key = (site.block, site.instr_index, site.value);
+        let Some(count) = remove.get_mut(&key) else {
+            return true;
+        };
+        if *count == 0 {
+            return true;
+        }
+        *count -= 1;
+        false
+    });
+}
+
 fn suppress_aggregate_retains_covered_by_stable_forks(
     blocks: &[BasicBlock],
     suspend_kinds: &HashMap<u32, SuspendKind>,
@@ -1858,7 +1875,16 @@ fn suppress_aggregate_retains_covered_by_stable_forks(
                     .count();
                 let preminted = owner_destinations
                     .iter()
-                    .filter(|owner| family.contains(owner))
+                    .filter(|owner| {
+                        family.contains(owner)
+                            && sources.contains(owner)
+                            && returned_aggregate_consumes_source(
+                                block,
+                                index,
+                                **owner,
+                                destination,
+                            )
+                    })
                     .count();
                 let transferable_base = family.iter().any(|member| {
                     sources.contains(member)
@@ -1889,17 +1915,7 @@ fn suppress_aggregate_retains_covered_by_stable_forks(
             }
         }
     }
-    retain_sites.retain(|site| {
-        let key = (site.block, site.instr_index, site.value);
-        let Some(count) = remove.get_mut(&key) else {
-            return true;
-        };
-        if *count == 0 {
-            return true;
-        }
-        *count -= 1;
-        false
-    });
+    remove_counted_string_retain_sites(retain_sites, remove);
 }
 /// Retain-aware drop derivation for heap-owning `string` bindings.
 ///

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -164,6 +164,29 @@ fn typed_handoff_owner_reaches_site(
     }
 }
 
+/// Prove that one exact local-to-local move's destination generation reaches a
+/// later site without any intervening read or write of that destination.
+///
+/// The caller supplies the already-classified ownership meaning of the move;
+/// this helper contributes only the generation-sensitive CFG proof.
+pub(super) fn unique_move_generation_reaches_site(
+    blocks: &[BasicBlock],
+    suspend_kinds: &HashMap<u32, SuspendKind>,
+    source: Place,
+    destination: Place,
+    target_block: u32,
+    target_instr_index: usize,
+) -> bool {
+    typed_handoff_owner_reaches_site(
+        blocks,
+        suspend_kinds,
+        &HashSet::from([(source, destination)]),
+        destination,
+        target_block,
+        target_instr_index,
+    )
+}
+
 /// Prove that a direct typed publication still carries the same generation at
 /// an aggregate ingress. Direct publications include ordinary call results and
 /// values initialized only on a suspend carrier's resume edge.

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -1643,6 +1643,132 @@ fn apply_string_retain_sites(
     }
     *instr_spans = new_spans;
 }
+
+fn stable_string_fork_families_at_site(
+    blocks: &[BasicBlock],
+    suspend_kinds: &HashMap<u32, SuspendKind>,
+    forks: &[(Place, Place, u32, usize)],
+    target_block: u32,
+    target_index: usize,
+) -> (HashSet<Place>, HashMap<Place, Vec<Place>>) {
+    let mut owner_destinations = HashSet::new();
+    let mut stable_family = HashMap::<Place, Vec<Place>>::new();
+    for (source, destination, move_block, move_index) in forks {
+        if !unique_move_generation_reaches_site(
+            blocks,
+            suspend_kinds,
+            *source,
+            *destination,
+            target_block,
+            target_index,
+        ) {
+            continue;
+        }
+        owner_destinations.insert(*destination);
+        if local_generation_survives_to_site(
+            blocks,
+            suspend_kinds,
+            *source,
+            *move_block,
+            *move_index,
+            target_block,
+            target_index,
+        ) {
+            stable_family.entry(*source).or_default().push(*destination);
+            stable_family.entry(*destination).or_default().push(*source);
+        }
+    }
+    (owner_destinations, stable_family)
+}
+
+fn suppress_aggregate_retains_covered_by_stable_forks(
+    blocks: &[BasicBlock],
+    suspend_kinds: &HashMap<u32, SuspendKind>,
+    retain_sites: &mut Vec<StringRetainSite>,
+) {
+    let forks: Vec<(Place, Place, u32, usize)> = retain_sites
+        .iter()
+        .filter(|site| matches!(site.condition, StringRetainCondition::Always))
+        .filter_map(|site| {
+            let instruction = block_by_id(blocks, site.block)?
+                .instructions
+                .get(site.instr_index)?;
+            let Instr::Move { dest, src } = instruction else {
+                return None;
+            };
+            (*src == site.value).then_some((*src, *dest, site.block, site.instr_index))
+        })
+        .collect();
+    let mut remove = HashMap::<(u32, usize, Place), usize>::new();
+    for block in blocks {
+        for (index, instruction) in block.instructions.iter().enumerate() {
+            let sources: Vec<Place> = match instruction {
+                Instr::TupleConstruct { elements, .. } => elements.clone(),
+                Instr::RecordInit { fields, .. } => {
+                    fields.iter().map(|(_offset, source)| *source).collect()
+                }
+                _ => continue,
+            };
+            let aggregate_sites: Vec<&StringRetainSite> = retain_sites
+                .iter()
+                .filter(|site| {
+                    site.block == block.id
+                        && site.instr_index == index
+                        && matches!(site.condition, StringRetainCondition::Always)
+                        && sources.contains(&site.value)
+                })
+                .collect();
+            let (owner_destinations, stable_family) =
+                stable_string_fork_families_at_site(blocks, suspend_kinds, &forks, block.id, index);
+            let mut processed = HashSet::new();
+            for site in &aggregate_sites {
+                if processed.contains(&site.value) {
+                    continue;
+                }
+                let mut family = HashSet::from([site.value]);
+                let mut work = vec![site.value];
+                while let Some(member) = work.pop() {
+                    for next in stable_family.get(&member).into_iter().flatten() {
+                        if family.insert(*next) {
+                            work.push(*next);
+                        }
+                    }
+                }
+                processed.extend(family.iter().copied());
+                let occurrences = sources
+                    .iter()
+                    .filter(|source| family.contains(source))
+                    .count();
+                let preminted = owner_destinations
+                    .iter()
+                    .filter(|owner| family.contains(owner))
+                    .count();
+                let required = occurrences.saturating_sub(preminted);
+                let family_sites: Vec<&StringRetainSite> = aggregate_sites
+                    .iter()
+                    .copied()
+                    .filter(|candidate| family.contains(&candidate.value))
+                    .collect();
+                for excess in family_sites.into_iter().skip(required) {
+                    *remove
+                        .entry((excess.block, excess.instr_index, excess.value))
+                        .or_default() += 1;
+                }
+            }
+        }
+    }
+    retain_sites.retain(|site| {
+        let key = (site.block, site.instr_index, site.value);
+        let Some(count) = remove.get_mut(&key) else {
+            return true;
+        };
+        if *count == 0 {
+            return true;
+        }
+        *count -= 1;
+        false
+    });
+}
 /// Retain-aware drop derivation for heap-owning `string` bindings.
 ///
 /// By-value calls borrow. A genuine co-owner mint (aggregate ingress,
@@ -4972,6 +5098,11 @@ pub(super) fn finalize_string_ownership(
             DischargeSite::BindingMoved,
         );
     }
+    suppress_aggregate_retains_covered_by_stable_forks(
+        &raw.blocks,
+        &builder.suspend_kinds,
+        &mut derivation.retain_sites,
+    );
     apply_string_retain_sites(
         &mut raw.blocks,
         &mut raw.instr_spans,

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -3,17 +3,17 @@ use super::*;
 #[cfg(not(test))]
 use super::{
     base_local, binder_read_is_borrow_safe_instr, binder_read_is_borrow_safe_terminator,
-    block_by_id, blocks_reachable_from, call_terminator_next, cow_value_leaf_drop_symbol, dataflow,
-    derive_local_bytes_drop_allowed, generator_yield_instr_escapes,
-    generator_yield_terminator_escapes, instr_source_places, local_is_used_after,
-    place_is_interior_projection, place_refs_local, propagate_whole_value_alias_roots,
-    propagate_whole_value_alias_roots_excluding_moves, shift_instr_spans_on_insert,
-    terminator_source_places, vec_iter_record_layout_key, ActorStateLoadMode, BTreeMap, BasicBlock,
-    BindingId, Builder, BytesDropDerivation, BytesRetainPlacement, BytesRetainSite,
-    ClosureEnvFieldOwnership, DischargeSite, Disposition, DropKind, ElabDrop, FieldOffset, HashMap,
-    HashSet, Instr, IntentKind, MirStatement, NestedDefSite, NestedUseSite, Place, RawMirFunction,
-    ResolvedTy, SelectArmKind, SiteId, StringDropDerivation, StringRetainCondition,
-    StringRetainSite, SuspendKind, Terminator,
+    block_by_id, block_dominators, blocks_reachable_from, call_terminator_next,
+    cow_value_leaf_drop_symbol, dataflow, derive_local_bytes_drop_allowed,
+    generator_yield_instr_escapes, generator_yield_terminator_escapes, instr_source_places,
+    local_is_used_after, place_is_interior_projection, place_refs_local,
+    propagate_whole_value_alias_roots, propagate_whole_value_alias_roots_excluding_moves,
+    shift_instr_spans_on_insert, terminator_source_places, vec_iter_record_layout_key,
+    ActorStateLoadMode, BTreeMap, BasicBlock, BindingId, Builder, BytesDropDerivation,
+    BytesRetainPlacement, BytesRetainSite, ClosureEnvFieldOwnership, DischargeSite, Disposition,
+    DropKind, ElabDrop, FieldOffset, HashMap, HashSet, Instr, IntentKind, MirStatement,
+    NestedDefSite, NestedUseSite, Place, RawMirFunction, ResolvedTy, SelectArmKind, SiteId,
+    StringDropDerivation, StringRetainCondition, StringRetainSite, SuspendKind, Terminator,
 };
 
 const STRING_RETURN_SOURCE_BORROWED: u8 = 0b001;
@@ -177,14 +177,106 @@ pub(super) fn unique_move_generation_reaches_site(
     target_block: u32,
     target_instr_index: usize,
 ) -> bool {
-    typed_handoff_owner_reaches_site(
+    let mut definitions = blocks.iter().flat_map(|block| {
+        block
+            .instructions
+            .iter()
+            .enumerate()
+            .filter_map(move |(index, instruction)| {
+                matches!(instruction, Instr::Move { dest, src }
+                    if *dest == destination && *src == source)
+                .then_some((block.id, index))
+            })
+    });
+    let Some((definition_block, definition_index)) = definitions.next() else {
+        return false;
+    };
+    if definitions.next().is_some() {
+        return false;
+    }
+    local_generation_survives_to_site(
         blocks,
         suspend_kinds,
-        &HashSet::from([(source, destination)]),
         destination,
+        definition_block,
+        definition_index,
         target_block,
         target_instr_index,
     )
+}
+
+/// Whether a local's generation after `definition_index` reaches `target`
+/// without an intervening write on any path that can reach the target.
+pub(super) fn local_generation_survives_to_site(
+    blocks: &[BasicBlock],
+    suspend_kinds: &HashMap<u32, SuspendKind>,
+    value: Place,
+    definition_block: u32,
+    definition_index: usize,
+    target_block: u32,
+    target_instr_index: usize,
+) -> bool {
+    let Some(local) = base_local(value) else {
+        return false;
+    };
+    let dominators = block_dominators(blocks);
+    if !dominators
+        .get(&target_block)
+        .is_some_and(|set| set.contains(&definition_block))
+    {
+        return false;
+    }
+    let reachable_from_definition = blocks_reachable_from(blocks, definition_block);
+    if definition_block != target_block && !reachable_from_definition.contains(&target_block) {
+        return false;
+    }
+
+    for block in blocks {
+        let reaches_target = block.id == target_block
+            || blocks_reachable_from(blocks, block.id).contains(&target_block);
+        let reached_from_definition =
+            block.id == definition_block || reachable_from_definition.contains(&block.id);
+        if !reaches_target || !reached_from_definition {
+            continue;
+        }
+        if blocks_reachable_from(blocks, block.id).contains(&block.id) {
+            return false;
+        }
+        let start = if block.id == definition_block {
+            definition_index.saturating_add(1)
+        } else {
+            0
+        };
+        let end = if block.id == target_block {
+            target_instr_index
+        } else {
+            block.instructions.len()
+        };
+        if start > end
+            || block.instructions[start..end].iter().any(|instruction| {
+                crate::dataflow::instr_reads_writes(instruction)
+                    .1
+                    .into_iter()
+                    .any(|place| base_local(place) == Some(local))
+            })
+        {
+            return false;
+        }
+        if block.id != target_block
+            && crate::dataflow::terminator_write_places(&block.terminator)
+                .into_iter()
+                .chain(
+                    suspend_kinds
+                        .get(&block.id)
+                        .into_iter()
+                        .flat_map(crate::dataflow::suspend_kind_write_places),
+                )
+                .any(|place| base_local(place) == Some(local))
+        {
+            return false;
+        }
+    }
+    true
 }
 
 /// Prove that a direct typed publication still carries the same generation at


### PR DESCRIPTION
## Summary

- retain nested projected string payloads when a returned record needs an independent owner
- account for repeated fields, retained aliases, overwrites, branches, and read-only loops by exact MIR generation
- credit existing owners only when an exact returned-aggregate consume transfers them into the constructor
- preserve required retains for non-returned aggregates whose source owners remain live

This fixes the rc2 double-release abort and the follow-on per-call over-retain cases found during dogfood review.

## Focused verification

- cargo test -p hew-cli --test returned_record_projected_string_payload -- --nocapture (9 passed)
- poisoned-allocator non-returned reuse control: clean
- all low/high 3/50 leak slopes: zero
- rebase range-diff: all nine reviewed commits patch-identical
- all nine commits signed

## Review provenance

The cumulative ownership delta received independent ACCEPT review before promotion. Five review rounds contributed falsifiers for repeated fields, aliases, overwritten generations, stable loops, fresh replacements, and non-returned reuse; all are now pinned by focused regression oracles.