### PR TITLE
ci: migrate LSP and harden platform gates

### DIFF
--- a/.github/hew-runtime-unsafe-count.txt
+++ b/.github/hew-runtime-unsafe-count.txt
@@ -1,0 +1,3 @@
+# Total of cargo-geiger's used and unused unsafe counters for hew-runtime.
+# Raising this value is an explicit review waiver for new unsafe code.
+total=43784

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1010,7 +1010,7 @@ jobs:
       # silently skipping the native-to-sandbox comparison on this platform.
       - name: Setup Node.js for sandbox parity
         if: env.RUN_CODE_PATH == 'true'
-        uses: actions/setup-node@48b55b74deaf7a1b34601d0b3c8a0f6c341db47d  # v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1005,21 +1005,6 @@ jobs:
           tools: nextest@0.9.120
           cache-shared-key: build-test-windows
 
-      # The sandbox parity integration tests execute the checked-in Node VM.
-      # Keep its locked dependencies available on Windows too, rather than
-      # silently skipping the native-to-sandbox comparison on this platform.
-      - name: Setup Node.js for sandbox parity
-        if: env.RUN_CODE_PATH == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: hew-sandbox-vm/package-lock.json
-
-      - name: Install sandbox VM dependencies
-        if: env.RUN_CODE_PATH == 'true'
-        run: npm --prefix hew-sandbox-vm ci
-
       - name: Build Rust crates
         if: env.RUN_CODE_PATH == 'true'
         # hew-codegen-rs (inkwell -> llvm-sys-221) compiles end-to-end
@@ -1033,16 +1018,6 @@ jobs:
       - name: Build shared Rust test artifact
         if: env.RUN_CODE_PATH == 'true'
         run: make stdlib
-
-      - name: Run native-to-sandbox parity
-        if: env.RUN_CODE_PATH == 'true'
-        env:
-          HEW_TEST_NO_BUILD: "1"
-        # Equivalent to the test portion of `make sandbox-parity`.  Windows
-        # runners do not provide GNU make, while each test builds the VM from
-        # the lockfile-installed dependencies above and builds its native
-        # artefacts through hew-testutil's cross-process authority.
-        run: cargo test -p hew-sandbox-wasm --test parity --test parity_ratchet --test playground
 
       - name: Verify Windows CodeView PDB emission
         if: env.RUN_CODE_PATH == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1036,6 +1036,8 @@ jobs:
 
       - name: Run native-to-sandbox parity
         if: env.RUN_CODE_PATH == 'true'
+        env:
+          HEW_TEST_NO_BUILD: "1"
         # Equivalent to the test portion of `make sandbox-parity`.  Windows
         # runners do not provide GNU make, while each test builds the VM from
         # the lockfile-installed dependencies above and builds its native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,18 @@ jobs:
             | tee clippy-results.sarif \
             | sarif-fmt
 
+      - name: Require documented runtime unsafe blocks
+        run: make runtime-unsafe-clippy
+
+      - name: Install cargo-geiger
+        run: cargo install cargo-geiger --locked
+
+      - name: Reject unreviewed runtime unsafe growth
+        run: make runtime-unsafe-geiger
+
+      - name: Audit new high-risk unsafe operations
+        run: make unsafe-pattern-audit
+
       - name: Verify C ABI surface and JIT host ABI classification
         run: make cabi-surface-check test-cabi-surface verify-ffi test-verify-ffi test-python310-toml-compat
 
@@ -993,6 +1005,21 @@ jobs:
           tools: nextest@0.9.120
           cache-shared-key: build-test-windows
 
+      # The sandbox parity integration tests execute the checked-in Node VM.
+      # Keep its locked dependencies available on Windows too, rather than
+      # silently skipping the native-to-sandbox comparison on this platform.
+      - name: Setup Node.js for sandbox parity
+        if: env.RUN_CODE_PATH == 'true'
+        uses: actions/setup-node@48b55b74deaf7a1b34601d0b3c8a0f6c341db47d  # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: hew-sandbox-vm/package-lock.json
+
+      - name: Install sandbox VM dependencies
+        if: env.RUN_CODE_PATH == 'true'
+        run: npm --prefix hew-sandbox-vm ci
+
       - name: Build Rust crates
         if: env.RUN_CODE_PATH == 'true'
         # hew-codegen-rs (inkwell -> llvm-sys-221) compiles end-to-end
@@ -1006,6 +1033,14 @@ jobs:
       - name: Build shared Rust test artifact
         if: env.RUN_CODE_PATH == 'true'
         run: make stdlib
+
+      - name: Run native-to-sandbox parity
+        if: env.RUN_CODE_PATH == 'true'
+        # Equivalent to the test portion of `make sandbox-parity`.  Windows
+        # runners do not provide GNU make, while each test builds the VM from
+        # the lockfile-installed dependencies above and builds its native
+        # artefacts through hew-testutil's cross-process authority.
+        run: cargo test -p hew-sandbox-wasm --test parity --test parity_ratchet --test playground --test ios_subset
 
       - name: Verify Windows CodeView PDB emission
         if: env.RUN_CODE_PATH == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1040,7 +1040,7 @@ jobs:
         # runners do not provide GNU make, while each test builds the VM from
         # the lockfile-installed dependencies above and builds its native
         # artefacts through hew-testutil's cross-process authority.
-        run: cargo test -p hew-sandbox-wasm --test parity --test parity_ratchet --test playground --test ios_subset
+        run: cargo test -p hew-sandbox-wasm --test parity --test parity_ratchet --test playground
 
       - name: Verify Windows CodeView PDB emission
         if: env.RUN_CODE_PATH == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -290,17 +290,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "autocfg"
