### PR TITLE
feat(sir): lower closed scalar call graphs

### DIFF
--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -11,11 +11,11 @@ implementation plan for this work.
 ### Migration status
 
 The intended steady-state ladder includes SIR between typed HIR and Raw MIR.
-The first executable SIR value/CFG slice is now present, but it uses a bounded
-legacy-MIR differential bridge while the remaining language surface migrates.
-That bridge is deliberately disposable: it is not a second release compiler
-configuration or a compatibility contract.  The cutover contract in §1.2
-defines exactly what must be removed before SIR becomes the normal path.
+The first value/CFG proof uses a bounded legacy-MIR differential bridge, while
+the first strict direct-call slice already produces fresh Raw/Checked MIR from
+SIR. The bridge is deliberately disposable: it is not a second release
+compiler configuration or a compatibility contract. The cutover contract in
+§1.2 defines exactly what must be removed before SIR becomes the normal path.
 
 ---
 
@@ -67,11 +67,26 @@ source.hew
 
 The current SIR bridge is bounded migration evidence, not a permanent dual
 pipeline. `--sir-shadow` is a temporary differential oracle, and `--sir-lower`
-is a temporary selector for the scalar CFG slice. Neither is a release-mode
+is a temporary selector for the migrated SIR domain. Neither is a release-mode
 compatibility promise.
 
+The first strict domain is already template-free: a closed reachable graph of
+ordinary, non-generic, default-convention direct calls with scalar `ReadOnly`
+parameters and scalar or `Unit` returns. SIR owns each callable's stable
+identity, emitted symbol, signature, source origin, effect summary, and
+parameter facts; SIR → Raw/Checked MIR independently legalizes call
+continuations and creates fresh boundary/scheduling facts. A reachable feature
+outside that domain fails explicitly. An unrelated unsupported body neither
+blocks the selected component nor becomes a hidden legacy callee.
+
+The temporary shadow adapter remains a scalar CFG differential probe and does
+not realize direct SIR calls through its legacy Raw-MIR template. Shadow
+success is therefore not evidence for direct-call correctness. Until the old
+body-lowering branch is deleted, each strict domain must instead carry an
+execution-parity test against the established lane.
+
 The following scaffolding is a deletion target: raw-function name matching,
-`lower_sir_function(..., RawMirFunction template)`, copied parameter-boundary
+`lower_sir_function_with_template(..., RawMirFunction template)`, copied parameter-boundary
 and scheduler facts, per-function legacy fallback, SIR mode flags, and the
 shadow corpus harness. The normal CLI flips only after all of these gates hold:
 
@@ -87,10 +102,11 @@ shadow corpus harness. The normal CLI flips only after all of these gates hold:
 5. The default path is changed to SIR and all bridge flags, template code, and
    legacy body-lowering branches are removed.
 
-The immediate next slice is declaration-keyed direct scalar calls: a verified
-SIR callable table feeds `Terminator::Call` legalization for a closed ordinary
-call graph, without looking up or copying a legacy Raw MIR template. Aggregates,
-ownership, async, actors, and machines follow as separate complete domains.
+The direct-call slice has replaced the immediate template dependency; the next
+semantic domains are abstract aggregates/projections, explicit ownership use
+modes, closures, async/suspension, actors, and machines. Each must enter as a
+closed reachable SIR lowering domain and delete its replaced HIR → Raw-MIR
+branch rather than accumulating a mixed artifact fallback.
 
 ### Design axioms
 

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -38,6 +38,40 @@ pub struct Cli {
     pub command: Option<Command>,
 }
 
