### PR TITLE
feat(sir): add semantic SSA shadow lane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ dependencies = [
  "hew-parser",
  "hew-pkg",
  "hew-runtime",
+ "hew-sir",
  "hew-testutil",
  "hew-types",
  "libc",
@@ -2014,6 +2015,15 @@ dependencies = [
  "tempfile",
  "walkdir",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "hew-sir"
+version = "0.6.0-rc2"
+dependencies = [
+ "hew-hir",
+ "hew-parser",
+ "hew-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "hew-analysis",
   "hew-compile",
   "hew-hir",
+  "hew-sir",
   "hew-mir",
   "hew-codegen-rs",
   "hew-capability-gen",

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -6,7 +6,7 @@ with the Hew compiler, runtime, and tools. Hew itself is dual-licensed under
 MIT OR Apache-2.0 (see LICENSE-MIT and LICENSE-APACHE in this archive).
 
 License summary by SPDX identifier:
-  Apache License 2.0 (399 packages)
+  Apache License 2.0 (400 packages)
   MIT License (116 packages)
   Unicode License v3 (19 packages)
   ISC License (8 packages)
@@ -8596,6 +8596,7 @@ Apache License 2.0
   * hew-runtime 0.6.0-rc2 — https://github.com/hew-lang/hew
   * hew-runtime-testkit 0.6.0-rc2 — https://github.com/hew-lang/hew
   * hew-sandbox-wasm 0.6.0-rc2 — https://github.com/hew-lang/hew
+  * hew-sir 0.6.0-rc2 — https://github.com/hew-lang/hew
   * hew-std 0.6.0-rc2 — https://github.com/hew-lang/hew
   * hew-testutil 0.6.0-rc2
   * hew-types 0.6.0-rc2 — https://github.com/hew-lang/hew

--- a/hew-cli/Cargo.toml
+++ b/hew-cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 hew-analysis = { path = "../hew-analysis" }
 hew-compile = { path = "../hew-compile" }
 hew-hir = { path = "../hew-hir" }
+hew-sir = { path = "../hew-sir" }
 hew-lexer = { path = "../hew-lexer" }
 hew-mir = { path = "../hew-mir" }
 hew-codegen-rs = { path = "../hew-codegen-rs" }

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -116,6 +116,14 @@ pub struct CompileArgs {
     /// spot-checking the front-half lowering during development.
     #[arg(long = "dump-mir", value_name = "STAGE", value_parser = ["raw", "checked", "elab"])]
     pub dump_mir: Option<String>,
+    /// Run the experimental HIR → Semantic IR shadow lane before the established
+    /// HIR → MIR path. It verifies SIR but never changes emitted code.
+    #[arg(long = "sir-shadow")]
+    pub sir_shadow: bool,
+    /// Emit the verified Semantic IR subset and exit. Unsupported functions are
+    /// reported explicitly; no MIR or LLVM artifacts are emitted.
+    #[arg(long = "dump-sir")]
+    pub dump_sir: bool,
     /// Compilation target. Omit for native; pass `wasm32-unknown-unknown` for WASM.
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -347,6 +347,67 @@ fn lower_file_to_mir(
     Ok(pipeline)
 }
 
+/// Run the experimental Semantic IR lane without changing the established
+/// backend path.  This intentionally repeats the frontend work while SIR is
+/// shadow-only: it keeps the existing MIR driver completely authoritative and
+/// makes a mismatch incapable of changing a user's artifact.
+fn lower_file_to_sir(
+    input_path: &Path,
+    requested_target: Option<&str>,
+) -> Result<hew_sir::LoweredModule, ()> {
+    let input = input_path.display().to_string();
+    let target = target::TargetSpec::from_requested(requested_target).map_err(|e| {
+        eprintln!("Error: {e}");
+    })?;
+    let fopts = compile::frontend_options(&target, &compile::CompileOptions::default());
+    let state = hew_compile::run_file_frontend_to_typecheck(&input, &fopts).map_err(|failure| {
+        compile::render_frontend_diagnostics(&failure.diagnostics);
+        if failure.diagnostics.is_empty() {
+            eprintln!("Error: {}", failure.message);
+        }
+    })?;
+    let tco = state.typecheck_result.tco.ok_or_else(|| {
+        eprintln!("Error: Semantic IR requires type checking");
+    })?;
+    let lowered = hew_hir::lower_program(
+        &state.program,
+        &tco,
+        &hew_hir::ResolutionCtx,
+        hir_target_arch(&target),
+    );
+    let mut hir_diagnostics = lowered.diagnostics;
+    for diagnostic in hew_hir::verify_hir(&lowered.module) {
+        if !hir_diagnostics
+            .iter()
+            .any(|existing| existing.kind == diagnostic.kind && existing.span == diagnostic.span)
+        {
+            hir_diagnostics.push(diagnostic);
+        }
+    }
+    if !hir_diagnostics.is_empty() {
+        let diagnostics = hew_compile::hir_diagnostics_to_frontend(
+            &state.program,
+            &state.source,
+            &input,
+            hir_diagnostics,
+        );
+        compile::render_frontend_diagnostics(&diagnostics);
+        return Err(());
+    }
+    let sir = hew_sir::lower_module(&lowered.module);
+    let diagnostics = hew_sir::verify_module(&sir.module);
+    if !diagnostics.is_empty() {
+        for diagnostic in diagnostics {
+            eprintln!(
+                "SIR verifier error in `{}`: {:?}",
+                diagnostic.function, diagnostic.kind
+            );
+        }
+        return Err(());
+    }
+    Ok(sir)
+}
+
 /// Lower a source file to MIR for an explicit, already-resolved target.
 ///
 /// Unlike `lower_file_to_mir` (which hardcodes `TargetArch::host()`), this
@@ -1289,6 +1350,32 @@ fn cmd_compile(a: &args::CompileArgs) {
 /// `return <code>`, so the caller's single flush chokepoint runs regardless.
 fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
     let json = a.format == args::DiagnosticFormat::Json;
+
+    if a.sir_shadow || a.dump_sir {
+        let Ok(sir) = lower_file_to_sir(&a.input, a.target.as_deref()) else {
+            return 1;
+        };
+        if a.dump_sir {
+            let dump = hew_sir::dump_sir(&sir.module);
+            if json {
+                eprint!("{dump}");
+            } else {
+                print!("{dump}");
+            }
+            for (name, status) in &sir.statuses {
+                if !matches!(status, hew_sir::SirLoweringStatus::Lowered) {
+                    eprintln!("SIR shadow fallback for `{name}`: {status:?}");
+                }
+            }
+            return 0;
+        }
+        let lowered = sir
+            .statuses
+            .iter()
+            .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::Lowered))
+            .count();
+        eprintln!("SIR shadow: verified {lowered}/{} function bodies; established MIR remains authoritative", sir.statuses.len());
+    }
 
     let Ok(pipeline) = lower_file_to_mir(&a.input, a.target.as_deref()) else {
         return 1;

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -299,6 +299,8 @@ mod tests {
             emit_dir: None,
             emit_llvm: false,
             dump_mir: None,
+            sir_shadow: false,
+            dump_sir: false,
             target: None,
             opt_level: "0".to_string(),
             format: crate::args::DiagnosticFormat::Text,

--- a/hew-sir/Cargo.toml
+++ b/hew-sir/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "hew-sir"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Value-oriented semantic SSA IR for the Hew compiler"
+repository = "https://github.com/hew-lang/hew"
+readme = "README.md"
+keywords = ["hew", "compiler", "ssa", "ir"]
+categories = ["compilers"]
+
+[dependencies]
+hew-hir = { path = "../hew-hir" }
+hew-parser = { path = "../hew-parser" }
+hew-types = { path = "../hew-types" }
+
+[lints]
+workspace = true

--- a/hew-sir/README.md
+++ b/hew-sir/README.md
@@ -1,0 +1,8 @@
+# Hew Semantic IR
+
+`hew-sir` is Hew's value-oriented semantic SSA intermediate representation.
+It sits between resolved HIR and the established ownership/layout MIR ladder.
+
+The initial implementation is intentionally shadow-only: it verifies a small,
+pure subset of HIR and then leaves the existing HIR-to-MIR-to-LLVM pipeline as
+the authoritative producer of compiler artifacts.

--- a/hew-sir/src/analysis.rs
+++ b/hew-sir/src/analysis.rs
@@ -1,0 +1,128 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use crate::{BlockId, SemFunction, ValueId};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dominators {
+    pub sets: BTreeMap<BlockId, BTreeSet<BlockId>>,
+}
+
+#[must_use]
+///
+/// # Panics
+///
+/// Panics only if a caller supplies a CFG whose predecessor relation names a
+/// block that is absent from the function. `verify_module` reports that shape
+/// before any valid SIR pipeline consumes the analysis.
+pub fn compute_dominators(function: &SemFunction) -> Dominators {
+    let all = function
+        .blocks
+        .iter()
+        .map(|b| b.id)
+        .collect::<BTreeSet<_>>();
+    let mut predecessors: BTreeMap<BlockId, Vec<BlockId>> = BTreeMap::new();
+    for block in &function.blocks {
+        for edge in block.terminator.successors() {
+            predecessors.entry(edge.target).or_default().push(block.id);
+        }
+    }
+    let mut sets = function
+        .blocks
+        .iter()
+        .map(|block| {
+            let initial = if block.id == function.entry {
+                [function.entry].into_iter().collect()
+            } else {
+                all.clone()
+            };
+            (block.id, initial)
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for block in &function.blocks {
+            if block.id == function.entry {
+                continue;
+            }
+            let mut next = predecessors
+                .get(&block.id)
+                .map_or_else(BTreeSet::new, |preds| {
+                    let mut result = all.clone();
+                    for pred in preds {
+                        result = result
+                            .intersection(sets.get(pred).expect("predecessor must be a block"))
+                            .copied()
+                            .collect();
+                    }
+                    result
+                });
+            next.insert(block.id);
+            if sets.get(&block.id) != Some(&next) {
+                sets.insert(block.id, next);
+                changed = true;
+            }
+        }
+    }
+    Dominators { sets }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DefUseIndex {
+    pub definitions: HashMap<ValueId, BlockId>,
+    pub uses: HashMap<ValueId, usize>,
+}
+
+#[must_use]
+pub fn build_def_use(function: &SemFunction) -> DefUseIndex {
+    let mut index = DefUseIndex::default();
+    for param in &function.params {
+        index.definitions.insert(param.value, function.entry);
+    }
+    for block in &function.blocks {
+        for arg in &block.args {
+            index.definitions.insert(arg.value, block.id);
+        }
+        for op in &block.ops {
+            for result in &op.results {
+                index.definitions.insert(result.id, block.id);
+            }
+            for value in op_uses(op) {
+                *index.uses.entry(value).or_default() += 1;
+            }
+        }
+        for value in terminator_uses(&block.terminator) {
+            *index.uses.entry(value).or_default() += 1;
+        }
+    }
+    index
+}
+
+fn op_uses(op: &crate::SemOp) -> Vec<ValueId> {
+    use crate::SemOpKind;
+    match &op.kind {
+        SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) => Vec::new(),
+        SemOpKind::Unary { value, .. } | SemOpKind::Cast { value, .. } => vec![value.value],
+        SemOpKind::Binary { lhs, rhs, .. } => vec![lhs.value, rhs.value],
+        SemOpKind::Call { args, .. } => args.iter().map(|arg| arg.value).collect(),
+    }
+}
+
+fn terminator_uses(terminator: &crate::SemTerminator) -> Vec<ValueId> {
+    use crate::SemTerminator;
+    match terminator {
+        SemTerminator::Return { value } => value.iter().copied().collect(),
+        SemTerminator::Goto(edge) => edge.args.clone(),
+        SemTerminator::Branch {
+            condition,
+            then_target,
+            else_target,
+        } => {
+            let mut values = vec![*condition];
+            values.extend(then_target.args.iter().copied());
+            values.extend(else_target.args.iter().copied());
+            values
+        }
+        SemTerminator::Unreachable => Vec::new(),
+    }
+}

--- a/hew-sir/src/dump.rs
+++ b/hew-sir/src/dump.rs
@@ -1,0 +1,113 @@
+use std::fmt::Write as _;
+
+use crate::{SemModule, SemOpKind, SemTerminator};
+
+/// Deterministic, one-way diagnostic printer for Semantic IR.
+#[must_use]
+pub fn dump_sir(module: &SemModule) -> String {
+    let mut out = String::new();
+    for function in &module.functions {
+        write!(out, "fn {}(", function.name).expect("write to String");
+        for (index, param) in function.params.iter().enumerate() {
+            if index != 0 {
+                write!(out, ", ").expect("write to String");
+            }
+            write!(out, "%{}: {}", param.value.0, param.ty.user_facing()).expect("write to String");
+        }
+        writeln!(out, ") -> {} {{", function.return_ty.user_facing()).expect("write to String");
+        for block in &function.blocks {
+            write!(out, "bb{}", block.id.0).expect("write to String");
+            if !block.args.is_empty() {
+                write!(out, "(").expect("write to String");
+                for (index, arg) in block.args.iter().enumerate() {
+                    if index != 0 {
+                        write!(out, ", ").expect("write to String");
+                    }
+                    write!(out, "%{}: {}", arg.value.0, arg.ty.user_facing())
+                        .expect("write to String");
+                }
+                write!(out, ")").expect("write to String");
+            }
+            writeln!(out, ":").expect("write to String");
+            for op in &block.ops {
+                dump_op(&mut out, op);
+            }
+            dump_term(&mut out, &block.terminator);
+        }
+        writeln!(out, "}}").expect("write to String");
+    }
+    out
+}
+
+fn dump_op(out: &mut String, op: &crate::SemOp) {
+    let result = &op.results[0];
+    write!(out, "    %{} = ", result.id.0).expect("write to String");
+    match &op.kind {
+        SemOpKind::ConstI64(value) => writeln!(out, "const {value}").expect("write to String"),
+        SemOpKind::ConstBool(value) => writeln!(out, "const {value}").expect("write to String"),
+        SemOpKind::Unary { op, value } => {
+            writeln!(out, "{op:?} %{}", value.value.0).expect("write to String");
+        }
+        SemOpKind::Binary { op, lhs, rhs } => {
+            writeln!(out, "{op:?} %{}, %{}", lhs.value.0, rhs.value.0).expect("write to String");
+        }
+        SemOpKind::Cast { value, to } => {
+            writeln!(out, "cast %{} to {}", value.value.0, to.user_facing())
+                .expect("write to String");
+        }
+        SemOpKind::Call { target, args } => {
+            write!(out, "call {target:?}(").expect("write to String");
+            for (index, arg) in args.iter().enumerate() {
+                if index != 0 {
+                    write!(out, ", ").expect("write to String");
+                }
+                write!(out, "%{}", arg.value.0).expect("write to String");
+            }
+            writeln!(out, ")").expect("write to String");
+        }
+    }
+}
+
+fn dump_term(out: &mut String, term: &SemTerminator) {
+    match term {
+        SemTerminator::Return { value: Some(value) } => {
+            writeln!(out, "    return %{}", value.0).expect("write to String");
+        }
+        SemTerminator::Return { value: None } => {
+            writeln!(out, "    return").expect("write to String");
+        }
+        SemTerminator::Goto(edge) => {
+            writeln!(out, "    goto bb{}{}", edge.target.0, edge_args(edge))
+                .expect("write to String");
+        }
+        SemTerminator::Branch {
+            condition,
+            then_target,
+            else_target,
+        } => writeln!(
+            out,
+            "    branch %{}, bb{}{}, bb{}{}",
+            condition.0,
+            then_target.target.0,
+            edge_args(then_target),
+            else_target.target.0,
+            edge_args(else_target)
+        )
+        .expect("write to String"),
+        SemTerminator::Unreachable => writeln!(out, "    unreachable").expect("write to String"),
+    }
+}
+
+fn edge_args(edge: &crate::Edge) -> String {
+    if edge.args.is_empty() {
+        return String::new();
+    }
+    format!(
+        "({})",
+        edge.args
+            .iter()
+            .map(|value| format!("%{}", value.0))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}

--- a/hew-sir/src/lib.rs
+++ b/hew-sir/src/lib.rs
@@ -1,0 +1,22 @@
+//! Hew Semantic IR (SIR).
+//!
+//! SIR is the value-oriented SSA layer between resolved HIR and the existing
+//! ownership/layout MIR ladder.  It deliberately contains no `Place`, alloca,
+//! ABI carrier, byte-offset, or LLVM operation.  The initial shadow lane is a
+//! conservative subset; unsupported HIR bodies report that fact to the driver,
+//! which continues through the established HIR -> MIR path.
+
+mod analysis;
+mod dump;
+mod lower;
+mod model;
+mod verify;
+
+pub use analysis::{build_def_use, compute_dominators, DefUseIndex, Dominators};
+pub use dump::dump_sir;
+pub use lower::{lower_module, LoweredModule, SirLoweringStatus};
+pub use model::{
+    BlockArg, BlockId, Edge, OpId, Operand, Provenance, SemBlock, SemFunction, SemModule, SemOp,
+    SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+};
+pub use verify::{verify_module, SirDiagnostic, SirDiagnosticKind};

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -1,0 +1,375 @@
+use std::collections::HashMap;
+
+use hew_hir::{
+    BindingId, HirBlock, HirExpr, HirExprKind, HirFn, HirItem, HirLiteral, HirModule, HirStmtKind,
+    ResolvedRef,
+};
+
+use crate::{
+    BlockArg, BlockId, Edge, OpId, Operand, Provenance, SemBlock, SemFunction, SemModule, SemOp,
+    SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SirLoweringStatus {
+    Lowered,
+    Unsupported { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoweredModule {
+    pub module: SemModule,
+    /// One status per HIR function, in source order. Shadow-mode callers must
+    /// only regard the SIR result as comparable when every status is `Lowered`.
+    pub statuses: Vec<(String, SirLoweringStatus)>,
+}
+
+#[must_use]
+pub fn lower_module(module: &HirModule) -> LoweredModule {
+    let mut output = SemModule::default();
+    let mut statuses = Vec::new();
+    for item in &module.items {
+        let HirItem::Function(function) = item else {
+            continue;
+        };
+        match Builder::new(function).lower() {
+            Ok(function) => {
+                statuses.push((function.name.clone(), SirLoweringStatus::Lowered));
+                output.functions.push(function);
+            }
+            Err(reason) => statuses.push((
+                function.name.clone(),
+                SirLoweringStatus::Unsupported { reason },
+            )),
+        }
+    }
+    LoweredModule {
+        module: output,
+        statuses,
+    }
+}
+
+struct Builder<'a> {
+    function: &'a HirFn,
+    blocks: Vec<SemBlock>,
+    current: BlockId,
+    values: u32,
+    ops: u32,
+    bindings: HashMap<BindingId, ValueId>,
+    params: Vec<BlockArg>,
+}
+
+impl<'a> Builder<'a> {
+    fn new(function: &'a HirFn) -> Self {
+        let entry = BlockId(0);
+        let mut values = 0;
+        let mut bindings = HashMap::new();
+        let params = function
+            .params
+            .iter()
+            .map(|param| {
+                let value = ValueId(values);
+                values += 1;
+                bindings.insert(param.id, value);
+                BlockArg {
+                    value,
+                    ty: param.ty.clone(),
+                }
+            })
+            .collect();
+        Self {
+            function,
+            blocks: vec![SemBlock {
+                id: entry,
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Unreachable,
+            }],
+            current: entry,
+            values,
+            ops: 0,
+            bindings,
+            params,
+        }
+    }
+
+    fn lower(mut self) -> Result<SemFunction, String> {
+        if self.function.is_generator || self.function.intrinsic_id.is_some() {
+            return Err(
+                "generators and floor intrinsics remain on the established MIR path".to_string(),
+            );
+        }
+        let result = self.lower_block(&self.function.body)?;
+        if self.is_open() {
+            self.set_terminator(SemTerminator::Return { value: result });
+        }
+        Ok(SemFunction {
+            id: self.function.id,
+            name: self.function.name.clone(),
+            params: self.params,
+            return_ty: self.function.return_ty.clone(),
+            entry: BlockId(0),
+            blocks: self.blocks,
+        })
+    }
+
+    fn lower_block(&mut self, block: &HirBlock) -> Result<Option<ValueId>, String> {
+        for statement in &block.statements {
+            if !self.is_open() {
+                break;
+            }
+            match &statement.kind {
+                HirStmtKind::Let(binding, value) => {
+                    if binding.mutable {
+                        return Err("mutable bindings are deferred until a dedicated SIR feature requires them".to_string());
+                    }
+                    let value = value
+                        .as_ref()
+                        .map(|expr| self.lower_expr(expr))
+                        .transpose()?
+                        .ok_or_else(|| {
+                            "uninitialised bindings are not in the initial SIR subset".to_string()
+                        })?;
+                    self.bindings.insert(binding.id, value);
+                }
+                HirStmtKind::Expr(expr) => {
+                    self.lower_expr(expr)?;
+                }
+                HirStmtKind::Return(value) => {
+                    let value = value
+                        .as_ref()
+                        .map(|expr| self.lower_expr(expr))
+                        .transpose()?;
+                    self.set_terminator(SemTerminator::Return { value });
+                }
+                HirStmtKind::Assign { .. } => {
+                    return Err(
+                        "assignment is deferred until SIR has an explicit mutable-location design"
+                            .to_string(),
+                    )
+                }
+                HirStmtKind::LetElse { .. } | HirStmtKind::Defer { .. } => {
+                    return Err(
+                        "control-flow ownership forms are deferred to a later SIR slice"
+                            .to_string(),
+                    )
+                }
+            }
+        }
+        if self.is_open() {
+            block
+                .tail
+                .as_deref()
+                .map(|expr| self.lower_expr(expr))
+                .transpose()
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the closed initial HIR-to-SIR expression mapping remains intentionally local"
+    )]
+    fn lower_expr(&mut self, expr: &HirExpr) -> Result<ValueId, String> {
+        match &expr.kind {
+            HirExprKind::Literal(HirLiteral::Integer(value)) => {
+                Ok(self.emit(expr, SemOpKind::ConstI64(*value)))
+            }
+            HirExprKind::Literal(HirLiteral::Bool(value)) => {
+                Ok(self.emit(expr, SemOpKind::ConstBool(*value)))
+            }
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(binding),
+                ..
+            } => self.bindings.get(binding).copied().ok_or_else(|| {
+                format!("binding `{binding}` is not available in the SIR environment")
+            }),
+            HirExprKind::Unary { op, operand, .. } => {
+                let value = self.lower_expr(operand)?;
+                Ok(self.emit(
+                    expr,
+                    SemOpKind::Unary {
+                        op: *op,
+                        value: Operand {
+                            value,
+                            mode: UseMode::Read,
+                        },
+                    },
+                ))
+            }
+            HirExprKind::Binary { op, left, right } => {
+                let lhs = self.lower_expr(left)?;
+                let rhs = self.lower_expr(right)?;
+                Ok(self.emit(
+                    expr,
+                    SemOpKind::Binary {
+                        op: *op,
+                        lhs: Operand {
+                            value: lhs,
+                            mode: UseMode::Read,
+                        },
+                        rhs: Operand {
+                            value: rhs,
+                            mode: UseMode::Read,
+                        },
+                    },
+                ))
+            }
+            HirExprKind::NumericCast { value, to_ty, .. } => {
+                let value = self.lower_expr(value)?;
+                Ok(self.emit(
+                    expr,
+                    SemOpKind::Cast {
+                        value: Operand {
+                            value,
+                            mode: UseMode::Read,
+                        },
+                        to: to_ty.clone(),
+                    },
+                ))
+            }
+            HirExprKind::Call {
+                target,
+                callee,
+                args,
+            } => {
+                if matches!(target, hew_types::CallTarget::IndirectFunctionValue) {
+                    return Err(
+                        "indirect calls are deferred until SIR models the callee value explicitly"
+                            .to_string(),
+                    );
+                }
+                if !matches!(callee.kind, HirExprKind::BindingRef { .. }) {
+                    return Err(
+                        "calls with an evaluated callee are deferred until SIR models callee values"
+                            .to_string(),
+                    );
+                }
+                let args = args
+                    .iter()
+                    .map(|arg| {
+                        self.lower_expr(arg).map(|value| Operand {
+                            value,
+                            mode: UseMode::Read,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(self.emit(
+                    expr,
+                    SemOpKind::Call {
+                        target: target.clone(),
+                        args,
+                    },
+                ))
+            }
+            HirExprKind::Block(block) => self
+                .lower_block(block)?
+                .ok_or_else(|| "a divergent block cannot produce a SIR value".to_string()),
+            HirExprKind::If {
+                condition,
+                then_expr,
+                else_expr: Some(else_expr),
+            } => self.lower_if(expr, condition, then_expr, else_expr),
+            HirExprKind::If {
+                else_expr: None, ..
+            } => Err(
+                "one-armed if expressions are deferred until unit values are modeled".to_string(),
+            ),
+            _ => Err("unsupported HIR expression kind in the initial SIR subset".to_string()),
+        }
+    }
+
+    fn lower_if(
+        &mut self,
+        whole: &HirExpr,
+        condition: &HirExpr,
+        then_expr: &HirExpr,
+        else_expr: &HirExpr,
+    ) -> Result<ValueId, String> {
+        let condition = self.lower_expr(condition)?;
+        let then_block = self.new_block(Vec::new());
+        let else_block = self.new_block(Vec::new());
+        let join_value = self.fresh_value();
+        let join_block = self.new_block(vec![BlockArg {
+            value: join_value,
+            ty: whole.ty.clone(),
+        }]);
+        self.set_terminator(SemTerminator::Branch {
+            condition,
+            then_target: Edge {
+                target: then_block,
+                args: Vec::new(),
+            },
+            else_target: Edge {
+                target: else_block,
+                args: Vec::new(),
+            },
+        });
+        let before = self.bindings.clone();
+        self.current = then_block;
+        self.bindings = before.clone();
+        let then_value = self.lower_expr(then_expr)?;
+        if self.is_open() {
+            self.set_terminator(SemTerminator::Goto(Edge {
+                target: join_block,
+                args: vec![then_value],
+            }));
+        }
+        self.current = else_block;
+        self.bindings = before;
+        let else_value = self.lower_expr(else_expr)?;
+        if self.is_open() {
+            self.set_terminator(SemTerminator::Goto(Edge {
+                target: join_block,
+                args: vec![else_value],
+            }));
+        }
+        self.current = join_block;
+        Ok(join_value)
+    }
+
+    fn emit(&mut self, expr: &HirExpr, kind: SemOpKind) -> ValueId {
+        let value = self.fresh_value();
+        let op = SemOp {
+            id: OpId(self.ops),
+            results: vec![ValueDef {
+                id: value,
+                ty: expr.ty.clone(),
+            }],
+            kind,
+            provenance: Provenance::Site(expr.site),
+        };
+        self.ops += 1;
+        self.current_block_mut().ops.push(op);
+        value
+    }
+
+    fn fresh_value(&mut self) -> ValueId {
+        let value = ValueId(self.values);
+        self.values += 1;
+        value
+    }
+    fn new_block(&mut self, args: Vec<BlockArg>) -> BlockId {
+        let id = BlockId(u32::try_from(self.blocks.len()).expect("SIR block count exceeds u32"));
+        self.blocks.push(SemBlock {
+            id,
+            args,
+            ops: Vec::new(),
+            terminator: SemTerminator::Unreachable,
+        });
+        id
+    }
+    fn current_block_mut(&mut self) -> &mut SemBlock {
+        &mut self.blocks[self.current.0 as usize]
+    }
+    fn is_open(&self) -> bool {
+        matches!(
+            self.blocks[self.current.0 as usize].terminator,
+            SemTerminator::Unreachable
+        )
+    }
+    fn set_terminator(&mut self, term: SemTerminator) {
+        self.current_block_mut().terminator = term;
+    }
+}

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -1,0 +1,134 @@
+use hew_hir::{ItemId, SiteId};
+use hew_types::{CallTarget, ResolvedTy};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlockId(pub u32);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ValueId(pub u32);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OpId(pub u32);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Provenance {
+    Site(SiteId),
+    Synthesized,
+    Derived(Vec<SiteId>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UseMode {
+    Read,
+    BorrowShared,
+    BorrowMut,
+    Move,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Operand {
+    pub value: ValueId,
+    pub mode: UseMode,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValueDef {
+    pub id: ValueId,
+    pub ty: ResolvedTy,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BlockArg {
+    pub value: ValueId,
+    pub ty: ResolvedTy,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Edge {
+    pub target: BlockId,
+    pub args: Vec<ValueId>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemBlock {
+    pub id: BlockId,
+    pub args: Vec<BlockArg>,
+    pub ops: Vec<SemOp>,
+    pub terminator: SemTerminator,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemFunction {
+    pub id: ItemId,
+    pub name: String,
+    pub params: Vec<BlockArg>,
+    pub return_ty: ResolvedTy,
+    pub entry: BlockId,
+    pub blocks: Vec<SemBlock>,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct SemModule {
+    pub functions: Vec<SemFunction>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemOp {
+    pub id: OpId,
+    pub results: Vec<ValueDef>,
+    pub kind: SemOpKind,
+    pub provenance: Provenance,
+}
+
+/// Pure, non-suspending operations in the first SIR slice.  Effects are
+/// derived from this closed operation set and resolved call metadata; they are
+/// intentionally not stored redundantly on each operation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SemOpKind {
+    ConstI64(i64),
+    ConstBool(bool),
+    Unary {
+        op: hew_parser::ast::UnaryOp,
+        value: Operand,
+    },
+    Binary {
+        op: hew_parser::ast::BinaryOp,
+        lhs: Operand,
+        rhs: Operand,
+    },
+    Cast {
+        value: Operand,
+        to: ResolvedTy,
+    },
+    Call {
+        target: CallTarget,
+        args: Vec<Operand>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SemTerminator {
+    Return {
+        value: Option<ValueId>,
+    },
+    Goto(Edge),
+    Branch {
+        condition: ValueId,
+        then_target: Edge,
+        else_target: Edge,
+    },
+    Unreachable,
+}
+
+impl SemTerminator {
+    #[must_use]
+    pub fn successors(&self) -> Vec<&Edge> {
+        match self {
+            Self::Return { .. } | Self::Unreachable => Vec::new(),
+            Self::Goto(edge) => vec![edge],
+            Self::Branch {
+                then_target,
+                else_target,
+                ..
+            } => vec![then_target, else_target],
+        }
+    }
+}

--- a/hew-sir/src/verify.rs
+++ b/hew-sir/src/verify.rs
@@ -1,0 +1,226 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::{BlockId, SemFunction, SemModule, SemTerminator, ValueId};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SirDiagnosticKind {
+    DuplicateBlock(BlockId),
+    UnknownBlock(BlockId),
+    EdgeArity {
+        from: BlockId,
+        to: BlockId,
+        expected: usize,
+        actual: usize,
+    },
+    EdgeType {
+        from: BlockId,
+        to: BlockId,
+        argument: usize,
+        expected: String,
+        actual: String,
+    },
+    DuplicateValue(ValueId),
+    UndefinedValue(ValueId),
+    NonDominatingUse {
+        value: ValueId,
+        definition: BlockId,
+        use_block: BlockId,
+    },
+    UseBeforeDefinition {
+        value: ValueId,
+        block: BlockId,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SirDiagnostic {
+    pub function: String,
+    pub kind: SirDiagnosticKind,
+}
+
+#[must_use]
+pub fn verify_module(module: &SemModule) -> Vec<SirDiagnostic> {
+    module.functions.iter().flat_map(verify_function).collect()
+}
+
+fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
+    let mut diagnostics = Vec::new();
+    let mut blocks = BTreeMap::new();
+    for block in &function.blocks {
+        if blocks.insert(block.id, block).is_some() {
+            diagnostics.push(diag(function, SirDiagnosticKind::DuplicateBlock(block.id)));
+        }
+    }
+    let mut values = HashSet::new();
+    let mut types = HashMap::new();
+    let mut definitions = HashMap::new();
+    for param in &function.params {
+        record_value(function, param.value, &mut values, &mut diagnostics);
+        types.insert(param.value, param.ty.clone());
+        definitions.insert(param.value, (function.entry, None));
+    }
+    for block in &function.blocks {
+        for arg in &block.args {
+            record_value(function, arg.value, &mut values, &mut diagnostics);
+            types.insert(arg.value, arg.ty.clone());
+            definitions.insert(arg.value, (block.id, None));
+        }
+        for (op_index, op) in block.ops.iter().enumerate() {
+            for result in &op.results {
+                record_value(function, result.id, &mut values, &mut diagnostics);
+                types.insert(result.id, result.ty.clone());
+                definitions.insert(result.id, (block.id, Some(op_index)));
+            }
+        }
+        for edge in block.terminator.successors() {
+            let Some(target) = blocks.get(&edge.target) else {
+                diagnostics.push(diag(function, SirDiagnosticKind::UnknownBlock(edge.target)));
+                continue;
+            };
+            if target.args.len() != edge.args.len() {
+                diagnostics.push(diag(
+                    function,
+                    SirDiagnosticKind::EdgeArity {
+                        from: block.id,
+                        to: edge.target,
+                        expected: target.args.len(),
+                        actual: edge.args.len(),
+                    },
+                ));
+            }
+            for (argument, (value, target_arg)) in edge.args.iter().zip(&target.args).enumerate() {
+                let Some(actual) = types.get(value) else {
+                    continue;
+                };
+                if actual != &target_arg.ty {
+                    diagnostics.push(diag(
+                        function,
+                        SirDiagnosticKind::EdgeType {
+                            from: block.id,
+                            to: edge.target,
+                            argument,
+                            expected: target_arg.ty.user_facing().to_string(),
+                            actual: actual.user_facing().to_string(),
+                        },
+                    ));
+                }
+            }
+        }
+    }
+    let dominators = crate::compute_dominators(function);
+    for block in &function.blocks {
+        for (op_index, op) in block.ops.iter().enumerate() {
+            verify_uses(
+                function,
+                &dominators,
+                &definitions,
+                block.id,
+                Some(op_index),
+                uses_in_op(op),
+                &mut diagnostics,
+            );
+        }
+        verify_uses(
+            function,
+            &dominators,
+            &definitions,
+            block.id,
+            None,
+            uses_in_terminator(&block.terminator),
+            &mut diagnostics,
+        );
+    }
+    diagnostics
+}
+
+#[allow(clippy::too_many_arguments, reason = "small verifier transfer helper")]
+fn verify_uses(
+    function: &SemFunction,
+    dominators: &crate::Dominators,
+    definitions: &HashMap<ValueId, (BlockId, Option<usize>)>,
+    use_block: BlockId,
+    use_index: Option<usize>,
+    uses: Vec<ValueId>,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    for value in uses {
+        let Some((definition, definition_index)) = definitions.get(&value) else {
+            diagnostics.push(diag(function, SirDiagnosticKind::UndefinedValue(value)));
+            continue;
+        };
+        if definition == &use_block {
+            if let (Some(definition_index), Some(use_index)) = (definition_index, use_index) {
+                if definition_index >= &use_index {
+                    diagnostics.push(diag(
+                        function,
+                        SirDiagnosticKind::UseBeforeDefinition {
+                            value,
+                            block: use_block,
+                        },
+                    ));
+                }
+            }
+            continue;
+        }
+        if !dominators
+            .sets
+            .get(&use_block)
+            .is_some_and(|set| set.contains(definition))
+        {
+            diagnostics.push(diag(
+                function,
+                SirDiagnosticKind::NonDominatingUse {
+                    value,
+                    definition: *definition,
+                    use_block,
+                },
+            ));
+        }
+    }
+}
+
+fn record_value(
+    function: &SemFunction,
+    value: ValueId,
+    values: &mut HashSet<ValueId>,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    if !values.insert(value) {
+        diagnostics.push(diag(function, SirDiagnosticKind::DuplicateValue(value)));
+    }
+}
+
+fn diag(function: &SemFunction, kind: SirDiagnosticKind) -> SirDiagnostic {
+    SirDiagnostic {
+        function: function.name.clone(),
+        kind,
+    }
+}
+
+fn uses_in_op(op: &crate::SemOp) -> Vec<ValueId> {
+    use crate::SemOpKind;
+    match &op.kind {
+        SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) => Vec::new(),
+        SemOpKind::Unary { value, .. } | SemOpKind::Cast { value, .. } => vec![value.value],
+        SemOpKind::Binary { lhs, rhs, .. } => vec![lhs.value, rhs.value],
+        SemOpKind::Call { args, .. } => args.iter().map(|arg| arg.value).collect(),
+    }
+}
+
+fn uses_in_terminator(term: &SemTerminator) -> Vec<ValueId> {
+    match term {
+        SemTerminator::Return { value } => value.iter().copied().collect(),
+        SemTerminator::Goto(edge) => edge.args.clone(),
+        SemTerminator::Branch {
+            condition,
+            then_target,
+            else_target,
+        } => {
+            let mut values = vec![*condition];
+            values.extend(then_target.args.iter().copied());
+            values.extend(else_target.args.iter().copied());
+            values
+        }
+        SemTerminator::Unreachable => Vec::new(),
+    }
+}

--- a/hew-sir/tests/sir.rs
+++ b/hew-sir/tests/sir.rs
@@ -1,0 +1,197 @@
+use hew_hir::ItemId;
+use hew_parser::ast::BinaryOp;
+use hew_sir::{
+    dump_sir, verify_module, BlockArg, BlockId, Edge, OpId, Operand, Provenance, SemBlock,
+    SemFunction, SemModule, SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+};
+use hew_types::ResolvedTy;
+
+fn definition(id: u32) -> ValueDef {
+    ValueDef {
+        id: ValueId(id),
+        ty: ResolvedTy::I64,
+    }
+}
+
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "one complete SSA diamond fixture is easier to audit as a single IR graph"
+)]
+fn block_arguments_are_ssa_join_values() {
+    let function = SemFunction {
+        id: ItemId(0),
+        name: "f".to_string(),
+        params: vec![
+            BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
+            },
+            BlockArg {
+                value: ValueId(1),
+                ty: ResolvedTy::I64,
+            },
+        ],
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![
+            SemBlock {
+                id: BlockId(0),
+                args: vec![],
+                ops: vec![
+                    SemOp {
+                        id: OpId(0),
+                        results: vec![definition(2)],
+                        kind: SemOpKind::ConstI64(0),
+                        provenance: Provenance::Synthesized,
+                    },
+                    SemOp {
+                        id: OpId(1),
+                        results: vec![ValueDef {
+                            id: ValueId(3),
+                            ty: ResolvedTy::Bool,
+                        }],
+                        kind: SemOpKind::Binary {
+                            op: BinaryOp::Greater,
+                            lhs: Operand {
+                                value: ValueId(0),
+                                mode: UseMode::Read,
+                            },
+                            rhs: Operand {
+                                value: ValueId(2),
+                                mode: UseMode::Read,
+                            },
+                        },
+                        provenance: Provenance::Synthesized,
+                    },
+                ],
+                terminator: SemTerminator::Branch {
+                    condition: ValueId(3),
+                    then_target: Edge {
+                        target: BlockId(1),
+                        args: vec![ValueId(1)],
+                    },
+                    else_target: Edge {
+                        target: BlockId(2),
+                        args: vec![ValueId(1)],
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: vec![BlockArg {
+                    value: ValueId(4),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: vec![
+                    SemOp {
+                        id: OpId(2),
+                        results: vec![definition(5)],
+                        kind: SemOpKind::ConstI64(1),
+                        provenance: Provenance::Synthesized,
+                    },
+                    SemOp {
+                        id: OpId(3),
+                        results: vec![definition(6)],
+                        kind: SemOpKind::Binary {
+                            op: BinaryOp::Add,
+                            lhs: Operand {
+                                value: ValueId(4),
+                                mode: UseMode::Read,
+                            },
+                            rhs: Operand {
+                                value: ValueId(5),
+                                mode: UseMode::Read,
+                            },
+                        },
+                        provenance: Provenance::Synthesized,
+                    },
+                ],
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(3),
+                    args: vec![ValueId(6)],
+                }),
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: vec![BlockArg {
+                    value: ValueId(7),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: vec![
+                    SemOp {
+                        id: OpId(4),
+                        results: vec![definition(8)],
+                        kind: SemOpKind::ConstI64(2),
+                        provenance: Provenance::Synthesized,
+                    },
+                    SemOp {
+                        id: OpId(5),
+                        results: vec![definition(9)],
+                        kind: SemOpKind::Binary {
+                            op: BinaryOp::Add,
+                            lhs: Operand {
+                                value: ValueId(7),
+                                mode: UseMode::Read,
+                            },
+                            rhs: Operand {
+                                value: ValueId(8),
+                                mode: UseMode::Read,
+                            },
+                        },
+                        provenance: Provenance::Synthesized,
+                    },
+                ],
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(3),
+                    args: vec![ValueId(9)],
+                }),
+            },
+            SemBlock {
+                id: BlockId(3),
+                args: vec![BlockArg {
+                    value: ValueId(10),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: vec![
+                    SemOp {
+                        id: OpId(6),
+                        results: vec![definition(11)],
+                        kind: SemOpKind::ConstI64(3),
+                        provenance: Provenance::Synthesized,
+                    },
+                    SemOp {
+                        id: OpId(7),
+                        results: vec![definition(12)],
+                        kind: SemOpKind::Binary {
+                            op: BinaryOp::Multiply,
+                            lhs: Operand {
+                                value: ValueId(10),
+                                mode: UseMode::Read,
+                            },
+                            rhs: Operand {
+                                value: ValueId(11),
+                                mode: UseMode::Read,
+                            },
+                        },
+                        provenance: Provenance::Synthesized,
+                    },
+                ],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(12)),
+                },
+            },
+        ],
+    };
+    let module = SemModule {
+        functions: vec![function],
+    };
+    assert!(
+        verify_module(&module).is_empty(),
+        "SIR must verify: {:#?}",
+        verify_module(&module)
+    );
+    let dump = dump_sir(&module);
+    assert!(dump.contains("bb3(%10: i64):"));
+    assert!(dump.contains("goto bb3(%6)"));
+}

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -561,7 +561,7 @@ def test_rust_diff_derives_its_warmup_artifacts_before_commands() -> None:
     assert result.returncode == 0, result.stderr
     packages = (
         "-p hew-analysis -p hew-cli -p hew-codegen-rs -p hew-compile -p hew-hir "
-        "-p hew-lsp -p hew-mir -p hew-parser -p hew-sandbox-wasm -p hew-types "
+        "-p hew-lsp -p hew-mir -p hew-parser -p hew-sandbox-wasm -p hew-sir -p hew-types "
         "-p hew-wasm -p xtask"
     )
     warmup = result.stdout.split("Warm-up:\n", 1)[1].split("Commands:\n", 1)[0]


### PR DESCRIPTION
## Summary
- add the hew-sir crate as the value-oriented SSA layer between HIR and the current MIR ladder
- implement the initial pure HIR subset with block arguments, dominance/def-use verification, and deterministic dumps
- add --sir-shadow and --dump-sir to hew compile; shadow mode never changes the established HIR → MIR → LLVM artifact path
- reject unsupported/mutable/indirect paths from SIR explicitly so they remain on the established pipeline

## Validation
- cargo test -p hew-sir
- cargo clippy -p hew-sir --all-targets -- -D warnings
- cargo check -p hew-cli
- hew compile tests/ll-oracle/corpus/r4_arith.hew --dump-sir

## Scope
This is the approved first vertical slice. SIR-to-raw-MIR lowering, broader surface lowering, and optimizations deliberately follow in later changes; the current backend is unchanged and authoritative.