### PR TITLE
feat(sir): specialize scalar generic instances

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -373,23 +373,31 @@ fn report_strict_sir_missing_body(
     let Some(callable) = sir.module.callable(missing_body) else {
         return;
     };
-    let reason = module
-        .items
-        .iter()
-        .filter_map(|item| match item {
-            hew_hir::HirItem::Function(function) => Some(function),
-            _ => None,
-        })
-        .zip(&sir.statuses)
-        .find_map(|(function, (_, status))| {
-            if function.id != callable.function {
-                return None;
-            }
-            match status {
-                hew_sir::SirLoweringStatus::Lowered => None,
-                hew_sir::SirLoweringStatus::Unsupported { reason } => Some(reason.as_str()),
-            }
-        });
+    let reason = match sir.status_for_callable(missing_body) {
+        Some(hew_sir::SirLoweringStatus::Unsupported { reason }) => Some(reason.as_str()),
+        Some(
+            hew_sir::SirLoweringStatus::Lowered
+            | hew_sir::SirLoweringStatus::GenericTemplate { .. },
+        )
+        | None => module
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                hew_hir::HirItem::Function(function) => Some(function),
+                _ => None,
+            })
+            .zip(&sir.statuses)
+            .find_map(|(function, (_, status))| {
+                if function.id != callable.function {
+                    return None;
+                }
+                match status {
+                    hew_sir::SirLoweringStatus::Unsupported { reason } => Some(reason.as_str()),
+                    hew_sir::SirLoweringStatus::Lowered
+                    | hew_sir::SirLoweringStatus::GenericTemplate { .. } => None,
+                }
+            }),
+    };
     match reason {
         Some(reason) => eprintln!(
             "SIR strict lowering: `{}` is outside the current semantic surface: {reason}; no legacy MIR fallback was used",
@@ -1618,6 +1626,12 @@ fn report_sir_lane(report: &SirLaneReport, mode: compile::SirMode) {
         .iter()
         .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::Lowered))
         .count();
+    let sir_templates = report
+        .sir
+        .statuses
+        .iter()
+        .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::GenericTemplate { .. }))
+        .count();
     if mode == compile::SirMode::Disabled {
         return;
     }
