### PR TITLE
feat(wire): serialize HashMap and HashSet

### DIFF
--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -2510,17 +2510,188 @@ fn primitive_value_layout_extern_name(rty: &ResolvedTy) -> Option<&'static str> 
 /// `*const HewMapKeyLayout` pointer cast, so the LLVM-side type does not need
 /// to match the Rust-side struct.
 fn declare_extern_layout_global<'ctx>(fn_ctx: &FnCtx<'_, 'ctx>, name: &str) -> PointerValue<'ctx> {
-    if let Some(g) = fn_ctx.llvm_mod.get_global(name) {
+    declare_wire_layout_global(fn_ctx.ctx, fn_ctx.llvm_mod, name)
+}
+
+/// Declare a runtime-owned collection layout global from a codegen path that
+/// does not have a per-function [`FnCtx`] (notably wire codec thunk emission).
+pub(crate) fn declare_wire_layout_global<'ctx>(
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    name: &str,
+) -> PointerValue<'ctx> {
+    if let Some(g) = llvm_mod.get_global(name) {
         return g.as_pointer_value();
     }
     // Use an opaque (i8) global type — the runtime owns the real shape and
     // the kernel pointer-casts on receipt. No initializer because the symbol
     // is resolved at link time against the runtime's `#[no_mangle]` static.
-    let i8_ty = fn_ctx.ctx.i8_type();
-    let g = fn_ctx.llvm_mod.add_global(i8_ty, None, name);
+    let i8_ty = ctx.i8_type();
+    let g = llvm_mod.add_global(i8_ty, None, name);
     g.set_linkage(Linkage::External);
     g.set_constant(true);
     g.as_pointer_value()
+}
+
+/// Resolve the runtime key descriptor used when a wire decoder reconstructs a
+/// `HashMap<K, _>` or `HashSet<K>`. Primitive key identity must use the exact
+/// same hash/equality/drop callbacks as ordinary collection construction.
+pub(crate) fn wire_map_key_layout_descriptor_ptr<'ctx>(
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    key_ty: &ResolvedTy,
+) -> CodegenResult<PointerValue<'ctx>> {
+    let name = primitive_key_layout_extern_name(key_ty).ok_or_else(|| {
+        CodegenError::FailClosed(format!(
+            "wire collection key `{key_ty:?}` has no standalone Hash+Eq layout; \
+             wire HashMap/HashSet keys currently require a primitive Hash type"
+        ))
+    })?;
+    Ok(declare_wire_layout_global(ctx, llvm_mod, name))
+}
+
+/// Resolve or emit the value descriptor used by a wire-decoded `HashMap`.
+/// This mirrors `hashmap_value_layout_descriptor_ptr`, but is callable from the
+/// module-level codec emitter, where no `FnCtx` exists.
+pub(crate) fn wire_map_value_layout_descriptor_ptr<'ctx>(
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    target_data: &TargetData,
+    regs: OwnedElemRegistries<'_, 'ctx>,
+    value_resolved_ty: &ResolvedTy,
+    value_llvm_ty: BasicTypeEnum<'ctx>,
+    requires_drop: bool,
+) -> CodegenResult<PointerValue<'ctx>> {
+    if let Some(name) = primitive_value_layout_extern_name(value_resolved_ty) {
+        return Ok(declare_wire_layout_global(ctx, llvm_mod, name));
+    }
+
+    let (size, align) = abi_size_align(value_llvm_ty, Some(target_data))?;
+    let Some((kind, key)) = crate::thunks::owned_elem_thunk_key(regs, value_resolved_ty) else {
+        if requires_drop {
+            return Err(CodegenError::FailClosed(format!(
+                "wire HashMap value `{value_resolved_ty:?}` carries a drop obligation but \
+                 has no resolvable map value clone/drop thunk"
+            )));
+        }
+        let global_name = format!("__hew_map_value_layout_{size}_{align}_plain");
+        if let Some(global) = llvm_mod.get_global(&global_name) {
+            return Ok(global.as_pointer_value());
+        }
+        let usize_ty = ctx.ptr_sized_int_type(target_data, None);
+        let i8_ty = ctx.i8_type();
+        let ptr_ty = ctx.ptr_type(AddressSpace::default());
+        let layout_ty = ctx.struct_type(
+            &[
+                usize_ty.into(),
+                usize_ty.into(),
+                i8_ty.into(),
+                ptr_ty.into(),
+                ptr_ty.into(),
+            ],
+            false,
+        );
+        let init = layout_ty.const_named_struct(&[
+            usize_ty.const_int(size, false).into(),
+            usize_ty.const_int(u64::from(align), false).into(),
+            i8_ty
+                .const_int(ownership_kind_byte(HewTypeOwnershipKind::Plain), false)
+                .into(),
+            ptr_ty.const_null().into(),
+            ptr_ty.const_null().into(),
+        ]);
+        let global = llvm_mod.add_global(layout_ty, None, &global_name);
+        global.set_constant(true);
+        global.set_linkage(Linkage::Private);
+        global.set_initializer(&init);
+        return Ok(global.as_pointer_value());
+    };
+
+    let kind_tag = match kind {
+        OwnedElemThunkKind::Record => "rec",
+        OwnedElemThunkKind::Enum => "enum",
+        OwnedElemThunkKind::Tuple => "tup",
+        OwnedElemThunkKind::PointerHandle => "handle",
+    };
+    let global_name = format!("__hew_map_value_layout_{kind_tag}_{key}_{size}_{align}_owned");
+    if let Some(global) = llvm_mod.get_global(&global_name) {
+        return Ok(global.as_pointer_value());
+    }
+    let (clone_fn, drop_fn) = match kind {
+        OwnedElemThunkKind::Record => (
+            get_or_declare_record_clone_inplace(ctx, llvm_mod, &key),
+            get_or_declare_record_drop_inplace(ctx, llvm_mod, &key),
+        ),
+        OwnedElemThunkKind::Enum => (
+            get_or_declare_enum_clone_inplace(ctx, llvm_mod, &key),
+            get_or_declare_enum_drop_inplace(ctx, llvm_mod, &key),
+        ),
+        OwnedElemThunkKind::Tuple => {
+            let ResolvedTy::Tuple(elems) = value_resolved_ty else {
+                return Err(CodegenError::FailClosed(format!(
+                    "wire HashMap value `{value_resolved_ty:?}` resolved to a tuple thunk"
+                )));
+            };
+            crate::thunks::emit_tuple_inplace_thunk_bodies(
+                ctx,
+                llvm_mod,
+                target_data,
+                regs,
+                &key,
+                elems,
+                value_llvm_ty,
+            )?;
+            (
+                get_or_declare_tuple_clone_inplace(ctx, llvm_mod, &key),
+                get_or_declare_tuple_drop_inplace(ctx, llvm_mod, &key),
+            )
+        }
+        OwnedElemThunkKind::PointerHandle => {
+            let (clone_sym, drop_sym) = collection_elem_clone_drop_syms(value_resolved_ty)
+                .ok_or_else(|| {
+                    CodegenError::FailClosed(format!(
+                        "wire HashMap collection value `{value_resolved_ty:?}` has no clone/free ABI"
+                    ))
+                })?;
+            crate::thunks::emit_collection_handle_thunk_bodies(
+                ctx, llvm_mod, &key, clone_sym, drop_sym,
+            )?;
+            (
+                get_or_declare_collection_clone_inplace(ctx, llvm_mod, &key),
+                get_or_declare_collection_drop_inplace(ctx, llvm_mod, &key),
+            )
+        }
+    };
+    let usize_ty = ctx.ptr_sized_int_type(target_data, None);
+    let i8_ty = ctx.i8_type();
+    let ptr_ty = ctx.ptr_type(AddressSpace::default());
+    let layout_ty = ctx.struct_type(
+        &[
+            usize_ty.into(),
+            usize_ty.into(),
+            i8_ty.into(),
+            ptr_ty.into(),
+            ptr_ty.into(),
+        ],
+        false,
+    );
+    let init = layout_ty.const_named_struct(&[
+        usize_ty.const_int(size, false).into(),
+        usize_ty.const_int(u64::from(align), false).into(),
+        i8_ty
+            .const_int(
+                ownership_kind_byte(HewTypeOwnershipKind::LayoutManaged),
+                false,
+            )
+            .into(),
+        drop_fn.as_global_value().as_pointer_value().into(),
+        clone_fn.as_global_value().as_pointer_value().into(),
+    ]);
+    let global = llvm_mod.add_global(layout_ty, None, &global_name);
+    global.set_constant(true);
+    global.set_linkage(Linkage::Private);
+    global.set_initializer(&init);
+    Ok(global.as_pointer_value())
 }
 
 /// Emit (or reuse) a `HewMapKeyLayout`-shaped private constant for `elem_ty`,

--- a/hew-codegen-rs/src/wire.rs
+++ b/hew-codegen-rs/src/wire.rs
@@ -39,9 +39,11 @@ use crate::llvm::*;
 // here. A module-init constructor registers each pair by its `msg_type`
 // discriminant so the receive path can find the decoder.
 //
-// Accepted subset == the `Serializable` floor the checker already enforces:
-// scalars, `string`, `bytes`, records (positional fields), enums (a tag + the
-// active variant's positional fields). Any other shape fails closed at codegen.
+// Accepted subset == the `Serializable` floor the checker enforces: scalars,
+// `string`, `bytes`, records, enums, supported Vec/Option shapes, HashMap with
+// primitive Hash+Eq keys, and HashSet with primitive Hash+Eq elements. Maps and
+// sets are reconstructed with their normal layout witnesses; unsupported
+// ownership/layout shapes fail closed instead of producing write-only data.
 
 /// Stable, symbol-safe key for a serializable message type, used as the
 /// `__hew_cbor_serialize_<key>` / `__hew_cbor_deserialize_<key>` suffix. Reuses
@@ -177,7 +179,33 @@ fn emit_de_drop_owned<'ctx>(
         // Named record: delegate to the codegen-emitted per-type in-place drop
         // helper (`__hew_record_drop_inplace_<name>`).  That helper walks the
         // struct's owned fields and drops them; null fields are safe.