+/// Selects how a compile-capable command uses Hew Semantic IR (SIR).
+///
+/// This is deliberately shared by every command that can reach native or
+/// WASM code generation. Keeping the selection at the CLI boundary prevents
+/// commands such as `run` and `test` from accidentally taking a different
+/// compiler lane than `compile` and `build`.
+#[derive(Debug, Args, Clone, Copy, Default)]
+pub struct SirModeArgs {
+    /// Run the experimental HIR → SIR → raw-MIR candidate lane and verify it
+    /// at the backend front gate, while keeping established MIR as the emitted
+    /// artifact.
+    #[arg(long = "sir-shadow", conflicts_with = "sir_lower")]
+    pub sir_shadow: bool,
+    /// Compile a closed scalar direct-call graph through SIR → raw/checked MIR
+    /// with no legacy function-body lowering. A reachable unsupported feature
+    /// is an explicit error; it never falls back to established MIR.
+    #[arg(long = "sir-lower", conflicts_with = "sir_shadow")]
+    pub sir_lower: bool,
+}
+
+impl SirModeArgs {
+    /// Convert parsed flags into the one compiler-driver mode threaded through
+    /// every compile-capable command.
+    pub fn mode(self) -> crate::compile::SirMode {
+        if self.sir_lower {
+            crate::compile::SirMode::Lower
+        } else if self.sir_shadow {
+            crate::compile::SirMode::Shadow
+        } else {
+            crate::compile::SirMode::Disabled
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Compile a .hew file through the v0.5 IR ladder.
@@ -120,20 +154,13 @@ pub struct CompileArgs {
     /// spot-checking the front-half lowering during development.
     #[arg(long = "dump-mir", value_name = "STAGE", value_parser = ["raw", "checked", "elab"])]
     pub dump_mir: Option<String>,
-    /// Run the experimental HIR → SIR → raw-MIR candidate lane and verify it
-    /// at the backend front gate, while keeping established MIR as the emitted
-    /// artifact.
-    #[arg(long = "sir-shadow", conflicts_with = "sir_lower")]
-    pub sir_shadow: bool,
-    /// Use the experimental SIR → raw-MIR realization for the verified scalar
-    /// CFG subset. Unsupported functions explicitly retain established MIR.
-    #[arg(long = "sir-lower", conflicts_with = "sir_shadow")]
-    pub sir_lower: bool,
+    #[command(flatten)]
+    pub sir: SirModeArgs,
     /// Emit the verified Semantic IR subset and exit. Unsupported functions are
     /// reported explicitly; no MIR or LLVM artifacts are emitted.
     #[arg(
         long = "dump-sir",
-        conflicts_with_all = ["sir_lower", "sir_shadow"]
+        conflicts_with_all = ["dump_mir", "sir_lower", "sir_shadow"]
     )]
     pub dump_sir: bool,
     /// Compilation target. Omit for native; pass `wasm32-unknown-unknown` for WASM.
@@ -337,6 +364,8 @@ pub struct RunArgs {
     pub timeout: Option<String>,
     #[command(flatten)]
     pub common: CommonBuildArgs,
+    #[command(flatten)]
+    pub sir: SirModeArgs,
     /// Surface diagnostic-only stack-allocation hints from the type checker.
     ///
     /// When set, the checker's escape-analysis pass prints
@@ -358,6 +387,7 @@ impl RunArgs {
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
         crate::compile::CompileOptions {
             target: self.target.clone(),
+            sir_mode: self.sir.mode(),
             ..self.common.base_compile_options()
         }
     }
@@ -383,6 +413,8 @@ pub struct DebugArgs {
     pub target: Option<String>,
     #[command(flatten)]
     pub common: CommonBuildArgs,
+    #[command(flatten)]
+    pub sir: SirModeArgs,
     /// Arguments to pass to the debugger/program (after --).
     #[arg(last = true)]
     pub program_args: Vec<String>,
@@ -392,6 +424,7 @@ impl DebugArgs {
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
         crate::compile::CompileOptions {
             target: self.target.clone(),
+            sir_mode: self.sir.mode(),
             ..self.common.base_compile_options()
         }
     }
@@ -501,6 +534,8 @@ pub struct BuildArgs {
     pub link_libs: Vec<String>,
     #[command(flatten)]
     pub common: CommonBuildArgs,
+    #[command(flatten)]
+    pub sir: SirModeArgs,
     /// Diagnostic output format: `text` (default) or `json`.
     #[arg(long, value_enum, default_value_t = DiagnosticFormat::Text, value_name = "FORMAT")]
     pub format: DiagnosticFormat,
@@ -510,6 +545,7 @@ impl BuildArgs {
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
         crate::compile::CompileOptions {
             target: self.target.clone(),
+            sir_mode: self.sir.mode(),
             ..self.common.base_compile_options()
         }
     }
@@ -614,6 +650,10 @@ pub struct EvalArgs {
     /// including in an interactive terminal.
     #[arg(long, short = 'q')]
     pub quiet: bool,
+    /// Select the SIR lowering lane for every evaluation compiled by this
+    /// command, including native AOT, WASM AOT, and interactive REPL input.
+    #[command(flatten)]
+    pub sir: SirModeArgs,
     /// Expression to evaluate (if no -f given).
     pub expr: Vec<String>,
 }
@@ -666,10 +706,8 @@ pub struct TestArgs {
     /// memory pressure from concurrent compilation tasks.
     #[arg(long, short = 'j', value_name = "N")]
     pub jobs: Option<std::num::NonZeroUsize>,
-    /// Exercise the SIR → raw-MIR candidate lane for each test compilation
-    /// while continuing to emit the established MIR artifact.
-    #[arg(long = "sir-shadow")]
-    pub sir_shadow: bool,
+    #[command(flatten)]
+    pub sir: SirModeArgs,
 }
 
 // ---------------------------------------------------------------------------
@@ -691,11 +729,48 @@ pub struct WatchArgs {
     pub debounce: u64,
     #[command(flatten)]
     pub common: CommonBuildArgs,
+    /// SIR flags are accepted only with `--run`, whose build goes through the
+    /// ordinary native compilation path. Check-only watches stop at the
+    /// frontend and therefore cannot truthfully select an IR lane.
+    #[command(flatten)]
+    pub sir: WatchSirModeArgs,
 }
 
 impl WatchArgs {
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
-        self.common.base_compile_options()
+        crate::compile::CompileOptions {
+            sir_mode: self.sir.mode(),
+            ..self.common.base_compile_options()
+        }
+    }
+}
+
+/// SIR mode selection for `hew watch`.
+///
+/// A check-only watch deliberately stops before MIR/SIR realization. Requiring
+/// `--run` at parse time prevents `--sir-lower` or `--sir-shadow` from being
+/// accepted and then silently doing nothing.
+#[derive(Debug, Args, Clone, Copy, Default)]
+pub struct WatchSirModeArgs {
+    /// Run the experimental HIR → SIR → raw-MIR candidate lane while keeping
+    /// established MIR as the emitted artifact.
+    #[arg(long = "sir-shadow", conflicts_with = "sir_lower", requires = "run")]
+    pub sir_shadow: bool,
+    /// Compile the watched program through the strict closed SIR direct-call
+    /// lane. Reachable unsupported features are errors, never fallbacks.
+    #[arg(long = "sir-lower", conflicts_with = "sir_shadow", requires = "run")]
+    pub sir_lower: bool,
+}
+
+impl WatchSirModeArgs {
+    pub fn mode(self) -> crate::compile::SirMode {
+        if self.sir_lower {
+            crate::compile::SirMode::Lower
+        } else if self.sir_shadow {
+            crate::compile::SirMode::Shadow
+        } else {
+            crate::compile::SirMode::Disabled
+        }
     }
 }
 
@@ -889,4 +964,90 @@ pub struct LspArgs {
     /// Arguments passed through to `hew-lsp`.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{Cli, Command};
+    use crate::compile::SirMode;
+
+    #[test]
+    fn sir_lower_is_selectable_for_every_compile_capable_command() {
+        let compile = Cli::try_parse_from(["hew", "compile", "sample.hew", "--sir-lower"])
+            .expect("compile should accept --sir-lower");
+        let run = Cli::try_parse_from(["hew", "run", "sample.hew", "--sir-lower"])
+            .expect("run should accept --sir-lower");
+        let build = Cli::try_parse_from(["hew", "build", "sample.hew", "--sir-lower"])
+            .expect("build should accept --sir-lower");
+        let debug = Cli::try_parse_from(["hew", "debug", "sample.hew", "--sir-lower"])
+            .expect("debug should accept --sir-lower");
+        let watch = Cli::try_parse_from(["hew", "watch", "sample.hew", "--run", "--sir-lower"])
+            .expect("watch should accept --sir-lower");
+        let test = Cli::try_parse_from(["hew", "test", "--sir-lower"])
+            .expect("test should accept --sir-lower");
+        let eval = Cli::try_parse_from(["hew", "eval", "--sir-lower", "let x = 1;"])
+            .expect("eval should accept --sir-lower");
+
+        for command in [compile, run, build, debug, watch, test, eval] {
+            assert_eq!(
+                command_sir_mode(command.command.expect("command should be present")),
+                SirMode::Lower
+            );
+        }
+    }
+
+    #[test]
+    fn sir_mode_defaults_to_disabled_and_rejects_competing_flags() {
+        let defaulted = Cli::try_parse_from(["hew", "build", "sample.hew"])
+            .expect("build should parse without an SIR mode");
+        assert_eq!(
+            command_sir_mode(defaulted.command.expect("build command should be present")),
+            SirMode::Disabled
+        );
+
+        let shadow = Cli::try_parse_from(["hew", "test", "--sir-shadow"])
+            .expect("test should preserve --sir-shadow");
+        assert_eq!(
+            command_sir_mode(shadow.command.expect("test command should be present")),
+            SirMode::Shadow
+        );
+
+        assert!(
+            Cli::try_parse_from(["hew", "run", "sample.hew", "--sir-shadow", "--sir-lower",])
+                .is_err()
+        );
+        assert!(Cli::try_parse_from(
+            ["hew", "compile", "sample.hew", "--dump-sir", "--sir-lower",]
+        )
+        .is_err());
+        assert!(Cli::try_parse_from([
+            "hew",
+            "compile",
+            "sample.hew",
+            "--dump-sir",
+            "--dump-mir",
+            "raw",
+        ])
+        .is_err());
+        assert!(Cli::try_parse_from(["hew", "watch", "sample.hew", "--sir-lower"]).is_err());
+        assert!(Cli::try_parse_from(["hew", "watch", "sample.hew", "--sir-shadow"]).is_err());
+        assert!(
+            Cli::try_parse_from(["hew", "eval", "--sir-shadow", "--sir-lower", "1 + 2"]).is_err()
+        );
+    }
+
+    fn command_sir_mode(command: Command) -> SirMode {
+        match command {
+            Command::Compile(args) => args.sir.mode(),
+            Command::Run(args) => args.to_compile_options().sir_mode,
+            Command::Debug(args) => args.to_compile_options().sir_mode,
+            Command::Build(args) => args.to_compile_options().sir_mode,
+            Command::Test(args) => args.sir.mode(),
+            Command::Watch(args) => args.to_compile_options().sir_mode,
+            Command::Eval(args) => args.sir.mode(),
+            other => panic!("expected a compile-capable command, got {other:?}"),
+        }
+    }
 }

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -27,11 +27,12 @@ use crate::target::TargetSpec;
 
 /// Selects how the Semantic IR lane participates in a compilation.
 ///
-/// `Shadow` realizes every currently eligible SIR body into a cloned raw-MIR
-/// pipeline, verifies the candidate reaches the backend front gate, then
-/// deliberately emits the established pipeline. `Lower` uses that same
-/// verified candidate for eligible functions and leaves explicit fallbacks on
-/// the established HIR → MIR path.
+/// `Shadow` realizes eligible SIR bodies into a cloned raw-MIR pipeline,
+/// verifies the candidate reaches the backend front gate, then deliberately
+/// emits the established pipeline. It is a temporary differential oracle.
+/// `Lower` is the strict cutover lane for its admitted domain: it lowers a
+/// closed SIR direct-call graph into fresh raw/checked MIR and rejects every
+/// reachable unsupported callee instead of mixing legacy function bodies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SirMode {
     #[default]

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -106,6 +106,7 @@ fn resolve_eval_target(
 /// Run the `hew eval` subcommand.
 pub fn cmd_eval(args: &crate::args::EvalArgs) {
     let timeout = resolve_eval_timeout(&args.timeout);
+    let sir_mode = args.sir.mode();
     let target_spec = resolve_eval_target(args.target.as_deref(), args.jit).unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
@@ -116,11 +117,11 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
     validate_eval_request(&request, args.json, target);
 
     if args.json {
-        emit_json_eval(&request, timeout, target, args.jit);
+        emit_json_eval(&request, timeout, target, args.jit, sir_mode);
         return;
     }
 
-    execute_eval_request(&request, timeout, target, args.jit, args.quiet);
+    execute_eval_request(&request, timeout, target, args.jit, sir_mode, args.quiet);
 }
 
 fn resolve_eval_timeout(raw: &str) -> std::time::Duration {
@@ -181,12 +182,15 @@ fn emit_json_eval(
     timeout: std::time::Duration,
     target: Option<&str>,
     jit: Option<crate::args::JitMode>,
+    sir_mode: crate::compile::SirMode,
 ) {
     let result = match request {
         EvalRequest::File(path) => {
-            capture_json_eval(|| repl::eval_file(path, timeout, target, jit))
+            capture_json_eval(|| repl::eval_file(path, timeout, target, jit, sir_mode))
         }
-        EvalRequest::Expr(expr) => capture_json_eval(|| repl::eval_one(expr, timeout, target, jit)),
+        EvalRequest::Expr(expr) => {
+            capture_json_eval(|| repl::eval_one(expr, timeout, target, jit, sir_mode))
+        }
         EvalRequest::Repl => unreachable!("validated before JSON evaluation"),
     };
 
@@ -213,13 +217,18 @@ fn execute_eval_request(
     timeout: std::time::Duration,
     target: Option<&str>,
     jit: Option<crate::args::JitMode>,
+    sir_mode: crate::compile::SirMode,
     quiet: bool,
 ) {
     match request {
-        EvalRequest::File(path) => emit_eval_output(repl::eval_file(path, timeout, target, jit)),
-        EvalRequest::Expr(expr) => emit_eval_output(repl::eval_one(expr, timeout, target, jit)),
+        EvalRequest::File(path) => {
+            emit_eval_output(repl::eval_file(path, timeout, target, jit, sir_mode));
+        }
+        EvalRequest::Expr(expr) => {
+            emit_eval_output(repl::eval_one(expr, timeout, target, jit, sir_mode));
+        }
         EvalRequest::Repl => {
-            if let Err(e) = repl::run_interactive(timeout, target, jit, quiet) {
+            if let Err(e) = repl::run_interactive(timeout, target, jit, sir_mode, quiet) {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -43,6 +43,10 @@ pub struct ReplSession {
     /// JIT execution mode.  When `None` (or `Worker`), uses the existing
     /// AOT+spawn path.  When `Inprocess`, routes through LLJIT.
     jit_mode: Option<crate::args::JitMode>,
+    /// SIR lane selected by `hew eval`. This stays on the session so every
+    /// synthetic fragment, loaded file, native AOT compile, and WASM AOT
+    /// compile makes the same explicit lowering choice.
+    sir_mode: crate::compile::SirMode,
 }
 
 #[derive(Debug)]
@@ -157,6 +161,17 @@ enum TypeQueryFailure {
 enum ExpressionEvalPlan {
     Compile { auto_print: bool },
     Display(String),
+}
+
+/// One explicit lowering/execution selection for an eval compilation.
+///
+/// Native and WASM AOT both consume this shared configuration, preventing a
+/// new compiler-lane flag from being threaded into only one execution backend.
+#[derive(Clone, Copy)]
+struct EvalBackendOptions<'a> {
+    target: Option<&'a str>,
+    jit_mode: Option<crate::args::JitMode>,
+    sir_mode: crate::compile::SirMode,
 }
 
 #[derive(Debug)]
@@ -604,6 +619,7 @@ impl ReplSession {
             project_dir: None,
             eval_target: None,
             jit_mode: None,
+            sir_mode: crate::compile::SirMode::Disabled,
         }
     }
 
@@ -623,6 +639,7 @@ impl ReplSession {
             project_dir,
             eval_target: None,
             jit_mode: None,
+            sir_mode: crate::compile::SirMode::Disabled,
         }
     }
 
@@ -655,6 +672,12 @@ impl ReplSession {
         self.jit_mode = mode;
     }
 
+    /// Select the SIR lowering lane for every compilation performed by this
+    /// session. `Disabled` remains the default for non-CLI embedding callers.
+    pub fn set_sir_mode(&mut self, mode: crate::compile::SirMode) {
+        self.sir_mode = mode;
+    }
+
     #[cfg(test)]
     pub(crate) fn add_item_for_test(&mut self, source: &str) {
         self.session.add_item(source);
@@ -664,6 +687,14 @@ impl ReplSession {
         self.eval_target.as_deref().is_some_and(|t| {
             crate::target::TargetSpec::from_requested(Some(t)).is_ok_and(|spec| spec.is_wasm())
         })
+    }
+
+    fn backend_options(&self) -> EvalBackendOptions<'_> {
+        EvalBackendOptions {
+            target: self.eval_target.as_deref(),
+            jit_mode: self.jit_mode,
+            sir_mode: self.sir_mode,
+        }
     }
 
     /// Evaluate a line of input and return the result.
@@ -743,8 +774,7 @@ impl ReplSession {
             "<repl>",
             self.execution_timeout,
             self.project_dir.clone(),
-            self.eval_target.as_deref(),
-            self.jit_mode,
+            self.backend_options(),
         ) {
             Ok(output) => {
                 // On success, persist the input into session state.
@@ -850,8 +880,7 @@ impl ReplSession {
             "<repl>",
             self.execution_timeout,
             self.project_dir.clone(),
-            self.eval_target.as_deref(),
-            self.jit_mode,
+            self.backend_options(),
         ) {
             Ok(output) => {
                 self.record_success(trimmed, &checked_program.kind);
@@ -932,8 +961,7 @@ impl ReplSession {
             source_label,
             self.execution_timeout,
             self.project_dir.clone(),
-            self.eval_target.as_deref(),
-            self.jit_mode,
+            self.backend_options(),
         ) {
             Ok(output) => {
                 self.record_success(trimmed, &kind);
@@ -1286,8 +1314,7 @@ impl ReplSession {
             source_label,
             self.execution_timeout,
             self.project_dir.clone(),
-            self.eval_target.as_deref(),
-            self.jit_mode,
+            self.backend_options(),
         ) {
             Ok(output) => Ok(output),
             Err(error) => Err(CliEvalError::from(error)),
@@ -1436,13 +1463,26 @@ fn handle_interactive_input(session: &mut ReplSession, input: &str) -> Interacti
 /// as the frontend-to-codegen path.  The REPL's fast in-process typecheck is
 /// kept for user-facing error reporting only; this function runs the full
 /// correctly-ordered pipeline for codegen.
+fn eval_compile_options(
+    project_dir: Option<PathBuf>,
+    backend: EvalBackendOptions<'_>,
+) -> crate::compile::CompileOptions {
+    crate::compile::CompileOptions {
+        project_dir,
+        target: backend.target.map(str::to_owned),
+        repl_fragment: true,
+        sir_mode: backend.sir_mode,
+        ..crate::compile::CompileOptions::default()
+    }
+}
+
 fn run_inprocess_compiled(
     program: hew_parser::ast::Program,
     source: &str,
     source_label: &str,
     timeout: Duration,
     project_dir: Option<PathBuf>,
-    target: Option<&str>,
+    backend: EvalBackendOptions<'_>,
 ) -> Result<String, CompiledEvalError> {
     let tmp_dir = tempfile::tempdir()
         .map_err(|e| CompiledEvalError::Message(format!("cannot create temp dir: {e}")))?;
@@ -1454,12 +1494,7 @@ fn run_inprocess_compiled(
         source,
         source_label,
         &bin_path,
-        &crate::compile::CompileOptions {
-            project_dir,
-            target: target.map(str::to_owned),
-            repl_fragment: true,
-            ..crate::compile::CompileOptions::default()
-        },
+        &eval_compile_options(project_dir, backend),
     )
     .map_err(|()| CompiledEvalError::DiagnosticsRendered)?;
 
@@ -1503,23 +1538,22 @@ fn run_eval_compiled(
     source_label: &str,
     timeout: Duration,
     project_dir: Option<PathBuf>,
-    target: Option<&str>,
-    jit_mode: Option<crate::args::JitMode>,
+    backend: EvalBackendOptions<'_>,
 ) -> Result<String, CompiledEvalError> {
     // Only an explicit `--jit=inprocess` reaches the fail-closed guard. `Auto`
     // selects the best available backend (today: AOT) and must not fail closed.
-    if matches!(jit_mode, Some(crate::args::JitMode::Inprocess)) {
+    if matches!(backend.jit_mode, Some(crate::args::JitMode::Inprocess)) {
         return run_inprocess_jit(program, source, source_label, project_dir);
     }
 
-    let is_wasm = target.is_some_and(|t| {
+    let is_wasm = backend.target.is_some_and(|t| {
         crate::target::TargetSpec::from_requested(Some(t)).is_ok_and(|spec| spec.is_wasm())
     });
 
     if is_wasm {
-        run_wasm_eval_compiled(program, source, source_label, timeout, project_dir, target)
+        run_wasm_eval_compiled(program, source, source_label, timeout, project_dir, backend)
     } else {
-        run_inprocess_compiled(program, source, source_label, timeout, project_dir, target)
+        run_inprocess_compiled(program, source, source_label, timeout, project_dir, backend)
     }
 }
 
@@ -1558,7 +1592,7 @@ fn run_wasm_eval_compiled(
     source_label: &str,
     timeout: Duration,
     project_dir: Option<PathBuf>,
-    target: Option<&str>,
+    backend: EvalBackendOptions<'_>,
 ) -> Result<String, CompiledEvalError> {
     let tmp_dir = tempfile::tempdir()
         .map_err(|e| CompiledEvalError::Message(format!("cannot create temp dir: {e}")))?;
@@ -1569,12 +1603,7 @@ fn run_wasm_eval_compiled(
         source,
         source_label,
         &module_path,
-        &crate::compile::CompileOptions {
-            project_dir,
-            target: target.map(str::to_owned),
-            repl_fragment: true,
-            ..crate::compile::CompileOptions::default()
-        },
+        &eval_compile_options(project_dir, backend),
     )
     .map_err(|()| CompiledEvalError::DiagnosticsRendered)?;
 
@@ -1630,6 +1659,7 @@ pub fn run_interactive(
     timeout: Duration,
     target: Option<&str>,
     jit: Option<crate::args::JitMode>,
+    sir_mode: crate::compile::SirMode,
     quiet: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::io::IsTerminal;
@@ -1637,6 +1667,7 @@ pub fn run_interactive(
     let mut rl = rustyline::DefaultEditor::new()?;
     let mut session = ReplSession::with_timeout_and_target(timeout, target);
     session.set_jit_mode(jit);
+    session.set_sir_mode(sir_mode);
     let (primary_prompt, continuation_prompt) = prompts_for_terminal_state(
         std::io::stdin().is_terminal(),
         std::io::stdout().is_terminal(),
@@ -1709,9 +1740,11 @@ pub fn eval_one(
     timeout: Duration,
     target: Option<&str>,
     jit: Option<crate::args::JitMode>,
+    sir_mode: crate::compile::SirMode,
 ) -> Result<String, CliEvalError> {
     let mut session = ReplSession::with_timeout_and_target(timeout, target);
     session.set_jit_mode(jit);
+    session.set_sir_mode(sir_mode);
     session.eval_cli(expr, "<eval>")
 }
 
@@ -1725,6 +1758,7 @@ pub fn eval_file(
     timeout: Duration,
     target: Option<&str>,
     jit: Option<crate::args::JitMode>,
+    sir_mode: crate::compile::SirMode,
 ) -> Result<String, CliEvalError> {
     let (source, input_name) = if path == "-" {
         let mut source = String::new();
@@ -1744,6 +1778,7 @@ pub fn eval_file(
         ReplSession::for_path_with_target(path, timeout, target)
     };
     session.set_jit_mode(jit);
+    session.set_sir_mode(sir_mode);
     session.eval_source_file_cli(&source, &input_name, &input_name)
 }
 
@@ -2158,7 +2193,13 @@ mod tests {
         if !require_toolchain() {
             return;
         }
-        let result = eval_one("2 * 3", DEFAULT_EVAL_TIMEOUT, None, None);
+        let result = eval_one(
+            "2 * 3",
+            DEFAULT_EVAL_TIMEOUT,
+            None,
+            None,
+            crate::compile::SirMode::Disabled,
+        );
         assert_eq!(result.unwrap(), "6\n");
     }
 
@@ -2304,7 +2345,13 @@ mod tests {
             "fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nadd(1, 2)\n",
         )
         .unwrap();
-        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, None, None);
+        let result = eval_file(
+            path.to_str().unwrap(),
+            DEFAULT_EVAL_TIMEOUT,
+            None,
+            None,
+            crate::compile::SirMode::Disabled,
+        );
         assert!(result.is_ok(), "eval_file failed: {result:?}");
     }
 
@@ -2317,7 +2364,13 @@ mod tests {
         let path = dir.path().join("hew_eval_balanced_incomplete_expr.hew");
         std::fs::write(&path, "1 +\n2\n").unwrap();
 
-        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, None, None);
+        let result = eval_file(
+            path.to_str().unwrap(),
+            DEFAULT_EVAL_TIMEOUT,
+            None,
+            None,
+            crate::compile::SirMode::Disabled,
+        );
         assert!(result.is_ok(), "eval_file failed: {result:?}");
     }
 
@@ -2415,6 +2468,7 @@ mod tests {
             DEFAULT_EVAL_TIMEOUT,
             None,
             None,
+            crate::compile::SirMode::Disabled,
         );
         assert!(
             result.is_ok(),
@@ -2573,7 +2627,13 @@ mod tests {
         if !require_wasi_toolchain() {
             return;
         }
-        let result = eval_one("1 + 2", DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"), None);
+        let result = eval_one(
+            "1 + 2",
+            DEFAULT_EVAL_TIMEOUT,
+            Some("wasm32-wasi"),
+            None,
+            crate::compile::SirMode::Disabled,
+        );
         assert_eq!(result.unwrap(), "3\n");
     }
 
@@ -2587,6 +2647,7 @@ mod tests {
             DEFAULT_EVAL_TIMEOUT,
             Some("wasm32-wasi"),
             None,
+            crate::compile::SirMode::Disabled,
         );
         assert_eq!(result.unwrap(), "hello from wasi\n");
     }
@@ -2634,6 +2695,7 @@ mod tests {
             DEFAULT_EVAL_TIMEOUT,
             Some("wasm32-wasi"),
             None,
+            crate::compile::SirMode::Disabled,
         );
         assert!(result.is_ok(), "wasi eval_file failed: {result:?}");
     }
@@ -2660,8 +2722,11 @@ mod tests {
             "<test>",
             DEFAULT_EVAL_TIMEOUT,
             None,
-            None,
-            Some(crate::args::JitMode::Inprocess),
+            EvalBackendOptions {
+                target: None,
+                jit_mode: Some(crate::args::JitMode::Inprocess),
+                sir_mode: crate::compile::SirMode::Disabled,
+            },
         );
         assert!(
             inprocess_result.is_err(),
@@ -2679,8 +2744,11 @@ mod tests {
             "<test>",
             DEFAULT_EVAL_TIMEOUT,
             None,
-            None,
-            Some(crate::args::JitMode::Auto),
+            EvalBackendOptions {
+                target: None,
+                jit_mode: Some(crate::args::JitMode::Auto),
+                sir_mode: crate::compile::SirMode::Disabled,
+            },
         );
         assert_eq!(
             auto_result.expect("Auto mode must succeed via AOT fallback"),
@@ -2697,13 +2765,20 @@ mod tests {
         if !require_toolchain() {
             return;
         }
-        let result_no_flag = eval_one("1 + 1", DEFAULT_EVAL_TIMEOUT, None, None)
-            .expect("eval without --jit should succeed");
+        let result_no_flag = eval_one(
+            "1 + 1",
+            DEFAULT_EVAL_TIMEOUT,
+            None,
+            None,
+            crate::compile::SirMode::Disabled,
+        )
+        .expect("eval without --jit should succeed");
         let result_worker = eval_one(
             "1 + 1",
             DEFAULT_EVAL_TIMEOUT,
             None,
             Some(crate::args::JitMode::Worker),
+            crate::compile::SirMode::Disabled,
         )
         .expect("eval with --jit=worker should succeed");
         assert_eq!(
@@ -2730,5 +2805,40 @@ mod tests {
             session.jit_mode, None,
             "set_jit_mode(None) should clear the mode"
         );
+    }
+
+    #[test]
+    fn sir_mode_is_preserved_for_native_and_wasm_eval_compiles() {
+        let native = eval_compile_options(
+            None,
+            EvalBackendOptions {
+                target: None,
+                jit_mode: None,
+                sir_mode: crate::compile::SirMode::Lower,
+            },
+        );
+        assert_eq!(native.sir_mode, crate::compile::SirMode::Lower);
+        assert!(native.repl_fragment);
+        assert!(native.target.is_none());
+
+        let wasm = eval_compile_options(
+            None,
+            EvalBackendOptions {
+                target: Some("wasm32-wasi"),
+                jit_mode: None,
+                sir_mode: crate::compile::SirMode::Shadow,
+            },
+        );
+        assert_eq!(wasm.sir_mode, crate::compile::SirMode::Shadow);
+        assert!(wasm.repl_fragment);
+        assert_eq!(wasm.target.as_deref(), Some("wasm32-wasi"));
+    }
+
+    #[test]
+    fn set_sir_mode_stores_mode_on_session() {
+        let mut session = ReplSession::new();
+        assert_eq!(session.sir_mode, crate::compile::SirMode::Disabled);
+        session.set_sir_mode(crate::compile::SirMode::Lower);
+        assert_eq!(session.sir_mode, crate::compile::SirMode::Lower);
     }
 }

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -265,28 +265,144 @@ fn render_pipeline_mir_lints(
 #[derive(Debug)]
 struct SirLaneReport {
     sir: hew_sir::LoweredModule,
-    bridge: hew_mir::SirMirLoweringReport,
+    realization: SirLaneRealization,
 }
 
-/// Run the semantic/value lane against the *same verified HIR module* that
-/// supplies the established ownership/layout MIR pipeline.
+/// The intentionally different roles of the temporary shadow oracle and the
+/// strict cutover lane. Only `Shadow` is permitted to consult established MIR
+/// bodies; `Strict` starts from verified SIR and owns the complete selected
+/// call graph through raw/checked MIR.
+#[derive(Debug)]
+enum SirLaneRealization {
+    Shadow(hew_mir::SirMirLoweringReport),
+    Strict { callables: Vec<hew_sir::CallableId> },
+}
+
+/// Choose a body-lowering lane after HIR has been verified.
 ///
-/// Shadow mode always returns the established pipeline; lower mode replaces
-/// only functions for which the SIR adapter can preserve every required raw
-/// MIR invariant. This is the shared driver seam used by file, package, and
-/// in-memory test compilation paths.
+/// `Shadow` remains a temporary differential oracle: it is allowed to build
+/// the established pipeline and compare a candidate realization. `Lower` is
+/// deliberately different: it builds a closed direct-call component from SIR
+/// and never asks the legacy HIR→MIR body lowerer for a function/template.
+/// This makes an unsupported reachable feature a clear compilation error,
+/// not a long-lived mixed-lowering compatibility path.
 fn lower_verified_hir_to_pipeline(
     module: &hew_hir::HirModule,
     tco: &hew_types::TypeCheckOutput,
     target: &target::TargetSpec,
     sir_mode: compile::SirMode,
 ) -> Result<(hew_mir::IrPipeline, Option<SirLaneReport>), ()> {
-    let mut pipeline = hew_mir::lower_hir_module_with_facts(module, mir_pointer_width(target));
-    pipeline.attach_lowering_facts(tco);
-    if sir_mode == compile::SirMode::Disabled {
-        return Ok((pipeline, None));
+    match sir_mode {
+        compile::SirMode::Disabled => {
+            let mut pipeline =
+                hew_mir::lower_hir_module_with_facts(module, mir_pointer_width(target));
+            pipeline.attach_lowering_facts(tco);
+            Ok((pipeline, None))
+        }
+        compile::SirMode::Shadow => {
+            let mut pipeline =
+                hew_mir::lower_hir_module_with_facts(module, mir_pointer_width(target));
+            pipeline.attach_lowering_facts(tco);
+            let sir = lower_verified_hir_to_sir(module)?;
+            let mut candidate = pipeline.clone();
+            let bridge = hew_mir::apply_sir_to_pipeline(&sir.module, &mut candidate);
+            if bridge.lowered_count() > 0 {
+                if let Err(error) = hew_codegen_rs::validate_codegen_front_for_triple(
+                    &candidate,
+                    target.normalized_triple(),
+                ) {
+                    eprintln!("SIR shadow candidate backend-front validation failed: {error}");
+                    return Err(());
+                }
+            }
+            Ok((
+                pipeline,
+                Some(SirLaneReport {
+                    sir,
+                    realization: SirLaneRealization::Shadow(bridge),
+                }),
+            ))
+        }
+        compile::SirMode::Lower => {
+            let sir = lower_verified_hir_to_sir(module)?;
+            let entry = sir.module.entry_callable.ok_or_else(|| {
+                eprintln!(
+                    "SIR strict lowering requires a root-unit scalar `main` with a resolved callable"
+                );
+            })?;
+            let component =
+                hew_mir::lower_closed_scalar_component(&sir.module, &[entry]).map_err(|error| {
+                    eprintln!("SIR strict lowering failed: {error}");
+                    report_strict_sir_missing_body(module, &sir, error.missing_body);
+                })?;
+            let callables = component.callables().to_vec();
+            let pipeline = component.into_pipeline();
+            if let Err(error) = hew_codegen_rs::validate_codegen_front_for_triple(
+                &pipeline,
+                target.normalized_triple(),
+            ) {
+                eprintln!("SIR strict backend-front validation failed: {error}");
+                return Err(());
+            }
+            Ok((
+                pipeline,
+                Some(SirLaneReport {
+                    sir,
+                    realization: SirLaneRealization::Strict { callables },
+                }),
+            ))
+        }
     }
+}
 
+/// Explain a strict closed-component refusal using the authoritative HIR→SIR
+/// lowering status when the component reached a callable without a SIR body.
+///
+/// The resolved [`hew_sir::CallableId`] comes from the component lowerer, not
+/// its display text. This keeps the diagnostic useful for both an unsupported
+/// entry body and an unsupported direct callee while making the no-fallback
+/// policy explicit at the driver boundary.
+fn report_strict_sir_missing_body(
+    module: &hew_hir::HirModule,
+    sir: &hew_sir::LoweredModule,
+    missing_body: Option<hew_sir::CallableId>,
+) {
+    let Some(missing_body) = missing_body else {
+        return;
+    };
+    let Some(callable) = sir.module.callable(missing_body) else {
+        return;
+    };
+    let reason = module
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            hew_hir::HirItem::Function(function) => Some(function),
+            _ => None,
+        })
+        .zip(&sir.statuses)
+        .find_map(|(function, (_, status))| {
+            if function.id != callable.function {
+                return None;
+            }
+            match status {
+                hew_sir::SirLoweringStatus::Lowered => None,
+                hew_sir::SirLoweringStatus::Unsupported { reason } => Some(reason.as_str()),
+            }
+        });
+    match reason {
+        Some(reason) => eprintln!(
+            "SIR strict lowering: `{}` is outside the current semantic surface: {reason}; no legacy MIR fallback was used",
+            callable.symbol
+        ),
+        None => eprintln!(
+            "SIR strict lowering: `{}` has no SIR body; no legacy MIR fallback was used",
+            callable.symbol
+        ),
+    }
+}
+
+fn lower_verified_hir_to_sir(module: &hew_hir::HirModule) -> Result<hew_sir::LoweredModule, ()> {
     let sir = hew_sir::lower_module(module);
     let diagnostics = hew_sir::verify_module(&sir.module);
     if !diagnostics.is_empty() {
@@ -298,34 +414,7 @@ fn lower_verified_hir_to_pipeline(
         }
         return Err(());
     }
-
-    let mut candidate = pipeline.clone();
-    let bridge = hew_mir::apply_sir_to_pipeline(&sir.module, &mut candidate);
-    if bridge.lowered_count() > 0 {
-        if let Err(error) = hew_codegen_rs::validate_codegen_front_for_triple(
-            &candidate,
-            target.normalized_triple(),
-        ) {
-            eprintln!("SIR candidate backend-front validation failed: {error}");
-            return Err(());
-        }
-    }
-    if sir_mode == compile::SirMode::Lower {
-        pipeline = candidate;
-    }
-    Ok((pipeline, Some(SirLaneReport { sir, bridge })))
-}
-
-fn lower_file_to_mir(
-    input_path: &Path,
-    requested_target: Option<&str>,
-) -> Result<hew_mir::IrPipeline, ()> {
-    lower_file_to_mir_with_options(
-        input_path,
-        requested_target,
-        &compile::CompileOptions::default(),
-    )
-    .map(|(pipeline, _sir)| pipeline)
+    Ok(sir)
 }
 
 /// File frontend plus verified HIR, shared by SIR inspection and every
@@ -482,12 +571,15 @@ fn lower_file_to_mir_for_target(
     options: &compile::CompileOptions,
 ) -> Result<(hew_mir::IrPipeline, Vec<std::path::PathBuf>), ()> {
     let verified = lower_file_to_verified_hir(input_path, target, options)?;
-    let (pipeline, _sir_report) = lower_verified_hir_to_pipeline(
+    let (pipeline, sir_report) = lower_verified_hir_to_pipeline(
         &verified.lower_output.module,
         verified.typecheck_output(),
         target,
         options.sir_mode,
     )?;
+    if let Some(report) = sir_report.as_ref() {
+        report_sir_lane(report, options.sir_mode);
+    }
     if render_pipeline_mir_diagnostics(
         &verified.state.program,
         &verified.state.source,
@@ -802,8 +894,15 @@ fn link_native_object_with_hew_lib_and_extra(
         })
 }
 
-pub(crate) fn compile_native_binary(input: &Path, bin_path: &Path) -> Result<(), ()> {
-    let pipeline = lower_file_to_mir(input, None)?;
+pub(crate) fn compile_native_binary(
+    input: &Path,
+    bin_path: &Path,
+    options: &compile::CompileOptions,
+) -> Result<(), ()> {
+    let (pipeline, sir_report) = lower_file_to_mir_with_options(input, None, options)?;
+    if let Some(report) = sir_report.as_ref() {
+        report_sir_lane(report, options.sir_mode);
+    }
     let emit_dir = bin_path.parent().unwrap_or_else(|| Path::new("."));
     let module_name = bin_path
         .file_stem()
@@ -915,8 +1014,11 @@ pub(crate) fn compile_native_from_program_with_paths(
         return Err(());
     }
 
-    let (pipeline, _sir_report) =
+    let (pipeline, sir_report) =
         lower_verified_hir_to_pipeline(&lower_output.module, &tco, &target, options.sir_mode)?;
+    if let Some(report) = sir_report.as_ref() {
+        report_sir_lane(report, options.sir_mode);
+    }
     if render_pipeline_mir_diagnostics(
         &state.program,
         &state.source,
@@ -1395,13 +1497,7 @@ fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
     if a.dump_sir {
         return cmd_dump_sir(a, json);
     }
-    let sir_mode = if a.sir_lower {
-        compile::SirMode::Lower
-    } else if a.sir_shadow {
-        compile::SirMode::Shadow
-    } else {
-        compile::SirMode::Disabled
-    };
+    let sir_mode = a.sir.mode();
     let options = compile::CompileOptions {
         sir_mode,
         ..compile::CompileOptions::default()
@@ -1522,17 +1618,9 @@ fn report_sir_lane(report: &SirLaneReport, mode: compile::SirMode) {
         .iter()
         .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::Lowered))
         .count();
-    let mode_label = match mode {
-        compile::SirMode::Disabled => return,
-        compile::SirMode::Shadow => "shadow",
-        compile::SirMode::Lower => "lower",
-    };
-    eprintln!(
-        "SIR {mode_label}: verified {sir_lowered}/{} HIR function bodies; realized {}/{} through raw MIR",
-        report.sir.statuses.len(),
-        report.bridge.lowered_count(),
-        report.sir.module.functions.len(),
-    );
+    if mode == compile::SirMode::Disabled {
+        return;
+    }
     let hir_fallbacks: Vec<_> = report
         .sir
         .statuses
@@ -1542,17 +1630,39 @@ fn report_sir_lane(report: &SirLaneReport, mode: compile::SirMode) {
             hew_sir::SirLoweringStatus::Lowered => None,
         })
         .collect();
-    let raw_fallbacks: Vec<_> = report
-        .bridge
-        .statuses
-        .iter()
-        .filter_map(|(name, status)| match status {
-            hew_mir::SirMirLoweringStatus::Unsupported { reason } => Some((name, reason)),
-            hew_mir::SirMirLoweringStatus::Lowered => None,
-        })
-        .collect();
-    report_sir_fallbacks("HIR", &hir_fallbacks);
-    report_sir_fallbacks("raw-MIR", &raw_fallbacks);
+    match &report.realization {
+        SirLaneRealization::Shadow(bridge) => {
+            eprintln!(
+                "SIR shadow: verified {sir_lowered}/{} HIR function bodies; realized {}/{} through raw MIR",
+                report.sir.statuses.len(),
+                bridge.lowered_count(),
+                report.sir.module.functions.len(),
+            );
+            let raw_fallbacks: Vec<_> = bridge
+                .statuses
+                .iter()
+                .filter_map(|(name, status)| match status {
+                    hew_mir::SirMirLoweringStatus::Unsupported { reason } => Some((name, reason)),
+                    hew_mir::SirMirLoweringStatus::Lowered => None,
+                })
+                .collect();
+            report_sir_fallbacks("HIR", &hir_fallbacks);
+            report_sir_fallbacks("raw-MIR", &raw_fallbacks);
+        }
+        SirLaneRealization::Strict { callables } => {
+            eprintln!(
+                "SIR lower: selected {} verified callable(s) from {sir_lowered}/{} HIR function bodies; no legacy MIR bodies were lowered",
+                callables.len(),
+                report.sir.statuses.len(),
+            );
+            if !hir_fallbacks.is_empty() {
+                eprintln!(
+                    "SIR lower: {} unrelated HIR bodies remain outside the current semantic surface; they were not compiled or used as fallbacks",
+                    hir_fallbacks.len()
+                );
+            }
+        }
+    }
 }
 
 fn report_sir_inspection(sir: &hew_sir::LoweredModule) {

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -184,7 +184,8 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::args::{
-        CompileArgs, CompletionsArgs, ShellChoice, WireCheckArgs, WireCommand, WireSubcommand,
+        CompileArgs, CompletionsArgs, ShellChoice, SirModeArgs, WireCheckArgs, WireCommand,
+        WireSubcommand,
     };
 
     use super::{
@@ -299,8 +300,7 @@ mod tests {
             emit_dir: None,
             emit_llvm: false,
             dump_mir: None,
-            sir_shadow: false,
-            sir_lower: false,
+            sir: SirModeArgs::default(),
             dump_sir: false,
             target: None,
             opt_level: "0".to_string(),
@@ -326,6 +326,7 @@ mod tests {
             opt_level: "0".to_string(),
             link_libs: Vec::new(),
             common: crate::args::CommonBuildArgs::default(),
+            sir: SirModeArgs::default(),
             format: crate::args::DiagnosticFormat::Text,
         });
         let mut dispatcher = RecordingDispatcher::default();

--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -210,11 +210,7 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
             compile_paths: &compile_paths,
             timeout,
             jobs: requested_jobs(args.jobs),
-            sir_mode: if args.sir_shadow {
-                crate::compile::SirMode::Shadow
-            } else {
-                crate::compile::SirMode::Disabled
-            },
+            sir_mode: args.sir.mode(),
         },
     );
     output::output_results(&summary, use_color, format);

--- a/hew-cli/src/watch.rs
+++ b/hew-cli/src/watch.rs
@@ -355,7 +355,7 @@ fn emit_check_start(check_target: &str, palette: &WatchPalette) {
 
 fn run_check_and_program(
     check_target: &str,
-    _options: &compile::CompileOptions,
+    options: &compile::CompileOptions,
     palette: &WatchPalette,
     start: Instant,
 ) {
@@ -363,7 +363,8 @@ fn run_check_and_program(
         return;
     };
 
-    let result = crate::compile_native_binary(Path::new(check_target), Path::new(&tmp_bin));
+    let result =
+        crate::compile_native_binary(Path::new(check_target), Path::new(&tmp_bin), options);
     let elapsed = start.elapsed();
 
     match result {

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -362,6 +362,60 @@ fn eval_inline_expression_succeeds() {
     assert_eq!(String::from_utf8_lossy(&output.stdout), "3\n");
 }
 
+/// Strict SIR mode must reach the strict lowering boundary for eval fragments
+/// rather than silently compiling the established HIR→MIR body. The generated
+/// auto-print call is deliberately outside the first direct-call SIR slice, so
+/// the command must fail before codegen with that exact no-fallback policy.
+#[test]
+fn eval_sir_lower_rejects_an_unadmitted_fragment_without_legacy_fallback() {
+    let output = Command::new(hew_binary())
+        .args(["eval", "--sir-lower", "1 + 2"])
+        .current_dir(repo_root())
+        .output()
+        .expect("run hew eval --sir-lower");
+
+    assert!(
+        !output.status.success(),
+        "strict SIR eval should reject its unsupported generated print call"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "strict SIR eval must not fall back and print the legacy result: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SIR strict lowering failed"),
+        "stderr should identify strict SIR lowering: {stderr}"
+    );
+    assert!(
+        stderr.contains("only ordinary user/impl direct calls"),
+        "stderr should surface the HIR→SIR rejection reason: {stderr}"
+    );
+    assert!(
+        stderr.contains("no legacy MIR fallback was used"),
+        "stderr should make the no-fallback policy explicit: {stderr}"
+    );
+}
+
+/// Shadow mode remains an observable differential oracle while the strict
+/// lane grows. Eval must report what it checked instead of silently using the
+/// established emitted pipeline.
+#[test]
+fn eval_sir_shadow_reports_candidate_coverage() {
+    let output = Command::new(hew_binary())
+        .args(["eval", "--sir-shadow", "1 + 2"])
+        .current_dir(repo_root())
+        .output()
+        .expect("run hew eval --sir-shadow");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SIR shadow: verified"),
+        "eval shadow mode must report its candidate coverage: {stderr}"
+    );
+}
+
 #[test]
 fn eval_std_observe_reads_runtime_metric() {
     require_codegen();

--- a/hew-cli/tests/sir_shadow_e2e.rs
+++ b/hew-cli/tests/sir_shadow_e2e.rs
@@ -1,9 +1,9 @@
 //! End-to-end contracts for the experimental Semantic IR lane.
 //!
-//! `--sir-shadow` must exercise and verify the SIR → raw-MIR candidate while
-//! leaving the established raw-MIR dump byte-for-byte authoritative.  Once a
-//! function is eligible, `--sir-lower` must select that same candidate rather
-//! than merely reporting that it was constructed.
+//! `--sir-shadow` must exercise and verify the temporary SIR → raw-MIR
+//! candidate while leaving the established raw-MIR dump byte-for-byte
+//! authoritative. `--sir-lower` is intentionally stronger: it must compile a
+//! closed SIR call graph without constructing legacy function bodies.
 
 mod support;
 
@@ -27,14 +27,21 @@ fn sir_scalar_diamond(x: i64) -> i64 {
 }
 ";
 
-const EXECUTABLE_SCALAR: &str = r"
-fn sir_selected_add(x: i64, y: i64) -> i64 {
-    x + y
+const CLOSED_DIRECT_CALLS: &str = r"
+fn main() -> i64 {
+    if twice(40) == 42 {
+        0
+    } else {
+        1
+    }
 }
 
-fn main() -> i64 {
-    println(sir_selected_add(19, 23));
-    0
+fn twice(value: i64) -> i64 {
+    increment(increment(value))
+}
+
+fn increment(value: i64) -> i64 {
+    value + 1
 }
 ";
 
@@ -70,7 +77,47 @@ fn sir_or_value(flag: bool) -> i64 {
 }
 
 fn main() -> i64 {
-    println(sir_and_value(false) + sir_and_value(true) + sir_or_value(false) + sir_or_value(true));
+    let total = sir_and_value(false) + sir_and_value(true) + sir_or_value(false) + sir_or_value(true);
+    if total == 1 { 0 } else { 1 }
+}
+";
+
+const REACHABLE_UNSUPPORTED_CALL: &str = r"
+fn main() -> i64 {
+    effectful()
+}
+
+fn effectful() -> i64 {
+    println(42);
+    0
+}
+";
+
+const RECURSIVE_DIRECT_CALLS: &str = r"
+fn main() -> i64 {
+    countdown(5)
+}
+
+fn countdown(value: i64) -> i64 {
+    if value == 0 {
+        0
+    } else {
+        countdown(value - 1)
+    }
+}
+";
+
+const UNREACHABLE_UNSUPPORTED_BODY: &str = r"
+fn main() -> i64 {
+    selected()
+}
+
+fn selected() -> i64 {
+    0
+}
+
+fn unrelated_effectful() -> i64 {
+    println(42);
     0
 }
 ";
@@ -161,13 +208,14 @@ fn sir_shadow_keeps_established_raw_mir_authoritative() {
     );
 }
 
-/// Lower mode selects the verified candidate for the supported scalar
-/// value/CFG subset.  Both straight-line arithmetic and a branch/join must be
-/// value-oriented (no legacy `stmt: use` markers); checked arithmetic retains
-/// its required raw-MIR trap CFG.
+/// Lower mode owns a closed direct-call graph. It must construct fresh bodies
+/// for `main`, `twice`, and `increment` from SIR, preserve call continuations
+/// and checked arithmetic, and omit every legacy HIR-use statement.
 #[test]
-fn sir_lower_selects_value_and_cfg_lowering() {
-    let (_dir, source) = scalar_fixture();
+fn sir_lower_owns_a_closed_direct_call_graph() {
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_closed_direct_calls.hew");
+    fs::write(&source, CLOSED_DIRECT_CALLS).expect("write strict SIR fixture");
     let baseline = raw_mir_dump(&source, None);
     let lowered = raw_mir_dump(&source, Some("--sir-lower"));
 
@@ -176,11 +224,11 @@ fn sir_lower_selects_value_and_cfg_lowering() {
 
     let baseline_dump = String::from_utf8_lossy(&baseline.stdout);
     let lowered_dump = String::from_utf8_lossy(&lowered.stdout);
-    let baseline_fn = function_section(&baseline_dump, "sir_scalar_add");
-    let lowered_fn = function_section(&lowered_dump, "sir_scalar_add");
+    let baseline_fn = function_section(&baseline_dump, "increment");
+    let lowered_fn = function_section(&lowered_dump, "increment");
     assert_ne!(
         baseline_fn, lowered_fn,
-        "--sir-lower must select the SIR candidate instead of only constructing it",
+        "--sir-lower must replace legacy body lowering instead of only constructing SIR",
     );
     assert!(
         !lowered_fn.contains("stmt: use"),
@@ -198,8 +246,8 @@ fn sir_lower_selects_value_and_cfg_lowering() {
         lowered_fn.contains("trap(IntegerOverflow)"),
         "SIR arithmetic overflow must preserve raw-MIR trap semantics:\n{lowered_fn}",
     );
-    let baseline_diamond = function_section(&baseline_dump, "sir_scalar_diamond");
-    let lowered_diamond = function_section(&lowered_dump, "sir_scalar_diamond");
+    let baseline_diamond = function_section(&baseline_dump, "main");
+    let lowered_diamond = function_section(&lowered_dump, "main");
     assert_ne!(
         baseline_diamond, lowered_diamond,
         "--sir-lower must select SIR block arguments for an ordinary scalar if/join",
@@ -212,32 +260,34 @@ fn sir_lower_selects_value_and_cfg_lowering() {
         lowered_diamond.contains("branch "),
         "the source if must remain explicit CFG in SIR realization:\n{lowered_diamond}",
     );
+    assert!(
+        lowered_diamond.contains("call twice"),
+        "the SIR caller must legalize its direct call as raw-MIR Call:\n{lowered_diamond}",
+    );
+    let lowered_twice = function_section(&lowered_dump, "twice");
+    assert!(
+        lowered_twice.matches("call increment").count() == 2,
+        "nested direct SIR calls must stay explicit through raw MIR:\n{lowered_twice}",
+    );
 
     let stderr = String::from_utf8_lossy(&lowered.stderr);
     assert!(
-        stderr.contains("SIR lower: verified"),
-        "lower run must report its verified SIR lane:\n{}",
-        describe_output(&lowered),
-    );
-    assert!(
-        !stderr.contains("realized 0/"),
-        "the eligible scalar arithmetic function must be selected from SIR:\n{}",
+        stderr.contains("SIR lower: selected 3 verified callable(s)")
+            && stderr.contains("no legacy MIR bodies were lowered"),
+        "lower run must report a closed strict SIR lane:\n{}",
         describe_output(&lowered),
     );
 }
 
-/// A selected SIR callee must survive all remaining established pipeline
-/// stages and execute with the same observable result. The caller stays on
-/// the legacy path because call realization is intentionally not part of this
-/// first adapter slice; that mixed module is the intended incremental-cutover
-/// topology.
+/// A strict SIR-only call component must survive raw/checked MIR, LLVM, link,
+/// and execution without a legacy caller or callee body.
 #[test]
-fn sir_lower_selected_scalar_callee_compiles_and_runs() {
+fn sir_lower_closed_direct_call_graph_compiles_and_runs() {
     require_codegen();
 
     let dir = support::tempdir();
     let source = dir.path().join("sir_lower_execution.hew");
-    fs::write(&source, EXECUTABLE_SCALAR).expect("write executable SIR fixture");
+    fs::write(&source, CLOSED_DIRECT_CALLS).expect("write executable SIR fixture");
 
     let mut compile = Command::new(hew_binary());
     compile
@@ -247,15 +297,16 @@ fn sir_lower_selected_scalar_callee_compiles_and_runs() {
         .arg(dir.path())
         .arg(&source)
         .current_dir(repo_root());
-    let compiled = support::run_bounded_command(compile, "compile selected SIR scalar callee");
+    let compiled = support::run_bounded_command(compile, "compile strict SIR direct-call graph");
     assert_success(
         &compiled,
-        "SIR-lowered scalar callee must compile through the established backend",
+        "strict SIR direct-call graph must compile through the established backend",
     );
     let compile_stderr = String::from_utf8_lossy(&compiled.stderr);
     assert!(
-        compile_stderr.contains("SIR lower: verified") && !compile_stderr.contains("realized 0/"),
-        "compile must select at least one SIR body:\n{}",
+        compile_stderr.contains("SIR lower: selected 3 verified callable(s)")
+            && compile_stderr.contains("no legacy MIR bodies were lowered"),
+        "compile must select the complete direct SIR graph:\n{}",
         describe_output(&compiled),
     );
 
@@ -268,17 +319,231 @@ fn sir_lower_selected_scalar_callee_compiles_and_runs() {
     );
     let executed = support::run_bounded_command(
         Command::new(&binary),
-        format!("run selected SIR scalar callee {}", binary.display()),
+        format!("run strict SIR direct-call graph {}", binary.display()),
     );
     assert_success(
         &executed,
-        "native binary containing SIR-lowered callee must run successfully",
+        "native binary containing only SIR-lowered bodies must run successfully",
+    );
+}
+
+/// Shadow intentionally cannot realize direct calls through its legacy raw-MIR
+/// template, so strict direct-call behavior is compared directly with the
+/// established compiler rather than inferred from a shadow success. This is
+/// temporary migration evidence: once SIR becomes the normal path, the legacy
+/// half of this comparison is deleted with its body lowerer.
+#[test]
+fn sir_lower_matches_established_execution_for_closed_direct_call_graph() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_direct_call_parity.hew");
+    let established_dir = dir.path().join("established");
+    let strict_dir = dir.path().join("strict");
+    fs::create_dir(&established_dir).expect("create established emit directory");
+    fs::create_dir(&strict_dir).expect("create strict emit directory");
+    fs::write(&source, CLOSED_DIRECT_CALLS).expect("write direct-call parity fixture");
+
+    let mut established_compile = Command::new(hew_binary());
+    established_compile
+        .arg("compile")
+        .arg("--emit-dir")
+        .arg(&established_dir)
+        .arg(&source)
+        .current_dir(repo_root());
+    let established_compiled = support::run_bounded_command(
+        established_compile,
+        "compile established direct-call parity graph",
+    );
+    assert_success(
+        &established_compiled,
+        "established direct-call graph must compile for parity",
+    );
+
+    let mut strict_compile = Command::new(hew_binary());
+    strict_compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--emit-dir")
+        .arg(&strict_dir)
+        .arg(&source)
+        .current_dir(repo_root());
+    let strict_compiled = support::run_bounded_command(
+        strict_compile,
+        "compile strict SIR direct-call parity graph",
+    );
+    assert_success(
+        &strict_compiled,
+        "strict SIR direct-call graph must compile for parity",
+    );
+
+    let established_binary =
+        hew_testutil::compiled_binary_path(&established_dir, "sir_direct_call_parity");
+    let strict_binary = hew_testutil::compiled_binary_path(&strict_dir, "sir_direct_call_parity");
+    let established = support::run_bounded_command(
+        Command::new(&established_binary),
+        format!(
+            "run established direct-call parity graph {}",
+            established_binary.display()
+        ),
+    );
+    let strict = support::run_bounded_command(
+        Command::new(&strict_binary),
+        format!(
+            "run strict direct-call parity graph {}",
+            strict_binary.display()
+        ),
+    );
+
+    assert_eq!(
+        strict.status.code(),
+        established.status.code(),
+        "strict and established direct-call graphs must have the same exit status\nstrict:\n{}\nestablished:\n{}",
+        describe_output(&strict),
+        describe_output(&established),
     );
     assert_eq!(
-        String::from_utf8_lossy(&executed.stdout),
-        "42\n",
-        "SIR-lowered scalar callee returned an unexpected result:\n{}",
-        describe_output(&executed),
+        strict.stdout,
+        established.stdout,
+        "strict and established direct-call graphs must have the same stdout\nstrict:\n{}\nestablished:\n{}",
+        describe_output(&strict),
+        describe_output(&established),
+    );
+}
+
+/// A closed SIR component may contain cycles.  The strict driver must select
+/// the recursive callable once, preserve its direct raw-MIR edge, and let the
+/// existing backend predeclare the cycle without falling back to HIR bodies.
+#[test]
+fn sir_lower_recursive_direct_call_graph_compiles_and_runs() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_recursive_execution.hew");
+    fs::write(&source, RECURSIVE_DIRECT_CALLS).expect("write recursive SIR fixture");
+
+    let lowered = raw_mir_dump(&source, Some("--sir-lower"));
+    assert_success(&lowered, "strict SIR recursive raw MIR dump must succeed");
+    let lowered_dump = String::from_utf8_lossy(&lowered.stdout);
+    let countdown = function_section(&lowered_dump, "countdown");
+    assert!(
+        countdown.contains("call countdown"),
+        "the recursive SIR edge must remain an explicit raw-MIR call:\n{countdown}",
+    );
+    assert!(
+        !countdown.contains("stmt: use"),
+        "the recursive caller must not be a legacy HIR-derived body:\n{countdown}",
+    );
+
+    let mut compile = Command::new(hew_binary());
+    compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--emit-dir")
+        .arg(dir.path())
+        .arg(&source)
+        .current_dir(repo_root());
+    let compiled = support::run_bounded_command(compile, "compile strict recursive SIR graph");
+    assert_success(
+        &compiled,
+        "strict SIR recursive graph must compile through the existing backend",
+    );
+    assert!(
+        String::from_utf8_lossy(&compiled.stderr)
+            .contains("SIR lower: selected 2 verified callable(s)"),
+        "strict recursion must select one closed two-callable component:\n{}",
+        describe_output(&compiled),
+    );
+
+    let binary = hew_testutil::compiled_binary_path(dir.path(), "sir_recursive_execution");
+    let executed = support::run_bounded_command(
+        Command::new(&binary),
+        format!("run strict recursive SIR graph {}", binary.display()),
+    );
+    assert_success(
+        &executed,
+        "native binary containing recursive SIR-only bodies must run successfully",
+    );
+}
+
+/// Strict selection is closed over calls from `main`, not over every HIR body
+/// in a source file.  An unsupported body outside that graph must neither
+/// force a fallback nor leak into the emitted component.
+#[test]
+fn sir_lower_excludes_unreachable_unsupported_hir_bodies() {
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_unreachable_unsupported.hew");
+    fs::write(&source, UNREACHABLE_UNSUPPORTED_BODY)
+        .expect("write unreachable unsupported SIR fixture");
+
+    let output = raw_mir_dump(&source, Some("--sir-lower"));
+    assert_success(
+        &output,
+        "an unrelated unsupported HIR body must not block strict SIR lowering",
+    );
+    let dump = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        dump.contains("fn main(") && dump.contains("fn selected("),
+        "the closed entry component must contain its selected bodies:\n{dump}",
+    );
+    assert!(
+        !dump.contains("fn unrelated_effectful("),
+        "strict SIR must not emit an unrelated legacy or unsupported body:\n{dump}",
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unrelated HIR bodies remain outside the current semantic surface")
+            && stderr.contains("were not compiled or used as fallbacks"),
+        "strict SIR must describe the excluded HIR body rather than silently using it:\n{}",
+        describe_output(&output),
+    );
+}
+
+/// Target selection must happen after strict SIR owns the body graph.  LLVM
+/// emission for WASM is a lightweight target-front proof that no native-only
+/// facts leaked into the SIR component or its MIR realization.
+#[test]
+fn sir_lower_closed_graph_emits_wasm_llvm() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_wasm_frontend.hew");
+    let emit_dir = dir.path().join("emit");
+    fs::create_dir(&emit_dir).expect("create strict SIR WASM emit directory");
+    fs::write(&source, CLOSED_DIRECT_CALLS).expect("write strict SIR WASM fixture");
+
+    let mut compile = Command::new(hew_binary());
+    compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .arg("--emit-llvm")
+        .arg("--emit-dir")
+        .arg(&emit_dir)
+        .arg(&source)
+        .current_dir(repo_root());
+    let compiled = support::run_bounded_command(compile, "emit strict SIR WASM LLVM");
+    assert_success(
+        &compiled,
+        "strict SIR closed graph must reach the WASM LLVM frontend",
+    );
+    assert!(
+        String::from_utf8_lossy(&compiled.stderr)
+            .contains("SIR lower: selected 3 verified callable(s)"),
+        "WASM frontend must receive the strict SIR component:\n{}",
+        describe_output(&compiled),
+    );
+
+    let llvm = fs::read_to_string(emit_dir.join("sir_wasm_frontend.ll"))
+        .expect("strict SIR WASM LLVM emission must produce an .ll artifact");
+    assert!(
+        llvm.contains("target triple = \"wasm32-unknown-unknown\""),
+        "strict SIR LLVM must retain the requested WASM target:\n{llvm}",
+    );
+    assert!(
+        llvm.contains("@main(") && llvm.contains("@twice(") && llvm.contains("@increment("),
+        "the WASM frontend must receive definitions for the complete strict SIR component:\n{llvm}",
     );
 }
 
@@ -334,9 +599,9 @@ fn sir_dump_preserves_short_circuit_control_flow() {
     );
 }
 
-/// Selected SIR CFG lowering must preserve both truth-table sides of `&&` and
-/// `||` through raw MIR, LLVM, and a native executable. The calling `main`
-/// remains temporary legacy scaffolding until the direct-call SIR cutover.
+/// Strict SIR lowering must preserve both truth-table sides of `&&` and `||`
+/// through raw MIR, LLVM, and a native executable, including the direct calls
+/// from the SIR-owned `main` body.
 #[test]
 fn sir_lower_short_circuit_truth_table_compiles_and_runs() {
     require_codegen();
@@ -353,15 +618,15 @@ fn sir_lower_short_circuit_truth_table_compiles_and_runs() {
         .arg(dir.path())
         .arg(&source)
         .current_dir(repo_root());
-    let compiled = support::run_bounded_command(compile, "compile selected SIR short-circuit CFG");
+    let compiled = support::run_bounded_command(compile, "compile strict SIR short-circuit CFG");
     assert_success(
         &compiled,
-        "SIR-lowered short-circuit functions must compile through the backend",
+        "strict SIR short-circuit call graph must compile through the backend",
     );
     let compile_stderr = String::from_utf8_lossy(&compiled.stderr);
     assert!(
-        compile_stderr.contains("SIR lower: verified") && !compile_stderr.contains("realized 0/"),
-        "compile must select the short-circuit SIR functions:\n{}",
+        compile_stderr.contains("no legacy MIR bodies were lowered"),
+        "compile must select the strict short-circuit SIR graph:\n{}",
         describe_output(&compiled),
     );
 
@@ -372,12 +637,44 @@ fn sir_lower_short_circuit_truth_table_compiles_and_runs() {
     );
     assert_success(
         &executed,
-        "native binary containing SIR-lowered short-circuit functions must run",
+        "native binary containing strict SIR short-circuit functions must run",
     );
-    assert_eq!(
-        String::from_utf8_lossy(&executed.stdout),
-        "1\n",
-        "SIR short-circuit truth table produced an unexpected result:\n{}",
-        describe_output(&executed),
+}
+
+/// Strict selection is a hard boundary: a reachable callable that has no
+/// supported SIR body must fail rather than re-entering HIR→MIR lowering.
+#[test]
+fn sir_lower_rejects_reachable_unsupported_call_without_fallback() {
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_reachable_unsupported.hew");
+    fs::write(&source, REACHABLE_UNSUPPORTED_CALL).expect("write unsupported strict SIR fixture");
+
+    let mut command = Command::new(hew_binary());
+    command
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--dump-mir")
+        .arg("raw")
+        .arg(&source)
+        .current_dir(repo_root());
+    let output = support::run_bounded_command(command, "reject unsupported strict SIR call");
+
+    assert!(
+        !output.status.success(),
+        "strict SIR lowering must fail instead of falling back:\n{}",
+        describe_output(&output),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SIR strict lowering failed")
+            && stderr.contains("requires one lowered body for `effectful`")
+            && stderr.contains("main → effectful"),
+        "failure must identify the closed SIR call-graph boundary:\n{}",
+        describe_output(&output),
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "strict failure must not emit a legacy raw-MIR dump:\n{}",
+        describe_output(&output),
     );
 }

--- a/hew-cli/tests/test_runner_e2e.rs
+++ b/hew-cli/tests/test_runner_e2e.rs
@@ -3,7 +3,7 @@ mod support;
 use std::fmt::Write as _;
 use std::path::Path;
 use std::process::Command;
-use support::{hew_binary, require_codegen, run_hew_in};
+use support::{hew_binary, repo_root, require_codegen, run_hew_in};
 
 fn write_file(root: &Path, relative_path: &str, contents: &str) {
     let path = root.join(relative_path);
@@ -102,6 +102,46 @@ fn passing_suite_exits_zero() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("test passes ... ok"));
     assert!(stdout.contains("1 passed; 0 failed; 0 ignored"));
+}
+
+/// The test runner synthesizes a unit-returning `main` which calls the
+/// discovered test.  This therefore exercises a closed strict SIR component
+/// containing two zero-result direct calls: `main -> unit_test -> helper`.
+/// A successful executable run proves the flag reaches the in-process test
+/// compiler and that SIR realizes those calls rather than merely parsing the
+/// test input.
+#[test]
+fn sir_lower_runs_unit_returning_direct_test_wrapper() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    write_file(
+        dir.path(),
+        "sir_unit_test.hew",
+        "fn helper() {}\n\n#[test]\nfn unit_test() {\n    helper();\n}\n",
+    );
+    let mut command = Command::new(hew_binary());
+    command
+        .args(["test", ".", "--sir-lower", "--no-color", "--jobs", "1"])
+        // Integration builds may place the compiler in an SSD target directory
+        // outside the checkout, where its dev-layout stdlib discovery cannot
+        // infer this source tree from a temporary test project.
+        .env("HEW_STD", repo_root().join("std"))
+        .current_dir(dir.path());
+    let output = support::run_bounded_command(command, "run strict SIR unit test wrapper");
+
+    assert!(
+        output.status.success(),
+        "strict SIR test wrapper must compile and execute successfully:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test unit_test ... ok"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("1 passed; 0 failed; 0 ignored"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -89,7 +89,7 @@ pub use ownership::{
 };
 pub use runtime_symbols::UnknownRuntimeSymbol;
 pub use sir::{
-    apply_sir_to_pipeline, lower_sir_function, SirMirLowered, SirMirLoweringError,
+    apply_sir_to_pipeline, lower_closed_scalar_component, SirMirComponent, SirMirLoweringError,
     SirMirLoweringReport, SirMirLoweringStatus,
 };
 pub use state_clone::{

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -9,10 +9,12 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use hew_hir::{IntentKind, SiteId, ValueClass};
 use hew_parser::ast::{BinaryOp, UnaryOp};
 use hew_sir::{
-    BlockArg, BlockId, Edge, FunctionSourceOrigin, Operand, SemBlock, SemFunction, SemModule,
-    SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+    BlockArg, BlockId, CallableId, Edge, FunctionSourceOrigin, Operand, SemBlock, SemCallConv,
+    SemCallable, SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind, SemParamPassing,
+    SemTerminator, UseMode, ValueDef, ValueId,
 };
 #[cfg(test)]
 use hew_types::DefId;
@@ -20,7 +22,8 @@ use hew_types::ResolvedTy;
 
 use crate::{
     dataflow, BasicBlock, CheckedMirFunction, FunctionCallConv, Instr, IntArithOp, IntSignedness,
-    IrPipeline, ModuleCapabilities, Place, RawMirFunction, Strategy, Terminator, TrapKind,
+    IrPipeline, ModuleCapabilities, ParamBoundaryFact, ParamBoundaryMode, Place, RawMirFunction,
+    Strategy, Terminator, TrapKind,
 };
 
 /// The result of lowering one SIR function into the existing raw/checked MIR
@@ -28,9 +31,53 @@ use crate::{
 /// scalar, non-owning values, and the code generator deliberately accepts a
 /// missing elaborated entry as an empty drop-plan set.
 #[derive(Debug, Clone, PartialEq)]
-pub struct SirMirLowered {
-    pub raw: RawMirFunction,
-    pub checked: CheckedMirFunction,
+struct SirMirLowered {
+    raw: RawMirFunction,
+    checked: CheckedMirFunction,
+}
+
+/// A closed, self-contained scalar SIR call-graph realization.
+///
+/// Unlike the temporary shadow bridge, this component has no raw-MIR
+/// template input. SIR owns each callable's symbol, signature, and parameter
+/// ABI facts; this lowering independently creates both raw and checked MIR.
+/// A driver either installs the entire selected call graph or reports its
+/// unsupported boundary — it never silently mixes a SIR caller with a legacy
+/// body inside the selected closure.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SirMirComponent {
+    /// Callables included in deterministic SIR table order.
+    callables: Vec<CallableId>,
+    raw_mir: Vec<RawMirFunction>,
+    checked_mir: Vec<CheckedMirFunction>,
+}
+
+impl SirMirComponent {
+    /// The deterministic closed callable set realized by this component.
+    #[must_use]
+    pub fn callables(&self) -> &[CallableId] {
+        &self.callables
+    }
+
+    /// Build the body portion of a fresh MIR pipeline from SIR-owned facts.
+    ///
+    /// This deliberately starts with `IrPipeline::default()` rather than a
+    /// legacy HIR→MIR pipeline. The admitted scalar direct-call domain has no
+    /// declaration layouts, runtime authorities, or ownership facts; later
+    /// SIR domains will receive a bodyless declaration-header input instead.
+    #[must_use]
+    pub fn into_pipeline(self) -> IrPipeline {
+        let mut pipeline = IrPipeline {
+            raw_mir: self.raw_mir,
+            checked_mir: self.checked_mir,
+            ..IrPipeline::default()
+        };
+        pipeline.capabilities =
+            ModuleCapabilities::from_raw_mir(&pipeline.raw_mir, &pipeline.extern_decls);
+        pipeline.lint_warnings = crate::liveness::run_mir_lints(&pipeline.raw_mir);
+        pipeline.debug_assert_capabilities_current();
+        pipeline
+    }
 }
 
 /// A conservative refusal to lower a SIR function through the first
@@ -38,12 +85,25 @@ pub struct SirMirLowered {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SirMirLoweringError {
     pub reason: String,
+    /// Callable whose missing SIR body caused a strict closed-component
+    /// refusal, when the failure is specifically a HIR→SIR surface gap.
+    /// Driver diagnostics use this resolved identity to report the originating
+    /// SIR lowering reason without parsing display strings.
+    pub missing_body: Option<CallableId>,
 }
 
 impl SirMirLoweringError {
     fn unsupported(reason: impl Into<String>) -> Self {
         Self {
             reason: reason.into(),
+            missing_body: None,
+        }
+    }
+
+    fn missing_body(callable: CallableId, reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            missing_body: Some(callable),
         }
     }
 }
@@ -78,6 +138,877 @@ impl SirMirLoweringReport {
             .filter(|(_, status)| matches!(status, SirMirLoweringStatus::Lowered))
             .count()
     }
+}
+
+/// Lower a closed scalar direct-call component without consulting legacy MIR.
+///
+/// `roots` are resolved SIR callable identities, normally the HIR-established
+/// root-unit entry callable. Every direct call reachable from a root must have
+/// exactly one SIR body in the admitted scalar domain. This is intentionally
+/// all-or-nothing: the strict SIR lane must not hide a legacy body behind a
+/// SIR call edge.
+///
+/// # Errors
+///
+/// Returns a deterministic refusal when module verification fails or a
+/// reachable callable has no SIR body / falls outside the initial direct-call
+/// domain.
+pub fn lower_closed_scalar_component(
+    module: &SemModule,
+    roots: &[CallableId],
+) -> Result<SirMirComponent, SirMirLoweringError> {
+    if let Some(diagnostic) = hew_sir::verify_module(module).into_iter().next() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "SIR module verifier rejected the direct-call component: {:?}",
+            diagnostic.kind
+        )));
+    }
+    if roots.is_empty() {
+        return Err(SirMirLoweringError::unsupported(
+            "strict SIR lowering requires at least one resolved callable root",
+        ));
+    }
+
+    let mut selected = BTreeSet::new();
+    let mut pending = roots
+        .iter()
+        .copied()
+        .map(|root| (root, vec![root]))
+        .collect::<Vec<_>>();
+
+    while let Some((callable_id, path)) = pending.pop() {
+        if !selected.insert(callable_id) {
+            continue;
+        }
+        let callable = module.callable(callable_id).ok_or_else(|| {
+            SirMirLoweringError::unsupported(format!(
+                "strict SIR direct-call closure reaches unknown callable {} via {}",
+                callable_id.0,
+                format_callable_path(module, &path)
+            ))
+        })?;
+        validate_direct_callable(callable)?;
+        let function = unique_function_for_callable(module, callable_id).ok_or_else(|| {
+            SirMirLoweringError::missing_body(
+                callable_id,
+                format!(
+                    "strict SIR direct-call closure requires one lowered body for `{}` via {}",
+                    callable.symbol,
+                    format_callable_path(module, &path)
+                ),
+            )
+        })?;
+        for callee in direct_callees(function) {
+            let mut next_path = path.clone();
+            next_path.push(callee);
+            pending.push((callee, next_path));
+        }
+    }
+
+    let mut raw_mir = Vec::with_capacity(selected.len());
+    let mut checked_mir = Vec::with_capacity(selected.len());
+    for callable_id in &selected {
+        let function = unique_function_for_callable(module, *callable_id).ok_or_else(|| {
+            SirMirLoweringError::unsupported(format!(
+                "selected SIR callable {} lost its body during component realization",
+                callable_id.0
+            ))
+        })?;
+        let lowered = lower_verified_sir_function(module, function)?;
+        raw_mir.push(lowered.raw);
+        checked_mir.push(lowered.checked);
+    }
+
+    Ok(SirMirComponent {
+        callables: selected.into_iter().collect(),
+        raw_mir,
+        checked_mir,
+    })
+}
+
+/// Test helper for lowering one verifier-approved SIR function.
+///
+/// Production callers must use [`lower_closed_scalar_component`] so every
+/// direct call resolves within a closed realized component.
+#[cfg(test)]
+fn lower_sir_function(
+    module: &SemModule,
+    function: &SemFunction,
+) -> Result<SirMirLowered, SirMirLoweringError> {
+    if let Some(diagnostic) = hew_sir::verify_module(module).into_iter().next() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "SIR module verifier rejected function `{}`: {:?}",
+            function.name, diagnostic.kind
+        )));
+    }
+    lower_verified_sir_function(module, function)
+}
+
+fn lower_verified_sir_function(
+    module: &SemModule,
+    function: &SemFunction,
+) -> Result<SirMirLowered, SirMirLoweringError> {
+    let callable = module.callable(function.callable).ok_or_else(|| {
+        SirMirLoweringError::unsupported(format!(
+            "SIR function `{}` has no resolved callable {}",
+            function.name, function.callable.0
+        ))
+    })?;
+    validate_direct_callable(callable)?;
+    validate_sir_function_signature(function, callable)?;
+    if function.entry != BlockId(0) {
+        return Err(SirMirLoweringError::unsupported(
+            "the initial raw-MIR realization requires SIR entry block bb0",
+        ));
+    }
+
+    let collected = CollectedValues::from_function(function)?;
+    let mut lowerer = RawLowerer::new(function, collected, Some(module))?;
+    for block in &function.blocks {
+        lowerer.lower_block(block)?;
+    }
+    let (locals, blocks) = lowerer.finish()?;
+    let parameter_decisions = sir_parameter_decisions(callable)?;
+    let raw = RawMirFunction {
+        name: callable.symbol.clone(),
+        return_ty: callable.signature.return_ty.clone(),
+        call_conv: FunctionCallConv::Default,
+        params: callable
+            .signature
+            .params
+            .iter()
+            .map(|parameter| parameter.ty.clone())
+            .collect(),
+        locals,
+        // SIR values do not yet carry source binding/scope debug identities.
+        // An empty debug projection is truthful and preferable to copying
+        // storage metadata authored for a legacy HIR→MIR body.
+        local_names: Vec::new(),
+        local_scopes: Vec::new(),
+        local_decl_bytes: Vec::new(),
+        scope_table: Vec::new(),
+        blocks,
+        decisions: parameter_decisions.clone(),
+        intrinsic_id: None,
+        await_deadline_ns: std::collections::HashMap::new(),
+        suspend_kinds: std::collections::HashMap::new(),
+        lambda_actor_user_param_locals: Vec::new(),
+        span: Some((
+            u32::try_from(function.span.start).unwrap_or(u32::MAX),
+            u32::try_from(function.span.end).unwrap_or(u32::MAX),
+        )),
+        instr_spans: std::collections::BTreeMap::new(),
+        source_origin: raw_source_origin(&callable.source_origin),
+    };
+    let checked = CheckedMirFunction {
+        name: raw.name.clone(),
+        return_ty: raw.return_ty.clone(),
+        blocks: raw.blocks.clone(),
+        decisions: parameter_decisions,
+        checks: crate::validate_context_markers(&raw),
+        // Strict SIR may introduce edge-forwarding blocks after the CFG nodes
+        // they target. Its scheduler therefore uses structural latches rather
+        // than the legacy raw-MIR numeric block-order convention.
+        cooperate_sites: dataflow::compute_structural_cooperate_sites(&raw.blocks),
+    };
+    verify_strict_sir_raw_checked(module, callable, &raw, &checked)?;
+    Ok(SirMirLowered { raw, checked })
+}
+
+/// Verify the small, deliberately storage-free SIR → raw/checked-MIR contract.
+///
+/// This is intentionally narrower than the legacy raw-MIR validators.  The
+/// strict SIR lane currently admits only scalar values, direct calls, and the
+/// CFG forms authored by [`RawLowerer`].  Checking that exact contract here
+/// means a future SIR lowering edit cannot accidentally smuggle an unmodelled
+/// ownership, place, or ABI convention through a raw-MIR body merely because
+/// a later backend happens to accept it.
+fn verify_strict_sir_raw_checked(
+    module: &SemModule,
+    callable: &SemCallable,
+    raw: &RawMirFunction,
+    checked: &CheckedMirFunction,
+) -> Result<(), SirMirLoweringError> {
+    if raw.name != callable.symbol
+        || raw.return_ty != callable.signature.return_ty
+        || raw.call_conv != FunctionCallConv::Default
+    {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw function does not match callable `{}` ABI",
+            callable.symbol
+        )));
+    }
+    if checked.name != raw.name || checked.return_ty != raw.return_ty {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: checked function identity does not match raw `{}`",
+            raw.name
+        )));
+    }
+
+    let expected_params = callable
+        .signature
+        .params
+        .iter()
+        .map(|parameter| parameter.ty.clone())
+        .collect::<Vec<_>>();
+    if raw.params != expected_params {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw parameters do not match callable `{}` ABI",
+            callable.symbol
+        )));
+    }
+    if raw.locals.len() < raw.params.len() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw `{}` has fewer locals than ABI parameters",
+            raw.name
+        )));
+    }
+    for (index, parameter_ty) in raw.params.iter().enumerate() {
+        if raw.locals[index] != *parameter_ty {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw `{}` parameter local {index} does not match its ABI type",
+                raw.name
+            )));
+        }
+    }
+    for (index, local_ty) in raw.locals.iter().enumerate() {
+        if !is_supported_value_type(local_ty) {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw `{}` local {index} has unsupported type `{}`",
+                raw.name,
+                local_ty.user_facing()
+            )));
+        }
+    }
+
+    verify_strict_sir_block_layout("raw", &raw.blocks)?;
+    verify_strict_sir_block_layout("checked", &checked.blocks)?;
+    if raw.blocks != checked.blocks {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw and checked blocks diverge for `{}`",
+            raw.name
+        )));
+    }
+    if raw.decisions != checked.decisions {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw and checked decisions diverge for `{}`",
+            raw.name
+        )));
+    }
+    if checked.checks != crate::validate_context_markers(raw) {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: checked context findings are stale for `{}`",
+            raw.name
+        )));
+    }
+    if checked.cooperate_sites != dataflow::compute_structural_cooperate_sites(&raw.blocks) {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: checked scheduler facts are stale for `{}`",
+            raw.name
+        )));
+    }
+    verify_strict_sir_parameter_boundary_facts(callable, raw)?;
+
+    for block in &raw.blocks {
+        if !block.statements.is_empty() {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw bb{} carries legacy MIR statements",
+                block.id
+            )));
+        }
+        for (instruction_index, instruction) in block.instructions.iter().enumerate() {
+            verify_strict_sir_instruction(raw, block.id, instruction_index, instruction)?;
+        }
+        verify_strict_sir_terminator(module, raw, block)?;
+    }
+    Ok(())
+}
+
+fn verify_strict_sir_block_layout(
+    lane: &str,
+    blocks: &[BasicBlock],
+) -> Result<(), SirMirLoweringError> {
+    if blocks.is_empty() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: {lane} MIR has no basic blocks"
+        )));
+    }
+    for (index, block) in blocks.iter().enumerate() {
+        let expected_id = u32::try_from(index).map_err(|_| {
+            SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: {lane} MIR block count exceeds u32"
+            ))
+        })?;
+        if block.id != expected_id {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: {lane} MIR has noncanonical block id bb{} at index {index}",
+                block.id
+            )));
+        }
+        for target in block.successors() {
+            let target_index = usize::try_from(target).map_err(|_| {
+                SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {lane} bb{} successor bb{target} cannot index the CFG",
+                    block.id
+                ))
+            })?;
+            if target_index >= blocks.len() {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {lane} bb{} targets missing bb{target}",
+                    block.id
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_strict_sir_parameter_boundary_facts(
+    callable: &SemCallable,
+    raw: &RawMirFunction,
+) -> Result<(), SirMirLoweringError> {
+    if raw.decisions.len() != callable.signature.params.len() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw `{}` has {} parameter-boundary facts for {} ABI parameters",
+            raw.name,
+            raw.decisions.len(),
+            callable.signature.params.len()
+        )));
+    }
+    let parameter_count = u32::try_from(callable.signature.params.len()).map_err(|_| {
+        SirMirLoweringError::unsupported(
+            "strict SIR raw/checked verifier: callable parameter count exceeds u32",
+        )
+    })?;
+    for (index, (decision, parameter)) in raw
+        .decisions
+        .iter()
+        .zip(&callable.signature.params)
+        .enumerate()
+    {
+        let parameter_index = u32::try_from(index).map_err(|_| {
+            SirMirLoweringError::unsupported(
+                "strict SIR raw/checked verifier: callable parameter index exceeds u32",
+            )
+        })?;
+        let Strategy::ParamBoundary(fact) = &decision.strategy else {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw `{}` decision {index} is not a parameter-boundary fact",
+                raw.name
+            )));
+        };
+        let expected = ParamBoundaryFact {
+            param_index: parameter_index,
+            param_count: parameter_count,
+            caller_visible_projection: parameter.caller_visible_projection,
+            mode: match parameter.passing {
+                SemParamPassing::ReadOnly => ParamBoundaryMode::BorrowReadOnly,
+            },
+        };
+        if decision.site != SiteId(parameter_index)
+            || decision.ty != parameter.ty
+            || decision.value_class != ValueClass::BitCopy
+            || decision.intent != IntentKind::Unknown
+            || *fact != expected
+        {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw `{}` parameter-boundary fact {index} does not match callable ABI",
+                raw.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "one exhaustive scalar-instruction allowlist makes the strict SIR-to-MIR boundary auditable in one place"
+)]
+fn verify_strict_sir_instruction(
+    raw: &RawMirFunction,
+    block_id: u32,
+    instruction_index: usize,
+    instruction: &Instr,
+) -> Result<(), SirMirLoweringError> {
+    let context = format!("raw bb{block_id} instruction {instruction_index}");
+    match instruction {
+        Instr::ConstI64 { dest, .. } => {
+            let destination_ty = strict_sir_local_ty(raw, *dest, &context)?;
+            if !destination_ty.is_integer() && *destination_ty != ResolvedTy::Bool {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} writes a constant to non-scalar `{}`",
+                    destination_ty.user_facing()
+                )));
+            }
+        }
+        Instr::BoolNot { dest, operand } => {
+            verify_strict_sir_same_type(raw, *dest, *operand, &context, &ResolvedTy::Bool)?;
+        }
+        Instr::IntNegChecked {
+            signed,
+            dest,
+            operand,
+            overflow_flag,
+        } => {
+            let destination_ty =
+                verify_strict_sir_same_integer_type(raw, *dest, *operand, &context)?;
+            if signedness(destination_ty)? != *signed
+                || strict_sir_local_ty(raw, *overflow_flag, &context)? != &ResolvedTy::Bool
+            {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} has an invalid checked-negation shape"
+                )));
+            }
+        }
+        Instr::IntBitNot { dest, operand } => {
+            let _ = verify_strict_sir_same_integer_type(raw, *dest, *operand, &context)?;
+        }
+        Instr::IntAdd { dest, lhs, rhs }
+        | Instr::IntSub { dest, lhs, rhs }
+        | Instr::IntMul { dest, lhs, rhs }
+        | Instr::IntBitAnd { dest, lhs, rhs }
+        | Instr::IntBitOr { dest, lhs, rhs }
+        | Instr::IntBitXor { dest, lhs, rhs } => {
+            let destination_ty = verify_strict_sir_same_integer_type(raw, *dest, *lhs, &context)?;
+            if strict_sir_local_ty(raw, *rhs, &context)? != destination_ty {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} mixes scalar arithmetic local types"
+                )));
+            }
+        }
+        Instr::IntArithChecked {
+            signed,
+            dest,
+            lhs,
+            rhs,
+            overflow_flag,
+            ..
+        } => {
+            let destination_ty = verify_strict_sir_same_integer_type(raw, *dest, *lhs, &context)?;
+            if strict_sir_local_ty(raw, *rhs, &context)? != destination_ty
+                || signedness(destination_ty)? != *signed
+                || strict_sir_local_ty(raw, *overflow_flag, &context)? != &ResolvedTy::Bool
+            {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} has an invalid checked-arithmetic shape"
+                )));
+            }
+        }
+        Instr::IntCmp {
+            dest,
+            pred,
+            lhs,
+            rhs,
+        } => {
+            if strict_sir_local_ty(raw, *dest, &context)? != &ResolvedTy::Bool {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} comparison result is not bool"
+                )));
+            }
+            let lhs_ty = strict_sir_local_ty(raw, *lhs, &context)?;
+            let is_bool_equality = lhs_ty == &ResolvedTy::Bool
+                && matches!(pred, crate::CmpPred::Eq | crate::CmpPred::NotEq);
+            if (!lhs_ty.is_integer() && !is_bool_equality)
+                || strict_sir_local_ty(raw, *rhs, &context)? != lhs_ty
+            {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} comparison operands are not same-typed integers or boolean equality operands"
+                )));
+            }
+        }
+        Instr::NumericCast {
+            dest,
+            src,
+            from_ty,
+            to_ty,
+        } => {
+            if strict_sir_local_ty(raw, *src, &context)? != from_ty
+                || strict_sir_local_ty(raw, *dest, &context)? != to_ty
+                || !from_ty.can_explicitly_numeric_cast_to(to_ty)
+            {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} has an invalid numeric-cast shape"
+                )));
+            }
+        }
+        Instr::Move { dest, src } => verify_strict_sir_move(raw, *dest, *src, &context)?,
+        _ => {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: {context} uses an instruction outside the scalar SIR subset"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn verify_strict_sir_terminator(
+    module: &SemModule,
+    raw: &RawMirFunction,
+    block: &BasicBlock,
+) -> Result<(), SirMirLoweringError> {
+    match &block.terminator {
+        Terminator::Return => {
+            let return_stores = block
+                .instructions
+                .iter()
+                .filter(|instruction| {
+                    matches!(
+                        instruction,
+                        Instr::Move {
+                            dest: Place::ReturnSlot,
+                            ..
+                        }
+                    )
+                })
+                .count();
+            if raw.return_ty == ResolvedTy::Unit {
+                if return_stores != 0 {
+                    return Err(SirMirLoweringError::unsupported(format!(
+                        "strict SIR raw/checked verifier: raw bb{} writes a value for a unit return",
+                        block.id
+                    )));
+                }
+            } else if return_stores != 1
+                || !matches!(
+                    block.instructions.last(),
+                    Some(Instr::Move {
+                        dest: Place::ReturnSlot,
+                        ..
+                    })
+                )
+            {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: raw bb{} must finish its scalar return with one return-slot move",
+                    block.id
+                )));
+            }
+        }
+        Terminator::Goto { .. }
+        | Terminator::Trap {
+            kind: TrapKind::IntegerOverflow,
+        } => {}
+        Terminator::Branch { cond, .. } => {
+            if strict_sir_local_ty(raw, *cond, &format!("raw bb{} branch", block.id))?
+                != &ResolvedTy::Bool
+            {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: raw bb{} branches on a non-bool local",
+                    block.id
+                )));
+            }
+        }
+        Terminator::Call {
+            callee,
+            authority,
+            args,
+            dest,
+            ..
+        } => verify_strict_sir_call(module, raw, block.id, callee, *authority, args, *dest)?,
+        _ => {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw bb{} uses a terminator outside the scalar SIR subset",
+                block.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn verify_strict_sir_call(
+    module: &SemModule,
+    raw: &RawMirFunction,
+    block_id: u32,
+    callee_symbol: &str,
+    authority: crate::CallAuthority,
+    args: &[Place],
+    dest: Option<Place>,
+) -> Result<(), SirMirLoweringError> {
+    if authority != crate::CallAuthority::Direct {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw bb{block_id} direct call `{callee_symbol}` has non-direct authority"
+        )));
+    }
+    let mut matching = module
+        .callables
+        .iter()
+        .filter(|callable| callable.symbol == callee_symbol);
+    let callee = matching.next().ok_or_else(|| {
+        SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw bb{block_id} calls unknown SIR callable `{callee_symbol}`"
+        ))
+    })?;
+    if matching.next().is_some() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw bb{block_id} call `{callee_symbol}` has ambiguous SIR callable identity"
+        )));
+    }
+    validate_direct_callable(callee)?;
+    if args.len() != callee.signature.params.len() {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: raw bb{block_id} call `{callee_symbol}` has {} arguments for {} ABI parameters",
+            args.len(),
+            callee.signature.params.len()
+        )));
+    }
+    for (index, (argument, parameter)) in args.iter().zip(&callee.signature.params).enumerate() {
+        if strict_sir_local_ty(
+            raw,
+            *argument,
+            &format!("raw bb{block_id} call argument {index}"),
+        )? != &parameter.ty
+        {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw bb{block_id} call `{callee_symbol}` argument {index} does not match its ABI type"
+            )));
+        }
+    }
+    match (&callee.signature.return_ty, dest) {
+        (ResolvedTy::Unit, None) => {}
+        (ResolvedTy::Unit, Some(_)) => {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw bb{block_id} unit call `{callee_symbol}` has a destination"
+            )));
+        }
+        (_, None) => {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: raw bb{block_id} value call `{callee_symbol}` lacks a destination"
+            )));
+        }
+        (return_ty, Some(destination)) => {
+            if strict_sir_local_ty(
+                raw,
+                destination,
+                &format!("raw bb{block_id} call destination"),
+            )? != return_ty
+            {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: raw bb{block_id} call `{callee_symbol}` destination does not match its ABI return"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_strict_sir_move(
+    raw: &RawMirFunction,
+    dest: Place,
+    src: Place,
+    context: &str,
+) -> Result<(), SirMirLoweringError> {
+    let source_ty = strict_sir_local_ty(raw, src, context)?;
+    match dest {
+        Place::Local(_) => {
+            if strict_sir_local_ty(raw, dest, context)? != source_ty {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} moves between different local types"
+                )));
+            }
+        }
+        Place::ReturnSlot => {
+            if raw.return_ty == ResolvedTy::Unit || &raw.return_ty != source_ty {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR raw/checked verifier: {context} writes an incompatible value to the return slot"
+                )));
+            }
+        }
+        _ => {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR raw/checked verifier: {context} moves into a non-scalar place"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn verify_strict_sir_same_type(
+    raw: &RawMirFunction,
+    dest: Place,
+    operand: Place,
+    context: &str,
+    expected: &ResolvedTy,
+) -> Result<(), SirMirLoweringError> {
+    if strict_sir_local_ty(raw, dest, context)? != expected
+        || strict_sir_local_ty(raw, operand, context)? != expected
+    {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: {context} does not use `{}` locals",
+            expected.user_facing()
+        )));
+    }
+    Ok(())
+}
+
+fn verify_strict_sir_same_integer_type<'a>(
+    raw: &'a RawMirFunction,
+    dest: Place,
+    operand: Place,
+    context: &str,
+) -> Result<&'a ResolvedTy, SirMirLoweringError> {
+    let destination_ty = strict_sir_local_ty(raw, dest, context)?;
+    if !destination_ty.is_integer() || strict_sir_local_ty(raw, operand, context)? != destination_ty
+    {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: {context} does not use same-typed integer locals"
+        )));
+    }
+    Ok(destination_ty)
+}
+
+fn strict_sir_local_ty<'a>(
+    raw: &'a RawMirFunction,
+    place: Place,
+    context: &str,
+) -> Result<&'a ResolvedTy, SirMirLoweringError> {
+    let Place::Local(local) = place else {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: {context} uses non-local place {place:?}"
+        )));
+    };
+    let local_index = usize::try_from(local).map_err(|_| {
+        SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: {context} local {local} cannot index raw locals"
+        ))
+    })?;
+    let local_ty = raw.locals.get(local_index).ok_or_else(|| {
+        SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: {context} references out-of-bounds local {local}"
+        ))
+    })?;
+    if !is_supported_value_type(local_ty) {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "strict SIR raw/checked verifier: {context} references non-scalar local {local}"
+        )));
+    }
+    Ok(local_ty)
+}
+
+fn validate_direct_callable(callable: &SemCallable) -> Result<(), SirMirLoweringError> {
+    if callable.call_conv != SemCallConv::Default || callable.kind != SemCallableKind::HewDirect {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "SIR callable `{}` is outside the initial default HewDirect ABI domain",
+            callable.symbol
+        )));
+    }
+    for (index, parameter) in callable.signature.params.iter().enumerate() {
+        if parameter.passing != SemParamPassing::ReadOnly
+            || parameter.caller_visible_projection
+            || !is_supported_value_type(&parameter.ty)
+        {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "SIR callable `{}` parameter {index} needs ownership or aggregate ABI lowering",
+                callable.symbol
+            )));
+        }
+    }
+    if !is_supported_return_type(&callable.signature.return_ty) {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "SIR callable `{}` return type `{}` needs later ABI lowering",
+            callable.symbol,
+            callable.signature.return_ty.user_facing()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sir_function_signature(
+    function: &SemFunction,
+    callable: &SemCallable,
+) -> Result<(), SirMirLoweringError> {
+    let function_params = function
+        .params
+        .iter()
+        .map(|parameter| &parameter.ty)
+        .collect::<Vec<_>>();
+    let callable_params = callable
+        .signature
+        .params
+        .iter()
+        .map(|parameter| &parameter.ty)
+        .collect::<Vec<_>>();
+    if function.callable != callable.id
+        || function.id != callable.function
+        || function.declaration != callable.declaration
+        || function.name != callable.symbol
+        || function.source_origin != callable.source_origin
+        || function.return_ty != callable.signature.return_ty
+        || function_params != callable_params
+    {
+        return Err(SirMirLoweringError::unsupported(format!(
+            "SIR function `{}` does not match its resolved callable authority",
+            function.name
+        )));
+    }
+    Ok(())
+}
+
+fn sir_parameter_decisions(
+    callable: &SemCallable,
+) -> Result<Vec<crate::DecisionFact>, SirMirLoweringError> {
+    let parameter_count = u32::try_from(callable.signature.params.len()).map_err(|_| {
+        SirMirLoweringError::unsupported("SIR parameter count exceeds raw-MIR ABI limits")
+    })?;
+    callable
+        .signature
+        .params
+        .iter()
+        .enumerate()
+        .map(|(index, parameter)| {
+            let index = u32::try_from(index).map_err(|_| {
+                SirMirLoweringError::unsupported("SIR parameter index exceeds raw-MIR ABI limits")
+            })?;
+            Ok(crate::DecisionFact {
+                // ABI boundary facts have no source expression site. The
+                // stable parameter ordinal is sufficient for the raw/checked
+                // decision stream and deliberately does not borrow a legacy
+                // HIR-to-MIR site identity.
+                site: SiteId(index),
+                ty: parameter.ty.clone(),
+                value_class: ValueClass::BitCopy,
+                intent: IntentKind::Unknown,
+                strategy: Strategy::ParamBoundary(ParamBoundaryFact {
+                    param_index: index,
+                    param_count: parameter_count,
+                    caller_visible_projection: false,
+                    mode: ParamBoundaryMode::BorrowReadOnly,
+                }),
+                why: "SIR scalar direct-call parameter boundary".to_string(),
+            })
+        })
+        .collect()
+}
+
+fn unique_function_for_callable(module: &SemModule, callable: CallableId) -> Option<&SemFunction> {
+    let mut matches = module
+        .functions
+        .iter()
+        .filter(|function| function.callable == callable);
+    let function = matches.next()?;
+    matches.next().is_none().then_some(function)
+}
+
+fn direct_callees(function: &SemFunction) -> impl Iterator<Item = CallableId> + '_ {
+    function.blocks.iter().flat_map(|block| {
+        block
+            .ops
+            .iter()
+            .filter_map(|operation| match &operation.kind {
+                SemOpKind::Call { callee, .. } => Some(*callee),
+                _ => None,
+            })
+    })
+}
+
+fn format_callable_path(module: &SemModule, path: &[CallableId]) -> String {
+    path.iter()
+        .map(|id| {
+            module.callable(*id).map_or_else(
+                || format!("callable#{}", id.0),
+                |callable| callable.symbol.clone(),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" → ")
 }
 
 /// Lower every executable SIR function possible into `pipeline`.
@@ -157,7 +1088,7 @@ pub fn apply_sir_to_pipeline(
             continue;
         }
         let template = pipeline.raw_mir[*raw_index].clone();
-        match lower_sir_function(function, &template) {
+        match lower_sir_function_with_template(function, &template) {
             Ok(mut lowered) => {
                 // The initial scalar SIR subset is acyclic and has no calls,
                 // so it creates no scheduler sites of its own.  Preserve the
@@ -250,7 +1181,7 @@ fn cooperate_sites_apply_to(raw: &RawMirFunction, sites: &[crate::CooperateSite]
 ///
 /// Returns an explicit unsupported reason whenever the function needs a
 /// semantic fact not carried by the initial SIR value/CFG subset.
-pub fn lower_sir_function(
+fn lower_sir_function_with_template(
     function: &SemFunction,
     template: &RawMirFunction,
 ) -> Result<SirMirLowered, SirMirLoweringError> {
@@ -262,7 +1193,7 @@ pub fn lower_sir_function(
     }
     let parameter_decisions = validate_template(function, template)?;
     let collected = CollectedValues::from_function(function)?;
-    let mut lowerer = RawLowerer::new(function, collected)?;
+    let mut lowerer = RawLowerer::new(function, collected, None)?;
     for block in &function.blocks {
         lowerer.lower_block(block)?;
     }
@@ -305,9 +1236,11 @@ pub fn lower_sir_function(
         blocks: raw.blocks.clone(),
         decisions: parameter_decisions,
         checks: crate::validate_context_markers(&raw),
-        // SIR may introduce edge-forwarding blocks after the CFG nodes they
-        // target. Its scheduler therefore uses structural latches rather than
-        // the legacy raw-MIR numeric block-order convention.
+        // Template-backed shadow realization is still SIR CFG production:
+        // edge-forwarding blocks do not preserve the legacy raw-MIR numeric
+        // allocation convention. `apply_sir_to_pipeline` may retain an
+        // established schedule only when it maps truthfully; candidate-local
+        // scheduling itself must remain structural.
         cooperate_sites: dataflow::compute_structural_cooperate_sites(&raw.blocks),
     };
     Ok(SirMirLowered { raw, checked })
@@ -546,6 +1479,7 @@ struct PendingBlock {
 
 struct RawLowerer<'a> {
     function: &'a SemFunction,
+    module: Option<&'a SemModule>,
     value_types: BTreeMap<ValueId, ResolvedTy>,
     block_args: BTreeMap<BlockId, Vec<BlockArg>>,
     value_places: BTreeMap<ValueId, Place>,
@@ -558,6 +1492,7 @@ impl<'a> RawLowerer<'a> {
     fn new(
         function: &'a SemFunction,
         collected: CollectedValues,
+        module: Option<&'a SemModule>,
     ) -> Result<Self, SirMirLoweringError> {
         let mut locals = Vec::new();
         let mut value_places = BTreeMap::new();
@@ -587,6 +1522,7 @@ impl<'a> RawLowerer<'a> {
             .collect();
         Ok(Self {
             function,
+            module,
             value_types: collected.types,
             block_args: collected.block_args,
             value_places,
@@ -605,6 +1541,9 @@ impl<'a> RawLowerer<'a> {
     }
 
     fn lower_op(&mut self, operation: &SemOp) -> Result<(), SirMirLoweringError> {
+        if let SemOpKind::Call { callee, args } = &operation.kind {
+            return self.lower_call(*callee, args, &operation.results);
+        }
         let (result, result_ty) = Self::single_result(operation)?;
         let dest = self.value_place(result)?;
         match &operation.kind {
@@ -653,12 +1592,93 @@ impl<'a> RawLowerer<'a> {
                     to_ty: to.clone(),
                 });
             }
-            SemOpKind::Call { .. } => {
-                return Err(SirMirLoweringError::unsupported(
-                    "direct calls remain on the established MIR path until SIR carries resolved emitted-symbol and ABI authority",
-                ));
-            }
+            SemOpKind::Call { .. } => unreachable!("calls return before value-result lowering"),
         }
+        Ok(())
+    }
+
+    /// Legalize a semantic direct call into raw MIR's CFG-splitting call
+    /// terminator. The callable signature determines whether the operation
+    /// has one destination value or no destination at all. The current SIR
+    /// block continues at the newly-created raw continuation, so subsequent
+    /// operations and its source terminator stay in program order without
+    /// manufacturing a second SIR CFG form.
+    fn lower_call(
+        &mut self,
+        callee: CallableId,
+        args: &[Operand],
+        results: &[ValueDef],
+    ) -> Result<(), SirMirLoweringError> {
+        let module = self.module.ok_or_else(|| {
+            SirMirLoweringError::unsupported(
+                "the temporary SIR shadow bridge does not lower direct calls; use the strict SIR component",
+            )
+        })?;
+        let callable = module.callable(callee).ok_or_else(|| {
+            SirMirLoweringError::unsupported(format!(
+                "SIR call targets unknown callable {}",
+                callee.0
+            ))
+        })?;
+        validate_direct_callable(callable)?;
+        let destination = match (callable.signature.return_ty == ResolvedTy::Unit, results) {
+            (true, []) => None,
+            (true, _) => {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "unit-returning SIR call to `{}` must have zero results",
+                    callable.symbol
+                )));
+            }
+            (false, [ValueDef { id, ty }]) if ty == &callable.signature.return_ty => {
+                Some(self.value_place(*id)?)
+            }
+            (false, [ValueDef { ty, .. }]) => {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "SIR call result `{}` does not match callable `{}` return `{}`",
+                    ty.user_facing(),
+                    callable.symbol,
+                    callable.signature.return_ty.user_facing()
+                )));
+            }
+            (false, _) => {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "non-unit SIR call to `{}` requires exactly one result",
+                    callable.symbol
+                )));
+            }
+        };
+        if args.len() != callable.signature.params.len() {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "SIR call to `{}` has {} argument(s), expected {}",
+                callable.symbol,
+                args.len(),
+                callable.signature.params.len()
+            )));
+        }
+        let mut raw_args = Vec::with_capacity(args.len());
+        for (index, (argument, parameter)) in
+            args.iter().zip(&callable.signature.params).enumerate()
+        {
+            Self::require_read(argument, "direct call")?;
+            let actual = self.value_type(argument.value)?;
+            if actual != &parameter.ty || parameter.passing != SemParamPassing::ReadOnly {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "SIR call argument {index} does not satisfy `{}` scalar ReadOnly ABI",
+                    callable.symbol
+                )));
+            }
+            raw_args.push(self.value_place(argument.value)?);
+        }
+
+        let continuation = self.fresh_block()?;
+        self.terminate(Terminator::Call {
+            callee: callable.symbol.clone(),
+            authority: crate::CallAuthority::Direct,
+            args: raw_args,
+            dest: destination,
+            next: continuation,
+        })?;
+        self.current = continuation;
         Ok(())
     }
 