@@ -1627,13 +1641,14 @@ fn report_sir_lane(report: &SirLaneReport, mode: compile::SirMode) {
         .iter()
         .filter_map(|(name, status)| match status {
             hew_sir::SirLoweringStatus::Unsupported { reason } => Some((name, reason)),
-            hew_sir::SirLoweringStatus::Lowered => None,
+            hew_sir::SirLoweringStatus::Lowered
+            | hew_sir::SirLoweringStatus::GenericTemplate { .. } => None,
         })
         .collect();
     match &report.realization {
         SirLaneRealization::Shadow(bridge) => {
             eprintln!(
-                "SIR shadow: verified {sir_lowered}/{} HIR function bodies; realized {}/{} through raw MIR",
+                "SIR shadow: verified {sir_lowered} monomorphic HIR body/bodies and registered {sir_templates} generic template(s) across {} HIR function declaration(s); realized {}/{} concrete SIR body/bodies through raw MIR",
                 report.sir.statuses.len(),
                 bridge.lowered_count(),
                 report.sir.module.functions.len(),
@@ -1651,7 +1666,7 @@ fn report_sir_lane(report: &SirLaneReport, mode: compile::SirMode) {
         }
         SirLaneRealization::Strict { callables } => {
             eprintln!(
-                "SIR lower: selected {} verified callable(s) from {sir_lowered}/{} HIR function bodies; no legacy MIR bodies were lowered",
+                "SIR lower: selected {} verified callable(s) from {sir_lowered} monomorphic HIR body/bodies and {sir_templates} generic template(s) across {} HIR function declaration(s); no legacy MIR bodies were lowered",
                 callables.len(),
                 report.sir.statuses.len(),
             );
@@ -1671,16 +1686,23 @@ fn report_sir_inspection(sir: &hew_sir::LoweredModule) {
         .iter()
         .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::Lowered))
         .count();
+    let templates = sir
+        .statuses
+        .iter()
+        .filter(|(_, status)| matches!(status, hew_sir::SirLoweringStatus::GenericTemplate { .. }))
+        .count();
     eprintln!(
-        "SIR inspect: verified {lowered}/{} HIR function bodies",
-        sir.statuses.len()
+        "SIR inspect: verified {lowered} monomorphic HIR body/bodies and registered {templates} generic template(s) across {} HIR function declaration(s); emitted {} concrete SIR body/bodies",
+        sir.statuses.len(),
+        sir.module.functions.len()
     );
     let fallbacks: Vec<_> = sir
         .statuses
         .iter()
         .filter_map(|(name, status)| match status {
             hew_sir::SirLoweringStatus::Unsupported { reason } => Some((name, reason)),
-            hew_sir::SirLoweringStatus::Lowered => None,
+            hew_sir::SirLoweringStatus::Lowered
+            | hew_sir::SirLoweringStatus::GenericTemplate { .. } => None,
         })
         .collect();
     report_sir_fallbacks("HIR", &fallbacks);

--- a/hew-cli/tests/sir_shadow_e2e.rs
+++ b/hew-cli/tests/sir_shadow_e2e.rs
@@ -107,6 +107,24 @@ fn countdown(value: i64) -> i64 {
 }
 ";
 
+const GENERIC_DIRECT_CALLS: &str = r"
+pub fn id<T>(value: T) -> T {
+    value
+}
+
+pub fn relay<U>(value: U) -> U {
+    id(id(value))
+}
+
+fn main() -> i64 {
+    if relay(40) == 40 {
+        0
+    } else {
+        1
+    }
+}
+";
+
 const UNREACHABLE_UNSUPPORTED_BODY: &str = r"
 fn main() -> i64 {
     selected()
@@ -324,6 +342,61 @@ fn sir_lower_closed_direct_call_graph_compiles_and_runs() {
     assert_success(
         &executed,
         "native binary containing only SIR-lowered bodies must run successfully",
+    );
+}
+
+/// Generic direct calls use the same strict body path as monomorphic calls.
+/// The concrete SIR instances must be emitted under their derived symbols;
+/// neither the abstract generic template nor a legacy MIR body is permitted
+/// to reach the selected component.
+#[test]
+fn sir_lower_generic_direct_call_graph_compiles_and_runs() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_generic_direct_calls.hew");
+    fs::write(&source, GENERIC_DIRECT_CALLS).expect("write generic SIR fixture");
+
+    let lowered = raw_mir_dump(&source, Some("--sir-lower"));
+    assert_success(&lowered, "strict generic SIR raw MIR dump must succeed");
+    let dump = String::from_utf8_lossy(&lowered.stdout);
+    assert!(
+        dump.contains("fn relay$$i64(") && dump.contains("fn id$$i64("),
+        "strict generic component must contain concrete instance bodies:\n{dump}",
+    );
+    assert!(
+        !dump.contains("fn relay(") && !dump.contains("fn id("),
+        "abstract generic templates must not reach raw MIR:\n{dump}",
+    );
+
+    let mut compile = Command::new(hew_binary());
+    compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--emit-dir")
+        .arg(dir.path())
+        .arg(&source)
+        .current_dir(repo_root());
+    let compiled = support::run_bounded_command(compile, "compile strict generic SIR graph");
+    assert_success(
+        &compiled,
+        "strict generic SIR graph must compile through the existing backend",
+    );
+    assert!(
+        String::from_utf8_lossy(&compiled.stderr)
+            .contains("SIR lower: selected 3 verified callable(s)"),
+        "generic strict component must report exactly main, relay<i64>, and cached id<i64>:\n{}",
+        describe_output(&compiled),
+    );
+
+    let binary = hew_testutil::compiled_binary_path(dir.path(), "sir_generic_direct_calls");
+    let executed = support::run_bounded_command(
+        Command::new(&binary),
+        format!("run strict generic SIR graph {}", binary.display()),
+    );
+    assert_success(
+        &executed,
+        "native binary containing only generic SIR instance bodies must run",
     );
 }
 

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -11,6 +11,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use hew_hir::{IntentKind, SiteId, ValueClass};
 use hew_parser::ast::{BinaryOp, UnaryOp};
+#[cfg(test)]
+use hew_sir::CallableInstance;
 use hew_sir::{
     BlockArg, BlockId, CallableId, Edge, FunctionSourceOrigin, Operand, SemBlock, SemCallConv,
     SemCallable, SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind, SemParamPassing,
@@ -2284,6 +2286,7 @@ mod tests {
             id: function.callable,
             function: function.id,
             declaration: function.declaration.clone(),
+            instance: CallableInstance::Monomorphic,
             symbol: function.name.clone(),
             source_origin: function.source_origin.clone(),
             signature: SemSignature {
@@ -2321,6 +2324,7 @@ mod tests {
             .map(|callable| callable.id);
         SemModule {
             callables,
+            generic_templates: Vec::new(),
             root_unit_callables,
             entry_callable,
             functions,
@@ -3409,6 +3413,7 @@ mod tests {
             id: CallableId(1),
             function: ItemId(1),
             declaration: DefId::for_test("missing"),
+            instance: CallableInstance::Monomorphic,
             symbol: "missing".to_string(),
             source_origin: FunctionSourceOrigin::Unknown,
             signature: SemSignature {

--- a/hew-mir/tests/sir_generic_instances.rs
+++ b/hew-mir/tests/sir_generic_instances.rs
@@ -1,0 +1,90 @@
+//! End-to-end proof for the first SIR-owned generic specialization slice.
+//!
+//! The HIR generic registry is intentionally cleared before SIR lowering.
+//! A successful strict component therefore proves concrete semantic instances
+//! came from SIR's `CallTarget::User` + call-site substitution service, then
+//! crossed the unchanged scalar raw/checked/elaborated MIR ladder without a
+//! legacy generic-body fallback.
+
+use hew_hir::{lower_program_host_target, ResolutionCtx};
+use hew_mir::lower_closed_scalar_component;
+use hew_types::{module_registry::ModuleRegistry, Checker};
+
+#[test]
+fn strict_scalar_component_realizes_sir_owned_generic_instances() {
+    let parsed = hew_parser::parse(
+        r"
+        pub fn id<T>(x: T) -> T {
+            x
+        }
+
+        pub fn relay<U>(y: U) -> U {
+            id(id(y))
+        }
+
+        fn main() -> i64 {
+            relay(41)
+        }
+        ",
+    );
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(Vec::new()));
+    let type_check = checker.check_program(&parsed.program);
+    assert!(
+        type_check.errors.is_empty(),
+        "type errors: {:#?}",
+        type_check.errors
+    );
+    let mut hir = lower_program_host_target(&parsed.program, &type_check, &ResolutionCtx);
+    assert!(
+        hir.diagnostics.is_empty(),
+        "HIR diagnostics: {:#?}",
+        hir.diagnostics
+    );
+    assert!(
+        !hir.module.monomorphisations.is_empty(),
+        "fixture must have a legacy HIR generic registry entry before it is cleared"
+    );
+    hir.module.monomorphisations.clear();
+
+    let sir = hew_sir::lower_module(&hir.module);
+    assert!(
+        hew_sir::verify_module(&sir.module).is_empty(),
+        "generic SIR must verify: {:#?}",
+        hew_sir::verify_module(&sir.module)
+    );
+    let entry = sir
+        .module
+        .entry_callable
+        .expect("scalar root main must be a strict SIR entry");
+    let component = lower_closed_scalar_component(&sir.module, &[entry])
+        .expect("closed generic SIR component must lower without an HIR/MIR template");
+    assert_eq!(
+        component.callables().len(),
+        3,
+        "the component must contain main, relay<i64>, and one cached id<i64> instance"
+    );
+    let pipeline = component.into_pipeline();
+    let names = pipeline
+        .raw_mir
+        .iter()
+        .map(|function| function.name.as_str())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"main"));
+    assert!(names.contains(&"relay$$i64"));
+    assert!(names.contains(&"id$$i64"));
+    assert_eq!(
+        pipeline.raw_mir.len(),
+        pipeline.checked_mir.len(),
+        "every generic SIR body must enter the unchanged checked-MIR ladder"
+    );
+    assert_eq!(
+        pipeline.raw_mir.len(),
+        pipeline.elaborated_mir.len(),
+        "every generic SIR body must receive explicit elaboration"
+    );
+}

--- a/hew-sir/src/lib.rs
+++ b/hew-sir/src/lib.rs
@@ -19,10 +19,11 @@ pub use analysis::{
 pub use dump::dump_sir;
 pub use lower::{lower_module, LoweredModule, SirLoweringStatus};
 pub use model::{
-    BlockArg, BlockId, CallableId, Edge, EffectSet, EffectSummary, FunctionSourceOrigin, OpId,
-    Operand, OperandSlot, Provenance, SemAbiParam, SemBlock, SemCallConv, SemCallable,
-    SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind, SemParamPassing, SemSignature,
-    SemTerminator, UseMode, UseSite, ValueDef, ValueId,
+    BlockArg, BlockId, CallableId, CallableInstance, Edge, EffectSet, EffectSummary,
+    FunctionSourceOrigin, GenericTemplateId, OpId, Operand, OperandSlot, Provenance, SemAbiParam,
+    SemBlock, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemGenericTemplate,
+    SemModule, SemOp, SemOpKind, SemParamPassing, SemSignature, SemTerminator, SirInstanceKey,
+    UseMode, UseSite, ValueDef, ValueId,
 };
 pub use verify::{
     verify_function, verify_function_in_module, verify_module, SirDiagnostic, SirDiagnosticKind,

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -1,85 +1,84 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use hew_hir::{
     BindingId, HirBlock, HirExpr, HirExprKind, HirFn, HirItem, HirLiteral, HirModule, HirStmtKind,
     IntentKind, ResolvedRef,
 };
+use hew_types::{CallTarget, DefId, ResolvedTy};
 
 use crate::{
-    BlockArg, BlockId, CallableId, Edge, EffectSummary, FunctionSourceOrigin, OpId, Operand,
-    Provenance, SemAbiParam, SemBlock, SemCallConv, SemCallable, SemCallableKind, SemFunction,
-    SemModule, SemOp, SemOpKind, SemParamPassing, SemSignature, SemTerminator, UseMode, ValueDef,
-    ValueId,
+    BlockArg, BlockId, CallableId, CallableInstance, Edge, EffectSummary, FunctionSourceOrigin,
+    GenericTemplateId, OpId, Operand, Provenance, SemAbiParam, SemBlock, SemCallConv, SemCallable,
+    SemCallableKind, SemFunction, SemGenericTemplate, SemModule, SemOp, SemOpKind, SemParamPassing,
+    SemSignature, SemTerminator, SirInstanceKey, UseMode, ValueDef, ValueId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SirLoweringStatus {
     Lowered,
-    Unsupported { reason: String },
+    /// A generic HIR definition is a canonical template, not a SIR body. Its
+    /// closed instances are materialized on demand by the SIR instance
+    /// service and reported separately through `callable_statuses`.
+    GenericTemplate {
+        instances: usize,
+        failed_instances: usize,
+    },
+    Unsupported {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LoweredModule {
     pub module: SemModule,
-    /// One status per HIR function, in source order. Shadow-mode callers must
-    /// only regard the SIR result as comparable when every status is `Lowered`.
+    /// One status per HIR function, in source order. A generic HIR definition
+    /// is reported as [`SirLoweringStatus::GenericTemplate`] because it never
+    /// becomes an abstract SIR body.
     pub statuses: Vec<(String, SirLoweringStatus)>,
+    /// Status for every concrete callable header, in `CallableId` order.
+    /// This lets strict component selection diagnose a failed concrete generic
+    /// instance without pretending that its generic HIR template was a body.
+    pub callable_statuses: Vec<(CallableId, SirLoweringStatus)>,
+}
+
+impl LoweredModule {
+    /// Return the lowering result for one concrete callable header.
+    #[must_use]
+    pub fn status_for_callable(&self, callable: CallableId) -> Option<&SirLoweringStatus> {
+        self.callable_statuses
+            .get(usize::try_from(callable.0).ok()?)
+            .filter(|(candidate, _)| *candidate == callable)
+            .map(|(_, status)| status)
+    }
 }
 
 #[must_use]
 pub fn lower_module(module: &HirModule) -> LoweredModule {
-    // Build declaration/signature authority before lowering any body. This
-    // permits forward calls and recursion without symbol reconstruction, and
-    // deliberately keeps an eligible callable when its own body later proves
-    // unsupported: strict drivers can then reject only a reachable missing
-    // body instead of every unrelated unsupported function in a module.
-    let callables = CallableTable::from_hir(module);
-    let mut output = SemModule {
-        callables: callables.callables.clone(),
-        root_unit_callables: callables.root_unit_callables.clone(),
-        entry_callable: callables.entry_callable,
-        functions: Vec::new(),
-    };
-    let mut statuses = Vec::new();
-    for item in &module.items {
-        let HirItem::Function(function) = item else {
-            continue;
-        };
-        let Some(callable) = callables.by_declaration.get(&function.declaration).copied() else {
-            let reason = callables
-                .ineligible
-                .get(&function.id)
-                .cloned()
-                .unwrap_or_else(|| {
-                    "function has no deterministic SIR direct-call entry".to_string()
-                });
-            statuses.push((
-                function.name.clone(),
-                SirLoweringStatus::Unsupported { reason },
-            ));
-            continue;
-        };
-        match Builder::new(
-            function,
-            function_source_origin(module, function),
-            &callables,
-            callable,
-        )
-        .lower()
-        {
-            Ok(function) => {
-                statuses.push((function.name.clone(), SirLoweringStatus::Lowered));
-                output.functions.push(function);
-            }
-            Err(reason) => statuses.push((
-                function.name.clone(),
-                SirLoweringStatus::Unsupported { reason },
-            )),
-        }
+    // The HIR monomorphisation registry remains deliberately unused here.
+    // SIR discovers concrete direct-user instances from each resolved call's
+    // `SiteId -> call_site_type_args` fact, applies the enclosing semantic
+    // substitution, and creates its own closed instance worklist.
+    let mut service = InstanceService::new(module);
+    for callable in service.monomorphic_callables() {
+        service.lower_monomorphic(callable);
     }
+    service.lower_pending_instances();
+
+    let statuses = module
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            HirItem::Function(function) => {
+                Some((function.name.clone(), service.source_status(function)))
+            }
+            _ => None,
+        })
+        .collect();
+    let callable_statuses = service.callable_statuses();
     LoweredModule {
-        module: output,
+        module: service.into_module(),
         statuses,
+        callable_statuses,
     }
 }
 
@@ -89,30 +88,76 @@ pub fn lower_module(module: &HirModule) -> LoweredModule {
 /// projects those checked facts into its semantic callable table; it never
 /// reconstructs a symbol from a declaration's presentation spelling.
 #[derive(Debug, Clone)]
-struct CallableTable {
+struct GenericTemplate<'a> {
+    function: &'a HirFn,
+    source_origin: FunctionSourceOrigin,
+    symbol: String,
+    id: GenericTemplateId,
+}
+
+/// A canonical type substitution applied while lowering one concrete SIR
+/// instance.  It is purely semantic: it rewrites `ResolvedTy` facts but never
+/// asks for a size, alignment, ABI class, or layout.
+#[derive(Debug, Clone, Default)]
+struct TypeSubstitution {
+    params: Vec<String>,
+    args: Vec<ResolvedTy>,
+}
+
+impl TypeSubstitution {
+    fn empty() -> Self {
+        Self::default()
+    }
+
+    fn for_instance(function: &HirFn, args: &[ResolvedTy]) -> Result<Self, String> {
+        if function.type_params.len() != args.len() {
+            return Err(format!(
+                "generic template `{}` expects {} type argument(s), SIR received {}",
+                function.declaration.full_path(),
+                function.type_params.len(),
+                args.len()
+            ));
+        }
+        Ok(Self {
+            params: function.type_params.clone(),
+            args: args.to_vec(),
+        })
+    }
+
+    fn apply(&self, ty: &ResolvedTy) -> ResolvedTy {
+        hew_hir::substitute_type_params(ty, &self.params, &self.args)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CallableTable<'a> {
     callables: Vec<SemCallable>,
+    generic_templates: Vec<SemGenericTemplate>,
     root_unit_callables: Vec<CallableId>,
     entry_callable: Option<CallableId>,
-    by_declaration: HashMap<hew_types::DefId, CallableId>,
+    monomorphic_by_declaration: HashMap<DefId, CallableId>,
+    templates: HashMap<DefId, GenericTemplate<'a>>,
+    functions_by_item: HashMap<hew_hir::ItemId, &'a HirFn>,
     ineligible: HashMap<hew_hir::ItemId, String>,
 }
 
-impl CallableTable {
-    fn from_hir(module: &HirModule) -> Self {
+impl<'a> CallableTable<'a> {
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one deterministic HIR collection pass keeps monomorphic and generic callable admission auditable together"
+    )]
+    fn from_hir(module: &'a HirModule) -> Self {
         let direct_symbols = hew_hir::dispatch::build_direct_call_symbol_index(&module.items);
         let mut pending = Vec::new();
         let mut ineligible = HashMap::new();
+        let mut templates = HashMap::new();
+        let mut generic_templates = Vec::new();
+        let mut functions_by_item = HashMap::new();
         for item in &module.items {
             let HirItem::Function(function) = item else {
                 continue;
             };
-            let signature = match scalar_callable_signature(function) {
-                Ok(signature) => signature,
-                Err(reason) => {
-                    ineligible.insert(function.id, reason);
-                    continue;
-                }
-            };
+            functions_by_item.insert(function.id, function);
             let Some(symbol) = direct_symbols.get(&function.declaration) else {
                 ineligible.insert(
                     function.id,
@@ -122,6 +167,54 @@ impl CallableTable {
                     ),
                 );
                 continue;
+            };
+            if !function.type_params.is_empty() {
+                let signature = match generic_template_signature(function) {
+                    Ok(signature) => signature,
+                    Err(reason) => {
+                        ineligible.insert(function.id, reason);
+                        continue;
+                    }
+                };
+                let id = GenericTemplateId {
+                    declaration: function.declaration.clone(),
+                };
+                let source_origin = function_source_origin(module, function);
+                if templates.contains_key(&function.declaration) {
+                    ineligible.insert(
+                        function.id,
+                        format!(
+                            "duplicate generic HIR template declaration `{}` has no unambiguous SIR template authority",
+                            function.declaration.full_path()
+                        ),
+                    );
+                    continue;
+                }
+                templates.insert(
+                    function.declaration.clone(),
+                    GenericTemplate {
+                        function,
+                        source_origin: source_origin.clone(),
+                        symbol: symbol.clone(),
+                        id: id.clone(),
+                    },
+                );
+                generic_templates.push(SemGenericTemplate {
+                    id,
+                    function: function.id,
+                    symbol: symbol.clone(),
+                    source_origin,
+                    type_params: function.type_params.clone(),
+                    signature,
+                });
+                continue;
+            }
+            let signature = match scalar_callable_signature(function) {
+                Ok(signature) => signature,
+                Err(reason) => {
+                    ineligible.insert(function.id, reason);
+                    continue;
+                }
             };
             pending.push((
                 function,
@@ -140,7 +233,7 @@ impl CallableTable {
         let mut callables = Vec::with_capacity(pending.len());
         let mut root_unit_callables = Vec::new();
         let mut entry_callable = None;
-        let mut by_declaration = HashMap::with_capacity(pending.len());
+        let mut monomorphic_by_declaration = HashMap::with_capacity(pending.len());
         for (index, (function, source_origin, symbol, signature)) in pending.into_iter().enumerate()
         {
             let id = CallableId(
@@ -152,11 +245,12 @@ impl CallableTable {
                     entry_callable = Some(id);
                 }
             }
-            by_declaration.insert(function.declaration.clone(), id);
+            monomorphic_by_declaration.insert(function.declaration.clone(), id);
             callables.push(SemCallable {
                 id,
                 function: function.id,
                 declaration: function.declaration.clone(),
+                instance: CallableInstance::Monomorphic,
                 symbol,
                 source_origin,
                 signature,
@@ -165,11 +259,15 @@ impl CallableTable {
                 effect_summary: EffectSummary::Unknown,
             });
         }
+        generic_templates.sort_by(|left, right| left.id.cmp(&right.id));
         Self {
             callables,
+            generic_templates,
             root_unit_callables,
             entry_callable,
-            by_declaration,
+            monomorphic_by_declaration,
+            templates,
+            functions_by_item,
             ineligible,
         }
     }
@@ -179,6 +277,397 @@ impl CallableTable {
             .get(usize::try_from(id.0).ok()?)
             .filter(|callable| callable.id == id)
     }
+}
+
+/// The first SIR generic slice deliberately has a finite, closed surface.
+/// It is large enough to prove template substitution and call-graph closure,
+/// but rejects any type that would force ownership, aggregate, reference,
+/// resource, or runtime representation policy into SIR.
+const SIR_GENERIC_INSTANCE_CAP: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CallableState {
+    Monomorphic,
+    Queued,
+    Lowering,
+    Lowered,
+    Failed,
+}
+
+/// SIR-owned generic specialization service.
+///
+/// A header is appended to the callable table *before* its body is queued.
+/// Recursive and mutually-recursive calls can therefore refer to the stable
+/// `CallableId` immediately, while a FIFO worklist keeps the construction
+/// deterministic.  The service intentionally never reads
+/// `HirModule::monomorphisations` or invokes MIR lowering.
+struct InstanceService<'a> {
+    module: &'a HirModule,
+    table: CallableTable<'a>,
+    states: Vec<CallableState>,
+    statuses: Vec<Option<SirLoweringStatus>>,
+    by_instance: HashMap<SirInstanceKey, CallableId>,
+    /// Only template headers that back a requested concrete SIR instance are
+    /// emitted into the SIR module. HIR remains the authority for unselected
+    /// generic definitions, so SIR does not accumulate an unrelated second
+    /// template inventory.
+    used_templates: std::collections::HashSet<GenericTemplateId>,
+    pending: VecDeque<CallableId>,
+    functions: Vec<SemFunction>,
+}
+
+impl<'a> InstanceService<'a> {
+    fn new(module: &'a HirModule) -> Self {
+        let table = CallableTable::from_hir(module);
+        let count = table.callables.len();
+        Self {
+            module,
+            table,
+            states: vec![CallableState::Monomorphic; count],
+            statuses: vec![None; count],
+            by_instance: HashMap::new(),
+            used_templates: std::collections::HashSet::new(),
+            pending: VecDeque::new(),
+            functions: Vec::new(),
+        }
+    }
+
+    fn monomorphic_callables(&self) -> Vec<CallableId> {
+        self.table
+            .callables
+            .iter()
+            .map(|callable| callable.id)
+            .collect()
+    }
+
+    fn callable(&self, id: CallableId) -> Option<&SemCallable> {
+        self.table.callable(id)
+    }
+
+    fn lower_monomorphic(&mut self, callable: CallableId) {
+        let result = self.lower_callable(callable);
+        self.record_callable_result(callable, result);
+    }
+
+    fn lower_pending_instances(&mut self) {
+        while let Some(callable) = self.pending.pop_front() {
+            if self.state(callable) != Some(CallableState::Queued) {
+                continue;
+            }
+            self.set_state(callable, CallableState::Lowering);
+            let result = self.lower_callable(callable);
+            self.record_callable_result(callable, result);
+        }
+    }
+
+    fn lower_callable(&mut self, callable: CallableId) -> Result<SemFunction, String> {
+        let input = self.input_for_callable(callable)?;
+        Builder::new(input.function, input.callable, input.substitution, self)?.lower()
+    }
+
+    fn record_callable_result(
+        &mut self,
+        callable: CallableId,
+        result: Result<SemFunction, String>,
+    ) {
+        let index = usize::try_from(callable.0).expect("SIR callable id exceeds usize");
+        match result {
+            Ok(function) => {
+                self.states[index] = CallableState::Lowered;
+                self.statuses[index] = Some(SirLoweringStatus::Lowered);
+                self.functions.push(function);
+            }
+            Err(reason) => {
+                self.states[index] = CallableState::Failed;
+                self.statuses[index] = Some(SirLoweringStatus::Unsupported { reason });
+            }
+        }
+    }
+
+    fn input_for_callable(&self, callable: CallableId) -> Result<LoweringInput<'a>, String> {
+        let callable_meta = self.callable(callable).cloned().ok_or_else(|| {
+            format!(
+                "SIR callable {} is absent from its deterministic table",
+                callable.0
+            )
+        })?;
+        let function = *self
+            .table
+            .functions_by_item
+            .get(&callable_meta.function)
+            .ok_or_else(|| {
+                format!(
+                    "SIR callable `{}` has no HIR source template for its provenance item",
+                    callable_meta.symbol
+                )
+            })?;
+        let substitution = match &callable_meta.instance {
+            CallableInstance::Monomorphic => {
+                if !function.type_params.is_empty() {
+                    return Err(format!(
+                        "generic HIR template `{}` was incorrectly admitted as a monomorphic SIR body",
+                        function.declaration.full_path()
+                    ));
+                }
+                TypeSubstitution::empty()
+            }
+            CallableInstance::Generic(key) => {
+                if key.template.declaration != function.declaration
+                    || callable_meta.declaration != function.declaration
+                {
+                    return Err(format!(
+                        "SIR generic callable `{}` does not agree with its source template declaration",
+                        callable_meta.symbol
+                    ));
+                }
+                TypeSubstitution::for_instance(function, &key.type_args)?
+            }
+        };
+        Ok(LoweringInput {
+            function,
+            callable: callable_meta,
+            substitution,
+        })
+    }
+
+    fn resolve_direct_call(
+        &mut self,
+        declaration: &DefId,
+        call_target: &CallTarget,
+        site: hew_hir::SiteId,
+        substitution: &TypeSubstitution,
+    ) -> Result<SemCallable, String> {
+        if self.table.templates.contains_key(declaration) {
+            if !matches!(call_target, CallTarget::User(_)) {
+                return Err(format!(
+                    "generic direct callee `{}` is not an ordinary user-function call",
+                    declaration.full_path()
+                ));
+            }
+            let raw_args = self.module.call_site_type_args.get(&site).ok_or_else(|| {
+                format!(
+                    "generic direct call to `{}` is missing checker-resolved type arguments at SIR site {}",
+                    declaration.full_path(),
+                    site.0
+                )
+            })?;
+            let type_args = raw_args
+                .iter()
+                .map(|argument| substitution.apply(argument))
+                .collect::<Vec<_>>();
+            let id = self.request_instance(declaration, type_args)?;
+            return self.callable(id).cloned().ok_or_else(|| {
+                format!(
+                    "requested SIR generic callable {} disappeared from its table",
+                    id.0
+                )
+            });
+        }
+        let id = self
+            .table
+            .monomorphic_by_declaration
+            .get(declaration)
+            .copied()
+            .ok_or_else(|| {
+                format!(
+                    "direct callee `{}` has no scalar default-call SIR callable",
+                    declaration.full_path()
+                )
+            })?;
+        self.callable(id)
+            .cloned()
+            .ok_or_else(|| format!("SIR callable {id:?} is absent from its deterministic table"))
+    }
+
+    fn request_instance(
+        &mut self,
+        declaration: &DefId,
+        type_args: Vec<ResolvedTy>,
+    ) -> Result<CallableId, String> {
+        let template = self
+            .table
+            .templates
+            .get(declaration)
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "generic direct callee `{}` has no SIR template admission record",
+                    declaration.full_path()
+                )
+            })?;
+        if type_args.len() != template.function.type_params.len() {
+            return Err(format!(
+                "generic direct callee `{}` expects {} type argument(s), HIR supplied {}",
+                declaration.full_path(),
+                template.function.type_params.len(),
+                type_args.len()
+            ));
+        }
+        for (index, argument) in type_args.iter().enumerate() {
+            if !is_initial_scalar(argument) {
+                return Err(format!(
+                    "generic direct callee `{}` type argument {index} is `{}`; initial SIR generic instances require closed scalar i*/u*/bool types",
+                    declaration.full_path(),
+                    argument.user_facing()
+                ));
+            }
+        }
+        let key = SirInstanceKey {
+            template: template.id,
+            type_args,
+        };
+        self.used_templates.insert(key.template.clone());
+        if let Some(existing) = self.by_instance.get(&key).copied() {
+            return Ok(existing);
+        }
+        if self.by_instance.len() >= SIR_GENERIC_INSTANCE_CAP {
+            return Err(format!(
+                "SIR generic instance cap ({SIR_GENERIC_INSTANCE_CAP}) exceeded while specializing `{}`; refuse unbounded semantic specialization",
+                declaration.full_path()
+            ));
+        }
+        let substitution = TypeSubstitution::for_instance(template.function, &key.type_args)?;
+        let signature =
+            scalar_callable_signature_with_substitution(template.function, &substitution)?;
+        let symbol =
+            hew_hir::monomorph::function_monomorph_symbol(&template.symbol, &key.type_args);
+        if let Some(existing) = self
+            .table
+            .callables
+            .iter()
+            .find(|callable| callable.symbol == symbol)
+        {
+            return Err(format!(
+                "SIR generic instance `{}` would collide with callable {} despite a distinct semantic key",
+                symbol, existing.id.0
+            ));
+        }
+        let id = CallableId(
+            u32::try_from(self.table.callables.len())
+                .map_err(|_| "SIR callable count exceeds the module-local ID range".to_string())?,
+        );
+        self.table.callables.push(SemCallable {
+            id,
+            function: template.function.id,
+            declaration: template.function.declaration.clone(),
+            instance: CallableInstance::Generic(key.clone()),
+            symbol,
+            source_origin: template.source_origin,
+            signature,
+            call_conv: SemCallConv::Default,
+            kind: SemCallableKind::HewDirect,
+            effect_summary: EffectSummary::Unknown,
+        });
+        self.by_instance.insert(key, id);
+        self.states.push(CallableState::Queued);
+        self.statuses.push(None);
+        self.pending.push_back(id);
+        Ok(id)
+    }
+
+    fn source_status(&self, function: &HirFn) -> SirLoweringStatus {
+        if self.table.templates.contains_key(&function.declaration) {
+            let (instances, failed_instances) =
+                self.template_instance_counts(&function.declaration);
+            return SirLoweringStatus::GenericTemplate {
+                instances,
+                failed_instances,
+            };
+        }
+        if let Some(callable) = self
+            .table
+            .monomorphic_by_declaration
+            .get(&function.declaration)
+            .copied()
+        {
+            return self
+                .statuses
+                .get(usize::try_from(callable.0).expect("SIR callable id exceeds usize"))
+                .cloned()
+                .flatten()
+                .unwrap_or_else(|| SirLoweringStatus::Unsupported {
+                    reason: "SIR callable header was never lowered".to_string(),
+                });
+        }
+        SirLoweringStatus::Unsupported {
+            reason: self
+                .table
+                .ineligible
+                .get(&function.id)
+                .cloned()
+                .unwrap_or_else(|| {
+                    "function has no deterministic SIR direct-call entry".to_string()
+                }),
+        }
+    }
+
+    fn template_instance_counts(&self, declaration: &DefId) -> (usize, usize) {
+        let mut instances = 0;
+        let mut failed = 0;
+        for (key, callable) in &self.by_instance {
+            if &key.template.declaration == declaration {
+                instances += 1;
+                if self.state(*callable) == Some(CallableState::Failed) {
+                    failed += 1;
+                }
+            }
+        }
+        (instances, failed)
+    }
+
+    fn state(&self, callable: CallableId) -> Option<CallableState> {
+        self.states.get(usize::try_from(callable.0).ok()?).copied()
+    }
+
+    fn set_state(&mut self, callable: CallableId, state: CallableState) {
+        let index = usize::try_from(callable.0).expect("SIR callable id exceeds usize");
+        self.states[index] = state;
+    }
+
+    fn into_module(self) -> SemModule {
+        let Self {
+            table,
+            used_templates,
+            functions,
+            ..
+        } = self;
+        let generic_templates = table
+            .generic_templates
+            .into_iter()
+            .filter(|template| used_templates.contains(&template.id))
+            .collect();
+        SemModule {
+            callables: table.callables,
+            generic_templates,
+            root_unit_callables: table.root_unit_callables,
+            entry_callable: table.entry_callable,
+            functions,
+        }
+    }
+
+    fn callable_statuses(&self) -> Vec<(CallableId, SirLoweringStatus)> {
+        self.table
+            .callables
+            .iter()
+            .map(|callable| {
+                let index = usize::try_from(callable.id.0).expect("SIR callable id exceeds usize");
+                (
+                    callable.id,
+                    self.statuses[index].clone().unwrap_or_else(|| {
+                        SirLoweringStatus::Unsupported {
+                            reason: "SIR callable header was never lowered".to_string(),
+                        }
+                    }),
+                )
+            })
+            .collect()
+    }
+}
+
+struct LoweringInput<'a> {
+    function: &'a HirFn,
+    callable: SemCallable,
+    substitution: TypeSubstitution,
 }
 
 fn function_source_origin(module: &HirModule, function: &HirFn) -> FunctionSourceOrigin {
@@ -191,55 +680,84 @@ fn function_source_origin(module: &HirModule, function: &HirFn) -> FunctionSourc
     }
 }
 
-fn scalar_callable_signature(function: &HirFn) -> Result<SemSignature, String> {
+fn generic_template_admission(function: &HirFn) -> Result<(), String> {
     if function.is_generator || function.intrinsic_id.is_some() {
         return Err(
             "generators and floor intrinsics remain outside SIR's ordinary direct-call domain"
                 .to_string(),
         );
     }
-    if !function.type_params.is_empty() {
-        return Err(
-            "generic origin functions remain outside SIR's monomorphic direct-call domain"
-                .to_string(),
-        );
-    }
-    let mut params = Vec::with_capacity(function.params.len());
     for (index, parameter) in function.params.iter().enumerate() {
         if parameter.is_consume {
             return Err(format!(
                 "parameter {index} is consume-owned; SIR direct calls initially require Read operands"
             ));
         }
-        if !is_initial_scalar(&parameter.ty) {
-            return Err(format!(
-                "parameter {index} has non-scalar type `{}`; aggregate/reference ABI lowering is deferred",
-                parameter.ty.user_facing()
-            ));
-        }
-        params.push(SemAbiParam {
-            ty: parameter.ty.clone(),
-            passing: SemParamPassing::ReadOnly,
-            caller_visible_projection: false,
-        });
     }
-    if !is_initial_scalar_return(&function.return_ty) {
-        return Err(format!(
-            "return type `{}` is outside SIR's initial scalar call-result domain",
-            function.return_ty.user_facing()
-        ));
-    }
+    Ok(())
+}
+
+fn generic_template_signature(function: &HirFn) -> Result<SemSignature, String> {
+    generic_template_admission(function)?;
     Ok(SemSignature {
-        params,
+        params: function
+            .params
+            .iter()
+            .map(|parameter| SemAbiParam {
+                ty: parameter.ty.clone(),
+                passing: SemParamPassing::ReadOnly,
+                caller_visible_projection: false,
+            })
+            .collect(),
         return_ty: function.return_ty.clone(),
     })
 }
 
-fn is_initial_scalar(ty: &hew_types::ResolvedTy) -> bool {
+fn scalar_callable_signature(function: &HirFn) -> Result<SemSignature, String> {
+    if !function.type_params.is_empty() {
+        return Err(
+            "generic origin functions are instantiated by the SIR instance service, not admitted as abstract callable bodies"
+                .to_string(),
+        );
+    }
+    scalar_callable_signature_with_substitution(function, &TypeSubstitution::empty())
+}
+
+fn scalar_callable_signature_with_substitution(
+    function: &HirFn,
+    substitution: &TypeSubstitution,
+) -> Result<SemSignature, String> {
+    generic_template_admission(function)?;
+    let mut params = Vec::with_capacity(function.params.len());
+    for (index, parameter) in function.params.iter().enumerate() {
+        let ty = substitution.apply(&parameter.ty);
+        if !is_initial_scalar(&ty) {
+            return Err(format!(
+                "parameter {index} has non-scalar type `{}` after semantic substitution; aggregate/reference ABI lowering is deferred",
+                ty.user_facing()
+            ));
+        }
+        params.push(SemAbiParam {
+            ty,
+            passing: SemParamPassing::ReadOnly,
+            caller_visible_projection: false,
+        });
+    }
+    let return_ty = substitution.apply(&function.return_ty);
+    if !is_initial_scalar_return(&return_ty) {
+        return Err(format!(
+            "return type `{}` is outside SIR's initial scalar call-result domain after semantic substitution",
+            return_ty.user_facing()
+        ));
+    }
+    Ok(SemSignature { params, return_ty })
+}
+
+fn is_initial_scalar(ty: &ResolvedTy) -> bool {
     ty.is_integer() || matches!(ty, hew_types::ResolvedTy::Bool)
 }
 
-fn is_initial_scalar_return(ty: &hew_types::ResolvedTy) -> bool {
+fn is_initial_scalar_return(ty: &ResolvedTy) -> bool {
     matches!(ty, hew_types::ResolvedTy::Unit) || is_initial_scalar(ty)
 }
 
@@ -312,11 +830,11 @@ fn initial_scalar_transfer_mode(
 }
 
 fn lower_initial_scalar_transfer_value(
-    builder: &mut Builder<'_>,
+    builder: &mut Builder<'_, '_>,
     expr: &HirExpr,
     context: &str,
 ) -> Result<ValueId, String> {
-    initial_scalar_transfer_mode(expr.intent, &expr.ty, context)?;
+    initial_scalar_transfer_mode(expr.intent, &builder.ty(&expr.ty), context)?;
     builder.lower_expr(expr)
 }
 
@@ -327,13 +845,14 @@ fn lower_initial_scalar_transfer_value(
 /// read-only in the initial slice. A unit expression in `return` instead
 /// transfers control to the caller; HIR marks that transfer `Consume`, which
 /// is harmless for `Unit` but must not be rechecked as an ordinary operand use.
-fn lower_initial_unit_return(builder: &mut Builder<'_>, expr: &HirExpr) -> Result<(), String> {
+fn lower_initial_unit_return(builder: &mut Builder<'_, '_>, expr: &HirExpr) -> Result<(), String> {
     let mode = use_mode_from_hir_intent(expr.intent)
         .map_err(|reason| format!("unit return value: {reason}"))?;
-    if !matches!(mode, UseMode::Read | UseMode::Move) || expr.ty != hew_types::ResolvedTy::Unit {
+    let ty = builder.ty(&expr.ty);
+    if !matches!(mode, UseMode::Read | UseMode::Move) || ty != ResolvedTy::Unit {
         return Err(format!(
             "unit return value: HIR intent maps to SIR {mode:?} for `{}`; initial SIR admits only Read or Unit Move return transfer",
-            expr.ty.user_facing()
+            ty.user_facing()
         ));
     }
     if !matches!(expr.kind, HirExprKind::Call { .. }) {
@@ -398,69 +917,82 @@ impl PendingBlock {
     }
 }
 
-struct Builder<'a> {
-    function: &'a HirFn,
-    callables: &'a CallableTable,
-    callable: CallableId,
+struct Builder<'hir, 'service> {
+    function: &'hir HirFn,
+    service: &'service mut InstanceService<'hir>,
+    callable: SemCallable,
+    substitution: TypeSubstitution,
     blocks: Vec<PendingBlock>,
     current: BlockId,
     values: u32,
     ops: u32,
     bindings: HashMap<BindingId, ValueId>,
     params: Vec<BlockArg>,
-    source_origin: FunctionSourceOrigin,
 }
 
-impl<'a> Builder<'a> {
+impl<'hir, 'service> Builder<'hir, 'service> {
     fn new(
-        function: &'a HirFn,
-        source_origin: FunctionSourceOrigin,
-        callables: &'a CallableTable,
-        callable: CallableId,
-    ) -> Self {
+        function: &'hir HirFn,
+        callable: SemCallable,
+        substitution: TypeSubstitution,
+        service: &'service mut InstanceService<'hir>,
+    ) -> Result<Self, String> {
+        if function.params.len() != callable.signature.params.len() {
+            return Err(format!(
+                "SIR callable `{}` has {} parameter ABI facts, but its HIR template has {} parameter(s)",
+                callable.symbol,
+                callable.signature.params.len(),
+                function.params.len()
+            ));
+        }
         let entry = BlockId(0);
         let mut values = 0;
         let mut bindings = HashMap::new();
         let params = function
             .params
             .iter()
-            .map(|param| {
+            .zip(&callable.signature.params)
+            .enumerate()
+            .map(|(index, (param, abi))| {
+                let ty = substitution.apply(&param.ty);
+                if ty != abi.ty {
+                    return Err(format!(
+                        "SIR callable `{}` parameter {index} has `{}`, but its substituted HIR template has `{}`",
+                        callable.symbol,
+                        abi.ty.user_facing(),
+                        ty.user_facing()
+                    ));
+                }
                 let value = ValueId(values);
                 values += 1;
                 bindings.insert(param.id, value);
-                BlockArg {
+                Ok(BlockArg {
                     value,
-                    ty: param.ty.clone(),
-                }
+                    ty,
+                })
             })
-            .collect();
-        Self {
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok(Self {
             function,
-            callables,
+            service,
             callable,
+            substitution,
             blocks: vec![PendingBlock::new(entry, Vec::new())],
             current: entry,
             values,
             ops: 0,
             bindings,
             params,
-            source_origin,
-        }
+        })
     }
 
     fn lower(mut self) -> Result<SemFunction, String> {
-        let callable = self.callables.callable(self.callable).ok_or_else(|| {
-            format!(
-                "SIR callable {:?} is absent while lowering `{}`",
-                self.callable, self.function.name
-            )
-        })?;
-        if callable.function != self.function.id
-            || callable.declaration != self.function.declaration
-            || callable.symbol != self.function.name
+        if self.callable.function != self.function.id
+            || self.callable.declaration != self.function.declaration
         {
             return Err(
-                "SIR callable table does not match the HIR function's checked identity".to_string(),
+                "SIR callable provenance does not match the HIR function's checked identity"
+                    .to_string(),
             );
         }
         if self.function.is_generator || self.function.intrinsic_id.is_some() {
@@ -468,11 +1000,26 @@ impl<'a> Builder<'a> {
                 "generators and floor intrinsics remain on the established MIR path".to_string(),
             );
         }
-        if !self.function.type_params.is_empty() {
-            return Err(
-                "generic origin functions remain on the established MIR path until SIR is monomorphization-aware"
+        match (
+            &self.callable.instance,
+            self.function.type_params.is_empty(),
+        ) {
+            (CallableInstance::Monomorphic, true) => {}
+            (CallableInstance::Generic(key), false)
+                if key.template.declaration == self.function.declaration
+                    && key.type_args == self.substitution.args => {}
+            _ => return Err(
+                "SIR callable instance does not match its HIR template and semantic substitution"
                     .to_string(),
-            );
+            ),
+        }
+        if self.callable.signature.return_ty != self.ty(&self.function.return_ty) {
+            return Err(format!(
+                "SIR callable `{}` return type `{}` differs from substituted HIR template return `{}`",
+                self.callable.symbol,
+                self.callable.signature.return_ty.user_facing(),
+                self.ty(&self.function.return_ty).user_facing()
+            ));
         }
         let result = self.lower_block(&self.function.body)?;
         if self.is_open() {
@@ -484,13 +1031,13 @@ impl<'a> Builder<'a> {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(SemFunction {
             id: self.function.id,
-            callable: self.callable,
+            callable: self.callable.id,
             declaration: self.function.declaration.clone(),
-            name: self.function.name.clone(),
+            name: self.callable.symbol.clone(),
             span: self.function.span.clone(),
-            source_origin: self.source_origin,
+            source_origin: self.callable.source_origin.clone(),
             params: self.params,
-            return_ty: self.function.return_ty.clone(),
+            return_ty: self.callable.signature.return_ty.clone(),
             entry: BlockId(0),
             blocks,
         })
@@ -537,7 +1084,7 @@ impl<'a> Builder<'a> {
                 }
                 HirStmtKind::Return(value) => {
                     let value = match value {
-                        Some(expr) if expr.ty == hew_types::ResolvedTy::Unit => {
+                        Some(expr) if self.ty(&expr.ty) == ResolvedTy::Unit => {
                             lower_initial_unit_return(self, expr)?;
                             None
                         }
@@ -565,7 +1112,7 @@ impl<'a> Builder<'a> {
         }
         if self.is_open() {
             match block.tail.as_deref() {
-                Some(expr) if expr.ty == hew_types::ResolvedTy::Unit => {
+                Some(expr) if self.ty(&expr.ty) == ResolvedTy::Unit => {
                     self.lower_discarded_expr(expr)?;
                     Ok(None)
                 }
@@ -600,19 +1147,19 @@ impl<'a> Builder<'a> {
     fn lower_expr(&mut self, expr: &HirExpr) -> Result<ValueId, String> {
         match &expr.kind {
             HirExprKind::Literal(HirLiteral::Integer(value)) => {
-                if !expr.ty.is_integer() {
+                if !self.ty(&expr.ty).is_integer() {
                     return Err(format!(
                         "integer literal resolved as `{}` needs a dedicated SIR literal representation",
-                        expr.ty.user_facing()
+                        self.ty(&expr.ty).user_facing()
                     ));
                 }
                 self.emit(expr, SemOpKind::ConstI64(*value))
             }
             HirExprKind::Literal(HirLiteral::Bool(value)) => {
-                if expr.ty != hew_types::ResolvedTy::Bool {
+                if self.ty(&expr.ty) != ResolvedTy::Bool {
                     return Err(format!(
                         "boolean literal resolved as `{}` violates the SIR bool literal invariant",
-                        expr.ty.user_facing()
+                        self.ty(&expr.ty).user_facing()
                     ));
                 }
                 self.emit(expr, SemOpKind::ConstBool(*value))
@@ -648,7 +1195,7 @@ impl<'a> Builder<'a> {
                     expr,
                     SemOpKind::Cast {
                         value,
-                        to: to_ty.clone(),
+                        to: self.ty(to_ty),
                     },
                 )
             }
@@ -701,9 +1248,8 @@ impl<'a> Builder<'a> {
         };
         let declaration =
             match target {
-                hew_types::CallTarget::User(declaration)
-                | hew_types::CallTarget::ImplMethod(declaration) => declaration,
-                hew_types::CallTarget::IndirectFunctionValue => {
+                CallTarget::User(declaration) | CallTarget::ImplMethod(declaration) => declaration,
+                CallTarget::IndirectFunctionValue => {
                     return Err(
                         "indirect calls are deferred until SIR models the callee value explicitly"
                             .to_string(),
@@ -720,30 +1266,13 @@ impl<'a> Builder<'a> {
                     .to_string(),
             );
         }
-        let callee = self
-            .callables
-            .by_declaration
-            .get(declaration)
-            .copied()
-            .ok_or_else(|| {
-                format!(
-                    "direct callee `{}` has no scalar default-call SIR callable",
-                    declaration.full_path()
-                )
-            })?;
-        let (callee_declaration, params, return_ty) = self
-            .callables
-            .callable(callee)
-            .map(|signature| {
-                (
-                    signature.declaration.clone(),
-                    signature.signature.params.clone(),
-                    signature.signature.return_ty.clone(),
-                )
-            })
-            .ok_or_else(|| {
-                format!("SIR callable {callee:?} is absent from its deterministic table")
-            })?;
+        let callee =
+            self.service
+                .resolve_direct_call(declaration, target, expr.site, &self.substitution)?;
+        let callee_id = callee.id;
+        let callee_declaration = callee.declaration.clone();
+        let params = callee.signature.params.clone();
+        let return_ty = callee.signature.return_ty.clone();
         if args.len() != params.len() {
             return Err(format!(
                 "direct callee `{}` expects {} argument(s), HIR carries {}",
@@ -752,12 +1281,13 @@ impl<'a> Builder<'a> {
                 args.len()
             ));
         }
-        if expr.ty != return_ty {
+        let expression_ty = self.ty(&expr.ty);
+        if expression_ty != return_ty {
             return Err(format!(
                 "direct callee `{}` returns `{}`, but call expression has `{}`",
                 callee_declaration.full_path(),
                 return_ty.user_facing(),
-                expr.ty.user_facing()
+                expression_ty.user_facing()
             ));
         }
         let mut lowered_args = Vec::with_capacity(args.len());
@@ -768,11 +1298,12 @@ impl<'a> Builder<'a> {
                     callee_declaration.full_path()
                 ));
             }
-            if arg.ty != expected.ty {
+            let argument_ty = self.ty(&arg.ty);
+            if argument_ty != expected.ty {
                 return Err(format!(
                     "direct call argument {index} to `{}` has `{}`, expected `{}`",
                     callee_declaration.full_path(),
-                    arg.ty.user_facing(),
+                    argument_ty.user_facing(),
                     expected.ty.user_facing()
                 ));
             }
@@ -785,10 +1316,10 @@ impl<'a> Builder<'a> {
             )?);
         }
         let kind = SemOpKind::Call {
-            callee,
+            callee: callee_id,
             args: lowered_args,
         };
-        if return_ty == hew_types::ResolvedTy::Unit {
+        if return_ty == ResolvedTy::Unit {
             if value_required {
                 return Err(format!(
                     "unit-valued direct call `{}` cannot produce an SSA value",
@@ -815,7 +1346,7 @@ impl<'a> Builder<'a> {
         let join_value = self.fresh_value();
         let join_block = self.new_block(vec![BlockArg {
             value: join_value,
-            ty: whole.ty.clone(),
+            ty: self.ty(&whole.ty),
         }]);
         self.set_terminator(SemTerminator::Branch {
             condition,
@@ -882,7 +1413,7 @@ impl<'a> Builder<'a> {
         right: &HirExpr,
         short_circuit_value: bool,
     ) -> Result<ValueId, String> {
-        if whole.ty != hew_types::ResolvedTy::Bool {
+        if self.ty(&whole.ty) != ResolvedTy::Bool {
             return Err("short-circuit logical expressions must have bool type in SIR".to_string());
         }
         let condition = self.lower_read_operand(left, "logical condition")?;
@@ -891,7 +1422,7 @@ impl<'a> Builder<'a> {
         let result = self.fresh_value();
         let join = self.new_block(vec![BlockArg {
             value: result,
-            ty: whole.ty.clone(),
+            ty: self.ty(&whole.ty),
         }]);
         let (then_target, else_target) = if short_circuit_value {
             (short_circuit, evaluate_right)
@@ -942,7 +1473,7 @@ impl<'a> Builder<'a> {
             id: OpId(self.ops),
             results: vec![ValueDef {
                 id: value,
-                ty: expr.ty.clone(),
+                ty: self.ty(&expr.ty),
             }],
             kind,
             provenance: Provenance::Site(expr.site),
@@ -969,6 +1500,11 @@ impl<'a> Builder<'a> {
         self.values += 1;
         value
     }
+
+    fn ty(&self, ty: &ResolvedTy) -> ResolvedTy {
+        self.substitution.apply(ty)
+    }
+
     fn new_block(&mut self, args: Vec<BlockArg>) -> BlockId {
         let id = BlockId(u32::try_from(self.blocks.len()).expect("SIR block count exceeds u32"));
         self.blocks.push(PendingBlock::new(id, args));

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -15,6 +15,39 @@ pub struct OpId(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CallableId(pub u32);
 
+/// Stable semantic identity for one generic HIR template.
+///
+/// This deliberately contains the resolver-minted declaration identity only.
+/// A linker symbol is an emitted-name projection, not part of semantic
+/// instance identity: two concrete SIR bodies are deduplicated by this
+/// template plus their closed semantic substitutions.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GenericTemplateId {
+    pub declaration: DefId,
+}
+
+/// Closed semantic specialization of a generic HIR template.
+///
+/// SIR creates these at the normalized-HIR boundary.  `type_args` are
+/// `ResolvedTy` facts only; no layout, ABI, storage, or target information is
+/// permitted to enter this key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SirInstanceKey {
+    pub template: GenericTemplateId,
+    pub type_args: Vec<ResolvedTy>,
+}
+
+/// Semantic instance kind of a resolved SIR callable.
+///
+/// `CallableId` is the identity of an emitted SIR body.  The source `ItemId`
+/// and `DefId` retained by [`SemCallable`] are provenance for that body; they
+/// are not sufficient to identify a generic instance on their own.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CallableInstance {
+    Monomorphic,
+    Generic(SirInstanceKey),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Provenance {
     Site(SiteId),
@@ -156,6 +189,10 @@ pub struct SemBlock {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemFunction {
+    /// Source HIR item provenance for this body.
+    ///
+    /// A generic template can produce several SIR functions with this same
+    /// value.  Consumers must use [`Self::callable`] as the body identity.
     pub id: ItemId,
     /// Module-local ABI-neutral identity of this body's resolved callable.
     /// The verifier proves this agrees with the callable table's checker
@@ -225,6 +262,31 @@ pub struct SemSignature {
     pub return_ty: ResolvedTy,
 }
 
+/// Body-free semantic header for one generic HIR definition.
+///
+/// SIR never retains an abstract generic function body: every
+/// [`CallableInstance::Generic`] is a concrete, closed semantic instance.
+/// The header preserves just enough pre-substitution semantic information for
+/// the verifier to prove that a concrete callable's provenance, signature,
+/// and derived emitted symbol actually match its [`SirInstanceKey`].  It is
+/// deliberately free of layout, ABI carrier, storage, and target facts.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SemGenericTemplate {
+    /// Semantic template identity used by every concrete instance key.
+    pub id: GenericTemplateId,
+    /// Source HIR provenance only; this is not the identity of a concrete SIR
+    /// callable body.
+    pub function: ItemId,
+    /// Base emitted symbol. Concrete symbols are derived from this *after*
+    /// semantic-key selection and are never part of the key itself.
+    pub symbol: String,
+    pub source_origin: FunctionSourceOrigin,
+    /// Canonical source-semantic parameters in substitution order.
+    pub type_params: Vec<String>,
+    /// Pre-substitution semantic callable signature.
+    pub signature: SemSignature,
+}
+
 /// Conservative interprocedural effect summary carried by a resolved SIR
 /// callable.
 ///
@@ -266,11 +328,18 @@ impl EffectSummary {
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemCallable {
     pub id: CallableId,
-    /// HIR function item that owns the body when it is lowered to SIR.
+    /// Source HIR item provenance for the body.  This is not an SIR-body
+    /// identity: one generic HIR item may have multiple concrete callables.
     pub function: ItemId,
     /// Resolver-minted semantic declaration identity.
     pub declaration: DefId,
-    /// Exact body symbol selected by HIR's direct-call symbol index.
+    /// Whether this callable is a monomorphic source body or one concrete
+    /// generic specialization.  This is the authoritative semantic instance
+    /// identity; `symbol` is only its derived emitted-name projection.
+    pub instance: CallableInstance,
+    /// Exact emitted body symbol. Monomorphic callables retain the resolver's
+    /// direct-call symbol; a generic callable derives this only after its
+    /// canonical semantic instance has been selected.
     pub symbol: String,
     pub source_origin: FunctionSourceOrigin,
     pub signature: SemSignature,
@@ -284,6 +353,10 @@ pub struct SemModule {
     /// Deterministic resolved direct-call authority.  IDs must equal their
     /// indexes in this vector; [`crate::verify_module`] checks that invariant.
     pub callables: Vec<SemCallable>,
+    /// Body-free generic semantic headers. These are the substitution
+    /// authority for concrete generic callables and must not be confused with
+    /// abstract SIR function bodies.
+    pub generic_templates: Vec<SemGenericTemplate>,
     /// Every root-unit callable in `callables` order. This supports source
     /// provenance and diagnostics; executable strict reachability starts only
     /// from [`Self::entry_callable`], so unrelated root bodies do not block a
@@ -306,12 +379,34 @@ impl SemModule {
             .filter(|callable| callable.id == id)
     }
 
-    /// Find a resolved callable from checker-owned declaration identity.
+    /// Find a monomorphic resolved callable from checker-owned declaration
+    /// identity.
+    ///
+    /// A generic declaration can own many concrete SIR bodies, so callers
+    /// must use [`Self::callable_for_instance`] for that case rather than
+    /// accidentally selecting an arbitrary specialization.
     #[must_use]
     pub fn callable_for_declaration(&self, declaration: &DefId) -> Option<&SemCallable> {
-        self.callables
+        self.callables.iter().find(|callable| {
+            &callable.declaration == declaration
+                && matches!(callable.instance, CallableInstance::Monomorphic)
+        })
+    }
+
+    /// Find one concrete generic callable from its closed semantic key.
+    #[must_use]
+    pub fn callable_for_instance(&self, key: &SirInstanceKey) -> Option<&SemCallable> {
+        self.callables.iter().find(|callable| {
+            matches!(&callable.instance, CallableInstance::Generic(candidate) if candidate == key)
+        })
+    }
+
+    /// Look up the body-free semantic template header for an instance key.
+    #[must_use]
+    pub fn generic_template(&self, id: &GenericTemplateId) -> Option<&SemGenericTemplate> {
+        self.generic_templates
             .iter()
-            .find(|callable| &callable.declaration == declaration)
+            .find(|template| &template.id == id)
     }
 
     /// Return the lowered SIR body for `id`, if the body was in the current

--- a/hew-sir/src/verify.rs
+++ b/hew-sir/src/verify.rs
@@ -2,9 +2,11 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::OpId;
 use crate::{
-    BlockId, CallableId, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule, SemOp,
-    SemOpKind, SemParamPassing, SemTerminator, UseMode, UseSite, ValueId,
+    BlockId, CallableId, CallableInstance, GenericTemplateId, SemCallConv, SemCallable,
+    SemCallableKind, SemFunction, SemGenericTemplate, SemModule, SemOp, SemOpKind, SemParamPassing,
+    SemSignature, SemTerminator, SirInstanceKey, UseMode, UseSite, ValueId,
 };
+use hew_hir::{monomorph::function_monomorph_symbol, substitute_type_params};
 use hew_types::ResolvedTy;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,7 +15,13 @@ pub enum SirDiagnosticKind {
     DuplicateFunctionDeclaration(String),
     DuplicateCallableId(CallableId),
     DuplicateCallableDeclaration(String),
+    DuplicateCallableInstance(String),
     DuplicateCallableSymbol(String),
+    DuplicateGenericTemplate(String),
+    InvalidGenericTemplate {
+        template: String,
+        reason: String,
+    },
     InvalidCallable {
         callable: CallableId,
         reason: String,
@@ -158,7 +166,10 @@ pub fn verify_module(module: &SemModule) -> Vec<SirDiagnostic> {
                 SirDiagnosticKind::DuplicateFunctionName(function.name.clone()),
             ));
         }
-        if !declarations.insert(function.declaration.clone()) {
+        let monomorphic_body = callables
+            .callable(function.callable)
+            .is_none_or(|callable| matches!(callable.instance, CallableInstance::Monomorphic));
+        if monomorphic_body && !declarations.insert(function.declaration.clone()) {
             diagnostics.push(diag(
                 function,
                 SirDiagnosticKind::DuplicateFunctionDeclaration(format!(
@@ -349,9 +360,12 @@ fn verify_callable_table<'a>(
     module: &'a SemModule,
     diagnostics: &mut Vec<SirDiagnostic>,
 ) -> CallableContext<'a> {
+    let generic_templates = verify_generic_template_headers(module, diagnostics);
     let mut by_id = BTreeMap::new();
     let mut ids = HashSet::new();
-    let mut declarations = HashSet::new();
+    let mut monomorphic_declarations = HashSet::new();
+    let mut generic_declarations = HashSet::new();
+    let mut generic_instances = HashSet::new();
     let mut symbols = HashSet::new();
     for (index, callable) in module.callables.iter().enumerate() {
         let expected = CallableId(
@@ -371,12 +385,49 @@ fn verify_callable_table<'a>(
                 callable.id,
             )));
         }
-        if !declarations.insert(callable.declaration.clone()) {
-            diagnostics.push(module_diag(
-                SirDiagnosticKind::DuplicateCallableDeclaration(
-                    callable.declaration.full_path().to_string(),
-                ),
-            ));
+        match &callable.instance {
+            CallableInstance::Monomorphic => {
+                if !monomorphic_declarations.insert(callable.declaration.clone()) {
+                    diagnostics.push(module_diag(
+                        SirDiagnosticKind::DuplicateCallableDeclaration(
+                            callable.declaration.full_path().to_string(),
+                        ),
+                    ));
+                }
+                if generic_declarations.contains(&callable.declaration) {
+                    diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                        callable: callable.id,
+                        reason: "a declaration cannot have both a monomorphic SIR body and concrete generic SIR instances"
+                            .to_string(),
+                    }));
+                }
+                if generic_templates.contains_key(&GenericTemplateId {
+                    declaration: callable.declaration.clone(),
+                }) {
+                    diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                        callable: callable.id,
+                        reason: "a declaration with a generic semantic template header cannot also be a monomorphic SIR body"
+                            .to_string(),
+                    }));
+                }
+            }
+            CallableInstance::Generic(key) => {
+                generic_declarations.insert(callable.declaration.clone());
+                if monomorphic_declarations.contains(&callable.declaration) {
+                    diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                        callable: callable.id,
+                        reason: "a declaration cannot have both a monomorphic SIR body and concrete generic SIR instances"
+                            .to_string(),
+                    }));
+                }
+                verify_generic_callable_instance(
+                    callable,
+                    key,
+                    &mut generic_instances,
+                    &generic_templates,
+                    diagnostics,
+                );
+            }
         }
         if !symbols.insert(callable.symbol.clone()) {
             diagnostics.push(module_diag(SirDiagnosticKind::DuplicateCallableSymbol(
@@ -506,6 +557,182 @@ fn verify_callable_table<'a>(
         }
     }
     CallableContext { by_id }
+}
+
+/// Collect and verify body-free semantic template headers before checking
+/// concrete generic callable bodies.
+fn verify_generic_template_headers<'a>(
+    module: &'a SemModule,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) -> BTreeMap<GenericTemplateId, &'a SemGenericTemplate> {
+    let mut templates = BTreeMap::new();
+    for template in &module.generic_templates {
+        let name = template.id.declaration.full_path().to_string();
+        if template.type_params.is_empty() {
+            diagnostics.push(module_diag(SirDiagnosticKind::InvalidGenericTemplate {
+                template: name.clone(),
+                reason: "a generic template header must retain at least one type parameter"
+                    .to_string(),
+            }));
+        }
+        let mut type_params = HashSet::new();
+        for (index, parameter) in template.type_params.iter().enumerate() {
+            if parameter.is_empty() {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidGenericTemplate {
+                    template: name.clone(),
+                    reason: format!("type parameter {index} has an empty semantic name"),
+                }));
+            }
+            if !type_params.insert(parameter) {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidGenericTemplate {
+                    template: name.clone(),
+                    reason: format!("type parameter `{parameter}` occurs more than once"),
+                }));
+            }
+        }
+        for (index, parameter) in template.signature.params.iter().enumerate() {
+            if parameter.passing != SemParamPassing::ReadOnly || parameter.caller_visible_projection
+            {
+                diagnostics.push(module_diag(SirDiagnosticKind::InvalidGenericTemplate {
+                    template: name.clone(),
+                    reason: format!(
+                        "template parameter {index} carries ownership or caller-visible ABI policy before SIR owns it"
+                    ),
+                }));
+            }
+        }
+        if templates.insert(template.id.clone(), template).is_some() {
+            diagnostics.push(module_diag(SirDiagnosticKind::DuplicateGenericTemplate(
+                name,
+            )));
+        }
+    }
+    templates
+}
+
+/// Verify the semantic identity of one concrete SIR generic body.
+///
+/// The initial generic slice intentionally accepts only scalar concrete type
+/// arguments, but the key still records them as `ResolvedTy` rather than any
+/// representation property.  This makes malformed or residual generic SIR
+/// fail here, before raw MIR is allowed to choose storage or ABI details.
+fn verify_generic_callable_instance(
+    callable: &SemCallable,
+    key: &SirInstanceKey,
+    seen: &mut HashSet<SirInstanceKey>,
+    templates: &BTreeMap<GenericTemplateId, &SemGenericTemplate>,
+    diagnostics: &mut Vec<SirDiagnostic>,
+) {
+    if key.template.declaration != callable.declaration {
+        diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+            callable: callable.id,
+            reason: "generic instance template declaration does not match callable provenance"
+                .to_string(),
+        }));
+    }
+    if key.type_args.is_empty() {
+        diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+            callable: callable.id,
+            reason: "generic instance has no semantic type arguments".to_string(),
+        }));
+    }
+    if !seen.insert(key.clone()) {
+        diagnostics.push(module_diag(SirDiagnosticKind::DuplicateCallableInstance(
+            format!(
+                "{}<{}>",
+                key.template.declaration.full_path(),
+                key.type_args
+                    .iter()
+                    .map(|ty| ty.user_facing().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        )));
+    }
+    for (index, argument) in key.type_args.iter().enumerate() {
+        if !is_initial_scalar(argument) {
+            diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+                callable: callable.id,
+                reason: format!(
+                    "generic semantic type argument {index} `{}` is outside the initial scalar SIR instance surface",
+                    argument.user_facing()
+                ),
+            }));
+        }
+    }
+    let Some(template) = templates.get(&key.template).copied() else {
+        diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+            callable: callable.id,
+            reason: "generic instance has no body-free semantic template header".to_string(),
+        }));
+        return;
+    };
+    if callable.function != template.function {
+        diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+            callable: callable.id,
+            reason: "generic instance source item provenance does not match its semantic template header"
+                .to_string(),
+        }));
+    }
+    if callable.source_origin != template.source_origin {
+        diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+            callable: callable.id,
+            reason: "generic instance source origin does not match its semantic template header"
+                .to_string(),
+        }));
+    }
+    if key.type_args.len() != template.type_params.len() {
+        diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+            callable: callable.id,
+            reason: format!(
+                "generic instance carries {} type argument(s), but template `{}` requires {}",
+                key.type_args.len(),
+                template.id.declaration.full_path(),
+                template.type_params.len()
+            ),
+        }));
+        return;
+    }
+    let expected_signature = substitute_template_signature(template, &key.type_args);
+    if callable.signature != expected_signature {
+        diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+            callable: callable.id,
+            reason: "generic instance signature does not equal its semantic template signature after substitution"
+                .to_string(),
+        }));
+    }
+    let expected_symbol = function_monomorph_symbol(&template.symbol, &key.type_args);
+    if callable.symbol != expected_symbol {
+        diagnostics.push(module_diag(SirDiagnosticKind::InvalidCallable {
+            callable: callable.id,
+            reason:
+                "generic instance emitted symbol is not the derived projection of its semantic key"
+                    .to_string(),
+        }));
+    }
+}
+
+fn substitute_template_signature(
+    template: &SemGenericTemplate,
+    type_args: &[ResolvedTy],
+) -> SemSignature {
+    SemSignature {
+        params: template
+            .signature
+            .params
+            .iter()
+            .map(|parameter| crate::SemAbiParam {
+                ty: substitute_type_params(&parameter.ty, &template.type_params, type_args),
+                passing: parameter.passing,
+                caller_visible_projection: parameter.caller_visible_projection,
+            })
+            .collect(),
+        return_ty: substitute_type_params(
+            &template.signature.return_ty,
+            &template.type_params,
+            type_args,
+        ),
+    }
 }
 
 fn verify_function_callable_identity(

--- a/hew-sir/tests/lower_calls.rs
+++ b/hew-sir/tests/lower_calls.rs
@@ -1,8 +1,10 @@
 use hew_hir::{lower_program_host_target, ResolutionCtx};
-use hew_sir::{dump_sir, lower_module, verify_module, SemOpKind, SirLoweringStatus};
-use hew_types::{module_registry::ModuleRegistry, Checker};
+use hew_sir::{
+    dump_sir, lower_module, verify_module, CallableInstance, SemOpKind, SirLoweringStatus,
+};
+use hew_types::{module_registry::ModuleRegistry, Checker, ResolvedTy};
 
-fn lower_source(source: &str) -> hew_sir::LoweredModule {
+fn lower_hir(source: &str) -> hew_hir::HirModule {
     let parsed = hew_parser::parse(source);
     assert!(
         parsed.errors.is_empty(),
@@ -17,7 +19,12 @@ fn lower_source(source: &str) -> hew_sir::LoweredModule {
         "source must lower to HIR before the SIR lowering test: {:#?}",
         hir.diagnostics
     );
-    lower_module(&hir.module)
+    hir.module
+}
+
+fn lower_source(source: &str) -> hew_sir::LoweredModule {
+    let hir = lower_hir(source);
+    lower_module(&hir)
 }
 
 #[test]
@@ -318,5 +325,291 @@ fn recursive_scalar_call_resolves_to_its_own_callable_id() {
         verify_module(module).is_empty(),
         "recursive direct-call SIR must verify: {:#?}",
         verify_module(module)
+    );
+}
+
+/// Generic SIR instances are discovered from checked call-site facts rather
+/// than copied from HIR's legacy monomorphisation registry.  This exercises
+/// three core requirements together: nested generic forwarding, per-instance
+/// deduplication, and a header-first self-recursive instance.
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the fixture intentionally verifies one complete instance graph, malformed-IR boundary, and dump"
+)]
+fn generic_scalar_instances_are_closed_cached_and_template_free() {
+    let mut hir = lower_hir(
+        r"
+        pub fn id<T>(x: T) -> T {
+            let result: T = x;
+            return result;
+        }
+
+        pub fn relay<U>(y: U) -> U {
+            id(id(y))
+        }
+
+        pub fn countdown<T>(value: T, n: i64) -> T {
+            if n == 0 {
+                value
+            } else {
+                countdown(value, n - 1)
+            }
+        }
+
+        fn main() -> i64 {
+            let forwarded: i64 = relay(40);
+            let counted: i64 = countdown(forwarded, 2);
+            let flag: bool = id(true);
+            if flag { counted } else { 0 }
+        }
+        ",
+    );
+    assert!(
+        !hir.monomorphisations.is_empty(),
+        "the fixture must prove SIR is not merely observing an empty legacy registry"
+    );
+    hir.monomorphisations.clear();
+
+    let lowered = lower_module(&hir);
+    assert!(
+        verify_module(&lowered.module).is_empty(),
+        "closed generic SIR instances must verify without the legacy registry: {:#?}",
+        verify_module(&lowered.module)
+    );
+    for name in ["id", "relay", "countdown"] {
+        assert!(
+            matches!(
+                lowered
+                    .statuses
+                    .iter()
+                    .find(|(candidate, _)| candidate == name),
+                Some((
+                    _,
+                    SirLoweringStatus::GenericTemplate {
+                        failed_instances: 0,
+                        ..
+                    }
+                ))
+            ),
+            "generic HIR origin `{name}` must remain a template, not an abstract SIR body: {:#?}",
+            lowered.statuses
+        );
+    }
+    assert!(matches!(
+        lowered
+            .statuses
+            .iter()
+            .find(|(candidate, _)| candidate == "main"),
+        Some((_, SirLoweringStatus::Lowered))
+    ));
+    assert_eq!(
+        lowered.module.generic_templates.len(),
+        3,
+        "SIR must retain only body-free template headers for id, relay, and countdown"
+    );
+
+    let generic_callables = lowered
+        .module
+        .callables
+        .iter()
+        .filter(|callable| matches!(&callable.instance, CallableInstance::Generic(_)))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        generic_callables.len(),
+        4,
+        "id<i64>, id<bool>, relay<i64>, and countdown<i64> must be the complete concrete SIR instance set: {generic_callables:#?}"
+    );
+    assert!(
+        lowered
+            .module
+            .functions
+            .iter()
+            .all(|function| !["id", "relay", "countdown"].contains(&function.name.as_str())),
+        "generic origin templates must never appear as abstract SIR functions: {:#?}",
+        lowered.module.functions
+    );
+    for symbol in ["id$$i64", "id$$bool", "relay$$i64", "countdown$$i64"] {
+        assert!(
+            lowered
+                .module
+                .functions
+                .iter()
+                .any(|function| function.name == symbol),
+            "missing concrete semantic SIR body `{symbol}`"
+        );
+    }
+
+    let id_i64 = generic_callables
+        .iter()
+        .find(|callable| callable.symbol == "id$$i64")
+        .expect("nested forwarding must request id<i64>");
+    let id_i64_key = match &id_i64.instance {
+        CallableInstance::Generic(key) => key,
+        CallableInstance::Monomorphic => panic!("id<i64> must retain a semantic instance key"),
+    };
+    assert_eq!(
+        lowered
+            .module
+            .callable_for_instance(id_i64_key)
+            .map(|callable| callable.id),
+        Some(id_i64.id),
+        "instance lookup must use the closed semantic key, not a mangled symbol"
+    );
+    let relay_i64 = generic_callables
+        .iter()
+        .find(|callable| callable.symbol == "relay$$i64")
+        .expect("main must request relay<i64>");
+    let relay_body = lowered
+        .module
+        .function_for_callable(relay_i64.id)
+        .expect("concrete relay<i64> body must be lowered");
+    let relay_callees = relay_body
+        .blocks
+        .iter()
+        .flat_map(|block| &block.ops)
+        .filter_map(|operation| match &operation.kind {
+            SemOpKind::Call { callee, .. } => Some(*callee),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(relay_callees, vec![id_i64.id, id_i64.id]);
+
+    let countdown_i64 = generic_callables
+        .iter()
+        .find(|callable| callable.symbol == "countdown$$i64")
+        .expect("main must request countdown<i64>");
+    let countdown_body = lowered
+        .module
+        .function_for_callable(countdown_i64.id)
+        .expect("concrete countdown<i64> body must be lowered");
+    assert!(countdown_body
+        .blocks
+        .iter()
+        .flat_map(|block| &block.ops)
+        .any(|operation| matches!(&operation.kind, SemOpKind::Call { callee, .. } if *callee == countdown_i64.id)),
+        "self-recursive concrete instance must resolve through its preallocated CallableId");
+    assert!(
+        lowered
+            .callable_statuses
+            .iter()
+            .all(|(_, status)| matches!(status, SirLoweringStatus::Lowered)),
+        "every requested concrete instance must have a body: {:#?}",
+        lowered.callable_statuses
+    );
+    let dump = dump_sir(&lowered.module);
+    assert!(dump.contains("fn relay$$i64("));
+    assert!(dump.contains("call @id$$i64"));
+    assert!(dump.contains("fn countdown$$i64("));
+
+    let mut forged_signature = lowered.module.clone();
+    let id_i64_index = usize::try_from(id_i64.id.0).expect("callable ID fits usize");
+    forged_signature.callables[id_i64_index].signature.return_ty = ResolvedTy::Bool;
+    assert!(
+        verify_module(&forged_signature).iter().any(|diagnostic| matches!(
+            &diagnostic.kind,
+            hew_sir::SirDiagnosticKind::InvalidCallable { callable, reason }
+                if *callable == id_i64.id
+                    && reason.contains("semantic template signature after substitution")
+        )),
+        "the verifier must reject a generic callable whose concrete signature does not match its key: {:#?}",
+        verify_module(&forged_signature)
+    );
+
+    let mut mixed_forms = lowered.module.clone();
+    let mut forged_monomorphic = (**id_i64).clone();
+    forged_monomorphic.id = hew_sir::CallableId(
+        u32::try_from(mixed_forms.callables.len()).expect("test callable count fits u32"),
+    );
+    forged_monomorphic.instance = CallableInstance::Monomorphic;
+    forged_monomorphic.symbol = "forged_id_monomorphic".to_string();
+    mixed_forms.callables.push(forged_monomorphic);
+    assert!(
+        verify_module(&mixed_forms)
+            .iter()
+            .any(|diagnostic| matches!(
+                &diagnostic.kind,
+                hew_sir::SirDiagnosticKind::InvalidCallable { reason, .. }
+                    if reason.contains("generic semantic template header")
+            )),
+        "the verifier must reject an abstract monomorphic body alongside a generic template: {:#?}",
+        verify_module(&mixed_forms)
+    );
+}
+
+/// A generic instance header must be published before its body is lowered.
+/// Otherwise the first body in this cycle could request `odd<i64>` but the
+/// second body would be unable to resolve its edge back to `even<i64>`.
+#[test]
+fn generic_scalar_instances_support_mutual_recursion_without_legacy_monomorphisation() {
+    let mut hir = lower_hir(
+        r"
+        pub fn even<T>(value: T, count: i64) -> T {
+            if count == 0 {
+                value
+            } else {
+                odd(value, count - 1)
+            }
+        }
+
+        pub fn odd<T>(value: T, count: i64) -> T {
+            if count == 0 {
+                value
+            } else {
+                even(value, count - 1)
+            }
+        }
+
+        fn main() -> i64 {
+            even(42, 2)
+        }
+        ",
+    );
+    assert!(
+        !hir.monomorphisations.is_empty(),
+        "the fixture must prove SIR closes the generic cycle itself"
+    );
+    hir.monomorphisations.clear();
+
+    let lowered = lower_module(&hir);
+    assert!(
+        verify_module(&lowered.module).is_empty(),
+        "mutually recursive generic instances must verify without legacy monomorphisation: {:#?}",
+        verify_module(&lowered.module)
+    );
+    let even = lowered
+        .module
+        .callables
+        .iter()
+        .find(|callable| callable.symbol == "even$$i64")
+        .expect("main must request a concrete even<i64> callable");
+    let odd = lowered
+        .module
+        .callables
+        .iter()
+        .find(|callable| callable.symbol == "odd$$i64")
+        .expect("even<i64> must request a concrete odd<i64> callable");
+    for (caller, expected_callee) in [(even, odd.id), (odd, even.id)] {
+        let body = lowered
+            .module
+            .function_for_callable(caller.id)
+            .expect("every predeclared concrete generic header must receive a body");
+        assert!(
+            body.blocks
+                .iter()
+                .flat_map(|block| &block.ops)
+                .any(|operation| matches!(&operation.kind, SemOpKind::Call { callee, .. } if *callee == expected_callee)),
+            "{} must retain the cross-recursive edge to callable {}",
+            caller.symbol,
+            expected_callee.0
+        );
+    }
+    assert!(
+        lowered
+            .callable_statuses
+            .iter()
+            .all(|(_, status)| matches!(status, SirLoweringStatus::Lowered)),
+        "the closed mutual-recursive instance graph must have no missing body: {:#?}",
+        lowered.callable_statuses
     );
 }

--- a/hew-sir/tests/sir.rs
+++ b/hew-sir/tests/sir.rs
@@ -2,7 +2,7 @@ use hew_hir::ItemId;
 use hew_parser::ast::BinaryOp;
 use hew_sir::{
     build_def_use, dump_sir, replace_all_uses, replace_use, verify_function_in_module,
-    verify_module, BlockArg, BlockId, CallableId, Edge, EffectSet, EffectSummary,
+    verify_module, BlockArg, BlockId, CallableId, CallableInstance, Edge, EffectSet, EffectSummary,
     FunctionSourceOrigin, OpId, Operand, OperandSlot, Provenance, RewriteError, SemAbiParam,
     SemBlock, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind,
     SemParamPassing, SemSignature, SemTerminator, SirDiagnosticKind, UseMode, UseSite, ValueDef,
@@ -29,6 +29,7 @@ fn callable_for(function: &SemFunction) -> SemCallable {
         id: function.callable,
         function: function.id,
         declaration: function.declaration.clone(),
+        instance: CallableInstance::Monomorphic,
         symbol: function.name.clone(),
         source_origin: function.source_origin.clone(),
         signature: SemSignature {
@@ -61,6 +62,7 @@ fn module(functions: Vec<SemFunction>) -> SemModule {
     }
     SemModule {
         callables,
+        generic_templates: Vec::new(),
         root_unit_callables: Vec::new(),
         entry_callable: None,
         functions,

--- a/scripts/sir-shadow-corpus.sh
+++ b/scripts/sir-shadow-corpus.sh
@@ -134,11 +134,15 @@ corpus_nonempty_assert "sir-shadow-fixtures" "${#fixtures[@]}" || exit 1
 
 # The report is informational for humans, but it is also the proof that this
 # gate actually reached the experimental lane.  It intentionally stays on
-# stderr so `--dump-mir` retains its ordinary stdout contract.
+# stderr so `--dump-mir` retains its ordinary stdout contract.  Keep this
+# parser exact: the five counts distinguish monomorphic HIR bodies, generic
+# templates, HIR declarations, realized concrete SIR bodies, and the concrete
+# SIR-body total.  Loosening it would let a reporting drift turn this coverage
+# gate into a green no-op.
 extract_report() {
     local stderr_path="$1"
     sed -nE \
-        's/^SIR shadow: verified ([0-9]+)\/([0-9]+) HIR function bodies; realized ([0-9]+)\/([0-9]+) through raw MIR$/\1 \2 \3 \4/p' \
+        's/^SIR shadow: verified ([0-9]+) monomorphic HIR body\/bodies and registered ([0-9]+) generic template\(s\) across ([0-9]+) HIR function declaration\(s\); realized ([0-9]+)\/([0-9]+) concrete SIR body\/bodies through raw MIR$/\1 \2 \3 \4 \5/p' \
         "$stderr_path"
 }
 
@@ -162,8 +166,10 @@ run_compile() {
 failures=0
 successes=0
 verified=0
-function_bodies=0
+generic_templates=0
+hir_declarations=0
 realized=0
+concrete_bodies=0
 
 for index in "${!fixtures[@]}"; do
     fixture="${fixtures[$index]}"
@@ -208,12 +214,15 @@ for index in "${!fixtures[@]}"; do
             echo "FAIL $label: ambiguous SIR coverage report" >&2
             fixture_failed=1
         else
-            read -r fixture_verified fixture_bodies fixture_realized _ <<<"$report"
+            read -r fixture_verified fixture_templates fixture_bodies fixture_realized fixture_concrete_bodies _ <<<"$report"
             verified=$((verified + fixture_verified))
-            function_bodies=$((function_bodies + fixture_bodies))
+            generic_templates=$((generic_templates + fixture_templates))
+            hir_declarations=$((hir_declarations + fixture_bodies))
             realized=$((realized + fixture_realized))
-            printf 'ok   %s  (SIR %s/%s verified, %s realized)\n' \
-                "$label" "$fixture_verified" "$fixture_bodies" "$fixture_realized"
+            concrete_bodies=$((concrete_bodies + fixture_concrete_bodies))
+            printf 'ok   %s  (SIR %s monomorphic, %s template(s), %s HIR declarations, %s/%s concrete realized)\n' \
+                "$label" "$fixture_verified" "$fixture_templates" "$fixture_bodies" \
+                "$fixture_realized" "$fixture_concrete_bodies"
         fi
     fi
 
@@ -236,4 +245,4 @@ if [[ "$failures" -ne 0 ]]; then
     exit 1
 fi
 
-echo "sir-shadow-corpus: OK (${#fixtures[@]} fixtures, $successes successful baseline compiles, SIR $verified/$function_bodies verified, $realized realized)"
+echo "sir-shadow-corpus: OK (${#fixtures[@]} fixtures, $successes successful baseline compiles, SIR $verified monomorphic, $generic_templates template(s), $hir_declarations HIR declarations, $realized/$concrete_bodies concrete realized)"


### PR DESCRIPTION
## Summary

- introduce a SIR-owned, deterministic generic instance service at the Normalized-HIR → SIR boundary
- specialize direct scalar user functions from closed `DefId + ResolvedTy[]` keys, with header-first FIFO discovery for self and mutual recursion
- retain body-free semantic template headers so the SIR verifier proves each instance key, substituted signature, provenance, and derived symbol agree
- keep generic template bodies out of SIR and deliberately ignore `HirModule.monomorphisations`
- strictly lower selected generic call graphs through existing Raw → Checked → Elaborated MIR with no legacy generic body fallback

## Scope

This first semantic specialization slice admits only closed scalar direct-user instances. It deliberately excludes generic aggregates, references, trait/impl dispatch, ownership transfer, runtime calls, and layout facts. Concrete types appear in SIR; layout and ABI remain below SIR.

## Dependency

Stacked on #3037, which completes explicit Elaborated MIR for the strict SIR lane. Once #3037 merges, this PR will be rebased/retargeted to `main` before merge.

## Validation

- `cargo test -p hew-sir --no-fail-fast` (31 tests)
- `cargo test -p hew-mir --test sir_generic_instances --no-fail-fast`
- `cargo test -p hew-cli --test sir_shadow_e2e --no-fail-fast` (11 tests, including native generic compile/run)
- `cargo check --workspace`
- affected-crate strict Clippy, formatting, and diff checks

## Review evidence

Regression coverage clears the legacy HIR monomorphization registry before SIR lowering; proves cached `id<i64>`/`id<bool>`, nested forwarding, explicit generic let/return substitution, self and mutual recursion, malformed signature rejection, and mixed mono/generic authority rejection.