-        ResolvedTy::Named { name, args, .. } => {
+        ResolvedTy::Named {
+            name,
+            args,
+            builtin,
+            ..
+        } => {
+            if let Some(symbol) = match builtin {
+                Some(BuiltinType::Vec) => Some("hew_vec_free"),
+                Some(BuiltinType::HashMap) => Some("hew_hashmap_free_layout"),
+                Some(BuiltinType::HashSet) => Some("hew_hashset_free_layout"),
+                _ => None,
+            } {
+                let handle = builder
+                    .build_load(ptr_ty, dst, "de_drop_collection_load")
+                    .llvm_ctx("de drop collection load")?
+                    .into_pointer_value();
+                let drop_fn = declare_codec_prim(
+                    ctx,
+                    llvm_mod,
+                    symbol,
+                    ctx.void_type().fn_type(&[ptr_ty.into()], false),
+                );
+                builder
+                    .build_call(drop_fn, &[handle.into()], "de_drop_collection")
+                    .llvm_ctx("de drop collection call")?;
+                return Ok(());
+            }
             let key = xnode_registry_key(name, args);
             if let Some(el) = enum_layouts.iter().find(|e| e.name == key) {
                 let drop_fn = get_or_declare_enum_drop_inplace(ctx, llvm_mod, &key);
@@ -534,6 +562,53 @@ fn emit_ser_value_cbor<'ctx>(
                     CodegenError::FailClosed("wire CBOR serialize: Vec<T> missing element".into())
                 })?;
                 emit_ser_vec_cbor(
+                    ctx,
+                    llvm_mod,
+                    builder,
+                    func,
+                    elem,
+                    value_ptr,
+                    buf,
+                    wire_layouts,
+                    record_layouts,
+                    machine_layouts,
+                    pipeline_records,
+                    enum_layouts,
+                    lifecycle_registry,
+                    target_data,
+                )
+            }
+            Some(BuiltinType::HashMap) => {
+                let [key, value] = args.as_slice() else {
+                    return Err(CodegenError::FailClosed(
+                        "wire CBOR serialize: HashMap<K, V> requires two type arguments".into(),
+                    ));
+                };
+                emit_ser_hashmap_cbor(
+                    ctx,
+                    llvm_mod,
+                    builder,
+                    func,
+                    key,
+                    value,
+                    value_ptr,
+                    buf,
+                    wire_layouts,
+                    record_layouts,
+                    machine_layouts,
+                    pipeline_records,
+                    enum_layouts,
+                    lifecycle_registry,
+                    target_data,
+                )
+            }
+            Some(BuiltinType::HashSet) => {
+                let elem = args.first().ok_or_else(|| {
+                    CodegenError::FailClosed(
+                        "wire CBOR serialize: HashSet<T> missing element".into(),
+                    )
+                })?;
+                emit_ser_hashset_cbor(
                     ctx,
                     llvm_mod,
                     builder,
@@ -973,6 +1048,53 @@ fn emit_de_value_cbor<'ctx>(
                     target_data,
                 )
             }
+            Some(BuiltinType::HashMap) => {
+                let [key, value] = args.as_slice() else {
+                    return Err(CodegenError::FailClosed(
+                        "wire CBOR deserialize: HashMap<K, V> requires two type arguments".into(),
+                    ));
+                };
+                emit_de_hashmap_cbor(
+                    ctx,
+                    llvm_mod,
+                    builder,
+                    func,
+                    key,
+                    value,
+                    dst,
+                    reader,
+                    wire_layouts,
+                    record_layouts,
+                    machine_layouts,
+                    pipeline_records,
+                    enum_layouts,
+                    lifecycle_registry,
+                    target_data,
+                )
+            }
+            Some(BuiltinType::HashSet) => {
+                let elem = args.first().ok_or_else(|| {
+                    CodegenError::FailClosed(
+                        "wire CBOR deserialize: HashSet<T> missing element".into(),
+                    )
+                })?;
+                emit_de_hashset_cbor(
+                    ctx,
+                    llvm_mod,
+                    builder,
+                    func,
+                    elem,
+                    dst,
+                    reader,
+                    wire_layouts,
+                    record_layouts,
+                    machine_layouts,
+                    pipeline_records,
+                    enum_layouts,
+                    lifecycle_registry,
+                    target_data,
+                )
+            }
             Some(BuiltinType::Option) => emit_de_option_cbor(
                 ctx,
                 llvm_mod,
@@ -1326,6 +1448,47 @@ fn build_text_descriptor_node(
                     },
                 );
                 format!(r#"{{"k":"vec","e":{elem}}}"#)
+            }
+            Some(BuiltinType::HashSet) => {
+                let elem = args.first().map_or_else(
+                    || r#"{"k":"opaque"}"#.to_string(),
+                    |e| {
+                        build_text_descriptor_node(
+                            e,
+                            format,
+                            wire_layouts,
+                            pipeline_records,
+                            enum_layouts,
+                            visiting,
+                        )
+                    },
+                );
+                format!(r#"{{"k":"set","e":{elem}}}"#)
+            }
+            Some(BuiltinType::HashMap) => {
+                let Some(key_ty) = args.first() else {
+                    return r#"{"k":"opaque"}"#.to_string();
+                };
+                let Some(value_ty) = args.get(1) else {
+                    return r#"{"k":"opaque"}"#.to_string();
+                };
+                let key = build_text_descriptor_node(
+                    key_ty,
+                    format,
+                    wire_layouts,
+                    pipeline_records,
+                    enum_layouts,
+                    visiting,
+                );
+                let value = build_text_descriptor_node(
+                    value_ty,
+                    format,
+                    wire_layouts,
+                    pipeline_records,
+                    enum_layouts,
+                    visiting,
+                );
+                format!(r#"{{"k":"map","key":{key},"value":{value}}}"#)
             }
             Some(BuiltinType::Option) => {
                 let elem = args.first().map_or_else(
@@ -1758,6 +1921,292 @@ fn codec_bitcopy_layout_descriptor_ptr<'ctx>(
     global.set_linkage(Linkage::Private);
     global.set_initializer(&init);
     Ok(global.as_pointer_value())
+}
+
+/// Encode a `HashMap<K, V>` as a deterministic CBOR map. The runtime iterator
+/// borrows slots, while the CBOR builder sorts fully encoded keys, so output is
+/// independent of hash-table capacity, insertion order, and slot placement.
+#[allow(clippy::too_many_arguments)]
+fn emit_ser_hashmap_cbor<'ctx>(
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    builder: &inkwell::builder::Builder<'ctx>,
+    func: FunctionValue<'ctx>,
+    key_ty: &ResolvedTy,
+    value_ty: &ResolvedTy,
+    value_ptr: PointerValue<'ctx>,
+    buf: PointerValue<'ctx>,
+    wire_layouts: &WireLayoutTable,
+    record_layouts: &RecordLayoutMap<'ctx>,
+    machine_layouts: &MachineLayoutMap<'ctx>,
+    pipeline_records: &[RecordLayout],
+    enum_layouts: &[EnumLayout],
+    lifecycle_registry: &hew_hir::LifecycleRegistry,
+    target_data: &TargetData,
+) -> CodegenResult<()> {
+    // Decode must be able to reconstruct the same key identity. Resolve this
+    // at encode emission too so unsupported keys fail at compile time in both
+    // directions, rather than producing write-only wire data.
+    crate::layout::wire_map_key_layout_descriptor_ptr(ctx, llvm_mod, key_ty)?;
+    let ptr_ty = ctx.ptr_type(AddressSpace::default());
+    let void_ty = ctx.void_type();
+    let map = builder
+        .build_load(ptr_ty, value_ptr, "cbor_ser_map_load")
+        .llvm_ctx("cbor ser hashmap load")?
+        .into_pointer_value();
+    let begin = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_ser_begin_map",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(begin, &[buf.into()], "cbor_ser_hashmap_begin")
+        .llvm_ctx("cbor ser hashmap begin")?;
+    let iter_new = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashmap_iter_new_layout",
+        ptr_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    let iter = builder
+        .build_call(iter_new, &[map.into()], "cbor_ser_hashmap_iter")
+        .llvm_ctx("cbor ser hashmap iter new")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hashmap iterator constructor void".into()))?
+        .into_pointer_value();
+    let key_slot = builder
+        .build_alloca(ptr_ty, "cbor_ser_hashmap_key_slot")
+        .llvm_ctx("cbor ser hashmap key slot")?;
+    let value_slot = builder
+        .build_alloca(ptr_ty, "cbor_ser_hashmap_value_slot")
+        .llvm_ctx("cbor ser hashmap value slot")?;
+    let head = ctx.append_basic_block(func, "cbor_ser_hashmap_head");
+    let body = ctx.append_basic_block(func, "cbor_ser_hashmap_body");
+    let done = ctx.append_basic_block(func, "cbor_ser_hashmap_done");
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor ser hashmap entry br")?;
+    builder.position_at_end(head);
+    let iter_next = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashmap_iter_next_layout",
+        ctx.bool_type()
+            .fn_type(&[ptr_ty.into(), ptr_ty.into(), ptr_ty.into()], false),
+    );
+    let has = builder
+        .build_call(
+            iter_next,
+            &[iter.into(), key_slot.into(), value_slot.into()],
+            "cbor_ser_hashmap_next",
+        )
+        .llvm_ctx("cbor ser hashmap iter next")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hashmap iterator next void".into()))?
+        .into_int_value();
+    builder
+        .build_conditional_branch(has, body, done)
+        .llvm_ctx("cbor ser hashmap loop br")?;
+    builder.position_at_end(body);
+    let key = builder
+        .build_load(ptr_ty, key_slot, "cbor_ser_hashmap_key")
+        .llvm_ctx("cbor ser hashmap key load")?
+        .into_pointer_value();
+    let value = builder
+        .build_load(ptr_ty, value_slot, "cbor_ser_hashmap_value")
+        .llvm_ctx("cbor ser hashmap value load")?
+        .into_pointer_value();
+    let begin_key = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_ser_begin_key",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(begin_key, &[buf.into()], "cbor_ser_hashmap_begin_key")
+        .llvm_ctx("cbor ser hashmap begin key")?;
+    emit_ser_value_cbor(
+        ctx,
+        llvm_mod,
+        builder,
+        func,
+        key_ty,
+        key,
+        buf,
+        wire_layouts,
+        record_layouts,
+        machine_layouts,
+        pipeline_records,
+        enum_layouts,
+        lifecycle_registry,
+        target_data,
+    )?;
+    emit_ser_value_cbor(
+        ctx,
+        llvm_mod,
+        builder,
+        func,
+        value_ty,
+        value,
+        buf,
+        wire_layouts,
+        record_layouts,
+        machine_layouts,
+        pipeline_records,
+        enum_layouts,
+        lifecycle_registry,
+        target_data,
+    )?;
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor ser hashmap body br")?;
+    builder.position_at_end(done);
+    let iter_free = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashmap_iter_free_layout",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(iter_free, &[iter.into()], "cbor_ser_hashmap_iter_free")
+        .llvm_ctx("cbor ser hashmap iter free")?;
+    let end = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_ser_end_map",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(end, &[buf.into()], "cbor_ser_hashmap_end")
+        .llvm_ctx("cbor ser hashmap end")?;
+    Ok(())
+}
+
+/// Encode a `HashSet<T>` as a canonically sorted CBOR array.
+#[allow(clippy::too_many_arguments)]
+fn emit_ser_hashset_cbor<'ctx>(
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    builder: &inkwell::builder::Builder<'ctx>,
+    func: FunctionValue<'ctx>,
+    elem_ty: &ResolvedTy,
+    value_ptr: PointerValue<'ctx>,
+    buf: PointerValue<'ctx>,
+    wire_layouts: &WireLayoutTable,
+    record_layouts: &RecordLayoutMap<'ctx>,
+    machine_layouts: &MachineLayoutMap<'ctx>,
+    pipeline_records: &[RecordLayout],
+    enum_layouts: &[EnumLayout],
+    lifecycle_registry: &hew_hir::LifecycleRegistry,
+    target_data: &TargetData,
+) -> CodegenResult<()> {
+    crate::layout::wire_map_key_layout_descriptor_ptr(ctx, llvm_mod, elem_ty)?;
+    let ptr_ty = ctx.ptr_type(AddressSpace::default());
+    let void_ty = ctx.void_type();
+    let set = builder
+        .build_load(ptr_ty, value_ptr, "cbor_ser_set_load")
+        .llvm_ctx("cbor ser hashset load")?
+        .into_pointer_value();
+    let begin = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_ser_begin_set",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(begin, &[buf.into()], "cbor_ser_hashset_begin")
+        .llvm_ctx("cbor ser hashset begin")?;
+    let iter_new = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashset_iter_new_layout",
+        ptr_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    let iter = builder
+        .build_call(iter_new, &[set.into()], "cbor_ser_hashset_iter")
+        .llvm_ctx("cbor ser hashset iter new")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hashset iterator constructor void".into()))?
+        .into_pointer_value();
+    let elem_slot = builder
+        .build_alloca(ptr_ty, "cbor_ser_hashset_elem_slot")
+        .llvm_ctx("cbor ser hashset elem slot")?;
+    let head = ctx.append_basic_block(func, "cbor_ser_hashset_head");
+    let body = ctx.append_basic_block(func, "cbor_ser_hashset_body");
+    let done = ctx.append_basic_block(func, "cbor_ser_hashset_done");
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor ser hashset entry br")?;
+    builder.position_at_end(head);
+    let iter_next = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashset_iter_next_layout",
+        ctx.bool_type()
+            .fn_type(&[ptr_ty.into(), ptr_ty.into()], false),
+    );
+    let has = builder
+        .build_call(
+            iter_next,
+            &[iter.into(), elem_slot.into()],
+            "cbor_ser_hashset_next",
+        )
+        .llvm_ctx("cbor ser hashset iter next")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hashset iterator next void".into()))?
+        .into_int_value();
+    builder
+        .build_conditional_branch(has, body, done)
+        .llvm_ctx("cbor ser hashset loop br")?;
+    builder.position_at_end(body);
+    let elem = builder
+        .build_load(ptr_ty, elem_slot, "cbor_ser_hashset_elem")
+        .llvm_ctx("cbor ser hashset elem load")?
+        .into_pointer_value();
+    emit_ser_value_cbor(
+        ctx,
+        llvm_mod,
+        builder,
+        func,
+        elem_ty,
+        elem,
+        buf,
+        wire_layouts,
+        record_layouts,
+        machine_layouts,
+        pipeline_records,
+        enum_layouts,
+        lifecycle_registry,
+        target_data,
+    )?;
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor ser hashset body br")?;
+    builder.position_at_end(done);
+    let iter_free = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashset_iter_free_layout",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(iter_free, &[iter.into()], "cbor_ser_hashset_iter_free")
+        .llvm_ctx("cbor ser hashset iter free")?;
+    let end = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_ser_end_array",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(end, &[buf.into()], "cbor_ser_hashset_end")
+        .llvm_ctx("cbor ser hashset end")?;
+    Ok(())
 }
 
 /// Encode a `Vec<T>` field as a CBOR array. Encode is uniform across element
