### PR TITLE
feat(sir): establish semantic operand rewrite foundation

### DIFF
--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -23,8 +23,15 @@ compiler configuration nor a compatibility contract. The cutover contract in
 ## 1. The IR ladder
 
 Hew v0.5 compiles through an explicit sequence of representations. Each layer
-has a distinct owner, a verifier or diagnostic class, and a deterministic text
-dump (`hew dump-<layer>`).
+has a distinct owner, verifier or diagnostic class, and an eventual
+deterministic text dump. Today the CLI exposes `hew compile --dump-sir` and
+`hew compile --dump-mir raw|checked|elab`; AST/HIR dumps are planned cutover
+tooling, not current commands.
+
+**Status convention:** this document defines the required final architecture.
+`[current]` names behavior implemented today, `[transitional]` names bounded
+migration scaffolding that must be deleted, and `[planned]` names a required
+target-state facility that must not be mistaken for present implementation.
 
 ```
 source / package graph
@@ -94,8 +101,9 @@ compile / run / build / debug / test / watch --run / eval
 Target choice begins no earlier than the MIR/LLVM boundary. Native, Wasm, and
 embedded builds are target outputs; ORC JIT is an execution mode over the same
 verified LLVM IR, not a second middle end. Inspection modes may intentionally
-stop after a layer (`dump-ast`, `dump-hir`, `dump-sir`, or a selected MIR dump),
-but no execution mode may skip, duplicate, or substitute semantic lowering.
+stop after a layer. [current] `hew compile --dump-sir` and `--dump-mir
+raw|checked|elab` do so today; AST/HIR inspection exits are planned. No
+execution mode may skip, duplicate, or substitute semantic lowering.
 
 ### 1.2 SIR hard-cutover contract
 
@@ -230,7 +238,7 @@ built to preserve.
 
 **Verifier / diagnostics:** parser diagnostics only (syntax).
 
-**Dump:** `hew dump-ast` (S-expression / pretty-print).
+**Dump:** [planned] deterministic AST S-expression / pretty-print.
 
 ---
 
@@ -256,7 +264,7 @@ target offsets, runtime carriers, LLVM concepts, or ownership proof.
 shadowing, type errors, trait/coherence and generic-constraint failures, and
 callee-contract violations. `Ty::Var` must be eliminated before SIR lowering.
 
-**Dump:** `hew dump-hir` with resolved type and ValueClass annotations.
+**Dump:** [planned] resolved HIR with type and ValueClass annotations.
 
 ---
 
@@ -275,7 +283,7 @@ junk to erase.
 **Done means:** HIR → SIR lowering is mechanical and does not need a separate
 case for every spelling of the same semantic operation.
 
-#### Generic-instance service at the Normalized-HIR → SIR boundary
+#### [planned] Generic-instance service at the Normalized-HIR → SIR boundary
 
 Genericity is semantic; concrete layout is representational. A normalized HIR
 generic body remains a canonical template, for example `identity<T>(T) -> T`.
@@ -297,6 +305,13 @@ Hew permits two semantically distinct selected implementations for the same
 type arguments. The service owns canonicalization, deterministic discovery
 order/naming, caching, recursion/SCC handling, and the diagnostic chain that
 led to an instance.
+
+The same service owns one semantic instance graph: concrete function instances,
+semantic type instances, and selected implementation evidence. A
+`TypeInstanceKey { template, type_args }` deduplicates substituted nominal
+shapes such as `Cache<String, i64>` and `HashMap<String, i64>` without naming a
+layout. Raw MIR later consumes a semantic type instance together with target
+layout to select representation.
 
 It lowers a `GenericBodyTemplate + SubstitutionEnvironment` to a concrete SIR
 function without permanently cloning a second HIR tree. Its instance graph has
@@ -397,7 +412,7 @@ coroutine-frame decisions once their semantic concepts have been lowered.
 places. That bridge is useful compatibility evidence, but it is not the final
 SIR → MIR contract.
 
-#### Virtual-value / `Place` seam (required before general SIR → MIR)
+#### [planned] Virtual-value / `Place` seam (required before general SIR → MIR)
 
 Raw MIR gains an explicit virtual-value versus addressable-`Place` distinction
 before this bridge becomes the general lowering path:
@@ -411,8 +426,11 @@ RawEdge     = target block plus typed RawValueId arguments
 
 `Place::Value(RawValueId)` is forbidden. A virtual value becomes storage only
 through an explicit `Materialize { value, local, reason }`, where `reason` is
-one of `AddressTaken`, `MutablePlace`, `AbiBoundary`, `LayoutOrProjection`,
-`CaptureOrEscape`, `Transport`, or `CoroutineFrame`. This makes every loss of
+one of `AddressTaken`, `MutablePlace`, `ByRefAbi`, `CaptureOrEscape`,
+`Transport`, `CoroutineFrame`, `OwnershipDrop`, or `ExplicitStorage`.
+Aggregate layout alone is never a materialization reason: representation-level
+`Pack`/`Extract` keep an inline aggregate virtual until an addressable or
+by-reference observation actually requires storage. This makes every loss of
 value form auditable and revisable rather than an accidental property of a
 lowerer.
 
@@ -424,10 +442,11 @@ scalar SSA must not be needlessly destroyed into memory for LLVM to reconstruct.
 There is no generic `Cell<T>` escape hatch: add a cell/place only when an
 address-taken or otherwise genuinely location-semantic feature requires it.
 
-The first virtual domain is deliberately no-drop: scalar `BitCopy` values and
-their CFG/call flow only. Values with destruction, borrow, aggregate-layout,
-capture, transport, or suspension obligations remain outside that domain until
-their materialization and elaboration rules are implemented.
+The first virtual domain is deliberately no-drop: scalar `BitCopy` values,
+structural inline aggregates, and their CFG/call flow only. Values with
+destruction, borrow, mutation/addressability, capture, transport, or suspension
+obligations remain outside that domain until their materialization and
+elaboration rules are implemented.
 
 `RawMirModuleHeader` owns the target-parameterized `TargetLayout` and logical
 linkage declarations used by Raw bodies. It is MIR metadata, not another IR and
@@ -456,7 +475,7 @@ an LLVM-specific backend.
 is dominated by its definition, every site has a chosen value-model operation
 (no "unclassified").
 
-**Dump:** `hew dump-mir=raw`.
+**Dump:** [current] `hew compile --dump-mir raw`.
 
 #### Current raw coroutine substrate
 
@@ -488,7 +507,7 @@ value-cost language (see §4.3).
 at <span> but read at <span>", "two mutations alias the same value", "affine
 resource `c` would be shared across an actor send — consume or materialize".
 
-**Dump:** `hew dump-mir=checked` (annotation overlay: `// read-share`,
+**Dump:** [current] `hew compile --dump-mir checked` (annotation overlay: `// read-share`,
 `// move (last use)`, `// ensure-unique → mutate`, `// materialize`, etc.).
 
 ---
@@ -496,9 +515,11 @@ resource `c` would be shared across an actor send — consume or materialize".
 ### 2.7 Elaborated MIR (`hew-mir::elab`)
 
 **Owns:** explicit `Drop(place)` statements on every exit path, explicit
-cleanup basic blocks, panic-edge CFG, coroutine state struct layout (proven
-from `CoroutineSchema`), actor-shutdown cleanup blocks, `DropPlan` per scope,
-storage classes materialised on every place, and the **DecisionMap**.
+cleanup basic blocks, panic-edge CFG, cancellation and actor-shutdown cleanup,
+`DropPlan` per scope, and the **DecisionMap**. Raw MIR chooses a coroutine
+frame, layout, and materialized place where representation requires one;
+Elaborated MIR adds lifetime and cleanup obligations over those already chosen
+places. It does not select storage classes or coroutine representation.
 
 The `DecisionMap` is a deterministic table of
 `DecisionFact { site_id, kind, chosen_strategy, why, cost_class }` keyed by
@@ -514,7 +535,7 @@ tables.
 no `Drop` of a moved-out place; cleanup-block dominance; coroutine frame-slot
 type matches yield value-class; DecisionMap is total and SiteIds are stable.
 
