### PR TITLE
feat(mir): add verified virtual Raw values

### DIFF
--- a/hew-cli/tests/sir_shadow_e2e.rs
+++ b/hew-cli/tests/sir_shadow_e2e.rs
@@ -45,6 +45,30 @@ fn increment(value: i64) -> i64 {
 }
 ";
 
+/// The smallest source-level vertical slice for Raw MIR virtual values. The
+/// tuple must remain semantic/value-only through strict SIR lowering; only
+/// its selected scalar field reaches the existing return ABI slot.
+const VIRTUAL_TUPLE_PROJECTION: &str = r"
+fn main() -> i64 {
+    let pair = (0, 42);
+    pair.0
+}
+";
+
+/// Extends the virtual tuple proof to the only ABI shape admitted by the
+/// first Raw-value slice: `BitCopy` scalar parameters. The tuple itself remains
+/// internal and semantic; `pair_second` returns only a selected scalar.
+const VIRTUAL_TUPLE_SCALAR_PARAMS: &str = r"
+fn pair_second(x: i64, y: i64) -> i64 {
+    let pair = (x, y);
+    pair.1
+}
+
+fn main() -> i64 {
+    pair_second(42, 0)
+}
+";
+
 const SHORT_CIRCUIT_INSPECTION: &str = r"
 fn rhs() -> bool {
     true
@@ -169,6 +193,24 @@ fn function_section<'a>(dump: &'a str, name: &str) -> &'a str {
     let end = rest[1..]
         .find("\nfn ")
         .map_or(rest.len(), |index| index + 1);
+    &rest[..end]
+}
+
+fn llvm_function_section<'a>(llvm: &'a str, name: &str) -> &'a str {
+    let symbol = format!("@{name}(");
+    let start = llvm
+        .match_indices(&symbol)
+        .find_map(|(symbol_start, _)| {
+            let line_start = llvm[..symbol_start]
+                .rfind('\n')
+                .map_or(0, |index| index + 1);
+            llvm[line_start..symbol_start]
+                .starts_with("define ")
+                .then_some(line_start)
+        })
+        .unwrap_or_else(|| panic!("LLVM IR must define `{symbol}`:\n{llvm}"));
+    let rest = &llvm[start..];
+    let end = rest.find("\n}").map_or(rest.len(), |index| index + 2);
     &rest[..end]
 }
 
@@ -342,6 +384,180 @@ fn sir_lower_closed_direct_call_graph_compiles_and_runs() {
     assert_success(
         &executed,
         "native binary containing only SIR-lowered bodies must run successfully",
+    );
+}
+
+/// A source tuple projection must select the strict SIR → virtual Raw MIR
+/// path, cross Checked and Elaborated MIR as a no-drop body, and execute as a
+/// native binary. The raw dump is part of the assertion: it rules out quietly
+/// returning to the legacy `Place`/storage lowering path merely because the
+/// observable result happens to be scalar.
+#[test]
+fn sir_lower_virtual_tuple_projection_compiles_and_runs_without_legacy_storage() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_virtual_tuple_projection.hew");
+    fs::write(&source, VIRTUAL_TUPLE_PROJECTION).expect("write virtual tuple SIR fixture");
+
+    let lowered = raw_mir_dump(&source, Some("--sir-lower"));
+    assert_success(&lowered, "strict SIR virtual tuple raw dump must succeed");
+    let dump = String::from_utf8_lossy(&lowered.stdout);
+    let main = function_section(&dump, "main");
+    assert!(
+        main.contains("tuple.make")
+            && main.contains("tuple.get")
+            && main.contains("materialize.return_abi"),
+        "source tuple must lower through Raw MIR virtual values:\n{main}"
+    );
+    assert!(
+        !main.contains("locals:") && !main.contains("tuple.construct"),
+        "virtual tuple lowering must not reintroduce legacy storage operations:\n{main}"
+    );
+    let dump_stderr = String::from_utf8_lossy(&lowered.stderr);
+    assert!(
+        dump_stderr.contains("no legacy MIR bodies were lowered"),
+        "strict tuple dump must report that no legacy body was used:\n{}",
+        describe_output(&lowered)
+    );
+
+    let mut compile = Command::new(hew_binary());
+    compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--emit-dir")
+        .arg(dir.path())
+        .arg(&source)
+        .current_dir(repo_root());
+    let compiled = support::run_bounded_command(compile, "compile strict SIR virtual tuple");
+    assert_success(
+        &compiled,
+        "source tuple must reach LLVM through strict SIR virtual Raw MIR",
+    );
+    let compile_stderr = String::from_utf8_lossy(&compiled.stderr);
+    assert!(
+        compile_stderr.contains("no legacy MIR bodies were lowered"),
+        "strict tuple compile must report no legacy fallback:\n{}",
+        describe_output(&compiled)
+    );
+
+    let binary = hew_testutil::compiled_binary_path(dir.path(), "sir_virtual_tuple_projection");
+    assert!(
+        binary.is_file(),
+        "virtual tuple compile did not produce expected native binary {}:\n{}",
+        binary.display(),
+        describe_output(&compiled),
+    );
+    let executed = support::run_bounded_command(
+        Command::new(&binary),
+        format!("run strict SIR virtual tuple {}", binary.display()),
+    );
+    assert_success(
+        &executed,
+        "native virtual tuple program must return the selected zero field",
+    );
+}
+
+/// Scalar parameters of a virtual tuple body must map directly to LLVM
+/// parameters, rather than acquiring legacy Raw-MIR locals or allocas. This
+/// is source-driver coverage for the ABI contract also exercised by the
+/// hand-built LLVM fixture.
+#[test]
+fn sir_lower_virtual_tuple_scalar_params_remain_value_only() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_virtual_tuple_scalar_params.hew");
+    let emit_dir = dir.path().join("emit");
+    fs::create_dir(&emit_dir).expect("create virtual tuple scalar parameter emit directory");
+    fs::write(&source, VIRTUAL_TUPLE_SCALAR_PARAMS)
+        .expect("write virtual tuple scalar parameter SIR fixture");
+
+    let lowered = raw_mir_dump(&source, Some("--sir-lower"));
+    assert_success(
+        &lowered,
+        "strict SIR virtual scalar-parameter raw dump must succeed",
+    );
+    let dump = String::from_utf8_lossy(&lowered.stdout);
+    let pair_second = function_section(&dump, "pair_second");
+    assert!(
+        pair_second.contains("param 0")
+            && pair_second.contains("param 1")
+            && pair_second.contains("tuple.make")
+            && pair_second.contains("tuple.get")
+            && pair_second.contains("materialize.return_abi"),
+        "scalar tuple parameters must lower through Raw virtual values:\n{pair_second}"
+    );
+    assert!(
+        !pair_second.contains("locals:")
+            && !pair_second.contains("local_0")
+            && !pair_second.contains("local_1")
+            && !pair_second.contains("tuple.construct"),
+        "virtual scalar parameters must not reintroduce storage or allocas:\n{pair_second}"
+    );
+    let dump_stderr = String::from_utf8_lossy(&lowered.stderr);
+    assert!(
+        dump_stderr.contains("no legacy MIR bodies were lowered"),
+        "strict scalar-parameter dump must report no legacy fallback:\n{}",
+        describe_output(&lowered)
+    );
+
+    let mut compile = Command::new(hew_binary());
+    compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--emit-llvm")
+        .arg("--emit-dir")
+        .arg(&emit_dir)
+        .arg(&source)
+        .current_dir(repo_root());
+    let compiled = support::run_bounded_command(
+        compile,
+        "compile strict SIR virtual tuple scalar parameters",
+    );
+    assert_success(
+        &compiled,
+        "source scalar parameters must reach LLVM through strict SIR virtual Raw MIR",
+    );
+    let compile_stderr = String::from_utf8_lossy(&compiled.stderr);
+    assert!(
+        compile_stderr.contains("no legacy MIR bodies were lowered"),
+        "strict scalar-parameter compile must report no legacy fallback:\n{}",
+        describe_output(&compiled)
+    );
+
+    let llvm = fs::read_to_string(emit_dir.join("sir_virtual_tuple_scalar_params.ll"))
+        .expect("strict scalar-parameter LLVM emission must produce an .ll artifact");
+    let pair_second_llvm = llvm_function_section(&llvm, "pair_second");
+    assert!(
+        pair_second_llvm.contains("insertvalue { i64, i64 }")
+            && pair_second_llvm.contains("extractvalue { i64, i64 }"),
+        "scalar tuple body must retain an LLVM aggregate value:\n{pair_second_llvm}"
+    );
+    assert!(
+        !pair_second_llvm.contains("alloca { i64, i64 }")
+            && !pair_second_llvm.contains("local_0")
+            && !pair_second_llvm.contains("local_1"),
+        "scalar tuple parameters must not acquire tuple or parameter local allocas:\n{pair_second_llvm}"
+    );
+
+    let binary = hew_testutil::compiled_binary_path(&emit_dir, "sir_virtual_tuple_scalar_params");
+    assert!(
+        binary.is_file(),
+        "virtual scalar-parameter compile did not produce expected native binary {}:\n{}",
+        binary.display(),
+        describe_output(&compiled),
+    );
+    let executed = support::run_bounded_command(
+        Command::new(&binary),
+        format!(
+            "run strict SIR virtual tuple scalar parameters {}",
+            binary.display()
+        ),
+    );
+    assert_success(
+        &executed,
+        "native virtual tuple scalar-parameter program must return the selected zero field",
     );
 }
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -75,14 +75,15 @@ use hew_hir::stdlib_catalog::PrintKind;
 use hew_hir::{mangle_dotted_name, ItemId};
 use hew_mir::{
     instr_source_places, is_string_const_ty, terminator_source_places, validate_context_markers,
-    ActorHandlerKind, ActorLayout, ActorStateLoadMode, CallAuthority, CheckedMirFunction, CmpPred,
-    CooperateKind, CooperateSite, DropFnSpec, DropKind, DynVtableInstance, ElabDrop,
-    ElaboratedMirFunction, EnumLayout, ExitPath, FieldOffset, FloatWidth, FunctionCallConv, Instr,
-    IntArithOp, IntSignedness, IoHandleKind, IrPipeline, LambdaEnvFieldDrop, MachineVariantLayout,
-    MirConst, MirConstValue, MirScope, ParamBoundaryMode, ParamLoanStorage, Place, RawMirFunction,
-    RecordLayout, RegexLiteral, ResourceCloseAuthority, RuntimeCall, SourceOrigin,
-    StateFieldCloneKind, Strategy, StringRetainCondition, SupervisorChildLayout, SuspendKind,
-    Terminator, TrapKind,
+    verify_raw_virtual_value_ladder, ActorHandlerKind, ActorLayout, ActorStateLoadMode,
+    CallAuthority, CheckedMirFunction, CmpPred, CooperateKind, CooperateSite, DropFnSpec, DropKind,
+    DynVtableInstance, ElabDrop, ElaboratedMirFunction, EnumLayout, ExitPath, FieldOffset,
+    FloatWidth, FunctionCallConv, Instr, IntArithOp, IntSignedness, IoHandleKind, IrPipeline,
+    LambdaEnvFieldDrop, MachineVariantLayout, MirConst, MirConstValue, MirScope, ParamBoundaryMode,
+    ParamLoanStorage, Place, RawMirFunction, RawValueDef, RawValueId, RawValueOp,
+    RawVirtualValueFacts, RecordLayout, RegexLiteral, ResourceCloseAuthority, RuntimeCall,
+    SourceOrigin, StateFieldCloneKind, Strategy, StringRetainCondition, SupervisorChildLayout,
+    SuspendKind, Terminator, TrapKind,
 };
 pub(crate) use hew_types::short_name;
 use hew_types::{
@@ -1952,6 +1953,10 @@ pub(crate) struct FnCtx<'a, 'ctx> {
     /// use their target-specific process/status boundary until LLVM exposes
     /// the corresponding funclet builders through Inkwell.
     pub(crate) unwind_enabled: bool,
+    /// The declared LLVM function currently being lowered. Raw virtual
+    /// parameter definitions bind directly to this function's incoming ABI
+    /// values, rather than creating a storage local solely for the prologue.
+    pub(crate) llvm_fn: FunctionValue<'ctx>,
     /// Emit `hew_shutdown_initiate_implicit(0)` + `hew_shutdown_wait()` before the
     /// `Terminator::Return` in the native program entry point of an
     /// actor-using program — the implicit actor-drain floor.
@@ -2082,6 +2087,11 @@ pub(crate) struct FnCtx<'a, 'ctx> {
     /// ABI helpers that must encode a value from its source type, not only its
     /// LLVM storage shape.
     pub(crate) local_tys: HashMap<u32, ResolvedTy>,
+    /// Raw value id → LLVM SSA value for the narrowly admitted value-only Raw
+    /// MIR subset. This is intentionally separate from `locals`: entries here
+    /// have no address and must cross an explicit `MaterializeValue` boundary
+    /// before a storage-oriented lowering may observe them.
+    pub(crate) raw_values: RefCell<HashMap<RawValueId, BasicValueEnum<'ctx>>>,
     /// Block id → LLVM `BasicBlock`. Populated up front so terminators can
     /// name forward targets.
     pub(crate) blocks: HashMap<u32, inkwell::basic_block::BasicBlock<'ctx>>,
@@ -12439,6 +12449,205 @@ fn lower_try_width_cast(
     }
 }
 
+fn raw_value_matches_type(value: BasicValueEnum<'_>, expected: BasicTypeEnum<'_>) -> bool {
+    match (value, expected) {
+        (BasicValueEnum::IntValue(value), BasicTypeEnum::IntType(expected)) => {
+            value.get_type() == expected
+        }
+        (BasicValueEnum::StructValue(value), BasicTypeEnum::StructType(expected)) => {
+            value.get_type() == expected
+        }
+        _ => false,
+    }
+}
+
+fn raw_value_type<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    ty: &ResolvedTy,
+    context: &str,
+) -> CodegenResult<BasicTypeEnum<'ctx>> {
+    resolve_value_ty(
+        fn_ctx.ctx,
+        fn_ctx.target_data,
+        ty,
+        fn_ctx.record_layouts,
+        fn_ctx.enum_layouts,
+    )
+    .map_err(|error| {
+        CodegenError::FailClosed(format!(
+            "{context} cannot resolve virtual value type `{}`: {error}",
+            ty.user_facing()
+        ))
+    })
+}
+
+fn raw_value_get<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    value: RawValueId,
+    context: &str,
+) -> CodegenResult<BasicValueEnum<'ctx>> {
+    fn_ctx
+        .raw_values
+        .borrow()
+        .get(&value)
+        .copied()
+        .ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "{context} reads undefined raw virtual value %{}",
+                value.0
+            ))
+        })
+}
+
+fn raw_value_define<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    dest: &RawValueDef,
+    value: BasicValueEnum<'ctx>,
+    context: &str,
+) -> CodegenResult<()> {
+    let expected = raw_value_type(fn_ctx, &dest.ty, context)?;
+    if !raw_value_matches_type(value, expected) {
+        return Err(CodegenError::FailClosed(format!(
+            "{context} defines raw virtual value %{} as LLVM type {:?}, expected `{}`",
+            dest.id.0,
+            value,
+            dest.ty.user_facing()
+        )));
+    }
+    if fn_ctx
+        .raw_values
+        .borrow_mut()
+        .insert(dest.id, value)
+        .is_some()
+    {
+        return Err(CodegenError::FailClosed(format!(
+            "{context} defines raw virtual value %{} more than once",
+            dest.id.0
+        )));
+    }
+    Ok(())
+}
+
+fn lower_raw_value_op<'ctx>(fn_ctx: &FnCtx<'_, 'ctx>, operation: &RawValueOp) -> CodegenResult<()> {
+    match operation {
+        RawValueOp::Param { dest, index } => {
+            let llvm_index = usize::try_from(*index)
+                .map_err(|_| {
+                    CodegenError::FailClosed("raw virtual parameter index exceeds usize".into())
+                })?
+                .saturating_add(usize::from(fn_ctx.execution_context.is_some()));
+            let llvm_index = u32::try_from(llvm_index).map_err(|_| {
+                CodegenError::FailClosed("raw virtual LLVM parameter index exceeds u32".into())
+            })?;
+            let incoming = fn_ctx.llvm_fn.get_nth_param(llvm_index).ok_or_else(|| {
+                CodegenError::FailClosed(format!(
+                    "raw virtual parameter {} has no corresponding LLVM ABI parameter",
+                    index
+                ))
+            })?;
+            raw_value_define(fn_ctx, dest, incoming, "raw virtual parameter")
+        }
+        RawValueOp::ConstI64 { dest, value } => {
+            let BasicTypeEnum::IntType(integer) =
+                raw_value_type(fn_ctx, &dest.ty, "raw virtual integer realization")?
+            else {
+                return Err(CodegenError::FailClosed(
+                    "raw virtual integer realization did not resolve to an LLVM integer".into(),
+                ));
+            };
+            #[allow(clippy::cast_sign_loss)]
+            let value = integer.const_int(*value as u64, true);
+            raw_value_define(fn_ctx, dest, value.into(), "raw virtual integer constant")
+        }
+        RawValueOp::ConstBool { dest, value } => {
+            let BasicTypeEnum::IntType(integer) =
+                raw_value_type(fn_ctx, &dest.ty, "raw virtual boolean realization")?
+            else {
+                return Err(CodegenError::FailClosed(
+                    "raw virtual boolean realization did not resolve to an LLVM integer".into(),
+                ));
+            };
+            let value = integer.const_int(u64::from(*value), false);
+            raw_value_define(fn_ctx, dest, value.into(), "raw virtual boolean constant")
+        }
+        RawValueOp::TupleMake { dest, fields } => {
+            let BasicTypeEnum::StructType(struct_ty) =
+                raw_value_type(fn_ctx, &dest.ty, "raw virtual tuple realization")?
+            else {
+                return Err(CodegenError::FailClosed(
+                    "raw virtual tuple realization did not resolve to an LLVM struct".into(),
+                ));
+            };
+            let mut aggregate = struct_ty.get_undef();
+            for (index, field) in fields.iter().enumerate() {
+                let field_value = raw_value_get(fn_ctx, *field, "raw virtual tuple.make")?;
+                let index = u32::try_from(index).map_err(|_| {
+                    CodegenError::FailClosed("raw virtual tuple field index exceeds u32".into())
+                })?;
+                aggregate = match fn_ctx
+                    .builder
+                    .build_insert_value(aggregate, field_value, index, "raw_tuple_make")
+                    .llvm_ctx("raw virtual tuple insertvalue")?
+                {
+                    inkwell::values::AggregateValueEnum::StructValue(value) => value,
+                    inkwell::values::AggregateValueEnum::ArrayValue(_) => {
+                        return Err(CodegenError::FailClosed(
+                            "raw virtual tuple insertvalue unexpectedly produced an LLVM array"
+                                .into(),
+                        ));
+                    }
+                };
+            }
+            raw_value_define(fn_ctx, dest, aggregate.into(), "raw virtual tuple.make")
+        }
+        RawValueOp::TupleGet { dest, tuple, index } => {
+            let tuple_value = raw_value_get(fn_ctx, *tuple, "raw virtual tuple.get")?;
+            let BasicValueEnum::StructValue(tuple_value) = tuple_value else {
+                return Err(CodegenError::FailClosed(format!(
+                    "raw virtual tuple.get reads non-struct value %{}",
+                    tuple.0
+                )));
+            };
+            let field_count = tuple_value.get_type().count_fields();
+            if *index >= field_count {
+                return Err(CodegenError::FailClosed(format!(
+                    "raw virtual tuple.get index {index} is outside tuple value %{} with {field_count} fields",
+                    tuple.0
+                )));
+            }
+            let value = fn_ctx
+                .builder
+                .build_extract_value(tuple_value, *index, "raw_tuple_get")
+                .llvm_ctx("raw virtual tuple extractvalue")?;
+            raw_value_define(fn_ctx, dest, value, "raw virtual tuple.get")
+        }
+    }
+}
+
+fn lower_raw_value_materialization<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    value: RawValueId,
+) -> CodegenResult<()> {
+    let value = raw_value_get(fn_ctx, value, "raw virtual ReturnAbi materialization")?;
+    let expected = raw_value_type(
+        fn_ctx,
+        &fn_ctx.return_resolved_ty,
+        "raw virtual ReturnAbi materialization",
+    )?;
+    if !raw_value_matches_type(value, expected) || !raw_value_matches_type(value, fn_ctx.return_ty)
+    {
+        return Err(CodegenError::FailClosed(format!(
+            "raw virtual ReturnAbi value is incompatible with return type `{}`",
+            fn_ctx.return_resolved_ty.user_facing()
+        )));
+    }
+    fn_ctx
+        .builder
+        .build_store(fn_ctx.return_slot, value)
+        .llvm_ctx("raw virtual ReturnAbi store")?;
+    Ok(())
+}
+
 fn lower_instruction_with_cancel_drops(
     fn_ctx: &FnCtx<'_, '_>,
     instr: &Instr,
@@ -12461,6 +12670,8 @@ fn lower_instruction_with_cancel_drops(
     })?;
 
     match instr {
+        Instr::Value(operation) => lower_raw_value_op(fn_ctx, operation)?,
+        Instr::MaterializeValue { value, .. } => lower_raw_value_materialization(fn_ctx, *value)?,
         Instr::OwnershipEvent(_) | Instr::InteriorMutationCommit { .. } => {}
         Instr::EnterContext | Instr::ExitContext => {
             if fn_ctx.execution_context.is_none() {
@@ -34695,6 +34906,23 @@ fn apply_optnone_for_debug<'ctx>(ctx: &'ctx Context, func: inkwell::values::Func
     }
 }
 
+/// Admit the Raw value-only lane through its complete MIR ladder before LLVM
+/// realizes it.  This uses the canonical `hew-mir` type/def-use facts rather
+/// than treating `RawValueOp::Param` as a prologue hint that codegen must
+/// independently validate.
+fn virtual_raw_value_facts(
+    func: &RawMirFunction,
+    checked: Option<&CheckedMirFunction>,
+    elaborated: Option<&ElaboratedMirFunction>,
+) -> CodegenResult<Option<RawVirtualValueFacts>> {
+    verify_raw_virtual_value_ladder(func, checked, elaborated).map_err(|error| {
+        CodegenError::FailClosed(format!(
+            "raw virtual-value admission failed for `{}`: {}",
+            func.name, error.reason
+        ))
+    })
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "module-lowering context is deliberately passed as explicit borrows"
@@ -34732,6 +34960,7 @@ fn lower_function<'ctx>(
         ))
     })?;
     let (llvm_fn, return_ty_llvm, _returns_unit) = symbol.real(&func.name, "lower_function")?;