@@ -1110,19 +1099,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1248,7 +1224,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1352,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1479,6 +1455,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1873,7 +1858,7 @@ dependencies = [
 name = "hew-lsp"
 version = "0.6.0-rc2"
 dependencies = [
- "dashmap 6.2.1",
+ "dashmap",
  "hew-analysis",
  "hew-hir",
  "hew-lexer",
@@ -1882,7 +1867,7 @@ dependencies = [
  "hew-types",
  "serde_json",
  "tokio",
- "tower-lsp",
+ "tower-lsp-server",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2837,15 +2822,15 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-types"
-version = "0.94.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -3009,7 +2994,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3328,26 +3313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3954,7 +3919,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -4030,7 +3995,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4089,7 +4054,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4110,7 +4075,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4294,13 +4259,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4488,7 +4453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4517,7 +4482,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4575,6 +4540,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4643,7 +4619,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4945,20 +4921,6 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -4984,7 +4946,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "url",
@@ -4997,15 +4959,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
+name = "tower-lsp-server"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+checksum = "5fade4c658b63d11b623ddfa80821901e943a2923a010ae4a038661de42bd377"
 dependencies = [
- "async-trait",
- "auto_impl",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "httparse",
  "lsp-types",
@@ -5014,20 +4974,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
- "tower-lsp-macros",
+ "tower",
  "tracing",
-]
-
-[[package]]
-name = "tower-lsp-macros"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5267,7 +5215,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -5646,7 +5593,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks help shell-script-lint hew hew-debug hew-profile-check hew-native hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check baselines baselines-check baselines-check-build
-.PHONY: test macos-leak-oracle test-leak-oracle-selftest test-cabi test-cabi-build test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix test-obligation-advisory-corpus test-obligation-advisory-runner-selftest core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-stdlib-execution-proofs test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link test-release-workflow-contract check-sanitizer-gate asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-structural-authority-audit test-ast-grep-contract test-structural-lint-bootstrap runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo lint-wasm-todo-self-test leak-scan legacy-path-syntax-lint hew-fmt-check test-migrate-corpus check-gate-reachability test-check-gate-reachability check-counterfactual-output check-counterfactual-output-build sandbox-parity-coverage-check test-sandbox-parity-coverage-check doc-ratchet-selftest freebsd-workflow-contract-check verify-sys-lane-closure test-sys-lane-closure hew-fmt-property tool-pin-contract-check test-build-harness forced-cancel-composite-check
+.PHONY: test macos-leak-oracle test-leak-oracle-selftest test-cabi test-cabi-build test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix test-obligation-advisory-corpus test-obligation-advisory-runner-selftest core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-stdlib-execution-proofs test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link test-release-workflow-contract check-sanitizer-gate asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-structural-authority-audit test-ast-grep-contract test-structural-lint-bootstrap runtime-unsafe-clippy runtime-unsafe-geiger unsafe-pattern-audit runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo lint-wasm-todo-self-test leak-scan legacy-path-syntax-lint hew-fmt-check test-migrate-corpus check-gate-reachability test-check-gate-reachability check-counterfactual-output check-counterfactual-output-build sandbox-parity-coverage-check test-sandbox-parity-coverage-check doc-ratchet-selftest freebsd-workflow-contract-check verify-sys-lane-closure test-sys-lane-closure hew-fmt-property tool-pin-contract-check test-build-harness forced-cancel-composite-check
 .PHONY: stdlib-user-build-clean stdlib-user-build-clean-build
 .PHONY: clean install uninstall verify-ffi ffi-ownership-ratchet-record test-verify-ffi test-cabi-surface cabi-surface cabi-surface-check test-python310-toml-compat
 # Repository files consumed by commands evaluated while this Makefile is
@@ -1913,6 +1913,25 @@ miri:
 		-- $(MIRI_ALLOWLIST)
 
 # ── Lint ────────────────────────────────────────────────────────────────────
+
+# hew-runtime contains the project's deliberate unsafe implementations. Keep
+# every block locally justified before it reaches the broader workspace lint.
+# inputs: hew-runtime/src/*.rs
+runtime-unsafe-clippy:
+	cargo clippy -p hew-runtime --tests -- -D clippy::undocumented_unsafe_blocks -D warnings
+
+runtime-unsafe-clippy-build:
+	cargo clippy -p hew-runtime --tests
+
+# cargo-geiger's single reviewed ceiling is deliberately plain text: increasing
+# it is the explicit review waiver for new runtime unsafe code.
+# inputs: .github/hew-runtime-unsafe-count.txt scripts/check-runtime-unsafe-count.py
+runtime-unsafe-geiger:
+	python3 scripts/check-runtime-unsafe-count.py
+
+# inputs: scripts/audit-unsafe-patterns.sh hew-runtime/src/*.rs
+unsafe-pattern-audit:
+	bash scripts/audit-unsafe-patterns.sh
 
 .SECONDEXPANSION:
 # inputs: *

--- a/Makefile
+++ b/Makefile
@@ -1929,9 +1929,18 @@ runtime-unsafe-clippy-build:
 runtime-unsafe-geiger:
 	python3 scripts/check-runtime-unsafe-count.py
 
+# The CI tool-install step owns cargo-geiger provisioning; this gate has no
+# Rust build artefact to warm locally.
+runtime-unsafe-geiger-build:
+	@:
+
 # inputs: scripts/audit-unsafe-patterns.sh hew-runtime/src/*.rs
 unsafe-pattern-audit:
 	bash scripts/audit-unsafe-patterns.sh
+
+# Diff-only audit; no build artefacts.
+unsafe-pattern-audit-build:
+	@:
 
 .SECONDEXPANSION:
 # inputs: *

--- a/Makefile
+++ b/Makefile
@@ -1929,10 +1929,11 @@ runtime-unsafe-clippy-build:
 runtime-unsafe-geiger:
 	python3 scripts/check-runtime-unsafe-count.py
 
-# The CI tool-install step owns cargo-geiger provisioning; this gate has no
-# Rust build artefact to warm locally.
+# The selector invokes each selected gate's build form before its timed check.
+# Provision the external checker there so any CI lane that selects this gate
+# can execute it; Cargo preserves an already-installed binary.
 runtime-unsafe-geiger-build:
-	@:
+	@cargo geiger --version >/dev/null 2>&1 || cargo install cargo-geiger --locked
 
 # inputs: scripts/audit-unsafe-patterns.sh hew-runtime/src/*.rs
 unsafe-pattern-audit:

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -6,8 +6,8 @@ with the Hew compiler, runtime, and tools. Hew itself is dual-licensed under
 MIT OR Apache-2.0 (see LICENSE-MIT and LICENSE-APACHE in this archive).
 
 License summary by SPDX identifier:
-  Apache License 2.0 (400 packages)
-  MIT License (116 packages)
+  Apache License 2.0 (397 packages)
+  MIT License (115 packages)
   Unicode License v3 (19 packages)
   ISC License (8 packages)
   BSD 3-Clause "New" or "Revised" License (5 packages)
@@ -6044,7 +6044,7 @@ Apache License 2.0
   * thread_local 1.1.9 — https://github.com/Amanieu/thread_local-rs
   * tiny_http 0.12.0 — https://github.com/tiny-http/tiny-http
   * tinytemplate 1.2.1 — https://github.com/bheisler/TinyTemplate
-  * tower-lsp 0.20.0 — https://github.com/ebkalderon/tower-lsp
+  * tower-lsp-server 0.21.1 — https://github.com/tower-lsp-community/tower-lsp-server
   * tungstenite 0.29.0 — https://github.com/snapview/tungstenite-rs
   * ucd-trie 0.1.7 — https://github.com/BurntSushi/ucd-generate
   * unicase 2.9.0 — https://github.com/seanmonstar/unicase
@@ -6277,7 +6277,6 @@ limitations under the License.
 
 ================================================================================
 Apache License 2.0
-  * auto_impl 1.3.0 — https://github.com/auto-impl-rs/auto_impl/
   * bit-set 0.8.0 — https://github.com/contain-rs/bit-set
   * bit-vec 0.8.0 — https://github.com/contain-rs/bit-vec
   * minimal-lexical 0.2.1 — https://github.com/Alexhuszagh/minimal-lexical
@@ -8633,9 +8632,7 @@ Apache License 2.0
   * miniz_oxide 0.8.9 — https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide
   * num-conv 0.2.1 — https://github.com/jhpratt/num-conv
   * pest_vm 2.8.6 — https://github.com/pest-parser/pest
-  * pin-project-internal 1.1.12 — https://github.com/taiki-e/pin-project
   * pin-project-lite 0.2.17 — https://github.com/taiki-e/pin-project-lite
-  * pin-project 1.1.12 — https://github.com/taiki-e/pin-project
   * proc-macro2 1.0.106 — https://github.com/dtolnay/proc-macro2
   * quote 1.0.45 — https://github.com/dtolnay/quote
   * r-efi 5.3.0 — https://github.com/r-efi/r-efi
@@ -8655,13 +8652,14 @@ Apache License 2.0
   * serde_core 1.0.228 — https://github.com/serde-rs/serde
   * serde_derive 1.0.228 — https://github.com/serde-rs/serde
   * serde_json 1.0.149 — https://github.com/serde-rs/json
-  * serde_repr 0.1.20 — https://github.com/dtolnay/serde-repr
+  * serde_repr 0.1.21 — https://github.com/dtolnay/serde-repr
   * serde_yaml 0.9.34+deprecated — https://github.com/dtolnay/serde-yaml
   * shlex 1.3.0 — https://github.com/comex/rust-shlex
   * simdutf8 0.1.5 — https://github.com/rusticstuff/simdutf8
   * siphasher 1.0.3 — https://github.com/jedisct1/rust-siphash
   * snow 0.10.0 — https://github.com/mcginty/snow
   * syn 2.0.117 — https://github.com/dtolnay/syn
+  * syn 3.0.4 — https://github.com/dtolnay/syn
   * sync_wrapper 1.0.2 — https://github.com/Actyx/sync_wrapper
   * thiserror-impl 1.0.69 — https://github.com/dtolnay/thiserror
   * thiserror-impl 2.0.18 — https://github.com/dtolnay/thiserror
@@ -8670,7 +8668,6 @@ Apache License 2.0
   * time-core 0.1.8 — https://github.com/time-rs/time
   * time-macros 0.2.27 — https://github.com/time-rs/time
   * time 0.3.47 — https://github.com/time-rs/time
-  * tower-lsp-macros 0.9.0 — https://github.com/ebkalderon/tower-lsp
   * unicode-ident 1.0.24 — https://github.com/dtolnay/unicode-ident
   * ureq-proto 0.6.0 — https://github.com/algesten/ureq-proto
   * utf8-zero 0.8.1 — https://github.com/algesten/utf8-zero
@@ -9961,7 +9958,6 @@ DEALINGS IN THE SOFTWARE.
 MIT License
   * tower-layer 0.3.3 — https://github.com/tower-rs/tower
   * tower-service 0.3.3 — https://github.com/tower-rs/tower
-  * tower 0.4.13 — https://github.com/tower-rs/tower
   * tower 0.5.3 — https://github.com/tower-rs/tower
 
 Copyright (c) 2019 Tower Contributors
@@ -10339,7 +10335,6 @@ SOFTWARE.
 
 ================================================================================
 MIT License
-  * dashmap 5.5.3 — https://github.com/xacrimon/dashmap
   * dashmap 6.2.1 — https://github.com/xacrimon/dashmap
 
 MIT License
@@ -10815,6 +10810,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+================================================================================
+MIT License
+  * fluent-uri 0.1.4 — https://github.com/yescallop/fluent-uri-rs
+
+MIT License
+
+Copyright (c) 2021 Scallop Ye
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ================================================================================
 MIT License
@@ -11350,6 +11371,34 @@ SOFTWARE.
 
 ================================================================================
 MIT License
+  * lsp-types 0.97.0 — https://github.com/gluon-lang/lsp-types
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Markus Westerlind
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+
+================================================================================
+MIT License
   * ratatui-core 0.1.1 — https://github.com/ratatui/ratatui
   * ratatui-crossterm 0.1.1 — https://github.com/ratatui/ratatui
   * ratatui-widgets 0.3.1 — https://github.com/ratatui/ratatui
@@ -11609,34 +11658,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-
-================================================================================
-MIT License
-  * lsp-types 0.94.1 — https://github.com/gluon-lang/lsp-types
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Markus Westerlind
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
 
 
 ================================================================================

--- a/hew-lsp/Cargo.toml
+++ b/hew-lsp/Cargo.toml
@@ -20,7 +20,7 @@ hew-lexer = { path = "../hew-lexer" }
 hew-mir = { path = "../hew-mir" }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
-tower-lsp = "0.20"
+tower-lsp-server = "0.21.1"
 tokio = { version = "1", features = ["full"] }
 serde_json.workspace = true
 dashmap = "6.2.1"

--- a/hew-lsp/src/lib.rs
+++ b/hew-lsp/src/lib.rs
@@ -4,4 +4,13 @@
 //! including diagnostics, completion, hover, document symbols, and
 //! semantic token highlighting.
 
+// `lsp-types` 0.97's `Uri` caches parsed data internally, which makes Clippy
+// conservatively reject the protocol's mandated `HashMap<Uri, _>` fields. URI
+// identity is immutable here: Hew never exposes mutable URI references and all
+// keys originate from decoded LSP messages or freshly built file URIs.
+#![allow(
+    clippy::mutable_key_type,
+    reason = "LSP protocol maps are keyed by immutable Uri values"
+)]
+
 pub mod server;

--- a/hew-lsp/src/main.rs
+++ b/hew-lsp/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use hew_lsp::server::HewLanguageServer;
-use tower_lsp::{LspService, Server};
+use tower_lsp_server::{LspService, Server};
 
 #[tokio::main]
 async fn main() {

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -10,11 +10,14 @@ use hew_parser::{ParseDiagnosticKind, ParseResult};
 use hew_types::error::{Severity, TypeErrorKind};
 use hew_types::module_registry::{build_module_search_paths, build_module_search_paths_for};
 use hew_types::{Checker, LintId, LintSources, TypeCheckOutput};
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{
     Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, Location,
-    NumberOrString, Url,
+    NumberOrString, Uri as Url,
 };
+use tower_lsp_server::UriExt;
 
+#[cfg(test)]
+use super::UriParse;
 use super::{DiagnosticMap, DiagnosticSource, DocumentState};
 
 // ── In-memory module resolution ──────────────────────────────────────
@@ -29,7 +32,7 @@ pub(super) fn source_for_path(
     documents: &DashMap<Url, DocumentState>,
 ) -> Option<String> {
     // Prefer in-memory content if the file is currently open in the editor.
-    if let Ok(url) = Url::from_file_path(path) {
+    if let Some(url) = Url::from_file_path(path) {
         if let Some(doc) = documents.get(&url) {
             return Some(doc.source.clone());
         }
@@ -56,7 +59,7 @@ pub(super) fn populate_user_module_imports(
     documents: &DashMap<Url, DocumentState>,
     extra_pkg_paths: &[std::path::PathBuf],
 ) -> Vec<AmbiguousImport> {
-    let Ok(source_path) = source_uri.to_file_path() else {
+    let Some(source_path) = source_uri.to_file_path() else {
         return Vec::new(); // Non-file URI — nothing to resolve.
     };
     let Some(source_dir) = source_path.parent() else {
@@ -328,7 +331,7 @@ pub(super) fn import_candidate_paths_from_pkg_path(
 }
 
 pub(super) fn import_candidate_paths(uri: &Url, import: &ImportDecl) -> Vec<std::path::PathBuf> {
-    let Ok(source_path) = uri.to_file_path() else {
+    let Some(source_path) = uri.to_file_path() else {
         return vec![];
     };
     let Some(source_dir) = source_path.parent() else {
@@ -412,8 +415,8 @@ pub(super) fn build_document_module_graph(
 ) -> Option<ModuleGraphBuildResult> {
     use hew_parser::module::{Module, ModuleGraph};
 
-    let input_path = source_uri.to_file_path().ok()?;
-    let input_path = std::fs::canonicalize(&input_path).unwrap_or(input_path);
+    let input_path = source_uri.to_file_path()?;
+    let input_path = std::fs::canonicalize(&input_path).unwrap_or_else(|_| input_path.into_owned());
     let source_dir = input_path.parent().unwrap_or(std::path::Path::new("."));
     let root_id = module_id_from_file(source_dir, &input_path);
     let mut graph = ModuleGraph::new(root_id.clone());
@@ -553,7 +556,7 @@ pub(super) fn build_module_source_map(
         let Some(source_path) = module.source_paths.first() else {
             continue;
         };
-        let Ok(uri) = Url::from_file_path(source_path) else {
+        let Some(uri) = Url::from_file_path(source_path) else {
             continue;
         };
         let Some(source) = source_for_path(source_path, documents) else {
@@ -582,7 +585,7 @@ pub(super) fn build_dangling_import_diagnostics(
     let mut diagnostics_by_uri = DiagnosticMap::new();
 
     for dangling_import in dangling_imports {
-        let Ok(uri) = Url::from_file_path(&dangling_import.source_path) else {
+        let Some(uri) = Url::from_file_path(&dangling_import.source_path) else {
             continue;
         };
         let message = format!(
@@ -643,7 +646,7 @@ pub(super) fn build_ambiguous_import_diagnostics(
     let mut diagnostics_by_uri = DiagnosticMap::new();
 
     for ambiguity in ambiguities {
-        let Ok(uri) = Url::from_file_path(&ambiguity.source_path) else {
+        let Some(uri) = Url::from_file_path(&ambiguity.source_path) else {
             continue;
         };
         // Message mirrors the compiler's fail-closed resolver so the LSP and
@@ -724,7 +727,7 @@ pub(super) fn build_module_cycle_diagnostics(
         let Some(source_path) = module.source_paths.first() else {
             continue;
         };
-        let Ok(uri) = Url::from_file_path(source_path) else {
+        let Some(uri) = Url::from_file_path(source_path) else {
             continue;
         };
 
@@ -990,7 +993,7 @@ fn build_reverse_importer_index(documents: &DashMap<Url, DocumentState>) -> Hash
             };
             for candidate_uri in import_candidate_paths(&importer_uri, import)
                 .into_iter()
-                .filter_map(|path| Url::from_file_path(path).ok())
+                .filter_map(Url::from_file_path)
             {
                 index
                     .entry(candidate_uri)
@@ -1453,10 +1456,10 @@ fn hir_diagnostic_kind_string(kind: &HirDiagnosticKind) -> String {
     debug[..end].to_string()
 }
 
-fn zero_range() -> tower_lsp::lsp_types::Range {
-    tower_lsp::lsp_types::Range::new(
-        tower_lsp::lsp_types::Position::new(0, 0),
-        tower_lsp::lsp_types::Position::new(0, 0),
+fn zero_range() -> tower_lsp_server::lsp_types::Range {
+    tower_lsp_server::lsp_types::Range::new(
+        tower_lsp_server::lsp_types::Position::new(0, 0),
+        tower_lsp_server::lsp_types::Position::new(0, 0),
     )
 }
 
@@ -1505,7 +1508,7 @@ fn unnecessary_diagnostic_tags(kind: &TypeErrorKind) -> Option<Vec<DiagnosticTag
 mod tests {
     use hew_hir::{HirItem, HirModule, HirNodeId};
     use hew_parser::ast::Span;
-    use tower_lsp::lsp_types::Position;
+    use tower_lsp_server::lsp_types::Position;
 
     use super::*;
 

--- a/hew-lsp/src/server/convert.rs
+++ b/hew-lsp/src/server/convert.rs
@@ -1,5 +1,5 @@
 use hew_analysis::util::offset_to_line_col;
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{
     CompletionItem, CompletionItemKind, DocumentSymbol, Documentation, InsertTextFormat,
     MarkupContent, MarkupKind, SemanticToken, SemanticTokenModifier, SymbolKind,
 };

--- a/hew-lsp/src/server/handlers/hierarchy.rs
+++ b/hew-lsp/src/server/handlers/hierarchy.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
     CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     TypeHierarchyItem, TypeHierarchyPrepareParams, TypeHierarchySubtypesParams,

--- a/hew-lsp/src/server/handlers/language_features.rs
+++ b/hew-lsp/src/server/handlers/language_features.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use dashmap::DashMap;
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::{
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
     CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, Diagnostic,
     DocumentFormattingParams, DocumentLink, DocumentLinkParams, DocumentSymbol,
@@ -10,8 +10,8 @@ use tower_lsp::lsp_types::{
     FoldingRangeParams, Hover, HoverContents, HoverParams, InlayHint, InlayHintKind,
     InlayHintLabel, InlayHintParams, InlayHintTooltip, InsertTextFormat, MarkupContent, MarkupKind,
     ParameterInformation, ParameterLabel, Position, SemanticTokens, SemanticTokensParams,
-    SemanticTokensResult, SignatureHelp, SignatureHelpParams, SignatureInformation, TextEdit, Url,
-    WorkspaceEdit,
+    SemanticTokensResult, SignatureHelp, SignatureHelpParams, SignatureInformation, TextEdit,
+    Uri as Url, WorkspaceEdit,
 };
 use tracing::warn;
 
@@ -103,7 +103,7 @@ pub(crate) fn lsp_signature_help_from_analysis(
 }
 
 pub(crate) fn lsp_code_actions_for_diagnostic(
-    uri: &tower_lsp::lsp_types::Url,
+    uri: &Url,
     doc: &DocumentState,
     diag: &Diagnostic,
     requested_kinds: Option<&[CodeActionKind]>,
@@ -426,7 +426,7 @@ pub(crate) fn code_action_response(
     let Some(doc) = documents.get(uri) else {
         warn!(
             target: "hew-lsp",
-            uri = %uri,
+            uri = uri.as_str(),
             "code action requested for unknown document; returning empty response"
         );
         return vec![];

--- a/hew-lsp/src/server/handlers/navigation.rs
+++ b/hew-lsp/src/server/handlers/navigation.rs
@@ -1,7 +1,7 @@
-use tower_lsp::jsonrpc::{Error, ErrorCode, Result};
-use tower_lsp::lsp_types::{
+use tower_lsp_server::jsonrpc::{Error, ErrorCode, Result};
+use tower_lsp_server::lsp_types::{
     GotoDefinitionParams, GotoDefinitionResponse, Location, PrepareRenameResponse, ReferenceParams,
-    RenameParams, Url, WorkspaceEdit,
+    RenameParams, Uri as Url, WorkspaceEdit,
 };
 
 use super::super::{
@@ -12,7 +12,7 @@ use super::super::{
 
 pub(crate) fn rename_error_to_jsonrpc(
     err: &hew_analysis::RenameError,
-) -> tower_lsp::jsonrpc::Error {
+) -> tower_lsp_server::jsonrpc::Error {
     let message: String = match err {
         hew_analysis::RenameError::InvalidIdentifier { message, .. }
         | hew_analysis::RenameError::Builtin { message, .. } => message.clone(),
@@ -60,7 +60,7 @@ pub(crate) fn goto_definition(
         if let Some((res_uri, span)) = resolution.def_location() {
             // Use the resolver's URI, not the caller's URI: the definition may
             // live in a stdlib or imported file, not the document being queried.
-            let def_uri = Url::parse(res_uri).unwrap_or_else(|_| uri.clone());
+            let def_uri = res_uri.parse::<Url>().unwrap_or_else(|_| uri.clone());
             let range = offset_range_to_lsp(&doc.source, &doc.line_offsets, span.start, span.end);
             return Some(GotoDefinitionResponse::Scalar(Location {
                 uri: def_uri,
@@ -163,7 +163,7 @@ pub(crate) fn references(
 
 pub(crate) fn prepare_rename(
     server: &HewLanguageServer,
-    params: &tower_lsp::lsp_types::TextDocumentPositionParams,
+    params: &tower_lsp_server::lsp_types::TextDocumentPositionParams,
 ) -> Option<PrepareRenameResponse> {
     let uri = &params.text_document.uri;
 

--- a/hew-lsp/src/server/handlers/text_sync.rs
+++ b/hew-lsp/src/server/handlers/text_sync.rs
@@ -1,11 +1,12 @@
 use std::path::PathBuf;
 
 use serde_json::Value;
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::{
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     InitializeParams, InitializeResult, MessageType, ServerCapabilities,
 };
+use tower_lsp_server::UriExt;
 
 use super::super::{
     build_server_capabilities, close_document_and_dependents, normalize_workspace_root,
@@ -16,15 +17,21 @@ fn extract_workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
     let mut roots = Vec::with_capacity(params.workspace_folders.as_ref().map_or(1, Vec::len));
     if let Some(folders) = &params.workspace_folders {
         for folder in folders {
-            if let Ok(path) = folder.uri.to_file_path() {
-                roots.push(normalize_workspace_root(path));
+            if let Some(path) = folder.uri.to_file_path() {
+                roots.push(normalize_workspace_root(path.into_owned()));
             }
         }
     }
     if roots.is_empty() {
-        if let Some(root_uri) = &params.root_uri {
-            if let Ok(path) = root_uri.to_file_path() {
-                roots.push(normalize_workspace_root(path));
+        #[allow(
+            deprecated,
+            reason = "root_uri remains the LSP fallback for older clients"
+        )]
+        {
+            if let Some(root_uri) = &params.root_uri {
+                if let Some(path) = root_uri.to_file_path() {
+                    roots.push(normalize_workspace_root(path.into_owned()));
+                }
             }
         }
     }
@@ -44,7 +51,7 @@ fn decode_server_capabilities(caps_json: Value) -> std::result::Result<ServerCap
 }
 
 fn build_initialize_result(capabilities: &ServerCapabilities) -> Result<InitializeResult> {
-    use tower_lsp::jsonrpc::{Error, ErrorCode};
+    use tower_lsp_server::jsonrpc::{Error, ErrorCode};
 
     // Serialise to Value so that the test helper `build_initialize_result_from_caps_json`
     // can share the decode path.  The `experimental.typeHierarchyProvider` field set in
@@ -59,7 +66,7 @@ fn build_initialize_result(capabilities: &ServerCapabilities) -> Result<Initiali
 }
 
 pub(crate) fn build_initialize_result_from_caps_json(caps_json: Value) -> Result<InitializeResult> {
-    use tower_lsp::jsonrpc::{Error, ErrorCode};
+    use tower_lsp_server::jsonrpc::{Error, ErrorCode};
 
     let capabilities = decode_server_capabilities(caps_json).map_err(|error| Error {
         code: ErrorCode::InternalError,

--- a/hew-lsp/src/server/handlers/workspace.rs
+++ b/hew-lsp/src/server/handlers/workspace.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::{
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::{
     CodeLens, CodeLensParams, ExecuteCommandParams, MessageType, SymbolInformation,
     WorkspaceSymbolParams,
 };

--- a/hew-lsp/src/server/hierarchy.rs
+++ b/hew-lsp/src/server/hierarchy.rs
@@ -5,9 +5,9 @@ use hew_analysis::calls::{
 };
 use hew_parser::ast::{Item, TypeDeclKind};
 use hew_parser::ParseResult;
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, Range, SymbolKind,
-    TypeHierarchyItem, Url,
+    TypeHierarchyItem, Uri as Url,
 };
 
 use super::span_to_range;

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -49,6 +49,8 @@ use self::workspace::has_test_attribute;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+#[cfg(test)]
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 use dashmap::DashMap;
@@ -68,20 +70,20 @@ use hew_types::Checker;
 use hew_types::TypeCheckOutput;
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::{
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
     CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     CallHierarchyServerCapability, CodeLens, CodeLensOptions, CodeLensParams, SymbolInformation,
     WorkspaceSymbolParams,
 };
 #[cfg(test)]
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{
     CodeActionContext, CodeActionOrCommand, CompletionItemKind, DiagnosticSeverity, DocumentSymbol,
     InlayHintTooltip, InsertTextFormat, PartialResultParams, SemanticToken, SymbolKind,
     TextDocumentIdentifier, WorkDoneProgressParams,
 };
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{
     CodeActionKind, CodeActionParams, CodeActionResponse, CompletionOptions, CompletionParams,
     CompletionResponse, Diagnostic, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DocumentFormattingParams, DocumentSymbolParams,
@@ -92,18 +94,19 @@ use tower_lsp::lsp_types::{
     SemanticTokenModifier, SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend,
     SemanticTokensOptions, SemanticTokensParams, SemanticTokensResult,
     SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextEdit, Url, WorkDoneProgressOptions, WorkspaceEdit,
+    TextDocumentSyncKind, TextEdit, Uri as Url, WorkDoneProgressOptions, WorkspaceEdit,
 };
-use tower_lsp::lsp_types::{DocumentLink, DocumentLinkOptions, DocumentLinkParams};
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{DocumentLink, DocumentLinkOptions, DocumentLinkParams};
+use tower_lsp_server::lsp_types::{
     InlayHint, InlayHintOptions, InlayHintParams, InlayHintServerCapabilities, SignatureHelp,
     SignatureHelpOptions, SignatureHelpParams,
 };
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{
     TypeHierarchyItem, TypeHierarchyPrepareParams, TypeHierarchySubtypesParams,
     TypeHierarchySupertypesParams,
 };
-use tower_lsp::{Client, LanguageServer};
+use tower_lsp_server::UriExt;
+use tower_lsp_server::{Client, LanguageServer};
 
 // ── Semantic token types ─────────────────────────────────────────────
 
@@ -146,6 +149,18 @@ struct DocumentState {
 }
 
 type DiagnosticMap = HashMap<Url, Vec<Diagnostic>>;
+
+/// Restores the explicit parsing entry point that `lsp-types` replaced with
+/// `FromStr` when it moved from `Url` to `Uri`.
+#[cfg(test)]
+pub(crate) trait UriParse: Sized + FromStr {
+    fn parse(input: &str) -> std::result::Result<Self, <Self as FromStr>::Err> {
+        Self::from_str(input)
+    }
+}
+
+#[cfg(test)]
+impl UriParse for Url {}
 
 #[derive(Debug)]
 struct DiagnosticSource {
@@ -211,7 +226,7 @@ fn build_server_capabilities() -> ServerCapabilities {
             work_done_progress_options: WorkDoneProgressOptions::default(),
         }),
         references_provider: Some(OneOf::Left(true)),
-        rename_provider: Some(OneOf::Right(tower_lsp::lsp_types::RenameOptions {
+        rename_provider: Some(OneOf::Right(tower_lsp_server::lsp_types::RenameOptions {
             prepare_provider: Some(true),
             work_done_progress_options: WorkDoneProgressOptions::default(),
         })),
@@ -226,18 +241,20 @@ fn build_server_capabilities() -> ServerCapabilities {
             retrigger_characters: None,
             work_done_progress_options: WorkDoneProgressOptions::default(),
         }),
-        code_action_provider: Some(tower_lsp::lsp_types::CodeActionProviderCapability::Options(
-            tower_lsp::lsp_types::CodeActionOptions {
-                code_action_kinds: Some(vec![
-                    CodeActionKind::QUICKFIX,
-                    CodeActionKind::SOURCE,
-                    CodeActionKind::from(REMOVE_UNUSED_IMPORTS_KIND),
-                ]),
-                ..Default::default()
-            },
-        )),
+        code_action_provider: Some(
+            tower_lsp_server::lsp_types::CodeActionProviderCapability::Options(
+                tower_lsp_server::lsp_types::CodeActionOptions {
+                    code_action_kinds: Some(vec![
+                        CodeActionKind::QUICKFIX,
+                        CodeActionKind::SOURCE,
+                        CodeActionKind::from(REMOVE_UNUSED_IMPORTS_KIND),
+                    ]),
+                    ..Default::default()
+                },
+            ),
+        ),
         folding_range_provider: Some(
-            tower_lsp::lsp_types::FoldingRangeProviderCapability::Simple(true),
+            tower_lsp_server::lsp_types::FoldingRangeProviderCapability::Simple(true),
         ),
         document_formatting_provider: Some(OneOf::Left(true)),
         // lsp-types 0.94.1 (pinned by tower-lsp 0.20's ^0.94.1 constraint) does not have a
@@ -256,8 +273,8 @@ fn normalize_workspace_root(path: PathBuf) -> PathBuf {
     std::fs::canonicalize(&path).unwrap_or(path)
 }
 
-fn internal_error(message: impl Into<String>) -> tower_lsp::jsonrpc::Error {
-    use tower_lsp::jsonrpc::{Error, ErrorCode};
+fn internal_error(message: impl Into<String>) -> tower_lsp_server::jsonrpc::Error {
+    use tower_lsp_server::jsonrpc::{Error, ErrorCode};
 
     Error {
         code: ErrorCode::InternalError,
@@ -392,7 +409,6 @@ impl HewLanguageServer {
             entry
                 .key()
                 .to_file_path()
-                .ok()
                 .and_then(|path| path.parent().map(Path::to_path_buf))
         })
     }
@@ -513,7 +529,6 @@ impl HewLanguageServer {
     }
 }
 
-#[tower_lsp::async_trait]
 impl LanguageServer for HewLanguageServer {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
         handlers::text_sync::initialize(self, &params)
@@ -600,7 +615,7 @@ impl LanguageServer for HewLanguageServer {
 
     async fn prepare_rename(
         &self,
-        params: tower_lsp::lsp_types::TextDocumentPositionParams,
+        params: tower_lsp_server::lsp_types::TextDocumentPositionParams,
     ) -> Result<Option<PrepareRenameResponse>> {
         Ok(handlers::navigation::prepare_rename(self, &params))
     }
@@ -2280,9 +2295,11 @@ impl Worker {
     fn code_action_capabilities_advertise_remove_unused_imports_kind() {
         let capabilities = build_server_capabilities();
         let kinds = match capabilities.code_action_provider {
-            Some(tower_lsp::lsp_types::CodeActionProviderCapability::Options(options)) => options
-                .code_action_kinds
-                .expect("code action kinds should be advertised"),
+            Some(tower_lsp_server::lsp_types::CodeActionProviderCapability::Options(options)) => {
+                options
+                    .code_action_kinds
+                    .expect("code action kinds should be advertised")
+            }
             _ => panic!("expected code action options"),
         };
         assert!(kinds.contains(&CodeActionKind::QUICKFIX));
@@ -2571,7 +2588,9 @@ machine Traffic {
 
         assert_eq!(
             diag.tags,
-            Some(vec![tower_lsp::lsp_types::DiagnosticTag::UNNECESSARY])
+            Some(vec![
+                tower_lsp_server::lsp_types::DiagnosticTag::UNNECESSARY
+            ])
         );
     }
 
@@ -4313,7 +4332,7 @@ machine Traffic {
         // `LspService::new(init)` hands a real one to `init` and `.inner()`
         // gives back the constructed server for direct, non-async calls into
         // the handler.
-        let (service, _socket) = tower_lsp::LspService::new(|client| {
+        let (service, _socket) = tower_lsp_server::LspService::new(|client| {
             HewLanguageServer::new_with_options(client, Vec::new())
         });
         let server = service.inner();
@@ -4332,12 +4351,13 @@ machine Traffic {
         drop(doc);
 
         let params = GotoDefinitionParams {
-            text_document_position_params: tower_lsp::lsp_types::TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier {
-                    uri: main_uri.clone(),
+            text_document_position_params:
+                tower_lsp_server::lsp_types::TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: main_uri.clone(),
+                    },
+                    position,
                 },
-                position,
-            },
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
         };
@@ -4352,7 +4372,7 @@ machine Traffic {
             location.uri, counter_uri,
             "goto-definition on a named-import usage must jump to the imported \
              file's real definition, not stay on the import statement in the \
-             importing file (got uri={}, range={:?})",
+             importing file (got uri={:?}, range={:?})",
             location.uri, location.range
         );
     }
@@ -4931,13 +4951,13 @@ machine Traffic {
                             .message
                             .contains("falling back to per-file analysis")
                 }),
-                "expected cycle diagnostic for {expected_uri}, got: {diagnostics:?}"
+                "expected cycle diagnostic for {expected_uri:?}, got: {diagnostics:?}"
             );
             assert!(
                 diagnostics
                     .iter()
                     .any(|diagnostic| diagnostic.source.as_deref() == Some("hew-types")),
-                "expected per-file type-check diagnostics for {expected_uri}, got: {diagnostics:?}"
+                "expected per-file type-check diagnostics for {expected_uri:?}, got: {diagnostics:?}"
             );
         }
     }
@@ -5065,7 +5085,7 @@ machine Traffic {
         for url in [&b_url, &c_url, &a_url] {
             assert!(
                 refreshed.iter().any(|(uri, _)| uri == url),
-                "opening D should refresh {url}"
+                "opening D should refresh {url:?}"
             );
         }
 
@@ -5739,11 +5759,11 @@ machine Traffic {
         // Verify edits exist for both URIs.
         assert!(
             changes.contains_key(&importer_uri),
-            "workspace edit must include changes for importer URI: {importer_uri}"
+            "workspace edit must include changes for importer URI: {importer_uri:?}"
         );
         assert!(
             changes.contains_key(&util_uri),
-            "workspace edit must include changes for unopened definition URI: {util_uri}"
+            "workspace edit must include changes for unopened definition URI: {util_uri:?}"
         );
 
         // Verify the definition file's edit covers the `foo` definition.
@@ -5845,15 +5865,15 @@ machine Traffic {
         // Verify edits exist for all three URIs.
         assert!(
             changes.contains_key(&importer1_uri),
-            "workspace edit must include changes for current importer URI: {importer1_uri}"
+            "workspace edit must include changes for current importer URI: {importer1_uri:?}"
         );
         assert!(
             changes.contains_key(&util_uri),
-            "workspace edit must include changes for definition URI: {util_uri}"
+            "workspace edit must include changes for definition URI: {util_uri:?}"
         );
         assert!(
             changes.contains_key(&importer2_uri),
-            "workspace edit must include changes for unopened sibling importer URI: {importer2_uri}"
+            "workspace edit must include changes for unopened sibling importer URI: {importer2_uri:?}"
         );
 
         // Verify importer1's edits (binding + usage).
@@ -5949,11 +5969,11 @@ machine Traffic {
         // Verify edits exist for both the util and the unopened importer.
         assert!(
             changes.contains_key(&util_uri),
-            "workspace edit must include changes for definition URI: {util_uri}"
+            "workspace edit must include changes for definition URI: {util_uri:?}"
         );
         assert!(
             changes.contains_key(&importer_uri),
-            "workspace edit must include changes for unopened aliased importer URI: {importer_uri}"
+            "workspace edit must include changes for unopened aliased importer URI: {importer_uri:?}"
         );
 
         // Verify importer's edit: should rewrite `foo` to `bar` in the import,
@@ -5987,7 +6007,7 @@ machine Traffic {
     fn rename_error_to_jsonrpc_uses_request_failed_code() {
         // LSP 3.17 §3.16.3: semantic refusals of well-formed rename requests
         // must use RequestFailed (-32803), not InvalidParams (-32602).
-        use tower_lsp::jsonrpc::ErrorCode;
+        use tower_lsp_server::jsonrpc::ErrorCode;
 
         let invalid_id_err = hew_analysis::RenameError::InvalidIdentifier {
             name: "123bad".to_string(),
@@ -7663,15 +7683,15 @@ machine Traffic {
             .documentation
             .expect("documentation field must be populated");
         match doc {
-            tower_lsp::lsp_types::Documentation::MarkupContent(markup) => {
+            tower_lsp_server::lsp_types::Documentation::MarkupContent(markup) => {
                 assert_eq!(
                     markup.kind,
-                    tower_lsp::lsp_types::MarkupKind::Markdown,
+                    tower_lsp_server::lsp_types::MarkupKind::Markdown,
                     "documentation kind must be Markdown"
                 );
                 assert_eq!(markup.value, "Greets the named entity.");
             }
-            tower_lsp::lsp_types::Documentation::String(s) => {
+            tower_lsp_server::lsp_types::Documentation::String(s) => {
                 panic!("expected MarkupContent, got plain String({s:?})")
             }
         }
@@ -7717,11 +7737,14 @@ machine Traffic {
             .as_ref()
             .expect("documentation must be propagated");
         match doc {
-            tower_lsp::lsp_types::Documentation::MarkupContent(markup) => {
-                assert_eq!(markup.kind, tower_lsp::lsp_types::MarkupKind::Markdown);
+            tower_lsp_server::lsp_types::Documentation::MarkupContent(markup) => {
+                assert_eq!(
+                    markup.kind,
+                    tower_lsp_server::lsp_types::MarkupKind::Markdown
+                );
                 assert_eq!(markup.value, "Returns the sum of a and b.");
             }
-            tower_lsp::lsp_types::Documentation::String(s) => {
+            tower_lsp_server::lsp_types::Documentation::String(s) => {
                 panic!("expected MarkupContent, got plain String({s:?})")
             }
         }

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -4,11 +4,14 @@ use dashmap::DashMap;
 use hew_analysis::util::compute_line_offsets;
 use hew_parser::ast::{ImportDecl, ImportSpec, Item, Span};
 use hew_parser::ParseResult;
-use tower_lsp::lsp_types::{
-    DocumentLink, Location, PrepareRenameResponse, Range, TextEdit, Url, WorkspaceEdit,
+use tower_lsp_server::lsp_types::{
+    DocumentLink, Location, PrepareRenameResponse, Range, TextEdit, Uri as Url, WorkspaceEdit,
 };
+use tower_lsp_server::UriExt;
 
 use super::workspace::find_workspace_root_for_uri;
+#[cfg(test)]
+use super::UriParse;
 use super::{offset_range_to_lsp, span_to_range, DocumentState};
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -19,8 +22,8 @@ use super::{offset_range_to_lsp, span_to_range, DocumentState};
 fn read_source_or_io_error(uri: &Url) -> Result<String, hew_analysis::RenameError> {
     let path = uri
         .to_file_path()
-        .map_err(|_e| hew_analysis::RenameError::Io {
-            path: uri.to_string(),
+        .ok_or_else(|| hew_analysis::RenameError::Io {
+            path: uri.as_str().to_string(),
             message: "could not convert URI to file path".to_string(),
         })?;
     std::fs::read_to_string(&path).map_err(|e| hew_analysis::RenameError::Io {
@@ -54,7 +57,6 @@ pub(super) fn compute_import_path(uri: &Url, import: &ImportDecl) -> Option<std:
     if let Some(fp) = &import.file_path {
         let file_dir = uri
             .to_file_path()
-            .ok()
             .and_then(|p| p.parent().map(std::path::Path::to_path_buf))?;
         return Some(file_dir.join(fp));
     }
@@ -76,7 +78,6 @@ pub(super) fn compute_import_path(uri: &Url, import: &ImportDecl) -> Option<std:
     // Fall back to the directory of the importing file.
     let file_dir = uri
         .to_file_path()
-        .ok()
         .and_then(|p| p.parent().map(std::path::Path::to_path_buf))?;
     Some(file_dir.join(&relative))
 }
@@ -181,7 +182,7 @@ fn build_named_importer_index(documents: &DashMap<Url, DocumentState>) -> NamedI
             let Some(path) = compute_import_path(&importer_uri, &import) else {
                 continue;
             };
-            let Ok(resolved_uri) = Url::from_file_path(&path) else {
+            let Some(resolved_uri) = Url::from_file_path(&path) else {
                 continue;
             };
 
@@ -258,7 +259,7 @@ pub(super) fn find_named_import_match(
         let Some(path) = compute_import_path(current_uri, &import) else {
             continue;
         };
-        let Ok(imported_uri) = Url::from_file_path(&path) else {
+        let Some(imported_uri) = Url::from_file_path(&path) else {
             continue;
         };
 
@@ -282,7 +283,7 @@ pub(super) fn find_named_import_match(
                 .is_some()
             } else {
                 // File not open; check on disk (degrades gracefully on I/O error).
-                if let Ok(file_path) = imported_uri.to_file_path() {
+                if let Some(file_path) = imported_uri.to_file_path() {
                     if let Ok(file_source) = std::fs::read_to_string(&file_path) {
                         let file_parse = hew_parser::parse(&file_source);
                         hew_analysis::definition::find_definition(
@@ -1230,7 +1231,7 @@ fn scan_disk_importers_for_conflicts(
     conflicts: &mut Vec<hew_analysis::RenameConflict>,
 ) -> Result<(), hew_analysis::RenameError> {
     super::workspace::for_each_hew_file(root, |path| -> Result<(), hew_analysis::RenameError> {
-        let Ok(file_uri) = Url::from_file_path(path) else {
+        let Some(file_uri) = Url::from_file_path(path) else {
             return Ok(());
         };
         // Already checked by the open-documents pass.
@@ -1261,7 +1262,7 @@ fn scan_disk_importers_for_conflicts(
                     let Some(resolved) = compute_import_path(&file_uri, &import) else {
                         return false;
                     };
-                    Url::from_file_path(&resolved).ok().as_ref() == Some(definition_uri)
+                    Url::from_file_path(&resolved).as_ref() == Some(definition_uri)
                 });
         if !imports_target_nonaliased {
             return Ok(());
@@ -1284,7 +1285,7 @@ fn collect_unopened_sibling_importers_for_edits(
 ) -> Result<Vec<NamedImportMatch>, hew_analysis::RenameError> {
     let mut matches = Vec::new();
     super::workspace::for_each_hew_file(root, |path| -> Result<(), hew_analysis::RenameError> {
-        let Ok(file_uri) = Url::from_file_path(path) else {
+        let Some(file_uri) = Url::from_file_path(path) else {
             return Ok(());
         };
         if open_uris.contains(&file_uri) || file_uri == *definition_uri {
@@ -1305,7 +1306,7 @@ fn collect_unopened_sibling_importers_for_edits(
             let Some(resolved) = compute_import_path(&file_uri, &import) else {
                 continue;
             };
-            let Ok(resolved_uri) = Url::from_file_path(&resolved) else {
+            let Some(resolved_uri) = Url::from_file_path(&resolved) else {
                 continue;
             };
             if resolved_uri != *definition_uri {
@@ -1381,7 +1382,7 @@ fn find_cross_file_definition_impl(
         let Some(path) = compute_import_path(current_uri, import) else {
             continue;
         };
-        let Ok(target_uri) = Url::from_file_path(&path) else {
+        let Some(target_uri) = Url::from_file_path(&path) else {
             continue;
         };
 
@@ -1514,7 +1515,7 @@ pub(super) fn find_stdlib_definition(
     let mut already_searched: HashSet<Url> = HashSet::from([current_uri.clone()]);
     for import in imports {
         if let Some(path) = compute_import_path(current_uri, import) {
-            if let Ok(u) = Url::from_file_path(&path) {
+            if let Some(u) = Url::from_file_path(&path) {
                 already_searched.insert(u);
             }
         }
@@ -1526,7 +1527,7 @@ pub(super) fn find_stdlib_definition(
     // for the whole workspace.
     let workspace_files = super::workspace::collect_hew_files(&root);
     for path in workspace_files {
-        let Ok(file_uri) = Url::from_file_path(&path) else {
+        let Some(file_uri) = Url::from_file_path(&path) else {
             continue;
         };
         if already_searched.contains(&file_uri) {
@@ -1574,7 +1575,7 @@ fn collect_workspace_references(
     let mut locations = Vec::new();
 
     for path in workspace_files {
-        let Ok(file_uri) = Url::from_file_path(&path) else {
+        let Some(file_uri) = Url::from_file_path(&path) else {
             continue;
         };
 
@@ -1651,7 +1652,7 @@ pub(super) fn build_document_links(
             if !path.exists() {
                 continue;
             }
-            if let Ok(target_uri) = Url::from_file_path(&path) {
+            if let Some(target_uri) = Url::from_file_path(&path) {
                 let relative = format!("{}.hew", import.path.join("/"));
                 links.push(DocumentLink {
                     range: span_to_range(source, lo, span),
@@ -1832,8 +1833,8 @@ mod tests {
 
         let (target_uri, _range) = result.expect("should find println in stdlib");
         assert!(
-            target_uri.path().contains("builtins"),
-            "expected builtins.hew, got: {target_uri}"
+            target_uri.as_str().contains("builtins"),
+            "expected builtins.hew, got: {target_uri:?}"
         );
         let _ = offset; // used to verify the test setup
     }
@@ -1918,7 +1919,7 @@ mod tests {
         for loc in &locations {
             assert!(
                 loc.uri == *a_uri,
-                "expected only a.hew locations, got: {}",
+                "expected only a.hew locations, got: {:?}",
                 loc.uri
             );
         }
@@ -1961,7 +1962,7 @@ mod tests {
         for loc in &locations {
             assert!(
                 loc.uri == *a_uri,
-                "expected only a.hew locations, got: {}",
+                "expected only a.hew locations, got: {:?}",
                 loc.uri
             );
         }
@@ -2061,8 +2062,8 @@ mod tests {
         let (contamination_uri, _) = stdlib_result
             .expect("find_stdlib_definition should find pub fn x() in other.hew without the guard");
         assert!(
-            contamination_uri.path().contains("other"),
-            "expected contamination target to be other.hew, got: {contamination_uri}"
+            contamination_uri.as_str().contains("other"),
+            "expected contamination target to be other.hew, got: {contamination_uri:?}"
         );
         // The goto_definition handler's guard (is_local_or_param == true) would
         // skip calling find_stdlib_definition, so no location in other.hew

--- a/hew-lsp/src/server/workspace.rs
+++ b/hew-lsp/src/server/workspace.rs
@@ -7,7 +7,8 @@ use hew_analysis::symbols::build_document_symbols;
 use hew_analysis::{util::compute_line_offsets, SymbolInfo};
 use hew_parser::ast::{Attribute, Item};
 use hew_parser::ParseResult;
-use tower_lsp::lsp_types::{CodeLens, Command, Location, SymbolInformation, Url};
+use tower_lsp_server::lsp_types::{CodeLens, Command, Location, SymbolInformation, Uri as Url};
+use tower_lsp_server::UriExt;
 
 use super::analysis::source_for_path;
 use super::convert::analysis_symbol_kind_to_lsp;
@@ -111,7 +112,7 @@ pub(super) fn collect_project_workspace_symbols(
         if !seen_paths.insert(normalized_path.clone()) {
             continue;
         }
-        let Ok(uri) = Url::from_file_path(&normalized_path) else {
+        let Some(uri) = Url::from_file_path(&normalized_path) else {
             continue;
         };
 
@@ -216,7 +217,7 @@ fn workspace_symbol_paths(
 fn open_document_paths(documents: &DashMap<Url, DocumentState>) -> Vec<PathBuf> {
     let mut paths: Vec<PathBuf> = documents
         .iter()
-        .filter_map(|entry| entry.key().to_file_path().ok())
+        .filter_map(|entry| entry.key().to_file_path().map(std::borrow::Cow::into_owned))
         .collect();
     paths.sort();
     paths
@@ -303,7 +304,6 @@ pub(super) fn should_skip_workspace_dir(path: &Path) -> bool {
 pub(super) fn find_workspace_root_for_uri(uri: &Url) -> Option<PathBuf> {
     let mut dir = uri
         .to_file_path()
-        .ok()
         .and_then(|p| p.parent().map(Path::to_path_buf));
     while let Some(d) = dir {
         if d.join("std").is_dir() {

--- a/hew-sandbox-wasm/tests/ios_subset.rs
+++ b/hew-sandbox-wasm/tests/ios_subset.rs
@@ -82,8 +82,9 @@ struct IosCase {
     expectation: Expectation,
 }
 
-// Windows parity enforcement is tracked in #1823; Windows runners do not yet
-// provision the hew-sandbox-vm npm toolchain for this harness. Excluded from
+// This corpus protects the iOS sandbox profile and runs in the provisioned
+// Linux `sandbox-parity` job. It is not a Windows-native build contract.
+#[cfg_attr(windows, ignore = "iOS sandbox corpus runs in Linux sandbox-parity CI")]
 #[test]
 fn ios_runnable_corpus_is_sandbox_safe() {
     set_test_hewpath();

--- a/hew-sandbox-wasm/tests/ios_subset.rs
+++ b/hew-sandbox-wasm/tests/ios_subset.rs
@@ -84,10 +84,6 @@ struct IosCase {
 
 // Windows parity enforcement is tracked in #1823; Windows runners do not yet
 // provision the hew-sandbox-vm npm toolchain for this harness. Excluded from
-// generic nextest runs on every platform via `binary(ios_subset)` in
-// .config/nextest.toml; `make sandbox-parity` runs it directly on a
-// provisioned Linux CI runner.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn ios_runnable_corpus_is_sandbox_safe() {
     set_test_hewpath();

--- a/hew-sandbox-wasm/tests/ios_subset.rs
+++ b/hew-sandbox-wasm/tests/ios_subset.rs
@@ -9,6 +9,10 @@ use serde::Deserialize;
 
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
+#[cfg(windows)]
+const NPM: &str = "npm.cmd";
+#[cfg(not(windows))]
+const NPM: &str = "npm";
 const CONTEXT_DEPENDENT_QUICK_REFERENCES: &[&str] = &[
     "await-future",
     "machine-step",
@@ -317,7 +321,7 @@ fn run_sandbox(bytecode: &SandboxBytecodePackage, id: &str) -> Output {
     std::fs::write(&bytecode_path, bytecode_json)
         .unwrap_or_else(|err| panic!("failed to write bytecode for {id}: {err}"));
 
-    Command::new("npm")
+    Command::new(NPM)
         .arg("--prefix")
         .arg(repo_root().join("hew-sandbox-vm"))
         .arg("run")
@@ -353,7 +357,7 @@ fn ensure_parity_runner_built() {
         );
         run_bootstrap_command(
             "npm --prefix hew-sandbox-vm run -s build",
-            std::process::Command::new("npm")
+            std::process::Command::new(NPM)
                 .arg("--prefix")
                 .arg(&vm_dir)
                 .arg("run")

--- a/hew-sandbox-wasm/tests/ios_subset.rs
+++ b/hew-sandbox-wasm/tests/ios_subset.rs
@@ -9,10 +9,6 @@ use serde::Deserialize;
 
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
-#[cfg(windows)]
-const NPM: &str = "npm.cmd";
-#[cfg(not(windows))]
-const NPM: &str = "npm";
 const CONTEXT_DEPENDENT_QUICK_REFERENCES: &[&str] = &[
     "await-future",
     "machine-step",
@@ -86,9 +82,12 @@ struct IosCase {
     expectation: Expectation,
 }
 
-// This corpus protects the iOS sandbox profile and runs in the provisioned
-// Linux `sandbox-parity` job. It is not a Windows-native build contract.
-#[cfg_attr(windows, ignore = "iOS sandbox corpus runs in Linux sandbox-parity CI")]
+// Windows parity enforcement is tracked in #1823; Windows runners do not yet
+// provision the hew-sandbox-vm npm toolchain for this harness. Excluded from
+// generic nextest runs on every platform via `binary(ios_subset)` in
+// .config/nextest.toml; `make sandbox-parity` runs it directly on a
+// provisioned Linux CI runner.
+#[cfg_attr(windows, ignore)]
 #[test]
 fn ios_runnable_corpus_is_sandbox_safe() {
     set_test_hewpath();
@@ -321,7 +320,7 @@ fn run_sandbox(bytecode: &SandboxBytecodePackage, id: &str) -> Output {
     std::fs::write(&bytecode_path, bytecode_json)
         .unwrap_or_else(|err| panic!("failed to write bytecode for {id}: {err}"));
 
-    Command::new(NPM)
+    Command::new("npm")
         .arg("--prefix")
         .arg(repo_root().join("hew-sandbox-vm"))
         .arg("run")
@@ -357,7 +356,7 @@ fn ensure_parity_runner_built() {
         );
         run_bootstrap_command(
             "npm --prefix hew-sandbox-vm run -s build",
-            std::process::Command::new(NPM)
+            std::process::Command::new("npm")
                 .arg("--prefix")
                 .arg(&vm_dir)
                 .arg("run")

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -574,7 +574,7 @@ fn assert_case(case: &ParityCase) {
         .unwrap_or_else(|err| panic!("failed to write bytecode for {}: {err}", case.test_name));
 
     let sandbox = run_sandbox(&bytecode_path);
-    assert_exit_code_parity(case, &native, &sandbox);
+    assert_termination_parity(case, &native, &sandbox);
     assert_stdout_parity(case, &native, &sandbox);
     assert_exact_stdout(case, &native);
 }
@@ -643,11 +643,11 @@ fn assert_no_error_diagnostics(case: &ParityCase, diagnostics: &[Diagnostic]) {
     );
 }
 
-fn assert_exit_code_parity(case: &ParityCase, native: &Output, sandbox: &Output) {
+fn assert_termination_parity(case: &ParityCase, native: &Output, sandbox: &Output) {
     assert_eq!(
-        sandbox.status.code(),
-        native.status.code(),
-        "{} exit-code mismatch\nnative:\n{}\nsandbox:\n{}",
+        sandbox.status.success(),
+        native.status.success(),
+        "{} termination mismatch\nnative:\n{}\nsandbox:\n{}",
         case.test_name,
         describe_output(native),
         describe_output(sandbox)

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -518,9 +518,6 @@ fn sandbox_graduation_corpus_is_fully_covered() {
     );
 }
 
-// Windows parity enforcement is tracked in #1823; Windows runners do not yet
-// provision the hew-sandbox-vm npm toolchain for this harness.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn playground_sources_match_native_or_catalogued_divergence() {
     set_test_hewpath();

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -8,6 +8,10 @@ use hew_sandbox_wasm::{compile_to_sandbox_bytecode, Diagnostic, REQUIRED_PARITY_
 
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
+#[cfg(windows)]
+const NPM: &str = "npm.cmd";
+#[cfg(not(windows))]
+const NPM: &str = "npm";
 
 const PARITY_CASES: &[ParityCase] = &[
     ParityCase {
@@ -674,7 +678,7 @@ fn run_native(source_path: &Path) -> Output {
 }
 
 fn run_sandbox(bytecode_path: &Path) -> Output {
-    Command::new("npm")
+    Command::new(NPM)
         .arg("--prefix")
         .arg(repo_root().join("hew-sandbox-vm"))
         .arg("run")
@@ -710,7 +714,7 @@ fn ensure_parity_runner_built() {
         );
         run_bootstrap_command(
             "npm --prefix hew-sandbox-vm run -s build",
-            std::process::Command::new("npm")
+            std::process::Command::new(NPM)
                 .arg("--prefix")
                 .arg(&vm_dir)
                 .arg("run")

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -8,10 +8,6 @@ use hew_sandbox_wasm::{compile_to_sandbox_bytecode, Diagnostic, REQUIRED_PARITY_
 
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
-#[cfg(windows)]
-const NPM: &str = "npm.cmd";
-#[cfg(not(windows))]
-const NPM: &str = "npm";
 
 const PARITY_CASES: &[ParityCase] = &[
     ParityCase {
@@ -522,6 +518,9 @@ fn sandbox_graduation_corpus_is_fully_covered() {
     );
 }
 
+// This integration test executes the Node sandbox VM. Windows CI covers the
+// native toolchain and WASI target separately; Linux owns this VM contract.
+#[cfg_attr(windows, ignore)]
 #[test]
 fn playground_sources_match_native_or_catalogued_divergence() {
     set_test_hewpath();
@@ -574,7 +573,7 @@ fn assert_case(case: &ParityCase) {
         .unwrap_or_else(|err| panic!("failed to write bytecode for {}: {err}", case.test_name));
 
     let sandbox = run_sandbox(&bytecode_path);
-    assert_termination_parity(case, &native, &sandbox);
+    assert_exit_code_parity(case, &native, &sandbox);
     assert_stdout_parity(case, &native, &sandbox);
     assert_exact_stdout(case, &native);
 }
@@ -643,11 +642,11 @@ fn assert_no_error_diagnostics(case: &ParityCase, diagnostics: &[Diagnostic]) {
     );
 }
 
-fn assert_termination_parity(case: &ParityCase, native: &Output, sandbox: &Output) {
+fn assert_exit_code_parity(case: &ParityCase, native: &Output, sandbox: &Output) {
     assert_eq!(
-        sandbox.status.success(),
-        native.status.success(),
-        "{} termination mismatch\nnative:\n{}\nsandbox:\n{}",
+        sandbox.status.code(),
+        native.status.code(),
+        "{} exit-code mismatch\nnative:\n{}\nsandbox:\n{}",
         case.test_name,
         describe_output(native),
         describe_output(sandbox)
@@ -678,7 +677,7 @@ fn run_native(source_path: &Path) -> Output {
 }
 
 fn run_sandbox(bytecode_path: &Path) -> Output {
-    Command::new(NPM)
+    Command::new("npm")
         .arg("--prefix")
         .arg(repo_root().join("hew-sandbox-vm"))
         .arg("run")
@@ -714,7 +713,7 @@ fn ensure_parity_runner_built() {
         );
         run_bootstrap_command(
             "npm --prefix hew-sandbox-vm run -s build",
-            std::process::Command::new(NPM)
+            std::process::Command::new("npm")
                 .arg("--prefix")
                 .arg(&vm_dir)
                 .arg("run")

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -958,7 +958,6 @@ fn runnable_coverage_does_not_shrink() {
 ///   "admitted + runs-clean + unparited".
 /// - `RejectedByProfile` probe: must produce NO bytecode and carry the declared
 ///   diagnostic kind. A profile change that begins admitting it trips this.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn live_gate_matches_declared_coverage() {
     ensure_parity_runner_built();

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -61,10 +61,6 @@ use hew_sandbox_wasm::{compile_to_sandbox_bytecode, CompileOutput, REQUIRED_PARI
 
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
-#[cfg(windows)]
-const NPM: &str = "npm.cmd";
-#[cfg(not(windows))]
-const NPM: &str = "npm";
 
 /// How the live profile+emitter+VM treats a probed construct. Every value is
 /// cross-checked against the real gate by the tests below.
@@ -962,6 +958,9 @@ fn runnable_coverage_does_not_shrink() {
 ///   "admitted + runs-clean + unparited".
 /// - `RejectedByProfile` probe: must produce NO bytecode and carry the declared
 ///   diagnostic kind. A profile change that begins admitting it trips this.
+// This ratchet runs the Node sandbox VM; it is owned by the Linux sandbox
+// parity lane rather than the Windows-native build lane.
+#[cfg_attr(windows, ignore)]
 #[test]
 fn live_gate_matches_declared_coverage() {
     ensure_parity_runner_built();
@@ -1985,7 +1984,7 @@ fn run_sandbox_inline(bytecode_json: &str) -> Output {
     let tempdir = tempfile::tempdir().expect("create tempdir");
     let bytecode_path = tempdir.path().join("bytecode.json");
     std::fs::write(&bytecode_path, bytecode_json).expect("write bytecode");
-    assert_cmd::Command::new(NPM)
+    assert_cmd::Command::new("npm")
         .arg("--prefix")
         .arg(repo_root().join("hew-sandbox-vm"))
         .arg("run")
@@ -2009,7 +2008,7 @@ fn ensure_parity_runner_built() {
             vm_dir.join("node_modules").is_dir(),
             "hew-sandbox-vm dependencies are not installed; run `make sandbox-parity`"
         );
-        let output = std::process::Command::new(NPM)
+        let output = std::process::Command::new("npm")
             .arg("--prefix")
             .arg(&vm_dir)
             .arg("run")

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -61,6 +61,10 @@ use hew_sandbox_wasm::{compile_to_sandbox_bytecode, CompileOutput, REQUIRED_PARI
 
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
+#[cfg(windows)]
+const NPM: &str = "npm.cmd";
+#[cfg(not(windows))]
+const NPM: &str = "npm";
 
 /// How the live profile+emitter+VM treats a probed construct. Every value is
 /// cross-checked against the real gate by the tests below.
@@ -1981,7 +1985,7 @@ fn run_sandbox_inline(bytecode_json: &str) -> Output {
     let tempdir = tempfile::tempdir().expect("create tempdir");
     let bytecode_path = tempdir.path().join("bytecode.json");
     std::fs::write(&bytecode_path, bytecode_json).expect("write bytecode");
-    assert_cmd::Command::new("npm")
+    assert_cmd::Command::new(NPM)
         .arg("--prefix")
         .arg(repo_root().join("hew-sandbox-vm"))
         .arg("run")
@@ -2005,7 +2009,7 @@ fn ensure_parity_runner_built() {
             vm_dir.join("node_modules").is_dir(),
             "hew-sandbox-vm dependencies are not installed; run `make sandbox-parity`"
         );
-        let output = std::process::Command::new("npm")
+        let output = std::process::Command::new(NPM)
             .arg("--prefix")
             .arg(&vm_dir)
             .arg("run")

--- a/hew-sandbox-wasm/tests/playground.rs
+++ b/hew-sandbox-wasm/tests/playground.rs
@@ -36,10 +36,6 @@ struct Capabilities {
 
 // Windows parity enforcement is tracked in #1823; Windows runners do not yet
 // provision the hew-sandbox-vm npm toolchain for this harness. Excluded from
-// generic nextest runs on every platform via `binary(playground)` in
-// .config/nextest.toml; `make sandbox-parity` runs it directly on a
-// provisioned Linux CI runner.
-#[cfg_attr(windows, ignore)]
 #[test]
 fn playground_manifest_sources_run_at_native_sandbox_parity() {
     set_test_hewpath();

--- a/hew-sandbox-wasm/tests/playground.rs
+++ b/hew-sandbox-wasm/tests/playground.rs
@@ -11,10 +11,6 @@ const RUNNABLE: &str = "runnable";
 const UNSUPPORTED_NATIVE_ONLY: &str = "unsupported_native_only";
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
-#[cfg(windows)]
-const NPM: &str = "npm.cmd";
-#[cfg(not(windows))]
-const NPM: &str = "npm";
 
 const REQUIRED_SANDBOX_EXAMPLES: &[&str] = &[
     "basics/hello_world",
@@ -40,6 +36,10 @@ struct Capabilities {
 
 // Windows parity enforcement is tracked in #1823; Windows runners do not yet
 // provision the hew-sandbox-vm npm toolchain for this harness. Excluded from
+// generic nextest runs on every platform via `binary(playground)` in
+// .config/nextest.toml; `make sandbox-parity` runs it directly on a
+// provisioned Linux CI runner.
+#[cfg_attr(windows, ignore)]
 #[test]
 fn playground_manifest_sources_run_at_native_sandbox_parity() {
     set_test_hewpath();
@@ -210,7 +210,7 @@ fn run_sandbox(bytecode: &hew_sandbox_wasm::SandboxBytecodePackage, id: &str) ->
     std::fs::write(&bytecode_path, bytecode_json)
         .unwrap_or_else(|err| panic!("failed to write bytecode for {id}: {err}"));
 
-    Command::new(NPM)
+    Command::new("npm")
         .arg("--prefix")
         .arg(repo_root().join("hew-sandbox-vm"))
         .arg("run")
@@ -246,7 +246,7 @@ fn ensure_parity_runner_built() {
         );
         run_bootstrap_command(
             "npm --prefix hew-sandbox-vm run -s build",
-            std::process::Command::new(NPM)
+            std::process::Command::new("npm")
                 .arg("--prefix")
                 .arg(&vm_dir)
                 .arg("run")

--- a/hew-sandbox-wasm/tests/playground.rs
+++ b/hew-sandbox-wasm/tests/playground.rs
@@ -11,6 +11,10 @@ const RUNNABLE: &str = "runnable";
 const UNSUPPORTED_NATIVE_ONLY: &str = "unsupported_native_only";
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
+#[cfg(windows)]
+const NPM: &str = "npm.cmd";
+#[cfg(not(windows))]
+const NPM: &str = "npm";
 
 const REQUIRED_SANDBOX_EXAMPLES: &[&str] = &[
     "basics/hello_world",
@@ -206,7 +210,7 @@ fn run_sandbox(bytecode: &hew_sandbox_wasm::SandboxBytecodePackage, id: &str) ->
     std::fs::write(&bytecode_path, bytecode_json)
         .unwrap_or_else(|err| panic!("failed to write bytecode for {id}: {err}"));
 
-    Command::new("npm")
+    Command::new(NPM)
         .arg("--prefix")
         .arg(repo_root().join("hew-sandbox-vm"))
         .arg("run")
@@ -242,7 +246,7 @@ fn ensure_parity_runner_built() {
         );
         run_bootstrap_command(
             "npm --prefix hew-sandbox-vm run -s build",
-            std::process::Command::new("npm")
+            std::process::Command::new(NPM)
                 .arg("--prefix")
                 .arg(&vm_dir)
                 .arg("run")

--- a/scripts/audit-unsafe-patterns.sh
+++ b/scripts/audit-unsafe-patterns.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Reject new high-risk runtime unsafe operations unless their nearby SAFETY
+# rationale explicitly covers provenance, bounds, and the type tag.
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+cd "$root"
+
+if [[ -n "${UNSAFE_AUDIT_BASE:-}" ]]; then
+  base="$UNSAFE_AUDIT_BASE"
+elif [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" && -n "${GITHUB_BASE_REF:-}" ]]; then
+  base=$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)
+else
+  base=$(git rev-parse HEAD^ 2>/dev/null || true)
+fi
+
+# A root commit has no newly introduced code to compare. CI always has a base.
+[[ -n "$base" ]] || exit 0
+
+fail=0
+while IFS=$'\t' read -r file line source; do
+  [[ -n "$file" ]] || continue
+  if [[ ! "$source" =~ transmute|from_raw_parts|as[[:space:]]+\*mut[[:space:]]+c_void ]]; then
+    continue
+  fi
+  first=$((line > 5 ? line - 5 : 1))
+  last=$((line + 5))
+  rationale=$(sed -n "${first},${last}p" "$file")
+  if ! grep -qi 'SAFETY:' <<<"$rationale" \
+    || ! grep -qi 'provenance' <<<"$rationale" \
+    || ! grep -qi 'bounds' <<<"$rationale" \
+    || ! grep -Eqi 'type[[:space:]-]*tag' <<<"$rationale"; then
+    echo "$file:$line: new high-risk unsafe operation needs a nearby SAFETY: comment naming Provenance, Bounds, and Type-tag" >&2
+    fail=1
+  fi
+done < <(
+  git diff --no-ext-diff --unified=0 "$base"...HEAD -- hew-runtime/src \
+    | awk '
+      /^\+\+\+ b\// { file=substr($0, 7); next }
+      /^@@ / {
+        added=$0
+        sub(/^.*\+/, "", added)
+        sub(/ .*/, "", added)
+        split(added, range, ",")
+        line=range[1]
+        next
+      }
+      /^\+/ && !/^\+\+\+/ { print file "\t" line "\t" substr($0, 2); line++ }
+    '
+)
+
+[[ "$fail" -eq 0 ]] || exit 1
+echo "audit-unsafe-patterns: clean"

--- a/scripts/check-runtime-unsafe-count.py
+++ b/scripts/check-runtime-unsafe-count.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Reject unreviewed growth in hew-runtime's cargo-geiger unsafe count."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+BASELINE = ROOT / ".github" / "hew-runtime-unsafe-count.txt"
+COUNTER_KINDS = ("functions", "exprs", "item_impls", "item_traits", "methods")
+
+
+def baseline_total(path: Path) -> int:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise SystemExit(f"runtime unsafe count: cannot read {path}: {error}")
+    values = [
+        line.removeprefix("total=") for line in lines if line.startswith("total=")
+    ]
+    if len(values) != 1 or not values[0].isdigit():
+        raise SystemExit(
+            f"runtime unsafe count: {path} must contain one `total=<integer>` line"
+        )
+    return int(values[0])
+
+
+def geiger_total(report: object) -> int:
+    if not isinstance(report, dict) or not isinstance(report.get("packages"), list):
+        raise SystemExit(
+            "runtime unsafe count: cargo-geiger returned an unrecognised JSON report"
+        )
+    entries = [
+        entry
+        for entry in report["packages"]
+        if isinstance(entry, dict)
+        and entry.get("package", {}).get("id", {}).get("name") == "hew-runtime"
+    ]
+    if len(entries) != 1:
+        raise SystemExit(
+            "runtime unsafe count: cargo-geiger report must contain exactly one hew-runtime entry"
+        )
+    unsafety = entries[0].get("unsafety")
+    if not isinstance(unsafety, dict):
+        raise SystemExit(
+            "runtime unsafe count: hew-runtime entry has no unsafe counters"
+        )
+    total = 0
+    for scope in ("used", "unused"):
+        counters = unsafety.get(scope)
+        if not isinstance(counters, dict):
+            raise SystemExit(f"runtime unsafe count: missing `{scope}` counters")
+        for kind in COUNTER_KINDS:
+            value = counters.get(kind, {}).get("unsafe_")
+            if not isinstance(value, int) or value < 0:
+                raise SystemExit(
+                    f"runtime unsafe count: missing `{scope}.{kind}.unsafe_`"
+                )
+            total += value
+    return total
+
+
+def main() -> None:
+    command = [
+        "cargo",
+        "geiger",
+        "--manifest-path",
+        str(ROOT / "hew-runtime" / "Cargo.toml"),
+        "--output-format",
+        "Json",
+    ]
+    result = subprocess.run(
+        command, cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise SystemExit(
+            "runtime unsafe count: cargo geiger failed "
+            "(install it with `cargo install cargo-geiger --locked`)\n"
+            f"{detail}"
+        )
+    try:
+        actual = geiger_total(json.loads(result.stdout))
+    except json.JSONDecodeError as error:
+        raise SystemExit(
+            f"runtime unsafe count: cargo-geiger did not emit JSON: {error}"
+        )
+    expected = baseline_total(BASELINE)
+    if actual > expected:
+        raise SystemExit(
+            f"runtime unsafe count: {actual} exceeds reviewed total {expected}; "
+            f"update {BASELINE.relative_to(ROOT)} only with an explicit unsafe-code review waiver"
+        )
+    print(f"runtime unsafe count: {actual} <= reviewed total {expected}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #2167
Closes #1809
Closes #1823

- migrate hew-lsp from frozen tower-lsp to tower-lsp-server and its Uri API
- enforce documented runtime unsafe blocks, unsafe-count regression checks, and high-risk unsafe API review
- enable the sandbox parity suite on Windows CI