### PR TITLE
feat(mir): legalize semantic unreachable through LLVM

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -30668,6 +30668,15 @@ fn lower_terminator<'ctx>(
             };
             emit_trap_with_code(fn_ctx, code, "trap")?;
         }
+        Terminator::Unreachable => {
+            // This is SIR's compiler-proven semantic endpoint, legalized
+            // through Raw/Checked/Elaborated MIR. It is not a language-visible
+            // trap and deliberately has no runtime call or cleanup edge.
+            fn_ctx
+                .builder
+                .build_unreachable()
+                .llvm_ctx("semantic unreachable")?;
+        }
         Terminator::Yield { value, next } => {
             // Generator suspension on the `llvm.coro.*` continuation substrate.
             //

--- a/hew-codegen-rs/src/llvm_tests.rs
+++ b/hew-codegen-rs/src/llvm_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use hew_hir::IntentKind;
 use hew_mir::{
-    BasicBlock, CallAuthority, CollectionLayoutProbeKind, CompilerCallKind, DecisionFact,
-    IrPipeline, MirStatement,
+    BasicBlock, BlockKind, CallAuthority, CollectionLayoutProbeKind, CompilerCallKind,
+    DecisionFact, ElabBlock, ElaboratedMirFunction, IrPipeline, MirStatement,
 };
 use inkwell::values::AnyValue;
 
@@ -451,6 +451,63 @@ fn empty_pipeline_with_const_42() -> IrPipeline {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     }
+}
+
+#[test]
+fn semantic_unreachable_emits_bare_llvm_unreachable_without_trap_or_drop_plan() {
+    let mut pipeline = empty_pipeline_with_const_42();
+    let (name, return_ty, blocks) = {
+        let raw = pipeline
+            .raw_mir
+            .first_mut()
+            .expect("fixture must contain its raw-MIR main body");
+        raw.blocks[0].instructions.clear();
+        raw.blocks[0].terminator = Terminator::Unreachable;
+        (raw.name.clone(), raw.return_ty.clone(), raw.blocks.clone())
+    };
+    pipeline.checked_mir = vec![CheckedMirFunction {
+        name: name.clone(),
+        return_ty: return_ty.clone(),
+        blocks,
+        decisions: Vec::new(),
+        checks: Vec::new(),
+        cooperate_sites: Vec::new(),
+    }];
+    pipeline.elaborated_mir = vec![ElaboratedMirFunction {
+        name,
+        return_ty,
+        statements: Vec::new(),
+        decisions: Vec::new(),
+        blocks: vec![ElabBlock {
+            id: 0,
+            kind: BlockKind::Normal,
+            drops: Vec::new(),
+            successor: None,
+        }],
+        drop_plans: Vec::new(),
+        coroutine: None,
+        lambda_captures: Vec::new(),
+    }];
+
+    let ctx = Context::create();
+    let module = build_module(&ctx, &pipeline, "semantic_unreachable")
+        .expect("semantic unreachable must lower through LLVM");
+    module
+        .verify()
+        .expect("bare LLVM unreachable must leave a valid module");
+    let main = module
+        .get_function("main")
+        .expect("fixture must emit its main function")
+        .print_to_string()
+        .to_string();
+    assert!(
+        main.contains("unreachable"),
+        "expected LLVM unreachable:\n{main}"
+    );
+    assert!(
+        !main.contains("hew_trap_with_code") && !main.contains("llvm.trap"),
+        "semantic unreachable must not become a runtime trap:\n{main}"
+    );
 }
 
 #[test]

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -959,6 +959,7 @@ pub(crate) fn write_place_local(place: Place) -> Option<u32> {
 pub fn terminator_write_places(term: &Terminator) -> Vec<Place> {
     match term {
         Terminator::Return
+        | Terminator::Unreachable
         | Terminator::Goto { .. }
         | Terminator::Trap { .. }
         | Terminator::Branch { .. }

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -371,11 +371,12 @@ fn render_terminator_with_kind(term: &Terminator, kind: Option<&SuspendKind>) ->
 
 #[allow(
     clippy::too_many_lines,
-    reason = "exhaustive match over all 27 Terminator variants; splitting would obscure locality"
+    reason = "exhaustive match over all 28 Terminator variants; splitting would obscure locality"
 )]
 fn render_terminator(term: &Terminator) -> String {
     match term {
         Terminator::Return => "return".to_string(),
+        Terminator::Unreachable => "unreachable".to_string(),
         Terminator::Goto { target } => format!("goto bb{target}"),
         Terminator::Branch {
             cond,
@@ -2557,6 +2558,22 @@ mod tests {
         assert!(
             dump.contains("trap(IntegerOverflow)"),
             "expected trap(IntegerOverflow) in dump:\n{dump}"
+        );
+    }
+
+    #[test]
+    fn semantic_unreachable_renders_as_its_own_endpoint() {
+        let mut func = minimal_raw_func("semantic_unreachable");
+        func.blocks[0].instructions.clear();
+        func.blocks[0].terminator = Terminator::Unreachable;
+        let dump = dump_mir(&minimal_pipeline_with_raw(func), DumpStage::Raw);
+        assert!(
+            dump.contains("unreachable"),
+            "expected semantic unreachable in dump:\n{dump}"
+        );
+        assert!(
+            !dump.contains("trap("),
+            "semantic unreachable must not render as a trap:\n{dump}"
         );
     }
 }

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -7225,8 +7225,10 @@ pub(super) fn binder_read_is_borrow_safe_instr(instr: &Instr, binder: u32) -> bo
 /// Build the elaborated block list + per-`ExitPath` drop plans for a
 /// function's CFG. Every basic block becomes one `ElabBlock` of
 /// `BlockKind::Normal`; `Terminator::Panic` synthesises a sibling
-/// `BlockKind::Cleanup` block. Each block's terminator maps to one
-/// `(ExitPath, DropPlan)` entry. `Return`-terminated blocks narrow
+/// `BlockKind::Cleanup` block. Every runtime-reachable terminator maps to one
+/// `(ExitPath, DropPlan)` entry. `Terminator::Unreachable` is instead a
+/// compiler-proven semantic endpoint: it deliberately has no `ExitPath`,
+/// cleanup block, or drop plan. `Return`-terminated blocks narrow
 /// the function-wide LIFO `lifo` sequence to bindings whose state at
 /// that block's exit is `Live` — bindings already `Consumed` on
 /// every reaching path do not need their drop fired again
@@ -7565,6 +7567,14 @@ pub(super) fn enumerate_exits(
     for block in blocks {
         let block_id = block.id;
         let plan = match &block.terminator {
+            Terminator::Unreachable => {
+                // A semantic unreachable is not a language-visible exit. In
+                // particular, do not reinterpret it as `Panic`/`Trap`, and do
+                // not run ownership cleanup for a path the compiler has proved
+                // impossible. The normal ElabBlock was still constructed above
+                // so this stage preserves the Raw-MIR CFG identity explicitly.
+                continue;
+            }
             Terminator::Return => (
                 ExitPath::Return { block: block_id },
                 DropPlan {
@@ -7871,6 +7881,44 @@ pub(super) fn enumerate_exits(
     }
     (elab_blocks, plans)
 }
+
+#[cfg(test)]
+mod semantic_unreachable_tests {
+    use super::*;
+
+    #[test]
+    fn semantic_unreachable_has_a_normal_block_but_no_exit_or_cleanup_plan() {
+        let raw = [BasicBlock {
+            id: 0,
+            statements: Vec::new(),
+            instructions: Vec::new(),
+            terminator: Terminator::Unreachable,
+        }];
+        let (elaborated, plans) = enumerate_exits(
+            &raw,
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashSet::new(),
+        );
+
+        assert_eq!(elaborated.len(), 1);
+        let block = &elaborated[0];
+        assert_eq!(block.id, 0);
+        assert_eq!(block.kind, BlockKind::Normal);
+        assert!(block.drops.is_empty());
+        assert_eq!(block.successor, None);
+        assert!(
+            plans.is_empty(),
+            "unreachable must not manufacture an ExitPath"
+        );
+    }
+}
+
 // ============================================================================
 // #2418 fan-out exclusivity boundary — direct-CFG tests against
 // `dedup_whole_value_handoff`'s guarded-component collapse. Hand-constructed

--- a/hew-mir/src/lower/pattern.rs
+++ b/hew-mir/src/lower/pattern.rs
@@ -1055,7 +1055,11 @@ impl Builder {
                             memo,
                         )
                     }
-                    Terminator::Trap { .. } => true,
+                    // Neither endpoint has a successor or transfers the
+                    // generator's value. `Unreachable` is semantically
+                    // impossible; `Trap` terminates the process. Both are
+                    // therefore safe for the body-end drop analysis.
+                    Terminator::Unreachable | Terminator::Trap { .. } => true,
                     // A `Return`-terminated path exits the function WITHOUT
                     // carrying the binding: `return v` moves the value through
                     // an `Instr::Move` into `Place::ReturnSlot`, and that Move

--- a/hew-mir/src/lower/suspend_places.rs
+++ b/hew-mir/src/lower/suspend_places.rs
@@ -307,7 +307,10 @@ pub fn terminator_source_places(
     suspend_kind: Option<&SuspendKind>,
 ) -> Vec<Place> {
     match term {
-        Terminator::Return | Terminator::Goto { .. } | Terminator::Trap { .. } => Vec::new(),
+        Terminator::Return
+        | Terminator::Unreachable
+        | Terminator::Goto { .. }
+        | Terminator::Trap { .. } => Vec::new(),
         Terminator::Branch { cond, .. } => vec![*cond],
         Terminator::Call { args, .. } => args.clone(),
         Terminator::Yield { value, .. } => vec![*value],
@@ -704,6 +707,7 @@ pub(super) fn generator_yield_terminator_escapes(
         ),
         Terminator::Goto { .. }
         | Terminator::Branch { .. }
+        | Terminator::Unreachable
         | Terminator::Trap { .. }
         | Terminator::MakeGenerator { .. } => false,
         // A bare `Suspend` escapes a yielded `local` exactly when its collapsed
@@ -1048,6 +1052,7 @@ pub(super) fn terminator_escape_places(
             suspend_kind.map_or_else(Vec::new, suspend_kind_escape_places)
         }
         Terminator::Return
+        | Terminator::Unreachable
         | Terminator::Goto { .. }
         | Terminator::Branch { .. }
         | Terminator::Trap { .. } => Vec::new(),

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -3473,7 +3473,7 @@ impl BasicBlock {
     #[must_use]
     pub fn successors(&self) -> Vec<u32> {
         match &self.terminator {
-            Terminator::Return | Terminator::Trap { .. } => Vec::new(),
+            Terminator::Return | Terminator::Unreachable | Terminator::Trap { .. } => Vec::new(),
             Terminator::Goto { target } => vec![*target],
             Terminator::Branch {
                 then_target,
@@ -3796,6 +3796,15 @@ pub enum Terminator {
     /// Return whatever has been written into `Place::ReturnSlot`. The
     /// emitter loads the slot and emits `ret`.
     Return,
+    /// A compiler-proven semantic CFG endpoint.
+    ///
+    /// This is deliberately distinct from [`Self::Trap`]: it carries no
+    /// language-visible failure, performs no runtime action, and owns no
+    /// cleanup edge. LLVM lowers it directly to its `unreachable` terminator.
+    /// SIR uses this form for an impossible semantic path; later CFG
+    /// canonicalization may create more such paths without manufacturing a
+    /// trap or an `ExitPath` drop plan.
+    Unreachable,
     /// Unconditional branch to another block in the same function.
     Goto { target: u32 },
     /// Two-way branch on an i1/i8/i32/i64 local treated as a boolean.

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -21,9 +21,10 @@ use hew_types::DefId;
 use hew_types::ResolvedTy;
 
 use crate::{
-    dataflow, BasicBlock, BlockKind, CheckedMirFunction, ElabBlock, ElaboratedMirFunction,
-    FunctionCallConv, Instr, IntArithOp, IntSignedness, IrPipeline, ModuleCapabilities,
-    ParamBoundaryFact, ParamBoundaryMode, Place, RawMirFunction, Strategy, Terminator, TrapKind,
+    dataflow, BasicBlock, BlockKind, CheckedMirFunction, DropPlan, ElabBlock,
+    ElaboratedMirFunction, ExitPath, FunctionCallConv, Instr, IntArithOp, IntSignedness,
+    IrPipeline, ModuleCapabilities, ParamBoundaryFact, ParamBoundaryMode, Place, RawMirFunction,
+    Strategy, Terminator, TrapKind,
 };
 
 /// The result of lowering one SIR function through the complete existing MIR
@@ -322,7 +323,7 @@ fn lower_verified_sir_function(
         cooperate_sites: dataflow::compute_structural_cooperate_sites(&raw.blocks),
     };
     verify_strict_sir_raw_checked(module, callable, &raw, &checked)?;
-    let elaborated = zero_drop_elaboration(&raw, &checked);
+    let elaborated = zero_drop_elaboration(&raw, &checked)?;
     Ok(SirMirLowered {
         raw,
         checked,
@@ -1140,6 +1141,23 @@ pub fn apply_sir_to_pipeline(
                     ));
                     continue;
                 }
+                // The scheduler bridge can replace the candidate's structural
+                // cooperation facts with the established legacy facts. Build
+                // elaboration only after that reconciliation so every
+                // injected cancellation exit has the same plan in Checked and
+                // Elaborated MIR.
+                match zero_drop_elaboration(&lowered.raw, &lowered.checked) {
+                    Ok(elaborated) => lowered.elaborated = elaborated,
+                    Err(error) => {
+                        report.statuses.push((
+                            function.name.clone(),
+                            SirMirLoweringStatus::Unsupported {
+                                reason: error.reason,
+                            },
+                        ));
+                        continue;
+                    }
+                }
                 let SirMirLowered {
                     raw,
                     checked,
@@ -1265,7 +1283,7 @@ fn lower_sir_function_with_template(
         // scheduling itself must remain structural.
         cooperate_sites: dataflow::compute_structural_cooperate_sites(&raw.blocks),
     };
-    let elaborated = zero_drop_elaboration(&raw, &checked);
+    let elaborated = zero_drop_elaboration(&raw, &checked)?;
     Ok(SirMirLowered {
         raw,
         checked,
@@ -1279,35 +1297,122 @@ fn lower_sir_function_with_template(
 /// This is intentionally not a second drop-elaboration algorithm. The subset
 /// rejects ownership-bearing values before Raw MIR, so it has no possible drop
 /// obligations. It nevertheless retains every Raw block as a normal `ElabBlock`
-/// and carries no `ExitPath` plans for a semantic `Unreachable`; that makes the
-/// Raw → Checked → Elaborated ladder total for SIR bodies without treating an
+/// and records an empty `DropPlan` for every runtime-reachable exit. Only a
+/// semantic `Unreachable` carries no `ExitPath` plan; that makes the Raw →
+/// Checked → Elaborated ladder total for SIR bodies without treating an
 /// impossible path as a trap or cleanup edge.
 fn zero_drop_elaboration(
     raw: &RawMirFunction,
     checked: &CheckedMirFunction,
-) -> ElaboratedMirFunction {
+) -> Result<ElaboratedMirFunction, SirMirLoweringError> {
     debug_assert_eq!(raw.name, checked.name);
     debug_assert_eq!(raw.return_ty, checked.return_ty);
     debug_assert_eq!(raw.blocks, checked.blocks);
-    ElaboratedMirFunction {
+    let mut blocks = raw
+        .blocks
+        .iter()
+        .map(|block| ElabBlock {
+            id: block.id,
+            kind: BlockKind::Normal,
+            drops: Vec::new(),
+            successor: None,
+        })
+        .collect::<Vec<_>>();
+    let mut next_cleanup_id = raw
+        .blocks
+        .iter()
+        .map(|block| block.id)
+        .max()
+        .map_or(0, |id| id.saturating_add(1));
+    // Codegen injects a cancellation branch at every cooperation site. That
+    // branch is an executable exit just as much as a terminator edge, so it
+    // must retain an explicit (empty in this subset) plan. Canonicalize by
+    // block id because distinct site kinds could otherwise name the same
+    // injected cancellation edge.
+    let cancellation_blocks = checked
+        .cooperate_sites
+        .iter()
+        .map(|site| site.bb_id)
+        .collect::<BTreeSet<_>>();
+    for block_id in &cancellation_blocks {
+        let Some(block) = raw.blocks.iter().find(|block| block.id == *block_id) else {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR zero-drop elaboration found a cooperate site for missing raw block bb{block_id}"
+            )));
+        };
+        // Codegen injects the cooperation/cancellation branch before the
+        // block's terminator. A semantic Unreachable must remain a bare,
+        // plan-free endpoint, so a stale scheduler fact naming it is invalid
+        // rather than something elaboration can silently skip.
+        if matches!(block.terminator, Terminator::Unreachable) {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "strict SIR zero-drop elaboration found a cooperate site for semantic unreachable bb{block_id}"
+            )));
+        }
+    }
+    let mut drop_plans = Vec::new();
+    for block in &raw.blocks {
+        let exit = match &block.terminator {
+            // A semantic unreachable is not a language-visible exit. It has no
+            // cleanup edge or drop plan even in the explicit Elaborated body.
+            Terminator::Unreachable => None,
+            Terminator::Return => Some(ExitPath::Return { block: block.id }),
+            Terminator::Goto { target } => Some(ExitPath::Goto {
+                block: block.id,
+                target: *target,
+            }),
+            Terminator::Branch {
+                then_target,
+                else_target,
+                ..
+            } => Some(ExitPath::Branch {
+                block: block.id,
+                then_target: *then_target,
+                else_target: *else_target,
+            }),
+            Terminator::Call { callee, next, .. } => Some(ExitPath::Call {
+                block: block.id,
+                callee: callee.clone(),
+                next: *next,
+            }),
+            Terminator::Trap { .. } => {
+                // A trap is an executable panic path, unlike semantic
+                // `Unreachable`. Even the no-drop SIR subset must preserve its
+                // exit identity and cleanup shape for codegen and future
+                // ownership elaboration.
+                blocks.push(ElabBlock {
+                    id: next_cleanup_id,
+                    kind: BlockKind::Cleanup,
+                    drops: Vec::new(),
+                    successor: None,
+                });
+                next_cleanup_id = next_cleanup_id.saturating_add(1);
+                Some(ExitPath::Panic { block: block.id })
+            }
+            other => {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "strict SIR zero-drop elaboration encountered unsupported raw terminator in bb{}: {other:?}",
+                    block.id
+                )));
+            }
+        };
+        if let Some(exit) = exit {
+            drop_plans.push((exit, DropPlan::default()));
+        }
+        if cancellation_blocks.contains(&block.id) {
+            drop_plans.push((ExitPath::Cancel { block: block.id }, DropPlan::default()));
+        }
+    }
+    Ok(ElaboratedMirFunction {
         name: raw.name.clone(),
         return_ty: raw.return_ty.clone(),
         statements: Vec::new(),
         decisions: checked.decisions.clone(),
-        blocks: raw
-            .blocks
-            .iter()
-            .map(|block| ElabBlock {
-                id: block.id,
-                kind: BlockKind::Normal,
-                drops: Vec::new(),
-                successor: None,
-            })
-            .collect(),
-        drop_plans: Vec::new(),
+        blocks,
+        drop_plans,
         coroutine: None,
         lambda_captures: Vec::new(),
-    }
+    })
 }
 
 fn raw_source_origin(origin: &FunctionSourceOrigin) -> crate::SourceOrigin {
@@ -2467,6 +2572,51 @@ mod tests {
     }
 
     #[test]
+    fn shadow_bridge_rejects_a_scheduler_site_for_semantic_unreachable_atomically() {
+        let function = strict_unreachable_function();
+        let raw = template("semantic_unreachable", Vec::new(), ResolvedTy::Unit);
+        let checked = CheckedMirFunction {
+            name: "semantic_unreachable".to_string(),
+            return_ty: ResolvedTy::Unit,
+            blocks: Vec::new(),
+            decisions: Vec::new(),
+            checks: Vec::new(),
+            cooperate_sites: vec![crate::CooperateSite {
+                bb_id: 0,
+                kind: crate::CooperateKind::FunctionEntry,
+            }],
+        };
+        let elaborated = ElaboratedMirFunction {
+            name: "semantic_unreachable".to_string(),
+            return_ty: ResolvedTy::Unit,
+            statements: Vec::new(),
+            decisions: Vec::new(),
+            blocks: Vec::new(),
+            drop_plans: Vec::new(),
+            coroutine: None,
+            lambda_captures: Vec::new(),
+        };
+        let mut pipeline = IrPipeline {
+            raw_mir: vec![raw.clone()],
+            checked_mir: vec![checked.clone()],
+            elaborated_mir: vec![elaborated.clone()],
+            ..IrPipeline::default()
+        };
+
+        let report = apply_sir_to_pipeline(&test_module(vec![function]), &mut pipeline);
+
+        assert_eq!(report.lowered_count(), 0, "{report:#?}");
+        assert_eq!(pipeline.raw_mir, vec![raw]);
+        assert_eq!(pipeline.checked_mir, vec![checked]);
+        assert_eq!(pipeline.elaborated_mir, vec![elaborated]);
+        assert!(report.statuses.iter().all(|(_, status)| matches!(
+            status,
+            SirMirLoweringStatus::Unsupported { reason }
+                if reason.contains("cooperate site for semantic unreachable bb0")
+        )));
+    }
+
+    #[test]
     fn strict_post_lowering_verifier_rejects_parameter_boundary_fact_drift() {
         let function = strict_i64_identity_function();
         let module = test_module(vec![function.clone()]);
@@ -2654,6 +2804,70 @@ mod tests {
                 })
         }));
         assert!(lowered.checked.checks.is_empty());
+        let cancellation_blocks = lowered
+            .checked
+            .cooperate_sites
+            .iter()
+            .filter_map(|site| {
+                lowered
+                    .raw
+                    .blocks
+                    .iter()
+                    .find(|block| block.id == site.bb_id)
+                    .filter(|block| !matches!(block.terminator, Terminator::Unreachable))
+                    .map(|_| site.bb_id)
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            lowered.elaborated.drop_plans.len(),
+            lowered
+                .raw
+                .blocks
+                .iter()
+                .filter(|block| !matches!(block.terminator, Terminator::Unreachable))
+                .count()
+                + cancellation_blocks.len(),
+            "every strict SIR runtime or injected cancellation exit needs an explicit zero-drop plan"
+        );
+        assert!(lowered
+            .elaborated
+            .drop_plans
+            .iter()
+            .all(|(_, plan)| plan.drops.is_empty()));
+        assert!(lowered
+            .elaborated
+            .drop_plans
+            .iter()
+            .any(|(exit, _)| { matches!(exit, ExitPath::Branch { block: 0, .. }) }));
+        let trap_block = lowered
+            .raw
+            .blocks
+            .iter()
+            .find(|block| {
+                matches!(
+                    block.terminator,
+                    Terminator::Trap {
+                        kind: TrapKind::IntegerOverflow
+                    }
+                )
+            })
+            .expect("checked arithmetic must preserve an overflow trap block")
+            .id;
+        assert!(lowered.elaborated.drop_plans.iter().any(|(exit, plan)| {
+            matches!(exit, ExitPath::Panic { block } if *block == trap_block)
+                && plan.drops.is_empty()
+        }));
+        assert!(lowered
+            .elaborated
+            .blocks
+            .iter()
+            .any(|block| block.kind == BlockKind::Cleanup && block.drops.is_empty()));
+        for block in cancellation_blocks {
+            assert!(lowered.elaborated.drop_plans.iter().any(|(exit, plan)| {
+                matches!(exit, ExitPath::Cancel { block: cancel_block } if *cancel_block == block)
+                    && plan.drops.is_empty()
+            }));
+        }
     }
 
     #[test]
@@ -2957,10 +3171,11 @@ mod tests {
             other => panic!("expected SIR call to lower as raw terminator, got {other:?}"),
         };
         assert!(matches!(destination, Place::Local(_)));
+        let call_next = continuation;
         let continuation = caller_raw
             .blocks
             .iter()
-            .find(|block| block.id == continuation)
+            .find(|block| block.id == call_next)
             .expect("raw call continuation must exist");
         assert!(continuation
             .instructions
@@ -2992,19 +3207,81 @@ mod tests {
                 ..
             }]
         ));
-        assert!(component
+        let main_cooperate_blocks = component
             .checked_mir
             .iter()
             .find(|checked| checked.name == "main")
-            .is_some_and(|checked| !checked.cooperate_sites.is_empty()));
+            .expect("caller must receive freshly-derived checked MIR")
+            .cooperate_sites
+            .iter()
+            .map(|site| site.bb_id)
+            .collect::<BTreeSet<_>>();
+        assert!(
+            !main_cooperate_blocks.is_empty(),
+            "the direct caller must retain a scheduler cooperation site"
+        );
         let pipeline = component.into_pipeline();
         assert_eq!(pipeline.raw_mir.len(), 2);
         assert_eq!(pipeline.checked_mir.len(), 2);
         assert_eq!(pipeline.elaborated_mir.len(), 2);
-        assert!(pipeline
+        let main_elaborated = pipeline
             .elaborated_mir
             .iter()
-            .all(|elaborated| elaborated.drop_plans.is_empty()));
+            .find(|elaborated| elaborated.name == "main")
+            .expect("selected caller must retain explicit elaboration");
+        assert!(main_elaborated.drop_plans.iter().any(|(exit, plan)| {
+            matches!(
+                exit,
+                ExitPath::Call {
+                    block: 0,
+                    callee,
+                    next,
+                } if callee == "add_one" && *next == call_next
+            ) && plan.drops.is_empty()
+        }));
+        for block in main_cooperate_blocks {
+            assert!(main_elaborated.drop_plans.iter().any(|(exit, plan)| {
+                matches!(exit, ExitPath::Cancel { block: cancel_block } if *cancel_block == block)
+                    && plan.drops.is_empty()
+            }));
+        }
+        for ((raw, checked), elaborated) in pipeline
+            .raw_mir
+            .iter()
+            .zip(&pipeline.checked_mir)
+            .zip(&pipeline.elaborated_mir)
+        {
+            let cancellation_blocks = checked
+                .cooperate_sites
+                .iter()
+                .filter_map(|site| {
+                    raw.blocks
+                        .iter()
+                        .find(|block| block.id == site.bb_id)
+                        .filter(|block| !matches!(block.terminator, Terminator::Unreachable))
+                        .map(|_| site.bb_id)
+                })
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                elaborated.drop_plans.len(),
+                raw.blocks
+                    .iter()
+                    .filter(|block| !matches!(block.terminator, Terminator::Unreachable))
+                    .count()
+                    + cancellation_blocks.len(),
+                "every strict SIR runtime or injected cancellation exit must retain its zero-drop elaboration plan"
+            );
+            assert!(elaborated
+                .drop_plans
+                .iter()
+                .all(|(_, plan)| plan.drops.is_empty()));
+            for block in cancellation_blocks {
+                assert!(elaborated.drop_plans.iter().any(|(exit, plan)| {
+                    matches!(exit, ExitPath::Cancel { block: cancel_block } if *cancel_block == block)
+                        && plan.drops.is_empty()
+                }));
+            }
+        }
     }
 
     #[test]
@@ -3183,7 +3460,14 @@ mod tests {
             blocks: Vec::new(),
             decisions: Vec::new(),
             checks: Vec::new(),
-            cooperate_sites: Vec::new(),
+            // The candidate's structural analysis has no site for this
+            // trivial constant return, while the temporary shadow bridge
+            // preserves this established entry site. Its elaboration must be
+            // rebuilt after that scheduler reconciliation.
+            cooperate_sites: vec![crate::CooperateSite {
+                bb_id: 0,
+                kind: crate::CooperateKind::FunctionEntry,
+            }],
         };
         let mut pipeline = IrPipeline {
             raw_mir: vec![raw],
@@ -3205,7 +3489,20 @@ mod tests {
         assert_eq!(report.lowered_count(), 1, "{report:#?}");
         assert_eq!(pipeline.elaborated_mir.len(), 1);
         assert_eq!(pipeline.elaborated_mir[0].name, "constant");
-        assert!(pipeline.elaborated_mir[0].drop_plans.is_empty());
+        assert!(matches!(
+            pipeline.elaborated_mir[0].drop_plans.as_slice(),
+            [
+                (ExitPath::Return { block: 0 }, return_plan),
+                (ExitPath::Cancel { block: 0 }, cancel_plan),
+            ] if return_plan.drops.is_empty() && cancel_plan.drops.is_empty()
+        ));
+        assert!(matches!(
+            pipeline.checked_mir[0].cooperate_sites.as_slice(),
+            [crate::CooperateSite {
+                bb_id: 0,
+                kind: crate::CooperateKind::FunctionEntry,
+            }]
+        ));
         assert_eq!(pipeline.elaborated_mir[0].blocks.len(), 1);
         assert!(matches!(
             pipeline.raw_mir[0].blocks[0].instructions.as_slice(),

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -21,19 +21,24 @@ use hew_types::DefId;
 use hew_types::ResolvedTy;
 
 use crate::{
-    dataflow, BasicBlock, CheckedMirFunction, FunctionCallConv, Instr, IntArithOp, IntSignedness,
-    IrPipeline, ModuleCapabilities, ParamBoundaryFact, ParamBoundaryMode, Place, RawMirFunction,
-    Strategy, Terminator, TrapKind,
+    dataflow, BasicBlock, BlockKind, CheckedMirFunction, ElabBlock, ElaboratedMirFunction,
+    FunctionCallConv, Instr, IntArithOp, IntSignedness, IrPipeline, ModuleCapabilities,
+    ParamBoundaryFact, ParamBoundaryMode, Place, RawMirFunction, Strategy, Terminator, TrapKind,
 };
 
-/// The result of lowering one SIR function into the existing raw/checked MIR
-/// boundary.  No elaborated MIR is produced for this slice: it accepts only
-/// scalar, non-owning values, and the code generator deliberately accepts a
-/// missing elaborated entry as an empty drop-plan set.
+/// The result of lowering one SIR function through the complete existing MIR
+/// ladder.
+///
+/// The first executable SIR slice admits only scalar, non-owning values, so
+/// its elaborated body has zero drop plans. It is nevertheless explicit: SIR
+/// must never rely on codegen's legacy "missing elaboration means no drops"
+/// compatibility behavior. In particular, a semantic `Unreachable` block is
+/// represented by a normal zero-drop elaborated block with no `ExitPath`.
 #[derive(Debug, Clone, PartialEq)]
 struct SirMirLowered {
     raw: RawMirFunction,
     checked: CheckedMirFunction,
+    elaborated: ElaboratedMirFunction,
 }
 
 /// A closed, self-contained scalar SIR call-graph realization.
@@ -50,6 +55,7 @@ pub struct SirMirComponent {
     callables: Vec<CallableId>,
     raw_mir: Vec<RawMirFunction>,
     checked_mir: Vec<CheckedMirFunction>,
+    elaborated_mir: Vec<ElaboratedMirFunction>,
 }
 
 impl SirMirComponent {
@@ -70,6 +76,7 @@ impl SirMirComponent {
         let mut pipeline = IrPipeline {
             raw_mir: self.raw_mir,
             checked_mir: self.checked_mir,
+            elaborated_mir: self.elaborated_mir,
             ..IrPipeline::default()
         };
         pipeline.capabilities =
@@ -207,6 +214,7 @@ pub fn lower_closed_scalar_component(
 
     let mut raw_mir = Vec::with_capacity(selected.len());
     let mut checked_mir = Vec::with_capacity(selected.len());
+    let mut elaborated_mir = Vec::with_capacity(selected.len());
     for callable_id in &selected {
         let function = unique_function_for_callable(module, *callable_id).ok_or_else(|| {
             SirMirLoweringError::unsupported(format!(
@@ -217,12 +225,14 @@ pub fn lower_closed_scalar_component(
         let lowered = lower_verified_sir_function(module, function)?;
         raw_mir.push(lowered.raw);
         checked_mir.push(lowered.checked);
+        elaborated_mir.push(lowered.elaborated);
     }
 
     Ok(SirMirComponent {
         callables: selected.into_iter().collect(),
         raw_mir,
         checked_mir,
+        elaborated_mir,
     })
 }
 
@@ -312,7 +322,12 @@ fn lower_verified_sir_function(
         cooperate_sites: dataflow::compute_structural_cooperate_sites(&raw.blocks),
     };
     verify_strict_sir_raw_checked(module, callable, &raw, &checked)?;
-    Ok(SirMirLowered { raw, checked })
+    let elaborated = zero_drop_elaboration(&raw, &checked);
+    Ok(SirMirLowered {
+        raw,
+        checked,
+        elaborated,
+    })
 }
 
 /// Verify the small, deliberately storage-free SIR → raw/checked-MIR contract.
@@ -684,6 +699,7 @@ fn verify_strict_sir_terminator(
             }
         }
         Terminator::Goto { .. }
+        | Terminator::Unreachable
         | Terminator::Trap {
             kind: TrapKind::IntegerOverflow,
         } => {}
@@ -1017,9 +1033,9 @@ fn format_callable_path(module: &SemModule, path: &[CallableId]) -> String {
 /// adapter replaces only independently lowerable scalar/CFG functions,
 /// preserves every module-level layout/runtime fact, and keeps the established
 /// raw/checked MIR for all other functions while the cutover is in progress.
-/// Replaced functions deliberately lose their prior elaborated entry:
-/// retaining a drop plan authored for a different CFG would be unsound, while
-/// this value-only slice requires no drops.
+/// A replacement receives a fresh, explicit zero-drop elaborated body. Retaining
+/// a plan authored for a different CFG would be unsound, but omitting
+/// elaborated MIR would perpetuate a legacy codegen compatibility shortcut.
 #[allow(
     clippy::too_many_lines,
     reason = "the temporary bridge keeps module verification, per-function eligibility, and atomic pipeline replacement together so a partial candidate cannot obscure the transition boundary"
@@ -1124,13 +1140,19 @@ pub fn apply_sir_to_pipeline(
                     ));
                     continue;
                 }
-                pipeline.raw_mir[*raw_index] = lowered.raw;
+                let SirMirLowered {
+                    raw,
+                    checked,
+                    elaborated,
+                } = lowered;
+                pipeline.raw_mir[*raw_index] = raw;
                 if let Some(&checked_index) = matching_checked.first() {
-                    pipeline.checked_mir[checked_index] = lowered.checked;
+                    pipeline.checked_mir[checked_index] = checked;
                 }
                 pipeline
                     .elaborated_mir
                     .retain(|elaborated| elaborated.name != function.name);
+                pipeline.elaborated_mir.push(elaborated);
                 report
                     .statuses
                     .push((function.name.clone(), SirMirLoweringStatus::Lowered));
@@ -1243,7 +1265,49 @@ fn lower_sir_function_with_template(
         // scheduling itself must remain structural.
         cooperate_sites: dataflow::compute_structural_cooperate_sites(&raw.blocks),
     };
-    Ok(SirMirLowered { raw, checked })
+    let elaborated = zero_drop_elaboration(&raw, &checked);
+    Ok(SirMirLowered {
+        raw,
+        checked,
+        elaborated,
+    })
+}
+
+/// Build the explicit elaborated artifact for the initial SIR value-only
+/// subset.
+///
+/// This is intentionally not a second drop-elaboration algorithm. The subset
+/// rejects ownership-bearing values before Raw MIR, so it has no possible drop
+/// obligations. It nevertheless retains every Raw block as a normal `ElabBlock`
+/// and carries no `ExitPath` plans for a semantic `Unreachable`; that makes the
+/// Raw → Checked → Elaborated ladder total for SIR bodies without treating an
+/// impossible path as a trap or cleanup edge.
+fn zero_drop_elaboration(
+    raw: &RawMirFunction,
+    checked: &CheckedMirFunction,
+) -> ElaboratedMirFunction {
+    debug_assert_eq!(raw.name, checked.name);
+    debug_assert_eq!(raw.return_ty, checked.return_ty);
+    debug_assert_eq!(raw.blocks, checked.blocks);
+    ElaboratedMirFunction {
+        name: raw.name.clone(),
+        return_ty: raw.return_ty.clone(),
+        statements: Vec::new(),
+        decisions: checked.decisions.clone(),
+        blocks: raw
+            .blocks
+            .iter()
+            .map(|block| ElabBlock {
+                id: block.id,
+                kind: BlockKind::Normal,
+                drops: Vec::new(),
+                successor: None,
+            })
+            .collect(),
+        drop_plans: Vec::new(),
+        coroutine: None,
+        lambda_captures: Vec::new(),
+    }
 }
 
 fn raw_source_origin(origin: &FunctionSourceOrigin) -> crate::SourceOrigin {
@@ -1919,9 +1983,7 @@ impl<'a> RawLowerer<'a> {
                     else_target,
                 })
             }
-            SemTerminator::Unreachable => Err(SirMirLoweringError::unsupported(
-                "SIR unreachable terminators remain deferred until raw MIR has a semantic unreachable terminator",
-            )),
+            SemTerminator::Unreachable => self.terminate(Terminator::Unreachable),
         }
     }
 
@@ -2258,6 +2320,26 @@ mod tests {
         }
     }
 
+    fn strict_unreachable_function() -> SemFunction {
+        SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("semantic_unreachable"),
+            name: "semantic_unreachable".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: Vec::new(),
+            return_ty: ResolvedTy::Unit,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Unreachable,
+            }],
+        }
+    }
+
     fn strict_boolean_equality_function() -> SemFunction {
         SemFunction {
             id: ItemId(0),
@@ -2345,6 +2427,43 @@ mod tests {
             verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
                 .expect_err("a raw target outside the canonical CFG must fail at the SIR boundary");
         assert!(error.reason.contains("targets missing bb1"));
+    }
+
+    #[test]
+    fn realizes_semantic_unreachable_through_the_explicit_zero_drop_ladder() {
+        let function = strict_unreachable_function();
+        let pipeline =
+            lower_closed_scalar_component(&test_module(vec![function]), &[CallableId(0)])
+                .expect("a semantic unreachable is a legal strict SIR endpoint")
+                .into_pipeline();
+
+        let raw = pipeline
+            .raw_mir
+            .first()
+            .expect("the component must contain one raw-MIR body");
+        assert!(matches!(raw.blocks[0].terminator, Terminator::Unreachable));
+        assert!(raw.blocks[0].successors().is_empty());
+
+        let checked = pipeline
+            .checked_mir
+            .first()
+            .expect("the component must contain one checked-MIR body");
+        assert_eq!(checked.blocks, raw.blocks);
+        assert!(checked.checks.is_empty());
+        assert!(checked.cooperate_sites.is_empty());
+
+        let elaborated = pipeline
+            .elaborated_mir
+            .first()
+            .expect("SIR bodies must carry an explicit elaborated artifact");
+        assert_eq!(elaborated.name, raw.name);
+        assert!(elaborated.drop_plans.is_empty());
+        assert_eq!(elaborated.blocks.len(), 1);
+        let block = &elaborated.blocks[0];
+        assert_eq!(block.id, 0);
+        assert_eq!(block.kind, BlockKind::Normal);
+        assert!(block.drops.is_empty());
+        assert_eq!(block.successor, None);
     }
 
     #[test]
@@ -2881,7 +3000,11 @@ mod tests {
         let pipeline = component.into_pipeline();
         assert_eq!(pipeline.raw_mir.len(), 2);
         assert_eq!(pipeline.checked_mir.len(), 2);
-        assert!(pipeline.elaborated_mir.is_empty());
+        assert_eq!(pipeline.elaborated_mir.len(), 2);
+        assert!(pipeline
+            .elaborated_mir
+            .iter()
+            .all(|elaborated| elaborated.drop_plans.is_empty()));
     }
 
     #[test]
@@ -3080,7 +3203,10 @@ mod tests {
 
         let report = apply_sir_to_pipeline(&test_module(vec![function]), &mut pipeline);
         assert_eq!(report.lowered_count(), 1, "{report:#?}");
-        assert!(pipeline.elaborated_mir.is_empty());
+        assert_eq!(pipeline.elaborated_mir.len(), 1);
+        assert_eq!(pipeline.elaborated_mir[0].name, "constant");
+        assert!(pipeline.elaborated_mir[0].drop_plans.is_empty());
+        assert_eq!(pipeline.elaborated_mir[0].blocks.len(), 1);
         assert!(matches!(
             pipeline.raw_mir[0].blocks[0].instructions.as_slice(),
             [

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -576,10 +576,9 @@ pub enum SemTerminator {
     },
     /// A semantically unreachable CFG endpoint.
     ///
-    /// SIR can represent this before Raw MIR has a matching terminator. The
-    /// SIR → Raw MIR bridge deliberately rejects it today; an explicit Raw-MIR
-    /// legalization is a prerequisite for CFG simplification/DCE to create or
-    /// preserve semantic unreachable blocks.
+    /// Raw MIR preserves this as its own semantic endpoint, and LLVM lowers it
+    /// directly to `unreachable`. It is not a language-visible trap and owns no
+    /// cleanup path.
     Unreachable,
 }
 


### PR DESCRIPTION
## Summary

- add a real Raw MIR `Terminator::Unreachable` and lower SIR semantic `Unreachable` through Raw, Checked, Elaborated MIR, and LLVM
- emit bare LLVM `unreachable`, never a Hew trap or implicit drop path
- make strict SIR elaboration explicit: every runtime exit—including calls, branches, overflow panic, and scheduler-injected cancellation—gets an empty `DropPlan`; only semantic `Unreachable` has none
- reject stale scheduler cooperation facts targeting semantic `Unreachable` atomically, so Checked and Elaborated MIR cannot diverge

## Architecture

This is a convergent-ladder change, not a compatibility shim. It completes the current SIR → Raw MIR → Checked MIR → Elaborated MIR boundary for semantic unreachable endpoints and removes reliance on the legacy missing-elaboration convention for this strict SIR subset.

## Validation

- `cargo test -p hew-mir --lib --no-fail-fast` (800 passed)
- `cargo test -p hew-codegen-rs --lib --no-fail-fast` (314 passed)
- `cargo test -p hew-cli --test sir_shadow_e2e --no-fail-fast` (10 passed)
- affected-crate `cargo check` and strict Clippy
- focused SIR/MIR and LLVM-unreachable regressions after rebase
- `cargo fmt --all --check` and `git diff --check`

## Review

Independent architecture review found and resolved the exit-plan and cancellation-plan gaps; final review approved with no P0/P1 findings.