@@ -1082,8 +2102,56 @@ fn ordering_predicate(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hew_hir::{IntentKind, ItemId, SiteId, ValueClass};
-    use hew_sir::{OpId, Provenance};
+    use hew_hir::ItemId;
+    use hew_sir::{OpId, Provenance, SemAbiParam, SemSignature};
+
+    fn test_callable(function: &SemFunction) -> SemCallable {
+        SemCallable {
+            id: function.callable,
+            function: function.id,
+            declaration: function.declaration.clone(),
+            symbol: function.name.clone(),
+            source_origin: function.source_origin.clone(),
+            signature: SemSignature {
+                params: function
+                    .params
+                    .iter()
+                    .map(|parameter| SemAbiParam {
+                        ty: parameter.ty.clone(),
+                        passing: SemParamPassing::ReadOnly,
+                        caller_visible_projection: false,
+                    })
+                    .collect(),
+                return_ty: function.return_ty.clone(),
+            },
+            call_conv: SemCallConv::Default,
+            kind: SemCallableKind::HewDirect,
+            effect_summary: hew_sir::EffectSummary::Unknown,
+        }
+    }
+
+    fn test_module(functions: Vec<SemFunction>) -> SemModule {
+        let mut callables = functions.iter().map(test_callable).collect::<Vec<_>>();
+        callables.sort_unstable_by_key(|callable| callable.id);
+        let root_unit_callables = callables
+            .iter()
+            .filter(|callable| callable.source_origin == FunctionSourceOrigin::RootUnit)
+            .map(|callable| callable.id)
+            .collect::<Vec<_>>();
+        let entry_callable = callables
+            .iter()
+            .find(|callable| {
+                callable.source_origin == FunctionSourceOrigin::RootUnit
+                    && callable.symbol == "main"
+            })
+            .map(|callable| callable.id);
+        SemModule {
+            callables,
+            root_unit_callables,
+            entry_callable,
+            functions,
+        }
+    }
 
     fn template(name: &str, params: Vec<ResolvedTy>, return_ty: ResolvedTy) -> RawMirFunction {
         let parameter_count = u32::try_from(params.len()).expect("test parameter count fits u32");
@@ -1149,6 +2217,152 @@ mod tests {
         }
     }
 
+    fn zero_result_op(id: u32, kind: SemOpKind) -> SemOp {
+        SemOp {
+            id: OpId(id),
+            results: Vec::new(),
+            kind,
+            provenance: Provenance::Synthesized,
+        }
+    }
+
+    fn strict_i64_identity_function() -> SemFunction {
+        SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("identity"),
+            name: "identity".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: vec![BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
+            }],
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(0)),
+                },
+            }],
+        }
+    }
+
+    fn strict_boolean_equality_function() -> SemFunction {
+        SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("same"),
+            name: "same".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: vec![
+                BlockArg {
+                    value: ValueId(0),
+                    ty: ResolvedTy::Bool,
+                },
+                BlockArg {
+                    value: ValueId(1),
+                    ty: ResolvedTy::Bool,
+                },
+            ],
+            return_ty: ResolvedTy::Bool,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![op(
+                    0,
+                    definition(2, ResolvedTy::Bool),
+                    SemOpKind::Binary {
+                        op: BinaryOp::Equal,
+                        lhs: operand(0),
+                        rhs: operand(1),
+                    },
+                )],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(2)),
+                },
+            }],
+        }
+    }
+
+    #[test]
+    fn strict_post_lowering_verifier_accepts_boolean_equality_and_rejects_bad_local() {
+        let function = strict_boolean_equality_function();
+        let module = test_module(vec![function.clone()]);
+        let mut lowered = lower_sir_function(&module, &function)
+            .expect("boolean equality is in the strict scalar SIR subset");
+        let callable = module
+            .callable(function.callable)
+            .expect("test callable must exist");
+        verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
+            .expect("the strict lowerer must produce a self-consistent raw/checked pair");
+        assert!(matches!(
+            lowered.raw.blocks[0].instructions[0],
+            Instr::IntCmp {
+                pred: crate::CmpPred::Eq,
+                ..
+            }
+        ));
+
+        match &mut lowered.raw.blocks[0].instructions[0] {
+            Instr::IntCmp { dest, .. } => *dest = Place::Local(99),
+            instruction => {
+                panic!("expected boolean equality to lower as IntCmp, got {instruction:?}")
+            }
+        }
+        lowered.checked.blocks = lowered.raw.blocks.clone();
+        let error =
+            verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
+                .expect_err("an out-of-bounds scalar local must fail at the SIR raw boundary");
+        assert!(error.reason.contains("out-of-bounds local 99"));
+    }
+
+    #[test]
+    fn strict_post_lowering_verifier_rejects_bad_cfg_target() {
+        let function = strict_i64_identity_function();
+        let module = test_module(vec![function.clone()]);
+        let mut lowered =
+            lower_sir_function(&module, &function).expect("the identity function should lower");
+        let callable = module
+            .callable(function.callable)
+            .expect("test callable must exist");
+        lowered.raw.blocks[0].terminator = Terminator::Goto { target: 1 };
+        lowered.checked.blocks = lowered.raw.blocks.clone();
+
+        let error =
+            verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
+                .expect_err("a raw target outside the canonical CFG must fail at the SIR boundary");
+        assert!(error.reason.contains("targets missing bb1"));
+    }
+
+    #[test]
+    fn strict_post_lowering_verifier_rejects_parameter_boundary_fact_drift() {
+        let function = strict_i64_identity_function();
+        let module = test_module(vec![function.clone()]);
+        let mut lowered =
+            lower_sir_function(&module, &function).expect("the identity function should lower");
+        let callable = module
+            .callable(function.callable)
+            .expect("test callable must exist");
+        lowered.raw.decisions[0].strategy = Strategy::ParamBoundary(ParamBoundaryFact {
+            param_index: 0,
+            param_count: 1,
+            caller_visible_projection: false,
+            mode: ParamBoundaryMode::TransferResource,
+        });
+        lowered.checked.decisions = lowered.raw.decisions.clone();
+
+        let error =
+            verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
+                .expect_err("a stale ownership boundary fact must fail before later MIR stages");
+        assert!(error.reason.contains("parameter-boundary fact 0"));
+    }
+
     #[test]
     #[allow(
         clippy::too_many_lines,