@@ -2392,6 +2841,403 @@ fn emit_de_vec_cbor<'ctx>(
     builder
         .build_call(exit, &[reader.into()], "cbor_de_vec_exit")
         .llvm_ctx("cbor de vec exit")?;
+    Ok(())
+}
+
+/// Decode a CBOR map into a layout-backed `HashMap<K, V>`, moving each decoded
+/// key/value into the collection. Duplicate semantic keys fail closed.
+#[allow(clippy::too_many_arguments)]
+fn emit_de_hashmap_cbor<'ctx>(
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    builder: &inkwell::builder::Builder<'ctx>,
+    func: FunctionValue<'ctx>,
+    key_ty: &ResolvedTy,
+    value_ty: &ResolvedTy,
+    dst: PointerValue<'ctx>,
+    reader: PointerValue<'ctx>,
+    wire_layouts: &WireLayoutTable,
+    record_layouts: &RecordLayoutMap<'ctx>,
+    machine_layouts: &MachineLayoutMap<'ctx>,
+    pipeline_records: &[RecordLayout],
+    enum_layouts: &[EnumLayout],
+    lifecycle_registry: &hew_hir::LifecycleRegistry,
+    target_data: &TargetData,
+) -> CodegenResult<()> {
+    let ptr_ty = ctx.ptr_type(AddressSpace::default());
+    let void_ty = ctx.void_type();
+    let i32_ty = ctx.i32_type();
+    let key_layout = crate::layout::wire_map_key_layout_descriptor_ptr(ctx, llvm_mod, key_ty)?;
+    let key_llvm = resolve_ty(ctx, target_data, key_ty, record_layouts)?;
+    let value_llvm = resolve_ty(ctx, target_data, value_ty, record_layouts)?;
+    let value_obligation = hew_mir::ty_drop_obligation(
+        value_ty,
+        &CborHeapLayouts {
+            pipeline_records,
+            enum_layouts,
+        },
+        lifecycle_registry,
+    );
+    let regs = cbor_owned_elem_registries(
+        pipeline_records,
+        enum_layouts,
+        machine_layouts,
+        lifecycle_registry,
+    );
+    let value_layout = crate::layout::wire_map_value_layout_descriptor_ptr(
+        ctx,
+        llvm_mod,
+        target_data,
+        regs.registries(),
+        value_ty,
+        value_llvm,
+        value_obligation.carries_obligation(),
+    )?;
+    let new_map = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashmap_new_with_layout",
+        ptr_ty.fn_type(&[ptr_ty.into(), ptr_ty.into()], false),
+    );
+    let map = builder
+        .build_call(
+            new_map,
+            &[key_layout.into(), value_layout.into()],
+            "cbor_de_hashmap_new",
+        )
+        .llvm_ctx("cbor de hashmap new")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hashmap constructor void".into()))?
+        .into_pointer_value();
+    builder
+        .build_store(dst, map)
+        .llvm_ctx("cbor de hashmap store")?;
+    let key_temp = builder
+        .build_alloca(key_llvm, "cbor_de_hashmap_key")
+        .llvm_ctx("cbor de hashmap key alloca")?;
+    let value_temp = builder
+        .build_alloca(value_llvm, "cbor_de_hashmap_value")
+        .llvm_ctx("cbor de hashmap value alloca")?;
+    let enter = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_enter_map_iter",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(enter, &[reader.into()], "cbor_de_hashmap_enter")
+        .llvm_ctx("cbor de hashmap enter")?;
+    let head = ctx.append_basic_block(func, "cbor_de_hashmap_head");
+    let body = ctx.append_basic_block(func, "cbor_de_hashmap_body");
+    let inserted = ctx.append_basic_block(func, "cbor_de_hashmap_inserted");
+    let duplicate = ctx.append_basic_block(func, "cbor_de_hashmap_duplicate");
+    let done = ctx.append_basic_block(func, "cbor_de_hashmap_done");
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor de hashmap entry br")?;
+    builder.position_at_end(head);
+    let next = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_map_next",
+        i32_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    let has = builder
+        .build_call(next, &[reader.into()], "cbor_de_hashmap_next")
+        .llvm_ctx("cbor de hashmap next")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("map iterator decode next void".into()))?
+        .into_int_value();
+    let has_entry = builder
+        .build_int_compare(
+            IntPredicate::NE,
+            has,
+            i32_ty.const_zero(),
+            "cbor_de_hashmap_has",
+        )
+        .llvm_ctx("cbor de hashmap has")?;
+    builder
+        .build_conditional_branch(has_entry, body, done)
+        .llvm_ctx("cbor de hashmap loop br")?;
+    builder.position_at_end(body);
+    builder
+        .build_store(key_temp, key_llvm.const_zero())
+        .llvm_ctx("cbor de hashmap key zero")?;
+    builder
+        .build_store(value_temp, value_llvm.const_zero())
+        .llvm_ctx("cbor de hashmap value zero")?;
+    emit_de_value_cbor(
+        ctx,
+        llvm_mod,
+        builder,
+        func,
+        key_ty,
+        key_temp,
+        reader,
+        wire_layouts,
+        record_layouts,
+        machine_layouts,
+        pipeline_records,
+        enum_layouts,
+        lifecycle_registry,
+        target_data,
+    )?;
+    let stage_value = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_map_value",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(stage_value, &[reader.into()], "cbor_de_hashmap_stage_value")
+        .llvm_ctx("cbor de hashmap stage value")?;
+    emit_de_value_cbor(
+        ctx,
+        llvm_mod,
+        builder,
+        func,
+        value_ty,
+        value_temp,
+        reader,
+        wire_layouts,
+        record_layouts,
+        machine_layouts,
+        pipeline_records,
+        enum_layouts,
+        lifecycle_registry,
+        target_data,
+    )?;
+    let insert = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashmap_insert_layout",
+        ctx.bool_type()
+            .fn_type(&[ptr_ty.into(), ptr_ty.into(), ptr_ty.into()], false),
+    );
+    let was_inserted = builder
+        .build_call(
+            insert,
+            &[map.into(), key_temp.into(), value_temp.into()],
+            "cbor_de_hashmap_insert",
+        )
+        .llvm_ctx("cbor de hashmap insert")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hashmap insert void".into()))?
+        .into_int_value();
+    builder
+        .build_conditional_branch(was_inserted, inserted, duplicate)
+        .llvm_ctx("cbor de hashmap insert br")?;
+    builder.position_at_end(inserted);
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor de hashmap inserted br")?;
+    builder.position_at_end(duplicate);
+    emit_de_drop_owned(
+        ctx,
+        llvm_mod,
+        builder,
+        key_ty,
+        key_temp,
+        record_layouts,
+        machine_layouts,
+        enum_layouts,
+    )?;
+    // `hew_hashmap_insert_layout` always MOVES the incoming value into the map:
+    // on a duplicate key it drops the old stored value and replaces it with the
+    // new one. Only the duplicate incoming key remains caller-owned. The
+    // enclosing failure cleanup frees the map and therefore drops `value_temp`
+    // exactly once from its new slot; dropping it here would double-free/UAF.
+    let fail = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_fail",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(fail, &[reader.into()], "cbor_de_hashmap_duplicate_fail")
+        .llvm_ctx("cbor de hashmap duplicate fail")?;
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor de hashmap duplicate br")?;
+    builder.position_at_end(done);
+    let exit = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_exit_map_iter",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(exit, &[reader.into()], "cbor_de_hashmap_exit")
+        .llvm_ctx("cbor de hashmap exit")?;
+    Ok(())
+}
+
+/// Decode a CBOR array into a layout-backed `HashSet<T>`. Duplicate semantic
+/// elements are malformed input rather than silently discarded.
+#[allow(clippy::too_many_arguments)]
+fn emit_de_hashset_cbor<'ctx>(
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    builder: &inkwell::builder::Builder<'ctx>,
+    func: FunctionValue<'ctx>,
+    elem_ty: &ResolvedTy,
+    dst: PointerValue<'ctx>,
+    reader: PointerValue<'ctx>,
+    wire_layouts: &WireLayoutTable,
+    record_layouts: &RecordLayoutMap<'ctx>,
+    machine_layouts: &MachineLayoutMap<'ctx>,
+    pipeline_records: &[RecordLayout],
+    enum_layouts: &[EnumLayout],
+    lifecycle_registry: &hew_hir::LifecycleRegistry,
+    target_data: &TargetData,
+) -> CodegenResult<()> {
+    let ptr_ty = ctx.ptr_type(AddressSpace::default());
+    let void_ty = ctx.void_type();
+    let i32_ty = ctx.i32_type();
+    let elem_layout = crate::layout::wire_map_key_layout_descriptor_ptr(ctx, llvm_mod, elem_ty)?;
+    let elem_llvm = resolve_ty(ctx, target_data, elem_ty, record_layouts)?;
+    let new_set = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashset_new_with_layout",
+        ptr_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    let set = builder
+        .build_call(new_set, &[elem_layout.into()], "cbor_de_hashset_new")
+        .llvm_ctx("cbor de hashset new")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hashset constructor void".into()))?
+        .into_pointer_value();
+    builder
+        .build_store(dst, set)
+        .llvm_ctx("cbor de hashset store")?;
+    let elem_temp = builder
+        .build_alloca(elem_llvm, "cbor_de_hashset_elem")
+        .llvm_ctx("cbor de hashset elem alloca")?;
+    let enter = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_enter_array",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(enter, &[reader.into()], "cbor_de_hashset_enter")
+        .llvm_ctx("cbor de hashset enter")?;
+    let head = ctx.append_basic_block(func, "cbor_de_hashset_head");
+    let body = ctx.append_basic_block(func, "cbor_de_hashset_body");
+    let inserted = ctx.append_basic_block(func, "cbor_de_hashset_inserted");
+    let duplicate = ctx.append_basic_block(func, "cbor_de_hashset_duplicate");
+    let done = ctx.append_basic_block(func, "cbor_de_hashset_done");
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor de hashset entry br")?;
+    builder.position_at_end(head);
+    let next = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_array_next",
+        i32_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    let has = builder
+        .build_call(next, &[reader.into()], "cbor_de_hashset_next")
+        .llvm_ctx("cbor de hashset next")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("array decode next void".into()))?
+        .into_int_value();
+    let has_elem = builder
+        .build_int_compare(
+            IntPredicate::NE,
+            has,
+            i32_ty.const_zero(),
+            "cbor_de_hashset_has",
+        )
+        .llvm_ctx("cbor de hashset has")?;
+    builder
+        .build_conditional_branch(has_elem, body, done)
+        .llvm_ctx("cbor de hashset loop br")?;
+    builder.position_at_end(body);
+    builder
+        .build_store(elem_temp, elem_llvm.const_zero())
+        .llvm_ctx("cbor de hashset elem zero")?;
+    emit_de_value_cbor(
+        ctx,
+        llvm_mod,
+        builder,
+        func,
+        elem_ty,
+        elem_temp,
+        reader,
+        wire_layouts,
+        record_layouts,
+        machine_layouts,
+        pipeline_records,
+        enum_layouts,
+        lifecycle_registry,
+        target_data,
+    )?;
+    let insert = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_hashset_insert_layout",
+        ctx.bool_type()
+            .fn_type(&[ptr_ty.into(), ptr_ty.into()], false),
+    );
+    let was_inserted = builder
+        .build_call(
+            insert,
+            &[set.into(), elem_temp.into()],
+            "cbor_de_hashset_insert",
+        )
+        .llvm_ctx("cbor de hashset insert")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hashset insert void".into()))?
+        .into_int_value();
+    builder
+        .build_conditional_branch(was_inserted, inserted, duplicate)
+        .llvm_ctx("cbor de hashset insert br")?;
+    builder.position_at_end(inserted);
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor de hashset inserted br")?;
+    builder.position_at_end(duplicate);
+    emit_de_drop_owned(
+        ctx,
+        llvm_mod,
+        builder,
+        elem_ty,
+        elem_temp,
+        record_layouts,
+        machine_layouts,
+        enum_layouts,
+    )?;
+    let fail = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_fail",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(fail, &[reader.into()], "cbor_de_hashset_duplicate_fail")
+        .llvm_ctx("cbor de hashset duplicate fail")?;
+    builder
+        .build_unconditional_branch(head)
+        .llvm_ctx("cbor de hashset duplicate br")?;
+    builder.position_at_end(done);
+    let exit = declare_codec_prim(
+        ctx,
+        llvm_mod,
+        "hew_cbor_de_exit_array",
+        void_ty.fn_type(&[ptr_ty.into()], false),
+    );
+    builder
+        .build_call(exit, &[reader.into()], "cbor_de_hashset_exit")
+        .llvm_ctx("cbor de hashset exit")?;
     Ok(())
 }
 