-**Dump:** `hew dump-mir=elab` (includes explicit drop / cleanup-block section
+**Dump:** [current] `hew compile --dump-mir elab` (includes explicit drop / cleanup-block section
 and DecisionMap).
 
 ---

--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -1,51 +1,70 @@
 # Hew v0.5 IR Ladder — Internal Reference
 
 This document is the canonical internal reference for the Hew v0.5 compiler
-IR ladder and value model.  It describes the compilation pipeline from source
+IR ladder and value model. It describes the compilation pipeline from source
 to machine code, the contract each layer owns, and the user-visible value
-semantics the ladder is built to support.
+semantics the ladder is built to support. There is no additional
+general-purpose IR between the layers defined here.
 
 The verifier rules and deletion milestones are detailed in the separate
 implementation plan for this work.
 
 ### Migration status
 
-The intended steady-state ladder includes SIR between typed HIR and Raw MIR.
-The first value/CFG proof uses a bounded legacy-MIR differential bridge, while
-the first strict direct-call slice already produces fresh Raw/Checked MIR from
-SIR. The bridge is deliberately disposable: it is not a second release
-compiler configuration or a compatibility contract. The cutover contract in
-§1.2 defines exactly what must be removed before SIR becomes the normal path.
+The intended steady-state ladder inserts SIR between normalized HIR and Raw
+MIR. The initial value/CFG proof uses a bounded legacy-MIR differential bridge,
+while the strict direct-call slice already produces fresh Raw/Checked MIR from
+SIR. That bridge is deliberately disposable: it is neither a second release
+compiler configuration nor a compatibility contract. The cutover contract in
+§1.2 defines what must be removed before SIR becomes the normal path.
 
 ---
 
 ## 1. The IR ladder
 
-Hew v0.5 compiles through an explicit sequence of intermediate representations.
-Each layer has a distinct owner, a verifier or diagnostic class, and a
-deterministic text dump (`hew dump-<layer>`).
+Hew v0.5 compiles through an explicit sequence of representations. Each layer
+has a distinct owner, a verifier or diagnostic class, and a deterministic text
+dump (`hew dump-<layer>`).
 
 ```
-source.hew
-  └→ AST              (hew-parser)                syntactic only; no resolution
-  └→ Resolved HIR     (hew-hir, name-resolved)    names, scopes, imports, capabilities
-  └→ THIR             (hew-hir, fully typed)       monomorphised types; ValueClass per type
-  └→ SIR              (hew-sir, semantic SSA)      semantic values, block-argument CFG, optimization
-  └→ Raw MIR          (hew-mir, CFG)               SSA/places; value-model ops chosen; not yet proven
-  └→ Checked MIR      (hew-mir)                    ownership proven; diagnostics emitted; FAIL-CLOSED gate
-  └→ Elaborated MIR   (hew-mir)                    explicit Drop edges; DecisionMap; cleanup CFG
-  └→ LLVM IR          (hew-codegen-rs/Inkwell)     direct emission from proven MIR facts
-  └→ Native/WASM obj  (LLVM TargetMachine/wasm-ld) target-specific; no Hew decisions remain
+source / package graph
+  └→ AST                         (hew-parser)      source syntax and provenance
+  └→ Resolved + Typed HIR         (hew-hir)         authoritative Hew meaning
+  └→ Normalized HIR invariant     (hew-hir)         canonical structured Hew form
+  └→ SIR — Hew Semantic SSA       (hew-sir)         semantic values, effects, CFG, optimization
+  └→ Raw MIR                      (hew-mir)         representation and ownership realization begins
+  └→ Checked MIR                  (hew-mir)         ownership/concurrency legality proven
+  └→ Elaborated MIR               (hew-mir)         drops, cleanup, and lifetime realization
+  └→ LLVM IR                      (hew-codegen-rs)  low-level computation
+  └→ LLVM backend / Machine IR    (LLVM)            target legalization and machine realization
+  └→ native / Wasm / embedded artifact, or ORC JIT execution
 ```
+
+The design question at every boundary is deliberately narrow:
+
+| Layer | Question it answers |
+| --- | --- |
+| AST | What did the programmer write? |
+| HIR | What does it mean in Hew? |
+| Normalized HIR | What is its canonical structured Hew form? |
+| SIR | What semantic values, effects, and control flow exist? |
+| MIR | How are those values represented, owned, transported, and destroyed? |
+| LLVM IR | What low-level computation should execute? |
+| LLVM backend | How does this target machine execute it? |
+
+`Normalized HIR` is primarily an invariant/state of HIR, not a requirement for
+a second, giant Rust type hierarchy. It remains recognizable as Hew; ordinary
+`let` bindings and other useful structured concepts do not disappear merely
+because they are structured.
 
 ### Why this ladder, not a single IR
 
-- **Ownership belongs in CFG MIR.** Every successful precedent (Rust MIR,
+- **Ownership realization belongs in CFG MIR.** Every successful precedent (Rust MIR,
   Swift SIL/OSSA, Flang FIR) decides ownership in a CFG IR with explicit
   `Place`s.  Doing it on a typed AST means reinventing CFG analysis on a tree.
-- **THIR exists to retire `Ty::Var`.** The fail-closed gate ("no `Ty::Var`
-  survives into codegen") becomes a structural verifier between THIR and
-  Raw MIR, not a post-hoc sweep.
+- **Typed HIR retires `Ty::Var`.** The fail-closed gate ("no `Ty::Var`
+  survives into codegen") is a structural verifier before SIR, not a post-hoc
+  sweep.
 - **SIR retains semantic values until ownership/layout realization.** It uses
   SSA values and block arguments from inception, so normal CFG and value
   simplification happen before allocation, storage, drop, ABI, and runtime
@@ -63,21 +82,54 @@ source.hew
   work now widens the Rust HIR/MIR/codegen-rs path instead of adding dialect
   conversion passes.
 
+### 1.1 One convergent compiler driver
+
+All artifact-producing commands share the same final body-lowering path:
+
+```
+compile / run / build / debug / test / watch --run / eval
+  └→ parse → resolved + typed HIR → normalize → SIR → MIR → LLVM IR → backend
+```
+
+Target choice begins no earlier than the MIR/LLVM boundary. Native, Wasm, and
+embedded builds are target outputs; ORC JIT is an execution mode over the same
+verified LLVM IR, not a second middle end. Inspection modes may intentionally
+stop after a layer (`dump-ast`, `dump-hir`, `dump-sir`, or a selected MIR dump),
+but no execution mode may skip, duplicate, or substitute semantic lowering.
+
 ### 1.2 SIR hard-cutover contract
 
 The current SIR bridge is bounded migration evidence, not a permanent dual
 pipeline. `--sir-shadow` is a temporary differential oracle, and `--sir-lower`
 is a temporary selector for the migrated SIR domain. Neither is a release-mode
-compatibility promise.
+compatibility promise. Unsupported SIR surface is an implementation gap, not a
+reason for a permanent hidden legacy fallback.
 
 The first strict domain is already template-free: a closed reachable graph of
-ordinary, non-generic, default-convention direct calls with scalar `ReadOnly`
-parameters and scalar or `Unit` returns. SIR owns each callable's stable
-identity, emitted symbol, signature, source origin, effect summary, and
-parameter facts; SIR → Raw/Checked MIR independently legalizes call
-continuations and creates fresh boundary/scheduling facts. A reachable feature
-outside that domain fails explicitly. An unrelated unsupported body neither
-blocks the selected component nor becomes a hidden legacy callee.
+ordinary, non-generic direct calls with scalar read-only parameters and scalar
+or `Unit` returns. SIR owns each callable's stable identity, semantic signature,
+source origin, resolved effect summary, and parameter-use facts; SIR →
+Raw/Checked MIR independently legalizes call continuations and creates fresh
+boundary/scheduling facts. The migration callable table temporarily also carries
+an emitted symbol and default convention so the first strict component can
+reach the unchanged backend. Final linkage names and concrete
+ABI/calling-convention realization move to the MIR declaration/header boundary.
+A reachable feature outside that domain fails explicitly. An unrelated
+unsupported body neither blocks the selected component nor becomes a hidden
+legacy callee.
+
+#### Transitional callable/linkage bridge
+
+Today, the strict bridge carries HIR's selected body spelling in
+`SemCallable::symbol` so it can fill the current `RawMirFunction.name` header.
+That symbol/default-convention carrier is transitional bridge metadata, not
+SIR's permanent ABI or linkage authority: SIR calls are resolved by `CallableId`
+and semantic declaration identity, never by rejoining bodies on a string
+spelling. At cutover, a SIR-derived Raw MIR module/header — metadata within the
+existing MIR layer, not a new IR — records target linkage names and concrete
+ABI/calling-convention choices from the semantic callable table and target
+layout. LLVM lowering consumes that header; SIR retains only the semantic
+callable relation.
 
 The temporary shadow adapter remains a scalar CFG differential probe and does
 not realize direct SIR calls through its legacy Raw-MIR template. Shadow
@@ -90,10 +142,16 @@ The following scaffolding is a deletion target: raw-function name matching,
 and scheduler facts, per-function legacy fallback, SIR mode flags, and the
 shadow corpus harness. The normal CLI flips only after all of these gates hold:
 
-1. SIR owns verified callable identity, symbol, signature, calling convention,
-   effect summary, and parameter-passing facts.
-2. SIR → MIR independently creates Raw/Checked facts and scheduling decisions;
-   it copies no legacy function body, ABI decision, or drop plan.
+1. SIR owns verified callable identity, semantic signature, source provenance,
+   effect summary, and semantic parameter-use facts. The transitional
+   symbol/default-convention carrier is replaced by a SIR-derived MIR module
+   header; Raw MIR/LLVM independently realize linkage and concrete
+   ABI/calling-convention details.
+2. SIR → MIR independently creates and verifies Raw, Checked, and Elaborated
+   MIR facts and scheduling decisions—including an explicit zero-drop
+   elaboration when appropriate. Each Raw body has exactly one Checked and one
+   Elaborated finalization; it copies no legacy function body, ABI decision, or
+   drop plan.
 3. Each migrated language surface is a closed reachable lowering domain. Its
    old HIR → Raw-MIR branch is deleted when SIR owns it rather than retained as
    a mixed-artifact fallback.
@@ -102,11 +160,25 @@ shadow corpus harness. The normal CLI flips only after all of these gates hold:
 5. The default path is changed to SIR and all bridge flags, template code, and
    legacy body-lowering branches are removed.
 
-The direct-call slice has replaced the immediate template dependency; the next
-semantic domains are abstract aggregates/projections, explicit ownership use
-modes, closures, async/suspension, actors, and machines. Each must enter as a
-closed reachable SIR lowering domain and delete its replaced HIR → Raw-MIR
-branch rather than accumulating a mixed artifact fallback.
+The direct-call slice has replaced the immediate template dependency. The next
+work first proves SIR infrastructure and simple optimization, then adds semantic
+domains in closed reachable increments: abstract aggregates/projections,
+closures, ownership-aware uses, machines, actors, and async/suspension. Each
+increment deletes its replaced HIR → Raw-MIR branch rather than accumulating a
+mixed-artifact fallback.
+
+### 1.3 Incremental acceptance gates
+
+| Milestone | Acceptance criterion |
+| --- | --- |
+| SIR foundation | A scalar function with a conditional lowers to typed SSA blocks and block arguments, verifies definition/dominance, edge arity and types, lowers mechanically to Raw MIR, and preserves behavior across the existing suite. |
+| SIR infrastructure | A pass can inspect and replace uses, erase an operation, rewrite an edge, and add/remove a block argument; every pass supports verify/dump before and after, timing, and pass bisection. |
+| Basic optimization | CFG simplification, SCCP, DCE, copy propagation, and local GVN operate on SIR rather than asking LLVM to recover the semantic CFG. |
+| Generic instances | A single normalized-HIR instance service deduplicates concrete function/type instances and selected implementation evidence, including recursive instances; the resulting concrete SIR bodies contain no layout or ABI facts. |
+| Value semantics | Tuples, records, and variants remain abstract values: an unused construction can disappear before MIR and no SIR operation observes a byte offset, physical tag, or payload layout. |
+| Closures | `closure.make` plus `closure.call` can eliminate a non-escaping closure allocation before it reaches MIR. |
+| Machines, actors, and async | Known machine transitions can specialize; actor messages remain typed semantic values; every suspension is an explicit SIR CFG terminator before runtime/coroutine lowering. |
+| Full cutover | Normal compilation has exactly `HIR → normalized HIR → SIR → Raw MIR → Checked MIR → Elaborated MIR → LLVM`; bridge flags, templates, shadow harnesses, and legacy body-lowering branches are deleted. |
 
 ### Design axioms
 
@@ -162,76 +234,223 @@ built to preserve.
 
 ---
 
-### 2.2 Resolved HIR (`hew-hir::resolved`)
+### 2.2 Resolved + Typed HIR (`hew-hir`)
 
-**Owns:** name resolution, scope/imports, module graph, capability declarations,
-sugar desugaring (canonical form), `Place` introduction for bindings, hygiene,
-and inferred intent per site (read / modify / consume / capture / yield) from
-value expressions and receiver shape.
+HIR is the authoritative representation of Hew language meaning, not a second
+copy of source syntax. It owns stable `ItemId`/`BindingId`/`SiteId` identities,
+resolved names and overloads, lexical scopes, imports, capability declarations,
+`ResolvedTy` on every semantic expression, generic parameters and resolved
+generic-instance facts, trait and method selection, pattern semantics,
+closure-capture facts, and actor,
+machine, state, event, and method identities. It also retains source-semantic
+ownership intent and diagnostic provenance. **ValueClass** is a resolved type
+fact (see §3), not a layout decision.
 
-No `&` / `&mut` / lifetime syntax in Hew's surface; the HIR infers intent
-without it.
+No `&` / `&mut` / lifetime syntax appears in Hew's surface; HIR resolves the
+language's semantic intent without inventing surface borrow syntax.
 
-**Must not own:** types beyond name resolution, ownership proof, surface borrow
-syntax.
+**Must not own:** CFG blocks, SSA values, `Place`, storage/lifetime realization,
+target offsets, runtime carriers, LLVM concepts, or ownership proof.
 
 **Verifier / diagnostics:** unresolved names, capability not in scope,
-shadowing; `var` declared but never modified (note); `mutating`/`consume`
-callee contract violated.
+shadowing, type errors, trait/coherence and generic-constraint failures, and
+callee-contract violations. `Ty::Var` must be eliminated before SIR lowering.
 
-**Dump:** `hew dump-hir`.
+**Dump:** `hew dump-hir` with resolved type and ValueClass annotations.
 
 ---
 
-### 2.3 THIR (`hew-hir::typed`)
+### 2.3 Normalized HIR (an invariant of `hew-hir`)
 
-**Owns:** fully resolved types on every expression; monomorphised generics;
-trait dispatch resolved; method dispatch chosen; `StructInit.type_args` carried
-structurally; `ResolvedTy` final here; **ValueClass per type** (see §3).
+Normalization reduces the number of semantically equivalent structured forms
+that SIR lowering must understand. It establishes canonical bindings and
+pattern/control semantics; expands surface/operator/call/try sugar; makes
+implicit returns explicit; and canonicalizes closure captures and
+actor/machine references. It deliberately preserves useful Hew structure such
+as ordinary `let` bindings rather than treating every structured construct as
+junk to erase.
 
-**Must not own:** ownership proof, drop elaboration, CFG, site-level cost
-decisions (those land in Raw / Checked MIR).
+**Must not own:** CFG, SSA, layout, allocation, ABI, or target facts.
 
-**Verifier / diagnostics:** type errors, trait selection failures, coherence,
-generic constraint failures; `Ty::Var` must be eliminated here.
+**Done means:** HIR → SIR lowering is mechanical and does not need a separate
+case for every spelling of the same semantic operation.
 
-**Dump:** `hew dump-thir` (indented with type + ValueClass annotations).
+#### Generic-instance service at the Normalized-HIR → SIR boundary
+
+Genericity is semantic; concrete layout is representational. A normalized HIR
+generic body remains a canonical template, for example `identity<T>(T) -> T`.
+When SIR lowering encounters a resolved use such as `identity<i64>`, it asks a
+single module-level instance service for the concrete semantic instance rather
+than letting each lowering subsystem invent a monomorphization path:
+
+```text
+InstanceKey {
+    item: ItemId,
+    type_args: GenericArgs,
+    selected_impls: ResolvedImplArgs,
+}
+```
+
+The exact selected-implementation component is omitted when it is a pure,
+deterministic consequence of the fully substituted types; it is included when
+Hew permits two semantically distinct selected implementations for the same
+type arguments. The service owns canonicalization, deterministic discovery
+order/naming, caching, recursion/SCC handling, and the diagnostic chain that
+led to an instance.
+
+It lowers a `GenericBodyTemplate + SubstitutionEnvironment` to a concrete SIR
+function without permanently cloning a second HIR tree. Its instance graph has
+separate semantic function identity from the generic HIR declaration: one HIR
+`ItemId` can produce many concrete SIR function/callable instances. SIR calls
+therefore name a concrete callable instance, never an unresolved generic item
+plus ad-hoc substitutions.
+
+Instantiation recursively resolves semantic types and selected implementations
+(`Cache<String, i64>`, `HashMap<String, i64>`, `Hash<String>`, and `Eq<String>`
+in one example), but it does **not** compute size, alignment, field offsets,
+storage class, parameter ABI, runtime carrier, or destruction strategy. SIR
+can consequently inline or simplify a concrete `HashMap<String, i64>` semantic
+operation before any map object, pointer, bucket layout, or drop glue exists.
+Those questions begin only at Raw MIR's target-parameterized representation
+boundary.
+
+**Done means:** generic function/type specialization is a canonical compiler
+service used by every SIR-producing path; no MIR body lowerer re-specializes a
+generic HIR body, and no concrete layout fact is embedded in `ResolvedTy` or
+SIR instance identity.
 
 ---
 
 ### 2.4 SIR (`hew-sir`)
 
-**Steady-state owns:** resolved semantic values, basic blocks, block arguments,
-explicit control-flow and suspension terminators, derived operation effects,
-and source provenance. Language concepts stay semantic here: abstract
-aggregates, typed closures, actor messages, machine dispatch/transitions, and
-coroutine suspension are retained until a later feature-specific lowering makes
-their representation necessary. The current implementation begins with scalar
-values and ordinary CFG; later slices add those semantic operation families.
+**Owns:** typed SSA `ValueId`s, `BlockId`s, basic blocks, block arguments,
+semantic CFG edges, def-use relationships, dominance, semantic operations,
+and optional/multi-origin source provenance. It is both the semantic CFG and
+the canonical SSA optimization IR; there is no general non-SSA CFG before it.
+
+Operands retain source-semantic ownership use modes:
+`Read`, `BorrowShared`, `BorrowMut`, `Move`, and `Consume`. These facts make
+rewriting legal or illegal, but SIR does not decide whether a consuming use
+becomes a copy, clone, retain/release, move-out, or drop. That physical
+realization belongs to MIR.
+
+Effects are normally derived from an operation's kind and resolved callee
+metadata, rather than stored as a mutable second source of truth. The current
+initial subset exposes `pure`, `may trap`, and conservative unknown-call
+barrier effects. Memory access, allocation, message, suspend, I/O, and
+ownership-sensitive classes are introduced only with their first semantic
+operations; effect-token SSA remains deferred until a concrete ordering
+optimization requires it.
+
+Language concepts stay semantic here until a feature-specific lowering needs
+their representation: abstract aggregates; `variant.make`, `variant.test`, and
+`variant.project` (never representation-implying `tag`/`payload` operations);
+typed closures; typed actor handles and messages; and machine dispatch versus a
+known transition. `actor.spawn` and `actor.send` may be ordinary effecting
+operations; an ask can produce a future, while waiting belongs to suspension.
+
+Potential suspension is always a terminator, not an ordinary operation:
+
+```
+Suspend {
+    kind: SuspendKind,
+    inputs: Vec<Operand>,
+    resumes: Vec<ResumeEdge>,
+    cancel: Option<Edge>,
+}
+```
+
+An await has one normal resume edge; select, receive, timeout, cancellation,
+and generator operations may have several. This is the semantic model; it does
+not expose an LLVM coroutine representation.
+
+`Unreachable` is likewise a semantic terminator, never a temporary marker for
+an unfinished SIR builder block. Builders use a separate private completion
+state. Before CFG simplification or DCE may create an unreachable block, Raw
+MIR must have a verified unreachable legalization so every verifier-accepted
+SIR terminator has a mechanical representation-lowering path.
 
 **Must not own:** addressable `Place`s, stack/heap allocation, concrete
-aggregate layout, ABI carriers, drop scheduling, ownership proof, or target
-instruction selection.
+aggregate layout, byte offsets, discriminant encoding, ABI carriers, drop
+scheduling, ownership proof, LLVM intrinsics, or target instruction selection.
 
-**Verifier:** module identity, operation/result types and arity, SSA
-definition/dominance, block-argument edge arity/types, entry parameter
-initialization, and operation-specific semantic constraints. The module SIR →
-MIR pipeline verifies at module scope before it can construct storage.
+**Verifier:** module identity; operation/result type and arity; use-mode and
+semantic-op constraints; SSA definition/dominance; block-argument edge
+arity/types; entry parameter initialization; and operation-specific semantic
+invariants. The module SIR → MIR pipeline verifies at module scope before it
+can construct representation or storage.
 
 **Dump:** `hew compile --dump-sir`.
 
 ### 2.5 Raw MIR (`hew-mir::raw`)
 
-**Owns:** CFG of basic blocks, `Place`s and `Operand`s,
-`Statement` / `Terminator`, drop scopes (lexical), explicit value-model
-operations at every use (`borrow_read`, `move`, `cow_share`, `ensure_unique`,
-`materialize`, `consume_call`, `drop`, `freeze`), coroutine `suspend` / `resume`
-terminators.
+**Owns:** a backend-independent but target-parameterized CFG realization of
+SIR values. It introduces virtual MIR values/temporaries and `Place`s where
+addressable storage is actually needed, representation/layout choices using an
+explicit target-layout contract, and physical value-model operations
+(`borrow_read`, `move`, `cow_share`, `ensure_unique`, `materialize`,
+`consume_call`, and `freeze`). It also owns runtime transport/carrier and
+coroutine-frame decisions once their semantic concepts have been lowered.
 
-The operations are chosen by the value-model classifier from THIR's ValueClass
-facts.  They have not yet been *proven* correct by analysis.
+**Current transitional adapter:** today's `RawLowerer` materializes every SIR
+`ValueId` as `Place::Local` because the current Raw MIR body format expects
+places. That bridge is useful compatibility evidence, but it is not the final
+SIR → MIR contract.
 
-**Must not own:** proof of uniqueness/aliasing, LLVM emission concerns.
+#### Virtual-value / `Place` seam (required before general SIR → MIR)
+
+Raw MIR gains an explicit virtual-value versus addressable-`Place` distinction
+before this bridge becomes the general lowering path:
+
+```text
+RawValueId  = typed virtual operation result or Raw block argument
+LocalId     = storage declaration identity
+Place       = LocalId plus storage projections; never a virtual value
+RawEdge     = target block plus typed RawValueId arguments
+```
+
+`Place::Value(RawValueId)` is forbidden. A virtual value becomes storage only
+through an explicit `Materialize { value, local, reason }`, where `reason` is
+one of `AddressTaken`, `MutablePlace`, `AbiBoundary`, `LayoutOrProjection`,
+`CaptureOrEscape`, `Transport`, or `CoroutineFrame`. This makes every loss of
+value form auditable and revisable rather than an accidental property of a
+lowerer.
+
+Raw blocks use typed `RawValueId` arguments and every `Goto`/`Branch`/resume
+edge carries a matching ordered value list. Ordinary mutable locals therefore
+flow through SIR/Raw SSA and block arguments until a listed materialization
+reason applies. A virtual value is not a stack slot, address, or `alloca`; SIR
+scalar SSA must not be needlessly destroyed into memory for LLVM to reconstruct.
+There is no generic `Cell<T>` escape hatch: add a cell/place only when an
+address-taken or otherwise genuinely location-semantic feature requires it.
+
+The first virtual domain is deliberately no-drop: scalar `BitCopy` values and
+their CFG/call flow only. Values with destruction, borrow, aggregate-layout,
+capture, transport, or suspension obligations remain outside that domain until
+their materialization and elaboration rules are implemented.
+
+`RawMirModuleHeader` owns the target-parameterized `TargetLayout` and logical
+linkage declarations used by Raw bodies. It is MIR metadata, not another IR and
+not LLVM metadata: no LLVM type, calling-convention ID, intrinsic, or address
+space appears there.
+
+#### Mandatory stage finalization
+
+Every Raw MIR function produced from SIR must finalize 1:1 into exactly one
+Checked MIR function and exactly one Elaborated MIR function with the same
+callable/function identity. Codegen never consumes Raw or header-only Checked
+MIR. The no-drop virtual domain still produces a verified explicit zero-drop
+Elaborated MIR body; it is not allowed to skip a stage.
+
+Raw MIR consumes resolved HIR type/value-class facts and SIR use modes. Its
+physical operations have not yet been *proven* correct by ownership/concurrency
+analysis.
+
+**Must not own:** `LLVMTypeRef`, LLVM calling-convention or attribute IDs,
+LLVM intrinsics, LLVM coroutine objects, LLVM address-space assumptions, or
+proof of uniqueness/aliasing. It may be target-parameterized by pointer width,
+endianness, alignment rules, and ABI integer widths, but remains independent of
+an LLVM-specific backend.
 
 **Verifier:** structural only — every block ends in a terminator, every place
 is dominated by its definition, every site has a chosen value-model operation
@@ -239,43 +458,26 @@ is dominated by its definition, every site has a chosen value-model operation
 
 **Dump:** `hew dump-mir=raw`.
 
-#### Stackless suspend carrier (`Terminator::Suspend`) — live substrate, dormant producer
+#### Current raw coroutine substrate
 
-`Terminator::Suspend { resume, cleanup, is_final }` is the carrier for a
-`coro.suspend` in a switched-resume LLVM coroutine (R326/R327, W6.007). It rides
-in the block terminator — the carrier the `RawMirFunction` → `lower_function`
-codegen path actually reads — NOT the `ElaboratedMirFunction.coroutine`
-descriptor (keying emission off that field, which the raw-MIR codegen path never
-consults, is a silent no-op). Codegen lowers any function whose CFG contains this
-terminator as a `presplitcoroutine`: the coro prologue (`coro.id`/`coro.alloc`/
-`coro.begin`) wraps the body, each `Suspend` emits `coro.suspend` + its 3-way
-switch (default = return-to-executor, `0` = resume, `1` = cleanup), and a shared
-epilogue runs `coro.free` → `hew_cont_frame_free` + `coro.end`. The runtime
-drives the resulting frame through the `HewCont` C ABI (`hew_cont_resume` /
-`hew_cont_done` / `hew_cont_destroy`), and the scheduler parks/resumes the
-continuation (the dispatch trampoline returns a nullable handle — D-A.2 — which
-`park_suspended_activation` parks; `enqueue_resume` wakes it; the free path
-destroys an abandoned frame exactly once — C1).
-
-**The substrate is production-capable but DORMANT: no source construct produces a
-`Terminator::Suspend` yet.** `await` / blocking `.recv()` / `scope`-join still
-thread-park on the condvar exactly as before, and the HIR / type-checker /
-codegen-scan gates (including the wasm `StructuredConcurrency` /
-`BlockingChannelRecv` exclusions in `docs/wasm-capability-matrix.md`) stay CLOSED
-— a relaxed gate with no readiness waker would be fail-OPEN. The source-to-suspend
-flip lands paired with the readiness waker (NEW-3): only then does a real `await`
-emit a `Terminator::Suspend`, the executor's park/resume cycle fire from a real
-program, and the gates relax per-construct. Until then the edge is validated
-synthetically (a test-only MIR builder + the `coro_emission_exec` round-trip).
+The existing `RawMirFunction::Terminator::Suspend { resume, cleanup, is_final }`
+is a backend-facing switched-resume coroutine carrier. It is not the source
+semantic model for async: SIR owns the general `Suspend` terminator above, then
+later lowers it to an appropriate Raw MIR/runtime representation. In particular,
+LLVM coroutine intrinsics and the `HewCont` runtime ABI must not surface in
+HIR or SIR. No source construct currently produces this raw terminator; its
+synthetic test coverage is infrastructure evidence, not a reason to relax the
+source async gates before a real readiness/waker path exists.
 
 ---
 
 ### 2.6 Checked MIR (`hew-mir::checked`)
 
-**Owns:** proven uniqueness, aliasing analysis (read-shared XOR mutate-unique
-at every program point), init / use-after-move, generator-borrow-across-yield
-analysis, actor-send escape analysis, Copy/COW/Materialize dispatch per
-operand.
+**Owns:** proofs and legality: uniqueness and aliasing (read-shared XOR
+mutate-unique at every program point), initialization/use-after-move,
+borrow/suspension legality, actor-send escape/concurrency safety, and
+cooperation requirements. It validates the physical strategy selected in Raw
+MIR; it does not own generic ABI or representation policy.
 
 **The fail-closed boundary for value semantics.**  Diagnostics fire here in
 value-cost language (see §4.3).
@@ -300,9 +502,9 @@ storage classes materialised on every place, and the **DecisionMap**.
 
 The `DecisionMap` is a deterministic table of
 `DecisionFact { site_id, kind, chosen_strategy, why, cost_class }` keyed by
-stable `SiteId`.  It is attached as a top-level region attribute on each
-elaborated function and is emitted into IR dumps.  `SiteId` is derived from
-the THIR/MIR structure (function id + canonical CFG path to the operation),
+stable `SiteId`. It is attached as top-level function metadata on each
+elaborated function and is emitted into IR dumps. `SiteId` is derived from the
+typed-HIR/SIR/MIR structure (function id + canonical CFG path to the operation),
 not from a source span — the table is stable across whitespace and reformat.
 
 **Must not own:** re-running ownership analysis, LLVM values, span-keyed side
@@ -317,19 +519,22 @@ and DecisionMap).
 
 ---
 
-### 2.8 LLVM IR emission (`hew-codegen-rs`)
+### 2.8 LLVM IR lowering (`hew-codegen-rs`)
 
-**Owns:** direct LLVM IR construction from `Elaborated MIR` using Inkwell,
-including function declarations, stack slots for MIR places, value loads and
-stores, arithmetic/control-flow lowering, runtime-symbol references, and
-module verification.
+**Owns:** direct LLVM IR construction from Elaborated MIR using Inkwell,
+including function declarations, storage only for MIR places that require it,
+value loads/stores, arithmetic/control-flow lowering, runtime-symbol
+references, and LLVM module verification. This is the boundary at which Hew
+semantics become low-level LLVM computation; LLVM IR optimization may then run
+over that computation.
 
 DecisionFacts stay attached to MIR inputs. Codegen may carry them into debug
 metadata or comments in dumps, but it must not reinterpret them or synthesize a
 replacement side table.
 
 **Must not own:** re-deriving any value-model fact; inventing ABI shape from
-LLVM value layout; ownership/drop decisions; source-level diagnostics.
+LLVM value layout; ownership/drop decisions; source-level diagnostics; target
+legalization; instruction selection; or machine policy.
 
 **Verifier:** `Module::verify()` after emission; fail-closed errors for
 unsupported MIR constructs, missing locals, unresolved runtime symbols, and
@@ -340,12 +545,17 @@ LLVM verifier failures.
 
 ---
 
-### 2.9 Native and WASM object emission
+### 2.9 LLVM backend and execution modes
 
-**Owns:** target-specific object emission from verified LLVM IR. Native builds
-write a relocatable object and then link it with `libhew.a`; WASM builds write
-a wasm object and link it into a standalone module with `wasm-ld` or
-`rust-lld`.
+**Owns:** LLVM's target-specific work below LLVM IR: target legalization,
+instruction selection, Machine IR, register allocation, scheduling, and object
+or module emission. Native builds write a relocatable object and then link it
+with `libhew.a`; Wasm builds write a Wasm object and link it into a standalone
+module with `wasm-ld` or `rust-lld`; embedded targets produce their appropriate
+object or image.
+
+ORC JIT is an execution mode over the same verified LLVM IR. It is not a Hew
+target and must not introduce a JIT-only frontend, SIR, or MIR path.
 
 **Must not own:** Hew-level semantics, ownership/drop decisions, or checker
 diagnostics. Unsupported target substrates must report a named fail-closed
@@ -400,12 +610,18 @@ The v0.5 surface is Swift/Kotlin-shaped, not Rust-shaped:
   side effect) or `@resource` (single-owner, has a drop side effect — file
   handle, socket, capability).
 
-### 3.3 Internal MIR operations (compiler vocabulary)
+### 3.3 Semantic use modes and physical MIR operations
 
-The value-model classifier emits exactly one of these at each value-use site.
-Users never type these; the diagnostics and Ownership Plan Report use them
-as implementation terms, and inlay hints / hovers surface them to compiler
-engineers.
+HIR establishes source intent and SIR carries it on each operand as one of
+`Read`, `BorrowShared`, `BorrowMut`, `Move`, or `Consume`. This is semantic
+information: an optimizer must not duplicate or reorder a move/consume as
+though it were an ordinary read. It does not prescribe a refcount, copy,
+allocation, or storage mechanism.
+
+Raw MIR realizes that semantic use through one physical operation or strategy.
+Checked MIR proves the selected realization legal. Users never type these
+operation names; diagnostics and the Ownership Plan Report may expose their
+cost in user-facing terms.
 
 | Operation         | When chosen | Cost class |
 |-------------------|-------------|------------|
@@ -420,8 +636,9 @@ engineers.
 
 ### 3.4 Actor / concurrency rules
 
-Actor isolation is the central concurrency boundary.  Send-path classification
-(computed in Checked MIR, attributed on `hew.actor_send` in the dialect):
+Actor isolation is the central concurrency boundary. Send-path classification
+is validated in Checked MIR after SIR has retained the typed actor handle,
+resolved `ActorMethodId`, and typed semantic message:
 
 - **Transfer mode:** last-use of an owned value; sender loses access, receiver
   gains it.  Cheapest path.  For AffineResource, the only valid send mode.
@@ -543,10 +760,10 @@ DecisionFact {
 }
 ```
 
-`SiteId` is derived from the THIR/MIR structure (function id + canonical path
-through the elaborated CFG), not from a source span.  `DecisionFact`s travel
-inside the IR (as region attributes on Elaborated MIR functions and as
-`hew.site_id` / `hew.value_decision` op attributes in the dialect).
+`SiteId` is derived from typed-HIR/SIR/MIR structure (function id + canonical
+path through the elaborated CFG), not from a source span. `DecisionFact`s travel
+with Elaborated MIR and its deterministic dump/JSON metadata; they do not
+require a dialect attribute system.
 
 ### 4.3 Hidden-copy budget
 
@@ -584,8 +801,8 @@ conventions.
 
 The checker and lowering work should be introduced as cohesive compiler changes
 against the v0.5 value model, progressing through each layer of the IR ladder
-(Resolved HIR → THIR → Raw MIR → Checked MIR → Elaborated MIR → LLVM IR →
-native/WASM emission).  The corpus fixtures in
+(resolved + typed HIR → normalized HIR → SIR → Raw MIR → Checked MIR →
+Elaborated MIR → LLVM IR → LLVM backend). The corpus fixtures in
 `tests/corpus/v05-value-model/` serve as the byte-level acceptance targets for
 the Checked MIR and Elaborated MIR stages.
 
@@ -593,8 +810,9 @@ the Checked MIR and Elaborated MIR stages.
 
 ## 7. Building the v0.5 spine
 
-`hew compile` runs the v0.5 Rust HIR/MIR/codegen-rs path. The backend is a
-normal Cargo dependency of `hew`; no retired C++ backend build step is involved:
+At hard cutover, `hew compile` runs the v0.5 Rust
+HIR/SIR/MIR/codegen-rs path. The backend is a normal Cargo dependency of `hew`;
+no retired C++ backend build step is involved:
 
 ```
 make hew          # debug: builds hew

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -1379,10 +1379,14 @@ fn has_cycle_from(
         states.insert(block_id, VisitState::Visited);
         return false;
     };
-    for edge in block.terminator.successors() {
-        if has_cycle_from(edge.target, by_id, states) {
-            return true;
+    let mut has_cycle = false;
+    block.terminator.visit_successors(|edge| {
+        if !has_cycle && has_cycle_from(edge.target, by_id, states) {
+            has_cycle = true;
         }
+    });
+    if has_cycle {
+        return true;
     }
     states.insert(block_id, VisitState::Visited);
     false

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -1868,14 +1868,15 @@ impl<'a> RawLowerer<'a> {
     fn lower_terminator(&mut self, terminator: &SemTerminator) -> Result<(), SirMirLoweringError> {
         match terminator {
             SemTerminator::Return { value: Some(value) } => {
-                if self.value_type(*value)? != &self.function.return_ty {
+                Self::require_read(value, "SIR return value")?;
+                if self.value_type(value.value)? != &self.function.return_ty {
                     return Err(SirMirLoweringError::unsupported(
                         "SIR return value type does not match function return type",
                     ));
                 }
                 self.push(Instr::Move {
                     dest: Place::ReturnSlot,
-                    src: self.value_place(*value)?,
+                    src: self.value_place(value.value)?,
                 });
                 self.terminate(Terminator::Return)
             }
@@ -1898,7 +1899,8 @@ impl<'a> RawLowerer<'a> {
                 then_target,
                 else_target,
             } => {
-                if self.value_type(*condition)? != &ResolvedTy::Bool {
+                Self::require_read(condition, "SIR branch condition")?;
+                if self.value_type(condition.value)? != &ResolvedTy::Bool {
                     return Err(SirMirLoweringError::unsupported(
                         "SIR branch condition must have bool type",
                     ));
@@ -1908,7 +1910,7 @@ impl<'a> RawLowerer<'a> {
                 let else_target = self.materialize_edge(else_target)?;
                 self.current = source;
                 self.terminate(Terminator::Branch {
-                    cond: self.value_place(*condition)?,
+                    cond: self.value_place(condition.value)?,
                     then_target,
                     else_target,
                 })
@@ -1943,7 +1945,8 @@ impl<'a> RawLowerer<'a> {
         self.current = forwarding;
         let mut copies = Vec::with_capacity(edge.args.len());
         for (source, target) in edge.args.iter().zip(&target_args) {
-            let source_ty = self.value_type(*source)?;
+            Self::require_read(source, "SIR edge argument")?;
+            let source_ty = self.value_type(source.value)?;
             if source_ty != &target.ty {
                 return Err(SirMirLoweringError::unsupported(
                     "SIR edge argument type does not match target block argument",
@@ -1952,7 +1955,7 @@ impl<'a> RawLowerer<'a> {
             let scratch = self.fresh_local(source_ty.clone())?;
             self.push(Instr::Move {
                 dest: scratch,
-                src: self.value_place(*source)?,
+                src: self.value_place(source.value)?,
             });
             copies.push((scratch, self.value_place(target.value)?));
         }
@@ -2245,7 +2248,7 @@ mod tests {
                 args: Vec::new(),
                 ops: Vec::new(),
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(0)),
+                    value: Some(operand(0)),
                 },
             }],
         }
@@ -2284,7 +2287,7 @@ mod tests {
                     },
                 )],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(2)),
+                    value: Some(operand(2)),
                 },
             }],
         }
@@ -2405,14 +2408,14 @@ mod tests {
                         ),
                     ],
                     terminator: SemTerminator::Branch {
-                        condition: ValueId(3),
+                        condition: operand(3),
                         then_target: Edge {
                             target: BlockId(1),
-                            args: vec![ValueId(1)],
+                            args: vec![operand(1)],
                         },
                         else_target: Edge {
                             target: BlockId(2),
-                            args: vec![ValueId(1)],
+                            args: vec![operand(1)],
                         },
                     },
                 },
@@ -2436,7 +2439,7 @@ mod tests {
                     ],
                     terminator: SemTerminator::Goto(Edge {
                         target: BlockId(3),
-                        args: vec![ValueId(6)],
+                        args: vec![operand(6)],
                     }),
                 },
                 SemBlock {
@@ -2459,7 +2462,7 @@ mod tests {
                     ],
                     terminator: SemTerminator::Goto(Edge {
                         target: BlockId(3),
-                        args: vec![ValueId(9)],
+                        args: vec![operand(9)],
                     }),
                 },
                 SemBlock {
@@ -2481,7 +2484,7 @@ mod tests {
                         ),
                     ],
                     terminator: SemTerminator::Return {
-                        value: Some(ValueId(12)),
+                        value: Some(operand(12)),
                     },
                 },
             ],
@@ -2550,7 +2553,7 @@ mod tests {
                 }],
                 ops: Vec::new(),
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(0)),
+                    value: Some(operand(0)),
                 },
             }],
         };