@@ -1157,6 +2371,7 @@ mod tests {
     fn realizes_ssa_diamond_into_raw_cfg_and_overflow_paths() {
         let function = SemFunction {
             id: ItemId(0),
+            callable: CallableId(0),
             declaration: DefId::for_test("f"),
             name: "f".to_string(),
             span: 12..96,
@@ -1272,7 +2487,7 @@ mod tests {
             ],
         };
 
-        let lowered = lower_sir_function(
+        let lowered = lower_sir_function_with_template(
             &function,
             &template("f", vec![ResolvedTy::I64, ResolvedTy::I64], ResolvedTy::I64),
         )
@@ -1319,6 +2534,7 @@ mod tests {
     fn rejects_unverified_sir_before_raw_realization() {
         let function = SemFunction {
             id: ItemId(0),
+            callable: CallableId(0),
             declaration: DefId::for_test("bad_entry"),
             name: "bad_entry".to_string(),
             span: 0..0,
@@ -1339,13 +2555,59 @@ mod tests {
             }],
         };
 
-        let error = lower_sir_function(
+        let error = lower_sir_function_with_template(
             &function,
             &template("bad_entry", Vec::new(), ResolvedTy::I64),
         )
         .expect_err("a malformed SIR entry must fail before raw MIR exists");
         assert!(error.reason.contains("SIR verifier rejected function"));
         assert!(error.reason.contains("EntryBlockArgs"));
+    }
+
+    #[test]
+    fn rejects_noncanonical_sir_blocks_before_raw_realization() {
+        let function = SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("noncanonical"),
+            name: "noncanonical".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: Vec::new(),
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![
+                SemBlock {
+                    id: BlockId(0),
+                    args: Vec::new(),
+                    ops: Vec::new(),
+                    terminator: SemTerminator::Goto(Edge {
+                        target: BlockId(2),
+                        args: Vec::new(),
+                    }),
+                },
+                SemBlock {
+                    id: BlockId(2),
+                    args: Vec::new(),
+                    ops: vec![op(
+                        0,
+                        definition(0, ResolvedTy::I64),
+                        SemOpKind::ConstI64(1),
+                    )],
+                    terminator: SemTerminator::Return {
+                        value: Some(ValueId(0)),
+                    },
+                },
+            ],
+        };
+        let module = test_module(vec![function.clone()]);
+
+        let error = lower_sir_function(&module, &function)
+            .expect_err("noncanonical SIR must fail verification before raw-MIR realization");
+        assert!(error
+            .reason
+            .contains("SIR module verifier rejected function"));
+        assert!(error.reason.contains("NonCanonicalBlockOrder"));
     }
 
     #[test]
@@ -1356,6 +2618,7 @@ mod tests {
     fn edge_argument_materialization_uses_parallel_copies() {
         let function = SemFunction {
             id: ItemId(0),
+            callable: CallableId(0),
             declaration: DefId::for_test("swap"),
             name: "swap".to_string(),
             span: 0..0,
@@ -1412,7 +2675,7 @@ mod tests {
                 },
             ],
         };
-        let lowered = lower_sir_function(
+        let lowered = lower_sir_function_with_template(
             &function,
             &template(
                 "swap",
@@ -1462,9 +2725,307 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::similar_names,
+        clippy::too_many_lines,
+        reason = "the complete direct-call component fixture keeps caller/callee ABI and continuation assertions together"
+    )]
+    fn realizes_a_closed_direct_call_component_without_a_raw_template() {
+        let callee = SemFunction {
+            id: ItemId(1),
+            callable: CallableId(0),
+            declaration: DefId::for_test("add_one"),
+            name: "add_one".to_string(),
+            span: 20..60,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: vec![BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
+            }],
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![
+                    op(0, definition(1, ResolvedTy::I64), SemOpKind::ConstI64(1)),
+                    op(
+                        1,
+                        definition(2, ResolvedTy::I64),
+                        SemOpKind::Binary {
+                            op: BinaryOp::Add,
+                            lhs: operand(0),
+                            rhs: operand(1),
+                        },
+                    ),
+                ],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(2)),
+                },
+            }],
+        };
+        let caller = SemFunction {
+            id: ItemId(0),
+            callable: CallableId(1),
+            declaration: DefId::for_test("main"),
+            name: "main".to_string(),
+            span: 0..80,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: Vec::new(),
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![
+                    op(0, definition(0, ResolvedTy::I64), SemOpKind::ConstI64(40)),
+                    op(
+                        1,
+                        definition(1, ResolvedTy::I64),
+                        SemOpKind::Call {
+                            callee: CallableId(0),
+                            args: vec![operand(0)],
+                        },
+                    ),
+                    // This operation must land in the Call continuation; it
+                    // proves raw-MIR's terminator call did not truncate the
+                    // semantic source block.
+                    op(2, definition(2, ResolvedTy::I64), SemOpKind::ConstI64(1)),
+                    op(
+                        3,
+                        definition(3, ResolvedTy::I64),
+                        SemOpKind::Binary {
+                            op: BinaryOp::Add,
+                            lhs: operand(1),
+                            rhs: operand(2),
+                        },
+                    ),
+                ],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(3)),
+                },
+            }],
+        };
+        let module = test_module(vec![caller, callee]);
+        let component = lower_closed_scalar_component(&module, &[CallableId(1)])
+            .expect("a closed scalar SIR direct-call graph should lower independently");
+
+        assert_eq!(component.callables(), &[CallableId(0), CallableId(1)]);
+        let caller_raw = component
+            .raw_mir
+            .iter()
+            .find(|raw| raw.name == "main")
+            .expect("selected caller must have a fresh raw body");
+        let (destination, continuation) = match &caller_raw.blocks[0].terminator {
+            Terminator::Call {
+                callee,
+                authority,
+                dest: Some(destination),
+                next,
+                ..
+            } => {
+                assert_eq!(callee, "add_one");
+                assert_eq!(*authority, crate::CallAuthority::Direct);
+                (*destination, *next)
+            }
+            other => panic!("expected SIR call to lower as raw terminator, got {other:?}"),
+        };
+        assert!(matches!(destination, Place::Local(_)));
+        let continuation = caller_raw
+            .blocks
+            .iter()
+            .find(|block| block.id == continuation)
+            .expect("raw call continuation must exist");
+        assert!(continuation
+            .instructions
+            .iter()
+            .any(|instruction| { matches!(instruction, Instr::ConstI64 { value: 1, .. }) }));
+        assert!(continuation.instructions.iter().any(|instruction| {
+            matches!(
+                instruction,
+                Instr::IntArithChecked {
+                    op: IntArithOp::Add,
+                    ..
+                }
+            )
+        }));
+        let callee_checked = component
+            .checked_mir
+            .iter()
+            .find(|checked| checked.name == "add_one")
+            .expect("callee must receive freshly-derived checked MIR");
+        assert!(matches!(
+            callee_checked.decisions.as_slice(),
+            [crate::DecisionFact {
+                strategy: Strategy::ParamBoundary(ParamBoundaryFact {
+                    param_index: 0,
+                    param_count: 1,
+                    caller_visible_projection: false,
+                    mode: ParamBoundaryMode::BorrowReadOnly,
+                }),
+                ..
+            }]
+        ));
+        assert!(component
+            .checked_mir
+            .iter()
+            .find(|checked| checked.name == "main")
+            .is_some_and(|checked| !checked.cooperate_sites.is_empty()));
+        let pipeline = component.into_pipeline();
+        assert_eq!(pipeline.raw_mir.len(), 2);
+        assert_eq!(pipeline.checked_mir.len(), 2);
+        assert!(pipeline.elaborated_mir.is_empty());
+    }
+
+    #[test]
+    #[allow(
+        clippy::similar_names,
+        reason = "the focused unit-call component fixture intentionally contrasts callee and caller raw-MIR realization"
+    )]
+    fn realizes_a_zero_result_unit_direct_call_without_a_raw_template() {
+        let callee = SemFunction {
+            id: ItemId(1),
+            callable: CallableId(0),
+            declaration: DefId::for_test("record"),
+            name: "record".to_string(),
+            span: 20..40,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: vec![BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
+            }],
+            return_ty: ResolvedTy::Unit,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return { value: None },
+            }],
+        };
+        let caller = SemFunction {
+            id: ItemId(0),
+            callable: CallableId(1),
+            declaration: DefId::for_test("main"),
+            name: "main".to_string(),
+            span: 0..60,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: Vec::new(),
+            return_ty: ResolvedTy::Unit,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![
+                    op(0, definition(0, ResolvedTy::I64), SemOpKind::ConstI64(7)),
+                    zero_result_op(
+                        1,
+                        SemOpKind::Call {
+                            callee: CallableId(0),
+                            args: vec![operand(0)],
+                        },
+                    ),
+                ],
+                terminator: SemTerminator::Return { value: None },
+            }],
+        };
+        let component =
+            lower_closed_scalar_component(&test_module(vec![caller, callee]), &[CallableId(1)])
+                .expect("a closed unit direct-call graph should lower independently");
+
+        let caller_raw = component
+            .raw_mir
+            .iter()
+            .find(|raw| raw.name == "main")
+            .expect("selected unit caller must have a fresh raw body");
+        let continuation = match &caller_raw.blocks[0].terminator {
+            Terminator::Call {
+                callee,
+                authority,
+                args,
+                dest: None,
+                next,
+            } => {
+                assert_eq!(callee, "record");
+                assert_eq!(*authority, crate::CallAuthority::Direct);
+                assert_eq!(args.len(), 1);
+                *next
+            }
+            other => panic!("expected zero-result SIR call to lower as raw call, got {other:?}"),
+        };
+        assert_eq!(
+            caller_raw.locals.len(),
+            1,
+            "the unit call must not allocate a raw-MIR destination local"
+        );
+        assert!(matches!(
+            caller_raw
+                .blocks
+                .iter()
+                .find(|block| block.id == continuation)
+                .expect("raw unit-call continuation must exist")
+                .terminator,
+            Terminator::Return
+        ));
+    }
+
+    #[test]
+    fn rejects_a_reachable_callable_without_a_sir_body_atomically() {
+        let caller = SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("main"),
+            name: "main".to_string(),
+            span: 0..20,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: Vec::new(),
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![op(
+                    0,
+                    definition(0, ResolvedTy::I64),
+                    SemOpKind::Call {
+                        callee: CallableId(1),
+                        args: Vec::new(),
+                    },
+                )],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(0)),
+                },
+            }],
+        };
+        let mut module = test_module(vec![caller]);
+        module.callables.push(SemCallable {
+            id: CallableId(1),
+            function: ItemId(1),
+            declaration: DefId::for_test("missing"),
+            symbol: "missing".to_string(),
+            source_origin: FunctionSourceOrigin::Unknown,
+            signature: SemSignature {
+                params: Vec::new(),
+                return_ty: ResolvedTy::I64,
+            },
+            call_conv: SemCallConv::Default,
+            kind: SemCallableKind::HewDirect,
+            effect_summary: hew_sir::EffectSummary::Unknown,
+        });
+
+        let error = lower_closed_scalar_component(&module, &[CallableId(0)])
+            .expect_err("a reachable callable without a SIR body must not fall back");
+        assert!(error
+            .reason
+            .contains("requires one lowered body for `missing`"));
+        assert!(error.reason.contains("main → missing"));
+    }
+
+    #[test]
     fn replacing_a_scalar_body_removes_stale_elaboration() {
         let function = SemFunction {
             id: ItemId(0),
+            callable: CallableId(0),
             declaration: DefId::for_test("constant"),
             name: "constant".to_string(),
             span: 0..0,
@@ -1510,12 +3071,7 @@ mod tests {
             ..IrPipeline::default()
         };
 
-        let report = apply_sir_to_pipeline(
-            &SemModule {
-                functions: vec![function],
-            },
-            &mut pipeline,
-        );
+        let report = apply_sir_to_pipeline(&test_module(vec![function]), &mut pipeline);
         assert_eq!(report.lowered_count(), 1, "{report:#?}");
         assert!(pipeline.elaborated_mir.is_empty());
         assert!(matches!(
@@ -1534,6 +3090,7 @@ mod tests {
     fn module_verification_prevents_duplicate_functions_from_mutating_mir() {
         let function = SemFunction {
             id: ItemId(0),
+            callable: CallableId(0),
             declaration: DefId::for_test("duplicate"),
             name: "duplicate".to_string(),
             span: 0..0,
@@ -1562,12 +3119,7 @@ mod tests {
             ..IrPipeline::default()
         };
 
-        let report = apply_sir_to_pipeline(
-            &SemModule {
-                functions: vec![function, duplicate],
-            },
-            &mut pipeline,
-        );
+        let report = apply_sir_to_pipeline(&test_module(vec![function, duplicate]), &mut pipeline);
 
         assert_eq!(report.lowered_count(), 0, "{report:#?}");
         assert_eq!(pipeline.raw_mir, vec![raw]);

--- a/hew-sir/src/dump.rs
+++ b/hew-sir/src/dump.rs
@@ -30,7 +30,7 @@ pub fn dump_sir(module: &SemModule) -> String {
             }
             writeln!(out, ":").expect("write to String");
             for op in &block.ops {
-                dump_op(&mut out, op);
+                dump_op(&mut out, module, op);
             }
             dump_term(&mut out, &block.terminator);
         }
@@ -39,9 +39,23 @@ pub fn dump_sir(module: &SemModule) -> String {
     out
 }
 
-fn dump_op(out: &mut String, op: &crate::SemOp) {
-    let result = &op.results[0];
-    write!(out, "    %{} = ", result.id.0).expect("write to String");
+fn dump_op(out: &mut String, module: &SemModule, op: &crate::SemOp) {
+    write!(out, "    ").expect("write to String");
+    match op.results.as_slice() {
+        [] => {}
+        [result] => write!(out, "%{} = ", result.id.0).expect("write to String"),
+        // The verifier rejects multi-result operations in this initial slice,
+        // but a dump must remain total for malformed IR used in diagnostics.
+        results => {
+            for (index, result) in results.iter().enumerate() {
+                if index != 0 {
+                    write!(out, ", ").expect("write to String");
+                }
+                write!(out, "%{}", result.id.0).expect("write to String");
+            }
+            write!(out, " = ").expect("write to String");
+        }
+    }
     match &op.kind {
         SemOpKind::ConstI64(value) => writeln!(out, "const {value}").expect("write to String"),
         SemOpKind::ConstBool(value) => writeln!(out, "const {value}").expect("write to String"),
@@ -55,8 +69,12 @@ fn dump_op(out: &mut String, op: &crate::SemOp) {
             writeln!(out, "cast %{} to {}", value.value.0, to.user_facing())
                 .expect("write to String");
         }
-        SemOpKind::Call { target, args } => {
-            write!(out, "call {target:?}(").expect("write to String");
+        SemOpKind::Call { callee, args } => {
+            let target = module.callable(*callee).map_or_else(
+                || format!("<invalid-callable:{}>", callee.0),
+                |callable| callable.symbol.clone(),
+            );
+            write!(out, "call @{target}(").expect("write to String");
             for (index, arg) in args.iter().enumerate() {
                 if index != 0 {
                     write!(out, ", ").expect("write to String");

--- a/hew-sir/src/lib.rs
+++ b/hew-sir/src/lib.rs
@@ -16,7 +16,11 @@ pub use analysis::{build_def_use, compute_dominators, DefUseIndex, Dominators};
 pub use dump::dump_sir;
 pub use lower::{lower_module, LoweredModule, SirLoweringStatus};
 pub use model::{
-    BlockArg, BlockId, Edge, EffectSet, FunctionSourceOrigin, OpId, Operand, Provenance, SemBlock,
-    SemFunction, SemModule, SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+    BlockArg, BlockId, CallableId, Edge, EffectSet, EffectSummary, FunctionSourceOrigin, OpId,
+    Operand, Provenance, SemAbiParam, SemBlock, SemCallConv, SemCallable, SemCallableKind,
+    SemFunction, SemModule, SemOp, SemOpKind, SemParamPassing, SemSignature, SemTerminator,
+    UseMode, ValueDef, ValueId,
 };
-pub use verify::{verify_function, verify_module, SirDiagnostic, SirDiagnosticKind};
+pub use verify::{
+    verify_function, verify_function_in_module, verify_module, SirDiagnostic, SirDiagnosticKind,
+};

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -2,12 +2,14 @@ use std::collections::HashMap;
 
 use hew_hir::{
     BindingId, HirBlock, HirExpr, HirExprKind, HirFn, HirItem, HirLiteral, HirModule, HirStmtKind,
-    ResolvedRef,
+    IntentKind, ResolvedRef,
 };
 
 use crate::{
-    BlockArg, BlockId, Edge, FunctionSourceOrigin, OpId, Operand, Provenance, SemBlock,
-    SemFunction, SemModule, SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+    BlockArg, BlockId, CallableId, Edge, EffectSummary, FunctionSourceOrigin, OpId, Operand,
+    Provenance, SemAbiParam, SemBlock, SemCallConv, SemCallable, SemCallableKind, SemFunction,
+    SemModule, SemOp, SemOpKind, SemParamPassing, SemSignature, SemTerminator, UseMode, ValueDef,
+    ValueId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,20 +28,45 @@ pub struct LoweredModule {
 
 #[must_use]
 pub fn lower_module(module: &HirModule) -> LoweredModule {
-    let mut output = SemModule::default();
+    // Build declaration/signature authority before lowering any body. This
+    // permits forward calls and recursion without symbol reconstruction, and
+    // deliberately keeps an eligible callable when its own body later proves
+    // unsupported: strict drivers can then reject only a reachable missing
+    // body instead of every unrelated unsupported function in a module.
+    let callables = CallableTable::from_hir(module);
+    let mut output = SemModule {
+        callables: callables.callables.clone(),
+        root_unit_callables: callables.root_unit_callables.clone(),
+        entry_callable: callables.entry_callable,
+        functions: Vec::new(),
+    };
     let mut statuses = Vec::new();
     for item in &module.items {
         let HirItem::Function(function) = item else {
             continue;
         };
-        let source_origin = if module.root_item_ids.contains(&function.id) {
-            FunctionSourceOrigin::RootUnit
-        } else if let Some(module_name) = module.diagnostic_source_modules.get(&function.id) {
-            FunctionSourceOrigin::Foreign(module_name.clone())
-        } else {
-            FunctionSourceOrigin::Unknown
+        let Some(callable) = callables.by_declaration.get(&function.declaration).copied() else {
+            let reason = callables
+                .ineligible
+                .get(&function.id)
+                .cloned()
+                .unwrap_or_else(|| {
+                    "function has no deterministic SIR direct-call entry".to_string()
+                });
+            statuses.push((
+                function.name.clone(),
+                SirLoweringStatus::Unsupported { reason },
+            ));
+            continue;
         };
-        match Builder::new(function, source_origin).lower() {
+        match Builder::new(
+            function,
+            function_source_origin(module, function),
+            &callables,
+            callable,
+        )
+        .lower()
+        {
             Ok(function) => {
                 statuses.push((function.name.clone(), SirLoweringStatus::Lowered));
                 output.functions.push(function);
@@ -56,8 +83,170 @@ pub fn lower_module(module: &HirModule) -> LoweredModule {
     }
 }
 
+/// Deterministic SIR view of the HIR direct-call projection.
+///
+/// The HIR dispatcher is still the owner of exact emitted symbols.  SIR only
+/// projects those checked facts into its semantic callable table; it never
+/// reconstructs a symbol from a declaration's presentation spelling.
+#[derive(Debug, Clone)]
+struct CallableTable {
+    callables: Vec<SemCallable>,
+    root_unit_callables: Vec<CallableId>,
+    entry_callable: Option<CallableId>,
+    by_declaration: HashMap<hew_types::DefId, CallableId>,
+    ineligible: HashMap<hew_hir::ItemId, String>,
+}
+
+impl CallableTable {
+    fn from_hir(module: &HirModule) -> Self {
+        let direct_symbols = hew_hir::dispatch::build_direct_call_symbol_index(&module.items);
+        let mut pending = Vec::new();
+        let mut ineligible = HashMap::new();
+        for item in &module.items {
+            let HirItem::Function(function) = item else {
+                continue;
+            };
+            let signature = match scalar_callable_signature(function) {
+                Ok(signature) => signature,
+                Err(reason) => {
+                    ineligible.insert(function.id, reason);
+                    continue;
+                }
+            };
+            let Some(symbol) = direct_symbols.get(&function.declaration) else {
+                ineligible.insert(
+                    function.id,
+                    format!(
+                        "HIR direct-call symbol index has no exact symbol for declaration `{}`",
+                        function.declaration.full_path()
+                    ),
+                );
+                continue;
+            };
+            pending.push((
+                function,
+                function_source_origin(module, function),
+                symbol.clone(),
+                signature,
+            ));
+        }
+        pending.sort_unstable_by(|(left, _, left_symbol, _), (right, _, right_symbol, _)| {
+            left.declaration
+                .cmp(&right.declaration)
+                .then_with(|| left_symbol.cmp(right_symbol))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+
+        let mut callables = Vec::with_capacity(pending.len());
+        let mut root_unit_callables = Vec::new();
+        let mut entry_callable = None;
+        let mut by_declaration = HashMap::with_capacity(pending.len());
+        for (index, (function, source_origin, symbol, signature)) in pending.into_iter().enumerate()
+        {
+            let id = CallableId(
+                u32::try_from(index).expect("SIR callable count exceeds the module-local ID range"),
+            );
+            if source_origin == FunctionSourceOrigin::RootUnit {
+                root_unit_callables.push(id);
+                if function.declaration.full_path() == "main" {
+                    entry_callable = Some(id);
+                }
+            }
+            by_declaration.insert(function.declaration.clone(), id);
+            callables.push(SemCallable {
+                id,
+                function: function.id,
+                declaration: function.declaration.clone(),
+                symbol,
+                source_origin,
+                signature,
+                call_conv: SemCallConv::Default,
+                kind: SemCallableKind::HewDirect,
+                effect_summary: EffectSummary::Unknown,
+            });
+        }
+        Self {
+            callables,
+            root_unit_callables,
+            entry_callable,
+            by_declaration,
+            ineligible,
+        }
+    }
+
+    fn callable(&self, id: CallableId) -> Option<&SemCallable> {
+        self.callables
+            .get(usize::try_from(id.0).ok()?)
+            .filter(|callable| callable.id == id)
+    }
+}
+
+fn function_source_origin(module: &HirModule, function: &HirFn) -> FunctionSourceOrigin {
+    if module.root_item_ids.contains(&function.id) {
+        FunctionSourceOrigin::RootUnit
+    } else if let Some(module_name) = module.diagnostic_source_modules.get(&function.id) {
+        FunctionSourceOrigin::Foreign(module_name.clone())
+    } else {
+        FunctionSourceOrigin::Unknown
+    }
+}
+
+fn scalar_callable_signature(function: &HirFn) -> Result<SemSignature, String> {
+    if function.is_generator || function.intrinsic_id.is_some() {
+        return Err(
+            "generators and floor intrinsics remain outside SIR's ordinary direct-call domain"
+                .to_string(),
+        );
+    }
+    if !function.type_params.is_empty() {
+        return Err(
+            "generic origin functions remain outside SIR's monomorphic direct-call domain"
+                .to_string(),
+        );
+    }
+    let mut params = Vec::with_capacity(function.params.len());
+    for (index, parameter) in function.params.iter().enumerate() {
+        if parameter.is_consume {
+            return Err(format!(
+                "parameter {index} is consume-owned; SIR direct calls initially require Read operands"
+            ));
+        }
+        if !is_initial_scalar(&parameter.ty) {
+            return Err(format!(
+                "parameter {index} has non-scalar type `{}`; aggregate/reference ABI lowering is deferred",
+                parameter.ty.user_facing()
+            ));
+        }
+        params.push(SemAbiParam {
+            ty: parameter.ty.clone(),
+            passing: SemParamPassing::ReadOnly,
+            caller_visible_projection: false,
+        });
+    }
+    if !is_initial_scalar_return(&function.return_ty) {
+        return Err(format!(
+            "return type `{}` is outside SIR's initial scalar call-result domain",
+            function.return_ty.user_facing()
+        ));
+    }
+    Ok(SemSignature {
+        params,
+        return_ty: function.return_ty.clone(),
+    })
+}
+
+fn is_initial_scalar(ty: &hew_types::ResolvedTy) -> bool {
+    ty.is_integer() || matches!(ty, hew_types::ResolvedTy::Bool)
+}
+
+fn is_initial_scalar_return(ty: &hew_types::ResolvedTy) -> bool {
+    matches!(ty, hew_types::ResolvedTy::Unit) || is_initial_scalar(ty)
+}
+
 struct Builder<'a> {
     function: &'a HirFn,
+    callables: &'a CallableTable,
+    callable: CallableId,
     blocks: Vec<SemBlock>,
     current: BlockId,
     values: u32,
@@ -68,7 +257,12 @@ struct Builder<'a> {
 }
 
 impl<'a> Builder<'a> {
-    fn new(function: &'a HirFn, source_origin: FunctionSourceOrigin) -> Self {
+    fn new(
+        function: &'a HirFn,
+        source_origin: FunctionSourceOrigin,
+        callables: &'a CallableTable,
+        callable: CallableId,
+    ) -> Self {
         let entry = BlockId(0);
         let mut values = 0;
         let mut bindings = HashMap::new();
@@ -87,6 +281,8 @@ impl<'a> Builder<'a> {
             .collect();
         Self {
             function,
+            callables,
+            callable,
             blocks: vec![SemBlock {
                 id: entry,
                 args: Vec::new(),
@@ -103,6 +299,20 @@ impl<'a> Builder<'a> {
     }
 
     fn lower(mut self) -> Result<SemFunction, String> {
+        let callable = self.callables.callable(self.callable).ok_or_else(|| {
+            format!(
+                "SIR callable {:?} is absent while lowering `{}`",
+                self.callable, self.function.name
+            )
+        })?;
+        if callable.function != self.function.id
+            || callable.declaration != self.function.declaration
+            || callable.symbol != self.function.name
+        {
+            return Err(
+                "SIR callable table does not match the HIR function's checked identity".to_string(),
+            );
+        }
         if self.function.is_generator || self.function.intrinsic_id.is_some() {
             return Err(
                 "generators and floor intrinsics remain on the established MIR path".to_string(),
@@ -120,6 +330,7 @@ impl<'a> Builder<'a> {
         }
         Ok(SemFunction {
             id: self.function.id,
+            callable: self.callable,
             declaration: self.function.declaration.clone(),
             name: self.function.name.clone(),
             span: self.function.span.clone(),
@@ -151,13 +362,17 @@ impl<'a> Builder<'a> {
                     self.bindings.insert(binding.id, value);
                 }
                 HirStmtKind::Expr(expr) => {
-                    self.lower_expr(expr)?;
+                    self.lower_discarded_expr(expr)?;
                 }
                 HirStmtKind::Return(value) => {
-                    let value = value
-                        .as_ref()
-                        .map(|expr| self.lower_expr(expr))
-                        .transpose()?;
+                    let value = match value {
+                        Some(expr) if expr.ty == hew_types::ResolvedTy::Unit => {
+                            self.lower_discarded_expr(expr)?;
+                            None
+                        }
+                        Some(expr) => Some(self.lower_expr(expr)?),
+                        None => None,
+                    };
                     self.set_terminator(SemTerminator::Return { value });
                 }
                 HirStmtKind::Assign { .. } => {
@@ -175,14 +390,31 @@ impl<'a> Builder<'a> {
             }
         }
         if self.is_open() {
-            block
-                .tail
-                .as_deref()
-                .map(|expr| self.lower_expr(expr))
-                .transpose()
+            match block.tail.as_deref() {
+                Some(expr) if expr.ty == hew_types::ResolvedTy::Unit => {
+                    self.lower_discarded_expr(expr)?;
+                    Ok(None)
+                }
+                Some(expr) => Ok(Some(self.lower_expr(expr)?)),
+                None => Ok(None),
+            }
         } else {
             Ok(None)
         }
+    }
+
+    /// Lower an expression whose value is intentionally discarded.
+    ///
+    /// Scalar expressions keep their ordinary one-result SSA operation even
+    /// when the result is unused.  A unit direct call is different: there is
+    /// no semantic value to define, but the call itself must remain in SIR so
+    /// later lowering can realize its call/continuation CFG edge.
+    fn lower_discarded_expr(&mut self, expr: &HirExpr) -> Result<(), String> {
+        if matches!(expr.kind, HirExprKind::Call { .. }) {
+            self.lower_direct_call(expr, false)?;
+            return Ok(());
+        }
+        self.lower_expr(expr).map(|_| ())
     }
 
     #[allow(
@@ -269,40 +501,10 @@ impl<'a> Builder<'a> {
                     },
                 ))
             }
-            HirExprKind::Call {
-                target,
-                callee,
-                args,
-            } => {
-                if matches!(target, hew_types::CallTarget::IndirectFunctionValue) {
-                    return Err(
-                        "indirect calls are deferred until SIR models the callee value explicitly"
-                            .to_string(),
-                    );
-                }
-                if !matches!(callee.kind, HirExprKind::BindingRef { .. }) {
-                    return Err(
-                        "calls with an evaluated callee are deferred until SIR models callee values"
-                            .to_string(),
-                    );
-                }
-                let args = args
-                    .iter()
-                    .map(|arg| {
-                        self.lower_expr(arg).map(|value| Operand {
-                            value,
-                            mode: UseMode::Read,
-                        })
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                Ok(self.emit(
-                    expr,
-                    SemOpKind::Call {
-                        target: target.clone(),
-                        args,
-                    },
-                ))
-            }
+            HirExprKind::Call { .. } => self.lower_direct_call(expr, true)?.ok_or_else(|| {
+                "unit-valued direct calls are valid only in a discarded or unit-return context"
+                    .to_string()
+            }),
             HirExprKind::Block(block) => self
                 .lower_block(block)?
                 .ok_or_else(|| "a divergent block cannot produce a SIR value".to_string()),
@@ -317,6 +519,138 @@ impl<'a> Builder<'a> {
                 "one-armed if expressions are deferred until unit values are modeled".to_string(),
             ),
             _ => Err("unsupported HIR expression kind in the initial SIR subset".to_string()),
+        }
+    }
+
+    /// Lower an HIR direct call through the resolved SIR callable table.
+    ///
+    /// `value_required` distinguishes a value context from a discarded/unit
+    /// context.  Non-unit calls always retain their single SSA result; unit
+    /// calls are admitted only in the latter and become zero-result `Call`
+    /// operations.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the initial direct-call ABI admission is deliberately kept as one auditable HIR-to-SIR boundary"
+    )]
+    fn lower_direct_call(
+        &mut self,
+        expr: &HirExpr,
+        value_required: bool,
+    ) -> Result<Option<ValueId>, String> {
+        let HirExprKind::Call {
+            target,
+            callee,
+            args,
+        } = &expr.kind
+        else {
+            return Err(
+                "internal SIR lowering error: direct-call lowering received a non-call".to_string(),
+            );
+        };
+        let declaration =
+            match target {
+                hew_types::CallTarget::User(declaration)
+                | hew_types::CallTarget::ImplMethod(declaration) => declaration,
+                hew_types::CallTarget::IndirectFunctionValue => {
+                    return Err(
+                        "indirect calls are deferred until SIR models the callee value explicitly"
+                            .to_string(),
+                    )
+                }
+                _ => return Err(
+                    "only ordinary user/impl direct calls are in SIR's initial scalar call domain"
+                        .to_string(),
+                ),
+            };
+        if !matches!(callee.kind, HirExprKind::BindingRef { .. }) {
+            return Err(
+                "calls with an evaluated callee are deferred until SIR models callee values"
+                    .to_string(),
+            );
+        }
+        let callee = self
+            .callables
+            .by_declaration
+            .get(declaration)
+            .copied()
+            .ok_or_else(|| {
+                format!(
+                    "direct callee `{}` has no scalar default-call SIR callable",
+                    declaration.full_path()
+                )
+            })?;
+        let (callee_declaration, params, return_ty) = self
+            .callables
+            .callable(callee)
+            .map(|signature| {
+                (
+                    signature.declaration.clone(),
+                    signature.signature.params.clone(),
+                    signature.signature.return_ty.clone(),
+                )
+            })
+            .ok_or_else(|| {
+                format!("SIR callable {callee:?} is absent from its deterministic table")
+            })?;
+        if args.len() != params.len() {
+            return Err(format!(
+                "direct callee `{}` expects {} argument(s), HIR carries {}",
+                callee_declaration.full_path(),
+                params.len(),
+                args.len()
+            ));
+        }
+        if expr.ty != return_ty {
+            return Err(format!(
+                "direct callee `{}` returns `{}`, but call expression has `{}`",
+                callee_declaration.full_path(),
+                return_ty.user_facing(),
+                expr.ty.user_facing()
+            ));
+        }
+        let mut lowered_args = Vec::with_capacity(args.len());
+        for (index, (arg, expected)) in args.iter().zip(&params).enumerate() {
+            if expected.passing != SemParamPassing::ReadOnly {
+                return Err(format!(
+                    "direct callee `{}` has a non-ReadOnly SIR ABI parameter {index}",
+                    callee_declaration.full_path()
+                ));
+            }
+            if arg.intent != IntentKind::Read {
+                return Err(format!(
+                    "direct call argument {index} to `{}` has {:?} intent; initial SIR calls require Read",
+                    callee_declaration.full_path(),
+                    arg.intent
+                ));
+            }
+            if arg.ty != expected.ty {
+                return Err(format!(
+                    "direct call argument {index} to `{}` has `{}`, expected `{}`",
+                    callee_declaration.full_path(),
+                    arg.ty.user_facing(),
+                    expected.ty.user_facing()
+                ));
+            }
+            lowered_args.push(Operand {
+                value: self.lower_expr(arg)?,
+                mode: UseMode::Read,
+            });
+        }
+        let kind = SemOpKind::Call {
+            callee,
+            args: lowered_args,
+        };
+        if return_ty == hew_types::ResolvedTy::Unit {
+            if value_required {
+                return Err(format!(
+                    "unit-valued direct call `{}` cannot produce an SSA value",
+                    callee_declaration.full_path()
+                ));
+            }
+            self.emit_without_result(expr, kind);
+            Ok(None)
+        } else {
+            Ok(Some(self.emit(expr, kind)))
         }
     }
 
@@ -465,6 +799,17 @@ impl<'a> Builder<'a> {
         self.ops += 1;
         self.current_block_mut().ops.push(op);
         value
+    }
+
+    fn emit_without_result(&mut self, expr: &HirExpr, kind: SemOpKind) {
+        let op = SemOp {
+            id: OpId(self.ops),
+            results: Vec::new(),
+            kind,
+            provenance: Provenance::Site(expr.site),
+        };
+        self.ops += 1;
+        self.current_block_mut().ops.push(op);
     }
 
     fn fresh_value(&mut self) -> ValueId {

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -1,6 +1,6 @@
 use hew_hir::{ItemId, SiteId};
 use hew_parser::ast::Span;
-use hew_types::{CallTarget, DefId, ResolvedTy};
+use hew_types::{DefId, ResolvedTy};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BlockId(pub u32);
@@ -8,6 +8,12 @@ pub struct BlockId(pub u32);
 pub struct ValueId(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpId(pub u32);
+/// Stable, module-local identity for a SIR direct-call target.
+///
+/// IDs are assigned from the deterministic [`SemModule::callables`] order;
+/// unlike an emitted symbol, they are not reconstructed from spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CallableId(pub u32);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Provenance {
@@ -73,6 +79,11 @@ pub struct SemBlock {
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemFunction {
     pub id: ItemId,
+    /// Module-local ABI-neutral identity of this body's resolved callable.
+    /// The verifier proves this agrees with the callable table's checker
+    /// declaration and exact emitted symbol; consumers must use it rather
+    /// than rejoining functions by a symbol spelling.
+    pub callable: CallableId,
     /// Resolver-minted source declaration identity.  `name` is an emitted
     /// symbol spelling, whereas calls and future monomorphization carry this
     /// stable semantic identity.
@@ -88,14 +99,162 @@ pub struct SemFunction {
     pub blocks: Vec<SemBlock>,
 }
 
+/// The call convention SIR is permitted to model before ownership/layout MIR
+/// decides concrete ABI carriers.
+///
+/// Runtime, C-ABI, coroutine, actor, and other specialised conventions stay
+/// outside this initial domain.  Keeping this enum explicit prevents a
+/// resolved SIR call from silently acquiring a target-specific ABI policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SemCallConv {
+    Default,
+}
+
+/// Semantic class of a callable in the initial SIR direct-call domain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SemCallableKind {
+    /// An ordinary Hew user function or flattened impl-method body.
+    HewDirect,
+}
+
+/// ABI disposition for one semantic callable parameter.
+///
+/// This is intentionally separate from [`UseMode`]: call operands express the
+/// semantic use at one call site, while this records the callee-side ABI
+/// obligation that ownership/layout MIR must eventually realize.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SemParamPassing {
+    /// The initial scalar direct-call domain accepts only non-owning reads.
+    ReadOnly,
+}
+
+/// ABI-neutral parameter facts owned by a resolved SIR callable.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemAbiParam {
+    pub ty: ResolvedTy,
+    pub passing: SemParamPassing,
+    /// Positive authority for a parameter whose storage projection is visible
+    /// to its caller. Scalar v1 direct calls always set this to `false`; later
+    /// ownership/layout slices must make any `true` fact explicit here rather
+    /// than borrowing a legacy raw-MIR decision.
+    pub caller_visible_projection: bool,
+}
+
+/// ABI-neutral signature of a resolved SIR callable.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemSignature {
+    pub params: Vec<SemAbiParam>,
+    pub return_ty: ResolvedTy,
+}
+
+/// Conservative interprocedural effect summary carried by a resolved SIR
+/// callable.
+///
+/// SIR does not yet compute a function-summary fixed point, so every
+/// producer currently writes [`Self::Unknown`].  The explicit carrier means
+/// call operations can derive their effects from resolved callee metadata when
+/// that analysis arrives, without turning `SemOp` into a second source of
+/// truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum EffectSummary {
+    #[default]
+    Unknown,
+    /// The callable has no other known observable effect, but can transfer
+    /// control to a language-visible trap. Initial scalar bodies commonly
+    /// fall in this class because checked integer operations can overflow.
+    MayTrap,
+    Pure,
+}
+
+impl EffectSummary {
+    #[must_use]
+    pub const fn effects(self) -> EffectSet {
+        match self {
+            Self::Unknown => EffectSet::UNKNOWN_CALL,
+            Self::MayTrap => EffectSet::MAY_TRAP,
+            Self::Pure => EffectSet::PURE,
+        }
+    }
+}
+
+/// One checker-resolved, ABI-neutral SIR callable.
+///
+/// This table is the sole SIR authority for a direct call's stable semantic
+/// declaration, exact emitted symbol, source provenance, and signature.  A
+/// callable may deliberately have no [`SemFunction`] body: HIR-to-SIR records
+/// every eligible scalar declaration before body lowering so a strict driver
+/// can diagnose a *reachable* missing body without treating unrelated
+/// unsupported functions as a module-wide failure.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemCallable {
+    pub id: CallableId,
+    /// HIR function item that owns the body when it is lowered to SIR.
+    pub function: ItemId,
+    /// Resolver-minted semantic declaration identity.
+    pub declaration: DefId,
+    /// Exact body symbol selected by HIR's direct-call symbol index.
+    pub symbol: String,
+    pub source_origin: FunctionSourceOrigin,
+    pub signature: SemSignature,
+    pub call_conv: SemCallConv,
+    pub kind: SemCallableKind,
+    pub effect_summary: EffectSummary,
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct SemModule {
+    /// Deterministic resolved direct-call authority.  IDs must equal their
+    /// indexes in this vector; [`crate::verify_module`] checks that invariant.
+    pub callables: Vec<SemCallable>,
+    /// Every root-unit callable in `callables` order. This supports source
+    /// provenance and diagnostics; executable strict reachability starts only
+    /// from [`Self::entry_callable`], so unrelated root bodies do not block a
+    /// selected program.
+    pub root_unit_callables: Vec<CallableId>,
+    /// Checked root-unit entry callable, if its signature belongs to the
+    /// current SIR surface. HIR establishes this from the root source `main`
+    /// declaration once; strict selection never rediscovers it by symbol.
+    pub entry_callable: Option<CallableId>,
     pub functions: Vec<SemFunction>,
+}
+
+impl SemModule {
+    /// Look up a callable only when its identity agrees with the canonical
+    /// table index.  This intentionally fails closed for malformed tables.
+    #[must_use]
+    pub fn callable(&self, id: CallableId) -> Option<&SemCallable> {
+        self.callables
+            .get(usize::try_from(id.0).ok()?)
+            .filter(|callable| callable.id == id)
+    }
+
+    /// Find a resolved callable from checker-owned declaration identity.
+    #[must_use]
+    pub fn callable_for_declaration(&self, declaration: &DefId) -> Option<&SemCallable> {
+        self.callables
+            .iter()
+            .find(|callable| &callable.declaration == declaration)
+    }
+
+    /// Return the lowered SIR body for `id`, if the body was in the current
+    /// supported surface slice.  Absence is meaningful to strict call-graph
+    /// selection and is not a malformed callable-table condition by itself.
+    #[must_use]
+    pub fn function_for_callable(&self, id: CallableId) -> Option<&SemFunction> {
+        self.callable(id)?;
+        self.functions
+            .iter()
+            .find(|function| function.callable == id)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemOp {
     pub id: OpId,
+    /// SSA values defined by this operation.  Ordinary value operations and
+    /// non-unit calls define exactly one value in the initial SIR slice.
+    /// A direct call whose resolved callable returns `Unit` defines no value:
+    /// its control/effect still remains explicit as a zero-result `Call`.
     pub results: Vec<ValueDef>,
     pub kind: SemOpKind,
     pub provenance: Provenance,
@@ -107,9 +266,9 @@ pub struct SemOp {
 /// can clone or synthesize operations without maintaining a second source of
 /// truth.  The initial bit set is intentionally small; it gives early
 /// canonicalization passes a sound motion/CSE barrier without committing SIR
-/// to memory SSA or effect tokens.  Resolved calls currently lack an effect
-/// summary, so they are conservatively [`Self::UNKNOWN_CALL`] until the call
-/// ABI slice introduces one.
+/// to memory SSA or effect tokens.  Isolated operations conservatively report
+/// [`Self::UNKNOWN_CALL`] for calls; module-aware consumers use the resolved
+/// callable's effect summary through [`SemOpKind::effects_in`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct EffectSet(u8);
 
@@ -136,7 +295,7 @@ impl EffectSet {
 
     #[must_use]
     pub const fn may_trap(self) -> bool {
-        self.contains(Self::MAY_TRAP) || self.contains(Self::UNKNOWN_CALL)
+        self.contains(Self::MAY_TRAP)
     }
 }
 
@@ -162,8 +321,14 @@ pub enum SemOpKind {
         value: Operand,
         to: ResolvedTy,
     },
+    /// A resolved ordinary Hew direct call.
+    ///
+    /// The callable table determines result arity: a non-unit callee produces
+    /// one SSA value, while a unit callee is an explicit zero-result operation.
+    /// This avoids inventing a unit SSA carrier solely to model a call with
+    /// observable control/effect behavior.
     Call {
-        target: CallTarget,
+        callee: CallableId,
         args: Vec<Operand>,
     },
 }
@@ -194,6 +359,21 @@ impl SemOpKind {
             | Self::Unary { .. }
             | Self::Binary { .. }
             | Self::Cast { .. } => EffectSet::PURE,
+        }
+    }
+
+    /// Return the operation's effect set using resolved module call metadata
+    /// when it is available.  The context-free [`Self::effects`] remains
+    /// conservative for tools that inspect isolated operations.
+    #[must_use]
+    pub fn effects_in(&self, module: &SemModule) -> EffectSet {
+        match self {
+            Self::Call { callee, .. } => module
+                .callable(*callee)
+                .map_or(EffectSet::UNKNOWN_CALL, |callable| {
+                    callable.effect_summary.effects()
+                }),
+            _ => self.effects(),
         }
     }
 }

--- a/hew-sir/src/verify.rs
+++ b/hew-sir/src/verify.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use crate::OpId;
 use crate::{
-    BlockId, OpId, SemFunction, SemModule, SemOp, SemOpKind, SemTerminator, UseMode, ValueId,
+    BlockId, CallableId, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule, SemOp,
+    SemOpKind, SemParamPassing, SemTerminator, UseMode, ValueId,
 };
 use hew_types::ResolvedTy;
 
@@ -9,10 +11,47 @@ use hew_types::ResolvedTy;
 pub enum SirDiagnosticKind {
     DuplicateFunctionName(String),
     DuplicateFunctionDeclaration(String),
+    DuplicateCallableId(CallableId),
+    DuplicateCallableDeclaration(String),
+    DuplicateCallableSymbol(String),
+    InvalidCallable {
+        callable: CallableId,
+        reason: String,
+    },
+    InvalidRootCallable {
+        callable: CallableId,
+        reason: String,
+    },
+    /// `entry_callable` is an executable-program boundary, not merely one of
+    /// the source roots.  Keep its source identity and ABI rule separate from
+    /// the general root-unit table invariant so a malformed entry cannot
+    /// silently become an arbitrary callable during SIR → MIR lowering.
+    InvalidEntryCallable {
+        callable: CallableId,
+        reason: String,
+    },
+    MissingFunctionCallable {
+        declaration: String,
+    },
+    FunctionCallableMismatch {
+        callable: CallableId,
+        reason: String,
+    },
+    UnknownCallable {
+        op: OpId,
+        callee: CallableId,
+    },
     MissingEntry(BlockId),
     EntryBlockArgs {
         entry: BlockId,
         actual: usize,
+    },
+    /// SIR block IDs are vector positions as well as CFG identities at the
+    /// raw-MIR realization boundary.  Keep that representation invariant
+    /// explicit so consumers may safely index a verified function by ID.
+    NonCanonicalBlockOrder {
+        expected: BlockId,
+        actual: BlockId,
     },
     DuplicateBlock(BlockId),
     UnknownBlock(BlockId),
@@ -33,6 +72,12 @@ pub enum SirDiagnosticKind {
     DuplicateOp(OpId),
     InvalidResultArity {
         op: OpId,
+        actual: usize,
+    },
+    InvalidCallResultArity {
+        op: OpId,
+        callee: CallableId,
+        expected: usize,
         actual: usize,
     },
     InvalidConstType {
@@ -56,6 +101,11 @@ pub enum SirDiagnosticKind {
         expected: String,
         actual: Option<String>,
     },
+    /// Unit-returning SIR functions use a zero-value `Return`; the initial
+    /// value domain intentionally has no unit SSA carrier.
+    UnitReturnValue {
+        value: ValueId,
+    },
     UndefinedValue(ValueId),
     NonDominatingUse {
         value: ValueId,
@@ -74,9 +124,21 @@ pub struct SirDiagnostic {
     pub kind: SirDiagnosticKind,
 }
 
+#[derive(Debug)]
+struct CallableContext<'a> {
+    by_id: BTreeMap<CallableId, &'a SemCallable>,
+}
+
+impl<'a> CallableContext<'a> {
+    fn callable(&self, id: CallableId) -> Option<&'a SemCallable> {
+        self.by_id.get(&id).copied()
+    }
+}
+
 #[must_use]
 pub fn verify_module(module: &SemModule) -> Vec<SirDiagnostic> {
     let mut diagnostics = Vec::new();
+    let callables = verify_callable_table(module, &mut diagnostics);
     let mut names = HashSet::new();
     let mut declarations = HashSet::new();
     for function in &module.functions {
@@ -95,8 +157,21 @@ pub fn verify_module(module: &SemModule) -> Vec<SirDiagnostic> {
                 )),
             ));
         }
-        diagnostics.extend(verify_function(function));
+        diagnostics.extend(verify_function_with_context(function, Some(&callables)));
     }
+    diagnostics
+}
+
+/// Verify one function against the resolved callable table in `module`.
+///
+/// Use this at an inter-IR boundary that can receive direct calls.  The
+/// context-free [`verify_function`] remains useful for local CFG construction,
+/// but cannot prove a `CallableId`'s signature or ABI facts in isolation.
+#[must_use]
+pub fn verify_function_in_module(module: &SemModule, function: &SemFunction) -> Vec<SirDiagnostic> {
+    let mut diagnostics = Vec::new();
+    let callables = verify_callable_table(module, &mut diagnostics);
+    diagnostics.extend(verify_function_with_context(function, Some(&callables)));
     diagnostics
 }
 
@@ -111,9 +186,33 @@ pub fn verify_module(module: &SemModule) -> Vec<SirDiagnostic> {
 )]
 #[must_use]
 pub fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
+    verify_function_with_context(function, None)
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "the verifier keeps SSA collection, CFG shape, and dominance checks together so the stage boundary is auditable"
+)]
+fn verify_function_with_context(
+    function: &SemFunction,
+    callable_context: Option<&CallableContext<'_>>,
+) -> Vec<SirDiagnostic> {
     let mut diagnostics = Vec::new();
+    verify_function_callable_identity(function, callable_context, &mut diagnostics);
     let mut blocks = BTreeMap::new();
-    for block in &function.blocks {
+    for (index, block) in function.blocks.iter().enumerate() {
+        let expected = BlockId(
+            u32::try_from(index).expect("SIR block count exceeds the module-local ID range"),
+        );
+        if block.id != expected {
+            diagnostics.push(diag(
+                function,
+                SirDiagnosticKind::NonCanonicalBlockOrder {
+                    expected,
+                    actual: block.id,
+                },
+            ));
+        }
         if blocks.insert(block.id, block).is_some() {
             diagnostics.push(diag(function, SirDiagnosticKind::DuplicateBlock(block.id)));
         }
@@ -165,7 +264,7 @@ pub fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
     // defined in a later block rather than silently skipping its type check.
     for block in &function.blocks {
         for op in &block.ops {
-            verify_operation_shape(function, op, &types, &mut diagnostics);
+            verify_operation_shape(function, op, &types, callable_context, &mut diagnostics);
         }
         for edge in block.terminator.successors() {
             let Some(target) = blocks.get(&edge.target) else {
@@ -233,14 +332,248 @@ pub fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
 
 #[allow(
     clippy::too_many_lines,
+    reason = "callable identity, signature, and root-entry invariants share one auditable module boundary"
+)]
+fn verify_callable_table<'a>(
+    module: &'a SemModule,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) -> CallableContext<'a> {
+    let mut by_id = BTreeMap::new();
+    let mut ids = HashSet::new();
+    let mut declarations = HashSet::new();
+    let mut symbols = HashSet::new();
+    for (index, callable) in module.callables.iter().enumerate() {
+        let expected = CallableId(
+            u32::try_from(index).expect("SIR callable count exceeds the module-local ID range"),
+        );
+        if callable.id != expected {
+            diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                callable: callable.id,
+                reason: format!(
+                    "table position {index} requires id {:?}, found {:?}",
+                    expected, callable.id
+                ),
+            }));
+        }
+        if !ids.insert(callable.id) {
+            diagnostics.push(module_diag(SirDiagnosticKind::DuplicateCallableId(
+                callable.id,
+            )));
+        }
+        if !declarations.insert(callable.declaration.clone()) {
+            diagnostics.push(module_diag(
+                SirDiagnosticKind::DuplicateCallableDeclaration(
+                    callable.declaration.full_path().to_string(),
+                ),
+            ));
+        }
+        if !symbols.insert(callable.symbol.clone()) {
+            diagnostics.push(module_diag(SirDiagnosticKind::DuplicateCallableSymbol(
+                callable.symbol.clone(),
+            )));
+        }
+        if callable.call_conv != SemCallConv::Default {
+            diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                callable: callable.id,
+                reason: "initial SIR direct-call domain requires Default call convention"
+                    .to_string(),
+            }));
+        }
+        if callable.kind != SemCallableKind::HewDirect {
+            diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                callable: callable.id,
+                reason: "initial SIR callable table admits only ordinary HewDirect bodies"
+                    .to_string(),
+            }));
+        }
+        for (parameter, abi) in callable.signature.params.iter().enumerate() {
+            if !is_initial_scalar(&abi.ty) {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                    callable: callable.id,
+                    reason: format!(
+                        "parameter {parameter} has non-scalar type `{}`",
+                        abi.ty.user_facing()
+                    ),
+                }));
+            }
+            if abi.passing != SemParamPassing::ReadOnly {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                    callable: callable.id,
+                    reason: format!("parameter {parameter} has non-ReadOnly ABI passing"),
+                }));
+            }
+            if abi.caller_visible_projection {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                    callable: callable.id,
+                    reason: format!(
+                        "parameter {parameter} has a caller-visible projection before SIR owns that ABI feature"
+                    ),
+                }));
+            }
+        }
+        if !is_initial_scalar_return(&callable.signature.return_ty) {
+            diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                callable: callable.id,
+                reason: format!(
+                    "return type `{}` is outside the initial scalar SIR callable domain",
+                    callable.signature.return_ty.user_facing()
+                ),
+            }));
+        }
+        by_id.entry(callable.id).or_insert(callable);
+    }
+
+    let mut previous_root = None;
+    for root in &module.root_unit_callables {
+        if previous_root.is_some_and(|previous| previous >= *root) {
+            diagnostics.push(module_diag(SirDiagnosticKind::InvalidRootCallable {
+                callable: *root,
+                reason: "root-unit callable IDs must be unique and table-ordered".to_string(),
+            }));
+        }
+        previous_root = Some(*root);
+        match by_id.get(root) {
+            None => diagnostics.push(module_diag(SirDiagnosticKind::InvalidRootCallable {
+                callable: *root,
+                reason: "root-unit callable does not exist in the table".to_string(),
+            })),
+            Some(callable) if callable.source_origin != crate::FunctionSourceOrigin::RootUnit => {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidRootCallable {
+                    callable: *root,
+                    reason: "root-unit callable has non-root source provenance".to_string(),
+                }));
+            }
+            Some(_) => {}
+        }
+    }
+    if let Some(entry) = module.entry_callable {
+        match by_id.get(&entry) {
+            None => diagnostics.push(module_diag(SirDiagnosticKind::InvalidEntryCallable {
+                callable: entry,
+                reason: "entry callable does not exist in the table".to_string(),
+            })),
+            Some(callable)
+                if callable.source_origin != crate::FunctionSourceOrigin::RootUnit
+                    || !module.root_unit_callables.contains(&entry) =>
+            {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidEntryCallable {
+                    callable: entry,
+                    reason: "entry callable must be a listed root-unit callable".to_string(),
+                }));
+            }
+            Some(callable) if callable.declaration.full_path() != "main" => {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidEntryCallable {
+                    callable: entry,
+                    reason: "entry callable must resolve to the canonical root-unit source `main` declaration"
+                        .to_string(),
+                }));
+            }
+            Some(callable) if callable.symbol != "main" => {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidEntryCallable {
+                    callable: entry,
+                    reason: "entry callable must retain the canonical emitted `main` symbol"
+                        .to_string(),
+                }));
+            }
+            Some(callable) if !callable.signature.params.is_empty() => {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidEntryCallable {
+                    callable: entry,
+                    reason: "entry callable must be parameterless for the native and WASI entry adapters"
+                        .to_string(),
+                }));
+            }
+            Some(callable)
+                if callable.signature.return_ty != ResolvedTy::Unit
+                    && !callable.signature.return_ty.is_integer() =>
+            {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidEntryCallable {
+                    callable: entry,
+                    reason: "entry callable must return unit or an integer exit status".to_string(),
+                }));
+            }
+            Some(_) => {}
+        }
+    }
+    CallableContext { by_id }
+}
+
+fn verify_function_callable_identity(
+    function: &SemFunction,
+    callable_context: Option<&CallableContext<'_>>,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    let Some(callable_context) = callable_context else {
+        return;
+    };
+    let Some(callable) = callable_context.callable(function.callable) else {
+        diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::MissingFunctionCallable {
+                declaration: function.declaration.full_path().to_string(),
+            },
+        ));
+        return;
+    };
+    let function_params = function
+        .params
+        .iter()
+        .map(|parameter| parameter.ty.clone())
+        .collect::<Vec<_>>();
+    let callable_params = callable
+        .signature
+        .params
+        .iter()
+        .map(|parameter| parameter.ty.clone())
+        .collect::<Vec<_>>();
+    let identity_matches = callable.function == function.id
+        && callable.declaration == function.declaration
+        && callable.symbol == function.name
+        && callable.source_origin == function.source_origin
+        && callable_params == function_params
+        && callable.signature.return_ty == function.return_ty;
+    if !identity_matches {
+        diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::FunctionCallableMismatch {
+                callable: function.callable,
+                reason: "function identity, provenance, or SSA signature differs from its resolved callable"
+                    .to_string(),
+            },
+        ));
+    }
+}
+
+fn is_initial_scalar(ty: &ResolvedTy) -> bool {
+    ty.is_integer() || matches!(ty, ResolvedTy::Bool)
+}
+
+fn is_initial_scalar_return(ty: &ResolvedTy) -> bool {
+    matches!(ty, ResolvedTy::Unit) || is_initial_scalar(ty)
+}
+
+#[allow(
+    clippy::too_many_lines,
     reason = "the closed first-slice operation relation table is deliberately central so additions must make their verifier rule explicit"
 )]
 fn verify_operation_shape(
     function: &SemFunction,
     operation: &SemOp,
     types: &HashMap<ValueId, ResolvedTy>,
+    callable_context: Option<&CallableContext<'_>>,
     diagnostics: &mut Vec<SirDiagnostic>,
 ) {
+    if let SemOpKind::Call { callee, args } = &operation.kind {
+        verify_direct_call_operation(
+            function,
+            operation,
+            *callee,
+            args,
+            types,
+            callable_context,
+            diagnostics,
+        );
+        return;
+    }
     if operation.results.len() != 1 {
         diagnostics.push(diag(
             function,
@@ -398,7 +731,134 @@ fn verify_operation_shape(
                 invalid_operation(function, operation.id, reason, diagnostics);
             }
         }
-        SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) | SemOpKind::Call { .. } => {}
+        SemOpKind::Call { .. } => unreachable!("calls return before value-result validation"),
+        SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) => {}
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "direct-call verification keeps callable ABI, result arity, and operand rules together at the SIR boundary"
+)]
+fn verify_direct_call_operation(
+    function: &SemFunction,
+    operation: &SemOp,
+    callee: CallableId,
+    args: &[crate::Operand],
+    types: &HashMap<ValueId, ResolvedTy>,
+    callable_context: Option<&CallableContext<'_>>,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    for argument in args {
+        require_read_operand(
+            function,
+            operation.id,
+            argument.mode,
+            "direct call argument",
+            diagnostics,
+        );
+    }
+    if operation.results.len() > 1 {
+        diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::InvalidResultArity {
+                op: operation.id,
+                actual: operation.results.len(),
+            },
+        ));
+        return;
+    }
+    let Some(callable_context) = callable_context else {
+        // A context-free verifier cannot know whether a legal direct call is
+        // unit-returning, but it can still enforce the initial 0-or-1 result
+        // representation and the operand-use discipline above.
+        return;
+    };
+    let Some(target) = callable_context.callable(callee) else {
+        diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::UnknownCallable {
+                op: operation.id,
+                callee,
+            },
+        ));
+        return;
+    };
+    if target.call_conv != SemCallConv::Default || target.kind != SemCallableKind::HewDirect {
+        invalid_operation(
+            function,
+            operation.id,
+            "direct call targets a callable outside SIR's default HewDirect ABI domain".to_string(),
+            diagnostics,
+        );
+    }
+    let expected_results = usize::from(target.signature.return_ty != ResolvedTy::Unit);
+    if operation.results.len() != expected_results {
+        diagnostics.push(diag(
+            function,
+            SirDiagnosticKind::InvalidCallResultArity {
+                op: operation.id,
+                callee,
+                expected: expected_results,
+                actual: operation.results.len(),
+            },
+        ));
+    } else if let [result] = operation.results.as_slice() {
+        if result.ty != target.signature.return_ty {
+            invalid_operation(
+                function,
+                operation.id,
+                format!(
+                    "direct call result has `{}`, callee `{}` returns `{}`",
+                    result.ty.user_facing(),
+                    target.declaration.full_path(),
+                    target.signature.return_ty.user_facing()
+                ),
+                diagnostics,
+            );
+        }
+    }
+    if args.len() != target.signature.params.len() {
+        invalid_operation(
+            function,
+            operation.id,
+            format!(
+                "direct call to `{}` has {} argument(s), expected {}",
+                target.declaration.full_path(),
+                args.len(),
+                target.signature.params.len()
+            ),
+            diagnostics,
+        );
+    }
+    for (index, (argument, parameter)) in args.iter().zip(&target.signature.params).enumerate() {
+        if parameter.passing != SemParamPassing::ReadOnly {
+            invalid_operation(
+                function,
+                operation.id,
+                format!(
+                    "direct call target `{}` parameter {index} has non-ReadOnly ABI passing",
+                    target.declaration.full_path()
+                ),
+                diagnostics,
+            );
+        }
+        if let Some(actual) = types.get(&argument.value) {
+            if actual != &parameter.ty {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "direct call argument {index} to `{}` has `{}`, expected `{}`",
+                        target.declaration.full_path(),
+                        actual.user_facing(),
+                        parameter.ty.user_facing()
+                    ),
+                    diagnostics,
+                );
+            }
+        }
     }
 }
 