--- a/hew-runtime/src/cbor_serial.rs
+++ b/hew-runtime/src/cbor_serial.rs
@@ -45,7 +45,7 @@
 //! delivers a partial or fabricated value.
 
 use core::ffi::{c_char, c_void};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Cursor;
 
 use ciborium::value::{Integer, Value};
@@ -56,15 +56,18 @@ use hew_cabi::cabi::malloc_cstring;
 /// One open container on the encoder stack.
 #[derive(Debug)]
 enum SerFrame {
-    /// A CBOR map under construction. `pending_key` is the integer key set by
-    /// the most recent `hew_cbor_ser_key_u64`, awaiting its value; it persists
-    /// while a child container is built on top of this frame.
+    /// A CBOR map under construction. `pending_key` awaits its value;
+    /// `accepting_key` allows an arbitrary recursively-encoded collection key.
     Map {
-        pending_key: Option<i128>,
+        pending_key: Option<Value>,
+        accepting_key: bool,
         entries: Vec<(Value, Value)>,
     },
-    /// A CBOR array under construction (a `List` / `Vec<T>` field).
-    Array { items: Vec<Value> },
+    /// A CBOR array under construction (`Vec<T>` or `HashSet<T>`).
+    Array {
+        items: Vec<Value>,
+        canonicalize: bool,
+    },
 }
 
 /// The CBOR encode builder behind a `hew_cbor_ser_new` handle.
