### PR TITLE
feat(sir): lower scalar SSA CFG into raw MIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,7 @@ dependencies = [
  "hew-hir",
  "hew-parser",
  "hew-runtime",
+ "hew-sir",
  "hew-types",
  "proptest",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ MAKEFILE_PARSE_INPUTS := \
 .PHONY: assemble assemble-release pre-release windows-release-candidate publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
 .PHONY: fuzz-corpus fuzz-oracle fuzz-oracle-selftest fuzz-smoke fuzz-smoke-bootstrap-install
-.PHONY: ll-diff ll-golden ll-identity-selftest dogfood-compile-measure dogfood-compile-measure-build
+.PHONY: ll-diff ll-golden ll-identity-selftest dogfood-compile-measure dogfood-compile-measure-build sir-shadow-verify sir-shadow-verify-build
 .PHONY: checked-mir-verify checked-mir-golden checked-mir-run checked-mir-expect
 .PHONY: hew-check-all
 
@@ -1146,7 +1146,8 @@ test-cabi-build: $(LIBHEW_READY)
 # before the fast typecheck path reports its diagnostic).
 # inputs: hew-lexer/src/*.rs editors/sublime/Hew.tmLanguage.json
 # inputs: hew-parser/src/*.rs hew-types/src/*.rs hew-hir/src/*.rs
-# inputs: hew-mir/src/*.rs hew-codegen-rs/src/*.rs hew-cli/src/*.rs hew-pkg/src/*.rs
+# inputs: hew-mir/src/*.rs hew-sir/src/*.rs hew-codegen-rs/src/*.rs hew-cli/src/*.rs hew-pkg/src/*.rs
+# inputs: tests/ll-oracle/corpus/*.hew scripts/sir-shadow-corpus.sh
 # preflight: comprehensive-only — Rust changes run the reverse-dependency closure instead
 test-compiler-pipeline: runtime wasm-runtime hew-native $(LIBHEW_READY)
 	$(TEST_RUN_ENV) cargo nextest run --profile ci \
@@ -1154,6 +1155,7 @@ test-compiler-pipeline: runtime wasm-runtime hew-native $(LIBHEW_READY)
 		-p hew-parser \
 		-p hew-types \
 		-p hew-hir \
+		-p hew-sir \
 		-p hew-mir \
 		-p hew-codegen-rs \
 		-p hew-cli \
@@ -1167,6 +1169,7 @@ test-compiler-pipeline-build: runtime wasm-runtime hew-native $(LIBHEW_READY)
 		-p hew-parser \
 		-p hew-types \
 		-p hew-hir \
+		-p hew-sir \
 		-p hew-mir \
 		-p hew-codegen-rs \
 		-p hew-cli \
@@ -1287,6 +1290,22 @@ checked-mir-run-build: hew-native runtime stdlib
 
 checked-mir-expect: hew-native runtime stdlib check-libhew-fresh
 	HEW_BIN="$(DEBUG_HEW)" bash scripts/checked-mir-corpus.sh expect
+
+# Temporary cutover proof for the SIR insertion lane; not a permanent dual
+# pipeline.  It compiles each standalone LL-oracle fixture twice: once through
+# the established HIR → MIR ladder and once through HIR → SIR → candidate raw
+# MIR, while retaining the established output as the observable result.  The
+# driver compares stdout, diagnostics (after removing only SIR's explicit
+# coverage report), exit status, and requires nonzero SIR realization coverage.
+# Retire it when SIR lowering becomes the default and the established path goes.
+# inputs: tests/ll-oracle/corpus/*.hew scripts/sir-shadow-corpus.sh hew-sir/src/*.rs
+# inputs: hew-mir/src/*.rs hew-cli/src/*.rs
+sir-shadow-verify: hew-native
+	HEW_BIN="$(DEBUG_HEW)" bash scripts/sir-shadow-corpus.sh
+
+# Warm-up form for the preflight dispatcher, which derives it by name.
+sir-shadow-verify-build: hew-native
+	@:
 
 # Per-function .ll byte-identity oracle (tests/ll-oracle/corpus/): proves a
 # pure codegen refactor (dedup, extract-helper, file-split) emits zero changed

--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -8,6 +8,15 @@ semantics the ladder is built to support.
 The verifier rules and deletion milestones are detailed in the separate
 implementation plan for this work.
 
+### Migration status
+
+The intended steady-state ladder includes SIR between typed HIR and Raw MIR.
+The first executable SIR value/CFG slice is now present, but it uses a bounded
+legacy-MIR differential bridge while the remaining language surface migrates.
+That bridge is deliberately disposable: it is not a second release compiler
+configuration or a compatibility contract.  The cutover contract in §1.2
+defines exactly what must be removed before SIR becomes the normal path.
+
 ---
 
 ## 1. The IR ladder
@@ -21,6 +30,7 @@ source.hew
   └→ AST              (hew-parser)                syntactic only; no resolution
   └→ Resolved HIR     (hew-hir, name-resolved)    names, scopes, imports, capabilities
   └→ THIR             (hew-hir, fully typed)       monomorphised types; ValueClass per type
+  └→ SIR              (hew-sir, semantic SSA)      semantic values, block-argument CFG, optimization
   └→ Raw MIR          (hew-mir, CFG)               SSA/places; value-model ops chosen; not yet proven
   └→ Checked MIR      (hew-mir)                    ownership proven; diagnostics emitted; FAIL-CLOSED gate
   └→ Elaborated MIR   (hew-mir)                    explicit Drop edges; DecisionMap; cleanup CFG
@@ -36,6 +46,12 @@ source.hew
 - **THIR exists to retire `Ty::Var`.** The fail-closed gate ("no `Ty::Var`
   survives into codegen") becomes a structural verifier between THIR and
   Raw MIR, not a post-hoc sweep.
+- **SIR retains semantic values until ownership/layout realization.** It uses
+  SSA values and block arguments from inception, so normal CFG and value
+  simplification happen before allocation, storage, drop, ABI, and runtime
+  choices discard the language structure that makes those transformations
+  meaningful. SIR control effects are terminators; ordinary operations have
+  derived effect classes rather than mutable effect metadata.
 - **Elaborated MIR exists so codegen consumes proven, not hypothetical, facts.**
   Drop elaboration changes the CFG; doing it in the LLVM emitter would mean
   either deferring ownership to codegen (rejected) or emitting unsafe IR and
@@ -46,6 +62,35 @@ source.hew
 - **No dialect bridge.** The old C++ backend ladder was retired in v0.5; v0.5
   work now widens the Rust HIR/MIR/codegen-rs path instead of adding dialect
   conversion passes.
+
+### 1.2 SIR hard-cutover contract
+
+The current SIR bridge is bounded migration evidence, not a permanent dual
+pipeline. `--sir-shadow` is a temporary differential oracle, and `--sir-lower`
+is a temporary selector for the scalar CFG slice. Neither is a release-mode
+compatibility promise.
+
+The following scaffolding is a deletion target: raw-function name matching,
+`lower_sir_function(..., RawMirFunction template)`, copied parameter-boundary
+and scheduler facts, per-function legacy fallback, SIR mode flags, and the
+shadow corpus harness. The normal CLI flips only after all of these gates hold:
+
+1. SIR owns verified callable identity, symbol, signature, calling convention,
+   effect summary, and parameter-passing facts.
+2. SIR → MIR independently creates Raw/Checked facts and scheduling decisions;
+   it copies no legacy function body, ABI decision, or drop plan.
+3. Each migrated language surface is a closed reachable lowering domain. Its
+   old HIR → Raw-MIR branch is deleted when SIR owns it rather than retained as
+   a mixed-artifact fallback.
+4. The accepted language surface reaches SIR → MIR across the examples and
+   ecosystem corpus, including native and WASM targets where supported.
+5. The default path is changed to SIR and all bridge flags, template code, and
+   legacy body-lowering branches are removed.
+
+The immediate next slice is declaration-keyed direct scalar calls: a verified
+SIR callable table feeds `Terminator::Call` legalization for a closed ordinary
+call graph, without looking up or copying a legacy Raw MIR template. Aggregates,
+ownership, async, actors, and machines follow as separate complete domains.
 
 ### Design axioms
 
@@ -138,7 +183,28 @@ generic constraint failures; `Ty::Var` must be eliminated here.
 
 ---
 
-### 2.4 Raw MIR (`hew-mir::raw`)
+### 2.4 SIR (`hew-sir`)
+
+**Steady-state owns:** resolved semantic values, basic blocks, block arguments,
+explicit control-flow and suspension terminators, derived operation effects,
+and source provenance. Language concepts stay semantic here: abstract
+aggregates, typed closures, actor messages, machine dispatch/transitions, and
+coroutine suspension are retained until a later feature-specific lowering makes
+their representation necessary. The current implementation begins with scalar
+values and ordinary CFG; later slices add those semantic operation families.
+
+**Must not own:** addressable `Place`s, stack/heap allocation, concrete
+aggregate layout, ABI carriers, drop scheduling, ownership proof, or target
+instruction selection.
+
+**Verifier:** module identity, operation/result types and arity, SSA
+definition/dominance, block-argument edge arity/types, entry parameter
+initialization, and operation-specific semantic constraints. The module SIR →
+MIR pipeline verifies at module scope before it can construct storage.
+
+**Dump:** `hew compile --dump-sir`.
+
+### 2.5 Raw MIR (`hew-mir::raw`)
 
 **Owns:** CFG of basic blocks, `Place`s and `Operand`s,
 `Statement` / `Terminator`, drop scopes (lexical), explicit value-model
@@ -188,7 +254,7 @@ synthetically (a test-only MIR builder + the `coro_emission_exec` round-trip).
 
 ---
 
-### 2.5 Checked MIR (`hew-mir::checked`)
+### 2.6 Checked MIR (`hew-mir::checked`)
 
 **Owns:** proven uniqueness, aliasing analysis (read-shared XOR mutate-unique
 at every program point), init / use-after-move, generator-borrow-across-yield
@@ -209,7 +275,7 @@ resource `c` would be shared across an actor send — consume or materialize".
 
 ---
 
-### 2.6 Elaborated MIR (`hew-mir::elab`)
+### 2.7 Elaborated MIR (`hew-mir::elab`)
 
 **Owns:** explicit `Drop(place)` statements on every exit path, explicit
 cleanup basic blocks, panic-edge CFG, coroutine state struct layout (proven
@@ -235,7 +301,7 @@ and DecisionMap).
 
 ---
 
-### 2.7 LLVM IR emission (`hew-codegen-rs`)
+### 2.8 LLVM IR emission (`hew-codegen-rs`)
 
 **Owns:** direct LLVM IR construction from `Elaborated MIR` using Inkwell,
 including function declarations, stack slots for MIR places, value loads and
@@ -258,7 +324,7 @@ LLVM verifier failures.
 
 ---
 
-### 2.8 Native and WASM object emission
+### 2.9 Native and WASM object emission
 
 **Owns:** target-specific object emission from verified LLVM IR. Native builds
 write a relocatable object and then link it with `libhew.a`; WASM builds write

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -98,6 +98,10 @@ pub enum Command {
     Pkg(hew_pkg::cli::PkgCommand),
 }
 
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "clap maps independent compile switches directly to booleans; collapsing them would obscure the CLI contract"
+)]
 #[derive(Debug, Args)]
 pub struct CompileArgs {
     /// Input .hew file.
@@ -116,13 +120,21 @@ pub struct CompileArgs {
     /// spot-checking the front-half lowering during development.
     #[arg(long = "dump-mir", value_name = "STAGE", value_parser = ["raw", "checked", "elab"])]
     pub dump_mir: Option<String>,
-    /// Run the experimental HIR → Semantic IR shadow lane before the established
-    /// HIR → MIR path. It verifies SIR but never changes emitted code.
-    #[arg(long = "sir-shadow")]
+    /// Run the experimental HIR → SIR → raw-MIR candidate lane and verify it
+    /// at the backend front gate, while keeping established MIR as the emitted
+    /// artifact.
+    #[arg(long = "sir-shadow", conflicts_with = "sir_lower")]
     pub sir_shadow: bool,
+    /// Use the experimental SIR → raw-MIR realization for the verified scalar
+    /// CFG subset. Unsupported functions explicitly retain established MIR.
+    #[arg(long = "sir-lower", conflicts_with = "sir_shadow")]
+    pub sir_lower: bool,
     /// Emit the verified Semantic IR subset and exit. Unsupported functions are
     /// reported explicitly; no MIR or LLVM artifacts are emitted.
-    #[arg(long = "dump-sir")]
+    #[arg(
+        long = "dump-sir",
+        conflicts_with_all = ["sir_lower", "sir_shadow"]
+    )]
     pub dump_sir: bool,
     /// Compilation target. Omit for native; pass `wasm32-unknown-unknown` for WASM.
     #[arg(long, value_name = "TRIPLE")]