@@ -440,6 +900,12 @@ fn verify_terminator_shape(
     diagnostics: &mut Vec<SirDiagnostic>,
 ) {
     match terminator {
+        SemTerminator::Return { value: Some(value) } if function.return_ty == ResolvedTy::Unit => {
+            diagnostics.push(diag(
+                function,
+                SirDiagnosticKind::UnitReturnValue { value: *value },
+            ));
+        }
         SemTerminator::Return { value: Some(value) } => {
             if let Some(actual) = types.get(value) {
                 if actual != &function.return_ty {
@@ -539,6 +1005,13 @@ fn record_value(
 fn diag(function: &SemFunction, kind: SirDiagnosticKind) -> SirDiagnostic {
     SirDiagnostic {
         function: function.name.clone(),
+        kind,
+    }
+}
+
+fn module_diag(kind: SirDiagnosticKind) -> SirDiagnostic {
+    SirDiagnostic {
+        function: "<module>".to_string(),
         kind,
     }
 }

--- a/hew-sir/tests/lower_calls.rs
+++ b/hew-sir/tests/lower_calls.rs
@@ -1,0 +1,226 @@
+use hew_hir::{lower_program_host_target, ResolutionCtx};
+use hew_sir::{dump_sir, lower_module, verify_module, SemOpKind, SirLoweringStatus};
+use hew_types::{module_registry::ModuleRegistry, Checker};
+
+fn lower_source(source: &str) -> hew_sir::LoweredModule {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "source must parse before the SIR lowering test: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(Vec::new()));
+    let type_check_output = checker.check_program(&parsed.program);
+    let hir = lower_program_host_target(&parsed.program, &type_check_output, &ResolutionCtx);
+    assert!(
+        hir.diagnostics.is_empty(),
+        "source must lower to HIR before the SIR lowering test: {:#?}",
+        hir.diagnostics
+    );
+    lower_module(&hir.module)
+}
+
+#[test]
+fn two_pass_lowering_resolves_forward_scalar_calls_through_callable_ids() {
+    // `main` is intentionally written before its callee. The callable table
+    // is declaration-sorted, while body lowering still handles this forward
+    // edge without any name-to-symbol reconstruction.
+    let lowered = lower_source(
+        r"
+        fn main() -> i64 {
+            add_one(41)
+        }
+
+        fn add_one(value: i64) -> i64 {
+            value + 1
+        }
+        ",
+    );
+    assert!(
+        ["main", "add_one"].into_iter().all(|name| {
+            matches!(
+                lowered
+                    .statuses
+                    .iter()
+                    .find(|(candidate, _)| candidate == name),
+                Some((_, SirLoweringStatus::Lowered))
+            )
+        }),
+        "the selected root call graph must lower even though unrelated stdlib bodies remain unsupported: {:#?}",
+        lowered.statuses
+    );
+    let module = &lowered.module;
+    let add_one = module
+        .callables
+        .iter()
+        .find(|callable| callable.symbol == "add_one")
+        .expect("scalar callee must have a resolved callable");
+    let main_callable = module
+        .callables
+        .iter()
+        .find(|callable| callable.symbol == "main")
+        .expect("root main must have a resolved callable");
+    assert!(
+        module
+            .callables
+            .iter()
+            .map(|callable| &callable.declaration)
+            .collect::<Vec<_>>()
+            .windows(2)
+            .all(|pair| pair[0] <= pair[1]),
+        "callable IDs must come from deterministic declaration ordering, not body order"
+    );
+    assert!(add_one.id < main_callable.id);
+    assert_eq!(module.root_unit_callables.len(), 2);
+    let entry = module
+        .entry_callable
+        .expect("root source main must establish an entry callable once in HIR-to-SIR lowering");
+    assert_eq!(
+        module
+            .callable(entry)
+            .map(|callable| callable.symbol.as_str()),
+        Some("main")
+    );
+    let main = module
+        .function_for_callable(entry)
+        .expect("selected entry must have a lowered scalar SIR body");
+    let callee = main
+        .blocks
+        .iter()
+        .flat_map(|block| &block.ops)
+        .find_map(|op| match &op.kind {
+            SemOpKind::Call { callee, .. } => Some(*callee),
+            _ => None,
+        })
+        .expect("main must contain a resolved SIR direct call");
+    assert_eq!(
+        module
+            .callable(callee)
+            .map(|callable| callable.symbol.as_str()),
+        Some("add_one"),
+        "SIR call must carry CallableId, whose table owns the exact HIR symbol"
+    );
+    assert!(
+        verify_module(module).is_empty(),
+        "resolved direct-call SIR must verify: {:#?}",
+        verify_module(module)
+    );
+    assert!(dump_sir(module).contains("call @add_one(%0)"));
+}
+
+#[test]
+fn unit_direct_call_is_a_zero_result_sir_operation() {
+    let lowered = lower_source(
+        r"
+        fn unit_helper(value: i64) {
+        }
+
+        fn main() {
+            unit_helper(7);
+        }
+        ",
+    );
+    let unit_helper = lowered
+        .module
+        .callables
+        .iter()
+        .find(|callable| callable.symbol == "unit_helper")
+        .expect("unit-returning declaration must retain an ABI callable entry");
+    assert_eq!(unit_helper.signature.return_ty, hew_types::ResolvedTy::Unit);
+    assert!(
+        lowered
+            .module
+            .function_for_callable(unit_helper.id)
+            .is_some(),
+        "unit return alone must not prevent its function body from reaching SIR"
+    );
+    let entry = lowered
+        .module
+        .entry_callable
+        .expect("unit main is still the root entry callable");
+    let main = lowered
+        .module
+        .function_for_callable(entry)
+        .expect("unit main must lower to a SIR body");
+    assert_eq!(main.return_ty, hew_types::ResolvedTy::Unit);
+    let call = main
+        .blocks
+        .iter()
+        .flat_map(|block| &block.ops)
+        .find(|op| matches!(&op.kind, SemOpKind::Call { .. }))
+        .expect("unit main must retain the direct call as SIR operation");
+    assert!(
+        call.results.is_empty(),
+        "a unit-returning direct call must not fabricate a unit SSA value"
+    );
+    assert!(
+        verify_module(&lowered.module).is_empty(),
+        "zero-result unit direct call must satisfy the module verifier: {:#?}",
+        verify_module(&lowered.module)
+    );
+    let dump = dump_sir(&lowered.module);
+    assert!(dump.contains("    call @unit_helper(%0)"));
+    assert!(
+        !dump.contains("= call @unit_helper"),
+        "the textual SIR form must distinguish a zero-result unit call"
+    );
+}
+
+/// Recursive call resolution must use the callable table built before body
+/// lowering, not a body-order-dependent symbol lookup.  This is the smallest
+/// SIR-only proof that a strict component can contain a cycle.
+#[test]
+fn recursive_scalar_call_resolves_to_its_own_callable_id() {
+    let lowered = lower_source(
+        r"
+        fn main() -> i64 {
+            countdown(3)
+        }
+
+        fn countdown(value: i64) -> i64 {
+            if value == 0 {
+                0
+            } else {
+                countdown(value - 1)
+            }
+        }
+        ",
+    );
+    assert!(
+        lowered
+            .statuses
+            .iter()
+            .filter(|(name, _)| name == "main" || name == "countdown")
+            .all(|(_, status)| matches!(status, SirLoweringStatus::Lowered)),
+        "recursive scalar fixture must lower as a closed SIR graph: {:#?}",
+        lowered.statuses
+    );
+
+    let module = &lowered.module;
+    let countdown = module
+        .callables
+        .iter()
+        .find(|callable| callable.symbol == "countdown")
+        .expect("recursive declaration must have a callable-table entry");
+    let function = module
+        .function_for_callable(countdown.id)
+        .expect("recursive callable must have a lowered SIR body");
+    let recursive_callee = function
+        .blocks
+        .iter()
+        .flat_map(|block| &block.ops)
+        .find_map(|op| match &op.kind {
+            SemOpKind::Call { callee, .. } => Some(*callee),
+            _ => None,
+        })
+        .expect("recursive SIR body must contain a direct call");
+    assert_eq!(
+        recursive_callee, countdown.id,
+        "the recursive edge must name the stable CallableId rather than a reconstructed symbol"
+    );
+    assert!(
+        verify_module(module).is_empty(),
+        "recursive direct-call SIR must verify: {:#?}",
+        verify_module(module)
+    );
+}

--- a/hew-sir/tests/sir.rs
+++ b/hew-sir/tests/sir.rs
@@ -1,16 +1,93 @@
 use hew_hir::ItemId;
 use hew_parser::ast::BinaryOp;
 use hew_sir::{
-    dump_sir, verify_module, BlockArg, BlockId, Edge, EffectSet, FunctionSourceOrigin, OpId,
-    Operand, Provenance, SemBlock, SemFunction, SemModule, SemOp, SemOpKind, SemTerminator,
-    SirDiagnosticKind, UseMode, ValueDef, ValueId,
+    dump_sir, verify_function_in_module, verify_module, BlockArg, BlockId, CallableId, Edge,
+    EffectSet, EffectSummary, FunctionSourceOrigin, OpId, Operand, Provenance, SemAbiParam,
+    SemBlock, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind,
+    SemParamPassing, SemSignature, SemTerminator, SirDiagnosticKind, UseMode, ValueDef, ValueId,
 };
-use hew_types::{CallTarget, DefId, ResolvedTy};
+use hew_types::{DefId, ResolvedTy};
 
 fn definition(id: u32) -> ValueDef {
     ValueDef {
         id: ValueId(id),
         ty: ResolvedTy::I64,
+    }
+}
+
+fn callable_for(function: &SemFunction) -> SemCallable {
+    SemCallable {
+        id: function.callable,
+        function: function.id,
+        declaration: function.declaration.clone(),
+        symbol: function.name.clone(),
+        source_origin: function.source_origin.clone(),
+        signature: SemSignature {
+            params: function
+                .params
+                .iter()
+                .map(|parameter| SemAbiParam {
+                    ty: parameter.ty.clone(),
+                    passing: SemParamPassing::ReadOnly,
+                    caller_visible_projection: false,
+                })
+                .collect(),
+            return_ty: function.return_ty.clone(),
+        },
+        call_conv: SemCallConv::Default,
+        kind: SemCallableKind::HewDirect,
+        effect_summary: EffectSummary::Unknown,
+    }
+}
+
+fn module(functions: Vec<SemFunction>) -> SemModule {
+    let mut callables = Vec::new();
+    for function in &functions {
+        if !callables
+            .iter()
+            .any(|callable: &SemCallable| callable.id == function.callable)
+        {
+            callables.push(callable_for(function));
+        }
+    }
+    SemModule {
+        callables,
+        root_unit_callables: Vec::new(),
+        entry_callable: None,
+        functions,
+    }
+}
+
+fn entry_module(function: SemFunction) -> SemModule {
+    let mut module = module(vec![function]);
+    module.root_unit_callables = vec![CallableId(0)];
+    module.entry_callable = Some(CallableId(0));
+    module
+}
+
+fn unit_function(
+    id: u32,
+    declaration: &str,
+    name: &str,
+    source_origin: FunctionSourceOrigin,
+    params: Vec<BlockArg>,
+) -> SemFunction {
+    SemFunction {
+        id: ItemId(id),
+        callable: CallableId(0),
+        declaration: DefId::for_test(declaration),
+        name: name.to_string(),
+        span: 0..0,
+        source_origin,
+        params,
+        return_ty: ResolvedTy::Unit,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: Vec::new(),
+            terminator: SemTerminator::Return { value: None },
+        }],
     }
 }
 
@@ -22,6 +99,7 @@ fn definition(id: u32) -> ValueDef {
 fn block_arguments_are_ssa_join_values() {
     let function = SemFunction {
         id: ItemId(0),
+        callable: CallableId(0),
         declaration: DefId::for_test("f"),
         name: "f".to_string(),
         span: 0..0,
@@ -187,9 +265,7 @@ fn block_arguments_are_ssa_join_values() {
             },
         ],
     };
-    let module = SemModule {
-        functions: vec![function],
-    };
+    let module = module(vec![function]);
     assert!(
         verify_module(&module).is_empty(),
         "SIR must verify: {:#?}",
@@ -202,35 +278,199 @@ fn block_arguments_are_ssa_join_values() {
 
 #[test]
 fn verifier_rejects_entry_block_arguments() {
-    let module = SemModule {
-        functions: vec![SemFunction {
-            id: ItemId(0),
-            declaration: DefId::for_test("bad_entry_args"),
-            name: "bad_entry_args".to_string(),
-            span: 0..0,
-            source_origin: FunctionSourceOrigin::Unknown,
-            params: Vec::new(),
-            return_ty: ResolvedTy::I64,
-            entry: BlockId(0),
-            blocks: vec![SemBlock {
-                id: BlockId(0),
-                args: vec![BlockArg {
-                    value: ValueId(0),
-                    ty: ResolvedTy::I64,
-                }],
-                ops: Vec::new(),
-                terminator: SemTerminator::Return {
-                    value: Some(ValueId(0)),
-                },
+    let module = module(vec![SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("bad_entry_args"),
+        name: "bad_entry_args".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: vec![BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
             }],
+            ops: Vec::new(),
+            terminator: SemTerminator::Return {
+                value: Some(ValueId(0)),
+            },
         }],
-    };
+    }]);
 
     assert!(verify_module(&module).iter().any(|diagnostic| matches!(
         diagnostic.kind,
         SirDiagnosticKind::EntryBlockArgs {
             entry: BlockId(0),
             actual: 1,
+        }
+    )));
+}
+
+#[test]
+fn verifier_requires_zero_results_for_a_unit_direct_call() {
+    let unit_helper = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("unit_helper"),
+        name: "unit_helper".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::Unit,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: Vec::new(),
+            terminator: SemTerminator::Return { value: None },
+        }],
+    };
+    let caller = SemFunction {
+        id: ItemId(1),
+        callable: CallableId(1),
+        declaration: DefId::for_test("caller"),
+        name: "caller".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::Unit,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![SemOp {
+                id: OpId(0),
+                results: Vec::new(),
+                kind: SemOpKind::Call {
+                    callee: CallableId(0),
+                    args: Vec::new(),
+                },
+                provenance: Provenance::Synthesized,
+            }],
+            terminator: SemTerminator::Return { value: None },
+        }],
+    };
+    let mut valid = module(vec![unit_helper, caller]);
+    assert!(
+        verify_module(&valid).is_empty(),
+        "a unit direct call with no SSA result must verify: {:#?}",
+        verify_module(&valid)
+    );
+
+    valid.functions[1].blocks[0].ops[0].results = vec![definition(0)];
+    assert!(
+        verify_module(&valid).iter().any(|diagnostic| matches!(
+            diagnostic.kind,
+            SirDiagnosticKind::InvalidCallResultArity {
+                callee: CallableId(0),
+                expected: 0,
+                actual: 1,
+                ..
+            }
+        )),
+        "a unit direct call must reject a fabricated SSA result: {:#?}",
+        verify_module(&valid)
+    );
+}
+
+#[test]
+fn verifier_rejects_noncanonical_block_ids_and_order() {
+    let non_contiguous = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("non_contiguous"),
+        name: "non_contiguous".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(2),
+                    args: Vec::new(),
+                }),
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![definition(0)],
+                    kind: SemOpKind::ConstI64(1),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(0)),
+                },
+            },
+        ],
+    };
+    let non_contiguous_diagnostics = verify_module(&module(vec![non_contiguous]));
+    assert!(non_contiguous_diagnostics.iter().any(|diagnostic| matches!(
+        diagnostic.kind,
+        SirDiagnosticKind::NonCanonicalBlockOrder {
+            expected: BlockId(1),
+            actual: BlockId(2),
+        }
+    )));
+
+    let out_of_order = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("out_of_order"),
+        name: "out_of_order".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![definition(0)],
+                    kind: SemOpKind::ConstI64(1),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Return {
+                    value: Some(ValueId(0)),
+                },
+            },
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(1),
+                    args: Vec::new(),
+                }),
+            },
+        ],
+    };
+    let out_of_order_diagnostics = verify_module(&module(vec![out_of_order]));
+    assert!(out_of_order_diagnostics.iter().any(|diagnostic| matches!(
+        diagnostic.kind,
+        SirDiagnosticKind::NonCanonicalBlockOrder {
+            expected: BlockId(0),
+            actual: BlockId(1),
+        }
+    )));
+    assert!(out_of_order_diagnostics.iter().any(|diagnostic| matches!(
+        diagnostic.kind,
+        SirDiagnosticKind::NonCanonicalBlockOrder {
+            expected: BlockId(1),
+            actual: BlockId(0),
         }
     )));
 }