@@ -2595,7 +2598,7 @@ mod tests {
                         SemOpKind::ConstI64(1),
                     )],
                     terminator: SemTerminator::Return {
-                        value: Some(ValueId(0)),
+                        value: Some(operand(0)),
                     },
                 },
             ],
@@ -2645,14 +2648,14 @@ mod tests {
                     args: Vec::new(),
                     ops: Vec::new(),
                     terminator: SemTerminator::Branch {
-                        condition: ValueId(2),
+                        condition: operand(2),
                         then_target: Edge {
                             target: BlockId(1),
-                            args: vec![ValueId(1), ValueId(0)],
+                            args: vec![operand(1), operand(0)],
                         },
                         else_target: Edge {
                             target: BlockId(1),
-                            args: vec![ValueId(0), ValueId(1)],
+                            args: vec![operand(0), operand(1)],
                         },
                     },
                 },
@@ -2670,7 +2673,7 @@ mod tests {
                     ],
                     ops: Vec::new(),
                     terminator: SemTerminator::Return {
-                        value: Some(ValueId(3)),
+                        value: Some(operand(3)),
                     },
                 },
             ],
@@ -2760,7 +2763,7 @@ mod tests {
                     ),
                 ],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(2)),
+                    value: Some(operand(2)),
                 },
             }],
         };
@@ -2802,7 +2805,7 @@ mod tests {
                     ),
                 ],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(3)),
+                    value: Some(operand(3)),
                 },
             }],
         };
@@ -2993,7 +2996,7 @@ mod tests {
                     },
                 )],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(0)),
+                    value: Some(operand(0)),
                 },
             }],
         };
@@ -3042,7 +3045,7 @@ mod tests {
                     SemOpKind::ConstI64(42),
                 )],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(0)),
+                    value: Some(operand(0)),
                 },
             }],
         };
@@ -3107,7 +3110,7 @@ mod tests {
                     SemOpKind::ConstI64(42),
                 )],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(0)),
+                    value: Some(operand(0)),
                 },
             }],
         };