@@ -654,6 +666,10 @@ pub struct TestArgs {
     /// memory pressure from concurrent compilation tasks.
     #[arg(long, short = 'j', value_name = "N")]
     pub jobs: Option<std::num::NonZeroUsize>,
+    /// Exercise the SIR → raw-MIR candidate lane for each test compilation
+    /// while continuing to emit the established MIR artifact.
+    #[arg(long = "sir-shadow")]
+    pub sir_shadow: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -25,6 +25,21 @@ use hew_parser::ast::{ImportDecl, Item, Spanned};
 
 use crate::target::TargetSpec;
 
+/// Selects how the Semantic IR lane participates in a compilation.
+///
+/// `Shadow` realizes every currently eligible SIR body into a cloned raw-MIR
+/// pipeline, verifies the candidate reaches the backend front gate, then
+/// deliberately emits the established pipeline. `Lower` uses that same
+/// verified candidate for eligible functions and leaves explicit fallbacks on
+/// the established HIR → MIR path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SirMode {
+    #[default]
+    Disabled,
+    Shadow,
+    Lower,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct CompileOptions {
     pub no_typecheck: bool,
@@ -47,6 +62,10 @@ pub struct CompileOptions {
     /// [`hew_compile::FrontendOptions::lint_levels`]. Defaults to every lint's
     /// built-in level.
     pub lint_levels: hew_types::LintLevels,
+    /// Experimental SIR execution mode. Kept in compile options rather than
+    /// only the `compile` command so the test runner can exercise the same
+    /// lane through the in-process native compiler.
+    pub sir_mode: SirMode,
 }
 
 pub(crate) fn frontend_options(target: &TargetSpec, options: &CompileOptions) -> FrontendOptions {

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -262,50 +262,131 @@ fn render_pipeline_mir_lints(
     had_error
 }
 
+#[derive(Debug)]
+struct SirLaneReport {
+    sir: hew_sir::LoweredModule,
+    bridge: hew_mir::SirMirLoweringReport,
+}
+
+/// Run the semantic/value lane against the *same verified HIR module* that
+/// supplies the established ownership/layout MIR pipeline.
+///
+/// Shadow mode always returns the established pipeline; lower mode replaces
+/// only functions for which the SIR adapter can preserve every required raw
+/// MIR invariant. This is the shared driver seam used by file, package, and
+/// in-memory test compilation paths.
+fn lower_verified_hir_to_pipeline(
+    module: &hew_hir::HirModule,
+    tco: &hew_types::TypeCheckOutput,
+    target: &target::TargetSpec,
+    sir_mode: compile::SirMode,
+) -> Result<(hew_mir::IrPipeline, Option<SirLaneReport>), ()> {
+    let mut pipeline = hew_mir::lower_hir_module_with_facts(module, mir_pointer_width(target));
+    pipeline.attach_lowering_facts(tco);
+    if sir_mode == compile::SirMode::Disabled {
+        return Ok((pipeline, None));
+    }
+
+    let sir = hew_sir::lower_module(module);
+    let diagnostics = hew_sir::verify_module(&sir.module);
+    if !diagnostics.is_empty() {
+        for diagnostic in diagnostics {
+            eprintln!(
+                "SIR verifier error in `{}`: {:?}",
+                diagnostic.function, diagnostic.kind
+            );
+        }
+        return Err(());
+    }
+
+    let mut candidate = pipeline.clone();
+    let bridge = hew_mir::apply_sir_to_pipeline(&sir.module, &mut candidate);
+    if bridge.lowered_count() > 0 {
+        if let Err(error) = hew_codegen_rs::validate_codegen_front_for_triple(
+            &candidate,
+            target.normalized_triple(),
+        ) {
+            eprintln!("SIR candidate backend-front validation failed: {error}");
+            return Err(());
+        }
+    }
+    if sir_mode == compile::SirMode::Lower {
+        pipeline = candidate;
+    }
+    Ok((pipeline, Some(SirLaneReport { sir, bridge })))
+}
+
 fn lower_file_to_mir(
     input_path: &Path,
     requested_target: Option<&str>,
 ) -> Result<hew_mir::IrPipeline, ()> {
-    let input = input_path.display().to_string();
-    let target = target::TargetSpec::from_requested(requested_target).map_err(|e| {
-        eprintln!("Error: {e}");
-    })?;
-    let fopts = compile::frontend_options(&target, &compile::CompileOptions::default());
+    lower_file_to_mir_with_options(
+        input_path,
+        requested_target,
+        &compile::CompileOptions::default(),
+    )
+    .map(|(pipeline, _sir)| pipeline)
+}
 
+/// File frontend plus verified HIR, shared by SIR inspection and every
+/// file-to-MIR driver. Keeping this boundary separate means `--dump-sir`
+/// stops at the semantic layer instead of inheriting a backend limitation from
+/// an unrelated later stage.
+struct VerifiedFileHir {
+    input: String,
+    state: hew_compile::FileFrontendState,
+    lower_output: hew_hir::LowerOutput,
+}
+
+impl VerifiedFileHir {
+    fn typecheck_output(&self) -> &hew_types::TypeCheckOutput {
+        self.state
+            .typecheck_result
+            .tco
+            .as_ref()
+            .expect("verified HIR requires a type-check output")
+    }
+}
+
+fn lower_file_to_verified_hir(
+    input_path: &Path,
+    target: &target::TargetSpec,
+    options: &compile::CompileOptions,
+) -> Result<VerifiedFileHir, ()> {
+    let input = input_path.display().to_string();
+    let fopts = compile::frontend_options(target, options);
     let state = hew_compile::run_file_frontend_to_typecheck(&input, &fopts).map_err(|failure| {
         compile::render_frontend_diagnostics(&failure.diagnostics);
         if failure.diagnostics.is_empty() {
             eprintln!("Error: {}", failure.message);
         }
     })?;
-
     compile::render_frontend_diagnostics(&state.diagnostics);
 
-    let tco = state.typecheck_result.tco.ok_or_else(|| {
-        eprintln!(
-            "Error: hew compile requires a type-checked program; \
-             this path should be unreachable (no_typecheck = false)"
-        );
-    })?;
-
-    let lower_output = hew_hir::lower_program(
-        &state.program,
-        &tco,
-        &hew_hir::ResolutionCtx,
-        hir_target_arch(&target),
-    );
-    let mut hir_diagnostics = lower_output.diagnostics;
+    let lower_output = {
+        let tco = state.typecheck_result.tco.as_ref().ok_or_else(|| {
+            eprintln!(
+                "Error: Hew lowering requires a type-checked program; \\
+                 this path should be unreachable (no_typecheck = false)"
+            );
+        })?;
+        hew_hir::lower_program(
+            &state.program,
+            tco,
+            &hew_hir::ResolutionCtx,
+            hir_target_arch(target),
+        )
+    };
+    let mut hir_diagnostics = lower_output.diagnostics.clone();
     // Defense-in-depth: the verifier may emit a second `NotYetImplemented`
-    // for any `Unsupported` placeholder that lacked a prior lowerer
-    // diagnostic. Dedup by (kind, span) so the user sees each problem
-    // once, not twice.
-    let verifier_diags = hew_hir::verify_hir(&lower_output.module);
-    for diag in verifier_diags {
-        let already_present = hir_diagnostics
+    // for an `Unsupported` placeholder that lacked a prior lowerer
+    // diagnostic. Dedup by (kind, span) so the user sees each problem once.
+    for diagnostic in hew_hir::verify_hir(&lower_output.module) {
+        if !hir_diagnostics
             .iter()
-            .any(|d| d.kind == diag.kind && d.span == diag.span);
-        if !already_present {
-            hir_diagnostics.push(diag);
+            .any(|existing| existing.kind == diagnostic.kind && existing.span == diagnostic.span)
+        {
+            hir_diagnostics.push(diagnostic);
         }
     }
     if !hir_diagnostics.is_empty() {
@@ -319,82 +400,25 @@ fn lower_file_to_mir(
         return Err(());
     }
 
-    let mut pipeline =
-        hew_mir::lower_hir_module_with_facts(&lower_output.module, mir_pointer_width(&target));
-    // Route checker-authored layout facts onto the pipeline.
-    pipeline.attach_lowering_facts(&tco);
-    if render_pipeline_mir_diagnostics(
-        &state.program,
-        &state.source,
-        &input,
-        &lower_output.module,
-        &pipeline.diagnostics,
-    ) {
-        return Err(());
-    }
-
-    // `hew compile` exposes no `-A/-W/-D` flags, so MIR lints surface at their
-    // default levels (`// hew:allow(...)` still suppresses).
-    if render_pipeline_mir_lints(
-        &state.source,
-        &input,
-        &pipeline,
-        &hew_types::LintLevels::default(),
-    ) {
-        return Err(());
-    }
-
-    Ok(pipeline)
+    Ok(VerifiedFileHir {
+        input,
+        state,
+        lower_output,
+    })
 }
 
-/// Run the experimental Semantic IR lane without changing the established
-/// backend path.  This intentionally repeats the frontend work while SIR is
-/// shadow-only: it keeps the existing MIR driver completely authoritative and
-/// makes a mismatch incapable of changing a user's artifact.
+/// Lower a source file into verified semantic SSA without constructing MIR or
+/// consulting the backend. This is the inspection boundary for `--dump-sir`.
 fn lower_file_to_sir(
     input_path: &Path,
     requested_target: Option<&str>,
+    options: &compile::CompileOptions,
 ) -> Result<hew_sir::LoweredModule, ()> {
-    let input = input_path.display().to_string();
-    let target = target::TargetSpec::from_requested(requested_target).map_err(|e| {
-        eprintln!("Error: {e}");
+    let target = target::TargetSpec::from_requested(requested_target).map_err(|error| {
+        eprintln!("Error: {error}");
     })?;
-    let fopts = compile::frontend_options(&target, &compile::CompileOptions::default());
-    let state = hew_compile::run_file_frontend_to_typecheck(&input, &fopts).map_err(|failure| {
-        compile::render_frontend_diagnostics(&failure.diagnostics);
-        if failure.diagnostics.is_empty() {
-            eprintln!("Error: {}", failure.message);
-        }
-    })?;
-    let tco = state.typecheck_result.tco.ok_or_else(|| {
-        eprintln!("Error: Semantic IR requires type checking");
-    })?;
-    let lowered = hew_hir::lower_program(
-        &state.program,
-        &tco,
-        &hew_hir::ResolutionCtx,
-        hir_target_arch(&target),
-    );
-    let mut hir_diagnostics = lowered.diagnostics;
-    for diagnostic in hew_hir::verify_hir(&lowered.module) {
-        if !hir_diagnostics
-            .iter()
-            .any(|existing| existing.kind == diagnostic.kind && existing.span == diagnostic.span)
-        {
-            hir_diagnostics.push(diagnostic);
-        }
-    }
-    if !hir_diagnostics.is_empty() {
-        let diagnostics = hew_compile::hir_diagnostics_to_frontend(
-            &state.program,
-            &state.source,
-            &input,
-            hir_diagnostics,
-        );
-        compile::render_frontend_diagnostics(&diagnostics);
-        return Err(());
-    }
-    let sir = hew_sir::lower_module(&lowered.module);
+    let verified = lower_file_to_verified_hir(input_path, &target, options)?;
+    let sir = hew_sir::lower_module(&verified.lower_output.module);
     let diagnostics = hew_sir::verify_module(&sir.module);
     if !diagnostics.is_empty() {
         for diagnostic in diagnostics {
@@ -408,6 +432,45 @@ fn lower_file_to_sir(
     Ok(sir)
 }
 
+fn lower_file_to_mir_with_options(
+    input_path: &Path,
+    requested_target: Option<&str>,
+    options: &compile::CompileOptions,
+) -> Result<(hew_mir::IrPipeline, Option<SirLaneReport>), ()> {
+    let target = target::TargetSpec::from_requested(requested_target).map_err(|e| {
+        eprintln!("Error: {e}");
+    })?;
+    let verified = lower_file_to_verified_hir(input_path, &target, options)?;
+    let (pipeline, sir_report) = lower_verified_hir_to_pipeline(
+        &verified.lower_output.module,
+        verified.typecheck_output(),
+        &target,
+        options.sir_mode,
+    )?;
+    if render_pipeline_mir_diagnostics(
+        &verified.state.program,
+        &verified.state.source,
+        &verified.input,
+        &verified.lower_output.module,
+        &pipeline.diagnostics,
+    ) {
+        return Err(());
+    }
+
+    // `hew compile` exposes no `-A/-W/-D` flags, so MIR lints surface at their
+    // default levels (`// hew:allow(...)` still suppresses).
+    if render_pipeline_mir_lints(
+        &verified.state.source,
+        &verified.input,
+        &pipeline,
+        &hew_types::LintLevels::default(),
+    ) {
+        return Err(());
+    }
+
+    Ok((pipeline, sir_report))
+}
+
 /// Lower a source file to MIR for an explicit, already-resolved target.
 ///
 /// Unlike `lower_file_to_mir` (which hardcodes `TargetArch::host()`), this
@@ -418,70 +481,33 @@ fn lower_file_to_mir_for_target(
     target: &target::TargetSpec,
     options: &compile::CompileOptions,
 ) -> Result<(hew_mir::IrPipeline, Vec<std::path::PathBuf>), ()> {
-    let input = input_path.display().to_string();
-    let fopts = compile::frontend_options(target, options);
-
-    let state = hew_compile::run_file_frontend_to_typecheck(&input, &fopts).map_err(|failure| {
-        compile::render_frontend_diagnostics(&failure.diagnostics);
-        if failure.diagnostics.is_empty() {
-            eprintln!("Error: {}", failure.message);
-        }
-    })?;
-
-    compile::render_frontend_diagnostics(&state.diagnostics);
-
-    let tco = state.typecheck_result.tco.ok_or_else(|| {
-        eprintln!(
-            "Error: hew build requires a type-checked program; \
-             this path should be unreachable (no_typecheck = false)"
-        );
-    })?;
-
-    let lower_output = hew_hir::lower_program(
-        &state.program,
-        &tco,
-        &hew_hir::ResolutionCtx,
-        hir_target_arch(target),
-    );
-    let mut hir_diagnostics = lower_output.diagnostics;
-    let verifier_diags = hew_hir::verify_hir(&lower_output.module);
-    for diag in verifier_diags {
-        let already_present = hir_diagnostics
-            .iter()
-            .any(|d| d.kind == diag.kind && d.span == diag.span);
-        if !already_present {
-            hir_diagnostics.push(diag);
-        }
-    }
-    if !hir_diagnostics.is_empty() {
-        let frontend_diagnostics = hew_compile::hir_diagnostics_to_frontend(
-            &state.program,
-            &state.source,
-            &input,
-            hir_diagnostics,
-        );
-        compile::render_frontend_diagnostics(&frontend_diagnostics);
-        return Err(());
-    }
-
-    let mut pipeline =
-        hew_mir::lower_hir_module_with_facts(&lower_output.module, mir_pointer_width(target));
-    pipeline.attach_lowering_facts(&tco);
+    let verified = lower_file_to_verified_hir(input_path, target, options)?;
+    let (pipeline, _sir_report) = lower_verified_hir_to_pipeline(
+        &verified.lower_output.module,
+        verified.typecheck_output(),
+        target,
+        options.sir_mode,
+    )?;
     if render_pipeline_mir_diagnostics(
-        &state.program,
-        &state.source,
-        &input,
-        &lower_output.module,
+        &verified.state.program,
+        &verified.state.source,
+        &verified.input,
+        &verified.lower_output.module,
         &pipeline.diagnostics,
     ) {
         return Err(());
     }
 
-    if render_pipeline_mir_lints(&state.source, &input, &pipeline, &options.lint_levels) {
+    if render_pipeline_mir_lints(
+        &verified.state.source,
+        &verified.input,
+        &pipeline,
+        &options.lint_levels,
+    ) {
         return Err(());
     }
 
-    let native_pkg_dirs = native_link::collect_import_pkg_dirs(&state.program);
+    let native_pkg_dirs = native_link::collect_import_pkg_dirs(&verified.state.program);
     Ok((pipeline, native_pkg_dirs))
 }
 
@@ -889,10 +915,8 @@ pub(crate) fn compile_native_from_program_with_paths(
         return Err(());
     }
 
-    let mut pipeline =
-        hew_mir::lower_hir_module_with_facts(&lower_output.module, mir_pointer_width(&target));
-    // Route checker-authored layout facts onto the pipeline.
-    pipeline.attach_lowering_facts(&tco);
+    let (pipeline, _sir_report) =
+        lower_verified_hir_to_pipeline(&lower_output.module, &tco, &target, options.sir_mode)?;
     if render_pipeline_mir_diagnostics(
         &state.program,
         &state.source,
@@ -1348,38 +1372,49 @@ fn cmd_compile(a: &args::CompileArgs) {
 /// `std::process::exit` (that bypasses the [`JsonDiagnosticFlush`] guard its
 /// caller holds and would drop accumulated advisories). Every failure path is a
 /// `return <code>`, so the caller's single flush chokepoint runs regardless.
-fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
-    let json = a.format == args::DiagnosticFormat::Json;
-
-    if a.sir_shadow || a.dump_sir {
-        let Ok(sir) = lower_file_to_sir(&a.input, a.target.as_deref()) else {
-            return 1;
-        };
-        if a.dump_sir {
-            let dump = hew_sir::dump_sir(&sir.module);
-            if json {
-                eprint!("{dump}");
-            } else {
-                print!("{dump}");
-            }
-            for (name, status) in &sir.statuses {
-                if !matches!(status, hew_sir::SirLoweringStatus::Lowered) {
-                    eprintln!("SIR shadow fallback for `{name}`: {status:?}");
-                }
-            }
-            return 0;
-        }
-        let lowered = sir
-            .statuses
-            .iter()
-            .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::Lowered))
-            .count();
-        eprintln!("SIR shadow: verified {lowered}/{} function bodies; established MIR remains authoritative", sir.statuses.len());
-    }
-
-    let Ok(pipeline) = lower_file_to_mir(&a.input, a.target.as_deref()) else {
+fn cmd_dump_sir(a: &args::CompileArgs, json: bool) -> i32 {
+    let Ok(sir) = lower_file_to_sir(
+        &a.input,
+        a.target.as_deref(),
+        &compile::CompileOptions::default(),
+    ) else {
         return 1;
     };
+    let dump = hew_sir::dump_sir(&sir.module);
+    if json {
+        eprint!("{dump}");
+    } else {
+        print!("{dump}");
+    }
+    report_sir_inspection(&sir);
+    0
+}
+
+fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
+    let json = a.format == args::DiagnosticFormat::Json;
+    if a.dump_sir {
+        return cmd_dump_sir(a, json);
+    }
+    let sir_mode = if a.sir_lower {
+        compile::SirMode::Lower
+    } else if a.sir_shadow {
+        compile::SirMode::Shadow
+    } else {
+        compile::SirMode::Disabled
+    };
+    let options = compile::CompileOptions {
+        sir_mode,
+        ..compile::CompileOptions::default()
+    };
+    let Ok((pipeline, sir_report)) =
+        lower_file_to_mir_with_options(&a.input, a.target.as_deref(), &options)
+    else {
+        return 1;
+    };
+
+    if let Some(report) = sir_report.as_ref() {
+        report_sir_lane(report, sir_mode);
+    }
 
     // Dump path: print the requested MIR stage and exit. Useful for
     // spot-checking the lowering during development.
@@ -1478,6 +1513,80 @@ fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
     }
     // Clean compile: exit 0. The guard flushes the (possibly empty) JSON array.
     0
+}
+
+fn report_sir_lane(report: &SirLaneReport, mode: compile::SirMode) {
+    let sir_lowered = report
+        .sir
+        .statuses
+        .iter()
+        .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::Lowered))
+        .count();
+    let mode_label = match mode {
+        compile::SirMode::Disabled => return,
+        compile::SirMode::Shadow => "shadow",
+        compile::SirMode::Lower => "lower",
+    };
+    eprintln!(
+        "SIR {mode_label}: verified {sir_lowered}/{} HIR function bodies; realized {}/{} through raw MIR",
+        report.sir.statuses.len(),
+        report.bridge.lowered_count(),
+        report.sir.module.functions.len(),
+    );
+    let hir_fallbacks: Vec<_> = report
+        .sir
+        .statuses
+        .iter()
+        .filter_map(|(name, status)| match status {
+            hew_sir::SirLoweringStatus::Unsupported { reason } => Some((name, reason)),
+            hew_sir::SirLoweringStatus::Lowered => None,
+        })
+        .collect();
+    let raw_fallbacks: Vec<_> = report
+        .bridge
+        .statuses
+        .iter()
+        .filter_map(|(name, status)| match status {
+            hew_mir::SirMirLoweringStatus::Unsupported { reason } => Some((name, reason)),
+            hew_mir::SirMirLoweringStatus::Lowered => None,
+        })
+        .collect();
+    report_sir_fallbacks("HIR", &hir_fallbacks);
+    report_sir_fallbacks("raw-MIR", &raw_fallbacks);
+}
+
+fn report_sir_inspection(sir: &hew_sir::LoweredModule) {
+    let lowered = sir
+        .statuses
+        .iter()
+        .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::Lowered))
+        .count();
+    eprintln!(
+        "SIR inspect: verified {lowered}/{} HIR function bodies",
+        sir.statuses.len()
+    );
+    let fallbacks: Vec<_> = sir
+        .statuses
+        .iter()
+        .filter_map(|(name, status)| match status {
+            hew_sir::SirLoweringStatus::Unsupported { reason } => Some((name, reason)),
+            hew_sir::SirLoweringStatus::Lowered => None,
+        })
+        .collect();
+    report_sir_fallbacks("HIR", &fallbacks);
+}
+
+fn report_sir_fallbacks(kind: &str, fallbacks: &[(&String, &String)]) {
+    const DETAIL_LIMIT: usize = 6;
+    for (name, reason) in fallbacks.iter().take(DETAIL_LIMIT) {
+        eprintln!("SIR {kind} fallback for `{name}`: {reason}");
+    }
+    if fallbacks.len() > DETAIL_LIMIT {
+        eprintln!(
+            "SIR {kind}: {} additional explicit fallbacks (use --dump-sir for the semantic subset)",
+            fallbacks.len() - DETAIL_LIMIT
+        );
+    }
 }
 
 struct CompiledTempExecutable {

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -300,6 +300,7 @@ mod tests {
             emit_llvm: false,
             dump_mir: None,
             sir_shadow: false,
+            sir_lower: false,
             dump_sir: false,
             target: None,
             opt_level: "0".to_string(),

--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -103,6 +103,10 @@ fn requested_test_paths(args: &crate::args::TestArgs) -> Vec<String> {
     })
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "test discovery, parse-failure handling, partitioning, and stable output form one fail-closed CLI transaction"
+)]
 pub fn cmd_test(args: &crate::args::TestArgs) {
     let filter = args.filter.as_deref();
     let partition = parse_partition_argument(args.partition.as_deref());
@@ -199,12 +203,19 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
 
     let summary = runner::run_tests(
         &all_tests,
-        filter,
-        include_ignored,
-        ffi_lib.as_deref(),
-        &compile_paths,
-        timeout,
-        requested_jobs(args.jobs),
+        runner::TestRunOptions {
+            filter,
+            include_ignored,
+            ffi_lib: ffi_lib.as_deref(),
+            compile_paths: &compile_paths,
+            timeout,
+            jobs: requested_jobs(args.jobs),
+            sir_mode: if args.sir_shadow {
+                crate::compile::SirMode::Shadow
+            } else {
+                crate::compile::SirMode::Disabled
+            },
+        },
     );
     output::output_results(&summary, use_color, format);
 

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -177,50 +177,35 @@ impl TestCompilePaths {
     }
 }
 
+/// Execution policy and compiler inputs shared by every test in a run.
+///
+/// Keeping this as one value prevents test-runner entry points from gaining a
+/// new positional argument every time the compiler pipeline gains a mode.
+#[derive(Debug, Clone, Copy)]
+pub struct TestRunOptions<'a> {
+    pub filter: Option<&'a str>,
+    pub include_ignored: bool,
+    pub ffi_lib: Option<&'a str>,
+    pub compile_paths: &'a TestCompilePaths,
+    pub timeout: Duration,
+    pub jobs: usize,
+    pub sir_mode: crate::compile::SirMode,
+}
+
 /// Run a set of test cases.
 ///
 /// Each test is compiled to a native binary via the `hew compile` pipeline and
 /// executed as a child process for isolation.
 #[must_use]
-pub fn run_tests(
-    tests: &[TestCase],
-    filter: Option<&str>,
-    include_ignored: bool,
-    ffi_lib: Option<&str>,
-    compile_paths: &TestCompilePaths,
-    timeout: Duration,
-    jobs: usize,
-) -> TestSummary {
-    if jobs <= 1 {
-        return run_tests_serial(
-            tests,
-            filter,
-            include_ignored,
-            ffi_lib,
-            compile_paths,
-            timeout,
-        );
+pub fn run_tests(tests: &[TestCase], options: TestRunOptions<'_>) -> TestSummary {
+    if options.jobs <= 1 {
+        return run_tests_serial(tests, &options);
     }
 
-    run_tests_parallel(
-        tests,
-        filter,
-        include_ignored,
-        ffi_lib,
-        compile_paths,
-        timeout,
-        jobs,
-    )
+    run_tests_parallel(tests, &options)
 }
 
-fn run_tests_serial(
-    tests: &[TestCase],
-    filter: Option<&str>,
-    include_ignored: bool,
-    ffi_lib: Option<&str>,
-    compile_paths: &TestCompilePaths,
-    timeout: Duration,
-) -> TestSummary {
+fn run_tests_serial(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestSummary {
     let mut results = Vec::new();
     let mut passed = 0;
     let mut failed = 0;
@@ -229,7 +214,7 @@ fn run_tests_serial(
     // Group tests by file for efficiency while preserving discovery order.
     let mut by_file: Vec<(&str, Vec<&TestCase>)> = Vec::new();
     for test in tests {
-        if let Some(pat) = filter {
+        if let Some(pat) = options.filter {
             if !test.name.contains(pat) {
                 continue;
             }
@@ -262,7 +247,7 @@ fn run_tests_serial(
         };
 
         for test in file_tests {
-            if test.ignored && !include_ignored {
+            if test.ignored && !options.include_ignored {
                 ignored += 1;
                 results.push(TestResult {
                     test: test.clone(),
@@ -273,7 +258,14 @@ fn run_tests_serial(
                 continue;
             }
 
-            let result = run_single_test(&source, test, ffi_lib, compile_paths, timeout);
+            let result = run_single_test(
+                &source,
+                test,
+                options.ffi_lib,
+                options.compile_paths,
+                options.timeout,
+                options.sir_mode,
+            );
             match &result.outcome {
                 TestOutcome::Passed => passed += 1,
                 TestOutcome::Failed(_) => failed += 1,
@@ -297,18 +289,17 @@ struct TestTask {
     test: TestCase,
 }
 
-fn run_tests_parallel(
-    tests: &[TestCase],
-    filter: Option<&str>,
-    include_ignored: bool,
-    ffi_lib: Option<&str>,
-    compile_paths: &TestCompilePaths,
-    timeout: Duration,
-    jobs: usize,
-) -> TestSummary {
+#[allow(
+    clippy::too_many_lines,
+    reason = "parallel scheduling, stable result placement, and serial-test exclusion form one cohesive execution policy"
+)]
+fn run_tests_parallel(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestSummary {
     let mut by_file: Vec<(&str, Vec<&TestCase>)> = Vec::new();
     for test in tests {
-        if filter.is_some_and(|pattern| !test.name.contains(pattern)) {
+        if options
+            .filter
+            .is_some_and(|pattern| !test.name.contains(pattern))
+        {
             continue;
         }
         if let Some((_, grouped_tests)) = by_file
@@ -345,7 +336,7 @@ fn run_tests_parallel(
         };
 
         for test in file_tests {
-            if test.ignored && !include_ignored {
+            if test.ignored && !options.include_ignored {
                 result_slots[result_index] = Some(TestResult {
                     test: test.clone(),
                     outcome: TestOutcome::Ignored,
@@ -366,7 +357,7 @@ fn run_tests_parallel(
     let next_task = AtomicUsize::new(0);
     let result_slots = Mutex::new(result_slots);
     let serial_gate = Mutex::new(());
-    let worker_count = jobs.min(tasks.len().max(1));
+    let worker_count = options.jobs.min(tasks.len().max(1));
 
     std::thread::scope(|scope| {
         for _ in 0..worker_count {
@@ -379,9 +370,23 @@ fn run_tests_parallel(
                     let _serial_guard = serial_gate
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    run_single_test(&task.source, &task.test, ffi_lib, compile_paths, timeout)
+                    run_single_test(
+                        &task.source,
+                        &task.test,
+                        options.ffi_lib,
+                        options.compile_paths,
+                        options.timeout,
+                        options.sir_mode,
+                    )
                 } else {
-                    run_single_test(&task.source, &task.test, ffi_lib, compile_paths, timeout)
+                    run_single_test(
+                        &task.source,
+                        &task.test,
+                        options.ffi_lib,
+                        options.compile_paths,
+                        options.timeout,
+                        options.sir_mode,
+                    )
                 };
                 result_slots
                     .lock()
@@ -431,6 +436,7 @@ fn compile_test(
     test: &TestCase,
     ffi_lib: Option<&str>,
     compile_paths: &TestCompilePaths,
+    sir_mode: crate::compile::SirMode,
 ) -> Result<CompiledTestArtifact, String> {
     let synthetic = format!(
         "{source}\n\nfn main() {{\n    {name}();\n}}\n",
@@ -464,6 +470,7 @@ fn compile_test(
         &binary_path,
         &crate::compile::CompileOptions {
             project_dir: Some(compile_paths.paths.project_dir.clone()),
+            sir_mode,
             ..crate::compile::CompileOptions::default()
         },
         Some(&compile_paths.paths),
@@ -492,10 +499,11 @@ fn run_single_test(
     ffi_lib: Option<&str>,
     compile_paths: &TestCompilePaths,
     timeout: Duration,
+    sir_mode: crate::compile::SirMode,
 ) -> TestResult {
     let start = std::time::Instant::now();
 
-    let artifact = match compile_test(source, test, ffi_lib, compile_paths) {
+    let artifact = match compile_test(source, test, ffi_lib, compile_paths, sir_mode) {
         Ok(artifact) => artifact,
         Err(msg) => {
             let outcome = if test.should_panic {
@@ -724,12 +732,15 @@ mod tests {
             .collect();
         run_tests(
             &tests,
-            None,
-            false,
-            None,
-            cargo_test_compile_paths(),
-            timeout,
-            1,
+            TestRunOptions {
+                filter: None,
+                include_ignored: false,
+                ffi_lib: None,
+                compile_paths: cargo_test_compile_paths(),
+                timeout,
+                jobs: 1,
+                sir_mode: crate::compile::SirMode::Disabled,
+            },
         )
     }
 
@@ -917,12 +928,15 @@ fn test_timeout() {
         };
         let summary = run_tests(
             &tests,
-            None,
-            false,
-            None,
-            &unused_paths,
-            DEFAULT_TEST_TIMEOUT,
-            2,
+            TestRunOptions {
+                filter: None,
+                include_ignored: false,
+                ffi_lib: None,
+                compile_paths: &unused_paths,
+                timeout: DEFAULT_TEST_TIMEOUT,
+                jobs: 2,
+                sir_mode: crate::compile::SirMode::Disabled,
+            },
         );
         let names: Vec<_> = summary
             .results

--- a/hew-cli/tests/sir_shadow_e2e.rs
+++ b/hew-cli/tests/sir_shadow_e2e.rs
@@ -1,0 +1,383 @@
+//! End-to-end contracts for the experimental Semantic IR lane.
+//!
+//! `--sir-shadow` must exercise and verify the SIR → raw-MIR candidate while
+//! leaving the established raw-MIR dump byte-for-byte authoritative.  Once a
+//! function is eligible, `--sir-lower` must select that same candidate rather
+//! than merely reporting that it was constructed.
+
+mod support;
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use support::{assert_success, describe_output, hew_binary, repo_root, require_codegen};
+
+const SCALAR_DIAMOND: &str = r"
+fn sir_scalar_add(x: i64, y: i64) -> i64 {
+    x + y
+}
+
+fn sir_scalar_diamond(x: i64) -> i64 {
+    if x > 0 {
+        42
+    } else {
+        23
+    }
+}
+";
+
+const EXECUTABLE_SCALAR: &str = r"
+fn sir_selected_add(x: i64, y: i64) -> i64 {
+    x + y
+}
+
+fn main() -> i64 {
+    println(sir_selected_add(19, 23));
+    0
+}
+";
+
+const SHORT_CIRCUIT_INSPECTION: &str = r"
+fn rhs() -> bool {
+    true
+}
+
+fn sir_and(flag: bool) -> bool {
+    flag && rhs()
+}
+
+fn sir_or(flag: bool) -> bool {
+    flag || rhs()
+}
+";
+
+const SHORT_CIRCUIT_EXECUTABLE: &str = r"
+fn sir_and_value(flag: bool) -> i64 {
+    if flag && false {
+        1
+    } else {
+        0
+    }
+}
+
+fn sir_or_value(flag: bool) -> i64 {
+    if flag || false {
+        1
+    } else {
+        0
+    }
+}
+
+fn main() -> i64 {
+    println(sir_and_value(false) + sir_and_value(true) + sir_or_value(false) + sir_or_value(true));
+    0
+}
+";
+
+fn raw_mir_dump(source: &Path, sir_flag: Option<&str>) -> Output {
+    let mut command = Command::new(hew_binary());
+    command.arg("compile").arg("--dump-mir").arg("raw");
+    if let Some(flag) = sir_flag {
+        command.arg(flag);
+    }
+    command.arg(source).current_dir(repo_root());
+    support::run_bounded_command(command, format!("raw MIR dump for {}", source.display()))
+}
+
+fn sir_dump(source: &Path) -> Output {
+    let mut command = Command::new(hew_binary());
+    command
+        .arg("compile")
+        .arg("--dump-sir")
+        .arg(source)
+        .current_dir(repo_root());
+    support::run_bounded_command(command, format!("SIR dump for {}", source.display()))
+}
+
+fn function_section<'a>(dump: &'a str, name: &str) -> &'a str {
+    let header = format!("fn {name}(");
+    let start = dump
+        .find(&header)
+        .unwrap_or_else(|| panic!("raw MIR dump must contain `{header}`:\n{dump}"));
+    let rest = &dump[start..];
+    let end = rest[1..]
+        .find("\nfn ")
+        .map_or(rest.len(), |index| index + 1);
+    &rest[..end]
+}
+
+fn scalar_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_scalar_diamond.hew");
+    fs::write(&source, SCALAR_DIAMOND).expect("write scalar SIR fixture");
+    (dir, source)
+}
+
+/// Shadow mode constructs, verifies, and backend-front validates the SIR
+/// candidate, but emits the established raw MIR unchanged.  This protects the
+/// initial migration against accidentally selecting the candidate in the
+/// default/shadow lane.
+#[test]
+fn sir_shadow_keeps_established_raw_mir_authoritative() {
+    let (_dir, source) = scalar_fixture();
+    let baseline = raw_mir_dump(&source, None);
+    let shadow = raw_mir_dump(&source, Some("--sir-shadow"));
+
+    assert_success(&baseline, "baseline raw MIR dump must succeed");
+    assert_success(&shadow, "SIR shadow raw MIR dump must succeed");
+    assert_eq!(
+        baseline.stdout,
+        shadow.stdout,
+        "--sir-shadow must retain the established raw MIR output\n\
+         baseline:\n{}\n\
+         shadow:\n{}",
+        String::from_utf8_lossy(&baseline.stdout),
+        String::from_utf8_lossy(&shadow.stdout),
+    );
+
+    let stderr = String::from_utf8_lossy(&shadow.stderr);
+    assert!(
+        stderr.contains("SIR shadow: verified"),
+        "shadow run must report that its SIR lane was verified:\n{}",
+        describe_output(&shadow),
+    );
+    assert!(
+        !stderr.contains("realized 0/"),
+        "the eligible scalar arithmetic function must be realized through the SIR-to-raw-MIR adapter:\n{}",
+        describe_output(&shadow),
+    );
+
+    let shadow_dump = String::from_utf8_lossy(&shadow.stdout);
+    let established = function_section(&shadow_dump, "sir_scalar_add");
+    assert!(
+        established.contains("stmt: use"),
+        "shadow output must still be the established statement-oriented lowering:\n{established}",
+    );
+    let established_diamond = function_section(&shadow_dump, "sir_scalar_diamond");
+    assert!(
+        established_diamond.contains("branch "),
+        "the shadow fixture must exercise an established scalar CFG body:\n{established_diamond}",
+    );
+}
+
+/// Lower mode selects the verified candidate for the supported scalar
+/// value/CFG subset.  Both straight-line arithmetic and a branch/join must be
+/// value-oriented (no legacy `stmt: use` markers); checked arithmetic retains
+/// its required raw-MIR trap CFG.
+#[test]
+fn sir_lower_selects_value_and_cfg_lowering() {
+    let (_dir, source) = scalar_fixture();
+    let baseline = raw_mir_dump(&source, None);
+    let lowered = raw_mir_dump(&source, Some("--sir-lower"));
+
+    assert_success(&baseline, "baseline raw MIR dump must succeed");
+    assert_success(&lowered, "SIR lower raw MIR dump must succeed");
+
+    let baseline_dump = String::from_utf8_lossy(&baseline.stdout);
+    let lowered_dump = String::from_utf8_lossy(&lowered.stdout);
+    let baseline_fn = function_section(&baseline_dump, "sir_scalar_add");
+    let lowered_fn = function_section(&lowered_dump, "sir_scalar_add");
+    assert_ne!(
+        baseline_fn, lowered_fn,
+        "--sir-lower must select the SIR candidate instead of only constructing it",
+    );
+    assert!(
+        !lowered_fn.contains("stmt: use"),
+        "SIR-realized raw MIR must not retain legacy HIR-use statements:\n{lowered_fn}",
+    );
+    assert!(
+        lowered_fn.contains("branch "),
+        "checked arithmetic must retain its raw-MIR trap CFG:\n{lowered_fn}",
+    );
+    assert!(
+        lowered_fn.contains("add.checked.s"),
+        "SIR arithmetic must legalize to checked raw-MIR arithmetic:\n{lowered_fn}",
+    );
+    assert!(
+        lowered_fn.contains("trap(IntegerOverflow)"),
+        "SIR arithmetic overflow must preserve raw-MIR trap semantics:\n{lowered_fn}",
+    );
+    let baseline_diamond = function_section(&baseline_dump, "sir_scalar_diamond");
+    let lowered_diamond = function_section(&lowered_dump, "sir_scalar_diamond");
+    assert_ne!(
+        baseline_diamond, lowered_diamond,
+        "--sir-lower must select SIR block arguments for an ordinary scalar if/join",
+    );
+    assert!(
+        !lowered_diamond.contains("stmt: use"),
+        "SIR-realized scalar CFG must not retain legacy HIR-use statements:\n{lowered_diamond}",
+    );
+    assert!(
+        lowered_diamond.contains("branch "),
+        "the source if must remain explicit CFG in SIR realization:\n{lowered_diamond}",
+    );
+
+    let stderr = String::from_utf8_lossy(&lowered.stderr);
+    assert!(
+        stderr.contains("SIR lower: verified"),
+        "lower run must report its verified SIR lane:\n{}",
+        describe_output(&lowered),
+    );
+    assert!(
+        !stderr.contains("realized 0/"),
+        "the eligible scalar arithmetic function must be selected from SIR:\n{}",
+        describe_output(&lowered),
+    );
+}
+
+/// A selected SIR callee must survive all remaining established pipeline
+/// stages and execute with the same observable result. The caller stays on
+/// the legacy path because call realization is intentionally not part of this
+/// first adapter slice; that mixed module is the intended incremental-cutover
+/// topology.
+#[test]
+fn sir_lower_selected_scalar_callee_compiles_and_runs() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_lower_execution.hew");
+    fs::write(&source, EXECUTABLE_SCALAR).expect("write executable SIR fixture");
+
+    let mut compile = Command::new(hew_binary());
+    compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--emit-dir")
+        .arg(dir.path())
+        .arg(&source)
+        .current_dir(repo_root());
+    let compiled = support::run_bounded_command(compile, "compile selected SIR scalar callee");
+    assert_success(
+        &compiled,
+        "SIR-lowered scalar callee must compile through the established backend",
+    );
+    let compile_stderr = String::from_utf8_lossy(&compiled.stderr);
+    assert!(
+        compile_stderr.contains("SIR lower: verified") && !compile_stderr.contains("realized 0/"),
+        "compile must select at least one SIR body:\n{}",
+        describe_output(&compiled),
+    );
+
+    let binary = hew_testutil::compiled_binary_path(dir.path(), "sir_lower_execution");
+    assert!(
+        binary.is_file(),
+        "SIR-lowered compile did not produce expected native binary {}:\n{}",
+        binary.display(),
+        describe_output(&compiled),
+    );
+    let executed = support::run_bounded_command(
+        Command::new(&binary),
+        format!("run selected SIR scalar callee {}", binary.display()),
+    );
+    assert_success(
+        &executed,
+        "native binary containing SIR-lowered callee must run successfully",
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&executed.stdout),
+        "42\n",
+        "SIR-lowered scalar callee returned an unexpected result:\n{}",
+        describe_output(&executed),
+    );
+}
+
+/// A logical RHS must remain in the CFG block guarded by its left-hand side.
+/// This drives the SIR inspector directly, so the test also proves `--dump-sir`
+/// does not need to construct legacy MIR or validate a backend candidate.
+#[test]
+fn sir_dump_preserves_short_circuit_control_flow() {
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_short_circuit_inspection.hew");
+    fs::write(&source, SHORT_CIRCUIT_INSPECTION).expect("write short-circuit SIR fixture");
+
+    let output = sir_dump(&source);
+    assert_success(&output, "SIR short-circuit inspection must succeed");
+    let dump = String::from_utf8_lossy(&output.stdout);
+    let and_body = function_section(&dump, "sir_and");
+    let or_body = function_section(&dump, "sir_or");
+
+    assert!(
+        and_body.contains("branch %0, bb1, bb2"),
+        "&& must evaluate its RHS only on the true edge:\n{and_body}",
+    );
+    assert!(
+        and_body.find("branch").is_some_and(|branch| {
+            and_body.find("call").is_some_and(|call| branch < call)
+                && and_body
+                    .find("const false")
+                    .is_some_and(|constant| branch < constant)
+        }),
+        "&& must materialize both RHS and false paths after its branch:\n{and_body}",
+    );
+    assert!(
+        !and_body.contains("Binary { op: And"),
+        "&& must not survive as an eager SIR binary operation:\n{and_body}",
+    );
+
+    assert!(
+        or_body.contains("branch %0, bb2, bb1"),
+        "|| must evaluate its RHS only on the false edge:\n{or_body}",
+    );
+    assert!(
+        or_body.find("branch").is_some_and(|branch| {
+            or_body.find("call").is_some_and(|call| branch < call)
+                && or_body
+                    .find("const true")
+                    .is_some_and(|constant| branch < constant)
+        }),
+        "|| must materialize both RHS and true paths after its branch:\n{or_body}",
+    );
+    assert!(
+        !or_body.contains("Binary { op: Or"),
+        "|| must not survive as an eager SIR binary operation:\n{or_body}",
+    );
+}
+
+/// Selected SIR CFG lowering must preserve both truth-table sides of `&&` and
+/// `||` through raw MIR, LLVM, and a native executable. The calling `main`
+/// remains temporary legacy scaffolding until the direct-call SIR cutover.
+#[test]
+fn sir_lower_short_circuit_truth_table_compiles_and_runs() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_short_circuit_execution.hew");
+    fs::write(&source, SHORT_CIRCUIT_EXECUTABLE).expect("write short-circuit execution fixture");
+
+    let mut compile = Command::new(hew_binary());
+    compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--emit-dir")
+        .arg(dir.path())
+        .arg(&source)
+        .current_dir(repo_root());
+    let compiled = support::run_bounded_command(compile, "compile selected SIR short-circuit CFG");
+    assert_success(
+        &compiled,
+        "SIR-lowered short-circuit functions must compile through the backend",
+    );
+    let compile_stderr = String::from_utf8_lossy(&compiled.stderr);
+    assert!(
+        compile_stderr.contains("SIR lower: verified") && !compile_stderr.contains("realized 0/"),
+        "compile must select the short-circuit SIR functions:\n{}",
+        describe_output(&compiled),
+    );
+
+    let binary = hew_testutil::compiled_binary_path(dir.path(), "sir_short_circuit_execution");
+    let executed = support::run_bounded_command(
+        Command::new(&binary),
+        format!("run selected SIR short-circuit CFG {}", binary.display()),
+    );
+    assert_success(
+        &executed,
+        "native binary containing SIR-lowered short-circuit functions must run",
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&executed.stdout),
+        "1\n",
+        "SIR short-circuit truth table produced an unexpected result:\n{}",
+        describe_output(&executed),
+    );
+}

--- a/hew-codegen-rs/src/lib.rs
+++ b/hew-codegen-rs/src/lib.rs
@@ -20,8 +20,8 @@
 //! - [`emit_module`] — emit native + freestanding wasm artefacts for an `IrPipeline`.
 //! - [`emit_module_objects`] — emit IR/object artefacts without freestanding wasm linking.
 //! - [`emit_wasi_entry_adapter`] — publish the canonical entry consumed by the WASI runtime.
-//! - [`validate_codegen_front`] — in-process build + LLVM-verify without any
-//!   artefact emission.
+//! - [`validate_codegen_front`] / [`validate_codegen_front_for_triple`] —
+//!   in-process build + LLVM-verify without any artefact emission.
 //! - [`verify_pipeline`] — compatibility alias for [`validate_codegen_front`].
 //! - [`EmitOptions`] — output configuration.
 //! - [`EmitArtefacts`] — paths of emitted files.
@@ -44,6 +44,6 @@ pub(crate) mod wire;
 
 pub use llvm::{
     emit_module, emit_module_objects, emit_module_objects_without_llvm, emit_module_without_llvm,
-    emit_wasi_entry_adapter, validate_codegen_front, verify_pipeline, CodegenError, EmitArtefacts,
-    EmitOptions, OptLevel,
+    emit_wasi_entry_adapter, validate_codegen_front, validate_codegen_front_for_triple,
+    verify_pipeline, CodegenError, EmitArtefacts, EmitOptions, OptLevel,
 };

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -840,7 +840,9 @@ fn emit_module_with_options(
 /// - Acquires the same `llvm_codegen_lock` used by object emission so
 ///   concurrent calls are safe.
 /// - Selects the same host-native triple as native object emission and runs
-///   target-specific pre-link substrate scans before lowering.
+///   target-specific pre-link substrate scans before lowering. Use
+///   [`validate_codegen_front_for_triple`] when the caller selected an
+///   explicit target.
 /// - Target initialisation and host-triple machine construction failures
 ///   surface as [`CodegenError::TargetSetup`], never as panics or silent
 ///   fallbacks.
@@ -855,12 +857,29 @@ fn emit_module_with_options(
 /// target-specific pre-link scan rejects the MIR, or `Module::verify()` rejects
 /// the emitted IR.
 pub fn validate_codegen_front(pipeline: &IrPipeline) -> CodegenResult<()> {
+    validate_codegen_front_for_triple(pipeline, &native_emission_triple())
+}
+
+/// Build and LLVM-verify `pipeline` for an explicit target triple without
+/// writing an artefact.
+///
+/// This is the target-aware sibling of [`validate_codegen_front`].  Compiler
+/// migration lanes must use it when a CLI build selected a non-host target so
+/// their proof covers the same target substrate and data layout that actual
+/// emission will use.
+///
+/// # Errors
+///
+/// Returns the same fail-closed [`CodegenError`] surface as
+/// [`validate_codegen_front`], including target setup and target-specific
+/// substrate failures.
+pub fn validate_codegen_front_for_triple(pipeline: &IrPipeline, triple: &str) -> CodegenResult<()> {
     // Enforce the layout-fact consistency invariant on every
     // codegen-front entry, mirroring `emit_module`.  `hew check` reaches
     // this path; surfacing a stuck-`Pending` fact here fails closed
     // before any LLVM module is built.
     verify_hashmap_lowering_facts_consistent(pipeline)?;
-    validate_codegen_front_with_name(pipeline, "__hew_codegen_front_verify__")
+    validate_codegen_front_with_name_and_triple(pipeline, "__hew_codegen_front_verify__", triple)
 }
 
 /// Compatibility name kept for early callers of the Stage 4 verifier API.
@@ -868,13 +887,21 @@ pub fn verify_pipeline(pipeline: &IrPipeline) -> CodegenResult<()> {
     validate_codegen_front(pipeline)
 }
 
+#[cfg(test)]
 fn validate_codegen_front_with_name(pipeline: &IrPipeline, module_name: &str) -> CodegenResult<()> {
+    validate_codegen_front_with_name_and_triple(pipeline, module_name, &native_emission_triple())
+}
+
+fn validate_codegen_front_with_name_and_triple(
+    pipeline: &IrPipeline,
+    module_name: &str,
+    triple: &str,
+) -> CodegenResult<()> {
     let _guard = llvm_codegen_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let triple = native_emission_triple();
-    validate_target_substrate(pipeline, &triple)?;
-    let machine = target_machine_for_triple(&triple)?;
+    validate_target_substrate(pipeline, triple)?;
+    let machine = target_machine_for_triple(triple)?;
     let ctx = Context::create();
     build_module_for_target(&ctx, pipeline, module_name, Some(&machine), None)?;
     Ok(())

--- a/hew-mir/Cargo.toml
+++ b/hew-mir/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["compilers"]
 
 [dependencies]
 hew-hir = { path = "../hew-hir" }
+hew-sir = { path = "../hew-sir" }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 serde.workspace = true

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -1528,25 +1528,106 @@ pub fn analyze_with_binding_locals<S: std::hash::BuildHasher>(
 /// constant the caller passes in so integration tests can override it.
 const LEAF_STATEMENT_THRESHOLD: usize = 10;
 
-/// Determine whether a block has a back-edge terminator — i.e., a
-/// `Goto` whose target block id is less than the current block's id.
+/// Return the source block ids of natural-loop `Goto` back-edges.
 ///
-/// WHY `target < block.id`: The MIR lowering emits blocks in
-/// monotonically increasing id order, with entry block id = 0. A
-/// forward edge always targets a block with a higher id than the
-/// source; a back-edge (loop) targets an earlier block. The invariant
-/// holds for all CFGs the v0.5 lowering constructs — forward Gotos
-/// target the join block (always allocated after the arm blocks).
-/// Synthetic test CFGs must respect this convention.
+/// A numeric block-id ordering is not a CFG invariant. In particular, an SSA
+/// lowering may append edge-forwarding blocks after the source blocks they
+/// serve, so a perfectly acyclic forwarding edge can legitimately have the
+/// shape `bb7 -> bb3`. Scheduling such an edge as a loop back-edge injects an
+/// unnecessary cooperate call and, worse, makes a value/CFG lowering appear to
+/// have changed the program's scheduler contract.
 ///
-/// WHEN-OBSOLETE: if a future lowering phase emits blocks in non-
-/// topological order, replace this predicate with a full DFS-ancestry
-/// check using a discovered DFS tree over the CFG.
-fn is_back_edge_goto(block: &BasicBlock) -> bool {
-    match block.terminator {
-        Terminator::Goto { target } => target < block.id,
-        _ => false,
+/// A `Goto { target }` is a natural-loop back-edge exactly when `target`
+/// dominates its source: every path from the entry to the source has already
+/// passed through the target. This is the structural property the scheduler
+/// needs, independent of allocation order. The current scheduler only places
+/// loop checks on `Goto` edges (structured Hew loop lowerings use `Goto` for
+/// their latch); other terminator forms deliberately retain the existing
+/// policy rather than broadening scheduling behaviour as a side effect of this
+/// correctness fix.
+fn goto_loop_back_edge_blocks(blocks: &[BasicBlock]) -> HashSet<u32> {
+    let by_id: HashMap<u32, &BasicBlock> = blocks.iter().map(|block| (block.id, block)).collect();
+    if !by_id.contains_key(&0) {
+        return HashSet::new();
     }
+
+    // Ignore malformed successor ids and unreachable blocks. The ordinary MIR
+    // producers guarantee valid CFG ids, but this keeps the scheduler analysis
+    // conservative for hand-built test fixtures: an unknown target cannot be
+    // proven to dominate anything, and an unreachable cycle never executes.
+    let reachable: HashSet<u32> = reachable_from_entry(blocks)
+        .into_iter()
+        .filter(|id| by_id.contains_key(id))
+        .collect();
+    if reachable.is_empty() {
+        return HashSet::new();
+    }
+
+    let predecessors = build_preds(blocks);
+    let mut dominators: HashMap<u32, HashSet<u32>> = reachable
+        .iter()
+        .copied()
+        .map(|id| {
+            let initial = if id == 0 {
+                HashSet::from([0])
+            } else {
+                reachable.clone()
+            };
+            (id, initial)
+        })
+        .collect();
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for &block_id in &reachable {
+            if block_id == 0 {
+                continue;
+            }
+            let reachable_predecessors: Vec<u32> = predecessors
+                .get(&block_id)
+                .into_iter()
+                .flatten()
+                .copied()
+                .filter(|predecessor| reachable.contains(predecessor))
+                .collect();
+            // A reachable non-entry block always has a reachable predecessor,
+            // but retain a conservative singleton if a malformed CFG violates
+            // that property.
+            let mut next = if let Some((first, rest)) = reachable_predecessors.split_first() {
+                let mut intersection = dominators.get(first).cloned().unwrap_or_default();
+                for predecessor in rest {
+                    if let Some(predecessor_dominators) = dominators.get(predecessor) {
+                        intersection.retain(|id| predecessor_dominators.contains(id));
+                    } else {
+                        intersection.clear();
+                    }
+                }
+                intersection
+            } else {
+                HashSet::new()
+            };
+            next.insert(block_id);
+            if dominators.get(&block_id) != Some(&next) {
+                dominators.insert(block_id, next);
+                changed = true;
+            }
+        }
+    }
+
+    blocks
+        .iter()
+        .filter_map(|block| {
+            let Terminator::Goto { target } = block.terminator else {
+                return None;
+            };
+            (reachable.contains(&block.id)
+                && dominators
+                    .get(&block.id)
+                    .is_some_and(|source_dominators| source_dominators.contains(&target)))
+            .then_some(block.id)
+        })
+        .collect()
 }
 
 /// Return true if a block contains a call — `Instr::CallRuntimeAbi` or
@@ -1578,7 +1659,7 @@ fn block_has_call(block: &BasicBlock) -> bool {
 ///
 /// WHEN-OBSOLETE: once a caller-supplied eligibility override (attribute
 /// flag) is wired, that gates this check entirely.
-fn is_leaf_function(blocks: &[BasicBlock]) -> bool {
+fn is_leaf_function(blocks: &[BasicBlock], loop_back_edge_blocks: &HashSet<u32>) -> bool {
     let total_statements: usize = blocks.iter().map(|b| b.statements.len()).sum();
     if total_statements >= LEAF_STATEMENT_THRESHOLD {
         return false;
@@ -1587,8 +1668,7 @@ fn is_leaf_function(blocks: &[BasicBlock]) -> bool {
     if has_call {
         return false;
     }
-    let has_back_edge = blocks.iter().any(is_back_edge_goto);
-    if has_back_edge {
+    if !loop_back_edge_blocks.is_empty() {
         return false;
     }
     true
@@ -1632,8 +1712,8 @@ fn is_yield_equivalent(block: &BasicBlock) -> bool {
 /// 2. **Function-entry site**: add a `FunctionEntry` site for block 0
 ///    unless that block's terminator is yield-equivalent (the actor
 ///    will cooperate via the yield anyway).
-/// 3. **Back-edge sweep**: for every block whose `Goto` target id is
-///    less than the block's own id, add a `LoopBackEdge` site — unless
+/// 3. **Back-edge sweep**: for every `Goto` whose target dominates its
+///    source, add a `LoopBackEdge` site — unless
 ///    the back-edge target block itself has a yield-equivalent
 ///    terminator (the loop header yields on every iteration).
 ///
@@ -1649,11 +1729,13 @@ fn is_yield_equivalent(block: &BasicBlock) -> bool {
 ///
 /// Loop lowering has constructed production back-edges since `8d878b8e`.
 /// `LoopBackEdge` sites are live for `for`, `while`, and `loop` bodies:
-/// a back-edge `Goto` is detected by `is_back_edge_goto` and receives a
-/// cooperate check before control returns to the loop header.
+/// a dominance-proven latch `Goto` receives a cooperate check before control
+/// returns to the loop header. This remains correct when a lowering pass adds
+/// forwarding blocks or otherwise does not number blocks topologically.
 #[must_use]
 pub fn compute_cooperate_sites(blocks: &[BasicBlock]) -> Vec<CooperateSite> {
-    if blocks.is_empty() || is_leaf_function(blocks) {
+    let loop_back_edge_blocks = goto_loop_back_edge_blocks(blocks);
+    if blocks.is_empty() || is_leaf_function(blocks, &loop_back_edge_blocks) {
         return Vec::new();
     }
 
@@ -1668,23 +1750,27 @@ pub fn compute_cooperate_sites(blocks: &[BasicBlock]) -> Vec<CooperateSite> {
         });
     }
 
-    // Back-edge sites: every block whose Goto targets an earlier block.
+    // Back-edge sites: every Goto whose target dominates its source.
     // Suppress if the loop-header block itself has a yield-equivalent
     // terminator (the actor already cooperates at the loop header).
     let by_id: HashMap<u32, &BasicBlock> = blocks.iter().map(|b| (b.id, b)).collect();
     for block in blocks {
-        if let Terminator::Goto { target } = block.terminator {
-            if target < block.id {
-                // Back-edge found. Check whether the loop-header block
-                // itself is yield-equivalent — if so, no cooperate needed.
-                let header_yields = by_id.get(&target).is_some_and(|h| is_yield_equivalent(h));
-                if !header_yields {
-                    sites.push(CooperateSite {
-                        bb_id: block.id,
-                        kind: CooperateKind::LoopBackEdge,
-                    });
-                }
-            }
+        let Terminator::Goto { target } = block.terminator else {
+            continue;
+        };
+        if !loop_back_edge_blocks.contains(&block.id) {
+            continue;
+        }
+        // Back-edge found. Check whether the loop-header block itself is
+        // yield-equivalent — if so, no cooperate needed.
+        let header_yields = by_id
+            .get(&target)
+            .is_some_and(|header| is_yield_equivalent(header));
+        if !header_yields {
+            sites.push(CooperateSite {
+                bb_id: block.id,
+                kind: CooperateKind::LoopBackEdge,
+            });
         }
     }
 
@@ -2398,6 +2484,56 @@ mod tests {
         assert!(
             sites.is_empty(),
             "leaf function should produce no cooperate sites, got {sites:?}"
+        );
+    }
+
+    /// SIR block arguments lower through edge-forwarding blocks. Those blocks
+    /// are allocated after the source CFG, so their numeric ids can be greater
+    /// than the original arm/join targets even though the overall graph is
+    /// acyclic. Scheduler loop detection must use graph structure rather than
+    /// that incidental allocation order.
+    ///
+    ///   bb0: Branch { then: bb4, else: bb5 }
+    ///   bb4: Goto bb1     // high-id edge forwarder, not a loop
+    ///   bb5: Goto bb2     // high-id edge forwarder, not a loop
+    ///   bb1: Goto bb6
+    ///   bb2: Goto bb7
+    ///   bb6: Goto bb3     // high-id edge forwarder into the join
+    ///   bb7: Goto bb3     // high-id edge forwarder into the join
+    ///   bb3: Return
+    ///
+    /// The statement threshold makes this non-leaf so the assertion proves
+    /// that only the entry site remains, rather than passing through the leaf
+    /// fast path.
+    #[test]
+    fn acyclic_high_id_edge_forwarders_do_not_create_loop_sites() {
+        let blocks = vec![
+            bb_with_stmts(
+                0,
+                Terminator::Branch {
+                    cond: Place::Local(0),
+                    then_target: 4,
+                    else_target: 5,
+                },
+                LEAF_STATEMENT_THRESHOLD,
+            ),
+            bb(1, Terminator::Goto { target: 6 }),
+            bb(2, Terminator::Goto { target: 7 }),
+            bb(3, Terminator::Return),
+            bb(4, Terminator::Goto { target: 1 }),
+            bb(5, Terminator::Goto { target: 2 }),
+            bb(6, Terminator::Goto { target: 3 }),
+            bb(7, Terminator::Goto { target: 3 }),
+        ];
+
+        let sites = compute_cooperate_sites(&blocks);
+        assert_eq!(
+            sites,
+            vec![CooperateSite {
+                bb_id: 0,
+                kind: CooperateKind::FunctionEntry,
+            }],
+            "acyclic forwarding edges must not be treated as scheduler loop latches: {sites:?}"
         );
     }
 

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -1528,24 +1528,36 @@ pub fn analyze_with_binding_locals<S: std::hash::BuildHasher>(
 /// constant the caller passes in so integration tests can override it.
 const LEAF_STATEMENT_THRESHOLD: usize = 10;
 
+/// Determine whether a legacy MIR block has a scheduler back-edge.
+///
+/// The established raw-MIR scheduler contract uses the builder's monotonic
+/// block allocation order: a `Goto` to a lower-numbered block is a loop latch.
+/// Keep that policy behind [`compute_cooperate_sites`] exactly as it was so
+/// ownership/drop lowering continues to receive the same cancellation sites.
+/// New CFG producers that do not preserve that allocation convention must opt
+/// into [`compute_structural_cooperate_sites`] instead.
+fn is_legacy_back_edge_goto(block: &BasicBlock) -> bool {
+    match block.terminator {
+        Terminator::Goto { target } => target < block.id,
+        _ => false,
+    }
+}
+
 /// Return the source block ids of natural-loop `Goto` back-edges.
 ///
-/// A numeric block-id ordering is not a CFG invariant. In particular, an SSA
-/// lowering may append edge-forwarding blocks after the source blocks they
-/// serve, so a perfectly acyclic forwarding edge can legitimately have the
-/// shape `bb7 -> bb3`. Scheduling such an edge as a loop back-edge injects an
-/// unnecessary cooperate call and, worse, makes a value/CFG lowering appear to
-/// have changed the program's scheduler contract.
+/// This is intentionally separate from the legacy scheduler predicate above.
+/// A numeric block-id ordering is not a CFG invariant: an SSA lowering may
+/// append edge-forwarding blocks after the source blocks they serve, so a
+/// perfectly acyclic forwarding edge can legitimately have the shape
+/// `bb7 -> bb3`.
 ///
 /// A `Goto { target }` is a natural-loop back-edge exactly when `target`
 /// dominates its source: every path from the entry to the source has already
-/// passed through the target. This is the structural property the scheduler
-/// needs, independent of allocation order. The current scheduler only places
-/// loop checks on `Goto` edges (structured Hew loop lowerings use `Goto` for
-/// their latch); other terminator forms deliberately retain the existing
-/// policy rather than broadening scheduling behaviour as a side effect of this
-/// correctness fix.
-fn goto_loop_back_edge_blocks(blocks: &[BasicBlock]) -> HashSet<u32> {
+/// passed through the target. The structural scheduler only places loop checks
+/// on `Goto` edges (structured Hew loop lowerings use `Goto` for their latch);
+/// other terminator forms deliberately retain the existing policy rather than
+/// broadening scheduling behaviour as a side effect of this analysis.
+fn structural_goto_loop_back_edge_blocks(blocks: &[BasicBlock]) -> HashSet<u32> {
     let by_id: HashMap<u32, &BasicBlock> = blocks.iter().map(|block| (block.id, block)).collect();
     if !by_id.contains_key(&0) {
         return HashSet::new();
@@ -1659,7 +1671,7 @@ fn block_has_call(block: &BasicBlock) -> bool {
 ///
 /// WHEN-OBSOLETE: once a caller-supplied eligibility override (attribute
 /// flag) is wired, that gates this check entirely.
-fn is_leaf_function(blocks: &[BasicBlock], loop_back_edge_blocks: &HashSet<u32>) -> bool {
+fn is_leaf_function(blocks: &[BasicBlock]) -> bool {
     let total_statements: usize = blocks.iter().map(|b| b.statements.len()).sum();
     if total_statements >= LEAF_STATEMENT_THRESHOLD {
         return false;
@@ -1668,10 +1680,29 @@ fn is_leaf_function(blocks: &[BasicBlock], loop_back_edge_blocks: &HashSet<u32>)
     if has_call {
         return false;
     }
-    if !loop_back_edge_blocks.is_empty() {
+    if blocks.iter().any(is_legacy_back_edge_goto) {
         return false;
     }
     true
+}
+
+/// The structural counterpart to [`is_leaf_function`].
+///
+/// Kept distinct so the legacy raw-MIR scheduler stays behaviorally aligned
+/// with its historic numeric heuristic, including for unusual hand-built CFG
+/// fixtures. SIR alone opts into dominance-based latch recognition.
+fn is_structural_leaf_function(
+    blocks: &[BasicBlock],
+    loop_back_edge_blocks: &HashSet<u32>,
+) -> bool {
+    let total_statements: usize = blocks.iter().map(|b| b.statements.len()).sum();
+    if total_statements >= LEAF_STATEMENT_THRESHOLD {
+        return false;
+    }
+    if blocks.iter().any(block_has_call) {
+        return false;
+    }
+    loop_back_edge_blocks.is_empty()
 }
 
 /// Yield-equivalent terminators already cause the actor to surrender the
@@ -1699,43 +1730,16 @@ fn is_yield_equivalent(block: &BasicBlock) -> bool {
     )
 }
 
-/// Compute the cooperate-check sites for a function.
+/// Compute structural cooperate-check sites using dominance-recognized loop
+/// latches.
 ///
-/// Returns a `Vec<CooperateSite>` that codegen injects
-/// `call @hew_actor_cooperate()` at. Empty means no injection is
-/// needed (leaf function or yield-equivalent first block).
-///
-/// ## Algorithm
-///
-/// 1. **Leaf check**: if the function is a short leaf (`is_leaf_function`),
-///    return an empty vec.
-/// 2. **Function-entry site**: add a `FunctionEntry` site for block 0
-///    unless that block's terminator is yield-equivalent (the actor
-///    will cooperate via the yield anyway).
-/// 3. **Back-edge sweep**: for every `Goto` whose target dominates its
-///    source, add a `LoopBackEdge` site — unless
-///    the back-edge target block itself has a yield-equivalent
-///    terminator (the loop header yields on every iteration).
-///
-/// ## Skip-eligibility extension point
-///
-/// This function does NOT implement the `#[no_reductions_check]`
-/// attribute or the receive-handler skip. Both are wired via the same
-/// return-empty-vec pattern: before calling `compute_cooperate_sites`,
-/// the caller checks its eligibility predicate and skips the call if
-/// ineligible. This keeps the analysis pure and testable in isolation.
-///
-/// ## Loop back-edges (v0.5)
-///
-/// Loop lowering has constructed production back-edges since `8d878b8e`.
-/// `LoopBackEdge` sites are live for `for`, `while`, and `loop` bodies:
-/// a dominance-proven latch `Goto` receives a cooperate check before control
-/// returns to the loop header. This remains correct when a lowering pass adds
-/// forwarding blocks or otherwise does not number blocks topologically.
-#[must_use]
-pub fn compute_cooperate_sites(blocks: &[BasicBlock]) -> Vec<CooperateSite> {
-    let loop_back_edge_blocks = goto_loop_back_edge_blocks(blocks);
-    if blocks.is_empty() || is_leaf_function(blocks, &loop_back_edge_blocks) {
+/// This deliberately does not serve legacy raw MIR: that scheduler preserves
+/// its historic numeric block-order contract in [`compute_cooperate_sites`].
+fn compute_structural_cooperate_sites_with_loop_back_edges(
+    blocks: &[BasicBlock],
+    loop_back_edge_blocks: &HashSet<u32>,
+) -> Vec<CooperateSite> {
+    if blocks.is_empty() || is_structural_leaf_function(blocks, loop_back_edge_blocks) {
         return Vec::new();
     }
 
@@ -1750,9 +1754,9 @@ pub fn compute_cooperate_sites(blocks: &[BasicBlock]) -> Vec<CooperateSite> {
         });
     }
 
-    // Back-edge sites: every Goto whose target dominates its source.
-    // Suppress if the loop-header block itself has a yield-equivalent
-    // terminator (the actor already cooperates at the loop header).
+    // Back-edge sites use the policy selected by the caller. Suppress if the
+    // loop-header block itself has a yield-equivalent terminator (the actor
+    // already cooperates at the loop header).
     let by_id: HashMap<u32, &BasicBlock> = blocks.iter().map(|b| (b.id, b)).collect();
     for block in blocks {
         let Terminator::Goto { target } = block.terminator else {
@@ -1761,8 +1765,6 @@ pub fn compute_cooperate_sites(blocks: &[BasicBlock]) -> Vec<CooperateSite> {
         if !loop_back_edge_blocks.contains(&block.id) {
             continue;
         }
-        // Back-edge found. Check whether the loop-header block itself is
-        // yield-equivalent — if so, no cooperate needed.
         let header_yields = by_id
             .get(&target)
             .is_some_and(|header| is_yield_equivalent(header));
@@ -1775,6 +1777,97 @@ pub fn compute_cooperate_sites(blocks: &[BasicBlock]) -> Vec<CooperateSite> {
     }
 
     sites
+}
+
+/// Compute the cooperate-check sites for a legacy raw-MIR function.
+///
+/// Returns a `Vec<CooperateSite>` that codegen injects
+/// `call @hew_actor_cooperate()` at. Empty means no injection is
+/// needed (leaf function or yield-equivalent first block).
+///
+/// ## Algorithm
+///
+/// 1. **Leaf check**: if the function is a short leaf (`is_leaf_function`),
+///    return an empty vec.
+/// 2. **Function-entry site**: add a `FunctionEntry` site for block 0
+///    unless that block's terminator is yield-equivalent (the actor
+///    will cooperate via the yield anyway).
+/// 3. **Back-edge sweep**: for every `Goto` whose target block id is less
+///    than the source block id, add a `LoopBackEdge` site — unless
+///    the back-edge target block itself has a yield-equivalent
+///    terminator (the loop header yields on every iteration).
+///
+/// ## Skip-eligibility extension point
+///
+/// This function does NOT implement the `#[no_reductions_check]`
+/// attribute or the receive-handler skip. Both are wired via the same
+/// return-empty-vec pattern: before calling `compute_cooperate_sites`,
+/// the caller checks its eligibility predicate and skips the call if
+/// ineligible. This keeps the analysis pure and testable in isolation.
+///
+/// ## Loop back-edges (v0.5)
+///
+/// Loop lowering has constructed production back-edges since `8d878b8e`.
+/// `LoopBackEdge` sites are live for `for`, `while`, and `loop` bodies. The
+/// legacy HIR → MIR builder allocates their latches after their headers, so a
+/// `Goto` to a lower-numbered block receives a cooperate check before control
+/// returns to the loop header. This compatibility policy is deliberately not
+/// generalized here: use [`compute_structural_cooperate_sites`] for a CFG
+/// whose block allocation order is not a scheduling invariant.
+#[must_use]
+pub fn compute_cooperate_sites(blocks: &[BasicBlock]) -> Vec<CooperateSite> {
+    if blocks.is_empty() || is_leaf_function(blocks) {
+        return Vec::new();
+    }
+
+    let mut sites: Vec<CooperateSite> = Vec::new();
+
+    // Function-entry site: block 0, unless its terminator already yields.
+    let entry_block = &blocks[0];
+    if !is_yield_equivalent(entry_block) {
+        sites.push(CooperateSite {
+            bb_id: 0,
+            kind: CooperateKind::FunctionEntry,
+        });
+    }
+
+    // Back-edge sites: every block whose Goto targets an earlier block.
+    // Suppress if the loop-header block itself has a yield-equivalent
+    // terminator (the actor already cooperates at the loop header).
+    let by_id: HashMap<u32, &BasicBlock> = blocks.iter().map(|b| (b.id, b)).collect();
+    for block in blocks {
+        if let Terminator::Goto { target } = block.terminator {
+            if target < block.id {
+                // Back-edge found. Check whether the loop-header block itself
+                // is yield-equivalent — if so, no cooperate needed.
+                let header_yields = by_id
+                    .get(&target)
+                    .is_some_and(|header| is_yield_equivalent(header));
+                if !header_yields {
+                    sites.push(CooperateSite {
+                        bb_id: block.id,
+                        kind: CooperateKind::LoopBackEdge,
+                    });
+                }
+            }
+        }
+    }
+
+    sites
+}
+
+/// Compute cooperate-check sites for a CFG whose block ids have no scheduling
+/// meaning, such as SIR lowered through SSA edge-forwarding blocks.
+///
+/// This applies the same leaf and yield-equivalence policy as
+/// [`compute_cooperate_sites`], but recognizes `Goto` latches structurally:
+/// the target must dominate the source. It is deliberately opt-in so adopting
+/// SIR does not silently change established ownership/drop cancellation sites
+/// in legacy raw-MIR lowering.
+#[must_use]
+pub fn compute_structural_cooperate_sites(blocks: &[BasicBlock]) -> Vec<CooperateSite> {
+    let loop_back_edge_blocks = structural_goto_loop_back_edge_blocks(blocks);
+    compute_structural_cooperate_sites_with_loop_back_edges(blocks, &loop_back_edge_blocks)
 }
 
 // ---------- Property tests for the lattice ----------
@@ -2490,8 +2583,8 @@ mod tests {
     /// SIR block arguments lower through edge-forwarding blocks. Those blocks
     /// are allocated after the source CFG, so their numeric ids can be greater
     /// than the original arm/join targets even though the overall graph is
-    /// acyclic. Scheduler loop detection must use graph structure rather than
-    /// that incidental allocation order.
+    /// acyclic. SIR's opt-in structural scheduler must use graph structure
+    /// rather than that incidental allocation order.
     ///
     ///   bb0: Branch { then: bb4, else: bb5 }
     ///   bb4: Goto bb1     // high-id edge forwarder, not a loop
@@ -2506,7 +2599,7 @@ mod tests {
     /// that only the entry site remains, rather than passing through the leaf
     /// fast path.
     #[test]
-    fn acyclic_high_id_edge_forwarders_do_not_create_loop_sites() {
+    fn acyclic_high_id_edge_forwarders_do_not_create_structural_loop_sites() {
         let blocks = vec![
             bb_with_stmts(
                 0,
@@ -2526,7 +2619,7 @@ mod tests {
             bb(7, Terminator::Goto { target: 3 }),
         ];
 
-        let sites = compute_cooperate_sites(&blocks);
+        let sites = compute_structural_cooperate_sites(&blocks);
         assert_eq!(
             sites,
             vec![CooperateSite {
@@ -2534,6 +2627,60 @@ mod tests {
                 kind: CooperateKind::FunctionEntry,
             }],
             "acyclic forwarding edges must not be treated as scheduler loop latches: {sites:?}"
+        );
+    }
+
+    /// The public raw-MIR scheduler retains its historical numeric rule even
+    /// for a CFG that a newer SIR producer would schedule structurally. This
+    /// is an explicit compatibility seam: ownership/drop cancellation plans
+    /// authored by legacy lowering cannot change merely because SIR gained a
+    /// better CFG analysis.
+    #[test]
+    fn legacy_scheduler_retains_numeric_high_id_goto_sites() {
+        let blocks = vec![
+            bb_with_stmts(
+                0,
+                Terminator::Branch {
+                    cond: Place::Local(0),
+                    then_target: 4,
+                    else_target: 5,
+                },
+                LEAF_STATEMENT_THRESHOLD,
+            ),
+            bb(1, Terminator::Goto { target: 6 }),
+            bb(2, Terminator::Goto { target: 7 }),
+            bb(3, Terminator::Return),
+            bb(4, Terminator::Goto { target: 1 }),
+            bb(5, Terminator::Goto { target: 2 }),
+            bb(6, Terminator::Goto { target: 3 }),
+            bb(7, Terminator::Goto { target: 3 }),
+        ];
+
+        assert_eq!(
+            compute_cooperate_sites(&blocks),
+            vec![
+                CooperateSite {
+                    bb_id: 0,
+                    kind: CooperateKind::FunctionEntry,
+                },
+                CooperateSite {
+                    bb_id: 4,
+                    kind: CooperateKind::LoopBackEdge,
+                },
+                CooperateSite {
+                    bb_id: 5,
+                    kind: CooperateKind::LoopBackEdge,
+                },
+                CooperateSite {
+                    bb_id: 6,
+                    kind: CooperateKind::LoopBackEdge,
+                },
+                CooperateSite {
+                    bb_id: 7,
+                    kind: CooperateKind::LoopBackEdge,
+                },
+            ],
+            "the legacy raw-MIR scheduler remains numeric by contract"
         );
     }
 

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -19,6 +19,7 @@ pub mod ownership;
 pub mod return_provenance;
 pub mod runtime_call;
 pub mod runtime_symbols;
+pub mod sir;
 pub mod state_clone;
 pub mod thunk_requirements;
 
@@ -87,6 +88,10 @@ pub use ownership::{
     ProvenanceOrigin, ValueOwnership, ValueProvenance,
 };
 pub use runtime_symbols::UnknownRuntimeSymbol;
+pub use sir::{
+    apply_sir_to_pipeline, lower_sir_function, SirMirLowered, SirMirLoweringError,
+    SirMirLoweringReport, SirMirLoweringStatus,
+};
 pub use state_clone::{
     classify_actor_state_fields_with_lifecycle_registry, classify_owned_string_record_fields,
     classify_state_field_with_lifecycle_registry, mangle_actor_state_clone_fn,

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -305,7 +305,10 @@ pub fn lower_sir_function(
         blocks: raw.blocks.clone(),
         decisions: parameter_decisions,
         checks: crate::validate_context_markers(&raw),
-        cooperate_sites: dataflow::compute_cooperate_sites(&raw.blocks),
+        // SIR may introduce edge-forwarding blocks after the CFG nodes they
+        // target. Its scheduler therefore uses structural latches rather than
+        // the legacy raw-MIR numeric block-order convention.
+        cooperate_sites: dataflow::compute_structural_cooperate_sites(&raw.blocks),
     };
     Ok(SirMirLowered { raw, checked })
 }
@@ -1346,6 +1349,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the parallel-copy edge materialization contract is clearest as one complete CFG fixture"
+    )]
     fn edge_argument_materialization_uses_parallel_copies() {
         let function = SemFunction {
             id: ItemId(0),
@@ -1425,6 +1432,15 @@ mod tests {
             })
             .collect();
         assert_eq!(forwarders.len(), 2, "one forwarding block per branch edge");
+        assert!(
+            forwarders.iter().all(|block| block.id > 1),
+            "SIR allocates edge-forwarding blocks after their bb1 target"
+        );
+        assert!(
+            lowered.checked.cooperate_sites.is_empty(),
+            "an acyclic SIR CFG with high-id forwarders must not acquire legacy numeric scheduler sites: {:?}",
+            lowered.checked.cooperate_sites
+        );
         for block in forwarders {
             let first_phase = &block.instructions[..2];
             let second_phase = &block.instructions[2..];

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -1,0 +1,1564 @@
+//! SIR → raw-MIR lowering for the initial value/CFG execution slice.
+//!
+//! This module is intentionally the *lowering boundary*, rather than a
+//! dependency of `hew-sir`: SIR owns semantic values and block arguments;
+//! raw MIR owns addressable storage, trap CFG, and the backend ABI.  The first
+//! executable subset is deliberately narrow and rejects a function as a unit
+//! when it would need ownership, aggregate layout, call ABI, or suspension
+//! facts that SIR does not yet carry.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use hew_parser::ast::{BinaryOp, UnaryOp};
+use hew_sir::{
+    BlockArg, BlockId, Edge, FunctionSourceOrigin, Operand, SemBlock, SemFunction, SemModule,
+    SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+};
+#[cfg(test)]
+use hew_types::DefId;
+use hew_types::ResolvedTy;
+
+use crate::{
+    dataflow, BasicBlock, CheckedMirFunction, FunctionCallConv, Instr, IntArithOp, IntSignedness,
+    IrPipeline, ModuleCapabilities, Place, RawMirFunction, Strategy, Terminator, TrapKind,
+};
+
+/// The result of lowering one SIR function into the existing raw/checked MIR
+/// boundary.  No elaborated MIR is produced for this slice: it accepts only
+/// scalar, non-owning values, and the code generator deliberately accepts a
+/// missing elaborated entry as an empty drop-plan set.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SirMirLowered {
+    pub raw: RawMirFunction,
+    pub checked: CheckedMirFunction,
+}
+
+/// A conservative refusal to lower a SIR function through the first
+/// executable SIR boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SirMirLoweringError {
+    pub reason: String,
+}
+
+impl SirMirLoweringError {
+    fn unsupported(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for SirMirLoweringError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.reason)
+    }
+}
+
+impl std::error::Error for SirMirLoweringError {}
+
+/// Per-function outcome when a SIR module is applied to an existing MIR
+/// pipeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SirMirLoweringStatus {
+    Lowered,
+    Unsupported { reason: String },
+}
+
+/// Deterministic summary of a SIR → MIR application attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SirMirLoweringReport {
+    pub statuses: Vec<(String, SirMirLoweringStatus)>,
+}
+
+impl SirMirLoweringReport {
+    #[must_use]
+    pub fn lowered_count(&self) -> usize {
+        self.statuses
+            .iter()
+            .filter(|(_, status)| matches!(status, SirMirLoweringStatus::Lowered))
+            .count()
+    }
+}
+
+/// Lower every executable SIR function possible into `pipeline`.
+///
+/// The caller normally begins with the established HIR → MIR pipeline. This
+/// adapter replaces only independently lowerable scalar/CFG functions,
+/// preserves every module-level layout/runtime fact, and keeps the established
+/// raw/checked MIR for all other functions while the cutover is in progress.
+/// Replaced functions deliberately lose their prior elaborated entry:
+/// retaining a drop plan authored for a different CFG would be unsound, while
+/// this value-only slice requires no drops.
+#[allow(
+    clippy::too_many_lines,
+    reason = "the temporary bridge keeps module verification, per-function eligibility, and atomic pipeline replacement together so a partial candidate cannot obscure the transition boundary"
+)]
+#[must_use]
+pub fn apply_sir_to_pipeline(
+    module: &SemModule,
+    pipeline: &mut IrPipeline,
+) -> SirMirLoweringReport {
+    let mut report = SirMirLoweringReport::default();
+    if let Some(diagnostic) = hew_sir::verify_module(module).into_iter().next() {
+        let reason = format!(
+            "SIR module verifier rejected the candidate before MIR realization: {:?}",
+            diagnostic.kind
+        );
+        report
+            .statuses
+            .extend(module.functions.iter().map(|function| {
+                (
+                    function.name.clone(),
+                    SirMirLoweringStatus::Unsupported {
+                        reason: reason.clone(),
+                    },
+                )
+            }));
+        return report;
+    }
+    let mut changed = false;
+
+    for function in &module.functions {
+        let matching_raw: Vec<_> = pipeline
+            .raw_mir
+            .iter()
+            .enumerate()
+            .filter_map(|(index, raw)| (raw.name == function.name).then_some(index))
+            .collect();
+        let [raw_index] = matching_raw.as_slice() else {
+            let reason = if matching_raw.is_empty() {
+                "no unique established raw-MIR function matches this SIR function"
+            } else {
+                "multiple established raw-MIR functions match this SIR function"
+            };
+            report.statuses.push((
+                function.name.clone(),
+                SirMirLoweringStatus::Unsupported {
+                    reason: reason.to_string(),
+                },
+            ));
+            continue;
+        };
+
+        let matching_checked: Vec<_> = pipeline
+            .checked_mir
+            .iter()
+            .enumerate()
+            .filter_map(|(index, checked)| (checked.name == function.name).then_some(index))
+            .collect();
+        if !pipeline.checked_mir.is_empty() && matching_checked.len() != 1 {
+            report.statuses.push((
+                function.name.clone(),
+                SirMirLoweringStatus::Unsupported {
+                    reason: "established checked MIR does not have one matching function"
+                        .to_string(),
+                },
+            ));
+            continue;
+        }
+        let template = pipeline.raw_mir[*raw_index].clone();
+        match lower_sir_function(function, &template) {
+            Ok(mut lowered) => {
+                // The initial scalar SIR subset is acyclic and has no calls,
+                // so it creates no scheduler sites of its own.  Preserve the
+                // established site plan exactly during this transition rather
+                // than deriving one from raw block numbering: SIR edge
+                // forwarders are deliberately inserted after their targets,
+                // which used to look like false back-edges to the legacy
+                // numeric heuristic.  A later SIR effect/CFG scheduling pass
+                // replaces this bridge; it is not a second long-term policy.
+                if let Some(&checked_index) = matching_checked.first() {
+                    let established_sites = &pipeline.checked_mir[checked_index].cooperate_sites;
+                    if !cooperate_sites_apply_to(&lowered.raw, established_sites) {
+                        report.statuses.push((
+                            function.name.clone(),
+                            SirMirLoweringStatus::Unsupported {
+                                reason: "established scheduler cooperate sites do not map to the SIR-realized CFG"
+                                    .to_string(),
+                            },
+                        ));
+                        continue;
+                    }
+                    lowered
+                        .checked
+                        .cooperate_sites
+                        .clone_from(established_sites);
+                } else if !lowered.checked.cooperate_sites.is_empty() {
+                    report.statuses.push((
+                        function.name.clone(),
+                        SirMirLoweringStatus::Unsupported {
+                            reason: "SIR realization would introduce scheduler cooperate sites without a scheduling-fact bridge"
+                                .to_string(),
+                        },
+                    ));
+                    continue;
+                }
+                pipeline.raw_mir[*raw_index] = lowered.raw;
+                if let Some(&checked_index) = matching_checked.first() {
+                    pipeline.checked_mir[checked_index] = lowered.checked;
+                }
+                pipeline
+                    .elaborated_mir
+                    .retain(|elaborated| elaborated.name != function.name);
+                report
+                    .statuses
+                    .push((function.name.clone(), SirMirLoweringStatus::Lowered));
+                changed = true;
+            }
+            Err(error) => report.statuses.push((
+                function.name.clone(),
+                SirMirLoweringStatus::Unsupported {
+                    reason: error.reason,
+                },
+            )),
+        }
+    }
+
+    if changed {
+        pipeline.capabilities =
+            ModuleCapabilities::from_raw_mir(&pipeline.raw_mir, &pipeline.extern_decls);
+        pipeline.lint_warnings = crate::liveness::run_mir_lints(&pipeline.raw_mir);
+        pipeline.debug_assert_capabilities_current();
+    }
+    report
+}
+
+fn cooperate_sites_apply_to(raw: &RawMirFunction, sites: &[crate::CooperateSite]) -> bool {
+    sites.iter().all(|site| {
+        raw.blocks.iter().any(|block| block.id == site.bb_id)
+            && match site.kind {
+                crate::CooperateKind::FunctionEntry => site.bb_id == 0,
+                // The first executable SIR slice rejects cyclic CFGs, so a
+                // legacy loop site cannot truthfully survive its realization.
+                crate::CooperateKind::LoopBackEdge => false,
+            }
+    })
+}
+
+/// Lower a verified semantic SSA function to scalar raw MIR using an
+/// established raw function as ABI/parameter-boundary template.
+///
+/// The template is not an instruction source: its body, locals, statements,
+/// decisions, debug-local names, and drop plans are discarded. It supplies
+/// only ABI identity that this first SIR slice does not yet preserve (the
+/// default-call ABI classification and finalized parameter boundary facts).
+/// SIR itself carries the source span and source origin. Those parameter facts
+/// are copied exactly into both replacement raw/checked functions; no
+/// source-operation ownership decisions are copied onto SIR-generated storage.
+///
+/// # Errors
+///
+/// Returns an explicit unsupported reason whenever the function needs a
+/// semantic fact not carried by the initial SIR value/CFG subset.
+pub fn lower_sir_function(
+    function: &SemFunction,
+    template: &RawMirFunction,
+) -> Result<SirMirLowered, SirMirLoweringError> {
+    if let Some(diagnostic) = hew_sir::verify_function(function).into_iter().next() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "SIR verifier rejected function `{}`: {:?}",
+            function.name, diagnostic.kind
+        )));
+    }
+    let parameter_decisions = validate_template(function, template)?;
+    let collected = CollectedValues::from_function(function)?;
+    let mut lowerer = RawLowerer::new(function, collected)?;
+    for block in &function.blocks {
+        lowerer.lower_block(block)?;
+    }
+    let (locals, blocks) = lowerer.finish()?;
+
+    let raw = RawMirFunction {
+        name: template.name.clone(),
+        return_ty: function.return_ty.clone(),
+        call_conv: template.call_conv,
+        params: function
+            .params
+            .iter()
+            .map(|param| param.ty.clone())
+            .collect(),
+        locals,
+        // SIR records operation provenance, but it intentionally does not yet
+        // carry source binding identity/lexical scopes. Leaving these empty is
+        // truthful; copying HIR-authored debug metadata onto different storage
+        // would create a false debugger view.
+        local_names: Vec::new(),
+        local_scopes: Vec::new(),
+        local_decl_bytes: Vec::new(),
+        scope_table: Vec::new(),
+        blocks,
+        decisions: parameter_decisions.clone(),
+        intrinsic_id: None,
+        await_deadline_ns: std::collections::HashMap::new(),
+        suspend_kinds: std::collections::HashMap::new(),
+        lambda_actor_user_param_locals: Vec::new(),
+        span: Some((
+            u32::try_from(function.span.start).unwrap_or(u32::MAX),
+            u32::try_from(function.span.end).unwrap_or(u32::MAX),
+        )),
+        instr_spans: std::collections::BTreeMap::new(),
+        source_origin: raw_source_origin(&function.source_origin),
+    };
+    let checked = CheckedMirFunction {
+        name: raw.name.clone(),
+        return_ty: raw.return_ty.clone(),
+        blocks: raw.blocks.clone(),
+        decisions: parameter_decisions,
+        checks: crate::validate_context_markers(&raw),
+        cooperate_sites: dataflow::compute_cooperate_sites(&raw.blocks),
+    };
+    Ok(SirMirLowered { raw, checked })
+}
+
+fn raw_source_origin(origin: &FunctionSourceOrigin) -> crate::SourceOrigin {
+    match origin {
+        FunctionSourceOrigin::RootUnit => crate::SourceOrigin::RootUnit,
+        FunctionSourceOrigin::Foreign(module) => crate::SourceOrigin::Foreign(module.clone()),
+        FunctionSourceOrigin::Unknown => crate::SourceOrigin::Unknown,
+    }
+}
+
+fn validate_template(
+    function: &SemFunction,
+    template: &RawMirFunction,
+) -> Result<Vec<crate::DecisionFact>, SirMirLoweringError> {
+    if template.name != function.name {
+        return Err(SirMirLoweringError::unsupported(
+            "SIR function name does not match the established raw-MIR ABI template",
+        ));
+    }
+    if template.call_conv != FunctionCallConv::Default {
+        return Err(SirMirLoweringError::unsupported(
+            "only ordinary default-call-convention functions are executable through initial SIR lowering",
+        ));
+    }
+    if template.intrinsic_id.is_some()
+        || !template.await_deadline_ns.is_empty()
+        || !template.suspend_kinds.is_empty()
+        || !template.lambda_actor_user_param_locals.is_empty()
+    {
+        return Err(SirMirLoweringError::unsupported(
+            "functions carrying intrinsic, suspension, or actor ABI facts remain on the established MIR path",
+        ));
+    }
+    if template.return_ty != function.return_ty {
+        return Err(SirMirLoweringError::unsupported(
+            "SIR return type does not match the established raw-MIR ABI template",
+        ));
+    }
+    let sir_params: Vec<_> = function.params.iter().map(|param| &param.ty).collect();
+    let template_params: Vec<_> = template.params.iter().collect();
+    if sir_params != template_params {
+        return Err(SirMirLoweringError::unsupported(
+            "SIR parameter types do not match the established raw-MIR ABI template",
+        ));
+    }
+    if !matches!(function.entry, BlockId(0)) {
+        return Err(SirMirLoweringError::unsupported(
+            "the initial raw-MIR bridge requires SIR entry block bb0",
+        ));
+    }
+    if !is_supported_return_type(&function.return_ty) {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "return type `{}` is not yet a scalar SIR-to-MIR value",
+            function.return_ty.user_facing()
+        )));
+    }
+    if sir_cfg_has_cycle(function) {
+        return Err(SirMirLoweringError::unsupported(
+            "cyclic SIR CFGs remain deferred until scheduler sites derive from SIR effects and CFG rather than legacy statement counts",
+        ));
+    }
+    template_parameter_decisions(function, template)
+}
+
+fn template_parameter_decisions(
+    function: &SemFunction,
+    template: &RawMirFunction,
+) -> Result<Vec<crate::DecisionFact>, SirMirLoweringError> {
+    let mut facts = template
+        .decisions
+        .iter()
+        .filter(|decision| matches!(decision.strategy, Strategy::ParamBoundary(_)))
+        .cloned()
+        .collect::<Vec<_>>();
+    facts.sort_unstable_by_key(|decision| match decision.strategy {
+        Strategy::ParamBoundary(fact) => fact.param_index,
+        _ => unreachable!("filtered to parameter-boundary decisions"),
+    });
+    if facts.len() != function.params.len() {
+        return Err(SirMirLoweringError::unsupported(
+            "established raw-MIR ABI template lacks one finalized parameter-boundary fact per SIR parameter",
+        ));
+    }
+    let parameter_count = u32::try_from(function.params.len()).map_err(|_| {
+        SirMirLoweringError::unsupported("SIR parameter count exceeds raw-MIR ABI limits")
+    })?;
+    for (expected_index, (decision, parameter)) in facts.iter().zip(&function.params).enumerate() {
+        let Strategy::ParamBoundary(fact) = decision.strategy else {
+            unreachable!("filtered to parameter-boundary decisions");
+        };
+        if fact.param_index != u32::try_from(expected_index).expect("index fits after count check")
+            || fact.param_count != parameter_count
+            || decision.ty != parameter.ty
+        {
+            return Err(SirMirLoweringError::unsupported(
+                "established parameter-boundary facts do not match the SIR ABI signature",
+            ));
+        }
+    }
+    Ok(facts)
+}
+
+fn sir_cfg_has_cycle(function: &SemFunction) -> bool {
+    let mut states = BTreeMap::<BlockId, VisitState>::new();
+    let by_id = function
+        .blocks
+        .iter()
+        .map(|block| (block.id, block))
+        .collect::<BTreeMap<_, _>>();
+    has_cycle_from(function.entry, &by_id, &mut states)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VisitState {
+    Visiting,
+    Visited,
+}
+
+fn has_cycle_from(
+    block_id: BlockId,
+    by_id: &BTreeMap<BlockId, &SemBlock>,
+    states: &mut BTreeMap<BlockId, VisitState>,
+) -> bool {
+    match states.get(&block_id) {
+        Some(VisitState::Visiting) => return true,
+        Some(VisitState::Visited) => return false,
+        None => {}
+    }
+    states.insert(block_id, VisitState::Visiting);
+    let Some(block) = by_id.get(&block_id) else {
+        // The SIR verifier diagnoses an unknown successor.  Keep this adapter
+        // failure separate and let its normal edge validation report it.
+        states.insert(block_id, VisitState::Visited);
+        return false;
+    };
+    for edge in block.terminator.successors() {
+        if has_cycle_from(edge.target, by_id, states) {
+            return true;
+        }
+    }
+    states.insert(block_id, VisitState::Visited);
+    false
+}
+
+fn is_supported_return_type(ty: &ResolvedTy) -> bool {
+    matches!(ty, ResolvedTy::Unit) || is_supported_value_type(ty)
+}
+
+fn is_supported_value_type(ty: &ResolvedTy) -> bool {
+    ty.is_integer() || matches!(ty, ResolvedTy::Bool)
+}
+
+#[derive(Debug)]
+struct CollectedValues {
+    types: BTreeMap<ValueId, ResolvedTy>,
+    block_args: BTreeMap<BlockId, Vec<BlockArg>>,
+}
+
+impl CollectedValues {
+    fn from_function(function: &SemFunction) -> Result<Self, SirMirLoweringError> {
+        let mut types = BTreeMap::new();
+        let mut block_args = BTreeMap::new();
+        for parameter in &function.params {
+            insert_value(&mut types, parameter.value, &parameter.ty)?;
+        }
+        if function.blocks.is_empty() {
+            return Err(SirMirLoweringError::unsupported(
+                "SIR function has no basic blocks",
+            ));
+        }
+        for (index, block) in function.blocks.iter().enumerate() {
+            if block.id.0
+                != u32::try_from(index).map_err(|_| {
+                    SirMirLoweringError::unsupported("SIR block count exceeds raw-MIR limits")
+                })?
+            {
+                return Err(SirMirLoweringError::unsupported(
+                    "the initial raw-MIR bridge requires SIR blocks ordered by contiguous id",
+                ));
+            }
+            if block_args.insert(block.id, block.args.clone()).is_some() {
+                return Err(SirMirLoweringError::unsupported(
+                    "SIR function contains duplicate basic-block ids",
+                ));
+            }
+            if block.id == function.entry && !block.args.is_empty() {
+                return Err(SirMirLoweringError::unsupported(
+                    "SIR entry block must not carry block arguments; SemFunction.params define entry values",
+                ));
+            }
+            for argument in &block.args {
+                insert_value(&mut types, argument.value, &argument.ty)?;
+            }
+            for operation in &block.ops {
+                for result in &operation.results {
+                    insert_value(&mut types, result.id, &result.ty)?;
+                }
+            }
+        }
+        for (value, ty) in &types {
+            if !is_supported_value_type(ty) {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "SSA value %{} of type `{}` needs aggregate, reference, or ownership lowering",
+                    value.0,
+                    ty.user_facing()
+                )));
+            }
+        }
+        Ok(Self { types, block_args })
+    }
+}
+
+fn insert_value(
+    values: &mut BTreeMap<ValueId, ResolvedTy>,
+    value: ValueId,
+    ty: &ResolvedTy,
+) -> Result<(), SirMirLoweringError> {
+    if values.insert(value, ty.clone()).is_some() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "SIR value %{} is defined more than once",
+            value.0
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct PendingBlock {
+    id: u32,
+    instructions: Vec<Instr>,
+    terminator: Option<Terminator>,
+}
+
+struct RawLowerer<'a> {
+    function: &'a SemFunction,
+    value_types: BTreeMap<ValueId, ResolvedTy>,
+    block_args: BTreeMap<BlockId, Vec<BlockArg>>,
+    value_places: BTreeMap<ValueId, Place>,
+    locals: Vec<ResolvedTy>,
+    blocks: Vec<PendingBlock>,
+    current: u32,
+}
+
+impl<'a> RawLowerer<'a> {
+    fn new(
+        function: &'a SemFunction,
+        collected: CollectedValues,
+    ) -> Result<Self, SirMirLoweringError> {
+        let mut locals = Vec::new();
+        let mut value_places = BTreeMap::new();
+        for parameter in &function.params {
+            let local = u32::try_from(locals.len())
+                .map_err(|_| SirMirLoweringError::unsupported("raw-MIR local count exceeds u32"))?;
+            locals.push(parameter.ty.clone());
+            value_places.insert(parameter.value, Place::Local(local));
+        }
+        for (value, ty) in &collected.types {
+            if value_places.contains_key(value) {
+                continue;
+            }
+            let local = u32::try_from(locals.len())
+                .map_err(|_| SirMirLoweringError::unsupported("raw-MIR local count exceeds u32"))?;
+            locals.push(ty.clone());
+            value_places.insert(*value, Place::Local(local));
+        }
+        let blocks = function
+            .blocks
+            .iter()
+            .map(|block| PendingBlock {
+                id: block.id.0,
+                instructions: Vec::new(),
+                terminator: None,
+            })
+            .collect();
+        Ok(Self {
+            function,
+            value_types: collected.types,
+            block_args: collected.block_args,
+            value_places,
+            locals,
+            blocks,
+            current: function.entry.0,
+        })
+    }
+
+    fn lower_block(&mut self, block: &SemBlock) -> Result<(), SirMirLoweringError> {
+        self.current = block.id.0;
+        for operation in &block.ops {
+            self.lower_op(operation)?;
+        }
+        self.lower_terminator(&block.terminator)
+    }
+
+    fn lower_op(&mut self, operation: &SemOp) -> Result<(), SirMirLoweringError> {
+        let (result, result_ty) = Self::single_result(operation)?;
+        let dest = self.value_place(result)?;
+        match &operation.kind {
+            SemOpKind::ConstI64(value) => {
+                if !result_ty.is_integer() {
+                    return Err(SirMirLoweringError::unsupported(format!(
+                        "integer constant result %{} has non-integer type `{}`",
+                        result.0,
+                        result_ty.user_facing()
+                    )));
+                }
+                self.push(Instr::ConstI64 {
+                    dest,
+                    value: *value,
+                });
+            }
+            SemOpKind::ConstBool(value) => {
+                if result_ty != ResolvedTy::Bool {
+                    return Err(SirMirLoweringError::unsupported(format!(
+                        "boolean constant result %{} has type `{}` rather than bool",
+                        result.0,
+                        result_ty.user_facing()
+                    )));
+                }
+                self.push(Instr::ConstI64 {
+                    dest,
+                    value: i64::from(*value),
+                });
+            }
+            SemOpKind::Unary { op, value } => self.lower_unary(*op, value, dest, &result_ty)?,
+            SemOpKind::Binary { op, lhs, rhs } => {
+                self.lower_binary(*op, lhs, rhs, dest, &result_ty)?;
+            }
+            SemOpKind::Cast { value, to } => {
+                Self::require_read(value, "cast")?;
+                let from_ty = self.value_type(value.value)?.clone();
+                if to != &result_ty || !from_ty.can_explicitly_numeric_cast_to(to) {
+                    return Err(SirMirLoweringError::unsupported(
+                        "SIR cast does not carry a checker-admitted scalar numeric conversion",
+                    ));
+                }
+                self.push(Instr::NumericCast {
+                    dest,
+                    src: self.value_place(value.value)?,
+                    from_ty,
+                    to_ty: to.clone(),
+                });
+            }
+            SemOpKind::Call { .. } => {
+                return Err(SirMirLoweringError::unsupported(
+                    "direct calls remain on the established MIR path until SIR carries resolved emitted-symbol and ABI authority",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn lower_unary(
+        &mut self,
+        op: UnaryOp,
+        operand: &Operand,
+        dest: Place,
+        result_ty: &ResolvedTy,
+    ) -> Result<(), SirMirLoweringError> {
+        Self::require_read(operand, "unary operation")?;
+        let operand_ty = self.value_type(operand.value)?.clone();
+        let operand_place = self.value_place(operand.value)?;
+        match op {
+            UnaryOp::Not if operand_ty == ResolvedTy::Bool && result_ty == &ResolvedTy::Bool => {
+                self.push(Instr::BoolNot {
+                    dest,
+                    operand: operand_place,
+                });
+            }
+            UnaryOp::Negate if operand_ty == *result_ty && operand_ty.is_integer() => {
+                let flag = self.fresh_local(ResolvedTy::Bool)?;
+                self.push(Instr::IntNegChecked {
+                    signed: signedness(&operand_ty)?,
+                    dest,
+                    operand: operand_place,
+                    overflow_flag: flag,
+                });
+                self.split_overflow(flag)?;
+            }
+            UnaryOp::BitNot if operand_ty == *result_ty && operand_ty.is_integer() => {
+                self.push(Instr::IntBitNot {
+                    dest,
+                    operand: operand_place,
+                });
+            }
+            UnaryOp::RawDeref | UnaryOp::Not | UnaryOp::Negate | UnaryOp::BitNot => {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "unary operator `{op:?}` is not in the scalar SIR-to-MIR subset"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the initial adapter intentionally uses one exhaustive operator map so its supported semantics are auditable at the SIR→MIR boundary"
+    )]
+    fn lower_binary(
+        &mut self,
+        op: BinaryOp,
+        lhs: &Operand,
+        rhs: &Operand,
+        dest: Place,
+        result_ty: &ResolvedTy,
+    ) -> Result<(), SirMirLoweringError> {
+        Self::require_read(lhs, "binary operation")?;
+        Self::require_read(rhs, "binary operation")?;
+        let lhs_ty = self.value_type(lhs.value)?.clone();
+        let rhs_ty = self.value_type(rhs.value)?.clone();
+        let lhs_place = self.value_place(lhs.value)?;
+        let rhs_place = self.value_place(rhs.value)?;
+
+        let comparison = match op {
+            BinaryOp::Equal => Some(crate::CmpPred::Eq),
+            BinaryOp::NotEqual => Some(crate::CmpPred::NotEq),
+            BinaryOp::Less => Some(ordering_predicate(&lhs_ty, crate::CmpPred::SignedLess)?),
+            BinaryOp::LessEqual => Some(ordering_predicate(&lhs_ty, crate::CmpPred::SignedLessEq)?),
+            BinaryOp::Greater => Some(ordering_predicate(&lhs_ty, crate::CmpPred::SignedGreater)?),
+            BinaryOp::GreaterEqual => Some(ordering_predicate(
+                &lhs_ty,
+                crate::CmpPred::SignedGreaterEq,
+            )?),
+            _ => None,
+        };
+        if let Some(pred) = comparison {
+            if lhs_ty != rhs_ty || result_ty != &ResolvedTy::Bool {
+                return Err(SirMirLoweringError::unsupported(
+                    "comparison operands/result do not have the scalar SIR-to-MIR shape",
+                ));
+            }
+            self.push(Instr::IntCmp {
+                dest,
+                pred,
+                lhs: lhs_place,
+                rhs: rhs_place,
+            });
+            return Ok(());
+        }
+
+        if lhs_ty != rhs_ty || lhs_ty != *result_ty || !lhs_ty.is_integer() {
+            return Err(SirMirLoweringError::unsupported(
+                "binary arithmetic requires same-typed integer SIR operands and result",
+            ));
+        }
+        match op {
+            BinaryOp::WrappingAdd => self.push(Instr::IntAdd {
+                dest,
+                lhs: lhs_place,
+                rhs: rhs_place,
+            }),
+            BinaryOp::WrappingSub => self.push(Instr::IntSub {
+                dest,
+                lhs: lhs_place,
+                rhs: rhs_place,
+            }),
+            BinaryOp::WrappingMul => self.push(Instr::IntMul {
+                dest,
+                lhs: lhs_place,
+                rhs: rhs_place,
+            }),
+            BinaryOp::BitAnd => self.push(Instr::IntBitAnd {
+                dest,
+                lhs: lhs_place,
+                rhs: rhs_place,
+            }),
+            BinaryOp::BitOr => self.push(Instr::IntBitOr {
+                dest,
+                lhs: lhs_place,
+                rhs: rhs_place,
+            }),
+            BinaryOp::BitXor => self.push(Instr::IntBitXor {
+                dest,
+                lhs: lhs_place,
+                rhs: rhs_place,
+            }),
+            BinaryOp::Add | BinaryOp::Subtract | BinaryOp::Multiply => {
+                let operation = match op {
+                    BinaryOp::Add => IntArithOp::Add,
+                    BinaryOp::Subtract => IntArithOp::Sub,
+                    BinaryOp::Multiply => IntArithOp::Mul,
+                    _ => unreachable!("matched above"),
+                };
+                let flag = self.fresh_local(ResolvedTy::Bool)?;
+                self.push(Instr::IntArithChecked {
+                    op: operation,
+                    signed: signedness(&lhs_ty)?,
+                    dest,
+                    lhs: lhs_place,
+                    rhs: rhs_place,
+                    overflow_flag: flag,
+                });
+                self.split_overflow(flag)?;
+            }
+            BinaryOp::And | BinaryOp::Or => {
+                return Err(SirMirLoweringError::unsupported(
+                    "logical operators must be represented as SIR control flow, not Binary operations",
+                ));
+            }
+            BinaryOp::Divide
+            | BinaryOp::Modulo
+            | BinaryOp::Shl
+            | BinaryOp::Shr
+            | BinaryOp::Range
+            | BinaryOp::RangeInclusive => {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "binary operator `{op}` needs a later SIR-to-MIR legalization slice"
+                )));
+            }
+            BinaryOp::Equal
+            | BinaryOp::NotEqual
+            | BinaryOp::Less
+            | BinaryOp::LessEqual
+            | BinaryOp::Greater
+            | BinaryOp::GreaterEqual => unreachable!("handled by comparison branch"),
+        }
+        Ok(())
+    }
+
+    fn split_overflow(&mut self, flag: Place) -> Result<(), SirMirLoweringError> {
+        let trap = self.fresh_block()?;
+        let continuation = self.fresh_block()?;
+        self.terminate(Terminator::Branch {
+            cond: flag,
+            then_target: trap,
+            else_target: continuation,
+        })?;
+        self.current = trap;
+        self.terminate(Terminator::Trap {
+            kind: TrapKind::IntegerOverflow,
+        })?;
+        self.current = continuation;
+        Ok(())
+    }
+
+    fn lower_terminator(&mut self, terminator: &SemTerminator) -> Result<(), SirMirLoweringError> {
+        match terminator {
+            SemTerminator::Return { value: Some(value) } => {
+                if self.value_type(*value)? != &self.function.return_ty {
+                    return Err(SirMirLoweringError::unsupported(
+                        "SIR return value type does not match function return type",
+                    ));
+                }
+                self.push(Instr::Move {
+                    dest: Place::ReturnSlot,
+                    src: self.value_place(*value)?,
+                });
+                self.terminate(Terminator::Return)
+            }
+            SemTerminator::Return { value: None } => {
+                if self.function.return_ty != ResolvedTy::Unit {
+                    return Err(SirMirLoweringError::unsupported(
+                        "value-less SIR return is valid only for a unit-returning function",
+                    ));
+                }
+                self.terminate(Terminator::Return)
+            }
+            SemTerminator::Goto(edge) => {
+                let source = self.current;
+                let target = self.materialize_edge(edge)?;
+                self.current = source;
+                self.terminate(Terminator::Goto { target })
+            }
+            SemTerminator::Branch {
+                condition,
+                then_target,
+                else_target,
+            } => {
+                if self.value_type(*condition)? != &ResolvedTy::Bool {
+                    return Err(SirMirLoweringError::unsupported(
+                        "SIR branch condition must have bool type",
+                    ));
+                }
+                let source = self.current;
+                let then_target = self.materialize_edge(then_target)?;
+                let else_target = self.materialize_edge(else_target)?;
+                self.current = source;
+                self.terminate(Terminator::Branch {
+                    cond: self.value_place(*condition)?,
+                    then_target,
+                    else_target,
+                })
+            }
+            SemTerminator::Unreachable => Err(SirMirLoweringError::unsupported(
+                "SIR unreachable terminators remain deferred until raw MIR has a semantic unreachable terminator",
+            )),
+        }
+    }
+
+    /// Materialise SIR block arguments into raw-MIR locals.
+    ///
+    /// Raw MIR has no block arguments. A forwarding block ensures a branch
+    /// writes only the selected edge, and the two-phase source→scratch then
+    /// scratch→argument sequence preserves *parallel-copy* semantics for loop
+    /// back edges such as `goto bb1(%b, %a)`.
+    fn materialize_edge(&mut self, edge: &Edge) -> Result<u32, SirMirLoweringError> {
+        let target_args = self
+            .block_args
+            .get(&edge.target)
+            .ok_or_else(|| SirMirLoweringError::unsupported("SIR edge targets an unknown block"))?
+            .clone();
+        if target_args.len() != edge.args.len() {
+            return Err(SirMirLoweringError::unsupported(
+                "SIR edge argument count does not match target block arguments",
+            ));
+        }
+        if edge.args.is_empty() {
+            return Ok(edge.target.0);
+        }
+        let forwarding = self.fresh_block()?;
+        self.current = forwarding;
+        let mut copies = Vec::with_capacity(edge.args.len());
+        for (source, target) in edge.args.iter().zip(&target_args) {
+            let source_ty = self.value_type(*source)?;
+            if source_ty != &target.ty {
+                return Err(SirMirLoweringError::unsupported(
+                    "SIR edge argument type does not match target block argument",
+                ));
+            }
+            let scratch = self.fresh_local(source_ty.clone())?;
+            self.push(Instr::Move {
+                dest: scratch,
+                src: self.value_place(*source)?,
+            });
+            copies.push((scratch, self.value_place(target.value)?));
+        }
+        for (scratch, destination) in copies {
+            self.push(Instr::Move {
+                dest: destination,
+                src: scratch,
+            });
+        }
+        self.terminate(Terminator::Goto {
+            target: edge.target.0,
+        })?;
+        Ok(forwarding)
+    }
+
+    fn single_result(operation: &SemOp) -> Result<(ValueId, ResolvedTy), SirMirLoweringError> {
+        let [ValueDef { id, ty }] = operation.results.as_slice() else {
+            return Err(SirMirLoweringError::unsupported(
+                "the initial SIR-to-MIR bridge requires exactly one result per operation",
+            ));
+        };
+        Ok((*id, ty.clone()))
+    }
+
+    fn require_read(operand: &Operand, context: &str) -> Result<(), SirMirLoweringError> {
+        if operand.mode != UseMode::Read {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "{context} uses {:?}; ownership-aware SIR operand lowering is not enabled yet",
+                operand.mode
+            )));
+        }
+        Ok(())
+    }
+
+    fn value_type(&self, value: ValueId) -> Result<&ResolvedTy, SirMirLoweringError> {
+        self.value_types.get(&value).ok_or_else(|| {
+            SirMirLoweringError::unsupported(format!("SIR uses undefined value %{}", value.0))
+        })
+    }
+
+    fn value_place(&self, value: ValueId) -> Result<Place, SirMirLoweringError> {
+        self.value_places.get(&value).copied().ok_or_else(|| {
+            SirMirLoweringError::unsupported(format!(
+                "SIR value %{} has no materialized raw-MIR local",
+                value.0
+            ))
+        })
+    }
+
+    fn fresh_local(&mut self, ty: ResolvedTy) -> Result<Place, SirMirLoweringError> {
+        let local = u32::try_from(self.locals.len())
+            .map_err(|_| SirMirLoweringError::unsupported("raw-MIR local count exceeds u32"))?;
+        self.locals.push(ty);
+        Ok(Place::Local(local))
+    }
+
+    fn fresh_block(&mut self) -> Result<u32, SirMirLoweringError> {
+        let id = u32::try_from(self.blocks.len())
+            .map_err(|_| SirMirLoweringError::unsupported("raw-MIR block count exceeds u32"))?;
+        self.blocks.push(PendingBlock {
+            id,
+            instructions: Vec::new(),
+            terminator: None,
+        });
+        Ok(id)
+    }
+
+    fn push(&mut self, instruction: Instr) {
+        self.current_block_mut().instructions.push(instruction);
+    }
+
+    fn terminate(&mut self, terminator: Terminator) -> Result<(), SirMirLoweringError> {
+        let block = self.current_block_mut();
+        if block.terminator.replace(terminator).is_some() {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "raw-MIR block bb{} received more than one terminator",
+                block.id
+            )));
+        }
+        Ok(())
+    }
+
+    fn current_block_mut(&mut self) -> &mut PendingBlock {
+        &mut self.blocks[self.current as usize]
+    }
+
+    fn finish(self) -> Result<(Vec<ResolvedTy>, Vec<BasicBlock>), SirMirLoweringError> {
+        let mut seen = BTreeSet::new();
+        let mut blocks = Vec::with_capacity(self.blocks.len());
+        for block in self.blocks {
+            if !seen.insert(block.id) {
+                return Err(SirMirLoweringError::unsupported(
+                    "raw-MIR bridge constructed duplicate block ids",
+                ));
+            }
+            let terminator = block.terminator.ok_or_else(|| {
+                SirMirLoweringError::unsupported(format!(
+                    "raw-MIR bridge left bb{} without a terminator",
+                    block.id
+                ))
+            })?;
+            blocks.push(BasicBlock {
+                id: block.id,
+                statements: Vec::new(),
+                instructions: block.instructions,
+                terminator,
+            });
+        }
+        Ok((self.locals, blocks))
+    }
+}
+
+fn signedness(ty: &ResolvedTy) -> Result<IntSignedness, SirMirLoweringError> {
+    if ty.is_signed_integer() {
+        Ok(IntSignedness::Signed)
+    } else if ty.is_unsigned_integer() {
+        Ok(IntSignedness::Unsigned)
+    } else {
+        Err(SirMirLoweringError::unsupported(format!(
+            "type `{}` is not an integer with a MIR signedness",
+            ty.user_facing()
+        )))
+    }
+}
+
+fn ordering_predicate(
+    ty: &ResolvedTy,
+    signed: crate::CmpPred,
+) -> Result<crate::CmpPred, SirMirLoweringError> {
+    if ty.is_signed_integer() {
+        return Ok(signed);
+    }
+    if !ty.is_unsigned_integer() {
+        return Err(SirMirLoweringError::unsupported(
+            "ordered SIR comparisons require integer operands",
+        ));
+    }
+    match signed {
+        crate::CmpPred::SignedLess => Ok(crate::CmpPred::UnsignedLess),
+        crate::CmpPred::SignedLessEq => Ok(crate::CmpPred::UnsignedLessEq),
+        crate::CmpPred::SignedGreater => Ok(crate::CmpPred::UnsignedGreater),
+        crate::CmpPred::SignedGreaterEq => Ok(crate::CmpPred::UnsignedGreaterEq),
+        _ => unreachable!("ordering_predicate accepts a signed ordering predicate"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hew_hir::{IntentKind, ItemId, SiteId, ValueClass};
+    use hew_sir::{OpId, Provenance};
+
+    fn template(name: &str, params: Vec<ResolvedTy>, return_ty: ResolvedTy) -> RawMirFunction {
+        let parameter_count = u32::try_from(params.len()).expect("test parameter count fits u32");
+        let decisions = params
+            .iter()
+            .enumerate()
+            .map(|(index, ty)| crate::DecisionFact {
+                site: SiteId(u32::try_from(index).expect("test parameter index fits u32")),
+                ty: ty.clone(),
+                value_class: ValueClass::BitCopy,
+                intent: IntentKind::Unknown,
+                strategy: Strategy::ParamBoundary(crate::ParamBoundaryFact {
+                    param_index: u32::try_from(index).expect("test parameter index fits u32"),
+                    param_count: parameter_count,
+                    caller_visible_projection: false,
+                    mode: crate::ParamBoundaryMode::BorrowReadOnly,
+                }),
+                why: "test parameter boundary".to_string(),
+            })
+            .collect();
+        RawMirFunction {
+            name: name.to_string(),
+            return_ty,
+            call_conv: FunctionCallConv::Default,
+            params,
+            locals: Vec::new(),
+            local_names: Vec::new(),
+            local_scopes: Vec::new(),
+            local_decl_bytes: Vec::new(),
+            scope_table: Vec::new(),
+            blocks: Vec::new(),
+            decisions,
+            intrinsic_id: None,
+            await_deadline_ns: std::collections::HashMap::new(),
+            suspend_kinds: std::collections::HashMap::new(),
+            lambda_actor_user_param_locals: Vec::new(),
+            span: None,
+            instr_spans: std::collections::BTreeMap::new(),
+            source_origin: crate::SourceOrigin::Unknown,
+        }
+    }
+
+    fn definition(id: u32, ty: ResolvedTy) -> ValueDef {
+        ValueDef {
+            id: ValueId(id),
+            ty,
+        }
+    }
+
+    fn operand(id: u32) -> Operand {
+        Operand {
+            value: ValueId(id),
+            mode: UseMode::Read,
+        }
+    }
+
+    fn op(id: u32, result: ValueDef, kind: SemOpKind) -> SemOp {
+        SemOp {
+            id: OpId(id),
+            results: vec![result],
+            kind,
+            provenance: Provenance::Synthesized,
+        }
+    }
+
+    #[test]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the complete diamond pins SIR block arguments, checked arithmetic legalization, and raw CFG construction together"
+    )]
+    fn realizes_ssa_diamond_into_raw_cfg_and_overflow_paths() {
+        let function = SemFunction {
+            id: ItemId(0),
+            declaration: DefId::for_test("f"),
+            name: "f".to_string(),
+            span: 12..96,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: vec![
+                BlockArg {
+                    value: ValueId(0),
+                    ty: ResolvedTy::I64,
+                },
+                BlockArg {
+                    value: ValueId(1),
+                    ty: ResolvedTy::I64,
+                },
+            ],
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![
+                SemBlock {
+                    id: BlockId(0),
+                    args: Vec::new(),
+                    ops: vec![
+                        op(0, definition(2, ResolvedTy::I64), SemOpKind::ConstI64(0)),
+                        op(
+                            1,
+                            definition(3, ResolvedTy::Bool),
+                            SemOpKind::Binary {
+                                op: BinaryOp::Greater,
+                                lhs: operand(0),
+                                rhs: operand(2),
+                            },
+                        ),
+                    ],
+                    terminator: SemTerminator::Branch {
+                        condition: ValueId(3),
+                        then_target: Edge {
+                            target: BlockId(1),
+                            args: vec![ValueId(1)],
+                        },
+                        else_target: Edge {
+                            target: BlockId(2),
+                            args: vec![ValueId(1)],
+                        },
+                    },
+                },
+                SemBlock {
+                    id: BlockId(1),
+                    args: vec![BlockArg {
+                        value: ValueId(4),
+                        ty: ResolvedTy::I64,
+                    }],
+                    ops: vec![
+                        op(2, definition(5, ResolvedTy::I64), SemOpKind::ConstI64(1)),
+                        op(
+                            3,
+                            definition(6, ResolvedTy::I64),
+                            SemOpKind::Binary {
+                                op: BinaryOp::Add,
+                                lhs: operand(4),
+                                rhs: operand(5),
+                            },
+                        ),
+                    ],
+                    terminator: SemTerminator::Goto(Edge {
+                        target: BlockId(3),
+                        args: vec![ValueId(6)],
+                    }),
+                },
+                SemBlock {
+                    id: BlockId(2),
+                    args: vec![BlockArg {
+                        value: ValueId(7),
+                        ty: ResolvedTy::I64,
+                    }],
+                    ops: vec![
+                        op(4, definition(8, ResolvedTy::I64), SemOpKind::ConstI64(2)),
+                        op(
+                            5,
+                            definition(9, ResolvedTy::I64),
+                            SemOpKind::Binary {
+                                op: BinaryOp::Add,
+                                lhs: operand(7),
+                                rhs: operand(8),
+                            },
+                        ),
+                    ],
+                    terminator: SemTerminator::Goto(Edge {
+                        target: BlockId(3),
+                        args: vec![ValueId(9)],
+                    }),
+                },
+                SemBlock {
+                    id: BlockId(3),
+                    args: vec![BlockArg {
+                        value: ValueId(10),
+                        ty: ResolvedTy::I64,
+                    }],
+                    ops: vec![
+                        op(6, definition(11, ResolvedTy::I64), SemOpKind::ConstI64(3)),
+                        op(
+                            7,
+                            definition(12, ResolvedTy::I64),
+                            SemOpKind::Binary {
+                                op: BinaryOp::Multiply,
+                                lhs: operand(10),
+                                rhs: operand(11),
+                            },
+                        ),
+                    ],
+                    terminator: SemTerminator::Return {
+                        value: Some(ValueId(12)),
+                    },
+                },
+            ],
+        };
+
+        let lowered = lower_sir_function(
+            &function,
+            &template("f", vec![ResolvedTy::I64, ResolvedTy::I64], ResolvedTy::I64),
+        )
+        .expect("the scalar SSA diamond should lower to raw MIR");
+
+        assert!(lowered.raw.blocks.len() > function.blocks.len());
+        assert_eq!(lowered.raw.span, Some((12, 96)));
+        assert_eq!(lowered.raw.source_origin, crate::SourceOrigin::RootUnit);
+        assert!(lowered.raw.blocks.iter().any(|block| {
+            matches!(
+                block.terminator,
+                Terminator::Trap {
+                    kind: TrapKind::IntegerOverflow
+                }
+            )
+        }));
+        assert!(lowered.raw.blocks.iter().any(|block| {
+            block.instructions.iter().any(|instruction| {
+                matches!(
+                    instruction,
+                    Instr::IntArithChecked {
+                        op: IntArithOp::Add,
+                        ..
+                    }
+                )
+            })
+        }));
+        assert!(lowered.raw.blocks.iter().any(|block| {
+            matches!(block.terminator, Terminator::Return)
+                && block.instructions.iter().any(|instruction| {
+                    matches!(
+                        instruction,
+                        Instr::Move {
+                            dest: Place::ReturnSlot,
+                            ..
+                        }
+                    )
+                })
+        }));
+        assert!(lowered.checked.checks.is_empty());
+    }
+
+    #[test]
+    fn rejects_unverified_sir_before_raw_realization() {
+        let function = SemFunction {
+            id: ItemId(0),
+            declaration: DefId::for_test("bad_entry"),
+            name: "bad_entry".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: Vec::new(),
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: vec![BlockArg {
+                    value: ValueId(0),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(0)),
+                },
+            }],
+        };
+
+        let error = lower_sir_function(
+            &function,
+            &template("bad_entry", Vec::new(), ResolvedTy::I64),
+        )
+        .expect_err("a malformed SIR entry must fail before raw MIR exists");
+        assert!(error.reason.contains("SIR verifier rejected function"));
+        assert!(error.reason.contains("EntryBlockArgs"));
+    }
+
+    #[test]
+    fn edge_argument_materialization_uses_parallel_copies() {
+        let function = SemFunction {
+            id: ItemId(0),
+            declaration: DefId::for_test("swap"),
+            name: "swap".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: vec![
+                BlockArg {
+                    value: ValueId(0),
+                    ty: ResolvedTy::I64,
+                },
+                BlockArg {
+                    value: ValueId(1),
+                    ty: ResolvedTy::I64,
+                },
+                BlockArg {
+                    value: ValueId(2),
+                    ty: ResolvedTy::Bool,
+                },
+            ],
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![
+                SemBlock {
+                    id: BlockId(0),
+                    args: Vec::new(),
+                    ops: Vec::new(),
+                    terminator: SemTerminator::Branch {
+                        condition: ValueId(2),
+                        then_target: Edge {
+                            target: BlockId(1),
+                            args: vec![ValueId(1), ValueId(0)],
+                        },
+                        else_target: Edge {
+                            target: BlockId(1),
+                            args: vec![ValueId(0), ValueId(1)],
+                        },
+                    },
+                },
+                SemBlock {
+                    id: BlockId(1),
+                    args: vec![
+                        BlockArg {
+                            value: ValueId(3),
+                            ty: ResolvedTy::I64,
+                        },
+                        BlockArg {
+                            value: ValueId(4),
+                            ty: ResolvedTy::I64,
+                        },
+                    ],
+                    ops: Vec::new(),
+                    terminator: SemTerminator::Return {
+                        value: Some(ValueId(3)),
+                    },
+                },
+            ],
+        };
+        let lowered = lower_sir_function(
+            &function,
+            &template(
+                "swap",
+                vec![ResolvedTy::I64, ResolvedTy::I64, ResolvedTy::Bool],
+                ResolvedTy::I64,
+            ),
+        )
+        .expect("a scalar branch with block arguments should lower");
+
+        let forwarders: Vec<_> = lowered
+            .raw
+            .blocks
+            .iter()
+            .filter(|block| {
+                matches!(block.terminator, Terminator::Goto { target: 1 })
+                    && block.instructions.len() == 4
+            })
+            .collect();
+        assert_eq!(forwarders.len(), 2, "one forwarding block per branch edge");
+        for block in forwarders {
+            let first_phase = &block.instructions[..2];
+            let second_phase = &block.instructions[2..];
+            assert!(first_phase.iter().all(|instruction| matches!(
+                instruction,
+                Instr::Move {
+                    dest: Place::Local(destination),
+                    ..
+                } if *destination >= 5
+            )));
+            assert!(second_phase.iter().all(|instruction| matches!(
+                instruction,
+                Instr::Move {
+                    dest: Place::Local(destination),
+                    ..
+                } if *destination == 3 || *destination == 4
+            )));
+        }
+    }
+
+    #[test]
+    fn replacing_a_scalar_body_removes_stale_elaboration() {
+        let function = SemFunction {
+            id: ItemId(0),
+            declaration: DefId::for_test("constant"),
+            name: "constant".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: Vec::new(),
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![op(
+                    0,
+                    definition(0, ResolvedTy::I64),
+                    SemOpKind::ConstI64(42),
+                )],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(0)),
+                },
+            }],
+        };
+        let raw = template("constant", Vec::new(), ResolvedTy::I64);
+        let checked = CheckedMirFunction {
+            name: "constant".to_string(),
+            return_ty: ResolvedTy::I64,
+            blocks: Vec::new(),
+            decisions: Vec::new(),
+            checks: Vec::new(),
+            cooperate_sites: Vec::new(),
+        };
+        let mut pipeline = IrPipeline {
+            raw_mir: vec![raw],
+            checked_mir: vec![checked],
+            elaborated_mir: vec![crate::ElaboratedMirFunction {
+                name: "constant".to_string(),
+                return_ty: ResolvedTy::I64,
+                statements: Vec::new(),
+                decisions: Vec::new(),
+                blocks: Vec::new(),
+                drop_plans: Vec::new(),
+                coroutine: None,
+                lambda_captures: Vec::new(),
+            }],
+            ..IrPipeline::default()
+        };
+
+        let report = apply_sir_to_pipeline(
+            &SemModule {
+                functions: vec![function],
+            },
+            &mut pipeline,
+        );
+        assert_eq!(report.lowered_count(), 1, "{report:#?}");
+        assert!(pipeline.elaborated_mir.is_empty());
+        assert!(matches!(
+            pipeline.raw_mir[0].blocks[0].instructions.as_slice(),
+            [
+                Instr::ConstI64 { value: 42, .. },
+                Instr::Move {
+                    dest: Place::ReturnSlot,
+                    ..
+                }
+            ]
+        ));
+    }
+
+    #[test]
+    fn module_verification_prevents_duplicate_functions_from_mutating_mir() {
+        let function = SemFunction {
+            id: ItemId(0),
+            declaration: DefId::for_test("duplicate"),
+            name: "duplicate".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: Vec::new(),
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![op(
+                    0,
+                    definition(0, ResolvedTy::I64),
+                    SemOpKind::ConstI64(42),
+                )],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(0)),
+                },
+            }],
+        };
+        let mut duplicate = function.clone();
+        duplicate.id = ItemId(1);
+        let raw = template("duplicate", Vec::new(), ResolvedTy::I64);
+        let mut pipeline = IrPipeline {
+            raw_mir: vec![raw.clone()],
+            ..IrPipeline::default()
+        };
+
+        let report = apply_sir_to_pipeline(
+            &SemModule {
+                functions: vec![function, duplicate],
+            },
+            &mut pipeline,
+        );
+
+        assert_eq!(report.lowered_count(), 0, "{report:#?}");
+        assert_eq!(pipeline.raw_mir, vec![raw]);
+        assert!(report.statuses.iter().all(|(_, status)| matches!(
+            status,
+            SirMirLoweringStatus::Unsupported { reason }
+                if reason.contains("SIR module verifier rejected")
+        )));
+    }
+}

--- a/hew-sir/Cargo.toml
+++ b/hew-sir/Cargo.toml
@@ -15,5 +15,8 @@ hew-hir = { path = "../hew-hir" }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 
+[dev-dependencies]
+hew-types = { path = "../hew-types", features = ["test"] }
+
 [lints]
 workspace = true

--- a/hew-sir/src/lib.rs
+++ b/hew-sir/src/lib.rs
@@ -3,8 +3,8 @@
 //! SIR is the value-oriented SSA layer between resolved HIR and the existing
 //! ownership/layout MIR ladder.  It deliberately contains no `Place`, alloca,
 //! ABI carrier, byte-offset, or LLVM operation.  The initial shadow lane is a
-//! conservative subset; unsupported HIR bodies report that fact to the driver,
-//! which continues through the established HIR -> MIR path.
+//! temporary cutover proof for a conservative subset; each supported family
+//! moves onto SIR -> MIR and deletes its established HIR -> MIR body lowering.
 
 mod analysis;
 mod dump;
@@ -16,7 +16,7 @@ pub use analysis::{build_def_use, compute_dominators, DefUseIndex, Dominators};
 pub use dump::dump_sir;
 pub use lower::{lower_module, LoweredModule, SirLoweringStatus};
 pub use model::{
-    BlockArg, BlockId, Edge, OpId, Operand, Provenance, SemBlock, SemFunction, SemModule, SemOp,
-    SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+    BlockArg, BlockId, Edge, EffectSet, FunctionSourceOrigin, OpId, Operand, Provenance, SemBlock,
+    SemFunction, SemModule, SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
 };
-pub use verify::{verify_module, SirDiagnostic, SirDiagnosticKind};
+pub use verify::{verify_function, verify_module, SirDiagnostic, SirDiagnosticKind};

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -6,8 +6,8 @@ use hew_hir::{
 };
 
 use crate::{
-    BlockArg, BlockId, Edge, OpId, Operand, Provenance, SemBlock, SemFunction, SemModule, SemOp,
-    SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+    BlockArg, BlockId, Edge, FunctionSourceOrigin, OpId, Operand, Provenance, SemBlock,
+    SemFunction, SemModule, SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,7 +32,14 @@ pub fn lower_module(module: &HirModule) -> LoweredModule {
         let HirItem::Function(function) = item else {
             continue;
         };
-        match Builder::new(function).lower() {
+        let source_origin = if module.root_item_ids.contains(&function.id) {
+            FunctionSourceOrigin::RootUnit
+        } else if let Some(module_name) = module.diagnostic_source_modules.get(&function.id) {
+            FunctionSourceOrigin::Foreign(module_name.clone())
+        } else {
+            FunctionSourceOrigin::Unknown
+        };
+        match Builder::new(function, source_origin).lower() {
             Ok(function) => {
                 statuses.push((function.name.clone(), SirLoweringStatus::Lowered));
                 output.functions.push(function);
@@ -57,10 +64,11 @@ struct Builder<'a> {
     ops: u32,
     bindings: HashMap<BindingId, ValueId>,
     params: Vec<BlockArg>,
+    source_origin: FunctionSourceOrigin,
 }
 
 impl<'a> Builder<'a> {
-    fn new(function: &'a HirFn) -> Self {
+    fn new(function: &'a HirFn, source_origin: FunctionSourceOrigin) -> Self {
         let entry = BlockId(0);
         let mut values = 0;
         let mut bindings = HashMap::new();
@@ -90,6 +98,7 @@ impl<'a> Builder<'a> {
             ops: 0,
             bindings,
             params,
+            source_origin,
         }
     }
 
@@ -99,13 +108,22 @@ impl<'a> Builder<'a> {
                 "generators and floor intrinsics remain on the established MIR path".to_string(),
             );
         }
+        if !self.function.type_params.is_empty() {
+            return Err(
+                "generic origin functions remain on the established MIR path until SIR is monomorphization-aware"
+                    .to_string(),
+            );
+        }
         let result = self.lower_block(&self.function.body)?;
         if self.is_open() {
             self.set_terminator(SemTerminator::Return { value: result });
         }
         Ok(SemFunction {
             id: self.function.id,
+            declaration: self.function.declaration.clone(),
             name: self.function.name.clone(),
+            span: self.function.span.clone(),
+            source_origin: self.source_origin,
             params: self.params,
             return_ty: self.function.return_ty.clone(),
             entry: BlockId(0),
@@ -174,9 +192,21 @@ impl<'a> Builder<'a> {
     fn lower_expr(&mut self, expr: &HirExpr) -> Result<ValueId, String> {
         match &expr.kind {
             HirExprKind::Literal(HirLiteral::Integer(value)) => {
+                if !expr.ty.is_integer() {
+                    return Err(format!(
+                        "integer literal resolved as `{}` needs a dedicated SIR literal representation",
+                        expr.ty.user_facing()
+                    ));
+                }
                 Ok(self.emit(expr, SemOpKind::ConstI64(*value)))
             }
             HirExprKind::Literal(HirLiteral::Bool(value)) => {
+                if expr.ty != hew_types::ResolvedTy::Bool {
+                    return Err(format!(
+                        "boolean literal resolved as `{}` violates the SIR bool literal invariant",
+                        expr.ty.user_facing()
+                    ));
+                }
                 Ok(self.emit(expr, SemOpKind::ConstBool(*value)))
             }
             HirExprKind::BindingRef {
@@ -198,6 +228,16 @@ impl<'a> Builder<'a> {
                     },
                 ))
             }
+            HirExprKind::Binary {
+                op: hew_parser::ast::BinaryOp::And,
+                left,
+                right,
+            } => self.lower_logical_and(expr, left, right),
+            HirExprKind::Binary {
+                op: hew_parser::ast::BinaryOp::Or,
+                left,
+                right,
+            } => self.lower_logical_or(expr, left, right),
             HirExprKind::Binary { op, left, right } => {
                 let lhs = self.lower_expr(left)?;
                 let rhs = self.lower_expr(right)?;
@@ -327,6 +367,88 @@ impl<'a> Builder<'a> {
         }
         self.current = join_block;
         Ok(join_value)
+    }
+
+    /// Lower short-circuit `&&` as CFG rather than an eager binary operation.
+    ///
+    /// The false edge materialises the result while the true edge alone
+    /// evaluates the right-hand side. This keeps effectful future SIR
+    /// operations on the RHS structurally guarded from the outset.
+    fn lower_logical_and(
+        &mut self,
+        whole: &HirExpr,
+        left: &HirExpr,
+        right: &HirExpr,
+    ) -> Result<ValueId, String> {
+        self.lower_short_circuit(whole, left, right, false)
+    }
+
+    /// Lower short-circuit `||` as CFG rather than an eager binary operation.
+    fn lower_logical_or(
+        &mut self,
+        whole: &HirExpr,
+        left: &HirExpr,
+        right: &HirExpr,
+    ) -> Result<ValueId, String> {
+        self.lower_short_circuit(whole, left, right, true)
+    }
+
+    fn lower_short_circuit(
+        &mut self,
+        whole: &HirExpr,
+        left: &HirExpr,
+        right: &HirExpr,
+        short_circuit_value: bool,
+    ) -> Result<ValueId, String> {
+        if whole.ty != hew_types::ResolvedTy::Bool {
+            return Err("short-circuit logical expressions must have bool type in SIR".to_string());
+        }
+        let condition = self.lower_expr(left)?;
+        let evaluate_right = self.new_block(Vec::new());
+        let short_circuit = self.new_block(Vec::new());
+        let result = self.fresh_value();
+        let join = self.new_block(vec![BlockArg {
+            value: result,
+            ty: whole.ty.clone(),
+        }]);
+        let (then_target, else_target) = if short_circuit_value {
+            (short_circuit, evaluate_right)
+        } else {
+            (evaluate_right, short_circuit)
+        };
+        self.set_terminator(SemTerminator::Branch {
+            condition,
+            then_target: Edge {
+                target: then_target,
+                args: Vec::new(),
+            },
+            else_target: Edge {
+                target: else_target,
+                args: Vec::new(),
+            },
+        });
+
+        let before = self.bindings.clone();
+        self.current = evaluate_right;
+        self.bindings = before.clone();
+        let right_value = self.lower_expr(right)?;
+        if self.is_open() {
+            self.set_terminator(SemTerminator::Goto(Edge {
+                target: join,
+                args: vec![right_value],
+            }));
+        }
+
+        self.current = short_circuit;
+        self.bindings = before;
+        let constant = self.emit(whole, SemOpKind::ConstBool(short_circuit_value));
+        self.set_terminator(SemTerminator::Goto(Edge {
+            target: join,
+            args: vec![constant],
+        }));
+
+        self.current = join;
+        Ok(result)
     }
 
     fn emit(&mut self, expr: &HirExpr, kind: SemOpKind) -> ValueId {

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -1,5 +1,6 @@
 use hew_hir::{ItemId, SiteId};
-use hew_types::{CallTarget, ResolvedTy};
+use hew_parser::ast::Span;
+use hew_types::{CallTarget, DefId, ResolvedTy};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BlockId(pub u32);
@@ -13,6 +14,20 @@ pub enum Provenance {
     Site(SiteId),
     Synthesized,
     Derived(Vec<SiteId>),
+}
+
+/// Proven source attribution for a semantic function body.
+///
+/// SIR carries this independently of raw MIR so the eventual direct SIR → MIR
+/// path owns diagnostic attribution instead of borrowing it from a legacy
+/// lowered function template.  The variants deliberately match the proven
+/// attribution model in HIR: absence is `Unknown`, never an inferred root.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum FunctionSourceOrigin {
+    RootUnit,
+    Foreign(String),
+    #[default]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,7 +73,15 @@ pub struct SemBlock {
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemFunction {
     pub id: ItemId,
+    /// Resolver-minted source declaration identity.  `name` is an emitted
+    /// symbol spelling, whereas calls and future monomorphization carry this
+    /// stable semantic identity.
+    pub declaration: DefId,
     pub name: String,
+    /// Function declaration/body extent in the attribution named by
+    /// [`Self::source_origin`].
+    pub span: Span,
+    pub source_origin: FunctionSourceOrigin,
     pub params: Vec<BlockArg>,
     pub return_ty: ResolvedTy,
     pub entry: BlockId,
@@ -78,9 +101,50 @@ pub struct SemOp {
     pub provenance: Provenance,
 }
 
-/// Pure, non-suspending operations in the first SIR slice.  Effects are
-/// derived from this closed operation set and resolved call metadata; they are
-/// intentionally not stored redundantly on each operation.
+/// Derived semantic effects for a value-producing SIR operation.
+///
+/// Effects deliberately live on operation *kinds*, not on [`SemOp`]: rewrites
+/// can clone or synthesize operations without maintaining a second source of
+/// truth.  The initial bit set is intentionally small; it gives early
+/// canonicalization passes a sound motion/CSE barrier without committing SIR
+/// to memory SSA or effect tokens.  Resolved calls currently lack an effect
+/// summary, so they are conservatively [`Self::UNKNOWN_CALL`] until the call
+/// ABI slice introduces one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct EffectSet(u8);
+
+impl EffectSet {
+    /// No observable effect or trap edge.
+    pub const PURE: Self = Self(0);
+    /// The operation can transfer control to a language-visible trap.
+    pub const MAY_TRAP: Self = Self(1 << 0);
+    /// The callee has no resolved SIR effect summary yet; treat it as a full
+    /// optimization barrier. It includes [`Self::MAY_TRAP`] so both the
+    /// semantic predicate and ordinary bit-set containment remain sound for
+    /// early optimizer clients.
+    pub const UNKNOWN_CALL: Self = Self(Self::MAY_TRAP.0 | (1 << 1));
+
+    #[must_use]
+    pub const fn contains(self, effect: Self) -> bool {
+        self.0 & effect.0 == effect.0
+    }
+
+    #[must_use]
+    pub const fn is_pure(self) -> bool {
+        self.0 == Self::PURE.0
+    }
+
+    #[must_use]
+    pub const fn may_trap(self) -> bool {
+        self.contains(Self::MAY_TRAP) || self.contains(Self::UNKNOWN_CALL)
+    }
+}
+
+/// Value-producing, non-suspending operations in the first SIR slice.
+///
+/// Effects are derived by [`Self::effects`] rather than stored redundantly on
+/// each operation. Suspension and control flow belong in terminators, not
+/// ordinary SSA operations.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SemOpKind {
     ConstI64(i64),
@@ -102,6 +166,36 @@ pub enum SemOpKind {
         target: CallTarget,
         args: Vec<Operand>,
     },
+}
+
+impl SemOpKind {
+    /// Return the operation's conservative semantic effect classification.
+    #[must_use]
+    pub const fn effects(&self) -> EffectSet {
+        match self {
+            Self::Call { .. } => EffectSet::UNKNOWN_CALL,
+            Self::Unary {
+                op: hew_parser::ast::UnaryOp::Negate | hew_parser::ast::UnaryOp::RawDeref,
+                ..
+            }
+            | Self::Binary {
+                op:
+                    hew_parser::ast::BinaryOp::Add
+                    | hew_parser::ast::BinaryOp::Subtract
+                    | hew_parser::ast::BinaryOp::Multiply
+                    | hew_parser::ast::BinaryOp::Divide
+                    | hew_parser::ast::BinaryOp::Modulo
+                    | hew_parser::ast::BinaryOp::Shl
+                    | hew_parser::ast::BinaryOp::Shr,
+                ..
+            } => EffectSet::MAY_TRAP,
+            Self::ConstI64(_)
+            | Self::ConstBool(_)
+            | Self::Unary { .. }
+            | Self::Binary { .. }
+            | Self::Cast { .. } => EffectSet::PURE,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/hew-sir/src/verify.rs
+++ b/hew-sir/src/verify.rs
@@ -1,9 +1,19 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use crate::{BlockId, SemFunction, SemModule, SemTerminator, ValueId};
+use crate::{
+    BlockId, OpId, SemFunction, SemModule, SemOp, SemOpKind, SemTerminator, UseMode, ValueId,
+};
+use hew_types::ResolvedTy;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SirDiagnosticKind {
+    DuplicateFunctionName(String),
+    DuplicateFunctionDeclaration(String),
+    MissingEntry(BlockId),
+    EntryBlockArgs {
+        entry: BlockId,
+        actual: usize,
+    },
     DuplicateBlock(BlockId),
     UnknownBlock(BlockId),
     EdgeArity {
@@ -20,6 +30,32 @@ pub enum SirDiagnosticKind {
         actual: String,
     },
     DuplicateValue(ValueId),
+    DuplicateOp(OpId),
+    InvalidResultArity {
+        op: OpId,
+        actual: usize,
+    },
+    InvalidConstType {
+        op: OpId,
+        expected: &'static str,
+        actual: String,
+    },
+    InvalidCast {
+        op: OpId,
+        reason: String,
+    },
+    InvalidOperation {
+        op: OpId,
+        reason: String,
+    },
+    BranchConditionType {
+        value: ValueId,
+        actual: String,
+    },
+    ReturnType {
+        expected: String,
+        actual: Option<String>,
+    },
     UndefinedValue(ValueId),
     NonDominatingUse {
         value: ValueId,
@@ -40,10 +76,41 @@ pub struct SirDiagnostic {
 
 #[must_use]
 pub fn verify_module(module: &SemModule) -> Vec<SirDiagnostic> {
-    module.functions.iter().flat_map(verify_function).collect()
+    let mut diagnostics = Vec::new();
+    let mut names = HashSet::new();
+    let mut declarations = HashSet::new();
+    for function in &module.functions {
+        if !names.insert(function.name.clone()) {
+            diagnostics.push(diag(
+                function,
+                SirDiagnosticKind::DuplicateFunctionName(function.name.clone()),
+            ));
+        }
+        if !declarations.insert(function.declaration.clone()) {
+            diagnostics.push(diag(
+                function,
+                SirDiagnosticKind::DuplicateFunctionDeclaration(format!(
+                    "{:?}",
+                    function.declaration
+                )),
+            ));
+        }
+        diagnostics.extend(verify_function(function));
+    }
+    diagnostics
 }
 
-fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
+/// Verify one semantic SSA function before it crosses into another SIR pass
+/// or the ownership/layout MIR boundary.
+///
+/// Keeping this public lets every consumer fail closed rather than relying on
+/// a particular CLI lane to have run whole-module verification first.
+#[allow(
+    clippy::too_many_lines,
+    reason = "the verifier keeps SSA collection, CFG shape, and dominance checks together so the stage boundary is auditable"
+)]
+#[must_use]
+pub fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
     let mut diagnostics = Vec::new();
     let mut blocks = BTreeMap::new();
     for block in &function.blocks {
@@ -51,9 +118,26 @@ fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
             diagnostics.push(diag(function, SirDiagnosticKind::DuplicateBlock(block.id)));
         }
     }
+    if !blocks.contains_key(&function.entry) {
+        diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::MissingEntry(function.entry),
+        ));
+    } else if let Some(entry) = blocks.get(&function.entry) {
+        if !entry.args.is_empty() {
+            diagnostics.push(diag(
+                function,
+                SirDiagnosticKind::EntryBlockArgs {
+                    entry: function.entry,
+                    actual: entry.args.len(),
+                },
+            ));
+        }
+    }
     let mut values = HashSet::new();
     let mut types = HashMap::new();
     let mut definitions = HashMap::new();
+    let mut operations = HashSet::new();
     for param in &function.params {
         record_value(function, param.value, &mut values, &mut diagnostics);
         types.insert(param.value, param.ty.clone());
@@ -66,11 +150,22 @@ fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
             definitions.insert(arg.value, (block.id, None));
         }
         for (op_index, op) in block.ops.iter().enumerate() {
+            if !operations.insert(op.id) {
+                diagnostics.push(diag(function, SirDiagnosticKind::DuplicateOp(op.id)));
+            }
             for result in &op.results {
                 record_value(function, result.id, &mut values, &mut diagnostics);
                 types.insert(result.id, result.ty.clone());
                 definitions.insert(result.id, (block.id, Some(op_index)));
             }
+        }
+    }
+    // Every value type is known before checking operations, edges, and
+    // terminators. In particular this catches a malformed use whose value is
+    // defined in a later block rather than silently skipping its type check.
+    for block in &function.blocks {
+        for op in &block.ops {
+            verify_operation_shape(function, op, &types, &mut diagnostics);
         }
         for edge in block.terminator.successors() {
             let Some(target) = blocks.get(&edge.target) else {
@@ -106,31 +201,282 @@ fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
                 }
             }
         }
+        verify_terminator_shape(function, &block.terminator, &types, &mut diagnostics);
     }
-    let dominators = crate::compute_dominators(function);
-    for block in &function.blocks {
-        for (op_index, op) in block.ops.iter().enumerate() {
+    if blocks.contains_key(&function.entry) {
+        let dominators = crate::compute_dominators(function);
+        for block in &function.blocks {
+            for (op_index, op) in block.ops.iter().enumerate() {
+                verify_uses(
+                    function,
+                    &dominators,
+                    &definitions,
+                    block.id,
+                    Some(op_index),
+                    uses_in_op(op),
+                    &mut diagnostics,
+                );
+            }
             verify_uses(
                 function,
                 &dominators,
                 &definitions,
                 block.id,
-                Some(op_index),
-                uses_in_op(op),
+                None,
+                uses_in_terminator(&block.terminator),
                 &mut diagnostics,
             );
         }
-        verify_uses(
-            function,
-            &dominators,
-            &definitions,
-            block.id,
-            None,
-            uses_in_terminator(&block.terminator),
-            &mut diagnostics,
-        );
     }
     diagnostics
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "the closed first-slice operation relation table is deliberately central so additions must make their verifier rule explicit"
+)]
+fn verify_operation_shape(
+    function: &SemFunction,
+    operation: &SemOp,
+    types: &HashMap<ValueId, ResolvedTy>,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    if operation.results.len() != 1 {
+        diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::InvalidResultArity {
+                op: operation.id,
+                actual: operation.results.len(),
+            },
+        ));
+        return;
+    }
+    let result = &operation.results[0];
+    match &operation.kind {
+        SemOpKind::ConstI64(_) if !result.ty.is_integer() => diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::InvalidConstType {
+                op: operation.id,
+                expected: "integer",
+                actual: result.ty.user_facing().to_string(),
+            },
+        )),
+        SemOpKind::ConstBool(_) if result.ty != ResolvedTy::Bool => diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::InvalidConstType {
+                op: operation.id,
+                expected: "bool",
+                actual: result.ty.user_facing().to_string(),
+            },
+        )),
+        SemOpKind::Cast { value, to } => {
+            require_read_operand(function, operation.id, value.mode, "cast", diagnostics);
+            if &result.ty != to {
+                diagnostics.push(diag(
+                    function,
+                    SirDiagnosticKind::InvalidCast {
+                        op: operation.id,
+                        reason: "operation result type differs from cast target type".to_string(),
+                    },
+                ));
+            }
+            if let Some(from) = types.get(&value.value) {
+                if !from.can_explicitly_numeric_cast_to(to) {
+                    diagnostics.push(diag(
+                        function,
+                        SirDiagnosticKind::InvalidCast {
+                            op: operation.id,
+                            reason: format!(
+                                "checker does not admit `{}` as `{}`",
+                                from.user_facing(),
+                                to.user_facing()
+                            ),
+                        },
+                    ));
+                }
+            }
+        }
+        SemOpKind::Unary { op, value } => {
+            require_read_operand(
+                function,
+                operation.id,
+                value.mode,
+                "unary operation",
+                diagnostics,
+            );
+            let Some(operand_ty) = types.get(&value.value) else {
+                return;
+            };
+            let valid = match op {
+                hew_parser::ast::UnaryOp::Not => {
+                    operand_ty == &ResolvedTy::Bool && result.ty == ResolvedTy::Bool
+                }
+                hew_parser::ast::UnaryOp::Negate => {
+                    operand_ty == &result.ty && (operand_ty.is_integer() || operand_ty.is_float())
+                }
+                hew_parser::ast::UnaryOp::BitNot => {
+                    operand_ty == &result.ty && operand_ty.is_integer()
+                }
+                // Raw dereference is rejected before HIR. A future safe load
+                // operation will carry explicit memory semantics instead.
+                hew_parser::ast::UnaryOp::RawDeref => false,
+            };
+            if !valid {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "unary `{op:?}` has invalid `{}` -> `{}` types",
+                        operand_ty.user_facing(),
+                        result.ty.user_facing()
+                    ),
+                    diagnostics,
+                );
+            }
+        }
+        SemOpKind::Binary { op, lhs, rhs } => {
+            require_read_operand(
+                function,
+                operation.id,
+                lhs.mode,
+                "binary left operand",
+                diagnostics,
+            );
+            require_read_operand(
+                function,
+                operation.id,
+                rhs.mode,
+                "binary right operand",
+                diagnostics,
+            );
+            let (Some(lhs_ty), Some(rhs_ty)) = (types.get(&lhs.value), types.get(&rhs.value))
+            else {
+                return;
+            };
+            let valid = match op {
+                hew_parser::ast::BinaryOp::And | hew_parser::ast::BinaryOp::Or => false,
+                hew_parser::ast::BinaryOp::Equal
+                | hew_parser::ast::BinaryOp::NotEqual
+                | hew_parser::ast::BinaryOp::Less
+                | hew_parser::ast::BinaryOp::LessEqual
+                | hew_parser::ast::BinaryOp::Greater
+                | hew_parser::ast::BinaryOp::GreaterEqual => {
+                    lhs_ty == rhs_ty && result.ty == ResolvedTy::Bool
+                }
+                hew_parser::ast::BinaryOp::Range | hew_parser::ast::BinaryOp::RangeInclusive => {
+                    lhs_ty == rhs_ty
+                }
+                hew_parser::ast::BinaryOp::Add
+                | hew_parser::ast::BinaryOp::Subtract
+                | hew_parser::ast::BinaryOp::Multiply
+                | hew_parser::ast::BinaryOp::Divide
+                | hew_parser::ast::BinaryOp::Modulo
+                | hew_parser::ast::BinaryOp::BitAnd
+                | hew_parser::ast::BinaryOp::BitOr
+                | hew_parser::ast::BinaryOp::BitXor
+                | hew_parser::ast::BinaryOp::Shl
+                | hew_parser::ast::BinaryOp::Shr
+                | hew_parser::ast::BinaryOp::WrappingAdd
+                | hew_parser::ast::BinaryOp::WrappingSub
+                | hew_parser::ast::BinaryOp::WrappingMul => {
+                    lhs_ty == rhs_ty && lhs_ty == &result.ty
+                }
+            };
+            if !valid {
+                let reason = match op {
+                    hew_parser::ast::BinaryOp::And | hew_parser::ast::BinaryOp::Or => {
+                        "logical `&&` / `||` must be represented as SIR branch CFG, not Binary"
+                            .to_string()
+                    }
+                    _ => format!(
+                        "binary `{op}` has incompatible `{}`, `{}` -> `{}` types",
+                        lhs_ty.user_facing(),
+                        rhs_ty.user_facing(),
+                        result.ty.user_facing()
+                    ),
+                };
+                invalid_operation(function, operation.id, reason, diagnostics);
+            }
+        }
+        SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) | SemOpKind::Call { .. } => {}
+    }
+}
+
+fn require_read_operand(
+    function: &SemFunction,
+    op: OpId,
+    mode: UseMode,
+    context: &str,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    if mode != UseMode::Read {
+        invalid_operation(
+            function,
+            op,
+            format!(
+                "{context} uses {mode:?}; only Read is legal until ownership-aware SIR operations exist"
+            ),
+            diagnostics,
+        );
+    }
+}
+
+fn invalid_operation(
+    function: &SemFunction,
+    op: OpId,
+    reason: String,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    diagnostics.push(diag(
+        function,
+        SirDiagnosticKind::InvalidOperation { op, reason },
+    ));
+}
+
+fn verify_terminator_shape(
+    function: &SemFunction,
+    terminator: &SemTerminator,
+    types: &HashMap<ValueId, ResolvedTy>,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    match terminator {
+        SemTerminator::Return { value: Some(value) } => {
+            if let Some(actual) = types.get(value) {
+                if actual != &function.return_ty {
+                    diagnostics.push(diag(
+                        function,
+                        SirDiagnosticKind::ReturnType {
+                            expected: function.return_ty.user_facing().to_string(),
+                            actual: Some(actual.user_facing().to_string()),
+                        },
+                    ));
+                }
+            }
+        }
+        SemTerminator::Return { value: None } if function.return_ty != ResolvedTy::Unit => {
+            diagnostics.push(diag(
+                function,
+                SirDiagnosticKind::ReturnType {
+                    expected: function.return_ty.user_facing().to_string(),
+                    actual: None,
+                },
+            ));
+        }
+        SemTerminator::Branch { condition, .. } => {
+            if let Some(actual) = types.get(condition) {
+                if actual != &ResolvedTy::Bool {
+                    diagnostics.push(diag(
+                        function,
+                        SirDiagnosticKind::BranchConditionType {
+                            value: *condition,
+                            actual: actual.user_facing().to_string(),
+                        },
+                    ));
+                }
+            }
+        }
+        SemTerminator::Return { .. } | SemTerminator::Goto(_) | SemTerminator::Unreachable => {}
+    }
 }
 
 #[allow(clippy::too_many_arguments, reason = "small verifier transfer helper")]
@@ -198,7 +544,6 @@ fn diag(function: &SemFunction, kind: SirDiagnosticKind) -> SirDiagnostic {
 }
 
 fn uses_in_op(op: &crate::SemOp) -> Vec<ValueId> {
-    use crate::SemOpKind;
     match &op.kind {
         SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) => Vec::new(),
         SemOpKind::Unary { value, .. } | SemOpKind::Cast { value, .. } => vec![value.value],

--- a/hew-sir/tests/sir.rs
+++ b/hew-sir/tests/sir.rs
@@ -1,10 +1,11 @@
 use hew_hir::ItemId;
 use hew_parser::ast::BinaryOp;
 use hew_sir::{
-    dump_sir, verify_module, BlockArg, BlockId, Edge, OpId, Operand, Provenance, SemBlock,
-    SemFunction, SemModule, SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+    dump_sir, verify_module, BlockArg, BlockId, Edge, EffectSet, FunctionSourceOrigin, OpId,
+    Operand, Provenance, SemBlock, SemFunction, SemModule, SemOp, SemOpKind, SemTerminator,
+    SirDiagnosticKind, UseMode, ValueDef, ValueId,
 };
-use hew_types::ResolvedTy;
+use hew_types::{CallTarget, DefId, ResolvedTy};
 
 fn definition(id: u32) -> ValueDef {
     ValueDef {
@@ -21,7 +22,10 @@ fn definition(id: u32) -> ValueDef {
 fn block_arguments_are_ssa_join_values() {
     let function = SemFunction {
         id: ItemId(0),
+        declaration: DefId::for_test("f"),
         name: "f".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
         params: vec![
             BlockArg {
                 value: ValueId(0),
@@ -194,4 +198,166 @@ fn block_arguments_are_ssa_join_values() {
     let dump = dump_sir(&module);
     assert!(dump.contains("bb3(%10: i64):"));
     assert!(dump.contains("goto bb3(%6)"));
+}
+
+#[test]
+fn verifier_rejects_entry_block_arguments() {
+    let module = SemModule {
+        functions: vec![SemFunction {
+            id: ItemId(0),
+            declaration: DefId::for_test("bad_entry_args"),
+            name: "bad_entry_args".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: Vec::new(),
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: vec![BlockArg {
+                    value: ValueId(0),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(0)),
+                },
+            }],
+        }],
+    };
+
+    assert!(verify_module(&module).iter().any(|diagnostic| matches!(
+        diagnostic.kind,
+        SirDiagnosticKind::EntryBlockArgs {
+            entry: BlockId(0),
+            actual: 1,
+        }
+    )));
+}
+
+#[test]
+fn operation_effects_are_derived_and_conservative() {
+    let checked_add = SemOpKind::Binary {
+        op: BinaryOp::Add,
+        lhs: Operand {
+            value: ValueId(0),
+            mode: UseMode::Read,
+        },
+        rhs: Operand {
+            value: ValueId(1),
+            mode: UseMode::Read,
+        },
+    };
+    assert_eq!(checked_add.effects(), EffectSet::MAY_TRAP);
+    assert!(checked_add.effects().may_trap());
+
+    let wrapping_add = SemOpKind::Binary {
+        op: BinaryOp::WrappingAdd,
+        lhs: Operand {
+            value: ValueId(0),
+            mode: UseMode::Read,
+        },
+        rhs: Operand {
+            value: ValueId(1),
+            mode: UseMode::Read,
+        },
+    };
+    assert!(wrapping_add.effects().is_pure());
+
+    let unresolved_call = SemOpKind::Call {
+        target: CallTarget::Builtin {
+            endpoint: "test".to_string(),
+        },
+        args: Vec::new(),
+    };
+    assert_eq!(unresolved_call.effects(), EffectSet::UNKNOWN_CALL);
+    assert!(unresolved_call.effects().contains(EffectSet::MAY_TRAP));
+    assert!(unresolved_call.effects().may_trap());
+}
+
+#[test]
+fn verifier_rejects_eager_logical_ops_and_ownership_modes_without_an_owner() {
+    let module = SemModule {
+        functions: vec![SemFunction {
+            id: ItemId(0),
+            declaration: DefId::for_test("bad_logical"),
+            name: "bad_logical".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: vec![BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::Bool,
+            }],
+            return_ty: ResolvedTy::Bool,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![ValueDef {
+                        id: ValueId(1),
+                        ty: ResolvedTy::Bool,
+                    }],
+                    kind: SemOpKind::Binary {
+                        op: BinaryOp::And,
+                        lhs: Operand {
+                            value: ValueId(0),
+                            mode: UseMode::BorrowShared,
+                        },
+                        rhs: Operand {
+                            value: ValueId(0),
+                            mode: UseMode::Read,
+                        },
+                    },
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(1)),
+                },
+            }],
+        }],
+    };
+
+    let diagnostics = verify_module(&module);
+    assert!(diagnostics.iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidOperation { reason, .. }
+            if reason.contains("only Read is legal")
+    )));
+    assert!(diagnostics.iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidOperation { reason, .. }
+            if reason.contains("must be represented as SIR branch CFG")
+    )));
+}
+
+#[test]
+fn verifier_rejects_duplicate_semantic_and_emitted_function_identities() {
+    let function = SemFunction {
+        id: ItemId(0),
+        declaration: DefId::for_test("duplicate"),
+        name: "duplicate".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::Unit,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: Vec::new(),
+            terminator: SemTerminator::Return { value: None },
+        }],
+    };
+    let diagnostics = verify_module(&SemModule {
+        functions: vec![function.clone(), function],
+    });
+    assert!(diagnostics
+        .iter()
+        .any(|diagnostic| matches!(diagnostic.kind, SirDiagnosticKind::DuplicateFunctionName(_))));
+    assert!(diagnostics.iter().any(|diagnostic| matches!(
+        diagnostic.kind,
+        SirDiagnosticKind::DuplicateFunctionDeclaration(_)
+    )));
 }

--- a/scripts/sir-shadow-corpus.sh
+++ b/scripts/sir-shadow-corpus.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# SIR shadow corpus driver.
+#
+# This is a temporary cutover proof, not a second supported compiler mode.  For
+# each fixture it invokes the established pipeline and the `--sir-shadow` lane
+# separately, then requires the observable compiler result to agree.  In
+# particular, raw MIR stdout must be byte-identical (the shadow lane must
+# return the established pipeline), while stderr is compared after removing
+# only the SIR coverage report that `--sir-shadow` deliberately adds.  A
+# changed diagnostic, exit status, or emitted raw MIR is a failure.  Remove this
+# parity gate when SIR lowering replaces the established path by default.
+#
+# The default corpus is tests/ll-oracle/corpus, whose fixtures are standalone
+# complete programs and library modules intended to reach the native backend.
+# Additional files and directories may be supplied to exercise a focused
+# surface while a new SIR lowering slice is being developed.
+#
+# Usage:
+#   scripts/sir-shadow-corpus.sh
+#   scripts/sir-shadow-corpus.sh path/to/fixture.hew path/to/corpus-dir
+#
+# Environment:
+#   HEW_BIN                    compiler binary (default: target/debug/hew)
+#   SIR_SHADOW_MIN_REALIZED    minimum total SIR→raw-MIR realizations (default: 1)
+#   SIR_SHADOW_MIN_SUCCESSES   minimum successful baseline compilations (default: 1)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CALLER_DIR="$PWD"
+# shellcheck source=scripts/lib/corpus-nonempty.sh
+# shellcheck disable=SC1091
+source "$ROOT/scripts/lib/corpus-nonempty.sh"
+
+HEW_BIN="${HEW_BIN:-$ROOT/target/debug/hew}"
+DEFAULT_CORPUS="$ROOT/tests/ll-oracle/corpus"
+MIN_REALIZED="${SIR_SHADOW_MIN_REALIZED:-1}"
+MIN_SUCCESSES="${SIR_SHADOW_MIN_SUCCESSES:-1}"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/sir-shadow-corpus.sh [fixture.hew | directory ...]
+
+Compare the established compiler pipeline with `--sir-shadow`.  With no
+arguments, runs every top-level .hew fixture in tests/ll-oracle/corpus.
+
+Environment:
+  HEW_BIN                    compiler binary (default: target/debug/hew)
+  SIR_SHADOW_MIN_REALIZED    minimum total SIR→raw-MIR realizations (default: 1)
+  SIR_SHADOW_MIN_SUCCESSES   minimum successful baseline compilations (default: 1)
+EOF
+}
+
+require_nonnegative_integer() {
+    local name="$1"
+    local value="$2"
+    if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+        echo "sir-shadow-corpus: $name must be a non-negative integer, got '$value'" >&2
+        exit 2
+    fi
+}
+
+require_nonnegative_integer SIR_SHADOW_MIN_REALIZED "$MIN_REALIZED"
+require_nonnegative_integer SIR_SHADOW_MIN_SUCCESSES "$MIN_SUCCESSES"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ ! -x "$HEW_BIN" ]]; then
+    echo "sir-shadow-corpus: compiler binary not found at $HEW_BIN" >&2
+    echo "build it first (make hew-native) or set HEW_BIN=<path>" >&2
+    exit 2
+fi
+if [[ "$HEW_BIN" != /* ]]; then
+    HEW_BIN="$(cd "$(dirname "$HEW_BIN")" && pwd)/$(basename "$HEW_BIN")"
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+fixture_list="$tmpdir/fixtures"
+: >"$fixture_list"
+
+resolve_input() {
+    local input="$1"
+    if [[ "$input" == /* ]]; then
+        printf '%s\n' "$input"
+    else
+        printf '%s/%s\n' "$CALLER_DIR" "$input"
+    fi
+}
+
+add_input() {
+    local input="$1"
+    if [[ -f "$input" ]]; then
+        case "$input" in
+            *.hew) printf '%s\n' "$input" >>"$fixture_list" ;;
+            *)
+                echo "sir-shadow-corpus: fixture is not a .hew file: $input" >&2
+                exit 2
+                ;;
+        esac
+    elif [[ -d "$input" ]]; then
+        while IFS= read -r fixture; do
+            printf '%s\n' "$fixture" >>"$fixture_list"
+        done < <(find "$input" -type f -name '*.hew' -print | LC_ALL=C sort)
+    else
+        echo "sir-shadow-corpus: no such fixture or directory: $input" >&2
+        exit 2
+    fi
+}
+
+if [[ $# -eq 0 ]]; then
+    # Keep the default deliberately shallow: LL-oracle fixtures are individual
+    # compiler inputs.  A caller can pass a directory explicitly when a
+    # recursive surface slice is appropriate.
+    while IFS= read -r fixture; do
+        printf '%s\n' "$fixture" >>"$fixture_list"
+    done < <(find "$DEFAULT_CORPUS" -maxdepth 1 -type f -name '*.hew' -print | LC_ALL=C sort)
+else
+    for argument in "$@"; do
+        add_input "$(resolve_input "$argument")"
+    done
+fi
+
+LC_ALL=C sort -u "$fixture_list" >"$tmpdir/fixtures.sorted"
+mv "$tmpdir/fixtures.sorted" "$fixture_list"
+fixtures=()
+while IFS= read -r fixture; do
+    fixtures+=("$fixture")
+done <"$fixture_list"
+corpus_nonempty_assert "sir-shadow-fixtures" "${#fixtures[@]}" || exit 1
+
+# The report is informational for humans, but it is also the proof that this
+# gate actually reached the experimental lane.  It intentionally stays on
+# stderr so `--dump-mir` retains its ordinary stdout contract.
+extract_report() {
+    local stderr_path="$1"
+    sed -nE \
+        's/^SIR shadow: verified ([0-9]+)\/([0-9]+) HIR function bodies; realized ([0-9]+)\/([0-9]+) through raw MIR$/\1 \2 \3 \4/p' \
+        "$stderr_path"
+}
+
+# Strip only the known coverage lines.  Do not broadly suppress stderr: a
+# diagnostic emitted by the shadow candidate must match the baseline just as an
+# ordinary compiler diagnostic would.
+without_sir_report() {
+    local stderr_path="$1"
+    sed -E '/^SIR (shadow|HIR|raw-MIR)(:| fallback )/d' "$stderr_path"
+}
+
+run_compile() {
+    local output_path="$1"
+    local stderr_path="$2"
+    local status=0
+    shift 2
+    "$@" >"$output_path" 2>"$stderr_path" || status=$?
+    return "$status"
+}
+
+failures=0
+successes=0
+verified=0
+function_bodies=0
+realized=0
+
+for index in "${!fixtures[@]}"; do
+    fixture="${fixtures[$index]}"
+    label="${fixture#"$ROOT"/}"
+    baseline_out="$tmpdir/$index.baseline.out"
+    baseline_err="$tmpdir/$index.baseline.err"
+    shadow_out="$tmpdir/$index.shadow.out"
+    shadow_err="$tmpdir/$index.shadow.err"
+    normalized_shadow_err="$tmpdir/$index.shadow.normalized.err"
+
+    baseline_status=0
+    run_compile "$baseline_out" "$baseline_err" \
+        "$HEW_BIN" compile --dump-mir raw "$fixture" || baseline_status=$?
+    shadow_status=0
+    run_compile "$shadow_out" "$shadow_err" \
+        "$HEW_BIN" compile --sir-shadow --dump-mir raw "$fixture" || shadow_status=$?
+
+    fixture_failed=0
+    if [[ "$baseline_status" -ne "$shadow_status" ]]; then
+        echo "FAIL $label: exit status baseline=$baseline_status shadow=$shadow_status" >&2
+        fixture_failed=1
+    fi
+
+    if ! diff -u "$baseline_out" "$shadow_out"; then
+        echo "FAIL $label: stdout differs between baseline and SIR shadow" >&2
+        fixture_failed=1
+    fi
+
+    without_sir_report "$shadow_err" >"$normalized_shadow_err"
+    if ! diff -u "$baseline_err" "$normalized_shadow_err"; then
+        echo "FAIL $label: diagnostics differ after removing the SIR coverage report" >&2
+        fixture_failed=1
+    fi
+
+    if [[ "$baseline_status" -eq 0 ]]; then
+        successes=$((successes + 1))
+        report="$(extract_report "$shadow_err")"
+        if [[ -z "$report" ]]; then
+            echo "FAIL $label: successful --sir-shadow run produced no SIR coverage report" >&2
+            fixture_failed=1
+        elif [[ "$(printf '%s\n' "$report" | wc -l | tr -d ' ')" -ne 1 ]]; then
+            echo "FAIL $label: ambiguous SIR coverage report" >&2
+            fixture_failed=1
+        else
+            read -r fixture_verified fixture_bodies fixture_realized _ <<<"$report"
+            verified=$((verified + fixture_verified))
+            function_bodies=$((function_bodies + fixture_bodies))
+            realized=$((realized + fixture_realized))
+            printf 'ok   %s  (SIR %s/%s verified, %s realized)\n' \
+                "$label" "$fixture_verified" "$fixture_bodies" "$fixture_realized"
+        fi
+    fi
+
+    if [[ "$fixture_failed" -ne 0 ]]; then
+        failures=$((failures + 1))
+    fi
+done
+
+if [[ "$successes" -lt "$MIN_SUCCESSES" ]]; then
+    echo "FAIL sir-shadow-corpus: only $successes successful baseline compilations; require $MIN_SUCCESSES" >&2
+    failures=$((failures + 1))
+fi
+if [[ "$realized" -lt "$MIN_REALIZED" ]]; then
+    echo "FAIL sir-shadow-corpus: only $realized SIR→raw-MIR realizations; require $MIN_REALIZED" >&2
+    failures=$((failures + 1))
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+    echo "sir-shadow-corpus: FAILED ($failures fixture/parity requirement failure(s))" >&2
+    exit 1
+fi
+
+echo "sir-shadow-corpus: OK (${#fixtures[@]} fixtures, $successes successful baseline compiles, SIR $verified/$function_bodies verified, $realized realized)"


### PR DESCRIPTION
## Summary

Introduces the first executable Semantic IR (SIR) value/CFG slice: verified scalar SSA with block arguments now lowers through raw and checked MIR to the existing backend.

- Lower scalar constants, arithmetic, comparisons, casts, branches, returns, and SSA block arguments; edge forwarding uses parallel copies and checked arithmetic retains overflow-trap CFG.
- Add SIR provenance, derived effects, structural and module-level verification, deterministic dumps, guarded lowering for && / ||, and target-aware candidate backend validation.
- Replace the scheduler’s block-number loop heuristic with dominance-based latch recognition.
- Make --dump-sir a semantic-only inspector; add --sir-lower for the executable subset and --sir-shadow as a temporary differential oracle.
- Document the SIR ladder and hard-cutover deletion gates.

## Hard-cutover contract

This is bounded migration evidence, not a permanent second compiler configuration. The raw-template bridge, name matching, copied boundary/scheduler facts, per-function fallback, SIR mode flags, and shadow corpus are explicit deletion targets.

The immediate next slice is declaration-keyed direct scalar calls: SIR will own callable identity, emitted symbol, signature, calling convention, effect summary, and parameter-passing facts, then lower a closed reachable direct-call graph without inspecting legacy raw MIR. Feature domains migrate as closed islands and delete their legacy HIR-to-MIR body branches; the normal CLI flips only when all accepted source reaches SIR-to-MIR.

## Verification

- cargo clippy -p hew-sir -p hew-mir -p hew-cli --all-targets -- -D warnings
- cargo test -p hew-sir --no-fail-fast (5 integration tests)
- cargo test -p hew-mir dataflow::tests:: --no-fail-fast (27 tests)
- cargo test -p hew-mir sir:: --no-fail-fast (5 tests)
- cargo test -p hew-cli --test sir_shadow_e2e --no-fail-fast (5 tests)
- cargo test -p hew-cli --bin hew test_runner::runner::tests:: --no-fail-fast (11 tests)
- scripts/sir-shadow-corpus.sh: 15/15 baseline parity; 236/414 SIR bodies verified; 2 realized
- target-aware wasm32-unknown-unknown SIR shadow compilation
- cargo fmt --all -- --check, shell-script lint, gate-reachability, and pre-push checks

All Cargo commands used sccache with CARGO_TARGET_DIR on /Volumes/Extreme SSD/src/.