@@ -97,12 +100,19 @@ impl CborSerBuf {
         match self.stack.last_mut() {
             Some(SerFrame::Map {
                 pending_key,
+                accepting_key,
                 entries,
-            }) => match pending_key.take() {
-                Some(key) => entries.push((Value::Integer(int_from_i128(key)), value)),
-                None => self.poisoned = true,
-            },
-            Some(SerFrame::Array { items }) => items.push(value),
+            }) => {
+                if *accepting_key {
+                    *accepting_key = false;
+                    *pending_key = Some(value);
+                } else if let Some(key) = pending_key.take() {
+                    entries.push((key, value));
+                } else {
+                    self.poisoned = true;
+                }
+            }
+            Some(SerFrame::Array { items, .. }) => items.push(value),
             None => {
                 if self.root.is_some() {
                     self.poisoned = true;
@@ -114,17 +124,12 @@ impl CborSerBuf {
     }
 }
 
-/// Build a ciborium `Integer` from an `i128`, clamping out-of-range values to a
-/// saturating bound (CBOR integers span `[-2^64, 2^64-1]`, i.e. they fit i128).
-/// A wire tag or scalar always fits, so this never actually clamps in practice.
-fn int_from_i128(v: i128) -> Integer {
-    Integer::try_from(v).unwrap_or_else(|_| {
-        if v < 0 {
-            Integer::from(i64::MIN)
-        } else {
-            Integer::from(u64::MAX)
-        }
-    })
+/// RFC 8949 deterministic ordering compares the length of each encoded key,
+/// then its bytewise lexical representation.
+fn canonical_bytes(value: &Value) -> Option<Vec<u8>> {
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(value, &mut bytes).ok()?;
+    Some(bytes)
 }
 
 /// SAFETY: `buf` must be null or a live handle from `hew_cbor_ser_new` that no
@@ -155,6 +160,7 @@ pub unsafe extern "C" fn hew_cbor_ser_begin_map(buf: *mut c_void) {
     if let Some(b) = unsafe { as_ser_buf(buf) } {
         b.stack.push(SerFrame::Map {
             pending_key: None,
+            accepting_key: false,
             entries: Vec::new(),
         });
     }
@@ -178,15 +184,31 @@ pub unsafe extern "C" fn hew_cbor_ser_end_map(buf: *mut c_void) {
         return;
     };
     match b.stack.pop() {
-        Some(SerFrame::Map { mut entries, .. }) => {
-            // Sort by integer key ascending = canonical order for the
-            // non-negative field-number keys this encoder emits. A stable sort
-            // keeps emission order for any (never-constructed) duplicate keys.
-            entries.sort_by_key(|(key, _)| match key {
-                Value::Integer(i) => i128::from(*i),
-                _ => i128::MIN,
-            });
-            b.emit(Value::Map(entries));
+        Some(SerFrame::Map {
+            pending_key,
+            accepting_key,
+            entries,
+        }) => {
+            if accepting_key || pending_key.is_some() {
+                b.poisoned = true;
+                return;
+            }
+            let mut keyed = Vec::with_capacity(entries.len());
+            for (key, value) in entries {
+                let Some(encoded) = canonical_bytes(&key) else {
+                    b.poisoned = true;
+                    return;
+                };
+                keyed.push((encoded, (key, value)));
+            }
+            keyed.sort_by(|(a, _), (b, _)| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
+            if keyed.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+                b.poisoned = true;
+                return;
+            }
+            b.emit(Value::Map(
+                keyed.into_iter().map(|(_, pair)| pair).collect(),
+            ));
         }
         _ => b.poisoned = true,
     }
@@ -200,7 +222,26 @@ pub unsafe extern "C" fn hew_cbor_ser_end_map(buf: *mut c_void) {
 pub unsafe extern "C" fn hew_cbor_ser_begin_array(buf: *mut c_void) {
     // SAFETY: buf is a live handle per this fn's contract.
     if let Some(b) = unsafe { as_ser_buf(buf) } {
-        b.stack.push(SerFrame::Array { items: Vec::new() });
+        b.stack.push(SerFrame::Array {
+            items: Vec::new(),
+            canonicalize: false,
+        });
+    }
+}
+
+/// Open a CBOR array whose elements are sorted by deterministic encoded form.
+/// This is the wire representation of a `HashSet<T>`.
+///
+/// # Safety
+/// `buf` must be a live handle from `hew_cbor_ser_new`.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cbor_ser_begin_set(buf: *mut c_void) {
+    // SAFETY: buf is a live handle per this fn's contract.
+    if let Some(b) = unsafe { as_ser_buf(buf) } {
+        b.stack.push(SerFrame::Array {
+            items: Vec::new(),
+            canonicalize: true,
+        });
     }
 }
 
@@ -215,7 +256,28 @@ pub unsafe extern "C" fn hew_cbor_ser_end_array(buf: *mut c_void) {
         return;
     };
     match b.stack.pop() {
-        Some(SerFrame::Array { items }) => b.emit(Value::Array(items)),
+        Some(SerFrame::Array {
+            mut items,
+            canonicalize,
+        }) => {
+            if canonicalize {
+                let mut keyed = Vec::with_capacity(items.len());
+                for item in items.drain(..) {
+                    let Some(encoded) = canonical_bytes(&item) else {
+                        b.poisoned = true;
+                        return;
+                    };
+                    keyed.push((encoded, item));
+                }
+                keyed.sort_by(|(a, _), (b, _)| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
+                if keyed.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+                    b.poisoned = true;
+                    return;
+                }
+                items = keyed.into_iter().map(|(_, item)| item).collect();
+            }
+            b.emit(Value::Array(items));
+        }
         _ => b.poisoned = true,
     }
 }
@@ -232,7 +294,33 @@ pub unsafe extern "C" fn hew_cbor_ser_key_u64(buf: *mut c_void, key: u64) {
         return;
     };
     match b.stack.last_mut() {
-        Some(SerFrame::Map { pending_key, .. }) => *pending_key = Some(i128::from(key)),
+        Some(SerFrame::Map {
+            pending_key,
+            accepting_key,
+            ..
+        }) if pending_key.is_none() && !*accepting_key => {
+            *pending_key = Some(Value::Integer(Integer::from(key)));
+        }
+        _ => b.poisoned = true,
+    }
+}
+
+/// Make the next recursively emitted value the key of the current map.
+///
+/// # Safety
+/// `buf` must be a live handle from `hew_cbor_ser_new`.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cbor_ser_begin_key(buf: *mut c_void) {
+    // SAFETY: buf is a live handle per this fn's contract.
+    let Some(b) = (unsafe { as_ser_buf(buf) }) else {
+        return;
+    };
+    match b.stack.last_mut() {
+        Some(SerFrame::Map {
+            pending_key,
+            accepting_key,
+            ..
+        }) if pending_key.is_none() && !*accepting_key => *accepting_key = true,
         _ => b.poisoned = true,
     }
 }
@@ -415,6 +503,11 @@ enum DeFrame {
     /// selects them; whatever remains at `exit_map` is unknown-forward-compatible
     /// and dropped.
     Map(BTreeMap<i128, Value>),
+    /// A collection map walked as arbitrary key/value pairs.
+    MapIter {
+        entries: std::vec::IntoIter<(Value, Value)>,
+        pending_value: Option<Value>,
+    },
     /// An entered CBOR array, walked by sequential `array_next`.
     Array(std::vec::IntoIter<Value>),
 }
@@ -597,6 +690,120 @@ pub unsafe extern "C" fn hew_cbor_de_select_key(reader: *mut c_void, key: u64) {
     match map.remove(&i128::from(key)) {
         Some(value) => r.staged = Some(value),
         None => r.failed = true,
+    }
+}
+
+/// Enter a staged collection map for sequential key/value decoding.
+/// Duplicate keys are rejected by deterministic encoded identity.
+///
+/// # Safety
+/// `reader` must be a live handle from `hew_cbor_de_new`.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cbor_de_enter_map_iter(reader: *mut c_void) {
+    // SAFETY: reader is a live handle per this fn's contract.
+    let Some(r) = (unsafe { as_de_reader(reader) }) else {
+        return;
+    };
+    let Some(Value::Map(entries)) = r.take_staged() else {
+        r.failed = true;
+        return;
+    };
+    let mut seen = BTreeSet::new();
+    for (key, _) in &entries {
+        let Some(encoded) = canonical_bytes(key) else {
+            r.failed = true;
+            return;
+        };
+        if !seen.insert((encoded.len(), encoded)) {
+            r.failed = true;
+            return;
+        }
+    }
+    r.stack.push(DeFrame::MapIter {
+        entries: entries.into_iter(),
+        pending_value: None,
+    });
+}
+
+/// Stage the next collection-map key. Returns 1 if present, 0 at end.
+///
+/// # Safety
+/// `reader` must be a live handle from `hew_cbor_de_new`.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cbor_de_map_next(reader: *mut c_void) -> i32 {
+    // SAFETY: reader is a live handle per this fn's contract.
+    let Some(r) = (unsafe { as_de_reader(reader) }) else {
+        return 0;
+    };
+    if r.staged.is_some() {
+        r.failed = true;
+        return 0;
+    }
+    let Some(DeFrame::MapIter {
+        entries,
+        pending_value,
+    }) = r.stack.last_mut()
+    else {
+        r.failed = true;
+        return 0;
+    };
+    if pending_value.is_some() {
+        r.failed = true;
+        return 0;
+    }
+    match entries.next() {
+        Some((key, value)) => {
+            r.staged = Some(key);
+            *pending_value = Some(value);
+            1
+        }
+        None => 0,
+    }
+}
+
+/// Stage the value paired with the most recently decoded collection-map key.
+///
+/// # Safety
+/// `reader` must be a live handle from `hew_cbor_de_new`.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cbor_de_map_value(reader: *mut c_void) {
+    // SAFETY: reader is a live handle per this fn's contract.
+    let Some(r) = (unsafe { as_de_reader(reader) }) else {
+        return;
+    };
+    if r.staged.is_some() {
+        r.failed = true;
+        return;
+    }
+    let Some(DeFrame::MapIter { pending_value, .. }) = r.stack.last_mut() else {
+        r.failed = true;
+        return;
+    };
+    match pending_value.take() {
+        Some(value) => r.staged = Some(value),
+        None => r.failed = true,
+    }
+}
+
+/// Exit a collection-map iterator after all entries have been consumed.
+///
+/// # Safety
+/// `reader` must be a live handle from `hew_cbor_de_new`.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cbor_de_exit_map_iter(reader: *mut c_void) {
+    // SAFETY: reader is a live handle per this fn's contract.
+    let Some(r) = (unsafe { as_de_reader(reader) }) else {
+        return;
+    };
+    if r.staged.is_some() {
+        r.failed = true;
+    }
+    match r.stack.pop() {
+        Some(DeFrame::MapIter {
+            entries,
+            pending_value,
+        }) if entries.as_slice().is_empty() && pending_value.is_none() => {}
+        _ => r.failed = true,
     }
 }
 
@@ -1051,7 +1258,79 @@ pub unsafe extern "C" fn hew_cbor_de_bytes(reader: *mut c_void, out_len: *mut u3
 
 #[cfg(test)]
 mod tests {
+    #![expect(
+        clippy::undocumented_unsafe_blocks,
+        reason = "these tests exclusively exercise the local C ABI with handles and buffers they construct and retain for each call"
+    )]
+
     use super::*;
+
+    unsafe fn finish_test_builder(buf: *mut c_void) -> Vec<u8> {
+        let mut len = 0usize;
+        let ptr = unsafe { hew_cbor_ser_finish(buf, &raw mut len) };
+        assert!(!ptr.is_null());
+        let bytes = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
+        unsafe { libc::free(ptr.cast()) };
+        bytes
+    }
+
+    #[test]
+    fn collection_map_and_set_encoding_is_insertion_order_independent() {
+        unsafe fn encode_map(reverse: bool) -> Vec<u8> {
+            let buf = hew_cbor_ser_new();
+            unsafe { hew_cbor_ser_begin_map(buf) };
+            for key in if reverse { [10, 1] } else { [1, 10] } {
+                unsafe {
+                    hew_cbor_ser_begin_key(buf);
+                    hew_cbor_ser_i64(buf, key);
+                    hew_cbor_ser_i64(buf, key * 2);
+                }
+            }
+            unsafe { hew_cbor_ser_end_map(buf) };
+            unsafe { finish_test_builder(buf) }
+        }
+        unsafe fn encode_set(reverse: bool) -> Vec<u8> {
+            let buf = hew_cbor_ser_new();
+            unsafe { hew_cbor_ser_begin_set(buf) };
+            for value in if reverse { [10, 1] } else { [1, 10] } {
+                unsafe { hew_cbor_ser_i64(buf, value) };
+            }
+            unsafe { hew_cbor_ser_end_array(buf) };
+            unsafe { finish_test_builder(buf) }
+        }
+        assert_eq!(unsafe { encode_map(false) }, unsafe { encode_map(true) });
+        assert_eq!(unsafe { encode_set(false) }, unsafe { encode_set(true) });
+    }
+
+    #[test]
+    fn generic_map_decoder_stages_each_key_then_value() {
+        let value = Value::Map(vec![
+            (Value::Text("a".to_string()), Value::Integer(1.into())),
+            (Value::Text("b".to_string()), Value::Integer(2.into())),
+        ]);
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&value, &mut bytes).unwrap();
+        unsafe {
+            let reader = hew_cbor_de_new(bytes.as_ptr(), bytes.len());
+            hew_cbor_de_enter_map_iter(reader);
+            assert_eq!(hew_cbor_de_map_next(reader), 1);
+            let first_key = hew_cbor_de_string(reader);
+            assert_eq!(core::ffi::CStr::from_ptr(first_key).to_str().unwrap(), "a");
+            hew_string_drop_for_test(first_key);
+            hew_cbor_de_map_value(reader);
+            assert_eq!(hew_cbor_de_i64(reader), 1);
+            assert_eq!(hew_cbor_de_map_next(reader), 1);
+            let second_key = hew_cbor_de_string(reader);
+            assert_eq!(core::ffi::CStr::from_ptr(second_key).to_str().unwrap(), "b");
+            hew_string_drop_for_test(second_key);
+            hew_cbor_de_map_value(reader);
+            assert_eq!(hew_cbor_de_i64(reader), 2);
+            assert_eq!(hew_cbor_de_map_next(reader), 0);
+            hew_cbor_de_exit_map_iter(reader);
+            assert_eq!(hew_cbor_de_failed(reader), 0);
+            hew_cbor_de_free(reader);
+        }
+    }
 
     /// A struct body `{1: "hi", 2: -7}` round-trips through encode → bytes →
     /// decode with the field values intact.

--- a/hew-runtime/src/hashmap.rs
+++ b/hew-runtime/src/hashmap.rs
@@ -112,6 +112,96 @@ pub struct HewLayoutHashMap {
     pub val_layout: HewMapValueLayout,
 }
 