--- a/hew-sir/src/analysis.rs
+++ b/hew-sir/src/analysis.rs
@@ -223,14 +223,29 @@ pub fn replace_use(
 /// The caller must verify that `function` has unique operation and block IDs
 /// before rewriting. See [`build_def_use`] for the malformed-SIR diagnostic
 /// contract.
-#[must_use]
-pub fn replace_all_uses(function: &mut SemFunction, from: ValueId, replacement: ValueId) -> usize {
+///
+/// # Errors
+///
+/// Returns the first [`RewriteError`] instead of silently applying a partial
+/// rewrite. The snapshot remains valid while this function changes only its
+/// operand values; a failure therefore signals malformed or concurrently
+/// mutated SIR that a pass must not treat as a completed rewrite.
+pub fn replace_all_uses(
+    function: &mut SemFunction,
+    from: ValueId,
+    replacement: ValueId,
+) -> Result<usize, RewriteError> {
     let sites = build_def_use(function).uses_of(from).to_vec();
+    // Rewrite a clone first so malformed identities cannot leave a caller with
+    // a partially rewritten semantic graph. Normal pass execution verifies
+    // unique identities before this point; this guard makes the public helper
+    // fail closed even when it is used during diagnostics or development.
+    let mut rewritten = function.clone();
     let mut replaced = 0;
     for site in sites {
-        if replace_use(function, site, replacement).is_ok() {
-            replaced += 1;
-        }
+        replace_use(&mut rewritten, site, replacement)?;
+        replaced += 1;
     }
-    replaced
+    *function = rewritten;
+    Ok(replaced)
 }

--- a/hew-sir/src/analysis.rs
+++ b/hew-sir/src/analysis.rs
@@ -94,7 +94,12 @@ impl DefUseIndex {
 /// Build the deterministic concrete def-use index for one semantic SSA
 /// function. The verifier remains authoritative for duplicate definitions and
 /// malformed CFGs; this index deliberately stays total to support diagnostics
-/// and repair tooling on malformed intermediate states.
+/// on malformed intermediate states.
+///
+/// Transformations using [`replace_use`] or [`replace_all_uses`] require a
+/// verifier-clean function with unique operation and block identities. A
+/// def-use index over malformed SIR is useful for diagnostics, but is not a
+/// repair authority for ambiguous identities.
 #[must_use]
 pub fn build_def_use(function: &SemFunction) -> DefUseIndex {
     let mut index = DefUseIndex::default();
@@ -214,6 +219,10 @@ pub fn replace_use(
 /// Definitions are intentionally untouched. The fresh index gives this a
 /// deterministic snapshot of all use sites; rewriting values cannot change
 /// operand slots, so every site stays valid for the duration of this operation.
+///
+/// The caller must verify that `function` has unique operation and block IDs
+/// before rewriting. See [`build_def_use`] for the malformed-SIR diagnostic
+/// contract.
 #[must_use]
 pub fn replace_all_uses(function: &mut SemFunction, from: ValueId, replacement: ValueId) -> usize {
     let sites = build_def_use(function).uses_of(from).to_vec();

--- a/hew-sir/src/analysis.rs
+++ b/hew-sir/src/analysis.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
-use crate::{BlockId, SemFunction, ValueId};
+use crate::{BlockId, OpId, SemFunction, UseSite, ValueId};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Dominators {
@@ -22,9 +22,9 @@ pub fn compute_dominators(function: &SemFunction) -> Dominators {
         .collect::<BTreeSet<_>>();
     let mut predecessors: BTreeMap<BlockId, Vec<BlockId>> = BTreeMap::new();
     for block in &function.blocks {
-        for edge in block.terminator.successors() {
-            predecessors.entry(edge.target).or_default().push(block.id);
-        }
+        block
+            .terminator
+            .visit_successors(|edge| predecessors.entry(edge.target).or_default().push(block.id));
     }
     let mut sets = function
         .blocks
@@ -67,12 +67,34 @@ pub fn compute_dominators(function: &SemFunction) -> Dominators {
     Dominators { sets }
 }
 
+/// Def-use facts for one SIR function.
+///
+/// Both maps are ordered by stable SIR identity. A use is not merely a count:
+/// it names the exact operation or terminator slot where a rewrite can act.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DefUseIndex {
-    pub definitions: HashMap<ValueId, BlockId>,
-    pub uses: HashMap<ValueId, usize>,
+    pub definitions: BTreeMap<ValueId, BlockId>,
+    pub uses: BTreeMap<ValueId, Vec<UseSite>>,
 }
 
+impl DefUseIndex {
+    /// Return deterministic concrete use sites for `value`.
+    #[must_use]
+    pub fn uses_of(&self, value: ValueId) -> &[UseSite] {
+        self.uses.get(&value).map_or(&[], Vec::as_slice)
+    }
+
+    /// Convenience count for clients that do not need the individual sites.
+    #[must_use]
+    pub fn use_count(&self, value: ValueId) -> usize {
+        self.uses_of(value).len()
+    }
+}
+
+/// Build the deterministic concrete def-use index for one semantic SSA
+/// function. The verifier remains authoritative for duplicate definitions and
+/// malformed CFGs; this index deliberately stays total to support diagnostics
+/// and repair tooling on malformed intermediate states.
 #[must_use]
 pub fn build_def_use(function: &SemFunction) -> DefUseIndex {
     let mut index = DefUseIndex::default();
@@ -87,42 +109,119 @@ pub fn build_def_use(function: &SemFunction) -> DefUseIndex {
             for result in &op.results {
                 index.definitions.insert(result.id, block.id);
             }
-            for value in op_uses(op) {
-                *index.uses.entry(value).or_default() += 1;
-            }
+            op.visit_operands(|operand, use_| {
+                index
+                    .uses
+                    .entry(use_.value)
+                    .or_default()
+                    .push(UseSite::Operation {
+                        op: op.id,
+                        operand,
+                        value: use_.value,
+                        mode: use_.mode,
+                    });
+            });
         }
-        for value in terminator_uses(&block.terminator) {
-            *index.uses.entry(value).or_default() += 1;
-        }
+        block.terminator.visit_operands(|operand, use_| {
+            index
+                .uses
+                .entry(use_.value)
+                .or_default()
+                .push(UseSite::Terminator {
+                    block: block.id,
+                    operand,
+                    value: use_.value,
+                    mode: use_.mode,
+                });
+        });
+    }
+    for uses in index.uses.values_mut() {
+        uses.sort_unstable();
     }
     index
 }
 
-fn op_uses(op: &crate::SemOp) -> Vec<ValueId> {
-    use crate::SemOpKind;
-    match &op.kind {
-        SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) => Vec::new(),
-        SemOpKind::Unary { value, .. } | SemOpKind::Cast { value, .. } => vec![value.value],
-        SemOpKind::Binary { lhs, rhs, .. } => vec![lhs.value, rhs.value],
-        SemOpKind::Call { args, .. } => args.iter().map(|arg| arg.value).collect(),
+/// Failure to apply an indexed rewrite site to the current mutable function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RewriteError {
+    UnknownOperation(OpId),
+    UnknownBlock(BlockId),
+    StaleUseSite(UseSite),
+}
+
+/// Rewrite one indexed semantic use to `replacement`.
+///
+/// The caller normally obtains `site` from [`build_def_use`]. If an earlier
+/// rewrite changed its ownership mode or removed the referenced operation or
+/// block, this returns a precise stale-site error rather than writing through
+/// an incidental vector index.
+///
+/// # Errors
+///
+/// Returns [`RewriteError::UnknownOperation`] or
+/// [`RewriteError::UnknownBlock`] when the indexed identity no longer exists,
+/// and [`RewriteError::StaleUseSite`] when its operand value or mode no longer
+/// agrees with the current function.
+pub fn replace_use(
+    function: &mut SemFunction,
+    site: UseSite,
+    replacement: ValueId,
+) -> Result<(), RewriteError> {
+    let replaced = match site {
+        UseSite::Operation {
+            op,
+            operand,
+            value,
+            mode,
+        } => {
+            let Some(operation) = function
+                .blocks
+                .iter_mut()
+                .flat_map(|block| block.ops.iter_mut())
+                .find(|operation| operation.id == op)
+            else {
+                return Err(RewriteError::UnknownOperation(op));
+            };
+            operation.replace_operand_at(operand, value, mode, replacement)
+        }
+        UseSite::Terminator {
+            block,
+            operand,
+            value,
+            mode,
+        } => {
+            let Some(block) = function
+                .blocks
+                .iter_mut()
+                .find(|candidate| candidate.id == block)
+            else {
+                return Err(RewriteError::UnknownBlock(block));
+            };
+            block
+                .terminator
+                .replace_operand_at(operand, value, mode, replacement)
+        }
+    };
+    if replaced {
+        Ok(())
+    } else {
+        Err(RewriteError::StaleUseSite(site))
     }
 }
 
-fn terminator_uses(terminator: &crate::SemTerminator) -> Vec<ValueId> {
-    use crate::SemTerminator;
-    match terminator {
-        SemTerminator::Return { value } => value.iter().copied().collect(),
-        SemTerminator::Goto(edge) => edge.args.clone(),
-        SemTerminator::Branch {
-            condition,
-            then_target,
-            else_target,
-        } => {
-            let mut values = vec![*condition];
-            values.extend(then_target.args.iter().copied());
-            values.extend(else_target.args.iter().copied());
-            values
+/// Replace every current semantic use of `from` with `replacement`.
+///
+/// Definitions are intentionally untouched. The fresh index gives this a
+/// deterministic snapshot of all use sites; rewriting values cannot change
+/// operand slots, so every site stays valid for the duration of this operation.
+#[must_use]
+pub fn replace_all_uses(function: &mut SemFunction, from: ValueId, replacement: ValueId) -> usize {
+    let sites = build_def_use(function).uses_of(from).to_vec();
+    let mut replaced = 0;
+    for site in sites {
+        if replace_use(function, site, replacement).is_ok() {
+            replaced += 1;
         }
-        SemTerminator::Unreachable => Vec::new(),
     }
+    replaced
 }

--- a/hew-sir/src/dump.rs
+++ b/hew-sir/src/dump.rs
@@ -60,13 +60,13 @@ fn dump_op(out: &mut String, module: &SemModule, op: &crate::SemOp) {
         SemOpKind::ConstI64(value) => writeln!(out, "const {value}").expect("write to String"),
         SemOpKind::ConstBool(value) => writeln!(out, "const {value}").expect("write to String"),
         SemOpKind::Unary { op, value } => {
-            writeln!(out, "{op:?} %{}", value.value.0).expect("write to String");
+            writeln!(out, "{op:?} {}", operand(value)).expect("write to String");
         }
         SemOpKind::Binary { op, lhs, rhs } => {
-            writeln!(out, "{op:?} %{}, %{}", lhs.value.0, rhs.value.0).expect("write to String");
+            writeln!(out, "{op:?} {}, {}", operand(lhs), operand(rhs)).expect("write to String");
         }
         SemOpKind::Cast { value, to } => {
-            writeln!(out, "cast %{} to {}", value.value.0, to.user_facing())
+            writeln!(out, "cast {} to {}", operand(value), to.user_facing())
                 .expect("write to String");
         }
         SemOpKind::Call { callee, args } => {
@@ -79,7 +79,7 @@ fn dump_op(out: &mut String, module: &SemModule, op: &crate::SemOp) {
                 if index != 0 {
                     write!(out, ", ").expect("write to String");
                 }
-                write!(out, "%{}", arg.value.0).expect("write to String");
+                write!(out, "{}", operand(arg)).expect("write to String");
             }
             writeln!(out, ")").expect("write to String");
         }
@@ -89,7 +89,7 @@ fn dump_op(out: &mut String, module: &SemModule, op: &crate::SemOp) {
 fn dump_term(out: &mut String, term: &SemTerminator) {
     match term {
         SemTerminator::Return { value: Some(value) } => {
-            writeln!(out, "    return %{}", value.0).expect("write to String");
+            writeln!(out, "    return {}", operand(value)).expect("write to String");
         }
         SemTerminator::Return { value: None } => {
             writeln!(out, "    return").expect("write to String");
@@ -104,8 +104,8 @@ fn dump_term(out: &mut String, term: &SemTerminator) {
             else_target,
         } => writeln!(
             out,
-            "    branch %{}, bb{}{}, bb{}{}",
-            condition.0,
+            "    branch {}, bb{}{}, bb{}{}",
+            operand(condition),
             then_target.target.0,
             edge_args(then_target),
             else_target.target.0,
@@ -122,10 +122,16 @@ fn edge_args(edge: &crate::Edge) -> String {
     }
     format!(
         "({})",
-        edge.args
-            .iter()
-            .map(|value| format!("%{}", value.0))
-            .collect::<Vec<_>>()
-            .join(", ")
+        edge.args.iter().map(operand).collect::<Vec<_>>().join(", ")
     )
+}
+
+fn operand(operand: &crate::Operand) -> String {
+    match operand.mode {
+        crate::UseMode::Read => format!("%{}", operand.value.0),
+        crate::UseMode::BorrowShared => format!("borrow %{}", operand.value.0),
+        crate::UseMode::BorrowMut => format!("borrow_mut %{}", operand.value.0),
+        crate::UseMode::Move => format!("move %{}", operand.value.0),
+        crate::UseMode::Consume => format!("consume %{}", operand.value.0),
+    }
 }

--- a/hew-sir/src/lib.rs
+++ b/hew-sir/src/lib.rs
@@ -12,14 +12,17 @@ mod lower;
 mod model;
 mod verify;
 
-pub use analysis::{build_def_use, compute_dominators, DefUseIndex, Dominators};
+pub use analysis::{
+    build_def_use, compute_dominators, replace_all_uses, replace_use, DefUseIndex, Dominators,
+    RewriteError,
+};
 pub use dump::dump_sir;
 pub use lower::{lower_module, LoweredModule, SirLoweringStatus};
 pub use model::{
     BlockArg, BlockId, CallableId, Edge, EffectSet, EffectSummary, FunctionSourceOrigin, OpId,
-    Operand, Provenance, SemAbiParam, SemBlock, SemCallConv, SemCallable, SemCallableKind,
-    SemFunction, SemModule, SemOp, SemOpKind, SemParamPassing, SemSignature, SemTerminator,
-    UseMode, ValueDef, ValueId,
+    Operand, OperandSlot, Provenance, SemAbiParam, SemBlock, SemCallConv, SemCallable,
+    SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind, SemParamPassing, SemSignature,
+    SemTerminator, UseMode, UseSite, ValueDef, ValueId,
 };
 pub use verify::{
     verify_function, verify_function_in_module, verify_module, SirDiagnostic, SirDiagnosticKind,

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -371,6 +371,17 @@ impl PendingBlock {
         self.terminator.is_none()
     }
 
+    fn append_op(&mut self, op: SemOp) -> Result<(), String> {
+        if self.terminator.is_some() {
+            return Err(format!(
+                "SIR builder attempted to append an operation after completed block bb{}",
+                self.id.0
+            ));
+        }
+        self.ops.push(op);
+        Ok(())
+    }
+
     fn into_sem_block(self) -> Result<SemBlock, String> {
         let terminator = self.terminator.ok_or_else(|| {
             format!(
@@ -595,7 +606,7 @@ impl<'a> Builder<'a> {
                         expr.ty.user_facing()
                     ));
                 }
-                Ok(self.emit(expr, SemOpKind::ConstI64(*value)))
+                self.emit(expr, SemOpKind::ConstI64(*value))
             }
             HirExprKind::Literal(HirLiteral::Bool(value)) => {
                 if expr.ty != hew_types::ResolvedTy::Bool {
@@ -604,7 +615,7 @@ impl<'a> Builder<'a> {
                         expr.ty.user_facing()
                     ));
                 }
-                Ok(self.emit(expr, SemOpKind::ConstBool(*value)))
+                self.emit(expr, SemOpKind::ConstBool(*value))
             }
             HirExprKind::BindingRef {
                 resolved: ResolvedRef::Binding(binding),
@@ -614,7 +625,7 @@ impl<'a> Builder<'a> {
             }),
             HirExprKind::Unary { op, operand, .. } => {
                 let value = self.lower_read_operand(operand, "unary operand")?;
-                Ok(self.emit(expr, SemOpKind::Unary { op: *op, value }))
+                self.emit(expr, SemOpKind::Unary { op: *op, value })
             }
             HirExprKind::Binary {
                 op: hew_parser::ast::BinaryOp::And,
@@ -629,17 +640,17 @@ impl<'a> Builder<'a> {
             HirExprKind::Binary { op, left, right } => {
                 let lhs = self.lower_read_operand(left, "binary left operand")?;
                 let rhs = self.lower_read_operand(right, "binary right operand")?;
-                Ok(self.emit(expr, SemOpKind::Binary { op: *op, lhs, rhs }))
+                self.emit(expr, SemOpKind::Binary { op: *op, lhs, rhs })
             }
             HirExprKind::NumericCast { value, to_ty, .. } => {
                 let value = self.lower_read_operand(value, "cast operand")?;
-                Ok(self.emit(
+                self.emit(
                     expr,
                     SemOpKind::Cast {
                         value,
                         to: to_ty.clone(),
                     },
-                ))
+                )
             }
             HirExprKind::Call { .. } => self.lower_direct_call(expr, true)?.ok_or_else(|| {
                 "unit-valued direct calls are valid only in a discarded or unit-return context"
@@ -784,10 +795,10 @@ impl<'a> Builder<'a> {
                     callee_declaration.full_path()
                 ));
             }
-            self.emit_without_result(expr, kind);
+            self.emit_without_result(expr, kind)?;
             Ok(None)
         } else {
-            Ok(Some(self.emit(expr, kind)))
+            Ok(Some(self.emit(expr, kind)?))
         }
     }
 
@@ -912,7 +923,7 @@ impl<'a> Builder<'a> {
 
         self.current = short_circuit;
         self.bindings = before;
-        let constant = self.emit(whole, SemOpKind::ConstBool(short_circuit_value));
+        let constant = self.emit(whole, SemOpKind::ConstBool(short_circuit_value))?;
         self.set_terminator(SemTerminator::Goto(Edge {
             target: join,
             args: vec![Operand {
@@ -925,7 +936,7 @@ impl<'a> Builder<'a> {
         Ok(result)
     }
 
-    fn emit(&mut self, expr: &HirExpr, kind: SemOpKind) -> ValueId {
+    fn emit(&mut self, expr: &HirExpr, kind: SemOpKind) -> Result<ValueId, String> {
         let value = self.fresh_value();
         let op = SemOp {
             id: OpId(self.ops),
@@ -936,20 +947,21 @@ impl<'a> Builder<'a> {
             kind,
             provenance: Provenance::Site(expr.site),
         };
+        self.current_block_mut().append_op(op)?;
         self.ops += 1;
-        self.current_block_mut().ops.push(op);
-        value
+        Ok(value)
     }
 
-    fn emit_without_result(&mut self, expr: &HirExpr, kind: SemOpKind) {
+    fn emit_without_result(&mut self, expr: &HirExpr, kind: SemOpKind) -> Result<(), String> {
         let op = SemOp {
             id: OpId(self.ops),
             results: Vec::new(),
             kind,
             provenance: Provenance::Site(expr.site),
         };
+        self.current_block_mut().append_op(op)?;
         self.ops += 1;
-        self.current_block_mut().ops.push(op);
+        Ok(())
     }
 
     fn fresh_value(&mut self) -> ValueId {
@@ -990,7 +1002,7 @@ mod tests {
         initial_scalar_transfer_mode, initial_scalar_use_mode, use_mode_from_hir_intent,
         PendingBlock,
     };
-    use crate::{BlockId, SemTerminator, UseMode};
+    use crate::{BlockId, OpId, Provenance, SemOp, SemOpKind, SemTerminator, UseMode};
     use hew_hir::IntentKind;
     use hew_types::ResolvedTy;
 
@@ -1067,5 +1079,21 @@ mod tests {
                 .terminator,
             SemTerminator::Unreachable
         ));
+    }
+
+    #[test]
+    fn pending_blocks_reject_operations_after_a_semantic_terminator() {
+        let mut completed = PendingBlock::new(BlockId(0), Vec::new());
+        completed.terminator = Some(SemTerminator::Return { value: None });
+        let error = completed
+            .append_op(SemOp {
+                id: OpId(0),
+                results: Vec::new(),
+                kind: SemOpKind::ConstI64(0),
+                provenance: Provenance::Synthesized,
+            })
+            .expect_err("completed blocks must reject late operations");
+        assert!(error.contains("after completed block bb0"));
+        assert!(completed.ops.is_empty());
     }
 }

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -1072,6 +1072,15 @@ mod tests {
         let mut completed = PendingBlock::new(BlockId(1), Vec::new());
         completed.terminator = Some(SemTerminator::Unreachable);
         assert!(!completed.is_open());
+        let error = completed
+            .append_op(SemOp {
+                id: OpId(0),
+                results: Vec::new(),
+                kind: SemOpKind::ConstI64(0),
+                provenance: Provenance::Synthesized,
+            })
+            .expect_err("semantic unreachable must close the builder block");
+        assert!(error.contains("after completed block bb1"));
         assert!(matches!(
             completed
                 .into_sem_block()

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -243,6 +243,46 @@ fn is_initial_scalar_return(ty: &hew_types::ResolvedTy) -> bool {
     matches!(ty, hew_types::ResolvedTy::Unit) || is_initial_scalar(ty)
 }
 
+/// Translate HIR's authoritative source-semantic intent into the SIR operand
+/// vocabulary exactly once.
+///
+/// This deliberately does *not* normalize an ownership intent to `Read` just
+/// because the first scalar SIR slice cannot realize it yet. Callers use the
+/// returned mode to reject unsupported ownership semantics at the HIR → SIR
+/// boundary, preserving a precise implementation gap for later domains.
+fn use_mode_from_hir_intent(intent: IntentKind) -> Result<UseMode, String> {
+    match intent {
+        IntentKind::Read => Ok(UseMode::Read),
+        IntentKind::Modify => Ok(UseMode::BorrowMut),
+        // HIR's `Consume` is an ownership transfer to a receiving semantic
+        // operation/callee, whereas `Discharge` releases an obligation with
+        // no receiver. SIR preserves that distinction as Move vs Consume.
+        IntentKind::Consume => Ok(UseMode::Move),
+        IntentKind::Discharge => Ok(UseMode::Consume),
+        IntentKind::Capture => Err(
+            "HIR Capture intent requires closure/COW capture semantics that the initial scalar SIR slice does not model"
+                .to_string(),
+        ),
+        IntentKind::Yield => Err(
+            "HIR Yield intent requires explicit SIR suspension semantics that the initial scalar slice does not model"
+                .to_string(),
+        ),
+        IntentKind::Unknown => Err(
+            "HIR Unknown intent is not a legal input to semantic SIR lowering".to_string(),
+        ),
+    }
+}
+
+fn initial_scalar_use_mode(intent: IntentKind) -> Result<UseMode, String> {
+    let mode = use_mode_from_hir_intent(intent)?;
+    if mode != UseMode::Read {
+        return Err(format!(
+            "HIR {intent:?} intent maps to SIR {mode:?}; initial scalar SIR admits only Read operands"
+        ));
+    }
+    Ok(mode)
+}
+
 struct Builder<'a> {
     function: &'a HirFn,
     callables: &'a CallableTable,
@@ -342,7 +382,26 @@ impl<'a> Builder<'a> {
         })
     }
 
-    fn lower_block(&mut self, block: &HirBlock) -> Result<Option<ValueId>, String> {
+    /// Lower one HIR expression in a semantic operand position.
+    ///
+    /// The initial scalar SIR domain admits only read uses, but it still
+    /// translates every HIR intent before rejecting a non-read mode. This
+    /// prevents a source move/borrow/discharge from being silently weakened
+    /// into a reusable SIR value during the migration.
+    fn lower_read_operand(&mut self, expr: &HirExpr, context: &str) -> Result<Operand, String> {
+        let mode = initial_scalar_use_mode(expr.intent)
+            .map_err(|reason| format!("{context}: {reason}"))?;
+        Ok(Operand {
+            value: self.lower_expr(expr)?,
+            mode,
+        })
+    }
+
+    fn lower_read_value(&mut self, expr: &HirExpr, context: &str) -> Result<ValueId, String> {
+        Ok(self.lower_read_operand(expr, context)?.value)
+    }
+
+    fn lower_block(&mut self, block: &HirBlock) -> Result<Option<Operand>, String> {
         for statement in &block.statements {
             if !self.is_open() {
                 break;
@@ -354,7 +413,7 @@ impl<'a> Builder<'a> {
                     }
                     let value = value
                         .as_ref()
-                        .map(|expr| self.lower_expr(expr))
+                        .map(|expr| self.lower_read_value(expr, "binding initializer"))
                         .transpose()?
                         .ok_or_else(|| {
                             "uninitialised bindings are not in the initial SIR subset".to_string()
@@ -370,7 +429,7 @@ impl<'a> Builder<'a> {
                             self.lower_discarded_expr(expr)?;
                             None
                         }
-                        Some(expr) => Some(self.lower_expr(expr)?),
+                        Some(expr) => Some(self.lower_read_operand(expr, "return value")?),
                         None => None,
                     };
                     self.set_terminator(SemTerminator::Return { value });
@@ -395,7 +454,7 @@ impl<'a> Builder<'a> {
                     self.lower_discarded_expr(expr)?;
                     Ok(None)
                 }
-                Some(expr) => Ok(Some(self.lower_expr(expr)?)),
+                Some(expr) => Ok(Some(self.lower_read_operand(expr, "block tail value")?)),
                 None => Ok(None),
             }
         } else {
@@ -410,6 +469,8 @@ impl<'a> Builder<'a> {
     /// no semantic value to define, but the call itself must remain in SIR so
     /// later lowering can realize its call/continuation CFG edge.
     fn lower_discarded_expr(&mut self, expr: &HirExpr) -> Result<(), String> {
+        initial_scalar_use_mode(expr.intent)
+            .map_err(|reason| format!("discarded expression: {reason}"))?;
         if matches!(expr.kind, HirExprKind::Call { .. }) {
             self.lower_direct_call(expr, false)?;
             return Ok(());
@@ -448,17 +509,8 @@ impl<'a> Builder<'a> {
                 format!("binding `{binding}` is not available in the SIR environment")
             }),
             HirExprKind::Unary { op, operand, .. } => {
-                let value = self.lower_expr(operand)?;
-                Ok(self.emit(
-                    expr,
-                    SemOpKind::Unary {
-                        op: *op,
-                        value: Operand {
-                            value,
-                            mode: UseMode::Read,
-                        },
-                    },
-                ))
+                let value = self.lower_read_operand(operand, "unary operand")?;
+                Ok(self.emit(expr, SemOpKind::Unary { op: *op, value }))
             }
             HirExprKind::Binary {
                 op: hew_parser::ast::BinaryOp::And,
@@ -471,32 +523,16 @@ impl<'a> Builder<'a> {
                 right,
             } => self.lower_logical_or(expr, left, right),
             HirExprKind::Binary { op, left, right } => {
-                let lhs = self.lower_expr(left)?;
-                let rhs = self.lower_expr(right)?;
-                Ok(self.emit(
-                    expr,
-                    SemOpKind::Binary {
-                        op: *op,
-                        lhs: Operand {
-                            value: lhs,
-                            mode: UseMode::Read,
-                        },
-                        rhs: Operand {
-                            value: rhs,
-                            mode: UseMode::Read,
-                        },
-                    },
-                ))
+                let lhs = self.lower_read_operand(left, "binary left operand")?;
+                let rhs = self.lower_read_operand(right, "binary right operand")?;
+                Ok(self.emit(expr, SemOpKind::Binary { op: *op, lhs, rhs }))
             }
             HirExprKind::NumericCast { value, to_ty, .. } => {
-                let value = self.lower_expr(value)?;
+                let value = self.lower_read_operand(value, "cast operand")?;
                 Ok(self.emit(
                     expr,
                     SemOpKind::Cast {
-                        value: Operand {
-                            value,
-                            mode: UseMode::Read,
-                        },
+                        value,
                         to: to_ty.clone(),
                     },
                 ))
@@ -507,6 +543,7 @@ impl<'a> Builder<'a> {
             }),
             HirExprKind::Block(block) => self
                 .lower_block(block)?
+                .map(|value| value.value)
                 .ok_or_else(|| "a divergent block cannot produce a SIR value".to_string()),
             HirExprKind::If {
                 condition,
@@ -616,13 +653,6 @@ impl<'a> Builder<'a> {
                     callee_declaration.full_path()
                 ));
             }
-            if arg.intent != IntentKind::Read {
-                return Err(format!(
-                    "direct call argument {index} to `{}` has {:?} intent; initial SIR calls require Read",
-                    callee_declaration.full_path(),
-                    arg.intent
-                ));
-            }
             if arg.ty != expected.ty {
                 return Err(format!(
                     "direct call argument {index} to `{}` has `{}`, expected `{}`",
@@ -631,10 +661,13 @@ impl<'a> Builder<'a> {
                     expected.ty.user_facing()
                 ));
             }
-            lowered_args.push(Operand {
-                value: self.lower_expr(arg)?,
-                mode: UseMode::Read,
-            });
+            lowered_args.push(self.lower_read_operand(
+                arg,
+                &format!(
+                    "direct call argument {index} to `{}`",
+                    callee_declaration.full_path()
+                ),
+            )?);
         }
         let kind = SemOpKind::Call {
             callee,
@@ -661,7 +694,7 @@ impl<'a> Builder<'a> {
         then_expr: &HirExpr,
         else_expr: &HirExpr,
     ) -> Result<ValueId, String> {
-        let condition = self.lower_expr(condition)?;
+        let condition = self.lower_read_operand(condition, "if condition")?;
         let then_block = self.new_block(Vec::new());
         let else_block = self.new_block(Vec::new());
         let join_value = self.fresh_value();
@@ -683,7 +716,7 @@ impl<'a> Builder<'a> {
         let before = self.bindings.clone();
         self.current = then_block;
         self.bindings = before.clone();
-        let then_value = self.lower_expr(then_expr)?;
+        let then_value = self.lower_read_operand(then_expr, "if then value")?;
         if self.is_open() {
             self.set_terminator(SemTerminator::Goto(Edge {
                 target: join_block,
@@ -692,7 +725,7 @@ impl<'a> Builder<'a> {
         }
         self.current = else_block;
         self.bindings = before;
-        let else_value = self.lower_expr(else_expr)?;
+        let else_value = self.lower_read_operand(else_expr, "if else value")?;
         if self.is_open() {
             self.set_terminator(SemTerminator::Goto(Edge {
                 target: join_block,
@@ -737,7 +770,7 @@ impl<'a> Builder<'a> {
         if whole.ty != hew_types::ResolvedTy::Bool {
             return Err("short-circuit logical expressions must have bool type in SIR".to_string());
         }
-        let condition = self.lower_expr(left)?;
+        let condition = self.lower_read_operand(left, "logical condition")?;
         let evaluate_right = self.new_block(Vec::new());
         let short_circuit = self.new_block(Vec::new());
         let result = self.fresh_value();
@@ -765,7 +798,7 @@ impl<'a> Builder<'a> {
         let before = self.bindings.clone();
         self.current = evaluate_right;
         self.bindings = before.clone();
-        let right_value = self.lower_expr(right)?;
+        let right_value = self.lower_read_operand(right, "logical right value")?;
         if self.is_open() {
             self.set_terminator(SemTerminator::Goto(Edge {
                 target: join,
@@ -778,7 +811,10 @@ impl<'a> Builder<'a> {
         let constant = self.emit(whole, SemOpKind::ConstBool(short_circuit_value));
         self.set_terminator(SemTerminator::Goto(Edge {
             target: join,
-            args: vec![constant],
+            args: vec![Operand {
+                value: constant,
+                mode: UseMode::Read,
+            }],
         }));
 
         self.current = join;
@@ -838,5 +874,50 @@ impl<'a> Builder<'a> {
     }
     fn set_terminator(&mut self, term: SemTerminator) {
         self.current_block_mut().terminator = term;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{initial_scalar_use_mode, use_mode_from_hir_intent};
+    use crate::UseMode;
+    use hew_hir::IntentKind;
+
+    #[test]
+    fn hir_intents_map_once_and_initial_scalar_sir_fails_closed() {
+        assert_eq!(
+            use_mode_from_hir_intent(IntentKind::Read),
+            Ok(UseMode::Read)
+        );
+        assert_eq!(
+            use_mode_from_hir_intent(IntentKind::Modify),
+            Ok(UseMode::BorrowMut)
+        );
+        assert_eq!(
+            use_mode_from_hir_intent(IntentKind::Consume),
+            Ok(UseMode::Move)
+        );
+        assert_eq!(
+            use_mode_from_hir_intent(IntentKind::Discharge),
+            Ok(UseMode::Consume)
+        );
+
+        for intent in [
+            IntentKind::Modify,
+            IntentKind::Consume,
+            IntentKind::Discharge,
+            IntentKind::Capture,
+            IntentKind::Yield,
+            IntentKind::Unknown,
+        ] {
+            let reason = initial_scalar_use_mode(intent)
+                .expect_err("non-Read or unresolved HIR intent must not become a scalar SIR Read");
+            assert!(
+                reason.contains("initial scalar SIR")
+                    || reason.contains("requires")
+                    || reason.contains("not a legal"),
+                "the failure must explain why {intent:?} is outside the current SIR ownership domain: {reason}"
+            );
+        }
     }
 }

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -283,11 +283,115 @@ fn initial_scalar_use_mode(intent: IntentKind) -> Result<UseMode, String> {
     Ok(mode)
 }
 
+/// Lower a value flowing into a binding or function return in the initial
+/// no-drop scalar domain.
+///
+/// HIR intentionally marks these positions `Consume`: their result transfers
+/// to a new binding or the caller. For `i*`/`u*`/`bool`, that semantic transfer
+/// has no exclusive ownership obligation, so SIR keeps the same virtual value
+/// and represents the receiving flow as `Read`. This is a narrow value-class
+/// rule, not a general weakening of `Move`: actual operand positions remain
+/// read-only in this slice, and every non-scalar transfer fails closed until
+/// ownership/layout MIR can realize it.
+fn initial_scalar_transfer_mode(
+    intent: IntentKind,
+    ty: &hew_types::ResolvedTy,
+    context: &str,
+) -> Result<(), String> {
+    let mode = use_mode_from_hir_intent(intent).map_err(|reason| format!("{context}: {reason}"))?;
+    match mode {
+        UseMode::Read | UseMode::Move if is_initial_scalar(ty) => Ok(()),
+        UseMode::Read | UseMode::Move => Err(format!(
+            "{context}: HIR intent maps to SIR {mode:?} for non-scalar `{}`; initial SIR only aliases BitCopy scalar binding/return flow",
+            ty.user_facing()
+        )),
+        other => Err(format!(
+            "{context}: HIR intent maps to SIR {other:?}; initial scalar binding/return flow admits only Read or BitCopy Move"
+        )),
+    }
+}
+
+fn lower_initial_scalar_transfer_value(
+    builder: &mut Builder<'_>,
+    expr: &HirExpr,
+    context: &str,
+) -> Result<ValueId, String> {
+    initial_scalar_transfer_mode(expr.intent, &expr.ty, context)?;
+    builder.lower_expr(expr)
+}
+
+/// Lower a unit expression transferred by an explicit `return`.
+///
+/// This is intentionally narrower than [`Builder::lower_discarded_expr`]. A
+/// standalone discarded expression is an ordinary effect position and stays
+/// read-only in the initial slice. A unit expression in `return` instead
+/// transfers control to the caller; HIR marks that transfer `Consume`, which
+/// is harmless for `Unit` but must not be rechecked as an ordinary operand use.
+fn lower_initial_unit_return(builder: &mut Builder<'_>, expr: &HirExpr) -> Result<(), String> {
+    let mode = use_mode_from_hir_intent(expr.intent)
+        .map_err(|reason| format!("unit return value: {reason}"))?;
+    if !matches!(mode, UseMode::Read | UseMode::Move) || expr.ty != hew_types::ResolvedTy::Unit {
+        return Err(format!(
+            "unit return value: HIR intent maps to SIR {mode:?} for `{}`; initial SIR admits only Read or Unit Move return transfer",
+            expr.ty.user_facing()
+        ));
+    }
+    if !matches!(expr.kind, HirExprKind::Call { .. }) {
+        return Err(
+            "unit return values are initially supported only for a resolved direct call"
+                .to_string(),
+        );
+    }
+    builder.lower_direct_call(expr, false).map(|_| ())
+}
+
+/// Builder-only block state.
+///
+/// `None` means lowering has not filled the block yet. It is deliberately
+/// distinct from `Some(SemTerminator::Unreachable)`: the latter is a completed
+/// semantic CFG endpoint and must never be overwritten by later builder work.
+struct PendingBlock {
+    id: BlockId,
+    args: Vec<BlockArg>,
+    ops: Vec<SemOp>,
+    terminator: Option<SemTerminator>,
+}
+
+impl PendingBlock {
+    fn new(id: BlockId, args: Vec<BlockArg>) -> Self {
+        Self {
+            id,
+            args,
+            ops: Vec::new(),
+            terminator: None,
+        }
+    }
+
+    fn is_open(&self) -> bool {
+        self.terminator.is_none()
+    }
+
+    fn into_sem_block(self) -> Result<SemBlock, String> {
+        let terminator = self.terminator.ok_or_else(|| {
+            format!(
+                "SIR builder left block bb{} without a semantic terminator",
+                self.id.0
+            )
+        })?;
+        Ok(SemBlock {
+            id: self.id,
+            args: self.args,
+            ops: self.ops,
+            terminator,
+        })
+    }
+}
+
 struct Builder<'a> {
     function: &'a HirFn,
     callables: &'a CallableTable,
     callable: CallableId,
-    blocks: Vec<SemBlock>,
+    blocks: Vec<PendingBlock>,
     current: BlockId,
     values: u32,
     ops: u32,
@@ -323,12 +427,7 @@ impl<'a> Builder<'a> {
             function,
             callables,
             callable,
-            blocks: vec![SemBlock {
-                id: entry,
-                args: Vec::new(),
-                ops: Vec::new(),
-                terminator: SemTerminator::Unreachable,
-            }],
+            blocks: vec![PendingBlock::new(entry, Vec::new())],
             current: entry,
             values,
             ops: 0,
@@ -366,8 +465,12 @@ impl<'a> Builder<'a> {
         }
         let result = self.lower_block(&self.function.body)?;
         if self.is_open() {
-            self.set_terminator(SemTerminator::Return { value: result });
+            self.set_terminator(SemTerminator::Return { value: result })?;
         }
+        let blocks = std::mem::take(&mut self.blocks)
+            .into_iter()
+            .map(PendingBlock::into_sem_block)
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(SemFunction {
             id: self.function.id,
             callable: self.callable,
@@ -378,7 +481,7 @@ impl<'a> Builder<'a> {
             params: self.params,
             return_ty: self.function.return_ty.clone(),
             entry: BlockId(0),
-            blocks: self.blocks,
+            blocks,
         })
     }
 
@@ -397,10 +500,6 @@ impl<'a> Builder<'a> {
         })
     }
 
-    fn lower_read_value(&mut self, expr: &HirExpr, context: &str) -> Result<ValueId, String> {
-        Ok(self.lower_read_operand(expr, context)?.value)
-    }
-
     fn lower_block(&mut self, block: &HirBlock) -> Result<Option<Operand>, String> {
         for statement in &block.statements {
             if !self.is_open() {
@@ -413,7 +512,9 @@ impl<'a> Builder<'a> {
                     }
                     let value = value
                         .as_ref()
-                        .map(|expr| self.lower_read_value(expr, "binding initializer"))
+                        .map(|expr| {
+                            lower_initial_scalar_transfer_value(self, expr, "binding initializer")
+                        })
                         .transpose()?
                         .ok_or_else(|| {
                             "uninitialised bindings are not in the initial SIR subset".to_string()
@@ -426,13 +527,16 @@ impl<'a> Builder<'a> {
                 HirStmtKind::Return(value) => {
                     let value = match value {
                         Some(expr) if expr.ty == hew_types::ResolvedTy::Unit => {
-                            self.lower_discarded_expr(expr)?;
+                            lower_initial_unit_return(self, expr)?;
                             None
                         }
-                        Some(expr) => Some(self.lower_read_operand(expr, "return value")?),
+                        Some(expr) => Some(Operand {
+                            value: lower_initial_scalar_transfer_value(self, expr, "return value")?,
+                            mode: UseMode::Read,
+                        }),
                         None => None,
                     };
-                    self.set_terminator(SemTerminator::Return { value });
+                    self.set_terminator(SemTerminator::Return { value })?;
                 }
                 HirStmtKind::Assign { .. } => {
                     return Err(
@@ -712,7 +816,7 @@ impl<'a> Builder<'a> {
                 target: else_block,
                 args: Vec::new(),
             },
-        });
+        })?;
         let before = self.bindings.clone();
         self.current = then_block;
         self.bindings = before.clone();
@@ -721,7 +825,7 @@ impl<'a> Builder<'a> {
             self.set_terminator(SemTerminator::Goto(Edge {
                 target: join_block,
                 args: vec![then_value],
-            }));
+            }))?;
         }
         self.current = else_block;
         self.bindings = before;
@@ -730,7 +834,7 @@ impl<'a> Builder<'a> {
             self.set_terminator(SemTerminator::Goto(Edge {
                 target: join_block,
                 args: vec![else_value],
-            }));
+            }))?;
         }
         self.current = join_block;
         Ok(join_value)
@@ -793,7 +897,7 @@ impl<'a> Builder<'a> {
                 target: else_target,
                 args: Vec::new(),
             },
-        });
+        })?;
 
         let before = self.bindings.clone();
         self.current = evaluate_right;
@@ -803,7 +907,7 @@ impl<'a> Builder<'a> {
             self.set_terminator(SemTerminator::Goto(Edge {
                 target: join,
                 args: vec![right_value],
-            }));
+            }))?;
         }
 
         self.current = short_circuit;
@@ -815,7 +919,7 @@ impl<'a> Builder<'a> {
                 value: constant,
                 mode: UseMode::Read,
             }],
-        }));
+        }))?;
 
         self.current = join;
         Ok(result)
@@ -855,33 +959,40 @@ impl<'a> Builder<'a> {
     }
     fn new_block(&mut self, args: Vec<BlockArg>) -> BlockId {
         let id = BlockId(u32::try_from(self.blocks.len()).expect("SIR block count exceeds u32"));
-        self.blocks.push(SemBlock {
-            id,
-            args,
-            ops: Vec::new(),
-            terminator: SemTerminator::Unreachable,
-        });
+        self.blocks.push(PendingBlock::new(id, args));
         id
     }
-    fn current_block_mut(&mut self) -> &mut SemBlock {
+    fn current_block(&self) -> &PendingBlock {
+        &self.blocks[self.current.0 as usize]
+    }
+    fn current_block_mut(&mut self) -> &mut PendingBlock {
         &mut self.blocks[self.current.0 as usize]
     }
     fn is_open(&self) -> bool {
-        matches!(
-            self.blocks[self.current.0 as usize].terminator,
-            SemTerminator::Unreachable
-        )
+        self.current_block().is_open()
     }
-    fn set_terminator(&mut self, term: SemTerminator) {
-        self.current_block_mut().terminator = term;
+    fn set_terminator(&mut self, term: SemTerminator) -> Result<(), String> {
+        let block = self.current_block_mut();
+        if block.terminator.is_some() {
+            return Err(format!(
+                "SIR builder attempted to overwrite completed block bb{}",
+                block.id.0
+            ));
+        }
+        block.terminator = Some(term);
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{initial_scalar_use_mode, use_mode_from_hir_intent};
-    use crate::UseMode;
+    use super::{
+        initial_scalar_transfer_mode, initial_scalar_use_mode, use_mode_from_hir_intent,
+        PendingBlock,
+    };
+    use crate::{BlockId, SemTerminator, UseMode};
     use hew_hir::IntentKind;
+    use hew_types::ResolvedTy;
 
     #[test]
     fn hir_intents_map_once_and_initial_scalar_sir_fails_closed() {
@@ -919,5 +1030,42 @@ mod tests {
                 "the failure must explain why {intent:?} is outside the current SIR ownership domain: {reason}"
             );
         }
+    }
+
+    #[test]
+    fn scalar_binding_and_return_transfers_admit_only_bitcopy_move() {
+        assert!(
+            initial_scalar_transfer_mode(IntentKind::Consume, &ResolvedTy::I64, "test").is_ok()
+        );
+        assert!(initial_scalar_transfer_mode(IntentKind::Read, &ResolvedTy::Bool, "test").is_ok());
+        for intent in [IntentKind::Read, IntentKind::Consume] {
+            let error = initial_scalar_transfer_mode(intent, &ResolvedTy::String, "test")
+                .expect_err("a non-BitCopy transfer must stay outside the scalar SIR subset");
+            assert!(
+                error.contains("non-scalar") && error.contains("only aliases BitCopy scalar"),
+                "the transfer diagnostic must explain that this would erase ownership: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn pending_blocks_do_not_conflate_open_with_semantic_unreachable() {
+        let open = PendingBlock::new(BlockId(0), Vec::new());
+        assert!(open.is_open());
+        assert!(open
+            .into_sem_block()
+            .expect_err("an unfilled builder block must fail finalization")
+            .contains("without a semantic terminator"));
+
+        let mut completed = PendingBlock::new(BlockId(1), Vec::new());
+        completed.terminator = Some(SemTerminator::Unreachable);
+        assert!(!completed.is_open());
+        assert!(matches!(
+            completed
+                .into_sem_block()
+                .expect("semantic unreachable is a completed block")
+                .terminator,
+            SemTerminator::Unreachable
+        ));
     }
 }

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -36,18 +36,62 @@ pub enum FunctionSourceOrigin {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum UseMode {
     Read,
     BorrowShared,
     BorrowMut,
+    /// Transfer this use's ownership into another semantic value or operation.
+    ///
+    /// This is deliberately distinct from [`Self::Consume`]: a move has a
+    /// receiving owner, while consumption discharges the source value without
+    /// creating a new semantic owner.
     Move,
+    /// Discharge a value's source-semantic ownership obligation.
+    ///
+    /// Ownership/layout MIR will later decide whether that becomes a drop,
+    /// release, move-out, or another concrete lifetime action.
+    Consume,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Operand {
     pub value: ValueId,
     pub mode: UseMode,
+}
+
+/// Stable position of an operand within one operation or terminator.
+///
+/// Operation slots follow the source order of their operands. Terminator
+/// slots are deliberately flattened in a deterministic order: return value;
+/// goto edge arguments; or branch condition, then-edge arguments, and
+/// else-edge arguments. Rewrites use this together with [`UseSite`] rather
+/// than relying on an incidental pointer into a mutable IR vector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OperandSlot(pub u32);
+
+/// Concrete, deterministic identity of one semantic SSA use.
+///
+/// A value's use site is either an operation operand, identified by its stable
+/// [`OpId`], or a terminator operand, identified by its containing [`BlockId`].
+/// The use mode is part of the identity so a rewrite cannot silently apply an
+/// analysis result after the operand's semantic ownership use changed. The
+/// expected value closes the final stale-index hole: a rewrite must not replace
+/// a different value that later occupies the same slot with the same mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum UseSite {
+    Operation {
+        op: OpId,
+        operand: OperandSlot,
+        value: ValueId,
+        mode: UseMode,
+    },
+    Terminator {
+        block: BlockId,
+        operand: OperandSlot,
+        value: ValueId,
+        mode: UseMode,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -65,7 +109,41 @@ pub struct BlockArg {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Edge {
     pub target: BlockId,
-    pub args: Vec<ValueId>,
+    /// Semantic uses forwarded to the target block arguments. These retain
+    /// their source ownership mode until ownership/layout MIR realizes it.
+    pub args: Vec<Operand>,
+}
+
+impl Edge {
+    /// Visit edge arguments in their deterministic target-argument order.
+    ///
+    /// # Panics
+    ///
+    /// Panics only when an edge carries more operands than the module-local
+    /// `u32` operand-slot range can represent.
+    pub fn visit_operands(&self, mut visit: impl FnMut(OperandSlot, &Operand)) {
+        for (index, operand) in self.args.iter().enumerate() {
+            visit(
+                OperandSlot(u32::try_from(index).expect("SIR edge operand count exceeds u32")),
+                operand,
+            );
+        }
+    }
+
+    /// Mutable counterpart to [`Self::visit_operands`].
+    ///
+    /// # Panics
+    ///
+    /// Panics only when an edge carries more operands than the module-local
+    /// `u32` operand-slot range can represent.
+    pub fn visit_operands_mut(&mut self, mut visit: impl FnMut(OperandSlot, &mut Operand)) {
+        for (index, operand) in self.args.iter_mut().enumerate() {
+            visit(
+                OperandSlot(u32::try_from(index).expect("SIR edge operand count exceeds u32")),
+                operand,
+            );
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -260,6 +338,42 @@ pub struct SemOp {
     pub provenance: Provenance,
 }
 
+impl SemOp {
+    /// Visit this operation's semantic operands in deterministic operand-slot
+    /// order. Analyses and rewrites must use this rather than matching every
+    /// [`SemOpKind`] variant themselves.
+    pub fn visit_operands(&self, visit: impl FnMut(OperandSlot, &Operand)) {
+        self.kind.visit_operands(visit);
+    }
+
+    /// Mutable counterpart to [`Self::visit_operands`].
+    pub fn visit_operands_mut(&mut self, visit: impl FnMut(OperandSlot, &mut Operand)) {
+        self.kind.visit_operands_mut(visit);
+    }
+
+    /// Replace the value at one concrete operand slot when its use mode still
+    /// agrees with an analysis result. Returning `false` makes stale rewrite
+    /// sites explicit instead of mutating an unrelated operand after an IR
+    /// change.
+    #[must_use]
+    pub fn replace_operand_at(
+        &mut self,
+        slot: OperandSlot,
+        expected: ValueId,
+        mode: UseMode,
+        replacement: ValueId,
+    ) -> bool {
+        let mut replaced = false;
+        self.visit_operands_mut(|candidate, operand| {
+            if candidate == slot && operand.value == expected && operand.mode == mode {
+                operand.value = replacement;
+                replaced = true;
+            }
+        });
+        replaced
+    }
+}
+
 /// Derived semantic effects for a value-producing SIR operation.
 ///
 /// Effects deliberately live on operation *kinds*, not on [`SemOp`]: rewrites
@@ -334,6 +448,69 @@ pub enum SemOpKind {
 }
 
 impl SemOpKind {
+    /// Visit operands in their deterministic source order.
+    ///
+    /// This is intentionally the single structural operand traversal for the
+    /// initial operation vocabulary. Extending `SemOpKind` therefore requires
+    /// choosing its operand order once, instead of teaching every analysis and
+    /// rewrite the new shape independently.
+    ///
+    /// # Panics
+    ///
+    /// Panics only when an operation carries more operands than the
+    /// module-local `u32` operand-slot range can represent.
+    pub fn visit_operands(&self, mut visit: impl FnMut(OperandSlot, &Operand)) {
+        match self {
+            Self::ConstI64(_) | Self::ConstBool(_) => {}
+            Self::Unary { value, .. } | Self::Cast { value, .. } => {
+                visit(OperandSlot(0), value);
+            }
+            Self::Binary { lhs, rhs, .. } => {
+                visit(OperandSlot(0), lhs);
+                visit(OperandSlot(1), rhs);
+            }
+            Self::Call { args, .. } => {
+                for (index, argument) in args.iter().enumerate() {
+                    visit(
+                        OperandSlot(
+                            u32::try_from(index).expect("SIR operation operand count exceeds u32"),
+                        ),
+                        argument,
+                    );
+                }
+            }
+        }
+    }
+
+    /// Mutable counterpart to [`Self::visit_operands`].
+    ///
+    /// # Panics
+    ///
+    /// Panics only when an operation carries more operands than the
+    /// module-local `u32` operand-slot range can represent.
+    pub fn visit_operands_mut(&mut self, mut visit: impl FnMut(OperandSlot, &mut Operand)) {
+        match self {
+            Self::ConstI64(_) | Self::ConstBool(_) => {}
+            Self::Unary { value, .. } | Self::Cast { value, .. } => {
+                visit(OperandSlot(0), value);
+            }
+            Self::Binary { lhs, rhs, .. } => {
+                visit(OperandSlot(0), lhs);
+                visit(OperandSlot(1), rhs);
+            }
+            Self::Call { args, .. } => {
+                for (index, argument) in args.iter_mut().enumerate() {
+                    visit(
+                        OperandSlot(
+                            u32::try_from(index).expect("SIR operation operand count exceeds u32"),
+                        ),
+                        argument,
+                    );
+                }
+            }
+        }
+    }
+
     /// Return the operation's conservative semantic effect classification.
     #[must_use]
     pub const fn effects(&self) -> EffectSet {
@@ -378,21 +555,186 @@ impl SemOpKind {
     }
 }
 
+/// Semantic control-flow terminator.
+///
+/// Value-producing operations retain their own [`Provenance`] today. A
+/// terminator can be caused by several source sites (for example, a synthesized
+/// short-circuit edge plus a branch expression), so this first rewrite
+/// foundation deliberately does not invent one misleading `SiteId` field for
+/// it. A future control-provenance design must use the existing multi-origin
+/// [`Provenance`] model rather than collapsing that attribution during a pass.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SemTerminator {
     Return {
-        value: Option<ValueId>,
+        value: Option<Operand>,
     },
     Goto(Edge),
     Branch {
-        condition: ValueId,
+        condition: Operand,
         then_target: Edge,
         else_target: Edge,
     },
+    /// A semantically unreachable CFG endpoint.
+    ///
+    /// SIR can represent this before Raw MIR has a matching terminator. The
+    /// SIR → Raw MIR bridge deliberately rejects it today; an explicit Raw-MIR
+    /// legalization is a prerequisite for CFG simplification/DCE to create or
+    /// preserve semantic unreachable blocks.
     Unreachable,
 }
 
 impl SemTerminator {
+    /// Visit every semantic use carried by this terminator.
+    ///
+    /// Slots are stable within the terminator shape: a return has slot `0`; a
+    /// goto uses its edge-argument indexes; and a branch uses condition `0`,
+    /// then-edge arguments beginning at `1`, followed by else-edge arguments.
+    ///
+    /// # Panics
+    ///
+    /// Panics only when a branch carries more operands than the module-local
+    /// `u32` operand-slot range can represent.
+    pub fn visit_operands(&self, mut visit: impl FnMut(OperandSlot, &Operand)) {
+        match self {
+            Self::Return { value } => {
+                if let Some(value) = value {
+                    visit(OperandSlot(0), value);
+                }
+            }
+            Self::Goto(edge) => edge.visit_operands(visit),
+            Self::Branch {
+                condition,
+                then_target,
+                else_target,
+            } => {
+                visit(OperandSlot(0), condition);
+                let mut next = 1_u32;
+                for operand in &then_target.args {
+                    visit(OperandSlot(next), operand);
+                    next = next
+                        .checked_add(1)
+                        .expect("SIR branch operand count exceeds u32");
+                }
+                for operand in &else_target.args {
+                    visit(OperandSlot(next), operand);
+                    next = next
+                        .checked_add(1)
+                        .expect("SIR branch operand count exceeds u32");
+                }
+            }
+            Self::Unreachable => {}
+        }
+    }
+
+    /// Mutable counterpart to [`Self::visit_operands`].
+    ///
+    /// # Panics
+    ///
+    /// Panics only when a branch carries more operands than the module-local
+    /// `u32` operand-slot range can represent.
+    pub fn visit_operands_mut(&mut self, mut visit: impl FnMut(OperandSlot, &mut Operand)) {
+        match self {
+            Self::Return { value } => {
+                if let Some(value) = value {
+                    visit(OperandSlot(0), value);
+                }
+            }
+            Self::Goto(edge) => edge.visit_operands_mut(visit),
+            Self::Branch {
+                condition,
+                then_target,
+                else_target,
+            } => {
+                visit(OperandSlot(0), condition);
+                let mut next = 1_u32;
+                for operand in &mut then_target.args {
+                    visit(OperandSlot(next), operand);
+                    next = next
+                        .checked_add(1)
+                        .expect("SIR branch operand count exceeds u32");
+                }
+                for operand in &mut else_target.args {
+                    visit(OperandSlot(next), operand);
+                    next = next
+                        .checked_add(1)
+                        .expect("SIR branch operand count exceeds u32");
+                }
+            }
+            Self::Unreachable => {}
+        }
+    }
+
+    /// Visit CFG successors without exposing terminator shape to each caller.
+    pub fn visit_successors(&self, mut visit: impl FnMut(&Edge)) {
+        match self {
+            Self::Return { .. } | Self::Unreachable => {}
+            Self::Goto(edge) => visit(edge),
+            Self::Branch {
+                then_target,
+                else_target,
+                ..
+            } => {
+                visit(then_target);
+                visit(else_target);
+            }
+        }
+    }
+
+    /// Mutable counterpart to [`Self::visit_successors`].
+    pub fn visit_successors_mut(&mut self, mut visit: impl FnMut(&mut Edge)) {
+        match self {
+            Self::Return { .. } | Self::Unreachable => {}
+            Self::Goto(edge) => visit(edge),
+            Self::Branch {
+                then_target,
+                else_target,
+                ..
+            } => {
+                visit(then_target);
+                visit(else_target);
+            }
+        }
+    }
+
+    /// Human-readable role of one operand slot, for exact verifier
+    /// diagnostics. Callers only pass slots previously produced by
+    /// [`Self::visit_operands`].
+    #[must_use]
+    pub fn operand_context(&self, slot: OperandSlot) -> &'static str {
+        match self {
+            Self::Return { .. } => "return value",
+            Self::Goto(_) => "goto edge argument",
+            Self::Branch { then_target, .. } if slot.0 == 0 => "branch condition",
+            Self::Branch { then_target, .. }
+                if usize::try_from(slot.0).is_ok_and(|slot| slot <= then_target.args.len()) =>
+            {
+                "branch then-edge argument"
+            }
+            Self::Branch { .. } => "branch else-edge argument",
+            Self::Unreachable => "unreachable terminator operand",
+        }
+    }
+
+    /// Replace the value at one concrete terminator operand slot when its use
+    /// mode still agrees with the indexed use site.
+    #[must_use]
+    pub fn replace_operand_at(
+        &mut self,
+        slot: OperandSlot,
+        expected: ValueId,
+        mode: UseMode,
+        replacement: ValueId,
+    ) -> bool {
+        let mut replaced = false;
+        self.visit_operands_mut(|candidate, operand| {
+            if candidate == slot && operand.value == expected && operand.mode == mode {
+                operand.value = replacement;
+                replaced = true;
+            }
+        });
+        replaced
+    }
+
     #[must_use]
     pub fn successors(&self) -> Vec<&Edge> {
         match self {

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -734,17 +734,4 @@ impl SemTerminator {
         });
         replaced
     }
-
-    #[must_use]
-    pub fn successors(&self) -> Vec<&Edge> {
-        match self {
-            Self::Return { .. } | Self::Unreachable => Vec::new(),
-            Self::Goto(edge) => vec![edge],
-            Self::Branch {
-                then_target,
-                else_target,
-                ..
-            } => vec![then_target, else_target],
-        }
-    }
 }

--- a/hew-sir/src/verify.rs
+++ b/hew-sir/src/verify.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use crate::OpId;
 use crate::{
     BlockId, CallableId, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule, SemOp,
-    SemOpKind, SemParamPassing, SemTerminator, UseMode, ValueId,
+    SemOpKind, SemParamPassing, SemTerminator, UseMode, UseSite, ValueId,
 };
 use hew_types::ResolvedTy;
 
@@ -92,6 +92,16 @@ pub enum SirDiagnosticKind {
     InvalidOperation {
         op: OpId,
         reason: String,
+    },
+    /// The initial scalar SIR surface is intentionally read-only even though
+    /// operands retain the broader ownership vocabulary for later slices.
+    /// Keeping the exact use site makes malformed edge/return/condition uses
+    /// fail at the SIR stage rather than reaching ownership MIR silently.
+    InvalidUseMode {
+        site: UseSite,
+        expected: UseMode,
+        actual: UseMode,
+        context: &'static str,
     },
     BranchConditionType {
         value: ValueId,
@@ -266,10 +276,11 @@ fn verify_function_with_context(
         for op in &block.ops {
             verify_operation_shape(function, op, &types, callable_context, &mut diagnostics);
         }
-        for edge in block.terminator.successors() {
+        verify_terminator_operand_modes(function, block.id, &block.terminator, &mut diagnostics);
+        block.terminator.visit_successors(|edge| {
             let Some(target) = blocks.get(&edge.target) else {
                 diagnostics.push(diag(function, SirDiagnosticKind::UnknownBlock(edge.target)));
-                continue;
+                return;
             };
             if target.args.len() != edge.args.len() {
                 diagnostics.push(diag(
@@ -283,7 +294,7 @@ fn verify_function_with_context(
                 ));
             }
             for (argument, (value, target_arg)) in edge.args.iter().zip(&target.args).enumerate() {
-                let Some(actual) = types.get(value) else {
+                let Some(actual) = types.get(&value.value) else {
                     continue;
                 };
                 if actual != &target_arg.ty {
@@ -299,7 +310,7 @@ fn verify_function_with_context(
                     ));
                 }
             }
-        }
+        });
         verify_terminator_shape(function, &block.terminator, &types, &mut diagnostics);
     }
     if blocks.contains_key(&function.entry) {
@@ -562,6 +573,19 @@ fn verify_operation_shape(
     callable_context: Option<&CallableContext<'_>>,
     diagnostics: &mut Vec<SirDiagnostic>,
 ) {
+    operation.visit_operands(|operand, use_| {
+        require_read_use(
+            function,
+            UseSite::Operation {
+                op: operation.id,
+                operand,
+                value: use_.value,
+                mode: use_.mode,
+            },
+            operation_operand_context(&operation.kind, operand),
+            diagnostics,
+        );
+    });
     if let SemOpKind::Call { callee, args } = &operation.kind {
         verify_direct_call_operation(
             function,
@@ -603,7 +627,6 @@ fn verify_operation_shape(
             },
         )),
         SemOpKind::Cast { value, to } => {
-            require_read_operand(function, operation.id, value.mode, "cast", diagnostics);
             if &result.ty != to {
                 diagnostics.push(diag(
                     function,
@@ -630,13 +653,6 @@ fn verify_operation_shape(
             }
         }
         SemOpKind::Unary { op, value } => {
-            require_read_operand(
-                function,
-                operation.id,
-                value.mode,
-                "unary operation",
-                diagnostics,
-            );
             let Some(operand_ty) = types.get(&value.value) else {
                 return;
             };
@@ -668,20 +684,6 @@ fn verify_operation_shape(
             }
         }
         SemOpKind::Binary { op, lhs, rhs } => {
-            require_read_operand(
-                function,
-                operation.id,
-                lhs.mode,
-                "binary left operand",
-                diagnostics,
-            );
-            require_read_operand(
-                function,
-                operation.id,
-                rhs.mode,
-                "binary right operand",
-                diagnostics,
-            );
             let (Some(lhs_ty), Some(rhs_ty)) = (types.get(&lhs.value), types.get(&rhs.value))
             else {
                 return;
@@ -750,15 +752,6 @@ fn verify_direct_call_operation(
     callable_context: Option<&CallableContext<'_>>,
     diagnostics: &mut Vec<SirDiagnostic>,
 ) {
-    for argument in args {
-        require_read_operand(
-            function,
-            operation.id,
-            argument.mode,
-            "direct call argument",
-            diagnostics,
-        );
-    }
     if operation.results.len() > 1 {
         diagnostics.push(diag(
             function,
@@ -862,23 +855,58 @@ fn verify_direct_call_operation(
     }
 }
 
-fn require_read_operand(
+fn require_read_use(
     function: &SemFunction,
-    op: OpId,
-    mode: UseMode,
-    context: &str,
+    site: UseSite,
+    context: &'static str,
     diagnostics: &mut Vec<SirDiagnostic>,
 ) {
+    let mode = match site {
+        UseSite::Operation { mode, .. } | UseSite::Terminator { mode, .. } => mode,
+    };
     if mode != UseMode::Read {
-        invalid_operation(
+        diagnostics.push(diag(
             function,
-            op,
-            format!(
-                "{context} uses {mode:?}; only Read is legal until ownership-aware SIR operations exist"
-            ),
+            SirDiagnosticKind::InvalidUseMode {
+                site,
+                expected: UseMode::Read,
+                actual: mode,
+                context,
+            },
+        ));
+    }
+}
+
+fn operation_operand_context(kind: &SemOpKind, operand: crate::OperandSlot) -> &'static str {
+    match kind {
+        SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) => "operation operand",
+        SemOpKind::Unary { .. } => "unary operand",
+        SemOpKind::Binary { .. } if operand.0 == 0 => "binary left operand",
+        SemOpKind::Binary { .. } => "binary right operand",
+        SemOpKind::Cast { .. } => "cast operand",
+        SemOpKind::Call { .. } => "direct call argument",
+    }
+}
+
+fn verify_terminator_operand_modes(
+    function: &SemFunction,
+    block: BlockId,
+    terminator: &SemTerminator,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    terminator.visit_operands(|operand, use_| {
+        require_read_use(
+            function,
+            UseSite::Terminator {
+                block,
+                operand,
+                value: use_.value,
+                mode: use_.mode,
+            },
+            terminator.operand_context(operand),
             diagnostics,
         );
-    }
+    });
 }
 
 fn invalid_operation(
@@ -903,11 +931,11 @@ fn verify_terminator_shape(
         SemTerminator::Return { value: Some(value) } if function.return_ty == ResolvedTy::Unit => {
             diagnostics.push(diag(
                 function,
-                SirDiagnosticKind::UnitReturnValue { value: *value },
+                SirDiagnosticKind::UnitReturnValue { value: value.value },
             ));
         }
         SemTerminator::Return { value: Some(value) } => {
-            if let Some(actual) = types.get(value) {
+            if let Some(actual) = types.get(&value.value) {
                 if actual != &function.return_ty {
                     diagnostics.push(diag(
                         function,
@@ -929,12 +957,12 @@ fn verify_terminator_shape(
             ));
         }
         SemTerminator::Branch { condition, .. } => {
-            if let Some(actual) = types.get(condition) {
+            if let Some(actual) = types.get(&condition.value) {
                 if actual != &ResolvedTy::Bool {
                     diagnostics.push(diag(
                         function,
                         SirDiagnosticKind::BranchConditionType {
-                            value: *condition,
+                            value: condition.value,
                             actual: actual.user_facing().to_string(),
                         },
                     ));
@@ -1017,28 +1045,13 @@ fn module_diag(kind: SirDiagnosticKind) -> SirDiagnostic {
 }
 
 fn uses_in_op(op: &crate::SemOp) -> Vec<ValueId> {
-    match &op.kind {
-        SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) => Vec::new(),
-        SemOpKind::Unary { value, .. } | SemOpKind::Cast { value, .. } => vec![value.value],
-        SemOpKind::Binary { lhs, rhs, .. } => vec![lhs.value, rhs.value],
-        SemOpKind::Call { args, .. } => args.iter().map(|arg| arg.value).collect(),
-    }
+    let mut uses = Vec::new();
+    op.visit_operands(|_, operand| uses.push(operand.value));
+    uses
 }
 
 fn uses_in_terminator(term: &SemTerminator) -> Vec<ValueId> {
-    match term {
-        SemTerminator::Return { value } => value.iter().copied().collect(),
-        SemTerminator::Goto(edge) => edge.args.clone(),
-        SemTerminator::Branch {
-            condition,
-            then_target,
-            else_target,
-        } => {
-            let mut values = vec![*condition];
-            values.extend(then_target.args.iter().copied());
-            values.extend(else_target.args.iter().copied());
-            values
-        }
-        SemTerminator::Unreachable => Vec::new(),
-    }
+    let mut uses = Vec::new();
+    term.visit_operands(|_, operand| uses.push(operand.value));
+    uses
 }

--- a/hew-sir/tests/lower_calls.rs
+++ b/hew-sir/tests/lower_calls.rs
@@ -166,6 +166,102 @@ fn unit_direct_call_is_a_zero_result_sir_operation() {
     );
 }
 
+#[test]
+fn scalar_binding_and_explicit_return_transfers_lower_without_erasing_resource_rules() {
+    let lowered = lower_source(
+        r"
+        fn f(x: i64, y: i64) -> i64 {
+            let z = if x > 0 {
+                y + 1
+            } else {
+                y + 2
+            };
+            return z * 3;
+        }
+
+        fn main() -> i64 {
+            f(1, 2)
+        }
+        ",
+    );
+
+    assert!(
+        lowered
+            .statuses
+            .iter()
+            .filter(|(name, _)| name == "f" || name == "main")
+            .all(|(_, status)| matches!(status, SirLoweringStatus::Lowered)),
+        "BitCopy binding/return transfers must be admitted without a legacy fallback: {:#?}",
+        lowered.statuses
+    );
+    assert!(
+        verify_module(&lowered.module).is_empty(),
+        "the scalar transfer fixture must produce verified SIR: {:#?}",
+        verify_module(&lowered.module)
+    );
+    let f = lowered
+        .module
+        .functions
+        .iter()
+        .find(|function| function.name == "f")
+        .expect("the scalar helper must have a SIR body");
+    assert!(
+        f.blocks.iter().any(|block| matches!(
+            block.terminator,
+            hew_sir::SemTerminator::Return { value: Some(_) }
+        )),
+        "the explicit HIR return must remain a value-carrying SIR return"
+    );
+}
+
+#[test]
+fn unit_direct_call_in_an_explicit_return_is_a_control_transfer_not_a_discarded_read() {
+    let lowered = lower_source(
+        r"
+        fn unit_helper() {
+        }
+
+        fn main() {
+            return unit_helper();
+        }
+        ",
+    );
+    assert!(
+        lowered
+            .statuses
+            .iter()
+            .filter(|(name, _)| name == "unit_helper" || name == "main")
+            .all(|(_, status)| matches!(status, SirLoweringStatus::Lowered)),
+        "a Unit direct call returned to the caller must not be rejected as a discarded Read: {:#?}",
+        lowered.statuses
+    );
+    let entry = lowered
+        .module
+        .entry_callable
+        .expect("the unit main must retain a root callable");
+    let main = lowered
+        .module
+        .function_for_callable(entry)
+        .expect("the unit main must lower to SIR");
+    assert!(
+        main.blocks
+            .iter()
+            .flat_map(|block| &block.ops)
+            .any(|operation| {
+                matches!(
+                    operation.kind,
+                    SemOpKind::Call { .. } if operation.results.is_empty()
+                )
+            }),
+        "the returned Unit call must remain a zero-result semantic call"
+    );
+    assert!(
+        verify_module(&lowered.module).is_empty(),
+        "the Unit-return transfer fixture must produce verified SIR: {:#?}",
+        verify_module(&lowered.module)
+    );
+}
+
 /// Recursive call resolution must use the callable table built before body
 /// lowering, not a body-order-dependent symbol lookup.  This is the smallest
 /// SIR-only proof that a strict component can contain a cycle.

--- a/hew-sir/tests/sir.rs
+++ b/hew-sir/tests/sir.rs
@@ -1094,11 +1094,16 @@ fn def_use_sites_are_deterministic_and_support_precise_rewrites() {
         "a precise rewrite must leave every other concrete use intact"
     );
 
-    assert_eq!(replace_all_uses(&mut function, ValueId(0), ValueId(1)), 3);
+    assert_eq!(
+        replace_all_uses(&mut function, ValueId(0), ValueId(1))
+            .expect("a stable function must rewrite every indexed use"),
+        3
+    );
     assert!(build_def_use(&function).uses_of(ValueId(0)).is_empty());
 
     assert_eq!(
-        replace_all_uses(&mut function, ValueId(2), ValueId(7)),
+        replace_all_uses(&mut function, ValueId(2), ValueId(7))
+            .expect("a stable function must rewrite the branch-condition use"),
         1,
         "replace_all_uses must reach a branch-condition operand"
     );
@@ -1108,7 +1113,8 @@ fn def_use_sites_are_deterministic_and_support_precise_rewrites() {
     );
 
     assert_eq!(
-        replace_all_uses(&mut function, ValueId(4), ValueId(1)),
+        replace_all_uses(&mut function, ValueId(4), ValueId(1))
+            .expect("a stable function must rewrite the goto-edge use"),
         1,
         "replace_all_uses must reach a goto-edge operand"
     );
@@ -1132,7 +1138,8 @@ fn def_use_sites_are_deterministic_and_support_precise_rewrites() {
         }
     );
     assert_eq!(
-        replace_all_uses(&mut function, ValueId(6), ValueId(1)),
+        replace_all_uses(&mut function, ValueId(6), ValueId(1))
+            .expect("a stable function must rewrite the return use"),
         1,
         "replace_all_uses must reach a return operand"
     );
@@ -1165,6 +1172,33 @@ fn indexed_rewrites_refuse_a_stale_ownership_mode() {
         replace_use(&mut function, site, ValueId(1)),
         Err(RewriteError::StaleUseSite(site)),
         "a replacement indexed before an ownership-mode rewrite must fail closed"
+    );
+}
+
+#[test]
+fn replace_all_uses_is_atomic_when_malformed_identities_make_a_site_stale() {
+    let mut function = rewrite_fixture();
+    function.blocks[0].ops.push(SemOp {
+        // Deliberately duplicate OpId(0): `build_def_use` can still produce
+        // useful diagnostics for malformed SIR, but it must not make a
+        // partially applied public rewrite look successful.
+        id: OpId(0),
+        results: vec![definition(8)],
+        kind: SemOpKind::Unary {
+            op: hew_parser::ast::UnaryOp::Negate,
+            value: read(ValueId(0)),
+        },
+        provenance: Provenance::Synthesized,
+    });
+    let before = function.clone();
+
+    assert!(matches!(
+        replace_all_uses(&mut function, ValueId(0), ValueId(1)),
+        Err(RewriteError::StaleUseSite(_))
+    ));
+    assert_eq!(
+        function, before,
+        "a failed all-uses rewrite must leave the original SIR graph intact"
     );
 }
 

--- a/hew-sir/tests/sir.rs
+++ b/hew-sir/tests/sir.rs
@@ -1,10 +1,12 @@
 use hew_hir::ItemId;
 use hew_parser::ast::BinaryOp;
 use hew_sir::{
-    dump_sir, verify_function_in_module, verify_module, BlockArg, BlockId, CallableId, Edge,
-    EffectSet, EffectSummary, FunctionSourceOrigin, OpId, Operand, Provenance, SemAbiParam,
+    build_def_use, dump_sir, replace_all_uses, replace_use, verify_function_in_module,
+    verify_module, BlockArg, BlockId, CallableId, Edge, EffectSet, EffectSummary,
+    FunctionSourceOrigin, OpId, Operand, OperandSlot, Provenance, RewriteError, SemAbiParam,
     SemBlock, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind,
-    SemParamPassing, SemSignature, SemTerminator, SirDiagnosticKind, UseMode, ValueDef, ValueId,
+    SemParamPassing, SemSignature, SemTerminator, SirDiagnosticKind, UseMode, UseSite, ValueDef,
+    ValueId,
 };
 use hew_types::{DefId, ResolvedTy};
 
@@ -12,6 +14,13 @@ fn definition(id: u32) -> ValueDef {
     ValueDef {
         id: ValueId(id),
         ty: ResolvedTy::I64,
+    }
+}
+
+fn read(value: ValueId) -> Operand {
+    Operand {
+        value,
+        mode: UseMode::Read,
     }
 }
 
@@ -148,14 +157,14 @@ fn block_arguments_are_ssa_join_values() {
                     },
                 ],
                 terminator: SemTerminator::Branch {
-                    condition: ValueId(3),
+                    condition: read(ValueId(3)),
                     then_target: Edge {
                         target: BlockId(1),
-                        args: vec![ValueId(1)],
+                        args: vec![read(ValueId(1))],
                     },
                     else_target: Edge {
                         target: BlockId(2),
-                        args: vec![ValueId(1)],
+                        args: vec![read(ValueId(1))],
                     },
                 },
             },
@@ -191,7 +200,7 @@ fn block_arguments_are_ssa_join_values() {
                 ],
                 terminator: SemTerminator::Goto(Edge {
                     target: BlockId(3),
-                    args: vec![ValueId(6)],
+                    args: vec![read(ValueId(6))],
                 }),
             },
             SemBlock {
@@ -226,7 +235,7 @@ fn block_arguments_are_ssa_join_values() {
                 ],
                 terminator: SemTerminator::Goto(Edge {
                     target: BlockId(3),
-                    args: vec![ValueId(9)],
+                    args: vec![read(ValueId(9))],
                 }),
             },
             SemBlock {
@@ -260,7 +269,7 @@ fn block_arguments_are_ssa_join_values() {
                     },
                 ],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(12)),
+                    value: Some(read(ValueId(12))),
                 },
             },
         ],
@@ -296,7 +305,7 @@ fn verifier_rejects_entry_block_arguments() {
             }],
             ops: Vec::new(),
             terminator: SemTerminator::Return {
-                value: Some(ValueId(0)),
+                value: Some(read(ValueId(0))),
             },
         }],
     }]);
@@ -409,7 +418,7 @@ fn verifier_rejects_noncanonical_block_ids_and_order() {
                     provenance: Provenance::Synthesized,
                 }],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(0)),
+                    value: Some(read(ValueId(0))),
                 },
             },
         ],
@@ -444,7 +453,7 @@ fn verifier_rejects_noncanonical_block_ids_and_order() {
                     provenance: Provenance::Synthesized,
                 }],
                 terminator: SemTerminator::Return {
-                    value: Some(ValueId(0)),
+                    value: Some(read(ValueId(0))),
                 },
             },
             SemBlock {
@@ -534,7 +543,7 @@ fn verifier_checks_resolved_direct_call_signature_and_use_mode() {
             args: Vec::new(),
             ops: Vec::new(),
             terminator: SemTerminator::Return {
-                value: Some(ValueId(0)),
+                value: Some(read(ValueId(0))),
             },
         }],
     };
@@ -570,15 +579,18 @@ fn verifier_checks_resolved_direct_call_signature_and_use_mode() {
                 provenance: Provenance::Synthesized,
             }],
             terminator: SemTerminator::Return {
-                value: Some(ValueId(1)),
+                value: Some(read(ValueId(1))),
             },
         }],
     };
     let diagnostics = verify_module(&module(vec![target, caller]));
     assert!(diagnostics.iter().any(|diagnostic| matches!(
         &diagnostic.kind,
-        SirDiagnosticKind::InvalidOperation { reason, .. }
-            if reason.contains("only Read is legal")
+        SirDiagnosticKind::InvalidUseMode {
+            actual: UseMode::BorrowShared,
+            context: "direct call argument",
+            ..
+        }
     )));
     assert!(diagnostics.iter().any(|diagnostic| matches!(
         &diagnostic.kind,
@@ -617,7 +629,7 @@ fn verifier_rejects_unknown_direct_callable() {
                 provenance: Provenance::Synthesized,
             }],
             terminator: SemTerminator::Return {
-                value: Some(ValueId(0)),
+                value: Some(read(ValueId(0))),
             },
         }],
     };
@@ -654,7 +666,7 @@ fn verifier_requires_one_result_for_a_non_unit_direct_call() {
                 provenance: Provenance::Synthesized,
             }],
             terminator: SemTerminator::Return {
-                value: Some(ValueId(0)),
+                value: Some(read(ValueId(0))),
             },
         }],
     };
@@ -728,13 +740,13 @@ fn verifier_rejects_eager_logical_ops_and_ownership_modes_without_an_owner() {
                     },
                     rhs: Operand {
                         value: ValueId(0),
-                        mode: UseMode::Read,
+                        mode: UseMode::Consume,
                     },
                 },
                 provenance: Provenance::Synthesized,
             }],
             terminator: SemTerminator::Return {
-                value: Some(ValueId(1)),
+                value: Some(read(ValueId(1))),
             },
         }],
     }]);
@@ -742,8 +754,19 @@ fn verifier_rejects_eager_logical_ops_and_ownership_modes_without_an_owner() {
     let diagnostics = verify_module(&module);
     assert!(diagnostics.iter().any(|diagnostic| matches!(
         &diagnostic.kind,
-        SirDiagnosticKind::InvalidOperation { reason, .. }
-            if reason.contains("only Read is legal")
+        SirDiagnosticKind::InvalidUseMode {
+            actual: UseMode::BorrowShared,
+            context: "binary left operand",
+            ..
+        }
+    )));
+    assert!(diagnostics.iter().any(|diagnostic| matches!(
+        &diagnostic.kind,
+        SirDiagnosticKind::InvalidUseMode {
+            actual: UseMode::Consume,
+            context: "binary right operand",
+            ..
+        }
     )));
     assert!(diagnostics.iter().any(|diagnostic| matches!(
         &diagnostic.kind,
@@ -865,7 +888,7 @@ fn verifier_requires_entry_to_be_canonical_parameterless_root_main_with_portable
                 provenance: Provenance::Synthesized,
             }],
             terminator: SemTerminator::Return {
-                value: Some(ValueId(0)),
+                value: Some(read(ValueId(0))),
             },
         }],
     };
@@ -922,7 +945,7 @@ fn verifier_rejects_value_carrying_return_from_unit_function() {
                 provenance: Provenance::Synthesized,
             }],
             terminator: SemTerminator::Return {
-                value: Some(ValueId(0)),
+                value: Some(read(ValueId(0))),
             },
         }],
     };
@@ -935,4 +958,517 @@ fn verifier_rejects_value_carrying_return_from_unit_function() {
         )),
         "unit returns must remain zero-value terminators: {diagnostics:#?}"
     );
+}
+
+fn rewrite_fixture() -> SemFunction {
+    SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("rewrite_fixture"),
+        name: "rewrite_fixture".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: vec![
+            BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
+            },
+            BlockArg {
+                value: ValueId(1),
+                ty: ResolvedTy::I64,
+            },
+            BlockArg {
+                value: ValueId(2),
+                ty: ResolvedTy::Bool,
+            },
+            BlockArg {
+                value: ValueId(7),
+                ty: ResolvedTy::Bool,
+            },
+        ],
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![definition(3)],
+                    kind: SemOpKind::Binary {
+                        op: BinaryOp::Add,
+                        lhs: read(ValueId(0)),
+                        rhs: read(ValueId(0)),
+                    },
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Branch {
+                    condition: read(ValueId(2)),
+                    then_target: Edge {
+                        target: BlockId(1),
+                        args: vec![read(ValueId(0))],
+                    },
+                    else_target: Edge {
+                        target: BlockId(2),
+                        args: vec![read(ValueId(0))],
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: vec![BlockArg {
+                    value: ValueId(4),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(3),
+                    args: vec![read(ValueId(4))],
+                }),
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: vec![BlockArg {
+                    value: ValueId(5),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(3),
+                    args: vec![read(ValueId(5))],
+                }),
+            },
+            SemBlock {
+                id: BlockId(3),
+                args: vec![BlockArg {
+                    value: ValueId(6),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(read(ValueId(6))),
+                },
+            },
+        ],
+    }
+}
+
+#[test]
+fn def_use_sites_are_deterministic_and_support_precise_rewrites() {
+    let mut function = rewrite_fixture();
+    let index = build_def_use(&function);
+    let expected_x_uses = vec![
+        UseSite::Operation {
+            op: OpId(0),
+            operand: OperandSlot(0),
+            value: ValueId(0),
+            mode: UseMode::Read,
+        },
+        UseSite::Operation {
+            op: OpId(0),
+            operand: OperandSlot(1),
+            value: ValueId(0),
+            mode: UseMode::Read,
+        },
+        UseSite::Terminator {
+            block: BlockId(0),
+            operand: OperandSlot(1),
+            value: ValueId(0),
+            mode: UseMode::Read,
+        },
+        UseSite::Terminator {
+            block: BlockId(0),
+            operand: OperandSlot(2),
+            value: ValueId(0),
+            mode: UseMode::Read,
+        },
+    ];
+    assert_eq!(index.uses_of(ValueId(0)), expected_x_uses);
+    assert_eq!(index.use_count(ValueId(0)), 4);
+
+    replace_use(&mut function, expected_x_uses[0], ValueId(1))
+        .expect("a fresh indexed operation use must be rewriteable");
+    assert_eq!(
+        build_def_use(&function).uses_of(ValueId(0)),
+        &expected_x_uses[1..],
+        "a precise rewrite must leave every other concrete use intact"
+    );
+
+    assert_eq!(replace_all_uses(&mut function, ValueId(0), ValueId(1)), 3);
+    assert!(build_def_use(&function).uses_of(ValueId(0)).is_empty());
+
+    assert_eq!(
+        replace_all_uses(&mut function, ValueId(2), ValueId(7)),
+        1,
+        "replace_all_uses must reach a branch-condition operand"
+    );
+    assert!(
+        build_def_use(&function).uses_of(ValueId(2)).is_empty(),
+        "the only branch-condition use must have been replaced"
+    );
+
+    assert_eq!(
+        replace_all_uses(&mut function, ValueId(4), ValueId(1)),
+        1,
+        "replace_all_uses must reach a goto-edge operand"
+    );
+    assert!(
+        build_def_use(&function).uses_of(ValueId(4)).is_empty(),
+        "the goto-edge use must have been replaced"
+    );
+
+    let return_site = build_def_use(&function)
+        .uses_of(ValueId(6))
+        .first()
+        .copied()
+        .expect("join block value must have a concrete return use");
+    assert_eq!(
+        return_site,
+        UseSite::Terminator {
+            block: BlockId(3),
+            operand: OperandSlot(0),
+            value: ValueId(6),
+            mode: UseMode::Read,
+        }
+    );
+    assert_eq!(
+        replace_all_uses(&mut function, ValueId(6), ValueId(1)),
+        1,
+        "replace_all_uses must reach a return operand"
+    );
+    assert!(
+        build_def_use(&function).uses_of(ValueId(6)).is_empty(),
+        "the return use must have been replaced"
+    );
+
+    assert!(
+        verify_module(&module(vec![function])).is_empty(),
+        "slot-addressed rewrites must preserve a valid scalar SIR graph"
+    );
+}
+
+#[test]
+fn indexed_rewrites_refuse_a_stale_ownership_mode() {
+    let mut function = rewrite_fixture();
+    let site = build_def_use(&function)
+        .uses_of(ValueId(0))
+        .first()
+        .copied()
+        .expect("fixture must have an operation use of its first parameter");
+    function.blocks[0].ops[0].visit_operands_mut(|slot, operand| {
+        if slot == OperandSlot(0) {
+            operand.mode = UseMode::Move;
+        }
+    });
+
+    assert_eq!(
+        replace_use(&mut function, site, ValueId(1)),
+        Err(RewriteError::StaleUseSite(site)),
+        "a replacement indexed before an ownership-mode rewrite must fail closed"
+    );
+}
+
+#[test]
+fn indexed_rewrites_refuse_a_stale_operand_value() {
+    let mut function = rewrite_fixture();
+    let site = build_def_use(&function)
+        .uses_of(ValueId(0))
+        .first()
+        .copied()
+        .expect("fixture must have an operation use of its first parameter");
+    function.blocks[0].ops[0].visit_operands_mut(|slot, operand| {
+        if slot == OperandSlot(0) {
+            operand.value = ValueId(1);
+        }
+    });
+
+    assert_eq!(
+        replace_use(&mut function, site, ValueId(0)),
+        Err(RewriteError::StaleUseSite(site)),
+        "an old index must not replace a different value in the same slot and mode"
+    );
+}
+
+#[test]
+fn operand_and_successor_visitors_centralize_cfg_rewrites() {
+    let mut function = rewrite_fixture();
+    let block = &mut function.blocks[0];
+    let mut op_slots = Vec::new();
+    block.ops[0].visit_operands(|slot, operand| op_slots.push((slot, operand.value)));
+    assert_eq!(
+        op_slots,
+        vec![(OperandSlot(0), ValueId(0)), (OperandSlot(1), ValueId(0))]
+    );
+
+    let mut successors = Vec::new();
+    block
+        .terminator
+        .visit_successors(|edge| successors.push(edge.target));
+    assert_eq!(successors, vec![BlockId(1), BlockId(2)]);
+
+    block.terminator.visit_successors_mut(|edge| {
+        edge.visit_operands_mut(|_, operand| operand.value = ValueId(1));
+    });
+    let mut terminator_uses = Vec::new();
+    block
+        .terminator
+        .visit_operands(|slot, operand| terminator_uses.push((slot, operand.value)));
+    assert_eq!(
+        terminator_uses,
+        vec![
+            (OperandSlot(0), ValueId(2)),
+            (OperandSlot(1), ValueId(1)),
+            (OperandSlot(2), ValueId(1)),
+        ],
+        "the terminator visitor must cover the condition and both edge operands in slot order"
+    );
+}
+
+#[test]
+fn dump_preserves_operand_modes_at_branch_edge_and_return_boundaries() {
+    let function = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("dump_modes"),
+        name: "dump_modes".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: vec![
+            BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
+            },
+            BlockArg {
+                value: ValueId(1),
+                ty: ResolvedTy::Bool,
+            },
+        ],
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Branch {
+                    condition: Operand {
+                        value: ValueId(1),
+                        mode: UseMode::BorrowShared,
+                    },
+                    then_target: Edge {
+                        target: BlockId(1),
+                        args: vec![Operand {
+                            value: ValueId(0),
+                            mode: UseMode::Move,
+                        }],
+                    },
+                    else_target: Edge {
+                        target: BlockId(2),
+                        args: vec![Operand {
+                            value: ValueId(0),
+                            mode: UseMode::BorrowMut,
+                        }],
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: vec![BlockArg {
+                    value: ValueId(2),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(Operand {
+                        value: ValueId(2),
+                        mode: UseMode::Consume,
+                    }),
+                },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: vec![BlockArg {
+                    value: ValueId(3),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(read(ValueId(3))),
+                },
+            },
+        ],
+    };
+
+    assert_eq!(
+        dump_sir(&module(vec![function])),
+        concat!(
+            "fn dump_modes(%0: i64, %1: bool) -> i64 {\n",
+            "bb0:\n",
+            "    branch borrow %1, bb1(move %0), bb2(borrow_mut %0)\n",
+            "bb1(%2: i64):\n",
+            "    return consume %2\n",
+            "bb2(%3: i64):\n",
+            "    return %3\n",
+            "}\n"
+        )
+    );
+}
+
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "one complete malformed CFG fixture makes every scalar terminator-use boundary auditable"
+)]
+fn verifier_rejects_nonread_operands_at_every_scalar_cfg_boundary() {
+    let function = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("bad_modes"),
+        name: "bad_modes".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params: vec![
+            BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
+            },
+            BlockArg {
+                value: ValueId(1),
+                ty: ResolvedTy::Bool,
+            },
+        ],
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Branch {
+                    condition: Operand {
+                        value: ValueId(1),
+                        mode: UseMode::BorrowShared,
+                    },
+                    then_target: Edge {
+                        target: BlockId(1),
+                        args: vec![Operand {
+                            value: ValueId(0),
+                            mode: UseMode::Move,
+                        }],
+                    },
+                    else_target: Edge {
+                        target: BlockId(2),
+                        args: vec![Operand {
+                            value: ValueId(0),
+                            mode: UseMode::BorrowMut,
+                        }],
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: vec![BlockArg {
+                    value: ValueId(2),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(Operand {
+                        value: ValueId(2),
+                        mode: UseMode::Consume,
+                    }),
+                },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: vec![BlockArg {
+                    value: ValueId(3),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(3),
+                    args: vec![Operand {
+                        value: ValueId(3),
+                        mode: UseMode::Move,
+                    }],
+                }),
+            },
+            SemBlock {
+                id: BlockId(3),
+                args: vec![BlockArg {
+                    value: ValueId(4),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(read(ValueId(4))),
+                },
+            },
+        ],
+    };
+    let diagnostics = verify_module(&module(vec![function]));
+    let expected = [
+        (
+            UseSite::Terminator {
+                block: BlockId(0),
+                operand: OperandSlot(0),
+                value: ValueId(1),
+                mode: UseMode::BorrowShared,
+            },
+            "branch condition",
+        ),
+        (
+            UseSite::Terminator {
+                block: BlockId(0),
+                operand: OperandSlot(1),
+                value: ValueId(0),
+                mode: UseMode::Move,
+            },
+            "branch then-edge argument",
+        ),
+        (
+            UseSite::Terminator {
+                block: BlockId(0),
+                operand: OperandSlot(2),
+                value: ValueId(0),
+                mode: UseMode::BorrowMut,
+            },
+            "branch else-edge argument",
+        ),
+        (
+            UseSite::Terminator {
+                block: BlockId(1),
+                operand: OperandSlot(0),
+                value: ValueId(2),
+                mode: UseMode::Consume,
+            },
+            "return value",
+        ),
+        (
+            UseSite::Terminator {
+                block: BlockId(2),
+                operand: OperandSlot(0),
+                value: ValueId(3),
+                mode: UseMode::Move,
+            },
+            "goto edge argument",
+        ),
+    ];
+    for (site, context) in expected {
+        assert!(
+            diagnostics.iter().any(|diagnostic| matches!(
+                &diagnostic.kind,
+                SirDiagnosticKind::InvalidUseMode {
+                    site: actual_site,
+                    expected: UseMode::Read,
+                    actual,
+                    context: actual_context,
+                } if *actual_site == site && *actual == match site {
+                    UseSite::Operation { mode, .. } | UseSite::Terminator { mode, .. } => mode
+                } && *actual_context == context
+            )),
+            "missing exact non-Read diagnostic for {site:?}: {diagnostics:#?}"
+        );
+    }
 }


### PR DESCRIPTION
Summary:

Establishes the SIR substrate required before expanding semantic domains or adding optimization passes.

- Every semantic use is now an Operand: operations, returns, branch conditions, and CFG-edge arguments.
- SIR retains read, borrow, move, and consume intent while the current scalar bridge intentionally accepts only Read.
- Def-use is deterministic and concrete; visitors centralize operand/successor traversal; rewrites reject stale value and mode sites.
- HIR intent mapping is explicit and fails closed for unsupported initial ownership modes.
- The strict SIR-to-MIR bridge rejects non-Read return, branch, and edge uses instead of silently treating them as reads.
- The architecture contract defines the convergent hard-cutover stack, the normalized-HIR to SIR generic-instance service, and the future Raw MIR virtual-value versus Place split.

Cutover discipline:

This adds no permanent compatibility lane. The strict direct-call component remains template-free. Shadow/template scaffolding is documented as temporary differential evidence and a deletion target.

Deliberately deferred:

- Raw MIR legalization for semantic Unreachable before CFG simplification and DCE can create dead blocks.
- Terminator multi-origin provenance and removal of transitional callable ABI bridge facts before hard cutover.
- Raw virtual values and explicit materialization; the tuple storage experiment is not the final architecture.

Validation:

- cargo fmt --all --check
- git diff --check
- cargo test -p hew-sir --no-fail-fast
- cargo test -p hew-mir --lib sir::tests --no-fail-fast
- cargo check -p hew-mir -p hew-cli
- cargo clippy -p hew-sir -p hew-mir --all-targets -- -D warnings
- cargo test -p hew-cli --test sir_shadow_e2e --no-fail-fast

All local Cargo validation used sccache and an SSD-backed target directory.