@@ -265,59 +505,239 @@ fn operation_effects_are_derived_and_conservative() {
     assert!(wrapping_add.effects().is_pure());
 
     let unresolved_call = SemOpKind::Call {
-        target: CallTarget::Builtin {
-            endpoint: "test".to_string(),
-        },
+        callee: CallableId(0),
         args: Vec::new(),
     };
     assert_eq!(unresolved_call.effects(), EffectSet::UNKNOWN_CALL);
     assert!(unresolved_call.effects().contains(EffectSet::MAY_TRAP));
     assert!(unresolved_call.effects().may_trap());
+    assert_eq!(EffectSummary::MayTrap.effects(), EffectSet::MAY_TRAP);
+}
+
+#[test]
+fn verifier_checks_resolved_direct_call_signature_and_use_mode() {
+    let target = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("target"),
+        name: "target".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: vec![BlockArg {
+            value: ValueId(0),
+            ty: ResolvedTy::I64,
+        }],
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: Vec::new(),
+            terminator: SemTerminator::Return {
+                value: Some(ValueId(0)),
+            },
+        }],
+    };
+    let caller = SemFunction {
+        id: ItemId(1),
+        callable: CallableId(1),
+        declaration: DefId::for_test("caller"),
+        name: "caller".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: vec![BlockArg {
+            value: ValueId(0),
+            ty: ResolvedTy::Bool,
+        }],
+        return_ty: ResolvedTy::Bool,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![SemOp {
+                id: OpId(0),
+                results: vec![ValueDef {
+                    id: ValueId(1),
+                    ty: ResolvedTy::Bool,
+                }],
+                kind: SemOpKind::Call {
+                    callee: CallableId(0),
+                    args: vec![Operand {
+                        value: ValueId(0),
+                        mode: UseMode::BorrowShared,
+                    }],
+                },
+                provenance: Provenance::Synthesized,
+            }],
+            terminator: SemTerminator::Return {
+                value: Some(ValueId(1)),
+            },
+        }],
+    };
+    let diagnostics = verify_module(&module(vec![target, caller]));
+    assert!(diagnostics.iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidOperation { reason, .. }
+            if reason.contains("only Read is legal")
+    )));
+    assert!(diagnostics.iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidOperation { reason, .. }
+            if reason.contains("direct call result")
+    )));
+    assert!(diagnostics.iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidOperation { reason, .. }
+            if reason.contains("direct call argument 0")
+    )));
+}
+
+#[test]
+fn verifier_rejects_unknown_direct_callable() {
+    let function = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("caller"),
+        name: "caller".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![SemOp {
+                id: OpId(0),
+                results: vec![definition(0)],
+                kind: SemOpKind::Call {
+                    callee: CallableId(9),
+                    args: Vec::new(),
+                },
+                provenance: Provenance::Synthesized,
+            }],
+            terminator: SemTerminator::Return {
+                value: Some(ValueId(0)),
+            },
+        }],
+    };
+    assert!(verify_module(&module(vec![function]))
+        .iter()
+        .any(|diagnostic| matches!(
+            diagnostic.kind,
+            SirDiagnosticKind::UnknownCallable {
+                op: OpId(0),
+                callee: CallableId(9),
+            }
+        )));
+}
+
+#[test]
+fn verifier_requires_one_result_for_a_non_unit_direct_call() {
+    let scalar_callee = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("scalar_callee"),
+        name: "scalar_callee".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![SemOp {
+                id: OpId(0),
+                results: vec![definition(0)],
+                kind: SemOpKind::ConstI64(1),
+                provenance: Provenance::Synthesized,
+            }],
+            terminator: SemTerminator::Return {
+                value: Some(ValueId(0)),
+            },
+        }],
+    };
+    let caller = SemFunction {
+        id: ItemId(1),
+        callable: CallableId(1),
+        declaration: DefId::for_test("unit_caller"),
+        name: "unit_caller".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::Unit,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![SemOp {
+                id: OpId(0),
+                results: Vec::new(),
+                kind: SemOpKind::Call {
+                    callee: CallableId(0),
+                    args: Vec::new(),
+                },
+                provenance: Provenance::Synthesized,
+            }],
+            terminator: SemTerminator::Return { value: None },
+        }],
+    };
+    assert!(verify_module(&module(vec![scalar_callee, caller]))
+        .iter()
+        .any(|diagnostic| matches!(
+            diagnostic.kind,
+            SirDiagnosticKind::InvalidCallResultArity {
+                callee: CallableId(0),
+                expected: 1,
+                actual: 0,
+                ..
+            }
+        )));
 }
 
 #[test]
 fn verifier_rejects_eager_logical_ops_and_ownership_modes_without_an_owner() {
-    let module = SemModule {
-        functions: vec![SemFunction {
-            id: ItemId(0),
-            declaration: DefId::for_test("bad_logical"),
-            name: "bad_logical".to_string(),
-            span: 0..0,
-            source_origin: FunctionSourceOrigin::Unknown,
-            params: vec![BlockArg {
-                value: ValueId(0),
-                ty: ResolvedTy::Bool,
-            }],
-            return_ty: ResolvedTy::Bool,
-            entry: BlockId(0),
-            blocks: vec![SemBlock {
-                id: BlockId(0),
-                args: Vec::new(),
-                ops: vec![SemOp {
-                    id: OpId(0),
-                    results: vec![ValueDef {
-                        id: ValueId(1),
-                        ty: ResolvedTy::Bool,
-                    }],
-                    kind: SemOpKind::Binary {
-                        op: BinaryOp::And,
-                        lhs: Operand {
-                            value: ValueId(0),
-                            mode: UseMode::BorrowShared,
-                        },
-                        rhs: Operand {
-                            value: ValueId(0),
-                            mode: UseMode::Read,
-                        },
-                    },
-                    provenance: Provenance::Synthesized,
-                }],
-                terminator: SemTerminator::Return {
-                    value: Some(ValueId(1)),
-                },
-            }],
+    let module = module(vec![SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("bad_logical"),
+        name: "bad_logical".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: vec![BlockArg {
+            value: ValueId(0),
+            ty: ResolvedTy::Bool,
         }],
-    };
+        return_ty: ResolvedTy::Bool,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![SemOp {
+                id: OpId(0),
+                results: vec![ValueDef {
+                    id: ValueId(1),
+                    ty: ResolvedTy::Bool,
+                }],
+                kind: SemOpKind::Binary {
+                    op: BinaryOp::And,
+                    lhs: Operand {
+                        value: ValueId(0),
+                        mode: UseMode::BorrowShared,
+                    },
+                    rhs: Operand {
+                        value: ValueId(0),
+                        mode: UseMode::Read,
+                    },
+                },
+                provenance: Provenance::Synthesized,
+            }],
+            terminator: SemTerminator::Return {
+                value: Some(ValueId(1)),
+            },
+        }],
+    }]);
 
     let diagnostics = verify_module(&module);
     assert!(diagnostics.iter().any(|diagnostic| matches!(
@@ -336,6 +756,7 @@ fn verifier_rejects_eager_logical_ops_and_ownership_modes_without_an_owner() {
 fn verifier_rejects_duplicate_semantic_and_emitted_function_identities() {
     let function = SemFunction {
         id: ItemId(0),
+        callable: CallableId(0),
         declaration: DefId::for_test("duplicate"),
         name: "duplicate".to_string(),
         span: 0..0,
@@ -350,9 +771,7 @@ fn verifier_rejects_duplicate_semantic_and_emitted_function_identities() {
             terminator: SemTerminator::Return { value: None },
         }],
     };
-    let diagnostics = verify_module(&SemModule {
-        functions: vec![function.clone(), function],
-    });
+    let diagnostics = verify_module(&module(vec![function.clone(), function]));
     assert!(diagnostics
         .iter()
         .any(|diagnostic| matches!(diagnostic.kind, SirDiagnosticKind::DuplicateFunctionName(_))));
@@ -360,4 +779,160 @@ fn verifier_rejects_duplicate_semantic_and_emitted_function_identities() {
         diagnostic.kind,
         SirDiagnosticKind::DuplicateFunctionDeclaration(_)
     )));
+}
+
+#[test]
+fn verifier_requires_entry_to_be_canonical_parameterless_root_main_with_portable_abi() {
+    let valid = entry_module(unit_function(
+        0,
+        "main",
+        "main",
+        FunctionSourceOrigin::RootUnit,
+        Vec::new(),
+    ));
+    assert!(
+        verify_module(&valid).is_empty(),
+        "canonical source main must satisfy the SIR entry boundary: {:#?}",
+        verify_module(&valid)
+    );
+
+    let non_main = entry_module(unit_function(
+        0,
+        "helper",
+        "helper",
+        FunctionSourceOrigin::RootUnit,
+        Vec::new(),
+    ));
+    assert!(verify_module(&non_main).iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidEntryCallable { callable: CallableId(0), reason }
+            if reason.contains("canonical root-unit source `main`")
+    )));
+
+    let parameterized_main = entry_module(unit_function(
+        0,
+        "main",
+        "main",
+        FunctionSourceOrigin::RootUnit,
+        vec![BlockArg {
+            value: ValueId(0),
+            ty: ResolvedTy::I64,
+        }],
+    ));
+    assert!(verify_module(&parameterized_main)
+        .iter()
+        .any(|diagnostic| matches!(
+            &diagnostic.kind,
+            SirDiagnosticKind::InvalidEntryCallable { callable: CallableId(0), reason }
+                if reason.contains("parameterless")
+        )));
+
+    let wrong_symbol = entry_module(unit_function(
+        0,
+        "main",
+        "not_main",
+        FunctionSourceOrigin::RootUnit,
+        Vec::new(),
+    ));
+    assert!(verify_module(&wrong_symbol)
+        .iter()
+        .any(|diagnostic| matches!(
+            &diagnostic.kind,
+            SirDiagnosticKind::InvalidEntryCallable { callable: CallableId(0), reason }
+                if reason.contains("emitted `main` symbol")
+        )));
+
+    let bool_main = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("main"),
+        name: "main".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::RootUnit,
+        params: Vec::new(),
+        return_ty: ResolvedTy::Bool,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![SemOp {
+                id: OpId(0),
+                results: vec![ValueDef {
+                    id: ValueId(0),
+                    ty: ResolvedTy::Bool,
+                }],
+                kind: SemOpKind::ConstBool(true),
+                provenance: Provenance::Synthesized,
+            }],
+            terminator: SemTerminator::Return {
+                value: Some(ValueId(0)),
+            },
+        }],
+    };
+    let bool_main = entry_module(bool_main);
+    assert!(verify_module(&bool_main).iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidEntryCallable { callable: CallableId(0), reason }
+            if reason.contains("unit or an integer exit status")
+    )));
+}
+
+#[test]
+fn function_verifier_keeps_callable_table_diagnostics() {
+    let function = unit_function(
+        0,
+        "f",
+        "f",
+        FunctionSourceOrigin::Unknown,
+        vec![BlockArg {
+            value: ValueId(0),
+            ty: ResolvedTy::I64,
+        }],
+    );
+    let mut module = module(vec![function.clone()]);
+    module.callables[0].signature.params[0].caller_visible_projection = true;
+
+    let diagnostics = verify_function_in_module(&module, &function);
+    assert!(diagnostics.iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidCallable { callable: CallableId(0), reason }
+            if reason.contains("caller-visible projection")
+    )), "function-at-boundary verification must not discard malformed callable-table diagnostics: {diagnostics:#?}");
+}
+
+#[test]
+fn verifier_rejects_value_carrying_return_from_unit_function() {
+    let function = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("returns_unit"),
+        name: "returns_unit".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: Vec::new(),
+        return_ty: ResolvedTy::Unit,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![SemOp {
+                id: OpId(0),
+                results: vec![definition(0)],
+                kind: SemOpKind::ConstI64(1),
+                provenance: Provenance::Synthesized,
+            }],
+            terminator: SemTerminator::Return {
+                value: Some(ValueId(0)),
+            },
+        }],
+    };
+
+    let diagnostics = verify_module(&module(vec![function]));
+    assert!(
+        diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic.kind,
+            SirDiagnosticKind::UnitReturnValue { value: ValueId(0) }
+        )),
+        "unit returns must remain zero-value terminators: {diagnostics:#?}"
+    );
 }