+    let virtual_value_facts = virtual_raw_value_facts(func, checked, elab)?;
     // gdb `-g`: mark every debug-built non-coroutine function `optnone noinline`
     // so the backend keeps each local's stack slot eagerly written. Without it,
     // even at `-O0` LLVM's instruction selection coalesces a `store slot; load
@@ -35235,6 +35464,13 @@ fn lower_function<'ctx>(
                     func.name
                 ))
             })?;
+        if virtual_value_facts.is_some() {
+            // `RawValueOp::Param` binds this incoming LLVM value directly at
+            // its explicit ordered body definition. The canonical Raw verifier
+            // proves every ABI parameter has exactly one such definition and
+            // that this body has no `Place::Local` representation.
+            continue;
+        }
         let (slot, slot_ty) = *locals.get(&param_idx_u32).ok_or_else(|| {
             CodegenError::FailClosed(format!(
                 "function `{}` has no local slot for param index {param_idx}",
@@ -35687,6 +35923,7 @@ fn lower_function<'ctx>(
         ctx,
         llvm_mod,
         unwind_enabled,
+        llvm_fn,
         emit_drain_epilogue,
         emit_immediate_shutdown_epilogue,
         emit_runtime_cleanup_epilogue,
@@ -35711,6 +35948,7 @@ fn lower_function<'ctx>(
         alloca_prologue: prologue_bb,
         locals,
         local_tys,
+        raw_values: RefCell::new(HashMap::new()),
         blocks: blocks.clone(),
         runtime_decls: RefCell::new(HashMap::new()),
         runtime_unwind_block: std::cell::Cell::new(None),

--- a/hew-codegen-rs/src/llvm_tests.rs
+++ b/hew-codegen-rs/src/llvm_tests.rs
@@ -1,8 +1,10 @@
 use super::*;
-use hew_hir::IntentKind;
+use hew_hir::{IntentKind, SiteId, ValueClass};
 use hew_mir::{
-    BasicBlock, BlockKind, CallAuthority, CollectionLayoutProbeKind, CompilerCallKind,
-    DecisionFact, ElabBlock, ElaboratedMirFunction, IrPipeline, MirStatement,
+    BasicBlock, BlockKind, CallAuthority, CheckedMirFunction, CollectionLayoutProbeKind,
+    CompilerCallKind, CooperateKind, CooperateSite, DecisionFact, DropPlan, ElabBlock,
+    ElaboratedMirFunction, ExitPath, IrPipeline, MirStatement, ParamBoundaryFact,
+    ParamBoundaryMode, RawValueDef, RawValueId, RawValueOp, Strategy, ValueMaterializationReason,
 };
 use inkwell::values::AnyValue;
 
@@ -451,6 +453,363 @@ fn empty_pipeline_with_const_42() -> IrPipeline {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     }
+}
+
+/// Raw-MIR fixture for the first value-only ABI proof. The two scalar
+/// parameters bind directly as `RawValueId`s; the tuple exists only as an LLVM
+/// aggregate value and its second field is materialized at the return ABI.
+/// No `Place::Local` is available for either parameter or the tuple.
+fn pipeline_with_virtual_tuple_parameter_projection() -> IrPipeline {
+    let pair_ty = ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64]);
+    let raw = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
+        name: "pair_second".to_string(),
+        return_ty: ResolvedTy::I64,
+        call_conv: hew_mir::FunctionCallConv::Default,
+        params: vec![ResolvedTy::I64, ResolvedTy::I64],
+        locals: Vec::new(),
+        local_names: Vec::new(),
+        local_scopes: Vec::new(),
+        local_decl_bytes: Vec::new(),
+        scope_table: Vec::new(),
+        blocks: vec![BasicBlock {
+            id: 0,
+            statements: Vec::new(),
+            instructions: vec![
+                Instr::Value(RawValueOp::Param {
+                    dest: RawValueDef {
+                        id: RawValueId(0),
+                        ty: ResolvedTy::I64,
+                    },
+                    index: 0,
+                }),
+                Instr::Value(RawValueOp::Param {
+                    dest: RawValueDef {
+                        id: RawValueId(1),
+                        ty: ResolvedTy::I64,
+                    },
+                    index: 1,
+                }),
+                Instr::Value(RawValueOp::TupleMake {
+                    dest: RawValueDef {
+                        id: RawValueId(2),
+                        ty: pair_ty,
+                    },
+                    fields: vec![RawValueId(0), RawValueId(1)],
+                }),
+                Instr::Value(RawValueOp::TupleGet {
+                    dest: RawValueDef {
+                        id: RawValueId(3),
+                        ty: ResolvedTy::I64,
+                    },
+                    tuple: RawValueId(2),
+                    index: 1,
+                }),
+                Instr::MaterializeValue {
+                    dest: Place::ReturnSlot,
+                    value: RawValueId(3),
+                    reason: ValueMaterializationReason::ReturnAbi,
+                },
+            ],
+            terminator: Terminator::Return,
+        }],
+        decisions: vec![
+            virtual_scalar_parameter_boundary_fact(0, 2, ResolvedTy::I64),
+            virtual_scalar_parameter_boundary_fact(1, 2, ResolvedTy::I64),
+        ],
+        intrinsic_id: None,
+        await_deadline_ns: std::collections::HashMap::new(),
+        suspend_kinds: std::collections::HashMap::new(),
+        lambda_actor_user_param_locals: Vec::new(),
+        span: None,
+        instr_spans: std::collections::BTreeMap::new(),
+    };
+    let mut pipeline = empty_pipeline_with_const_42();
+    let mut checked = CheckedMirFunction {
+        name: raw.name.clone(),
+        return_ty: raw.return_ty.clone(),
+        blocks: raw.blocks.clone(),
+        decisions: raw.decisions.clone(),
+        checks: hew_mir::validate_context_markers(&raw),
+        cooperate_sites: hew_mir::dataflow::compute_structural_cooperate_sites(&raw.blocks),
+        ownership_elaboration: None,
+    };
+    let elaborated = ElaboratedMirFunction {
+        name: raw.name.clone(),
+        return_ty: raw.return_ty.clone(),
+        statements: Vec::new(),
+        decisions: raw.decisions.clone(),
+        blocks: vec![ElabBlock {
+            id: 0,
+            kind: BlockKind::Normal,
+            drops: Vec::new(),
+            successor: None,
+        }],
+        drop_plans: vec![(ExitPath::Return { block: 0 }, DropPlan::default())],
+        coroutine: None,
+        lambda_captures: Vec::new(),
+    };
+    checked.ownership_elaboration = Some(Box::new(elaborated.clone()));
+    pipeline.raw_mir = vec![raw];
+    pipeline.checked_mir = vec![checked];
+    pipeline.elaborated_mir = vec![elaborated];
+    pipeline
+}
+
+fn virtual_scalar_parameter_boundary_fact(index: u32, count: u32, ty: ResolvedTy) -> DecisionFact {
+    DecisionFact {
+        site: SiteId(index),
+        ty,
+        value_class: ValueClass::BitCopy,
+        intent: IntentKind::Unknown,
+        strategy: Strategy::ParamBoundary(ParamBoundaryFact {
+            param_index: index,
+            param_count: count,
+            caller_visible_projection: false,
+            mode: ParamBoundaryMode::BorrowReadOnly,
+        }),
+        why: "test virtual scalar parameter boundary".to_string(),
+    }
+}
+
+#[test]
+fn virtual_raw_tuple_values_use_llvm_values_not_parameter_or_tuple_allocas() {
+    let ctx = Context::create();
+    let pipeline = pipeline_with_virtual_tuple_parameter_projection();
+    let module = build_module(&ctx, &pipeline, "virtual_raw_tuple_values")
+        .expect("virtual scalar params and an internal tuple must lower to LLVM values");
+    module
+        .verify()
+        .expect("virtual raw tuple module must verify");
+    let function = module
+        .get_function("pair_second")
+        .expect("fixture must emit pair_second")
+        .print_to_string()
+        .to_string();
+
+    assert!(
+        function.contains("insertvalue { i64, i64 }")
+            && function.contains("extractvalue { i64, i64 }"),
+        "the semantic tuple must stay an LLVM aggregate value:\n{function}"
+    );
+    assert!(
+        !function.contains("alloca { i64, i64 }"),
+        "the internal tuple must not acquire addressable storage:\n{function}"
+    );
+    assert!(
+        !function.contains("local_0") && !function.contains("local_1"),
+        "virtual scalar ABI parameters must not be allocated as legacy locals:\n{function}"
+    );
+}
+
+/// The public Raw -> LLVM entry must reject a virtual body that mixes its
+/// direct ABI values with legacy `Place::Local` storage before it can emit an
+/// uninitialized local load.
+#[test]
+fn virtual_raw_param_mixed_with_place_body_fails_codegen_admission() {
+    let mut pipeline = pipeline_with_virtual_tuple_parameter_projection();
+    let raw = pipeline
+        .raw_mir
+        .first_mut()
+        .expect("virtual tuple fixture must contain one Raw body");
+    raw.locals = vec![ResolvedTy::I64, ResolvedTy::I64];
+    raw.blocks[0].instructions.insert(
+        2,
+        Instr::Move {
+            dest: Place::Local(0),
+            src: Place::Local(1),
+        },
+    );
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &pipeline, "virtual_raw_param_mixed_place").expect_err(
+        "a virtual parameter body mixed with Place::Local must fail before LLVM lowering",
+    );
+    let CodegenError::FailClosed(message) = error else {
+        panic!("mixed virtual/storage body must fail closed");
+    };
+    assert!(
+        message.contains("declares local storage") && message.contains("Place::Local"),
+        "codegen must reject the mixed virtual/storage body at admission: {message}"
+    );
+}
+
+#[test]
+fn virtual_raw_values_require_checked_and_elaborated_mir_at_codegen() {
+    let ctx = Context::create();
+    let mut missing_checked = pipeline_with_virtual_tuple_parameter_projection();
+    missing_checked.checked_mir.clear();
+    let error = build_module(&ctx, &missing_checked, "virtual_raw_missing_checked")
+        .expect_err("virtual Raw must not bypass Checked MIR at the public codegen entry");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("missing virtual Checked MIR must fail closed");
+    };
+    assert!(
+        message.contains("requires matching Checked MIR"),
+        "missing Checked MIR must be diagnosed at virtual admission: {message}"
+    );
+
+    let ctx = Context::create();
+    let mut missing_elaborated = pipeline_with_virtual_tuple_parameter_projection();
+    missing_elaborated.elaborated_mir.clear();
+    let error = build_module(&ctx, &missing_elaborated, "virtual_raw_missing_elaborated")
+        .expect_err("virtual Raw must not bypass Elaborated MIR at the public codegen entry");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("missing virtual Elaborated MIR must fail closed");
+    };
+    assert!(
+        message.contains("requires matching Elaborated MIR"),
+        "missing Elaborated MIR must be diagnosed at virtual admission: {message}"
+    );
+}
+
+#[test]
+fn virtual_raw_values_require_ordered_parameter_boundary_facts() {
+    let mut pipeline = pipeline_with_virtual_tuple_parameter_projection();
+    pipeline.raw_mir[0].decisions.clear();
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &pipeline, "virtual_raw_missing_param_facts").expect_err(
+        "virtual Raw parameter ABI must not reach codegen without its ordered decision facts",
+    );
+    let CodegenError::FailClosed(message) = error else {
+        panic!("missing virtual parameter facts must fail closed");
+    };
+    assert!(
+        message.contains("parameter-boundary facts"),
+        "canonical Raw admission must reject missing ABI decisions: {message}"
+    );
+}
+
+#[test]
+fn virtual_raw_semantic_tuple_projection_type_mismatch_fails_before_llvm() {
+    let mut pipeline = pipeline_with_virtual_tuple_parameter_projection();
+    let raw = pipeline
+        .raw_mir
+        .first_mut()
+        .expect("virtual tuple fixture must contain one Raw body");
+    raw.params[1] = ResolvedTy::U64;
+    raw.decisions[1].ty = ResolvedTy::U64;
+    let Instr::Value(RawValueOp::Param { dest, .. }) = &mut raw.blocks[0].instructions[1] else {
+        panic!("fixture instruction 1 must be the second virtual parameter");
+    };
+    dest.ty = ResolvedTy::U64;
+    let Instr::Value(RawValueOp::TupleMake { dest, .. }) = &mut raw.blocks[0].instructions[2]
+    else {
+        panic!("fixture instruction 2 must be tuple.make");
+    };
+    dest.ty = ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::U64]);
+    let Instr::Value(RawValueOp::TupleGet { dest, .. }) = &mut raw.blocks[0].instructions[3] else {
+        panic!("fixture instruction 3 must be tuple.get");
+    };
+    dest.ty = ResolvedTy::I64;
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &pipeline, "virtual_raw_semantic_type_mismatch").expect_err(
+        "i64/u64 LLVM shape equality must not admit a forged semantic tuple projection",
+    );
+    let CodegenError::FailClosed(message) = error else {
+        panic!("semantic virtual-value mismatch must fail closed");
+    };
+    assert!(
+        message.contains("tuple.get result") && message.contains("u64"),
+        "canonical Raw type facts must reject the forged projection before LLVM: {message}"
+    );
+}
+
+#[test]
+fn virtual_raw_tuple_return_abi_is_rejected_before_layout_lowering() {
+    let mut pipeline = pipeline_with_virtual_tuple_parameter_projection();
+    let raw = pipeline
+        .raw_mir
+        .first_mut()
+        .expect("virtual tuple fixture must contain one Raw body");
+    raw.return_ty = ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64]);
+    let Instr::MaterializeValue { value, .. } = &mut raw.blocks[0].instructions[4] else {
+        panic!("fixture instruction 4 must be ReturnAbi materialization");
+    };
+    *value = RawValueId(2);
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &pipeline, "virtual_raw_tuple_return")
+        .expect_err("virtual tuples must remain internal rather than choosing a tuple ABI");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("tuple return ABI must fail closed");
+    };
+    assert!(
+        message.contains("scalar-or-unit ABI subset") && message.contains("tuples remain internal"),
+        "tuple ABI admission must fail before LLVM layout lowering: {message}"
+    );
+}
+
+#[test]
+fn virtual_raw_checked_scheduler_site_fails_before_codegen() {
+    let mut pipeline = pipeline_with_virtual_tuple_parameter_projection();
+    pipeline.checked_mir[0].cooperate_sites.push(CooperateSite {
+        bb_id: 0,
+        kind: CooperateKind::FunctionEntry,
+    });
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &pipeline, "virtual_raw_checked_scheduler").expect_err(
+        "a virtual Raw body must reject a checked scheduler fact before LLVM can inject it",
+    );
+    let CodegenError::FailClosed(message) = error else {
+        panic!("virtual checked scheduler fact must fail closed");
+    };
+    assert!(
+        message.contains("scheduler cooperate sites"),
+        "virtual admission must reject scheduler injection: {message}"
+    );
+}
+
+#[test]
+fn virtual_raw_coroutine_and_synthesized_provenance_fail_before_codegen() {
+    let mut coroutine = pipeline_with_virtual_tuple_parameter_projection();
+    coroutine.raw_mir[0].name = format!("{}virtual_value", hew_mir::GEN_BODY_PREFIX);
+    coroutine.checked_mir[0].name = coroutine.raw_mir[0].name.clone();
+    coroutine.elaborated_mir[0].name = coroutine.raw_mir[0].name.clone();
+    let ctx = Context::create();
+    let error = build_module(&ctx, &coroutine, "virtual_raw_coroutine_name")
+        .expect_err("a generator-name coroutine fact must not enter the virtual value-only lane");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("virtual coroutine realization facts must fail closed");
+    };
+    assert!(
+        message.contains("coroutine realization facts"),
+        "canonical Raw admission must reject no-yield generator identity: {message}"
+    );
+
+    let mut actor = pipeline_with_virtual_tuple_parameter_projection();
+    actor.raw_mir[0].source_origin = hew_mir::SourceOrigin::SynthesizedActorHandler {
+        kind: hew_mir::ActorHandlerKind::Receive,
+        actor_layout_key: "test.Actor".to_string(),
+    };
+    let ctx = Context::create();
+    let error = build_module(&ctx, &actor, "virtual_raw_actor_provenance")
+        .expect_err("a synthesized actor identity must not enter the virtual value-only lane");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("virtual synthesized actor provenance must fail closed");
+    };
+    assert!(
+        message.contains("synthesized actor or machine provenance"),
+        "canonical Raw admission must reject synthesized actor provenance: {message}"
+    );
+
+    let mut machine = pipeline_with_virtual_tuple_parameter_projection();
+    machine.raw_mir[0].source_origin = hew_mir::SourceOrigin::SynthesizedMachineStep {
+        machine_name: "TestMachine".to_string(),
+    };
+    let ctx = Context::create();
+    let error = build_module(&ctx, &machine, "virtual_raw_machine_provenance")
+        .expect_err("a synthesized machine identity must not enter the virtual value-only lane");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("virtual synthesized machine provenance must fail closed");
+    };
+    assert!(
+        message.contains("synthesized actor or machine provenance"),
+        "canonical Raw admission must reject synthesized machine provenance: {message}"
+    );
 }
 
 #[test]
