### PR TITLE
fix(ci): provision FreeBSD aarch64 WASI std

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -787,6 +787,24 @@ jobs:
             test -x "$PYTHON"
             /usr/local/llvm22/bin/llvm-config --version
 
+            # Upstream does not publish a rustup host toolchain for aarch64
+            # FreeBSD, so keep the pkg compiler and install its matching,
+            # host-independent WASI standard-library component directly.
+            RUST_VERSION=$(rustc --version | awk '{print $2}')
+            RUST_STD_COMPONENT="rust-std-${RUST_VERSION}-wasm32-wasip1"
+            RUST_STD_DIR=$(mktemp -d)
+            trap 'rm -rf "$RUST_STD_DIR"' EXIT
+            /usr/bin/fetch -o "$RUST_STD_DIR/${RUST_STD_COMPONENT}.tar.xz" \
+              "https://static.rust-lang.org/dist/${RUST_STD_COMPONENT}.tar.xz"
+            /usr/bin/fetch -o "$RUST_STD_DIR/${RUST_STD_COMPONENT}.tar.xz.sha256" \
+              "https://static.rust-lang.org/dist/${RUST_STD_COMPONENT}.tar.xz.sha256"
+            test "$(sha256 -q "$RUST_STD_DIR/${RUST_STD_COMPONENT}.tar.xz")" = \
+              "$(awk '{print $1}' "$RUST_STD_DIR/${RUST_STD_COMPONENT}.tar.xz.sha256")"
+            tar -xJf "$RUST_STD_DIR/${RUST_STD_COMPONENT}.tar.xz" -C "$RUST_STD_DIR"
+            sh "$RUST_STD_DIR/${RUST_STD_COMPONENT}/install.sh" \
+              --prefix="$(rustc --print sysroot)" --disable-ldconfig
+            test -d "$(rustc --print sysroot)/lib/rustlib/wasm32-wasip1/lib"
+
             # The wasm codegen tests link with `wasm-ld`; llvm22 ships it in its
             # own bin dir, which is not on PATH. Expose it like the macOS gate's
             # lld@22 so the linker probe finds it instead of failing to spawn

--- a/scripts/tests/test_release_workflow_contract.py
+++ b/scripts/tests/test_release_workflow_contract.py
@@ -3233,6 +3233,38 @@ def test_foundational_release_gates_are_platform_scoped_and_mandatory() -> None:
         raise AssertionError("foundational release-gate mutation escaped")
 
 
+def test_freebsd_aarch64_installs_wasi_std_before_building_stdlib() -> None:
+    job = workflow_job(RELEASE_GATE.read_text(), "gate-freebsd-aarch64")
+    version = "RUST_VERSION=$(rustc --version | awk '{print $2}')"
+    component = 'RUST_STD_COMPONENT="rust-std-${RUST_VERSION}-wasm32-wasip1"'
+    archive = '"https://static.rust-lang.org/dist/${RUST_STD_COMPONENT}.tar.xz"'
+    checksum = (
+        '"https://static.rust-lang.org/dist/${RUST_STD_COMPONENT}.tar.xz.sha256"'
+    )
+    verify = (
+        'test "$(sha256 -q "$RUST_STD_DIR/${RUST_STD_COMPONENT}.tar.xz")" = \\\n'
+        '              "$(awk \'{print $1}\' '
+        '"$RUST_STD_DIR/${RUST_STD_COMPONENT}.tar.xz.sha256")"'
+    )
+    install = (
+        'sh "$RUST_STD_DIR/${RUST_STD_COMPONENT}/install.sh" \\\n'
+        '              --prefix="$(rustc --print sysroot)" --disable-ldconfig'
+    )
+    probe = 'test -d "$(rustc --print sysroot)/lib/rustlib/wasm32-wasip1/lib"'
+
+    for required in (version, component, archive, checksum, verify, install, probe):
+        assert job.count(required) == 1
+    assert (
+        job.index(version)
+        < job.index(archive)
+        < job.index(checksum)
+        < job.index(verify)
+        < job.index(install)
+        < job.index(probe)
+        < job.index("gmake stdlib")
+    )
+
+
 def _discover_tests() -> list:
     """Return every test function after the module has finished loading."""
     return [


### PR DESCRIPTION
The provisional rc2 release gate exposed a FreeBSD aarch64 environment gap after the native compiler build had succeeded: pkg Rust did not include the `wasm32-wasip1` standard library, so `gmake stdlib` failed with E0463 for `core`/`std`.\n\nThis installs the official host-independent `rust-std` component matching the guest pkg `rustc` version, verifies its published SHA-256, installs it into that compiler sysroot, and probes the target before `gmake stdlib`. It also adds the focused workflow contract.\n\nFocused evidence:\n- `actionlint .github/workflows/release-gate.yml`\n- `make test-release-workflow-contract` (80 release cases plus dependent 32/11/2 contracts)\n- `git diff --check`\n- independent exact-delta review: ACCEPT\n\nNo release-gate dispatch is requested here; normal PR checks are sufficient before merge.