### PR DESCRIPTION
## Summary

- Adds a declaration-keyed, verified SIR callable table and two-pass HIR → SIR lowering for closed ordinary scalar direct-call graphs.
- Makes `--sir-lower` construct fresh Raw/Checked MIR from SIR, including call continuations, unit calls, structural CFG scheduling, independently derived ABI facts, and a post-lowering verifier. It never uses legacy body lowering inside the selected closure.
- Threads SIR mode honestly through compile, run, build, debug, watch --run, test, and eval (native, WASM, file, JSON, and REPL). Unsupported reachable features fail explicitly; shadow reports coverage everywhere it is accepted.
- Keeps the old template bridge shadow-only and documents its deletion gates. Shadow deliberately does not validate direct calls; strict-versus-legacy execution parity covers this migrated domain instead.

## Hard-cutover contract

This is a convergent migration slice, not a permanent dual compiler. The strict direct-call island is template-free and closed over reachability. The remaining shadow/template path, mode flags, and legacy HIR-body branches are explicitly documented deletion targets; each new SIR domain must delete the branch it replaces.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p hew-sir -p hew-mir -p hew-cli --all-targets -- -D warnings`
- `cargo test -p hew-sir --no-fail-fast`
- `cargo test -p hew-mir --lib sir::tests --no-fail-fast`
- `cargo test -p hew-cli --bin hew --no-fail-fast` (348 passed)
- `cargo test -p hew-cli --test sir_shadow_e2e --no-fail-fast` (10 passed)
- strict eval and test-runner E2E coverage

All local Rust builds used `sccache` with SSD-backed target directories.