@@ -6221,6 +6580,7 @@ fn make_test_fn_ctx<'a, 'ctx>(
         ctx,
         llvm_mod,
         unwind_enabled: true,
+        llvm_fn,
         // Test harness contexts never exercise the drain epilogue; keep
         // the flag off so the test builder's block does not attempt to
         // intern shutdown symbols that are absent from the minimal fixture.
@@ -6250,6 +6610,7 @@ fn make_test_fn_ctx<'a, 'ctx>(
         alloca_prologue: entry,
         locals: HashMap::new(),
         local_tys: HashMap::new(),
+        raw_values: RefCell::new(HashMap::new()),
         blocks: HashMap::new(),
         runtime_decls: RefCell::new(HashMap::new()),
         runtime_unwind_block: std::cell::Cell::new(None),

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -657,6 +657,11 @@ impl ContextFlowState {
 )]
 pub(crate) fn instr_reads_writes(instr: &Instr) -> (Vec<Place>, Vec<Place>, Vec<Place>) {
     match instr {
+        // Raw value operations use a disjoint virtual-value namespace. They
+        // neither read nor write addressable MIR places; the explicit ABI
+        // materialization below is the sole storage boundary in this slice.
+        Instr::Value(_) => (vec![], vec![], vec![]),
+        Instr::MaterializeValue { dest, .. } => (vec![], vec![*dest], vec![]),
         Instr::OwnershipEvent(_)
         | Instr::EnterContext
         | Instr::ExitContext

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -35,8 +35,9 @@ use crate::model::{
     ElabDrop, ElaboratedMirFunction, ExitPath, FloatWidth, FunctionCallConv, Instr, IntArithOp,
     IntSignedness, IrPipeline, JoinBranch, LambdaEnvFieldDrop, MirCheck, MirDiagnostic,
     MirDiagnosticKind, MirStatement, ParamBoundaryFact, ParamBoundaryMode, ParamLoanStorage,
-    ParamRepresentationEffect, Place, RawMirFunction, SelectArm, SelectArmKind,
-    SpawnEnvFieldOwnership, Strategy, StringRetainCondition, SuspendKind, Terminator, TrapKind,
+    ParamRepresentationEffect, Place, RawMirFunction, RawValueId, RawValueOp, SelectArm,
+    SelectArmKind, SpawnEnvFieldOwnership, Strategy, StringRetainCondition, SuspendKind,
+    Terminator, TrapKind, ValueMaterializationReason,
 };
 
 /// Which stage of the pipeline to render.
@@ -311,6 +312,47 @@ fn render_place(place: &Place) -> String {
     }
 }
 
+fn render_raw_value(value: RawValueId) -> String {
+    format!("%v{}", value.0)
+}
+
+fn render_raw_value_op(op: &RawValueOp) -> String {
+    match op {
+        RawValueOp::Param { dest, index } => format!(
+            "{}:{} = param {index}",
+            render_raw_value(dest.id),
+            dest.ty.user_facing()
+        ),
+        RawValueOp::ConstI64 { dest, value } => format!(
+            "{}:{} = const.i64 {value}",
+            render_raw_value(dest.id),
+            dest.ty.user_facing()
+        ),
+        RawValueOp::ConstBool { dest, value } => format!(
+            "{}:{} = const.bool {value}",
+            render_raw_value(dest.id),
+            dest.ty.user_facing()
+        ),
+        RawValueOp::TupleMake { dest, fields } => format!(
+            "{}:{} = tuple.make {}",
+            render_raw_value(dest.id),
+            dest.ty.user_facing(),
+            fields
+                .iter()
+                .copied()
+                .map(render_raw_value)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        RawValueOp::TupleGet { dest, tuple, index } => format!(
+            "{}:{} = tuple.get {}, {index}",
+            render_raw_value(dest.id),
+            dest.ty.user_facing(),
+            render_raw_value(*tuple)
+        ),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Terminator renderer
 // ---------------------------------------------------------------------------
@@ -582,6 +624,18 @@ fn render_instr(instr: &Instr) -> String {
         Instr::InteriorMutationCommit { place } => {
             format!("interior_mutation.commit {}", render_place(place))
         }
+        Instr::Value(operation) => render_raw_value_op(operation),
+        Instr::MaterializeValue {
+            dest,
+            value,
+            reason,
+        } => match reason {
+            ValueMaterializationReason::ReturnAbi => format!(
+                "materialize.return_abi {} -> {}",
+                render_raw_value(*value),
+                render_place(dest)
+            ),
+        },
         // Context markers
         Instr::EnterContext => "enter_context".to_string(),
         Instr::ExitContext => "exit_context".to_string(),

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -16,6 +16,7 @@ pub mod liveness;
 pub mod lower;
 pub mod model;
 pub mod ownership;
+pub mod raw_values;
 pub mod return_provenance;
 pub mod runtime_call;
 pub mod runtime_symbols;
@@ -76,17 +77,23 @@ pub use model::{
     MirScope, MirStatement, ModuleCapabilities, NeutralizeAuthority, OwnerId, OwnershipEvent,
     OwnershipGuardKind, ParamBoundaryFact, ParamBoundaryMode, ParamCrashCleanupKind,
     ParamLoanStorage, ParamRepresentationEffect, Place, PointerWidth, PolymorphicMirFunction,
-    PoolCount, PreparedCarrierBoundary, ProjectedPayloadRejectReason, RawMirFunction, RecordLayout,
-    RegexLiteral, RuntimeCall, SelectArm, SelectArmKind, SendAliasMode, SourceOrigin,
-    SpawnEnvFieldOwnership, StableActorRole, Strategy, StringRetainCondition,
-    SupervisorChildLayout, SupervisorConfigParam, SupervisorLayout, SuspendKind, Terminator,
-    ThirFunction, TraitObjectStorage, TrapKind, WitnessOperand, GEN_BODY_PREFIX,
-    INDIRECT_CLOSURE_CALLEE,
+    PoolCount, PreparedCarrierBoundary, ProjectedPayloadRejectReason, RawMirFunction, RawValueDef,
+    RawValueId, RawValueOp, RecordLayout, RegexLiteral, RuntimeCall, SelectArm, SelectArmKind,
+    SendAliasMode, SourceOrigin, SpawnEnvFieldOwnership, StableActorRole, Strategy,
+    StringRetainCondition, SupervisorChildLayout, SupervisorConfigParam, SupervisorLayout,
+    SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind,
+    ValueMaterializationReason, WitnessOperand, GEN_BODY_PREFIX, INDIRECT_CLOSURE_CALLEE,
 };
 pub use ownership::{
     AbiClass, CowHeapRelease, DropClass, FailClosedReason, HandleRole, HeapLeaf,
     InPlaceReleaseKind, LayoutClass, OwnershipCtx, OwnershipDecision, PlaceProvenance, Projection,
     ProvenanceOrigin, ValueOwnership, ValueProvenance,
+};
+pub use raw_values::{
+    is_supported_raw_virtual_scalar_type, is_supported_raw_virtual_value_type,
+    raw_uses_virtual_values, verify_raw_virtual_value_checked, verify_raw_virtual_value_elaborated,
+    verify_raw_virtual_value_function, verify_raw_virtual_value_ladder, RawVirtualValueError,
+    RawVirtualValueFacts,
 };
 pub use runtime_symbols::UnknownRuntimeSymbol;
 pub use sir::{

--- a/hew-mir/src/lower/split_consume.rs
+++ b/hew-mir/src/lower/split_consume.rs
@@ -453,10 +453,14 @@ fn transfer_block_split(
 #[cfg(test)]
 fn instr_places(instr: &Instr) -> Vec<Place> {
     match instr {
-        Instr::OwnershipEvent(_)
+        // Raw virtual values deliberately have no `Place` identity. Their
+        // sole storage boundary is handled by `MaterializeValue` below.
+        Instr::Value(_)
+        | Instr::OwnershipEvent(_)
         | Instr::EnterContext
         | Instr::ExitContext
         | Instr::CheckCancellation => Vec::new(),
+        Instr::MaterializeValue { dest, .. } => vec![*dest],
         Instr::InteriorMutationCommit { place } => vec![*place],
         Instr::ContextField { dest, .. } => vec![*dest],
         // Const-like producers write only their dest place.

--- a/hew-mir/src/lower/suspend_places.rs
+++ b/hew-mir/src/lower/suspend_places.rs
@@ -38,6 +38,11 @@ pub fn instr_source_places(instr: &Instr) -> Vec<Place> {
         | Instr::EnterContext
         | Instr::ExitContext
         | Instr::CheckCancellation
+        // Raw value operations are deliberately disjoint from `Place`; the
+        // ReturnAbi materialization has a virtual source rather than a
+        // place-source, so neither can alias a storage owner out of scope.
+        | Instr::Value(_)
+        | Instr::MaterializeValue { .. }
         | Instr::ContextField { .. }
         | Instr::ConstI64 { .. }
         | Instr::StringLit { .. }
@@ -573,6 +578,8 @@ pub(super) fn generator_yield_instr_escapes(instr: &Instr, local: u32) -> bool {
         | Instr::EnterContext
         | Instr::ExitContext
         | Instr::CheckCancellation
+        | Instr::Value(_)
+        | Instr::MaterializeValue { .. }
         | Instr::ContextField { .. }
         | Instr::ConstI64 { .. }
         | Instr::IntAdd { .. }

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -705,7 +705,12 @@ fn projection_alias_dest(instr: &Instr) -> Option<Place> {
         // place that does not alias a live aggregate's interior. Listed
         // exhaustively (no wildcard) so a new projection-shaped load forces
         // a classification decision here.
-        Instr::OwnershipEvent(_)
+        // Raw virtual values are not places and do not participate in
+        // projection-alias tracking. Materialization writes the return slot,
+        // but it cannot create an interior aggregate alias either.
+        Instr::Value(_)
+        | Instr::MaterializeValue { .. }
+        | Instr::OwnershipEvent(_)
         | Instr::InteriorMutationCommit { .. }
         | Instr::EnterContext
         | Instr::ExitContext

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4932,6 +4932,69 @@ pub enum OwnershipEvent {
     },
 }
 
+/// A typed compiler value in the value-only subset of raw MIR.
+///
+/// This is intentionally distinct from [`Place`]. A `RawValueId` has no
+/// address, storage lifetime, or layout-derived projection. The initial use
+/// is a small no-drop scalar/tuple slice lowered from SIR; later raw-MIR
+/// value-flow work may extend it with block arguments and value edges without
+/// teaching `Place` to masquerade as an SSA value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RawValueId(pub u32);
+
+/// One typed definition in raw MIR's value-only instruction stream.
+///
+/// The first slice keeps the type adjacent to its definition instead of adding
+/// a function-global value table. That avoids making every existing raw-MIR
+/// constructor own a second, partially populated value namespace while the
+/// current subset remains one-block and def-before-use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawValueDef {
+    pub id: RawValueId,
+    pub ty: ResolvedTy,
+}
+
+/// Value-only raw-MIR operations.
+///
+/// These operations describe semantic values before any addressable storage is
+/// needed. They are deliberately limited to bit-copy scalar and tuple values:
+/// ownership, aggregate layout, calls, and control-flow value transport remain
+/// outside this first vertical slice.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RawValueOp {
+    /// Bind one declared ABI parameter as a virtual raw-MIR value. Codegen
+    /// reads the incoming LLVM parameter directly rather than first storing it
+    /// in a `Place::Local` alloca.
+    Param { dest: RawValueDef, index: u32 },
+    /// An integer constant.
+    ConstI64 { dest: RawValueDef, value: i64 },
+    /// A boolean constant.
+    ConstBool { dest: RawValueDef, value: bool },
+    /// Construct an abstract tuple value in field order. `fields` are virtual
+    /// values, not addressable tuple slots.
+    TupleMake {
+        dest: RawValueDef,
+        fields: Vec<RawValueId>,
+    },
+    /// Observe one semantic tuple member by positional index. This is not a
+    /// byte-offset or physical-layout operation.
+    TupleGet {
+        dest: RawValueDef,
+        tuple: RawValueId,
+        index: u32,
+    },
+}
+
+/// Why a virtual raw-MIR value becomes addressable storage.
+///
+/// Keep this explicit so storage cannot quietly leak back into value-only
+/// lowering. The initial slice admits only the final ABI return handoff.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueMaterializationReason {
+    /// The ABI return epilogue consumes `Place::ReturnSlot` today.
+    ReturnAbi,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Instr {
     /// Ownership-SSA operation. This is semantic MIR authority and intentionally
@@ -4944,6 +5007,16 @@ pub enum Instr {
     /// marker begins the normal successor and refreshes backend crash-cleanup
     /// state without emitting user-visible machine code.
     InteriorMutationCommit { place: Place },
+    /// Define a virtual, value-only raw-MIR value. This instruction never
+    /// names a [`Place`] and therefore does not itself imply an alloca.
+    Value(RawValueOp),
+    /// Make a virtual value addressable for a concrete representation boundary.
+    /// The first slice permits only `ReturnAbi` into [`Place::ReturnSlot`].
+    MaterializeValue {
+        dest: Place,
+        value: RawValueId,
+        reason: ValueMaterializationReason,
+    },
     /// Semantic marker at actor-handler entry. Codegen emits no user-visible
     /// instruction, but validates that the hidden execution-context argument is
     /// bound before any context-dependent carrier op can execute.

--- a/hew-mir/src/raw_values.rs
+++ b/hew-mir/src/raw_values.rs
@@ -1,0 +1,638 @@
+//! Verification facts for Raw MIR's first value-only execution subset.
+//!
+//! Raw MIR normally owns addressable [`crate::Place`]s and their lifetime
+//! realization.  This deliberately narrow lane instead carries a small,
+//! typed stream of virtual values until the one permitted representation
+//! boundary: `ReturnAbi -> Place::ReturnSlot`.  Keeping its semantic verifier
+//! in `hew-mir` makes the Raw -> Checked -> Elaborated contract authoritative
+//! for both SIR lowering and direct Raw -> LLVM consumers.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use hew_hir::{IntentKind, SiteId, ValueClass};
+use hew_types::ResolvedTy;
+
+use crate::{
+    dataflow, validate_context_markers, BlockKind, CheckedMirFunction, DropPlan,
+    ElaboratedMirFunction, ExitPath, FunctionCallConv, Instr, ParamBoundaryMode, Place,
+    RawMirFunction, RawValueDef, RawValueId, RawValueOp, SourceOrigin, Strategy, Terminator,
+    ValueMaterializationReason,
+};
+
+/// Semantic facts proven for an admitted Raw virtual-value function.
+///
+/// `parameter_values[index]` is the one virtual definition of ABI parameter
+/// `index`; keeping it ordered makes the ABI-prefix invariant explicit instead
+/// of leaving codegen to reconstruct it from a hash map.  `value_tys` is the
+/// canonical semantic type map used to reject LLVM-type aliases such as
+/// `i64`/`u64` before LLVM lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawVirtualValueFacts {
+    pub value_tys: BTreeMap<RawValueId, ResolvedTy>,
+    pub parameter_values: Vec<RawValueId>,
+    pub return_value: Option<RawValueId>,
+}
+
+/// A malformed first-slice virtual Raw-MIR body or its required ladder stage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawVirtualValueError {
+    pub reason: String,
+}
+
+impl RawVirtualValueError {
+    fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+impl fmt::Display for RawVirtualValueError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.reason)
+    }
+}
+
+impl std::error::Error for RawVirtualValueError {}
+
+/// Whether a Raw body enters the value-only lane at all.
+#[must_use]
+pub fn raw_uses_virtual_values(raw: &RawMirFunction) -> bool {
+    raw.blocks.iter().any(|block| {
+        block.instructions.iter().any(|instruction| {
+            matches!(
+                instruction,
+                Instr::Value(_) | Instr::MaterializeValue { .. }
+            )
+        })
+    })
+}
+
+/// Whether a type can cross the initial virtual-value function ABI.
+///
+/// Tuples deliberately do not qualify: they are internal value expressions in
+/// this slice, not an ABI decision.
+#[must_use]
+pub fn is_supported_raw_virtual_scalar_type(ty: &ResolvedTy) -> bool {
+    ty.is_integer() || *ty == ResolvedTy::Bool
+}
+
+/// Whether a type is valid for an internal Raw virtual value.
+#[must_use]
+pub fn is_supported_raw_virtual_value_type(ty: &ResolvedTy) -> bool {
+    is_supported_raw_virtual_scalar_type(ty)
+        || matches!(ty, ResolvedTy::Tuple(elements)
+            if !elements.is_empty()
+                && elements.iter().all(is_supported_raw_virtual_value_type))
+}
+
+/// Verify a Raw body in the first, one-block virtual-value subset.
+///
+/// Returns `Ok(None)` for ordinary storage-oriented Raw MIR.  A value body
+/// must use the exact no-storage subset; callers can use the returned facts to
+/// bind parameters and values without re-deriving semantic types.
+///
+/// # Errors
+///
+/// Returns [`RawVirtualValueError`] when a body enters the virtual lane but
+/// violates its scalar ABI, semantic def-use, or no-storage invariants.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the initial Raw virtual-value contract is intentionally exhaustive and centralized"
+)]
+pub fn verify_raw_virtual_value_function(
+    raw: &RawMirFunction,
+) -> Result<Option<RawVirtualValueFacts>, RawVirtualValueError> {
+    if !raw_uses_virtual_values(raw) {
+        return Ok(None);
+    }
+
+    if raw.call_conv != FunctionCallConv::Default {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` requires the default call convention",
+            raw.name
+        )));
+    }
+    if raw.coroutine_facts().is_coroutine {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` carries coroutine realization facts outside the first value-only slice",
+            raw.name
+        )));
+    }
+    if matches!(
+        &raw.source_origin,
+        SourceOrigin::SynthesizedActorHandler { .. } | SourceOrigin::SynthesizedMachineStep { .. }
+    ) {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` carries synthesized actor or machine provenance outside the first value-only slice",
+            raw.name
+        )));
+    }
+    if !raw.locals.is_empty()
+        || !raw.local_names.is_empty()
+        || !raw.local_scopes.is_empty()
+        || !raw.local_decl_bytes.is_empty()
+        || !raw.scope_table.is_empty()
+    {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` declares local storage; virtual values have no Place::Local representation",
+            raw.name
+        )));
+    }
+    if raw.intrinsic_id.is_some()
+        || !raw.await_deadline_ns.is_empty()
+        || !raw.suspend_kinds.is_empty()
+        || !raw.lambda_actor_user_param_locals.is_empty()
+    {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` carries intrinsic, suspension, or actor ABI facts outside the first value-only slice",
+            raw.name
+        )));
+    }
+    if raw.return_ty != ResolvedTy::Unit && !is_supported_raw_virtual_scalar_type(&raw.return_ty) {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` return type `{}` is outside the scalar-or-unit ABI subset; tuples remain internal values",
+            raw.name,
+            raw.return_ty.user_facing()
+        )));
+    }
+    verify_virtual_parameter_decisions(raw)?;
+
+    let [block] = raw.blocks.as_slice() else {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` must contain exactly entry bb0",
+            raw.name
+        )));
+    };
+    if block.id != 0
+        || !block.statements.is_empty()
+        || !matches!(block.terminator, Terminator::Return)
+    {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` must have a statement-free bb0 Return body",
+            raw.name
+        )));
+    }
+
+    let mut value_tys = BTreeMap::new();
+    let mut parameter_values = Vec::with_capacity(raw.params.len());
+    let mut next_instruction = 0_usize;
+    for (parameter_index, parameter_ty) in raw.params.iter().enumerate() {
+        if !is_supported_raw_virtual_scalar_type(parameter_ty) {
+            return Err(raw_virtual_error(format!(
+                "raw virtual-value function `{}` ABI parameter {parameter_index} `{}` is outside the scalar ABI subset",
+                raw.name,
+                parameter_ty.user_facing()
+            )));
+        }
+        let expected_index = u32::try_from(parameter_index).map_err(|_| {
+            raw_virtual_error(format!(
+                "raw virtual-value function `{}` exceeds the u32 parameter ABI range",
+                raw.name
+            ))
+        })?;
+        let context = format!(
+            "raw virtual-value function `{}` bb0 instruction {next_instruction}",
+            raw.name
+        );
+        let Some(Instr::Value(RawValueOp::Param { dest, index })) =
+            block.instructions.get(next_instruction)
+        else {
+            return Err(raw_virtual_error(format!(
+                "{context} must define ABI parameter {expected_index} in the ordered RawValueOp::Param prefix"
+            )));
+        };
+        if *index != expected_index {
+            return Err(raw_virtual_error(format!(
+                "{context} defines ABI parameter {index}, expected ordered parameter {expected_index}"
+            )));
+        }
+        if dest.ty != *parameter_ty {
+            return Err(raw_virtual_error(format!(
+                "{context} virtual parameter %{} type `{}` does not match ABI parameter {parameter_index} type `{}`",
+                dest.id.0,
+                dest.ty.user_facing(),
+                parameter_ty.user_facing()
+            )));
+        }
+        define_virtual_value(&mut value_tys, dest, &context)?;
+        parameter_values.push(dest.id);
+        next_instruction = next_instruction.saturating_add(1);
+    }
+
+    let mut return_value = None;
+    for (instruction_index, instruction) in
+        block.instructions.iter().enumerate().skip(next_instruction)
+    {
+        let context = format!(
+            "raw virtual-value function `{}` bb0 instruction {instruction_index}",
+            raw.name
+        );
+        if return_value.is_some() {
+            return Err(raw_virtual_error(format!(
+                "{context} follows ReturnAbi materialization"
+            )));
+        }
+        match instruction {
+            Instr::Value(RawValueOp::Param { .. }) => {
+                return Err(raw_virtual_error(format!(
+                    "{context} defines a parameter outside the ordered ABI prefix"
+                )));
+            }
+            Instr::Value(operation) => {
+                verify_virtual_value_operation(&mut value_tys, operation, &context)?;
+            }
+            Instr::MaterializeValue {
+                dest,
+                value,
+                reason,
+            } => {
+                if *dest != Place::ReturnSlot || *reason != ValueMaterializationReason::ReturnAbi {
+                    return Err(raw_virtual_error(format!(
+                        "{context} materializes outside the ReturnAbi -> ReturnSlot boundary"
+                    )));
+                }
+                let value_ty = value_tys.get(value).ok_or_else(|| {
+                    raw_virtual_error(format!(
+                        "{context} materializes undefined virtual value %{}",
+                        value.0
+                    ))
+                })?;
+                if raw.return_ty == ResolvedTy::Unit || value_ty != &raw.return_ty {
+                    return Err(raw_virtual_error(format!(
+                        "{context} materializes `{}` for scalar return `{}`",
+                        value_ty.user_facing(),
+                        raw.return_ty.user_facing()
+                    )));
+                }
+                return_value = Some(*value);
+            }
+            other => {
+                return Err(raw_virtual_error(format!(
+                    "{context} uses storage-oriented instruction {other:?}; virtual-value functions cannot mix RawValueOp with Place-based lowering"
+                )));
+            }
+        }
+    }
+
+    match (raw.return_ty == ResolvedTy::Unit, return_value) {
+        (true, None) | (false, Some(_)) => {}
+        (true, Some(_)) => {
+            return Err(raw_virtual_error(format!(
+                "unit raw virtual-value function `{}` must not materialize a return value",
+                raw.name
+            )));
+        }
+        (false, None) => {
+            return Err(raw_virtual_error(format!(
+                "non-unit raw virtual-value function `{}` lacks ReturnAbi materialization",
+                raw.name
+            )));
+        }
+    }
+
+    Ok(Some(RawVirtualValueFacts {
+        value_tys,
+        parameter_values,
+        return_value,
+    }))
+}
+
+/// Verify that Checked MIR is the scheduler-free, context-free mirror of an
+/// admitted virtual Raw body.
+///
+/// # Errors
+///
+/// Returns [`RawVirtualValueError`] when the facts no longer match Raw MIR or
+/// Checked MIR introduces divergent CFG, context, or scheduler state.
+pub fn verify_raw_virtual_value_checked(
+    raw: &RawMirFunction,
+    checked: &CheckedMirFunction,
+    facts: &RawVirtualValueFacts,
+) -> Result<(), RawVirtualValueError> {
+    verify_facts_match_raw(raw, facts)?;
+    if checked.name != raw.name || checked.return_ty != raw.return_ty {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value checked MIR does not match Raw identity for `{}`",
+            raw.name
+        )));
+    }
+    if checked.blocks != raw.blocks || checked.decisions != raw.decisions {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value checked MIR does not mirror Raw blocks or decisions for `{}`",
+            raw.name
+        )));
+    }
+
+    let expected_checks = validate_context_markers(raw);
+    if !expected_checks.is_empty() {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` unexpectedly requires execution-context checks",
+            raw.name
+        )));
+    }
+    if !checked.checks.is_empty() {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value checked MIR for `{}` carries context findings outside the value-only subset",
+            raw.name
+        )));
+    }
+
+    let expected_cooperate_sites = dataflow::compute_structural_cooperate_sites(&raw.blocks);
+    if !expected_cooperate_sites.is_empty() {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` requires scheduler cooperation outside the first value-only subset",
+            raw.name
+        )));
+    }
+    if !checked.cooperate_sites.is_empty() {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value checked MIR for `{}` carries scheduler cooperate sites outside the value-only subset",
+            raw.name
+        )));
+    }
+    Ok(())
+}
+
+/// Verify the zero-drop Elaborated-MIR mirror required by a virtual Raw body.
+///
+/// # Errors
+///
+/// Returns [`RawVirtualValueError`] when Raw/Checked verification fails or the
+/// Elaborated body carries any ownership, drop, coroutine, or cleanup work.
+pub fn verify_raw_virtual_value_elaborated(
+    raw: &RawMirFunction,
+    checked: &CheckedMirFunction,
+    elaborated: &ElaboratedMirFunction,
+    facts: &RawVirtualValueFacts,
+) -> Result<(), RawVirtualValueError> {
+    verify_raw_virtual_value_checked(raw, checked, facts)?;
+    if elaborated.name != raw.name
+        || elaborated.return_ty != raw.return_ty
+        || elaborated.decisions != checked.decisions
+        || !elaborated.statements.is_empty()
+        || elaborated.coroutine.is_some()
+        || !elaborated.lambda_captures.is_empty()
+    {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value Elaborated MIR does not preserve the zero-drop identity of `{}`",
+            raw.name
+        )));
+    }
+    let [block] = elaborated.blocks.as_slice() else {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value Elaborated MIR for `{}` must retain exactly one normal block",
+            raw.name
+        )));
+    };
+    if block.id != 0
+        || block.kind != BlockKind::Normal
+        || !block.drops.is_empty()
+        || block.successor.is_some()
+    {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value Elaborated MIR for `{}` carries storage or drop work in bb0",
+            raw.name
+        )));
+    }
+    let [(exit, plan)] = elaborated.drop_plans.as_slice() else {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value Elaborated MIR for `{}` must contain one return drop plan",
+            raw.name
+        )));
+    };
+    if *exit != (ExitPath::Return { block: 0 }) || *plan != DropPlan::default() {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value Elaborated MIR for `{}` has a non-empty or non-return exit plan",
+            raw.name
+        )));
+    }
+    Ok(())
+}
+
+/// Verify the mandatory Raw -> Checked -> Elaborated ladder for a virtual Raw
+/// body, returning the canonical facts codegen may use for LLVM realization.
+///
+/// Legacy storage-oriented Raw MIR deliberately retains its existing optional
+/// stage behavior.  Once a body contains any virtual value, however, both
+/// mirrors are mandatory so a hand-built pipeline cannot bypass ownership or
+/// scheduler admission at codegen.
+///
+/// # Errors
+///
+/// Returns [`RawVirtualValueError`] when a virtual Raw body is malformed or
+/// either mandatory ladder mirror is missing or not the zero-effect mirror.
+pub fn verify_raw_virtual_value_ladder(
+    raw: &RawMirFunction,
+    checked: Option<&CheckedMirFunction>,
+    elaborated: Option<&ElaboratedMirFunction>,
+) -> Result<Option<RawVirtualValueFacts>, RawVirtualValueError> {
+    let Some(facts) = verify_raw_virtual_value_function(raw)? else {
+        return Ok(None);
+    };
+    let checked = checked.ok_or_else(|| {
+        raw_virtual_error(format!(
+            "raw virtual-value function `{}` requires matching Checked MIR before codegen",
+            raw.name
+        ))
+    })?;
+    let elaborated = elaborated.ok_or_else(|| {
+        raw_virtual_error(format!(
+            "raw virtual-value function `{}` requires matching Elaborated MIR before codegen",
+            raw.name
+        ))
+    })?;
+    verify_raw_virtual_value_elaborated(raw, checked, elaborated, &facts)?;
+    Ok(Some(facts))
+}
+
+fn raw_virtual_error(reason: impl Into<String>) -> RawVirtualValueError {
+    RawVirtualValueError::new(reason)
+}
+
+fn verify_facts_match_raw(
+    raw: &RawMirFunction,
+    facts: &RawVirtualValueFacts,
+) -> Result<(), RawVirtualValueError> {
+    let Some(expected) = verify_raw_virtual_value_function(raw)? else {
+        return Err(raw_virtual_error(format!(
+            "ordinary Raw function `{}` cannot carry virtual-value facts",
+            raw.name
+        )));
+    };
+    if expected != *facts {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value facts do not match the canonical Raw verification for `{}`",
+            raw.name
+        )));
+    }
+    Ok(())
+}
+
+/// Validate the Raw-owned ABI decision stream without consulting SIR.
+///
+/// The first virtual-value lane has only immutable `BitCopy` parameters. The
+/// decision facts are still codegen-visible authority, so accepting a missing
+/// or forged stream merely because Checked mirrors it would create a second
+/// unverified ABI path.
+fn verify_virtual_parameter_decisions(raw: &RawMirFunction) -> Result<(), RawVirtualValueError> {
+    if raw.decisions.len() != raw.params.len() {
+        return Err(raw_virtual_error(format!(
+            "raw virtual-value function `{}` has {} parameter-boundary facts for {} ABI parameters",
+            raw.name,
+            raw.decisions.len(),
+            raw.params.len()
+        )));
+    }
+    let parameter_count = u32::try_from(raw.params.len()).map_err(|_| {
+        raw_virtual_error(format!(
+            "raw virtual-value function `{}` exceeds the u32 parameter ABI range",
+            raw.name
+        ))
+    })?;
+    for (index, (decision, parameter_ty)) in raw.decisions.iter().zip(&raw.params).enumerate() {
+        let parameter_index = u32::try_from(index).map_err(|_| {
+            raw_virtual_error(format!(
+                "raw virtual-value function `{}` exceeds the u32 parameter ABI range",
+                raw.name
+            ))
+        })?;
+        let Strategy::ParamBoundary(fact) = &decision.strategy else {
+            return Err(raw_virtual_error(format!(
+                "raw virtual-value function `{}` decision {index} is not an ordered ParamBoundary fact",
+                raw.name
+            )));
+        };
+        if decision.site != SiteId(parameter_index)
+            || decision.ty != *parameter_ty
+            || decision.value_class != ValueClass::BitCopy
+            || decision.intent != IntentKind::Unknown
+            || fact.param_index != parameter_index
+            || fact.param_count != parameter_count
+            || fact.caller_visible_projection
+            || fact.mode != ParamBoundaryMode::BorrowReadOnly
+        {
+            return Err(raw_virtual_error(format!(
+                "raw virtual-value function `{}` parameter-boundary fact {index} is not the immutable BitCopy ABI fact for parameter {parameter_index}",
+                raw.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn define_virtual_value(
+    value_tys: &mut BTreeMap<RawValueId, ResolvedTy>,
+    dest: &RawValueDef,
+    context: &str,
+) -> Result<(), RawVirtualValueError> {
+    if !is_supported_raw_virtual_value_type(&dest.ty) {
+        return Err(raw_virtual_error(format!(
+            "{context} defines unsupported virtual value %{} type `{}`",
+            dest.id.0,
+            dest.ty.user_facing()
+        )));
+    }
+    if value_tys.insert(dest.id, dest.ty.clone()).is_some() {
+        return Err(raw_virtual_error(format!(
+            "{context} defines virtual value %{} more than once",
+            dest.id.0
+        )));
+    }
+    Ok(())
+}
+
+fn verify_virtual_value_operation(
+    value_tys: &mut BTreeMap<RawValueId, ResolvedTy>,
+    operation: &RawValueOp,
+    context: &str,
+) -> Result<(), RawVirtualValueError> {
+    match operation {
+        RawValueOp::Param { .. } => Err(raw_virtual_error(format!(
+            "{context} parameter definition escaped the ABI prefix"
+        ))),
+        RawValueOp::ConstI64 { dest, .. } => {
+            if !dest.ty.is_integer() {
+                return Err(raw_virtual_error(format!(
+                    "{context} integer constant has non-integer type `{}`",
+                    dest.ty.user_facing()
+                )));
+            }
+            define_virtual_value(value_tys, dest, context)
+        }
+        RawValueOp::ConstBool { dest, .. } => {
+            if dest.ty != ResolvedTy::Bool {
+                return Err(raw_virtual_error(format!(
+                    "{context} boolean constant has type `{}`",
+                    dest.ty.user_facing()
+                )));
+            }
+            define_virtual_value(value_tys, dest, context)
+        }
+        RawValueOp::TupleMake { dest, fields } => {
+            let ResolvedTy::Tuple(element_tys) = &dest.ty else {
+                return Err(raw_virtual_error(format!(
+                    "{context} tuple.make result %{} is not a tuple",
+                    dest.id.0
+                )));
+            };
+            if fields.len() != element_tys.len() {
+                return Err(raw_virtual_error(format!(
+                    "{context} tuple.make has {} fields for {} semantic elements",
+                    fields.len(),
+                    element_tys.len()
+                )));
+            }
+            for (field_index, (field, expected_ty)) in fields.iter().zip(element_tys).enumerate() {
+                let actual_ty = value_tys.get(field).ok_or_else(|| {
+                    raw_virtual_error(format!(
+                        "{context} tuple.make field {field_index} reads undefined virtual value %{}",
+                        field.0
+                    ))
+                })?;
+                if actual_ty != expected_ty {
+                    return Err(raw_virtual_error(format!(
+                        "{context} tuple.make field {field_index} has `{}`, expected `{}`",
+                        actual_ty.user_facing(),
+                        expected_ty.user_facing()
+                    )));
+                }
+            }
+            define_virtual_value(value_tys, dest, context)
+        }
+        RawValueOp::TupleGet { dest, tuple, index } => {
+            let element_tys = match value_tys.get(tuple) {
+                Some(ResolvedTy::Tuple(element_tys)) => element_tys,
+                Some(tuple_ty) => {
+                    return Err(raw_virtual_error(format!(
+                        "{context} tuple.get reads non-tuple `{}`",
+                        tuple_ty.user_facing()
+                    )));
+                }
+                None => {
+                    return Err(raw_virtual_error(format!(
+                        "{context} tuple.get reads undefined virtual value %{}",
+                        tuple.0
+                    )));
+                }
+            };
+            let index = usize::try_from(*index).map_err(|_| {
+                raw_virtual_error(format!("{context} tuple.get index cannot index a tuple"))
+            })?;
+            let expected_ty = element_tys.get(index).ok_or_else(|| {
+                raw_virtual_error(format!(
+                    "{context} tuple.get index {index} is out of bounds"
+                ))
+            })?;
+            if &dest.ty != expected_ty {
+                return Err(raw_virtual_error(format!(
+                    "{context} tuple.get result `{}` does not match `{}`",
+                    dest.ty.user_facing(),
+                    expected_ty.user_facing()
+                )));
+            }
+            define_virtual_value(value_tys, dest, context)
+        }
+    }
+}

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -23,10 +23,13 @@ use hew_types::DefId;
 use hew_types::ResolvedTy;
 
 use crate::{
-    dataflow, BasicBlock, BlockKind, CheckedMirFunction, DropPlan, ElabBlock,
-    ElaboratedMirFunction, ExitPath, FunctionCallConv, Instr, IntArithOp, IntSignedness,
+    dataflow, is_supported_raw_virtual_value_type, raw_uses_virtual_values,
+    verify_raw_virtual_value_checked, verify_raw_virtual_value_elaborated,
+    verify_raw_virtual_value_function, BasicBlock, BlockKind, CheckedMirFunction, DropPlan,
+    ElabBlock, ElaboratedMirFunction, ExitPath, FunctionCallConv, Instr, IntArithOp, IntSignedness,
     IrPipeline, ModuleCapabilities, ParamBoundaryFact, ParamBoundaryMode, Place, RawMirFunction,
-    Strategy, Terminator, TrapKind,
+    RawValueDef, RawValueId, RawValueOp, Strategy, Terminator, TrapKind,
+    ValueMaterializationReason,
 };
 
 /// The result of lowering one SIR function through the complete existing MIR
@@ -275,12 +278,16 @@ fn lower_verified_sir_function(
         ));
     }
 
-    let collected = CollectedValues::from_function(function)?;
-    let mut lowerer = RawLowerer::new(function, collected, Some(module))?;
-    for block in &function.blocks {
-        lowerer.lower_block(block)?;
-    }
-    let (locals, blocks) = lowerer.finish()?;
+    let (locals, blocks) = if function_uses_virtual_tuple_values(function) {
+        VirtualRawLowerer::new(function)?.finish()
+    } else {
+        let collected = CollectedValues::from_function(function)?;
+        let mut lowerer = RawLowerer::new(function, collected, Some(module))?;
+        for block in &function.blocks {
+            lowerer.lower_block(block)?;
+        }
+        lowerer.finish()?
+    };
     let parameter_decisions = sir_parameter_decisions(callable)?;
     let raw = RawMirFunction {
         name: callable.symbol.clone(),
@@ -328,6 +335,9 @@ fn lower_verified_sir_function(
     verify_strict_sir_raw_checked(module, callable, &raw, &checked)?;
     let elaborated = zero_drop_elaboration(&raw, &checked)?;
     checked.ownership_elaboration = Some(Box::new(elaborated.clone()));
+    if raw_uses_virtual_values(&raw) {
+        verify_strict_sir_virtual_elaboration(&raw, &checked, &elaborated)?;
+    }
     Ok(SirMirLowered {
         raw,
         checked,
@@ -376,6 +386,9 @@ fn verify_strict_sir_raw_checked(
             "strict SIR raw/checked verifier: raw parameters do not match callable `{}` ABI",
             callable.symbol
         )));
+    }
+    if raw_uses_virtual_values(raw) {
+        return verify_strict_sir_virtual_raw_checked(callable, raw, checked);
     }
     if raw.locals.len() < raw.params.len() {
         return Err(SirMirLoweringError::unsupported(format!(
@@ -442,6 +455,34 @@ fn verify_strict_sir_raw_checked(
         verify_strict_sir_terminator(module, raw, block)?;
     }
     Ok(())
+}
+
+/// Verify the one-block virtual-value Raw → Checked boundary.
+///
+/// Raw-MIR owns the semantic virtual-value contract, including its `RawValueId`
+/// type map and no-storage ABI. SIR retains only its callable-specific
+/// parameter-boundary facts here; LLVM consumes the same Raw verifier facts.
+fn verify_strict_sir_virtual_raw_checked(
+    callable: &SemCallable,
+    raw: &RawMirFunction,
+    checked: &CheckedMirFunction,
+) -> Result<(), SirMirLoweringError> {
+    let facts = verify_raw_virtual_value_function(raw)
+        .map_err(strict_sir_virtual_value_error)?
+        .ok_or_else(|| {
+            SirMirLoweringError::unsupported(format!(
+                "strict SIR virtual verifier: raw `{}` has no virtual values",
+                raw.name
+            ))
+        })?;
+    verify_raw_virtual_value_checked(raw, checked, &facts)
+        .map_err(strict_sir_virtual_value_error)?;
+    verify_strict_sir_parameter_boundary_facts(callable, raw)
+}
+
+fn strict_sir_virtual_value_error(error: crate::RawVirtualValueError) -> SirMirLoweringError {
+    let crate::RawVirtualValueError { reason } = error;
+    SirMirLoweringError::unsupported(format!("strict SIR virtual verifier: {reason}"))
 }
 
 fn verify_strict_sir_block_layout(
@@ -1108,8 +1149,18 @@ pub fn apply_sir_to_pipeline(
             ));
             continue;
         }
+        let Some(callable) = module.callable(function.callable) else {
+            report.statuses.push((
+                function.name.clone(),
+                SirMirLoweringStatus::Unsupported {
+                    reason: "SIR function has no resolved callable for raw-MIR verification"
+                        .to_string(),
+                },
+            ));
+            continue;
+        };
         let template = pipeline.raw_mir[*raw_index].clone();
-        match lower_sir_function_with_template(function, &template) {
+        match lower_sir_function_with_template(function, callable, &template) {
             Ok(mut lowered) => {
                 // The initial scalar SIR subset is acyclic and has no calls,
                 // so it creates no scheduler sites of its own.  Preserve the
@@ -1119,31 +1170,45 @@ pub fn apply_sir_to_pipeline(
                 // which used to look like false back-edges to the legacy
                 // numeric heuristic.  A later SIR effect/CFG scheduling pass
                 // replaces this bridge; it is not a second long-term policy.
-                if let Some(&checked_index) = matching_checked.first() {
-                    let established_sites = &pipeline.checked_mir[checked_index].cooperate_sites;
-                    if !cooperate_sites_apply_to(&lowered.raw, established_sites) {
-                        report.statuses.push((
+                let uses_virtual_values = raw_uses_virtual_values(&lowered.raw);
+                if uses_virtual_values && !lowered.checked.cooperate_sites.is_empty() {
+                    report.statuses.push((
+                        function.name.clone(),
+                        SirMirLoweringStatus::Unsupported {
+                            reason: "value-only SIR realization unexpectedly introduced a scheduler cooperate site"
+                                .to_string(),
+                        },
+                    ));
+                    continue;
+                }
+                if !uses_virtual_values {
+                    if let Some(&checked_index) = matching_checked.first() {
+                        let established_sites =
+                            &pipeline.checked_mir[checked_index].cooperate_sites;
+                        if !cooperate_sites_apply_to(&lowered.raw, established_sites) {
+                            report.statuses.push((
                             function.name.clone(),
                             SirMirLoweringStatus::Unsupported {
                                 reason: "established scheduler cooperate sites do not map to the SIR-realized CFG"
                                     .to_string(),
                             },
                         ));
-                        continue;
-                    }
-                    lowered
-                        .checked
-                        .cooperate_sites
-                        .clone_from(established_sites);
-                } else if !lowered.checked.cooperate_sites.is_empty() {
-                    report.statuses.push((
+                            continue;
+                        }
+                        lowered
+                            .checked
+                            .cooperate_sites
+                            .clone_from(established_sites);
+                    } else if !lowered.checked.cooperate_sites.is_empty() {
+                        report.statuses.push((
                         function.name.clone(),
                         SirMirLoweringStatus::Unsupported {
                             reason: "SIR realization would introduce scheduler cooperate sites without a scheduling-fact bridge"
                                 .to_string(),
                         },
                     ));
-                    continue;
+                        continue;
+                    }
                 }
                 // The scheduler bridge can replace the candidate's structural
                 // cooperation facts with the established legacy facts. Build
@@ -1156,6 +1221,34 @@ pub fn apply_sir_to_pipeline(
                         lowered.elaborated = elaborated;
                     }
                     Err(error) => {
+                        report.statuses.push((
+                            function.name.clone(),
+                            SirMirLoweringStatus::Unsupported {
+                                reason: error.reason,
+                            },
+                        ));
+                        continue;
+                    }
+                }
+                if uses_virtual_values {
+                    if let Err(error) = verify_strict_sir_virtual_raw_checked(
+                        callable,
+                        &lowered.raw,
+                        &lowered.checked,
+                    ) {
+                        report.statuses.push((
+                            function.name.clone(),
+                            SirMirLoweringStatus::Unsupported {
+                                reason: error.reason,
+                            },
+                        ));
+                        continue;
+                    }
+                    if let Err(error) = verify_strict_sir_virtual_elaboration(
+                        &lowered.raw,
+                        &lowered.checked,
+                        &lowered.elaborated,
+                    ) {
                         report.statuses.push((
                             function.name.clone(),
                             SirMirLoweringStatus::Unsupported {
@@ -1230,6 +1323,7 @@ fn cooperate_sites_apply_to(raw: &RawMirFunction, sites: &[crate::CooperateSite]
 /// semantic fact not carried by the initial SIR value/CFG subset.
 fn lower_sir_function_with_template(
     function: &SemFunction,
+    callable: &SemCallable,
     template: &RawMirFunction,
 ) -> Result<SirMirLowered, SirMirLoweringError> {
     if let Some(diagnostic) = hew_sir::verify_function(function).into_iter().next() {
@@ -1238,13 +1332,22 @@ fn lower_sir_function_with_template(
             function.name, diagnostic.kind
         )));
     }
-    let parameter_decisions = validate_template(function, template)?;
-    let collected = CollectedValues::from_function(function)?;
-    let mut lowerer = RawLowerer::new(function, collected, None)?;
-    for block in &function.blocks {
-        lowerer.lower_block(block)?;
+    if function.callable != callable.id {
+        return Err(SirMirLoweringError::unsupported(
+            "SIR function callable does not match the template bridge callable",
+        ));
     }
-    let (locals, blocks) = lowerer.finish()?;
+    let parameter_decisions = validate_template(function, template)?;
+    let (locals, blocks) = if function_uses_virtual_tuple_values(function) {
+        VirtualRawLowerer::new(function)?.finish()
+    } else {
+        let collected = CollectedValues::from_function(function)?;
+        let mut lowerer = RawLowerer::new(function, collected, None)?;
+        for block in &function.blocks {
+            lowerer.lower_block(block)?;
+        }
+        lowerer.finish()?
+    };
 
     let raw = RawMirFunction {
         name: template.name.clone(),
@@ -1291,8 +1394,17 @@ fn lower_sir_function_with_template(
         cooperate_sites: dataflow::compute_structural_cooperate_sites(&raw.blocks),
         ownership_elaboration: None,
     };
+    if raw_uses_virtual_values(&raw) {
+        verify_strict_sir_virtual_raw_checked(callable, &raw, &checked)?;
+    }
     let elaborated = zero_drop_elaboration(&raw, &checked)?;
     checked.ownership_elaboration = Some(Box::new(elaborated.clone()));
+    if raw_uses_virtual_values(&raw) {
+        // The template bridge uses the same strict value-only Raw body. Its
+        // elaboration must therefore prove the same explicit no-drop contract
+        // before it can replace an established function in the pipeline.
+        verify_strict_sir_virtual_elaboration(&raw, &checked, &elaborated)?;
+    }
     Ok(SirMirLowered {
         raw,
         checked,
@@ -1422,6 +1534,27 @@ fn zero_drop_elaboration(
         coroutine: None,
         lambda_captures: Vec::new(),
     })
+}
+
+/// Verify the explicit Elaborated-MIR artifact for a virtual-value Raw body.
+///
+/// Raw-MIR owns the zero-drop mirror invariant so direct Raw -> LLVM lowering
+/// cannot accept a different elaboration shape than SIR lowering does.
+fn verify_strict_sir_virtual_elaboration(
+    raw: &RawMirFunction,
+    checked: &CheckedMirFunction,
+    elaborated: &ElaboratedMirFunction,
+) -> Result<(), SirMirLoweringError> {
+    let facts = verify_raw_virtual_value_function(raw)
+        .map_err(strict_sir_virtual_value_error)?
+        .ok_or_else(|| {
+            SirMirLoweringError::unsupported(format!(
+                "strict SIR virtual elaboration: raw `{}` has no virtual values",
+                raw.name
+            ))
+        })?;
+    verify_raw_virtual_value_elaborated(raw, checked, elaborated, &facts)
+        .map_err(strict_sir_virtual_value_error)
 }
 
 fn raw_source_origin(origin: &FunctionSourceOrigin) -> crate::SourceOrigin {
@@ -1576,6 +1709,306 @@ fn is_supported_return_type(ty: &ResolvedTy) -> bool {
 
 fn is_supported_value_type(ty: &ResolvedTy) -> bool {
     ty.is_integer() || matches!(ty, ResolvedTy::Bool)
+}
+
+/// Whether a SIR function needs the narrowly admitted raw-MIR virtual-value
+/// realization instead of the established local/Place lowerer.
+///
+/// The presence of a semantic tuple operation is intentional evidence that
+/// lowering through `Place::Local` would destroy the value-only boundary this
+/// slice is proving. Do not silently fall back to the legacy tuple lowering:
+/// an unsupported shape must remain an explicit SIR implementation gap.
+fn function_uses_virtual_tuple_values(function: &SemFunction) -> bool {
+    function.blocks.iter().any(|block| {
+        block.ops.iter().any(|operation| {
+            matches!(
+                &operation.kind,
+                SemOpKind::TupleMake { .. } | SemOpKind::TupleGet { .. }
+            )
+        })
+    })
+}
+
+/// Typed SIR values used by the one-block raw virtual-value realization.
+///
+/// This deliberately does not reuse [`CollectedValues`]: the established
+/// `RawLowerer` remains scalar/Place based, while this collector admits the
+/// separately verified recursive `BitCopy` tuple family.
+fn collect_virtual_value_types(
+    function: &SemFunction,
+) -> Result<BTreeMap<ValueId, ResolvedTy>, SirMirLoweringError> {
+    let mut types = BTreeMap::new();
+    for parameter in &function.params {
+        insert_value(&mut types, parameter.value, &parameter.ty)?;
+    }
+    for block in &function.blocks {
+        for argument in &block.args {
+            insert_value(&mut types, argument.value, &argument.ty)?;
+        }
+        for operation in &block.ops {
+            for result in &operation.results {
+                insert_value(&mut types, result.id, &result.ty)?;
+            }
+        }
+    }
+    for (value, ty) in &types {
+        if !is_supported_raw_virtual_value_type(ty) {
+            return Err(SirMirLoweringError::unsupported(format!(
+                "virtual raw value %{} of type `{}` needs ownership or representation lowering",
+                value.0,
+                ty.user_facing()
+            )));
+        }
+    }
+    Ok(types)
+}
+
+/// Lower SIR's first aggregate family directly to Raw MIR virtual values.
+///
+/// This is intentionally not a second general IR. It is a short, strict Raw
+/// MIR construction path whose only addressable operation is the final ABI
+/// store to `ReturnSlot`. Control-flow value transport, calls, ownership, and
+/// aggregate ABI lowering remain rejected until their dedicated Raw-MIR work.
+struct VirtualRawLowerer<'a> {
+    function: &'a SemFunction,
+    value_types: BTreeMap<ValueId, ResolvedTy>,
+    instructions: Vec<Instr>,
+}
+
+impl<'a> VirtualRawLowerer<'a> {
+    fn new(function: &'a SemFunction) -> Result<Self, SirMirLoweringError> {
+        if function.entry != BlockId(0) {
+            return Err(SirMirLoweringError::unsupported(
+                "the raw virtual-value slice requires SIR entry block bb0",
+            ));
+        }
+        let [block] = function.blocks.as_slice() else {
+            return Err(SirMirLoweringError::unsupported(
+                "the raw virtual-value slice admits exactly one SIR basic block",
+            ));
+        };
+        if block.id != BlockId(0) || !block.args.is_empty() {
+            return Err(SirMirLoweringError::unsupported(
+                "the raw virtual-value slice requires an argument-free entry bb0",
+            ));
+        }
+        let value_types = collect_virtual_value_types(function)?;
+        let mut lowerer = Self {
+            function,
+            value_types,
+            instructions: Vec::new(),
+        };
+        lowerer.lower_params()?;
+        for operation in &block.ops {
+            lowerer.lower_op(operation)?;
+        }
+        lowerer.lower_terminator(&block.terminator)?;
+        Ok(lowerer)
+    }
+
+    fn lower_params(&mut self) -> Result<(), SirMirLoweringError> {
+        for (index, parameter) in self.function.params.iter().enumerate() {
+            if !is_supported_value_type(&parameter.ty) {
+                return Err(SirMirLoweringError::unsupported(format!(
+                    "raw virtual-value parameter {index} has non-scalar type `{}`; tuple ABI lowering is deferred",
+                    parameter.ty.user_facing()
+                )));
+            }
+            let index = u32::try_from(index).map_err(|_| {
+                SirMirLoweringError::unsupported(
+                    "raw virtual-value parameter count exceeds the u32 ABI range",
+                )
+            })?;
+            self.instructions.push(Instr::Value(RawValueOp::Param {
+                dest: self.value_def(parameter.value)?,
+                index,
+            }));
+        }
+        Ok(())
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the bounded virtual-value operation vocabulary stays in one match so every admitted SIR operation is visible at the Raw boundary"
+    )]
+    fn lower_op(&mut self, operation: &SemOp) -> Result<(), SirMirLoweringError> {
+        let (result, result_ty) = RawLowerer::single_result(operation)?;
+        let dest = self.value_def(result)?;
+        let operation = match &operation.kind {
+            SemOpKind::ConstI64(value) => {
+                if !result_ty.is_integer() {
+                    return Err(SirMirLoweringError::unsupported(format!(
+                        "raw virtual integer constant result %{} has non-integer type `{}`",
+                        result.0,
+                        result_ty.user_facing()
+                    )));
+                }
+                RawValueOp::ConstI64 {
+                    dest,
+                    value: *value,
+                }
+            }
+            SemOpKind::ConstBool(value) => {
+                if result_ty != ResolvedTy::Bool {
+                    return Err(SirMirLoweringError::unsupported(format!(
+                        "raw virtual boolean constant result %{} has type `{}` rather than bool",
+                        result.0,
+                        result_ty.user_facing()
+                    )));
+                }
+                RawValueOp::ConstBool {
+                    dest,
+                    value: *value,
+                }
+            }
+            SemOpKind::TupleMake { elements } => {
+                let ResolvedTy::Tuple(element_tys) = &result_ty else {
+                    return Err(SirMirLoweringError::unsupported(format!(
+                        "SIR tuple.make result %{} has non-tuple type `{}`",
+                        result.0,
+                        result_ty.user_facing()
+                    )));
+                };
+                if elements.len() != element_tys.len() {
+                    return Err(SirMirLoweringError::unsupported(
+                        "SIR tuple.make operand count does not match its semantic tuple type",
+                    ));
+                }
+                let mut fields = Vec::with_capacity(elements.len());
+                for (index, (element, expected_ty)) in elements.iter().zip(element_tys).enumerate()
+                {
+                    Self::require_read(element, "SIR tuple.make element")?;
+                    let actual_ty = self.value_type(element.value)?;
+                    if actual_ty != expected_ty {
+                        return Err(SirMirLoweringError::unsupported(format!(
+                            "SIR tuple.make element {index} type `{}` does not match semantic tuple element `{}`",
+                            actual_ty.user_facing(),
+                            expected_ty.user_facing()
+                        )));
+                    }
+                    fields.push(Self::raw_value_id(element.value));
+                }
+                RawValueOp::TupleMake { dest, fields }
+            }
+            SemOpKind::TupleGet { tuple, index } => {
+                Self::require_read(tuple, "SIR tuple.get operand")?;
+                let tuple_ty = self.value_type(tuple.value)?;
+                let ResolvedTy::Tuple(element_tys) = tuple_ty else {
+                    return Err(SirMirLoweringError::unsupported(format!(
+                        "SIR tuple.get operand %{} has non-tuple type `{}`",
+                        tuple.value.0,
+                        tuple_ty.user_facing()
+                    )));
+                };
+                let index_usize = usize::try_from(*index).map_err(|_| {
+                    SirMirLoweringError::unsupported(
+                        "SIR tuple.get index cannot index the semantic tuple",
+                    )
+                })?;
+                let expected_ty = element_tys.get(index_usize).ok_or_else(|| {
+                    SirMirLoweringError::unsupported(format!(
+                        "SIR tuple.get index {index} is outside `{}`",
+                        tuple_ty.user_facing()
+                    ))
+                })?;
+                if &result_ty != expected_ty {
+                    return Err(SirMirLoweringError::unsupported(format!(
+                        "SIR tuple.get result type `{}` does not match selected element `{}`",
+                        result_ty.user_facing(),
+                        expected_ty.user_facing()
+                    )));
+                }
+                RawValueOp::TupleGet {
+                    dest,
+                    tuple: Self::raw_value_id(tuple.value),
+                    index: *index,
+                }
+            }
+            SemOpKind::Unary { .. }
+            | SemOpKind::Binary { .. }
+            | SemOpKind::Cast { .. }
+            | SemOpKind::Call { .. } => {
+                return Err(SirMirLoweringError::unsupported(
+                    "the raw virtual-value slice admits only constants and semantic tuple make/get operations",
+                ));
+            }
+        };
+        self.instructions.push(Instr::Value(operation));
+        Ok(())
+    }
+
+    fn lower_terminator(&mut self, terminator: &SemTerminator) -> Result<(), SirMirLoweringError> {
+        match terminator {
+            SemTerminator::Return { value: Some(value) } => {
+                Self::require_read(value, "SIR virtual return value")?;
+                if self.value_type(value.value)? != &self.function.return_ty {
+                    return Err(SirMirLoweringError::unsupported(
+                        "SIR virtual return value type does not match the function return type",
+                    ));
+                }
+                if self.function.return_ty == ResolvedTy::Unit {
+                    return Err(SirMirLoweringError::unsupported(
+                        "unit SIR function must not materialize a virtual return value",
+                    ));
+                }
+                self.instructions.push(Instr::MaterializeValue {
+                    dest: Place::ReturnSlot,
+                    value: Self::raw_value_id(value.value),
+                    reason: ValueMaterializationReason::ReturnAbi,
+                });
+                Ok(())
+            }
+            SemTerminator::Return { value: None }
+                if self.function.return_ty == ResolvedTy::Unit =>
+            {
+                Ok(())
+            }
+            SemTerminator::Return { value: None } => Err(SirMirLoweringError::unsupported(
+                "non-unit SIR function has a value-less virtual return",
+            )),
+            SemTerminator::Goto(_) | SemTerminator::Branch { .. } | SemTerminator::Unreachable => {
+                Err(SirMirLoweringError::unsupported(
+                    "the raw virtual-value slice admits only an ordinary Return terminator",
+                ))
+            }
+        }
+    }
+
+    fn raw_value_id(value: ValueId) -> RawValueId {
+        RawValueId(value.0)
+    }
+
+    fn value_def(&self, value: ValueId) -> Result<RawValueDef, SirMirLoweringError> {
+        Ok(RawValueDef {
+            id: Self::raw_value_id(value),
+            ty: self.value_type(value)?.clone(),
+        })
+    }
+
+    fn value_type(&self, value: ValueId) -> Result<&ResolvedTy, SirMirLoweringError> {
+        self.value_types.get(&value).ok_or_else(|| {
+            SirMirLoweringError::unsupported(format!(
+                "SIR virtual raw lowering uses undefined value %{}",
+                value.0
+            ))
+        })
+    }
+
+    fn require_read(operand: &Operand, context: &str) -> Result<(), SirMirLoweringError> {
+        RawLowerer::require_read(operand, context)
+    }
+
+    fn finish(self) -> (Vec<ResolvedTy>, Vec<BasicBlock>) {
+        (
+            Vec::new(),
+            vec![BasicBlock {
+                id: 0,
+                statements: Vec::new(),
+                instructions: self.instructions,
+                terminator: Terminator::Return,
+            }],
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -1773,6 +2206,11 @@ impl<'a> RawLowerer<'a> {
                     from_ty,
                     to_ty: to.clone(),
                 });
+            }
+            SemOpKind::TupleMake { .. } | SemOpKind::TupleGet { .. } => {
+                return Err(SirMirLoweringError::unsupported(
+                    "SIR tuple values require the raw virtual-value lowering path",
+                ));
             }
             SemOpKind::Call { .. } => unreachable!("calls return before value-result lowering"),
         }
@@ -2495,6 +2933,103 @@ mod tests {
         }
     }
 
+    /// The bounded virtual-value proof body: values are constructed and
+    /// projected as a semantic tuple, but only the scalar result crosses the
+    /// existing ABI return slot. This is deliberately parameter-free so it
+    /// exercises no aggregate ABI policy.
+    fn strict_virtual_tuple_projection_function() -> SemFunction {
+        let pair_ty = ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64]);
+        SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("main"),
+            name: "main".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: Vec::new(),
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![
+                    op(0, definition(0, ResolvedTy::I64), SemOpKind::ConstI64(0)),
+                    op(1, definition(1, ResolvedTy::I64), SemOpKind::ConstI64(42)),
+                    op(
+                        2,
+                        definition(2, pair_ty),
+                        SemOpKind::TupleMake {
+                            elements: vec![operand(0), operand(1)],
+                        },
+                    ),
+                    op(
+                        3,
+                        definition(3, ResolvedTy::I64),
+                        SemOpKind::TupleGet {
+                            tuple: operand(2),
+                            index: 0,
+                        },
+                    ),
+                ],
+                terminator: SemTerminator::Return {
+                    value: Some(operand(3)),
+                },
+            }],
+        }
+    }
+
+    /// This only exists as a Raw/LLVM ABI regression fixture. Tuple
+    /// parameters and results intentionally remain outside the first slice;
+    /// individual scalar parameters can still be bound directly as virtual
+    /// values and feed an internal tuple.
+    fn strict_virtual_scalar_param_tuple_projection_function() -> SemFunction {
+        let pair_ty = ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64]);
+        SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("pair_second"),
+            name: "pair_second".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::RootUnit,
+            params: vec![
+                BlockArg {
+                    value: ValueId(0),
+                    ty: ResolvedTy::I64,
+                },
+                BlockArg {
+                    value: ValueId(1),
+                    ty: ResolvedTy::I64,
+                },
+            ],
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![
+                    op(
+                        0,
+                        definition(2, pair_ty),
+                        SemOpKind::TupleMake {
+                            elements: vec![operand(0), operand(1)],
+                        },
+                    ),
+                    op(
+                        1,
+                        definition(3, ResolvedTy::I64),
+                        SemOpKind::TupleGet {
+                            tuple: operand(2),
+                            index: 1,
+                        },
+                    ),
+                ],
+                terminator: SemTerminator::Return {
+                    value: Some(operand(3)),
+                },
+            }],
+        }
+    }
+
     #[test]
     fn strict_post_lowering_verifier_accepts_boolean_equality_and_rejects_bad_local() {
         let function = strict_boolean_equality_function();
@@ -2525,6 +3060,177 @@ mod tests {
             verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
                 .expect_err("an out-of-bounds scalar local must fail at the SIR raw boundary");
         assert!(error.reason.contains("out-of-bounds local 99"));
+    }
+
+    #[test]
+    fn realizes_semantic_tuple_values_through_the_no_drop_mir_ladder() {
+        let function = strict_virtual_tuple_projection_function();
+        let module = test_module(vec![function.clone()]);
+        let lowered = lower_sir_function(&module, &function)
+            .expect("the internal tuple projection must use virtual Raw MIR values");
+        let callable = module
+            .callable(function.callable)
+            .expect("test callable must exist");
+
+        assert!(lowered.raw.locals.is_empty());
+        assert_eq!(lowered.raw.blocks.len(), 1);
+        assert_eq!(lowered.checked.blocks, lowered.raw.blocks);
+        assert_eq!(
+            lowered.raw.blocks[0].instructions,
+            vec![
+                Instr::Value(RawValueOp::ConstI64 {
+                    dest: RawValueDef {
+                        id: RawValueId(0),
+                        ty: ResolvedTy::I64,
+                    },
+                    value: 0,
+                }),
+                Instr::Value(RawValueOp::ConstI64 {
+                    dest: RawValueDef {
+                        id: RawValueId(1),
+                        ty: ResolvedTy::I64,
+                    },
+                    value: 42,
+                }),
+                Instr::Value(RawValueOp::TupleMake {
+                    dest: RawValueDef {
+                        id: RawValueId(2),
+                        ty: ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64]),
+                    },
+                    fields: vec![RawValueId(0), RawValueId(1)],
+                }),
+                Instr::Value(RawValueOp::TupleGet {
+                    dest: RawValueDef {
+                        id: RawValueId(3),
+                        ty: ResolvedTy::I64,
+                    },
+                    tuple: RawValueId(2),
+                    index: 0,
+                }),
+                Instr::MaterializeValue {
+                    dest: Place::ReturnSlot,
+                    value: RawValueId(3),
+                    reason: ValueMaterializationReason::ReturnAbi,
+                },
+            ]
+        );
+        verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
+            .expect("the virtual Raw and Checked bodies must agree");
+        verify_strict_sir_virtual_elaboration(&lowered.raw, &lowered.checked, &lowered.elaborated)
+            .expect("the virtual body must elaborate to one explicit empty return plan");
+    }
+
+    #[test]
+    fn virtual_raw_verifier_requires_exact_scalar_param_binding_and_return_boundary() {
+        let function = strict_virtual_scalar_param_tuple_projection_function();
+        let module = test_module(vec![function.clone()]);
+        let mut lowered = lower_sir_function(&module, &function)
+            .expect("scalar params may feed an internal virtual tuple");
+        let callable = module
+            .callable(function.callable)
+            .expect("test callable must exist");
+
+        assert!(lowered.raw.locals.is_empty());
+        assert!(matches!(
+            lowered.raw.blocks[0].instructions.as_slice(),
+            [
+                Instr::Value(RawValueOp::Param { index: 0, .. }),
+                Instr::Value(RawValueOp::Param { index: 1, .. }),
+                ..,
+                Instr::MaterializeValue {
+                    dest: Place::ReturnSlot,
+                    reason: ValueMaterializationReason::ReturnAbi,
+                    ..
+                },
+            ]
+        ));
+
+        let Instr::Value(RawValueOp::Param { index, .. }) =
+            &mut lowered.raw.blocks[0].instructions[1]
+        else {
+            panic!("the second instruction must bind ABI parameter 1");
+        };
+        *index = 0;
+        lowered.checked.blocks = lowered.raw.blocks.clone();
+        let error =
+            verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
+                .expect_err("one ABI parameter may map to exactly one virtual definition");
+        assert!(error.reason.contains("expected ordered parameter 1"));
+
+        let mut lowered = lower_sir_function(&module, &function)
+            .expect("fresh virtual lowering must remain valid");
+        let Instr::MaterializeValue { dest, .. } = lowered.raw.blocks[0]
+            .instructions
+            .last_mut()
+            .expect("virtual return materialization")
+        else {
+            panic!("the final virtual instruction must materialize the ABI return");
+        };
+        *dest = Place::Local(0);
+        lowered.checked.blocks = lowered.raw.blocks.clone();
+        let error =
+            verify_strict_sir_raw_checked(&module, callable, &lowered.raw, &lowered.checked)
+                .expect_err("only ReturnSlot may materialize a virtual value");
+        assert!(error.reason.contains("ReturnAbi -> ReturnSlot"));
+    }
+
+    #[test]
+    fn shadow_bridge_realizes_tuple_values_through_the_verified_virtual_lane() {
+        let function = strict_virtual_tuple_projection_function();
+        let module = test_module(vec![function.clone()]);
+        let template = template("main", Vec::new(), ResolvedTy::I64);
+        let mut pipeline = IrPipeline {
+            raw_mir: vec![template.clone()],
+            checked_mir: vec![CheckedMirFunction {
+                name: template.name.clone(),
+                return_ty: template.return_ty.clone(),
+                blocks: Vec::new(),
+                decisions: template.decisions.clone(),
+                checks: Vec::new(),
+                cooperate_sites: Vec::new(),
+                ownership_elaboration: None,
+            }],
+            elaborated_mir: vec![ElaboratedMirFunction {
+                name: template.name,
+                return_ty: template.return_ty,
+                statements: Vec::new(),
+                decisions: Vec::new(),
+                blocks: Vec::new(),
+                drop_plans: Vec::new(),
+                coroutine: None,
+                lambda_captures: Vec::new(),
+            }],
+            ..IrPipeline::default()
+        };
+
+        let report = apply_sir_to_pipeline(&module, &mut pipeline);
+        assert_eq!(report.lowered_count(), 1, "{report:#?}");
+        let raw = pipeline
+            .raw_mir
+            .first()
+            .expect("shadow bridge must replace the main raw body");
+        let checked = pipeline
+            .checked_mir
+            .first()
+            .expect("shadow bridge must install matching checked MIR");
+        let elaborated = pipeline
+            .elaborated_mir
+            .first()
+            .expect("shadow bridge must install matching elaborated MIR");
+        let callable = module
+            .callable(function.callable)
+            .expect("test callable must exist");
+
+        assert!(raw.locals.is_empty());
+        assert!(raw.blocks[0]
+            .instructions
+            .iter()
+            .any(|instruction| matches!(instruction, Instr::Value(RawValueOp::TupleMake { .. }))));
+        verify_strict_sir_virtual_raw_checked(callable, raw, checked).expect(
+            "shadow virtual body must pass the same raw/checked verifier as strict lowering",
+        );
+        verify_strict_sir_virtual_elaboration(raw, checked, elaborated)
+            .expect("shadow virtual body must pass the no-drop elaboration verifier");
     }
 
     #[test]
@@ -2775,8 +3481,10 @@ mod tests {
             ],
         };
 
+        let callable = test_callable(&function);
         let lowered = lower_sir_function_with_template(
             &function,
+            &callable,
             &template("f", vec![ResolvedTy::I64, ResolvedTy::I64], ResolvedTy::I64),
         )
         .expect("the scalar SSA diamond should lower to raw MIR");
@@ -2907,8 +3615,10 @@ mod tests {
             }],
         };
 
+        let callable = test_callable(&function);
         let error = lower_sir_function_with_template(
             &function,
+            &callable,
             &template("bad_entry", Vec::new(), ResolvedTy::I64),
         )
         .expect_err("a malformed SIR entry must fail before raw MIR exists");
@@ -3027,8 +3737,10 @@ mod tests {
                 },
             ],
         };
+        let callable = test_callable(&function);
         let lowered = lower_sir_function_with_template(
             &function,
+            &callable,
             &template(
                 "swap",
                 vec![ResolvedTy::I64, ResolvedTy::I64, ResolvedTy::Bool],

--- a/hew-sir/src/dump.rs
+++ b/hew-sir/src/dump.rs
@@ -59,6 +59,19 @@ fn dump_op(out: &mut String, module: &SemModule, op: &crate::SemOp) {
     match &op.kind {
         SemOpKind::ConstI64(value) => writeln!(out, "const {value}").expect("write to String"),
         SemOpKind::ConstBool(value) => writeln!(out, "const {value}").expect("write to String"),
+        SemOpKind::TupleMake { elements } => {
+            write!(out, "tuple.make(").expect("write to String");
+            for (index, element) in elements.iter().enumerate() {
+                if index != 0 {
+                    write!(out, ", ").expect("write to String");
+                }
+                write!(out, "{}", operand(element)).expect("write to String");
+            }
+            writeln!(out, ")").expect("write to String");
+        }
+        SemOpKind::TupleGet { tuple, index } => {
+            writeln!(out, "tuple.get {}, {index}", operand(tuple)).expect("write to String");
+        }
         SemOpKind::Unary { op, value } => {
             writeln!(out, "{op:?} {}", operand(value)).expect("write to String");
         }

--- a/hew-sir/src/lower.rs
+++ b/hew-sir/src/lower.rs
@@ -757,6 +757,18 @@ fn is_initial_scalar(ty: &ResolvedTy) -> bool {
     ty.is_integer() || matches!(ty, hew_types::ResolvedTy::Bool)
 }
 
+/// The first aggregate value family admitted into SIR.
+///
+/// These values remain purely semantic until Raw MIR decides whether a
+/// representation boundary requires storage. Restricting tuple leaves to the
+/// existing `BitCopy` scalar domain keeps this first slice free of drops,
+/// borrowing, reference counts, and layout-dependent behavior.
+fn is_initial_value_type(ty: &ResolvedTy) -> bool {
+    is_initial_scalar(ty)
+        || matches!(ty, ResolvedTy::Tuple(elements)
+            if !elements.is_empty() && elements.iter().all(is_initial_value_type))
+}
+
 fn is_initial_scalar_return(ty: &ResolvedTy) -> bool {
     matches!(ty, hew_types::ResolvedTy::Unit) || is_initial_scalar(ty)
 }
@@ -802,39 +814,40 @@ fn initial_scalar_use_mode(intent: IntentKind) -> Result<UseMode, String> {
 }
 
 /// Lower a value flowing into a binding or function return in the initial
-/// no-drop scalar domain.
+/// no-drop scalar/tuple domain.
 ///
 /// HIR intentionally marks these positions `Consume`: their result transfers
 /// to a new binding or the caller. For `i*`/`u*`/`bool`, that semantic transfer
 /// has no exclusive ownership obligation, so SIR keeps the same virtual value
-/// and represents the receiving flow as `Read`. This is a narrow value-class
+/// and represents the receiving flow as `Read`. The same applies recursively
+/// to tuples made solely from such scalar values. This is a narrow value-class
 /// rule, not a general weakening of `Move`: actual operand positions remain
-/// read-only in this slice, and every non-scalar transfer fails closed until
-/// ownership/layout MIR can realize it.
-fn initial_scalar_transfer_mode(
+/// read-only in this slice, and every ownership-bearing transfer fails closed
+/// until ownership/layout MIR can realize it.
+fn initial_value_transfer_mode(
     intent: IntentKind,
     ty: &hew_types::ResolvedTy,
     context: &str,
 ) -> Result<(), String> {
     let mode = use_mode_from_hir_intent(intent).map_err(|reason| format!("{context}: {reason}"))?;
     match mode {
-        UseMode::Read | UseMode::Move if is_initial_scalar(ty) => Ok(()),
+        UseMode::Read | UseMode::Move if is_initial_value_type(ty) => Ok(()),
         UseMode::Read | UseMode::Move => Err(format!(
-            "{context}: HIR intent maps to SIR {mode:?} for non-scalar `{}`; initial SIR only aliases BitCopy scalar binding/return flow",
+            "{context}: HIR intent maps to SIR {mode:?} for ownership-bearing `{}`; initial SIR only aliases BitCopy scalar/tuple binding/return flow",
             ty.user_facing()
         )),
         other => Err(format!(
-            "{context}: HIR intent maps to SIR {other:?}; initial scalar binding/return flow admits only Read or BitCopy Move"
+            "{context}: HIR intent maps to SIR {other:?}; initial scalar/tuple binding/return flow admits only Read or BitCopy Move"
         )),
     }
 }
 
-fn lower_initial_scalar_transfer_value(
+fn lower_initial_value_transfer(
     builder: &mut Builder<'_, '_>,
     expr: &HirExpr,
     context: &str,
 ) -> Result<ValueId, String> {
-    initial_scalar_transfer_mode(expr.intent, &builder.ty(&expr.ty), context)?;
+    initial_value_transfer_mode(expr.intent, &builder.ty(&expr.ty), context)?;
     builder.lower_expr(expr)
 }
 
@@ -1070,9 +1083,7 @@ impl<'hir, 'service> Builder<'hir, 'service> {
                     }
                     let value = value
                         .as_ref()
-                        .map(|expr| {
-                            lower_initial_scalar_transfer_value(self, expr, "binding initializer")
-                        })
+                        .map(|expr| lower_initial_value_transfer(self, expr, "binding initializer"))
                         .transpose()?
                         .ok_or_else(|| {
                             "uninitialised bindings are not in the initial SIR subset".to_string()
@@ -1089,7 +1100,7 @@ impl<'hir, 'service> Builder<'hir, 'service> {
                             None
                         }
                         Some(expr) => Some(Operand {
-                            value: lower_initial_scalar_transfer_value(self, expr, "return value")?,
+                            value: lower_initial_value_transfer(self, expr, "return value")?,
                             mode: UseMode::Read,
                         }),
                         None => None,
@@ -1164,6 +1175,8 @@ impl<'hir, 'service> Builder<'hir, 'service> {
                 }
                 self.emit(expr, SemOpKind::ConstBool(*value))
             }
+            HirExprKind::TupleLiteral { elements } => self.lower_tuple_make(expr, elements),
+            HirExprKind::TupleIndex { tuple, index } => self.lower_tuple_get(expr, tuple, *index),
             HirExprKind::BindingRef {
                 resolved: ResolvedRef::Binding(binding),
                 ..
@@ -1219,6 +1232,100 @@ impl<'hir, 'service> Builder<'hir, 'service> {
             ),
             _ => Err("unsupported HIR expression kind in the initial SIR subset".to_string()),
         }
+    }
+
+    /// Lower an immutable, no-drop tuple as one semantic aggregate value.
+    ///
+    /// The tuple's exact `ResolvedTy` is retained; neither its field layout nor
+    /// an addressable temporary is introduced at the HIR → SIR boundary.
+    fn lower_tuple_make(
+        &mut self,
+        expr: &HirExpr,
+        elements: &[HirExpr],
+    ) -> Result<ValueId, String> {
+        let tuple_ty = self.ty(&expr.ty);
+        let ResolvedTy::Tuple(expected_elements) = &tuple_ty else {
+            return Err(format!(
+                "tuple literal has non-tuple resolved type `{}` in SIR lowering",
+                tuple_ty.user_facing()
+            ));
+        };
+        if !is_initial_value_type(&tuple_ty) {
+            return Err(format!(
+                "tuple literal type `{}` is outside SIR's initial no-drop scalar/tuple value domain",
+                tuple_ty.user_facing()
+            ));
+        }
+        if expected_elements.len() != elements.len() {
+            return Err(format!(
+                "tuple literal has {} element(s), but its resolved type `{}` has {} element type(s)",
+                elements.len(),
+                tuple_ty.user_facing(),
+                expected_elements.len()
+            ));
+        }
+        let mut lowered_elements = Vec::with_capacity(elements.len());
+        for (index, (element, expected_ty)) in elements.iter().zip(expected_elements).enumerate() {
+            let actual_ty = self.ty(&element.ty);
+            if &actual_ty != expected_ty {
+                return Err(format!(
+                    "tuple literal element {index} has resolved type `{}`, expected `{}`",
+                    actual_ty.user_facing(),
+                    expected_ty.user_facing()
+                ));
+            }
+            lowered_elements
+                .push(self.lower_read_operand(element, &format!("tuple literal element {index}"))?);
+        }
+        self.emit(
+            expr,
+            SemOpKind::TupleMake {
+                elements: lowered_elements,
+            },
+        )
+    }
+
+    /// Lower a semantic tuple projection without exposing aggregate layout.
+    fn lower_tuple_get(
+        &mut self,
+        expr: &HirExpr,
+        tuple_expr: &HirExpr,
+        index: usize,
+    ) -> Result<ValueId, String> {
+        let tuple_ty = self.ty(&tuple_expr.ty);
+        let ResolvedTy::Tuple(elements) = &tuple_ty else {
+            return Err(format!(
+                "tuple projection has non-tuple operand type `{}` in SIR lowering",
+                tuple_ty.user_facing()
+            ));
+        };
+        if !is_initial_value_type(&tuple_ty) {
+            return Err(format!(
+                "tuple projection operand type `{}` is outside SIR's initial no-drop scalar/tuple value domain",
+                tuple_ty.user_facing()
+            ));
+        }
+        let expected_ty = elements.get(index).ok_or_else(|| {
+            format!(
+                "tuple projection index {index} is out of bounds for `{}` with {} element(s)",
+                tuple_ty.user_facing(),
+                elements.len()
+            )
+        })?;
+        let result_ty = self.ty(&expr.ty);
+        if &result_ty != expected_ty {
+            return Err(format!(
+                "tuple projection index {index} from `{}` has result type `{}`, expected `{}`",
+                tuple_ty.user_facing(),
+                result_ty.user_facing(),
+                expected_ty.user_facing()
+            ));
+        }
+        let index = u32::try_from(index).map_err(|_| {
+            "tuple projection index exceeds SIR's target-independent u32 field range".to_string()
+        })?;
+        let tuple = self.lower_read_operand(tuple_expr, "tuple projection operand")?;
+        self.emit(expr, SemOpKind::TupleGet { tuple, index })
     }
 
     /// Lower an HIR direct call through the resolved SIR callable table.
@@ -1535,8 +1642,8 @@ impl<'hir, 'service> Builder<'hir, 'service> {
 #[cfg(test)]
 mod tests {
     use super::{
-        initial_scalar_transfer_mode, initial_scalar_use_mode, use_mode_from_hir_intent,
-        PendingBlock,
+        initial_scalar_use_mode, initial_value_transfer_mode, is_initial_value_type,
+        use_mode_from_hir_intent, PendingBlock,
     };
     use crate::{BlockId, OpId, Provenance, SemOp, SemOpKind, SemTerminator, UseMode};
     use hew_hir::IntentKind;
@@ -1581,17 +1688,24 @@ mod tests {
     }
 
     #[test]
-    fn scalar_binding_and_return_transfers_admit_only_bitcopy_move() {
-        assert!(
-            initial_scalar_transfer_mode(IntentKind::Consume, &ResolvedTy::I64, "test").is_ok()
-        );
-        assert!(initial_scalar_transfer_mode(IntentKind::Read, &ResolvedTy::Bool, "test").is_ok());
+    fn scalar_and_tuple_binding_transfers_admit_only_bitcopy_values() {
+        assert!(initial_value_transfer_mode(IntentKind::Consume, &ResolvedTy::I64, "test").is_ok());
+        assert!(initial_value_transfer_mode(IntentKind::Read, &ResolvedTy::Bool, "test").is_ok());
+        let tuple = ResolvedTy::Tuple(vec![
+            ResolvedTy::I64,
+            ResolvedTy::Tuple(vec![ResolvedTy::Bool]),
+        ]);
+        assert!(is_initial_value_type(&tuple));
+        assert!(initial_value_transfer_mode(IntentKind::Consume, &tuple, "test").is_ok());
         for intent in [IntentKind::Read, IntentKind::Consume] {
-            let error = initial_scalar_transfer_mode(intent, &ResolvedTy::String, "test")
-                .expect_err("a non-BitCopy transfer must stay outside the scalar SIR subset");
+            let error = initial_value_transfer_mode(intent, &ResolvedTy::String, "test")
+                .expect_err(
+                    "an ownership-bearing transfer must stay outside the SIR value-only subset",
+                );
             assert!(
-                error.contains("non-scalar") && error.contains("only aliases BitCopy scalar"),
-                "the transfer diagnostic must explain that this would erase ownership: {error}"
+                error.contains("ownership-bearing")
+                    && error.contains("only aliases BitCopy scalar/tuple"),
+                "the transfer diagnostic must explain that this would erase ownership: {error}",
             );
         }
     }

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -517,6 +517,23 @@ impl EffectSet {
 pub enum SemOpKind {
     ConstI64(i64),
     ConstBool(bool),
+    /// Construct a semantic tuple value from its ordered elements.
+    ///
+    /// This is deliberately an aggregate-value operation: it says nothing
+    /// about field offsets, padding, allocation, or storage. Raw MIR decides
+    /// whether the resulting value can remain virtual or must be materialized.
+    TupleMake {
+        elements: Vec<Operand>,
+    },
+    /// Observe one semantic element of a tuple value.
+    ///
+    /// `index` is a target-independent semantic position, not a byte offset
+    /// or representation tag. The verifier proves that it is in bounds for
+    /// the tuple type and that the result has the selected element type.
+    TupleGet {
+        tuple: Operand,
+        index: u32,
+    },
     Unary {
         op: hew_parser::ast::UnaryOp,
         value: Operand,
@@ -557,6 +574,17 @@ impl SemOpKind {
     pub fn visit_operands(&self, mut visit: impl FnMut(OperandSlot, &Operand)) {
         match self {
             Self::ConstI64(_) | Self::ConstBool(_) => {}
+            Self::TupleMake { elements } => {
+                for (index, element) in elements.iter().enumerate() {
+                    visit(
+                        OperandSlot(
+                            u32::try_from(index).expect("SIR operation operand count exceeds u32"),
+                        ),
+                        element,
+                    );
+                }
+            }
+            Self::TupleGet { tuple, .. } => visit(OperandSlot(0), tuple),
             Self::Unary { value, .. } | Self::Cast { value, .. } => {
                 visit(OperandSlot(0), value);
             }
@@ -586,6 +614,17 @@ impl SemOpKind {
     pub fn visit_operands_mut(&mut self, mut visit: impl FnMut(OperandSlot, &mut Operand)) {
         match self {
             Self::ConstI64(_) | Self::ConstBool(_) => {}
+            Self::TupleMake { elements } => {
+                for (index, element) in elements.iter_mut().enumerate() {
+                    visit(
+                        OperandSlot(
+                            u32::try_from(index).expect("SIR operation operand count exceeds u32"),
+                        ),
+                        element,
+                    );
+                }
+            }
+            Self::TupleGet { tuple, .. } => visit(OperandSlot(0), tuple),
             Self::Unary { value, .. } | Self::Cast { value, .. } => {
                 visit(OperandSlot(0), value);
             }
@@ -628,6 +667,8 @@ impl SemOpKind {
             } => EffectSet::MAY_TRAP,
             Self::ConstI64(_)
             | Self::ConstBool(_)
+            | Self::TupleMake { .. }
+            | Self::TupleGet { .. }
             | Self::Unary { .. }
             | Self::Binary { .. }
             | Self::Cast { .. } => EffectSet::PURE,

--- a/hew-sir/src/verify.rs
+++ b/hew-sir/src/verify.rs
@@ -785,6 +785,18 @@ fn is_initial_scalar(ty: &ResolvedTy) -> bool {
     ty.is_integer() || matches!(ty, ResolvedTy::Bool)
 }
 
+/// Value types the initial Raw-MIR virtual-value bridge can realize without
+/// borrowing, drops, allocation, or layout-dependent semantics.
+///
+/// SIR retains tuples as abstract values; this predicate merely bounds the
+/// first lowering slice to recursively `BitCopy` scalar elements until the
+/// ownership/layout layer owns aggregate resource realization.
+fn is_initial_value_type(ty: &ResolvedTy) -> bool {
+    is_initial_scalar(ty)
+        || matches!(ty, ResolvedTy::Tuple(elements)
+            if !elements.is_empty() && elements.iter().all(is_initial_value_type))
+}
+
 fn is_initial_scalar_return(ty: &ResolvedTy) -> bool {
     matches!(ty, ResolvedTy::Unit) || is_initial_scalar(ty)
 }
@@ -853,6 +865,117 @@ fn verify_operation_shape(
                 actual: result.ty.user_facing().to_string(),
             },
         )),
+        SemOpKind::TupleMake { elements } => {
+            let ResolvedTy::Tuple(element_tys) = &result.ty else {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "tuple.make result must have a semantic tuple type, found `{}`",
+                        result.ty.user_facing()
+                    ),
+                    diagnostics,
+                );
+                return;
+            };
+            if !is_initial_value_type(&result.ty) {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "tuple.make result `{}` is outside SIR's initial no-drop scalar/tuple value domain",
+                        result.ty.user_facing()
+                    ),
+                    diagnostics,
+                );
+            }
+            if element_tys.len() != elements.len() {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "tuple.make for `{}` has {} operand(s), expected {}",
+                        result.ty.user_facing(),
+                        elements.len(),
+                        element_tys.len()
+                    ),
+                    diagnostics,
+                );
+            }
+            for (index, (element, expected_ty)) in elements.iter().zip(element_tys).enumerate() {
+                if let Some(actual_ty) = types.get(&element.value) {
+                    if actual_ty != expected_ty {
+                        invalid_operation(
+                            function,
+                            operation.id,
+                            format!(
+                                "tuple.make operand {index} has `{}`, expected `{}`",
+                                actual_ty.user_facing(),
+                                expected_ty.user_facing()
+                            ),
+                            diagnostics,
+                        );
+                    }
+                }
+            }
+        }
+        SemOpKind::TupleGet { tuple, index } => {
+            let Some(tuple_ty) = types.get(&tuple.value) else {
+                return;
+            };
+            let ResolvedTy::Tuple(element_tys) = tuple_ty else {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "tuple.get operand has non-tuple semantic type `{}`",
+                        tuple_ty.user_facing()
+                    ),
+                    diagnostics,
+                );
+                return;
+            };
+            if !is_initial_value_type(tuple_ty) {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "tuple.get operand `{}` is outside SIR's initial no-drop scalar/tuple value domain",
+                        tuple_ty.user_facing()
+                    ),
+                    diagnostics,
+                );
+            }
+            let Some(expected_ty) = usize::try_from(*index)
+                .ok()
+                .and_then(|index| element_tys.get(index))
+            else {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "tuple.get index {index} is out of bounds for `{}` with {} element(s)",
+                        tuple_ty.user_facing(),
+                        element_tys.len()
+                    ),
+                    diagnostics,
+                );
+                return;
+            };
+            if &result.ty != expected_ty {
+                invalid_operation(
+                    function,
+                    operation.id,
+                    format!(
+                        "tuple.get index {index} from `{}` produces `{}`, expected `{}`",
+                        tuple_ty.user_facing(),
+                        result.ty.user_facing(),
+                        expected_ty.user_facing()
+                    ),
+                    diagnostics,
+                );
+            }
+        }
         SemOpKind::Cast { value, to } => {
             if &result.ty != to {
                 diagnostics.push(diag(
@@ -1107,6 +1230,8 @@ fn require_read_use(
 fn operation_operand_context(kind: &SemOpKind, operand: crate::OperandSlot) -> &'static str {
     match kind {
         SemOpKind::ConstI64(_) | SemOpKind::ConstBool(_) => "operation operand",
+        SemOpKind::TupleMake { .. } => "tuple.make element",
+        SemOpKind::TupleGet { .. } => "tuple.get operand",
         SemOpKind::Unary { .. } => "unary operand",
         SemOpKind::Binary { .. } if operand.0 == 0 => "binary left operand",
         SemOpKind::Binary { .. } => "binary right operand",

--- a/hew-sir/tests/lower_tuples.rs
+++ b/hew-sir/tests/lower_tuples.rs
@@ -1,0 +1,273 @@
+use hew_hir::{lower_program_host_target, ItemId, ResolutionCtx};
+use hew_sir::{
+    build_def_use, dump_sir, lower_module, verify_function, verify_module, BlockId, CallableId,
+    CallableInstance, EffectSet, FunctionSourceOrigin, OpId, Operand, Provenance, SemBlock,
+    SemFunction, SemOp, SemOpKind, SemTerminator, UseMode, ValueDef, ValueId,
+};
+use hew_types::{module_registry::ModuleRegistry, Checker, DefId, ResolvedTy};
+
+fn lower_hir(source: &str) -> hew_hir::HirModule {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "source must parse before the SIR tuple lowering test: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(Vec::new()));
+    let type_check_output = checker.check_program(&parsed.program);
+    let hir = lower_program_host_target(&parsed.program, &type_check_output, &ResolutionCtx);
+    assert!(
+        hir.diagnostics.is_empty(),
+        "source must lower to HIR before the SIR tuple lowering test: {:#?}",
+        hir.diagnostics
+    );
+    hir.module
+}
+
+#[test]
+fn immutable_scalar_tuple_lowering_keeps_aggregate_semantics_in_sir() {
+    let hir = lower_hir(
+        r"
+        fn main() -> i64 {
+            let pair = (0, 42);
+            pair.0
+        }
+        ",
+    );
+    let lowered = lower_module(&hir);
+    let entry = lowered
+        .module
+        .entry_callable
+        .expect("root main must have a resolved SIR callable");
+    let main = lowered
+        .module
+        .function_for_callable(entry)
+        .expect("the tuple main must lower into SIR");
+
+    assert!(
+        verify_module(&lowered.module).is_empty(),
+        "tuple SIR must verify before crossing to Raw MIR: {:#?}",
+        verify_module(&lowered.module)
+    );
+    let ops = &main.blocks[0].ops;
+    assert!(matches!(ops[0].kind, SemOpKind::ConstI64(0)));
+    assert!(matches!(ops[1].kind, SemOpKind::ConstI64(42)));
+    let tuple_value = ops[2]
+        .results
+        .first()
+        .expect("tuple.make must define one semantic value");
+    assert_eq!(
+        tuple_value.ty,
+        ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64])
+    );
+    assert!(matches!(
+        &ops[2].kind,
+        SemOpKind::TupleMake { elements }
+            if elements.iter().map(|element| element.value).collect::<Vec<_>>()
+                == vec![ops[0].results[0].id, ops[1].results[0].id]
+                && elements.iter().all(|element| element.mode == UseMode::Read)
+    ));
+    assert!(matches!(
+        &ops[3].kind,
+        SemOpKind::TupleGet { tuple, index: 0 }
+            if tuple.value == tuple_value.id && tuple.mode == UseMode::Read
+    ));
+    assert!(ops[2].kind.effects().is_pure());
+    assert!(ops[3].kind.effects().is_pure());
+    assert_eq!(
+        build_def_use(main).use_count(tuple_value.id),
+        1,
+        "tuple.get must participate in the shared operand visitor/def-use index"
+    );
+
+    let dump = dump_sir(&lowered.module);
+    assert_eq!(
+        dump,
+        concat!(
+            "fn main() -> i64 {\n",
+            "bb0:\n",
+            "    %0 = const 0\n",
+            "    %1 = const 42\n",
+            "    %2 = tuple.make(%0, %1)\n",
+            "    %3 = tuple.get %2, 0\n",
+            "    return %3\n",
+            "}\n"
+        )
+    );
+    assert!(
+        !dump.contains("offset") && !dump.contains("alloca") && !dump.contains("field.load"),
+        "SIR tuple text must not expose representation details: {dump}"
+    );
+}
+
+#[test]
+fn generic_scalar_instances_substitute_tuple_values_before_raw_mir() {
+    let hir = lower_hir(
+        r"
+        fn first<T>(left: T, right: T) -> T {
+            let pair = (left, right);
+            pair.0
+        }
+
+        fn main() -> i64 {
+            first(7, 9)
+        }
+        ",
+    );
+    let lowered = lower_module(&hir);
+    assert!(
+        verify_module(&lowered.module).is_empty(),
+        "the generic tuple instance must verify: {:#?}",
+        verify_module(&lowered.module)
+    );
+    let instance = lowered
+        .module
+        .callables
+        .iter()
+        .find(|callable| matches!(callable.instance, CallableInstance::Generic(_)))
+        .expect("main's generic call must request one concrete SIR instance");
+    let function = lowered
+        .module
+        .function_for_callable(instance.id)
+        .expect("the concrete generic instance must lower a SIR body");
+    let tuple_make = function
+        .blocks
+        .iter()
+        .flat_map(|block| &block.ops)
+        .find(|op| matches!(op.kind, SemOpKind::TupleMake { .. }))
+        .expect("the concrete generic body must retain tuple.make");
+    assert_eq!(
+        tuple_make.results[0].ty,
+        ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64]),
+        "SIR must specialize semantic types before Raw MIR chooses a layout"
+    );
+}
+
+#[test]
+fn nested_bitcopy_tuples_remain_abstract_through_projection() {
+    let hir = lower_hir(
+        r"
+        fn main() -> i64 {
+            let pair = (0, (41, 42));
+            let inner = pair.1;
+            inner.0
+        }
+        ",
+    );
+    let lowered = lower_module(&hir);
+    assert!(
+        verify_module(&lowered.module).is_empty(),
+        "nested tuple SIR must verify: {:#?}",
+        verify_module(&lowered.module)
+    );
+    let entry = lowered
+        .module
+        .entry_callable
+        .expect("nested tuple main must be the entry callable");
+    let main = lowered
+        .module
+        .function_for_callable(entry)
+        .expect("nested tuple main must lower to SIR");
+    let tuple_makes = main
+        .blocks
+        .iter()
+        .flat_map(|block| &block.ops)
+        .filter(|op| matches!(op.kind, SemOpKind::TupleMake { .. }))
+        .count();
+    let tuple_gets = main
+        .blocks
+        .iter()
+        .flat_map(|block| &block.ops)
+        .filter(|op| matches!(op.kind, SemOpKind::TupleGet { .. }))
+        .count();
+    assert_eq!(tuple_makes, 2);
+    assert_eq!(tuple_gets, 2);
+}
+
+#[test]
+fn tuple_verifier_rejects_non_tuple_construction_and_projection() {
+    let function = SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test("malformed_tuple"),
+        name: "malformed_tuple".to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::default(),
+        params: Vec::new(),
+        return_ty: ResolvedTy::I64,
+        entry: BlockId(0),
+        blocks: vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: vec![
+                SemOp {
+                    id: OpId(0),
+                    results: vec![ValueDef {
+                        id: ValueId(0),
+                        ty: ResolvedTy::I64,
+                    }],
+                    kind: SemOpKind::ConstI64(0),
+                    provenance: Provenance::Synthesized,
+                },
+                SemOp {
+                    id: OpId(1),
+                    results: vec![ValueDef {
+                        id: ValueId(1),
+                        ty: ResolvedTy::I64,
+                    }],
+                    kind: SemOpKind::TupleMake {
+                        elements: vec![Operand {
+                            value: ValueId(0),
+                            mode: UseMode::Read,
+                        }],
+                    },
+                    provenance: Provenance::Synthesized,
+                },
+                SemOp {
+                    id: OpId(2),
+                    results: vec![ValueDef {
+                        id: ValueId(2),
+                        ty: ResolvedTy::I64,
+                    }],
+                    kind: SemOpKind::TupleGet {
+                        tuple: Operand {
+                            value: ValueId(0),
+                            mode: UseMode::Read,
+                        },
+                        index: 0,
+                    },
+                    provenance: Provenance::Synthesized,
+                },
+            ],
+            terminator: SemTerminator::Return {
+                value: Some(Operand {
+                    value: ValueId(2),
+                    mode: UseMode::Read,
+                }),
+            },
+        }],
+    };
+
+    let diagnostics = verify_function(&function);
+    assert!(diagnostics.iter().any(|diagnostic| {
+        matches!(
+            &diagnostic.kind,
+            hew_sir::SirDiagnosticKind::InvalidOperation { op: OpId(1), reason }
+                if reason.contains("tuple.make result must have a semantic tuple type")
+        )
+    }));
+    assert!(diagnostics.iter().any(|diagnostic| {
+        matches!(
+            &diagnostic.kind,
+            hew_sir::SirDiagnosticKind::InvalidOperation { op: OpId(2), reason }
+                if reason.contains("tuple.get operand has non-tuple semantic type")
+        )
+    }));
+    assert_eq!(
+        EffectSet::PURE,
+        SemOpKind::TupleMake {
+            elements: Vec::new()
+        }
+        .effects()
+    );
+}

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -123,7 +123,7 @@ string-method-identity	qualified-format-macro	hew-analysis/src/hover.rs	5	stage-
 string-method-identity	qualified-format-macro	hew-analysis/src/inlay_hints.rs	5	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-analysis/src/signature_help.rs	1	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/layout.rs	20	stage-5	reviewed qualified string identity construction
-string-method-identity	qualified-format-macro	hew-codegen-rs/src/llvm.rs	114	stage-5	reviewed qualified string identity construction
+string-method-identity	qualified-format-macro	hew-codegen-rs/src/llvm.rs	114	stage-5	reviewed qualified string identity construction; Raw virtual-value semantic admission belongs to the canonical hew-mir verifier, leaving LLVM realization diagnostics only
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/llvm/identity.rs	6	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/runtime_abi.rs	64	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/suspend.rs	11	stage-5	reviewed qualified string identity construction
@@ -132,6 +132,7 @@ string-method-identity	qualified-format-macro	hew-hir/src/dump.rs	2	stage-1	revi
 string-method-identity	qualified-format-macro	hew-hir/src/lower.rs	32	stage-1	reviewed compatibility-key factory for unique imported tagged-union constructors and `?` checker payload mismatch diagnostics; exact source owner remains the authority
 string-method-identity	qualified-format-macro	hew-hir/src/node.rs	1	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-mir/src/dump.rs	6	stage-5	reviewed qualified string identity construction
+string-method-identity	qualified-format-macro	hew-mir/src/raw_values.rs	2	stage-5	canonical Raw virtual-value verifier reports the verified Raw/Checked/Elaborated ladder boundary
 string-method-identity	qualified-format-macro	hew-mir/src/lower/consts.rs	2	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-mir/src/lower/control_flow.rs	3	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-mir/src/lower/drop_plan.rs	2	stage-3	reviewed qualified string identity construction


### PR DESCRIPTION
## Summary

Introduces the first durable value-only lane inside Raw MIR. This is not another general-purpose IR: it separates virtual `RawValueId` values from addressable `Place`s for a deliberately small, no-drop tuple proof.

- Adds `RawValueId`, typed value definitions, `RawValueOp::{Param, ConstI64, ConstBool, TupleMake, TupleGet}`, and the sole materialization boundary: `ReturnAbi -> Place::ReturnSlot`.
- Preserves tuple semantics through SIR and Raw MIR; LLVM alone realizes it with `insertvalue` / `extractvalue`.
- Adds one canonical Raw verifier used by both strict SIR lowering and Raw-to-LLVM codegen. Virtual bodies must be scalar-ABI, non-coroutine, non-synthesized, storage-free, and have exact parameter facts plus matching Checked and zero-drop Elaborated MIR.
- Fails closed for semantic type aliases, aggregate return ABI, place/storage mixing, stale scheduler/context facts, missing ladder stages, coroutine metadata, and synthetic actor/machine provenance.
- Adds strict source E2E proving scalar parameters remain virtual through SIR -> Raw -> Checked -> Elaborated -> LLVM, with no legacy fallback or tuple/parameter allocas.

## Intentionally deferred

Raw CFG value edges/block arguments, tuple ABI, calls, ownership-bearing values, records/enums, and layout-dependent lowering. The existing `ValueId -> Place::Local` bridge remains a temporary compatibility route outside this new admitted lane.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `make structural-lint`
- `cargo clippy -p hew-mir -p hew-codegen-rs -p hew-sir --tests -- -D warnings`
- `cargo test -p hew-codegen-rs virtual_raw --lib` (8)
- `cargo test -p hew-mir sir::tests:: --lib` (17)
- `cargo test -p hew-sir` (35)
- strict CLI source -> SIR -> Raw -> Checked -> Elaborated -> LLVM tuple/parameter E2E
- affected machine-transition group rerun with the in-tree stdlib path: 17 passed

A broad pipeline run was also attempted; its failures were environmental (an ephemeral-port startup race, then a manual test invocation without `HEW_STD`), not a compiler failure. CI remains the full clean-environment gate.