+/// Opaque cursor for borrowing occupied entries from a layout-backed map.
+///
+/// The cursor owns no collection data. The map must remain alive and must not
+/// be mutated until the cursor is freed.
+#[repr(C)]
+#[derive(Debug)]
+pub struct HewLayoutHashMapIter {
+    map: *const HewLayoutHashMap,
+    next_slot: usize,
+}
+
+/// Create an iterator over the occupied entries in `m`.
+///
+/// # Safety
+///
+/// `m` must point to a live map and remain live and unmodified until the
+/// returned iterator is freed.
+#[no_mangle]
+pub unsafe extern "C" fn hew_hashmap_iter_new_layout(
+    m: *const HewLayoutHashMap,
+) -> *mut HewLayoutHashMapIter {
+    // SAFETY: m is a live map per this fn's contract.
+    unsafe { validate_op_map(m) };
+    Box::into_raw(Box::new(HewLayoutHashMapIter {
+        map: m,
+        next_slot: 0,
+    }))
+}
+
+/// Advance an iterator, returning borrowed pointers to its next key and value.
+///
+/// # Safety
+///
+/// `iter`, `out_key`, and `out_value` must be non-null. The iterator's map
+/// must still be live and unmodified. Returned pointers remain valid only
+/// while that condition holds.
+#[no_mangle]
+pub unsafe extern "C" fn hew_hashmap_iter_next_layout(
+    iter: *mut HewLayoutHashMapIter,
+    out_key: *mut *const c_void,
+    out_value: *mut *const c_void,
+) -> bool {
+    if iter.is_null() || out_key.is_null() || out_value.is_null() {
+        crate::set_last_error("HewLayoutHashMap iterator: null argument");
+        std::process::abort();
+    }
+    // SAFETY: all three pointers were checked above; the caller guarantees the
+    // iterator and its source map remain live and unmodified.
+    let cursor = unsafe { &mut *iter };
+    // SAFETY: cursor.map is the live source map captured by the constructor.
+    unsafe { validate_op_map(cursor.map) };
+    // SAFETY: validate_op_map just established that cursor.map is live.
+    let map = unsafe { &*cursor.map };
+    while cursor.next_slot < map.cap {
+        let index = cursor.next_slot;
+        cursor.next_slot += 1;
+        // SAFETY: index is below map.cap and validate_op_map established the
+        // backing allocation and layout invariants.
+        if unsafe { *slot_state(map.entries, index, map.stride) } != OCCUPIED {
+            continue;
+        }
+        // SAFETY: this is an occupied in-bounds slot. The returned pointers
+        // borrow its initialized key/value storage for the iterator lifetime.
+        unsafe {
+            *out_key = slot_key(map.entries, index, map.stride, map.key_offset)
+                .cast_const()
+                .cast();
+            *out_value = slot_val(map.entries, index, map.stride, map.val_offset)
+                .cast_const()
+                .cast();
+        }
+        return true;
+    }
+    false
+}
+
+/// Free a map iterator. A null pointer is a no-op.
+///
+/// # Safety
+///
+/// `iter` must be null or a pointer returned by
+/// [`hew_hashmap_iter_new_layout`] that has not already been freed.
+#[no_mangle]
+pub unsafe extern "C" fn hew_hashmap_iter_free_layout(iter: *mut HewLayoutHashMapIter) {
+    if !iter.is_null() {
+        // SAFETY: iter has unique ownership from Box::into_raw per the contract.
+        drop(unsafe { Box::from_raw(iter) });
+    }
+}
+
 /// Borrow each occupied entry in slot order and append its structural rendering.
 ///
 /// # Safety

--- a/hew-runtime/src/hashset.rs
+++ b/hew-runtime/src/hashset.rs
@@ -23,9 +23,10 @@ use hew_cabi::vec::HewTypeOwnershipKind;
 
 use crate::hashmap::{
     hew_hashmap_clear_layout, hew_hashmap_clone_layout, hew_hashmap_contains_key_layout,
-    hew_hashmap_free_layout, hew_hashmap_insert_layout, hew_hashmap_keys_layout,
+    hew_hashmap_free_layout, hew_hashmap_insert_layout, hew_hashmap_iter_free_layout,
+    hew_hashmap_iter_new_layout, hew_hashmap_iter_next_layout, hew_hashmap_keys_layout,
     hew_hashmap_len_layout, hew_hashmap_new_with_layout, hew_hashmap_remove_layout,
-    HewLayoutHashMap,
+    HewLayoutHashMap, HewLayoutHashMapIter,
 };
 use crate::vec::HewVec;
 
@@ -110,6 +111,67 @@ static VALUE_LAYOUT: HewMapValueLayout = HewMapValueLayout {
 pub struct HewLayoutHashSet {
     /// Underlying layout-backed map. Elements are keys; values are ZST.
     map: *mut HewLayoutHashMap,
+}
+
+/// Opaque borrowing cursor over a layout-backed set.
+#[repr(C)]
+#[derive(Debug)]
+pub struct HewLayoutHashSetIter {
+    inner: *mut HewLayoutHashMapIter,
+}
+
+/// Create an iterator over `set`'s elements.
+///
+/// # Safety
+///
+/// `set` must remain live and unmodified until the iterator is freed.
+#[no_mangle]
+pub unsafe extern "C" fn hew_hashset_iter_new_layout(
+    set: *const HewLayoutHashSet,
+) -> *mut HewLayoutHashSetIter {
+    // SAFETY: set is live per this fn's contract.
+    unsafe { validate_set_op(set) };
+    // SAFETY: validation established set and its wrapped map are live; the
+    // caller guarantees neither is mutated while the iterator exists.
+    let inner = unsafe { hew_hashmap_iter_new_layout((*set).map) };
+    Box::into_raw(Box::new(HewLayoutHashSetIter { inner }))
+}
+
+/// Advance a set iterator, returning a borrowed pointer to its next element.
+///
+/// # Safety
+///
+/// `iter` and `out_elem` must be non-null and the source set must remain live
+/// and unmodified.
+#[no_mangle]
+pub unsafe extern "C" fn hew_hashset_iter_next_layout(
+    iter: *mut HewLayoutHashSetIter,
+    out_elem: *mut *const c_void,
+) -> bool {
+    if iter.is_null() || out_elem.is_null() {
+        crate::set_last_error("HewLayoutHashSet iterator: null argument");
+        std::process::abort();
+    }
+    let mut ignored_value = ptr::null();
+    // SAFETY: the arguments were checked above, and the constructor captured a
+    // live map iterator whose source remains unmodified by contract.
+    unsafe { hew_hashmap_iter_next_layout((*iter).inner, out_elem, &raw mut ignored_value) }
+}
+
+/// Free a set iterator. A null pointer is a no-op.
+///
+/// # Safety
+///
+/// `iter` must be null or a live iterator returned by
+/// [`hew_hashset_iter_new_layout`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_hashset_iter_free_layout(iter: *mut HewLayoutHashSetIter) {
+    if !iter.is_null() {
+        // SAFETY: iter has unique ownership from Box::into_raw per the contract.
+        let cursor = unsafe { Box::from_raw(iter) };
+        // SAFETY: cursor.inner is the still-live iterator owned by cursor.
+        unsafe { hew_hashmap_iter_free_layout(cursor.inner) };
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-runtime/src/wire_text.rs
+++ b/hew-runtime/src/wire_text.rs
@@ -63,7 +63,7 @@ const FORMAT_YAML: c_int = 1;
 //
 // The compiler emits a compact JSON descriptor string per wire type that maps
 // each field's wire tag (`@N`) to its JSON/YAML key name, recursively for nested
-// wire structs/enums, vectors, and options. The runtime parses it once per bridge
+// wire structs/enums, collections, and options. The runtime parses it once per bridge
 // call. The format is intentionally small and explicit so the codegen emitter is
 // trivial to keep in sync with this parser.
 //
@@ -72,6 +72,8 @@ const FORMAT_YAML: c_int = 1;
 //   struct : {"k":"struct","f":[{"t":<tag>,"n":"<name>","d":<node>}, ...]}
 //   enum   : {"k":"enum","v":[{"t":<tag>,"n":"<name>","p":[<node>, ...]}, ...]}
 //   vec    : {"k":"vec","e":<node>}
+//   set    : {"k":"set","e":<node>}
+//   map    : {"k":"map","key":<node>,"value":<node>}
 //   option : {"k":"opt","e":<node>}
 //   opaque : {"k":"opaque"}   // a shape outside the text floor — fail closed
 
@@ -97,6 +99,11 @@ enum Desc {
     Enum(Vec<EnumVariant>),
     /// A `Vec<T>`: CBOR array ↔ JSON array, element-wise transcoded.
     Vec(Box<Desc>),
+    /// A `HashSet<T>`: a deterministically ordered CBOR/JSON array.
+    Set(Box<Desc>),
+    /// A `HashMap<K, V>`: CBOR map ↔ a JSON object for string keys, otherwise
+    /// an array of `[key, value]` pairs so key types are never stringified.
+    Map(Box<Desc>, Box<Desc>),
     /// An `Option<T>`: CBOR null/value ↔ JSON null/value.
     Opt(Box<Desc>),
     /// A shape the text codec does not support (outside the wire-body floor).
@@ -138,6 +145,11 @@ impl Desc {
             "bytes" => Some(Self::Bytes),
             "opaque" => Some(Self::Opaque),
             "vec" => Some(Self::Vec(Box::new(Self::parse(obj.get("e")?, depth + 1)?))),
+            "set" => Some(Self::Set(Box::new(Self::parse(obj.get("e")?, depth + 1)?))),
+            "map" => Some(Self::Map(
+                Box::new(Self::parse(obj.get("key")?, depth + 1)?),
+                Box::new(Self::parse(obj.get("value")?, depth + 1)?),
+            )),
             "opt" => Some(Self::Opt(Box::new(Self::parse(obj.get("e")?, depth + 1)?))),
             "struct" => {
                 let mut fields = Vec::new();
@@ -191,6 +203,10 @@ unsafe fn parse_descriptor(ptr: *const c_char) -> Option<Desc> {
 /// integer field tags) into a `serde_json::Value` (keyed by JSON/YAML key names)
 /// guided by `desc`. Fails closed on any shape that does not match the
 /// descriptor.
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeping the exhaustive descriptor conversion in one match makes the accepted wire shapes auditable"
+)]
 fn cbor_to_json(value: &CborValue, desc: &Desc, depth: usize) -> Result<serde_json::Value, String> {
     if depth >= MAX_TRANSCODE_DEPTH {
         return Err("value nesting exceeds the supported depth".to_string());
@@ -254,7 +270,7 @@ fn cbor_to_json(value: &CborValue, desc: &Desc, depth: usize) -> Result<serde_js
             CborValue::Null => Ok(serde_json::Value::Null),
             other => cbor_to_json(other, inner, depth + 1),
         },
-        Desc::Vec(elem) => match value {
+        Desc::Vec(elem) | Desc::Set(elem) => match value {
             CborValue::Array(items) => {
                 let mut out = Vec::with_capacity(items.len());
                 for it in items {
@@ -264,6 +280,33 @@ fn cbor_to_json(value: &CborValue, desc: &Desc, depth: usize) -> Result<serde_js
             }
             _ => Err("expected an array".to_string()),
         },
+        Desc::Map(key_desc, value_desc) => {
+            let CborValue::Map(entries) = value else {
+                return Err("expected a map".to_string());
+            };
+            if matches!(key_desc.as_ref(), Desc::Str) {
+                let mut out = serde_json::Map::new();
+                for (key, item) in entries {
+                    let CborValue::Text(name) = key else {
+                        return Err("expected a string map key".to_string());
+                    };
+                    if out.contains_key(name) {
+                        return Err("duplicate map key".to_string());
+                    }
+                    out.insert(name.clone(), cbor_to_json(item, value_desc, depth + 1)?);
+                }
+                Ok(serde_json::Value::Object(out))
+            } else {
+                let mut out = Vec::with_capacity(entries.len());
+                for (key, item) in entries {
+                    out.push(serde_json::Value::Array(vec![
+                        cbor_to_json(key, key_desc, depth + 1)?,
+                        cbor_to_json(item, value_desc, depth + 1)?,
+                    ]));
+                }
+                Ok(serde_json::Value::Array(out))
+            }
+        }
         Desc::Struct(fields) => {
             let CborValue::Map(pairs) = value else {
                 return Err("expected a map".to_string());
@@ -365,6 +408,10 @@ fn enum_cbor_to_json(
 /// Transcode a `serde_json::Value` (parsed from JSON or YAML, keyed by names)
 /// into a `ciborium::Value` (keyed by integer tags) matching exactly the shape
 /// the binary CBOR decode walk expects. Fails closed on any shape mismatch.
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeping the exhaustive descriptor conversion in one match makes the accepted wire shapes auditable"
+)]
 fn json_to_cbor(value: &serde_json::Value, desc: &Desc, depth: usize) -> Result<CborValue, String> {
     if depth >= MAX_TRANSCODE_DEPTH {
         return Err("value nesting exceeds the supported depth".to_string());
@@ -423,7 +470,7 @@ fn json_to_cbor(value: &serde_json::Value, desc: &Desc, depth: usize) -> Result<
                 json_to_cbor(value, inner, depth + 1)
             }
         }
-        Desc::Vec(elem) => {
+        Desc::Vec(elem) | Desc::Set(elem) => {
             let arr = value
                 .as_array()
                 .ok_or_else(|| "expected an array".to_string())?;
@@ -432,6 +479,39 @@ fn json_to_cbor(value: &serde_json::Value, desc: &Desc, depth: usize) -> Result<
                 out.push(json_to_cbor(it, elem, depth + 1)?);
             }
             Ok(CborValue::Array(out))
+        }
+        Desc::Map(key_desc, value_desc) => {
+            let mut out = Vec::new();
+            if matches!(key_desc.as_ref(), Desc::Str) {
+                let obj = value
+                    .as_object()
+                    .ok_or_else(|| "expected an object for a string-keyed map".to_string())?;
+                out.reserve(obj.len());
+                for (key, item) in obj {
+                    out.push((
+                        CborValue::Text(key.clone()),
+                        json_to_cbor(item, value_desc, depth + 1)?,
+                    ));
+                }
+            } else {
+                let entries = value.as_array().ok_or_else(|| {
+                    "expected an array of [key, value] pairs for a non-string-keyed map".to_string()
+                })?;
+                out.reserve(entries.len());
+                for entry in entries {
+                    let pair = entry
+                        .as_array()
+                        .ok_or_else(|| "map entry is not a [key, value] pair".to_string())?;
+                    if pair.len() != 2 {
+                        return Err("map entry must contain exactly two values".to_string());
+                    }
+                    out.push((
+                        json_to_cbor(&pair[0], key_desc, depth + 1)?,
+                        json_to_cbor(&pair[1], value_desc, depth + 1)?,
+                    ));
+                }
+            }
+            Ok(CborValue::Map(out))
         }
         Desc::Struct(fields) => {
             let obj = value
@@ -1000,5 +1080,54 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str("[256]").unwrap();
         let err = json_to_cbor(&json, &Desc::Bytes, 0).unwrap_err();
         assert!(err.contains("exceeds 255"), "got: {err}");
+    }
+
+    #[test]
+    fn maps_and_sets_preserve_key_types_in_json() {
+        let string_map = Desc::Map(Box::new(Desc::Str), Box::new(Desc::Int));
+        let cbor = CborValue::Map(vec![
+            (
+                CborValue::Text("a".to_string()),
+                CborValue::Integer(1.into()),
+            ),
+            (
+                CborValue::Text("b".to_string()),
+                CborValue::Integer(2.into()),
+            ),
+        ]);
+        let json = cbor_to_json(&cbor, &string_map, 0).unwrap();
+        assert_eq!(serde_json::to_string(&json).unwrap(), r#"{"a":1,"b":2}"#);
+        assert_eq!(json_to_cbor(&json, &string_map, 0).unwrap(), cbor);
+
+        let int_map = Desc::Map(Box::new(Desc::Int), Box::new(Desc::Str));
+        let pairs: serde_json::Value = serde_json::from_str(r#"[[1,"one"],[2,"two"]]"#).unwrap();
+        let encoded = json_to_cbor(&pairs, &int_map, 0).unwrap();
+        assert!(matches!(encoded, CborValue::Map(_)));
+        assert_eq!(cbor_to_json(&encoded, &int_map, 0).unwrap(), pairs);
+
+        let set = Desc::Set(Box::new(Desc::Int));
+        let values: serde_json::Value = serde_json::from_str("[1,2,3]").unwrap();
+        let encoded = json_to_cbor(&values, &set, 0).unwrap();
+        assert_eq!(cbor_to_json(&encoded, &set, 0).unwrap(), values);
+    }
+
+    #[test]
+    fn map_text_shapes_fail_closed_without_key_coercion() {
+        let string_map = Desc::Map(Box::new(Desc::Str), Box::new(Desc::Int));
+        let err = json_to_cbor(
+            &serde_json::from_str::<serde_json::Value>(r#"[["a",1]]"#).unwrap(),
+            &string_map,
+            0,
+        )
+        .unwrap_err();
+        assert!(err.contains("string-keyed map"), "got: {err}");
+
+        let int_map = Desc::Map(Box::new(Desc::Int), Box::new(Desc::Str));
+        let object = serde_json::from_str::<serde_json::Value>(r#"{"1":"one"}"#).unwrap();
+        let err = json_to_cbor(&object, &int_map, 0).unwrap_err();
+        assert!(err.contains("[key, value]"), "got: {err}");
+        let malformed = serde_json::from_str::<serde_json::Value>(r#"[[1,"one",3]]"#).unwrap();
+        let err = json_to_cbor(&malformed, &int_map, 0).unwrap_err();
+        assert!(err.contains("exactly two"), "got: {err}");
     }
 }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -3094,8 +3094,8 @@ impl Checker {
             missing.push("Decode");
         }
         if missing.is_empty() {
-            "it is outside the current Serializable subset (scalars, string, bytes, \
-             tuples/arrays, records/enums, or wire-marked types whose members are Serializable)"
+            "it is outside the current Serializable codec subset (including only \
+             collection key/element layouts with a complete encode, decode, clone, and drop path)"
                 .to_string()
         } else {
             format!("missing required marker trait(s): {}", missing.join(" + "))

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -344,6 +344,81 @@ impl TraitRegistry {
             && self.implements_marker(ty, MarkerTrait::Decode)
     }
 
+    /// Key/element shapes for which the wire decoder can reconstruct the same
+    /// runtime Hash+Eq identity used by ordinary HashMap/HashSet construction.
+    fn is_wire_hash_key(ty: &Ty) -> bool {
+        matches!(
+            ty,
+            Ty::I32 | Ty::I64 | Ty::U32 | Ty::U64 | Ty::Bool | Ty::Char | Ty::String | Ty::Bytes
+        )
+    }
+
+    /// Exact collection-element lane currently implemented by the CBOR Vec
+    /// codec. Nested collections and bytes lack a Vec ownership layout; an
+    /// Option element is admitted only when its payload is heap-free.
+    fn is_wire_vec_element(&self, ty: &Ty, visiting: &mut HashSet<String>) -> bool {
+        match ty {
+            Ty::Bool
+            | Ty::I8
+            | Ty::U8
+            | Ty::I16
+            | Ty::U16
+            | Ty::I32
+            | Ty::U32
+            | Ty::Char
+            | Ty::I64
+            | Ty::U64
+            | Ty::Isize
+            | Ty::Usize
+            | Ty::Duration
+            | Ty::F32
+            | Ty::F64
+            | Ty::String
+            | Ty::Named { builtin: None, .. } => self.implements_serializable_inner(ty, visiting),
+            Ty::Named {
+                builtin: Some(BuiltinType::Option),
+                args,
+                ..
+            } => {
+                args.len() == 1
+                    && self.is_wire_heap_free(&args[0], &mut HashSet::new())
+                    && self.implements_serializable_inner(&args[0], visiting)
+            }
+            _ => false,
+        }
+    }
+
+    fn is_wire_heap_free(&self, ty: &Ty, visiting: &mut HashSet<String>) -> bool {
+        match ty {
+            Ty::Tuple(elems) => elems
+                .iter()
+                .all(|elem| self.is_wire_heap_free(elem, visiting)),
+            Ty::Array(elem, _) => self.is_wire_heap_free(elem, visiting),
+            Ty::Named {
+                name,
+                builtin: None,
+                ..
+            } => {
+                if !visiting.insert(name.clone()) {
+                    return false;
+                }
+                let heap_free = self.serializable_members_any(name).is_some_and(|members| {
+                    members
+                        .iter()
+                        .all(|member| self.is_wire_heap_free(member, visiting))
+                });
+                visiting.remove(name);
+                heap_free
+            }
+            Ty::String
+            | Ty::Bytes
+            | Ty::Named {
+                builtin: Some(_), ..
+            } => false,
+            _ => true,
+        }
+    }
+
     fn implements_serializable_inner(&self, ty: &Ty, visiting: &mut HashSet<String>) -> bool {
         match ty {
             Ty::Var(_) | Ty::Error => true,
@@ -383,21 +458,25 @@ impl TraitRegistry {
                         return false;
                     }
                 }
-                if matches!(builtin, Some(BuiltinType::Option | BuiltinType::Result)) {
-                    return args
-                        .iter()
-                        .all(|arg| self.implements_serializable_inner(arg, visiting));
+                match builtin {
+                    Some(BuiltinType::Option | BuiltinType::Result) => {
+                        return args
+                            .iter()
+                            .all(|arg| self.implements_serializable_inner(arg, visiting));
+                    }
+                    Some(BuiltinType::Vec) => {
+                        return args.len() == 1 && self.is_wire_vec_element(&args[0], visiting);
+                    }
+                    Some(BuiltinType::HashMap) => {
+                        return args.len() == 2
+                            && Self::is_wire_hash_key(&args[0])
+                            && self.implements_serializable_inner(&args[1], visiting);
+                    }
+                    Some(BuiltinType::HashSet) => {
+                        return args.len() == 1 && Self::is_wire_hash_key(&args[0]);
+                    }
+                    _ => {}
                 }
-                // Fix 1: Vec, HashMap, and HashSet are NOT in `serializable_members`
-                // (they are never registered via `register_serializable_type`), so
-                // `serializable_members_any` returns `None` for them and they fall to
-                // `return false` below.  This is the fail-closed boundary for the
-                // RemotePid serialization gate: neither the codegen walk
-                // (`emit_{ser,de}_value`) nor the on-wire codec handles collection
-                // types, so admitting them here would be a silent correctness hole.
-                //
-                // Tests in the `tests` module assert this property for
-                // `Vec<i64>` and `HashMap<String, i64>` by name.
                 let Some(members) = self.serializable_members_any(name).cloned() else {
                     return false;
                 };
@@ -1491,40 +1570,84 @@ mod tests {
         assert!(registry.implements_marker(&closure, MarkerTrait::Clone));
     }
 
-    // Fix 1: confirm Vec and HashMap are rejected at the RemotePid serialization
-    // boundary.  The codegen codec walk (`emit_{ser,de}_value`) does not handle
-    // collection types; admitting them via `is_serializable` would silently skip
-    // serialization.  These tests are the gate-level proof that the checker
-    // is already fail-closed for collections — any future change that accidentally
-    // admits Vec/HashMap will break them immediately.
     #[test]
-    fn vec_payload_rejected_at_serializable_boundary() {
+    fn collection_payloads_are_serializable_when_members_are() {
         let registry = TraitRegistry::new();
         let vec_i64 = Ty::Named {
             builtin: Some(BuiltinType::Vec),
             name: "Vec".to_string(),
             args: vec![Ty::I64],
         };
-        assert!(
-            !registry.is_serializable(&vec_i64),
-            "Vec<i64> must NOT be Serializable at the RemotePid boundary \
-             (codec walk does not support collection types)"
-        );
-    }
-
-    #[test]
-    fn hashmap_payload_rejected_at_serializable_boundary() {
-        let registry = TraitRegistry::new();
+        assert!(registry.is_serializable(&vec_i64));
         let map_str_i64 = Ty::Named {
             builtin: Some(BuiltinType::HashMap),
             name: "HashMap".to_string(),
             args: vec![Ty::String, Ty::I64],
         };
-        assert!(
-            !registry.is_serializable(&map_str_i64),
-            "HashMap<String, i64> must NOT be Serializable at the RemotePid boundary \
-             (codec walk does not support collection types)"
-        );
+        assert!(registry.is_serializable(&map_str_i64));
+        let set_string = Ty::Named {
+            builtin: Some(BuiltinType::HashSet),
+            name: "HashSet".to_string(),
+            args: vec![Ty::String],
+        };
+        assert!(registry.is_serializable(&set_string));
+    }
+
+    #[test]
+    fn collection_payloads_reject_non_serializable_members() {
+        let registry = TraitRegistry::new();
+        let pointer = Ty::Pointer {
+            pointee: Box::new(Ty::I64),
+            is_mutable: false,
+        };
+        let map = Ty::Named {
+            builtin: Some(BuiltinType::HashMap),
+            name: "HashMap".to_string(),
+            args: vec![Ty::String, pointer],
+        };
+        assert!(!registry.is_serializable(&map));
+    }
+
+    #[test]
+    fn collection_serializable_admission_matches_wire_layout_lanes() {
+        let mut registry = TraitRegistry::new();
+        registry.register_type("Key".to_string(), vec![Ty::I64]);
+        registry.register_record_type("Key".to_string());
+        registry.register_serializable_type("Key".to_string(), vec![Ty::I64]);
+        let record_key = Ty::Named {
+            builtin: None,
+            name: "Key".to_string(),
+            args: vec![],
+        };
+        let record_map = Ty::Named {
+            builtin: Some(BuiltinType::HashMap),
+            name: "HashMap".to_string(),
+            args: vec![record_key.clone(), Ty::String],
+        };
+        let record_set = Ty::Named {
+            builtin: Some(BuiltinType::HashSet),
+            name: "HashSet".to_string(),
+            args: vec![record_key],
+        };
+        assert!(!registry.is_serializable(&record_map));
+        assert!(!registry.is_serializable(&record_set));
+
+        let vec_bytes = Ty::Named {
+            builtin: Some(BuiltinType::Vec),
+            name: "Vec".to_string(),
+            args: vec![Ty::Bytes],
+        };
+        let nested_vec = Ty::Named {
+            builtin: Some(BuiltinType::Vec),
+            name: "Vec".to_string(),
+            args: vec![Ty::Named {
+                builtin: Some(BuiltinType::Vec),
+                name: "Vec".to_string(),
+                args: vec![Ty::I64],
+            }],
+        };
+        assert!(!registry.is_serializable(&vec_bytes));
+        assert!(!registry.is_serializable(&nested_vec));
     }
 
     /// RI-01: the `TraitRegistry` is the single source of truth for the

--- a/std/encoding/wire/wire.hew
+++ b/std/encoding/wire/wire.hew
@@ -25,6 +25,12 @@
 //! for a different field is a schema-compatibility break, not just a style
 //! issue. `e.to_json()` and `TypeName.from_json(text)` (a call on the type
 //! name itself, not `::`) round-trip a `#[wire]` type through JSON today.
+//! `HashMap` and `HashSet` may be fields of that wire type: string-keyed maps
+//! become JSON objects, other supported primitive-key maps become arrays of
+//! `[key, value]` pairs (so key types are not stringified), and sets become
+//! deterministically ordered arrays. The same layouts round-trip through CBOR
+//! and YAML. Bare collections do not acquire collection-specific codec methods;
+//! put them in a named `#[wire]` envelope to define a stable schema boundary.
 //! Check schema compatibility between two versions of a wire type with:
 //!
 //! ```text

--- a/tests/vertical-slice/accept/wire_json_hash_collections_roundtrip.hew
+++ b/tests/vertical-slice/accept/wire_json_hash_collections_roundtrip.hew
@@ -1,0 +1,75 @@
+// Validation: HashMap and HashSet are first-class fields/payloads in a named
+// #[wire] value. String-keyed maps use JSON objects, non-string-keyed maps use
+// [key, value] pairs, and sets use canonical arrays. Decoding reconstructs
+// ordinary mutable collections.
+#[wire]
+type Feature {
+    enabled: bool @1,
+    note: string @2,
+}
+
+#[wire]
+type Registry {
+    features: HashMap<string, Feature> @1,
+    codes: HashMap<i64, string> @2,
+    ids: HashSet<i64> @3,
+}
+
+fn main() -> i64 {
+    let features: HashMap<string, Feature> = HashMap.new();
+    features.insert("beta", Feature { enabled: false, note: "later" });
+    features.insert("alpha", Feature { enabled: true, note: "now" });
+
+    let codes: HashMap<i64, string> = HashMap.new();
+    codes.insert(2, "two");
+    codes.insert(1, "one");
+
+    let ids: HashSet<i64> = HashSet.new();
+    ids.insert(3);
+    ids.insert(1);
+    ids.insert(2);
+
+    let registry = Registry { features: features, codes: codes, ids: ids };
+
+    let binary_back = Registry.decode(registry.encode());
+    if binary_back.features.len() != 2 { return 12; }
+    if binary_back.codes.len() != 2 { return 13; }
+    if binary_back.ids.len() != 3 { return 14; }
+
+    let yaml = registry.to_yaml();
+    match Registry.from_yaml(yaml) {
+        .Ok(yaml_back) => {
+            if yaml_back.features.len() != 2 { return 15; }
+            if yaml_back.codes.len() != 2 { return 16; }
+            if yaml_back.ids.len() != 3 { return 17; }
+        },
+        .Err(_) => { return 18; }
+    }
+
+    let json = registry.to_json();
+    if json != "{\"codes\":[[1,\"one\"],[2,\"two\"]],\"features\":{\"alpha\":{\"enabled\":true,\"note\":\"now\"},\"beta\":{\"enabled\":false,\"note\":\"later\"}},\"ids\":[1,2,3]}" {
+        return 1;
+    }
+
+    match Registry.from_json(json) {
+        .Ok(back) => {
+            if back.features.len() != 2 { return 2; }
+            if back.codes.len() != 2 { return 3; }
+            if back.ids.len() != 3 { return 4; }
+            if !back.ids.contains(2) { return 5; }
+            match back.features.get("alpha") {
+                .Some(feature) => {
+                    if !feature.enabled { return 6; }
+                    if feature.note != "now" { return 7; }
+                },
+                .None => { return 8; }
+            }
+            match back.codes.get(2) {
+                .Some(label) => { if label != "two" { return 9; } },
+                .None => { return 10; }
+            }
+            42
+        },
+        .Err(_) => 11,
+    }
+}

--- a/tests/vertical-slice/accept/wire_json_hashmap_duplicate_key_is_err.hew
+++ b/tests/vertical-slice/accept/wire_json_hashmap_duplicate_key_is_err.hew
@@ -1,0 +1,14 @@
+// Validation (FAIL CLOSED + OWNERSHIP): duplicate non-string map keys are
+// rejected. Values own strings, so the error path also proves the partially
+// reconstructed map is cleaned up exactly once rather than double-freed.
+#[wire]
+type DuplicateMap {
+    values: HashMap<i64, string> @1,
+}
+
+fn main() -> i64 {
+    match DuplicateMap.from_json("{\"values\":[[1,\"old\"],[1,\"new\"]]}") {
+        .Err(_) => 42,
+        .Ok(_) => 1,
+    }
+}

--- a/tests/vertical-slice/accept/wire_json_hashset_duplicate_is_err.hew
+++ b/tests/vertical-slice/accept/wire_json_hashset_duplicate_is_err.hew
@@ -1,0 +1,13 @@
+// Validation (FAIL CLOSED + OWNERSHIP): duplicate set elements are rejected.
+// String elements exercise the owned-key cleanup path.
+#[wire]
+type DuplicateSet {
+    values: HashSet<string> @1,
+}
+
+fn main() -> i64 {
+    match DuplicateSet.from_json("{\"values\":[\"same\",\"same\"]}") {
+        .Err(_) => 42,
+        .Ok(_) => 1,
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -5614,6 +5614,9 @@ run_accept_expect_status "wire_json_nested_roundtrip" 42
 run_accept_expect_status "wire_json_enum_unit_roundtrip" 42
 run_accept_expect_status "wire_json_enum_payload_roundtrip" 42
 run_accept_expect_status "wire_json_vec_option_roundtrip" 42
+run_accept_expect_status "wire_json_hash_collections_roundtrip" 42
+run_accept_expect_status "wire_json_hashmap_duplicate_key_is_err" 42
+run_accept_expect_status "wire_json_hashset_duplicate_is_err" 42
 # An unnamed fresh string concat result into from_json: the transient-string
 # drop pass must not free the operand before the WireCodec parse reads it.
 run_accept_expect_status "wire_json_fresh_concat_operand" 42


### PR DESCRIPTION
## Summary

- add deterministic CBOR serialization and decoding for HashMap and HashSet wire fields and payloads
- represent string-keyed maps as JSON objects, other primitive-key maps as key/value pair arrays, and sets as arrays
- reconstruct real layout-backed collections with ownership-safe duplicate handling and failure cleanup
- align Serializable admission with the implemented collection codec lanes and improve unsupported-shape diagnostics
- document the typed wire-schema surface and add JSON, YAML, CBOR, determinism, and malformed-input coverage

## Validation

- cargo test -p hew-runtime --lib: 2440 passed
- cargo test -p hew-codegen-rs --lib: 312 passed
- cargo test -p hew-types --lib traits::tests: 46 passed
- focused HashMap and HashSet vertical-slice fixtures exit successfully
- full pre-commit Clippy hook passes
- pre-push formatting and shell gates pass