### PR TITLE
runtime: share COW envelope lifecycle

### DIFF
--- a/hew-runtime/src/cow_envelope.rs
+++ b/hew-runtime/src/cow_envelope.rs
@@ -1,0 +1,386 @@
+//! Target-neutral COW mailbox envelope representation and lifecycle.
+//!
+//! Native and WASM mailboxes deliberately keep different queue and scheduling
+//! implementations. The payload envelope, however, is ABI-identical and has
+//! one lifecycle, so this module is its sole implementation authority.
+
+use std::ffi::c_void;
+use std::ptr;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+use crate::mailbox_header::{
+    header_validate, HEW_MSG_ENVELOPE_ALIAS_ACTIVE, HEW_MSG_ENVELOPE_FORKED,
+};
+
+/// Drop glue invoked once, before the envelope releases its payload allocation.
+pub type HewMsgEnvelopeDropFn = unsafe extern "C" fn(*mut c_void);
+
+/// ABI-stable, refcounted COW container for an actor message payload.
+#[repr(C)]
+pub struct HewMsgEnvelope {
+    /// Number of live observers.
+    pub refcount: AtomicUsize,
+    /// Envelope contract bits; see [`crate::mailbox_header`].
+    pub header_bits: AtomicU32,
+    /// Heap-allocated payload bytes.
+    pub payload: *mut c_void,
+    /// Size of `payload` in bytes.
+    pub payload_size: usize,
+    /// Optional typed destructor run before the payload allocation is freed.
+    pub drop_glue: Option<HewMsgEnvelopeDropFn>,
+}
+
+impl std::fmt::Debug for HewMsgEnvelope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HewMsgEnvelope")
+            .field("refcount", &self.refcount.load(Ordering::Relaxed))
+            .field("header_bits", &self.header_bits.load(Ordering::Relaxed))
+            .field("payload", &self.payload)
+            .field("payload_size", &self.payload_size)
+            .field("drop_glue_set", &self.drop_glue.is_some())
+            .finish()
+    }
+}
+
+// SAFETY: only atomic fields mutate after construction; payload is read-only
+// while an observer exists and is dropped only by the final releaser.
+unsafe impl Send for HewMsgEnvelope {}
+// SAFETY: see the `Send` implementation above.
+unsafe impl Sync for HewMsgEnvelope {}
+
+/// Target mailbox allocator, retained as an argument so target test hooks and
+/// allocation policies remain owned by their respective mailbox modules.
+pub type EnvelopeAlloc = fn(usize) -> *mut c_void;
+
+/// Allocate an envelope with one observer.
+///
+/// # Safety
+///
+/// `payload` must be allocated by `libc::malloc` (or be null for a zero-sized
+/// payload). Ownership transfers to the returned envelope.
+pub unsafe fn new(
+    payload: *mut c_void,
+    payload_size: usize,
+    drop_glue: Option<HewMsgEnvelopeDropFn>,
+    allocate: EnvelopeAlloc,
+) -> *mut HewMsgEnvelope {
+    let env = allocate(std::mem::size_of::<HewMsgEnvelope>()).cast::<HewMsgEnvelope>();
+    if env.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: `env` is a fresh allocation with suitable size and alignment.
+    unsafe {
+        ptr::write(&raw mut (*env).refcount, AtomicUsize::new(1));
+        ptr::write(&raw mut (*env).header_bits, AtomicU32::new(0));
+        (*env).payload = payload;
+        (*env).payload_size = payload_size;
+        (*env).drop_glue = drop_glue;
+    }
+    env
+}
+
+/// Add an alias observer and return the same envelope pointer.
+///
+/// # Safety
+///
+/// `env` must be live and the caller must own one reference.
+pub unsafe fn clone_alias(env: *mut HewMsgEnvelope) -> *mut HewMsgEnvelope {
+    if env.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: the caller guarantees a live envelope.
+    unsafe {
+        let prev = (*env).refcount.fetch_add(1, Ordering::Relaxed);
+        debug_assert!(prev >= 1, "clone_alias on a released envelope");
+        (*env)
+            .header_bits
+            .fetch_or(HEW_MSG_ENVELOPE_ALIAS_ACTIVE, Ordering::Relaxed);
+    }
+    env
+}
+
+/// Release one observer, destroying the payload and envelope on the final one.
+///
+/// # Safety
+///
+/// `env` must be null or a live envelope for which the caller owns a reference.
+pub unsafe fn release(env: *mut HewMsgEnvelope) {
+    if env.is_null() {
+        return;
+    }
+    // SAFETY: the caller guarantees a live envelope reference.
+    unsafe {
+        let prev = (*env).refcount.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(prev >= 1, "release on a zero-count envelope");
+        if prev == 1 {
+            header_validate((*env).header_bits.load(Ordering::Acquire));
+            if let Some(drop_fn) = (*env).drop_glue {
+                if !(*env).payload.is_null() {
+                    drop_fn((*env).payload);
+                }
+            }
+            if !(*env).payload.is_null() {
+                libc::free((*env).payload);
+            }
+            libc::free(env.cast());
+        }
+    }
+}
+
+/// Return a read-only borrowed payload pointer, or null for a null envelope.
+///
+/// # Safety
+///
+/// `env` must be null or live; the result remains valid while a reference exists.
+pub unsafe fn payload_ptr(env: *mut HewMsgEnvelope) -> *mut c_void {
+    if env.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: the caller guarantees a live envelope.
+    unsafe { (*env).payload }
+}
+
+/// Fork an envelope into a private single-observer payload copy.
+///
+/// # Safety
+///
+/// `env` must be live and the caller transfers one owned reference to this call.
+pub unsafe fn fork_for_write(
+    env: *mut HewMsgEnvelope,
+    allocate: EnvelopeAlloc,
+) -> *mut HewMsgEnvelope {
+    if env.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: the caller guarantees a live envelope and the payload alias
+    // contract permits this read-only snapshot.
+    let (payload_size, drop_glue, src_payload, src_bits) = unsafe {
+        (
+            (*env).payload_size,
+            (*env).drop_glue,
+            (*env).payload,
+            (*env).header_bits.load(Ordering::Relaxed),
+        )
+    };
+    let new_payload = if payload_size > 0 && !src_payload.is_null() {
+        let buf = allocate(payload_size);
+        if buf.is_null() {
+            return ptr::null_mut();
+        }
+        // SAFETY: `buf` is fresh and `src_payload` is readable under the alias contract.
+        unsafe { libc::memcpy(buf, src_payload, payload_size) };
+        buf
+    } else {
+        ptr::null_mut()
+    };
+    // SAFETY: `new_payload` is a fresh compatible allocation.
+    let forked = unsafe { new(new_payload, payload_size, drop_glue, allocate) };
+    if forked.is_null() {
+        if !new_payload.is_null() {
+            // SAFETY: this unpublished allocation belongs to this function.
+            unsafe { libc::free(new_payload) };
+        }
+        return ptr::null_mut();
+    }
+    let inherited_bits = (src_bits & !HEW_MSG_ENVELOPE_ALIAS_ACTIVE) | HEW_MSG_ENVELOPE_FORKED;
+    // SAFETY: `forked` was created above and is live.
+    unsafe {
+        (*forked)
+            .header_bits
+            .fetch_or(inherited_bits, Ordering::Relaxed);
+        release(env);
+    }
+    forked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mailbox_header::{
+        HEW_MSG_ENVELOPE_ARENA_BACKED, HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER,
+        HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK, HEW_MSG_ENVELOPE_RESERVED_DELTA_A,
+        HEW_MSG_ENVELOPE_RESERVED_GAMMA_B, HEW_MSG_ENVELOPE_SHARED_FROZEN,
+    };
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::Mutex;
+
+    static CORE_TEST_LOCK: Mutex<()> = Mutex::new(());
+    static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+    static ALLOC_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static FAIL_ALLOC_ON_CALL: AtomicUsize = AtomicUsize::new(usize::MAX);
+
+    unsafe extern "C" fn drop_probe(_payload: *mut c_void) {
+        DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn alloc(size: usize) -> *mut c_void {
+        // SAFETY: the shared lifecycle requires a malloc-compatible allocator.
+        unsafe { libc::malloc(size) }
+    }
+
+    fn fail_on_selected_call(size: usize) -> *mut c_void {
+        let call = ALLOC_CALLS.fetch_add(1, Ordering::SeqCst);
+        if call == FAIL_ALLOC_ON_CALL.load(Ordering::SeqCst) {
+            return ptr::null_mut();
+        }
+        // SAFETY: the shared lifecycle requires a malloc-compatible allocator.
+        unsafe { libc::malloc(size) }
+    }
+
+    fn payload(bytes: &[u8]) -> *mut c_void {
+        // SAFETY: malloc returns a buffer of `bytes.len()` bytes or null; tests
+        // refuse OOM before copying the known-valid input bytes.
+        unsafe {
+            let allocation = libc::malloc(bytes.len());
+            assert!(!allocation.is_null());
+            ptr::copy_nonoverlapping(bytes.as_ptr(), allocation.cast::<u8>(), bytes.len());
+            allocation
+        }
+    }
+
+    #[test]
+    fn layout_fingerprint_is_a_five_word_c_abi_record() {
+        let word = std::mem::size_of::<usize>();
+        assert_eq!(std::mem::align_of::<HewMsgEnvelope>(), word);
+        assert_eq!(std::mem::size_of::<HewMsgEnvelope>(), 5 * word);
+        assert_eq!(std::mem::offset_of!(HewMsgEnvelope, refcount), 0);
+        assert_eq!(std::mem::offset_of!(HewMsgEnvelope, header_bits), word);
+        assert_eq!(std::mem::offset_of!(HewMsgEnvelope, payload), 2 * word);
+        assert_eq!(std::mem::offset_of!(HewMsgEnvelope, payload_size), 3 * word);
+        assert_eq!(std::mem::offset_of!(HewMsgEnvelope, drop_glue), 4 * word);
+    }
+
+    #[test]
+    fn alias_refcount_starts_at_one_and_sets_the_alias_bit() {
+        let _serial = CORE_TEST_LOCK.lock().unwrap();
+        // SAFETY: the test owns the payload and every envelope reference.
+        unsafe {
+            let env = new(payload(b"alias"), 5, None, alloc);
+            assert_eq!((*env).refcount.load(Ordering::SeqCst), 1);
+            assert_eq!((*env).header_bits.load(Ordering::SeqCst), 0);
+            assert_eq!(clone_alias(env), env);
+            assert_eq!((*env).refcount.load(Ordering::SeqCst), 2);
+            assert_ne!(
+                (*env).header_bits.load(Ordering::SeqCst) & HEW_MSG_ENVELOPE_ALIAS_ACTIVE,
+                0
+            );
+            release(env);
+            release(env);
+        }
+    }
+
+    #[test]
+    fn null_payload_is_borrowable_and_never_calls_drop_glue() {
+        let _serial = CORE_TEST_LOCK.lock().unwrap();
+        DROP_COUNT.store(0, Ordering::SeqCst);
+        // SAFETY: the test owns the null-payload envelope reference.
+        unsafe {
+            let env = new(ptr::null_mut(), 0, Some(drop_probe), alloc);
+            assert!(!env.is_null());
+            assert!(payload_ptr(env).is_null());
+            release(env);
+        }
+        assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn final_release_runs_drop_glue_exactly_once() {
+        let _serial = CORE_TEST_LOCK.lock().unwrap();
+        DROP_COUNT.store(0, Ordering::SeqCst);
+        // SAFETY: the test owns the payload and both alias references.
+        unsafe {
+            let env = new(payload(b"drop"), 4, Some(drop_probe), alloc);
+            clone_alias(env);
+            release(env);
+            assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 0);
+            release(env);
+        }
+        assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn fork_oom_rolls_back_without_consuming_the_source_reference() {
+        let _serial = CORE_TEST_LOCK.lock().unwrap();
+        DROP_COUNT.store(0, Ordering::SeqCst);
+        ALLOC_CALLS.store(0, Ordering::SeqCst);
+        FAIL_ALLOC_ON_CALL.store(usize::MAX, Ordering::SeqCst);
+        // SAFETY: the test owns the payload and both alias references.
+        unsafe {
+            let env = new(
+                payload(b"rollback"),
+                8,
+                Some(drop_probe),
+                fail_on_selected_call,
+            );
+            assert!(!env.is_null());
+            clone_alias(env);
+            ALLOC_CALLS.store(0, Ordering::SeqCst);
+            // The payload copy succeeds, then allocating its envelope fails.
+            FAIL_ALLOC_ON_CALL.store(1, Ordering::SeqCst);
+            assert!(fork_for_write(env, fail_on_selected_call).is_null());
+            assert_eq!((*env).refcount.load(Ordering::SeqCst), 2);
+            assert_eq!(
+                std::slice::from_raw_parts((*env).payload.cast::<u8>(), 8),
+                b"rollback"
+            );
+            release(env);
+            release(env);
+        }
+        FAIL_ALLOC_ON_CALL.store(usize::MAX, Ordering::SeqCst);
+        assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn fork_copies_payload_and_inherits_only_non_alias_bits() {
+        let _serial = CORE_TEST_LOCK.lock().unwrap();
+        DROP_COUNT.store(0, Ordering::SeqCst);
+        let inherited = HEW_MSG_ENVELOPE_SHARED_FROZEN
+            | HEW_MSG_ENVELOPE_ARENA_BACKED
+            | HEW_MSG_ENVELOPE_CAPABILITY_TRANSFER
+            | HEW_MSG_ENVELOPE_RESERVED_GAMMA_B
+            | HEW_MSG_ENVELOPE_RESERVED_DELTA_A;
+        // SAFETY: the test owns the payload and both resulting envelope references.
+        unsafe {
+            let env = new(payload(b"fork"), 4, Some(drop_probe), alloc);
+            clone_alias(env);
+            (*env).header_bits.fetch_or(inherited, Ordering::SeqCst);
+            let forked = fork_for_write(env, alloc);
+            assert!(!forked.is_null());
+            assert_ne!((*forked).payload, (*env).payload);
+            assert_eq!((*forked).refcount.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                (*forked).header_bits.load(Ordering::SeqCst),
+                inherited | HEW_MSG_ENVELOPE_FORKED
+            );
+            *(*forked).payload.cast::<u8>() = b'F';
+            assert_eq!(
+                std::slice::from_raw_parts((*forked).payload.cast::<u8>(), 4),
+                b"Fork"
+            );
+            assert_eq!(
+                std::slice::from_raw_parts((*env).payload.cast::<u8>(), 4),
+                b"fork"
+            );
+            release(forked);
+            release(env);
+        }
+        assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn reserved_bits_refuse_final_release() {
+        let _serial = CORE_TEST_LOCK.lock().unwrap();
+        // SAFETY: this test restores the live envelope after observing the
+        // fail-closed panic so it can release the allocation normally.
+        unsafe {
+            let env = new(ptr::null_mut(), 0, None, alloc);
+            (*env)
+                .header_bits
+                .store(HEW_MSG_ENVELOPE_MUST_BE_ZERO_MASK, Ordering::SeqCst);
+            assert!(catch_unwind(AssertUnwindSafe(|| release(env))).is_err());
+            (*env).refcount.store(1, Ordering::SeqCst);
+            (*env).header_bits.store(0, Ordering::SeqCst);
+            release(env);
+        }
+    }
+}

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -797,6 +797,8 @@ pub mod stdio;
 
 #[cfg(any(target_arch = "wasm32", test))]
 pub mod bridge;
+/// Target-neutral COW mailbox payload envelope lifecycle.
+pub mod cow_envelope;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod crash;
 #[cfg(not(target_arch = "wasm32"))]

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -30,7 +30,7 @@ use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 
 use crate::internal::types::{HewError, HewOverflowPolicy};
-use crate::mailbox_header::{header_validate, normalize_coalesce_fallback, Origin};
+use crate::mailbox_header::{normalize_coalesce_fallback, Origin};
 use crate::scheduler::{MESSAGES_RECEIVED, MESSAGES_SENT};
 use crate::set_last_error;
 use crate::tracing::HewTraceContext;
@@ -350,6 +350,7 @@ fn run_mpsc_post_swap_pre_link_hook(node: *mut HewMsgNode) {
     }
 }
 
+pub use crate::cow_envelope::{HewMsgEnvelope, HewMsgEnvelopeDropFn};
 pub use crate::mailbox_header::HewSysMsg;
 pub use crate::mailbox_header::{
     HEW_MSG_ENVELOPE_ALIAS_ACTIVE, HEW_MSG_ENVELOPE_ARENA_BACKED,
@@ -481,307 +482,76 @@ pub struct HewMsgNode {
     pub cancel_token_handle: u64,
 }
 
-// ── Phase-α COW message envelope ────────────────────────────────────────
-//
-// `HewMsgEnvelope` is a refcounted container for actor message payloads.
-// Today, every actor send `libc::memcpy`s the payload bytes into a fresh
-// buffer; under the COW envelope, the receiver borrows the sender's
-// already-owned payload by bumping the envelope's refcount, and the
-// sender's binding is invalidated by the move-checker so no observable
-// alias remains. The fork-on-write path exists for completeness but is
-// expected to be cold — the move-checker rejects observable writes after
-// send for non-`Copy` types, so a runtime fork only fires for the
-// narrow corner cases the static analysis cannot prove safe.
-//
-// The cross-target header assignments and pure bit logic live in
-// `crate::mailbox_header`; native allocation and scheduling remain here.
+// The envelope representation and lifecycle live in `crate::cow_envelope`.
+// This module retains the native allocator and C-ABI null-error policy.
 
-/// Drop glue invoked when an envelope's refcount drops to zero.
-///
-/// Receives the payload pointer; runs destructors on the payload's
-/// fields. The envelope's release path calls this BEFORE freeing the
-/// payload buffer itself, mirroring how `hew_msg_node_free` walked
-/// drop responsibilities for legacy nodes.
-pub type HewMsgEnvelopeDropFn = unsafe extern "C" fn(*mut c_void);
-
-/// Refcounted COW envelope for actor message payloads.
-///
-/// All envelope FFI functions take `*mut HewMsgEnvelope`. The struct
-/// is `#[repr(C)]` so codegen can reference its layout; the fields
-/// are `pub` for the same reason but should only be read/written
-/// through the FFI surface.
-#[repr(C)]
-pub struct HewMsgEnvelope {
-    /// Number of live observers. Released atomically; payload + drop
-    /// glue fire on the transition to zero.
-    pub refcount: AtomicUsize,
-    /// Header bits — see `HEW_MSG_ENVELOPE_*` constants.
-    pub header_bits: std::sync::atomic::AtomicU32,
-    /// Pointer to the heap-allocated payload bytes (malloc'd).
-    pub payload: *mut c_void,
-    /// Size of `payload` in bytes.
-    pub payload_size: usize,
-    /// Optional drop glue invoked once the refcount drops to zero,
-    /// before the envelope frees the payload buffer.
-    pub drop_glue: Option<HewMsgEnvelopeDropFn>,
-}
-
-impl std::fmt::Debug for HewMsgEnvelope {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HewMsgEnvelope")
-            .field("refcount", &self.refcount.load(Ordering::Relaxed))
-            .field("header_bits", &self.header_bits.load(Ordering::Relaxed))
-            .field("payload", &self.payload)
-            .field("payload_size", &self.payload_size)
-            .field("drop_glue_set", &self.drop_glue.is_some())
-            .finish()
-    }
-}
-
-// SAFETY: the envelope's mutable state is the atomics on refcount and
-// header_bits; payload bytes are only read while ≥1 observer holds
-// the envelope, and codegen guarantees the alias contract (read-only).
-// The raw `*mut c_void` payload pointer is opaque to Rust here — the
-// only reads/writes through it are by the receiver (read-only) and
-// the drop_glue invoked under exclusive last-release ownership.
-unsafe impl Send for HewMsgEnvelope {}
-// SAFETY: see the `Send` impl above; concurrent reads are read-only,
-// concurrent refcount/header mutations go through atomics.
-unsafe impl Sync for HewMsgEnvelope {}
-
-/// Allocate a fresh envelope wrapping `payload`.
-///
-/// The envelope takes ownership of `payload` (which must be a pointer
-/// returned by `libc::malloc` or compatible) and of running `drop_glue`
-/// before freeing the buffer. Initial refcount is 1. Initial header
-/// bits are 0 (no alias active until `clone_alias` bumps the refcount).
-///
-/// Returns null on OOM.
+/// Allocate a fresh COW envelope using the native mailbox allocator.
 ///
 /// # Safety
 ///
-/// `payload` must be a `libc::malloc`-allocated buffer of at least
-/// `payload_size` bytes, or null when `payload_size` is 0. After this
-/// call the envelope owns the buffer; the caller must not free it
-/// directly.
-///
-/// `drop_glue`, when set, is called exactly once with the payload
-/// pointer when the refcount drops to zero. It must run destructors
-/// only — the envelope frees the buffer afterwards.
+/// `payload` must be a malloc-compatible allocation of `payload_size` bytes
+/// (or null for zero bytes). Ownership transfers to the returned envelope.
 #[no_mangle]
 pub unsafe extern "C" fn hew_msg_envelope_new(
     payload: *mut c_void,
     payload_size: usize,
     drop_glue: Option<HewMsgEnvelopeDropFn>,
 ) -> *mut HewMsgEnvelope {
-    let env = mailbox_malloc(std::mem::size_of::<HewMsgEnvelope>()).cast::<HewMsgEnvelope>();
-    if env.is_null() {
-        return ptr::null_mut();
-    }
-    // SAFETY: `env` is non-null, properly aligned, and we own it exclusively.
-    unsafe {
-        ptr::write(&raw mut (*env).refcount, AtomicUsize::new(1));
-        ptr::write(
-            &raw mut (*env).header_bits,
-            std::sync::atomic::AtomicU32::new(0),
-        );
-        (*env).payload = payload;
-        (*env).payload_size = payload_size;
-        (*env).drop_glue = drop_glue;
-    }
-    env
+    // SAFETY: forwarded unchanged to the shared envelope lifecycle.
+    unsafe { crate::cow_envelope::new(payload, payload_size, drop_glue, mailbox_malloc) }
 }
 
-/// Bump the envelope's refcount and set the `ALIAS_ACTIVE` bit.
-///
-/// Used by the in-process COW send path: the sender's already-owned
-/// payload is wrapped, then `clone_alias` bumps to refcount=2 so both
-/// the sender's send-site bookkeeping and the receiver's mailbox node
-/// hold one count. (Under symmetric-affine sends — see Q7 — the
-/// sender's count is released at the send site immediately, leaving
-/// the receiver as the sole observer.)
-///
-/// Returns the same pointer for caller convenience.
+/// Add an alias observer to a live COW envelope.
 ///
 /// # Safety
 ///
-/// `env` must be a live envelope obtained from `hew_msg_envelope_new`
-/// (or already-cloned). The caller guarantees no concurrent
-/// `hew_msg_envelope_release` on the last reference.
+/// `env` must be live and the caller must own one of its references.
 #[no_mangle]
 pub unsafe extern "C" fn hew_msg_envelope_clone_alias(
     env: *mut HewMsgEnvelope,
 ) -> *mut HewMsgEnvelope {
     cabi_guard!(env.is_null(), ptr::null_mut());
-    // SAFETY: `env` is live; refcount + header_bits are atomics.
-    unsafe {
-        let prev = (*env).refcount.fetch_add(1, Ordering::Relaxed);
-        debug_assert!(prev >= 1, "clone_alias on a released envelope");
-        (*env)
-            .header_bits
-            .fetch_or(HEW_MSG_ENVELOPE_ALIAS_ACTIVE, Ordering::Relaxed);
-    }
-    env
+    // SAFETY: the C ABI contract requires a live envelope.
+    unsafe { crate::cow_envelope::clone_alias(env) }
 }
 
-/// Drop one observer's reference. Frees the envelope (and runs drop
-/// glue + frees the payload) when the count reaches zero.
-///
-/// Idempotent against a null pointer; calling this twice on the same
-/// reference is undefined (the standard refcount contract).
-///
-/// ## D355 borrow model — who runs the single `drop_glue`
-///
-/// Under the D355 design an aliased message is *borrowed* read-only by
-/// the receiver, never moved into it: there is no CONSUMED bit and the
-/// receiver does not take ownership of the payload. The envelope owns
-/// the one and only `drop_glue` invocation, run here on the final
-/// release (refcount 1 → 0). Every node that carries the envelope
-/// funnels its release through [`hew_msg_node_free`], so the buffer is
-/// dropped exactly once regardless of which exit (dispatch, drain,
-/// close, supervisor-cancel, session-reset, mailbox-free) retires it.
-///
-/// This invariant is why owned-value dispatch of an envelope-mode node
-/// is a fail-closed bug: if a handler received the payload *by value*
-/// it would run `drop_glue` a second time. The scheduler refuses that
-/// path until the borrow-only receive ABI exists (P5.2) — see the
-/// envelope-mode guard in `scheduler.rs` dispatch.
+/// Release one live COW envelope observer.
 ///
 /// # Safety
 ///
-/// `env` must be a live envelope; the caller is decrementing exactly
-/// one reference they own.
+/// `env` must be live and the caller must own exactly one reference.
 #[no_mangle]
 pub unsafe extern "C" fn hew_msg_envelope_release(env: *mut HewMsgEnvelope) {
     cabi_guard!(env.is_null());
-    // SAFETY: `env` is live; refcount is atomic.
-    unsafe {
-        let prev = (*env).refcount.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(prev >= 1, "release on a zero-count envelope");
-        if prev == 1 {
-            // Final release: validate header bits, run drop glue, free
-            // the payload buffer, and free the envelope itself.
-            let bits = (*env).header_bits.load(Ordering::Acquire);
-            header_validate(bits);
-            if let Some(drop_fn) = (*env).drop_glue {
-                if !(*env).payload.is_null() {
-                    drop_fn((*env).payload);
-                }
-            }
-            if !(*env).payload.is_null() {
-                libc::free((*env).payload);
-            }
-            libc::free(env.cast());
-        }
-    }
+    // SAFETY: the C ABI contract requires a live envelope reference.
+    unsafe { crate::cow_envelope::release(env) }
 }
 
-/// Borrow the payload pointer for read-only access.
-///
-/// The receiver uses this to read fields off an aliased payload. The
-/// returned pointer is borrow-only — the receiver must not free it
-/// (the envelope owns the allocation).
-///
-/// Returns null on a null envelope.
+/// Borrow a COW envelope payload pointer for read-only access.
 ///
 /// # Safety
 ///
-/// `env` must be a live envelope. The returned pointer is valid for
-/// reads only as long as the caller holds a refcount.
+/// `env` must be null or live. The result remains valid only while the caller
+/// owns a reference and must not be used to mutate or free the payload.
 #[no_mangle]
 pub unsafe extern "C" fn hew_msg_envelope_payload_ptr(env: *mut HewMsgEnvelope) -> *mut c_void {
-    if env.is_null() {
-        return ptr::null_mut();
-    }
-    // SAFETY: `env` is live; payload is a stable pointer for the life
-    // of the envelope (forks allocate a fresh envelope, not a fresh
-    // payload on the original).
-    unsafe { (*env).payload }
+    // SAFETY: a non-null C ABI argument must be a live envelope.
+    unsafe { crate::cow_envelope::payload_ptr(env) }
 }
 
-/// Fork an envelope for write. Allocates a fresh, single-observer
-/// envelope holding a private copy of the payload bytes; decrements
-/// the original's refcount; sets `FORKED` on the new envelope.
-///
-/// Used as the fail-safe write path when codegen could not prove the
-/// sender's binding was invalidated post-send. Expected to be cold —
-/// the move-checker rejects observable post-send writes for non-`Copy`
-/// types. The runtime fork is the safety net for cases the static
-/// analysis cannot reason about.
-///
-/// Returns null on OOM (the original envelope's refcount is
-/// unchanged in that case so the caller still owns it).
+/// Fork a COW envelope into a private writable payload copy.
 ///
 /// # Safety
 ///
-/// `env` must be a live envelope the caller holds a reference on.
-/// After a successful fork the caller's reference points to the new
-/// envelope; the old reference has been released as part of the fork.
+/// `env` must be live and the caller transfers one owned reference to this
+/// call. On success, that reference is replaced by the returned envelope.
 #[no_mangle]
 pub unsafe extern "C" fn hew_msg_envelope_fork_for_write(
     env: *mut HewMsgEnvelope,
 ) -> *mut HewMsgEnvelope {
     cabi_guard!(env.is_null(), ptr::null_mut());
-
-    // SAFETY: `env` is live; we read payload size + bytes under the
-    // alias contract (read-only) and write into a fresh buffer. We
-    // also snapshot `header_bits` so the forked envelope inherits the
-    // source's reserved bits (`SHARED_FROZEN`, `CAPABILITY_TRANSFER`,
-    // γ/δ reserved bits). `ALIAS_ACTIVE` is intentionally cleared on
-    // the fork — the new envelope starts as the sole observer.
-    let (payload_size, drop_glue, src_payload, src_bits) = unsafe {
-        (
-            (*env).payload_size,
-            (*env).drop_glue,
-            (*env).payload,
-            (*env).header_bits.load(Ordering::Relaxed),
-        )
-    };
-
-    // Allocate fresh payload buffer + memcpy.
-    let new_payload = if payload_size > 0 && !src_payload.is_null() {
-        let buf = mailbox_malloc(payload_size);
-        if buf.is_null() {
-            return ptr::null_mut();
-        }
-        // SAFETY: `buf` is a fresh allocation of `payload_size` bytes;
-        // `src_payload` is readable for `payload_size` bytes under
-        // the alias contract.
-        unsafe { libc::memcpy(buf, src_payload, payload_size) };
-        buf
-    } else {
-        ptr::null_mut()
-    };
-
-    // SAFETY: standard envelope-new path. The new envelope inherits
-    // payload_size + drop_glue; refcount=1; header_bits initialised
-    // to 0 then we set FORKED. `SHARED_FROZEN` / `CAPABILITY_TRANSFER`
-    // / γ-δ reserved bits from the source are OR'd in below so the
-    // contract bits survive a fork; `ALIAS_ACTIVE` is masked out
-    // because the new envelope has only one observer.
-    let forked = unsafe { hew_msg_envelope_new(new_payload, payload_size, drop_glue) };
-    if forked.is_null() {
-        if !new_payload.is_null() {
-            // SAFETY: we allocated this buffer above and never published it.
-            unsafe { libc::free(new_payload) };
-        }
-        return ptr::null_mut();
-    }
-    // Preserve reserved/contract bits from the source (everything
-    // except `ALIAS_ACTIVE`) and set `FORKED` on the new envelope.
-    let inherited_bits = (src_bits & !HEW_MSG_ENVELOPE_ALIAS_ACTIVE) | HEW_MSG_ENVELOPE_FORKED;
-    // SAFETY: `forked` is a live envelope we just created.
-    unsafe {
-        (*forked)
-            .header_bits
-            .fetch_or(inherited_bits, Ordering::Relaxed);
-    }
-
-    // Release the caller's old reference; the new envelope replaces it.
-    // SAFETY: caller transferred their reference into this call.
-    unsafe { hew_msg_envelope_release(env) };
-
-    forked
+    // SAFETY: the C ABI contract transfers one live envelope reference.
+    unsafe { crate::cow_envelope::fork_for_write(env, mailbox_malloc) }
 }
 
 /// Allocate a [`HewMsgNode`] via `libc::malloc`, deep-copying `data`.

--- a/hew-runtime/src/mailbox_wasm.rs
+++ b/hew-runtime/src/mailbox_wasm.rs
@@ -22,9 +22,10 @@ use std::ptr;
 use std::sync::atomic::AtomicPtr;
 
 use crate::internal::types::{HewError, HewOverflowPolicy};
-use crate::mailbox_header::{header_validate, normalize_coalesce_fallback, Origin};
+use crate::mailbox_header::{normalize_coalesce_fallback, Origin};
 use crate::set_last_error;
 
+pub use crate::cow_envelope::{HewMsgEnvelope, HewMsgEnvelopeDropFn};
 pub use crate::mailbox_header::HewSysMsg;
 pub use crate::mailbox_header::{
     HEW_MSG_ENVELOPE_ALIAS_ACTIVE, HEW_MSG_ENVELOPE_ARENA_BACKED,
@@ -254,232 +255,87 @@ const _: () = {
 
 // ── Message node helpers ────────────────────────────────────────────────
 
-// ── Phase-α COW message envelope (WASM parity surface) ──────────────────
-//
-// Mirrors the native envelope in `crate::mailbox`. WASM is single-threaded
-// today; the atomic operations degrade to non-contended ops but the API
-// contract (refcount-based COW, fail-closed reserved bits) is identical
-// so codegen-emitted calls resolve transparently on both targets.
-
-// The cross-target header assignments and pure bit logic live in
-// `crate::mailbox_header`; WASM allocation and scheduling remain here.
-
-/// Drop glue invoked when an envelope's refcount drops to zero.
-pub type HewMsgEnvelopeDropFn = unsafe extern "C" fn(*mut c_void);
-
-/// Refcounted COW envelope — WASM mirror of the native struct.
-#[repr(C)]
-pub struct HewMsgEnvelope {
-    pub refcount: std::sync::atomic::AtomicUsize,
-    pub header_bits: std::sync::atomic::AtomicU32,
-    pub payload: *mut c_void,
-    pub payload_size: usize,
-    pub drop_glue: Option<HewMsgEnvelopeDropFn>,
-}
-
-impl std::fmt::Debug for HewMsgEnvelope {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use std::sync::atomic::Ordering;
-        f.debug_struct("HewMsgEnvelope")
-            .field("refcount", &self.refcount.load(Ordering::Relaxed))
-            .field("header_bits", &self.header_bits.load(Ordering::Relaxed))
-            .field("payload", &self.payload)
-            .field("payload_size", &self.payload_size)
-            .field("drop_glue_set", &self.drop_glue.is_some())
-            .finish()
-    }
-}
-
-// SAFETY: WASM is single-threaded today; the atomics still provide a
-// stable contract should the runtime ever gain a worker model. The
-// payload pointer is opaque — only the receiver (read-only) and the
-// drop_glue (under exclusive last-release ownership) touch it.
-unsafe impl Send for HewMsgEnvelope {}
-// SAFETY: see the `Send` impl above; concurrent reads are read-only,
-// concurrent refcount/header mutations go through atomics.
-unsafe impl Sync for HewMsgEnvelope {}
-
-// On native builds the WASM envelope must layout-match the native one
-// so codegen treats them interchangeably across targets.
-#[cfg(not(target_arch = "wasm32"))]
-const _: () = {
-    use std::mem::offset_of;
-    type W = HewMsgEnvelope;
-    type N = crate::mailbox::HewMsgEnvelope;
-
-    assert!(
-        align_of::<W>() == align_of::<N>(),
-        "WASM HewMsgEnvelope alignment diverged from native"
-    );
-    assert!(
-        size_of::<W>() == size_of::<N>(),
-        "WASM HewMsgEnvelope size diverged from native"
-    );
-    assert!(offset_of!(W, refcount) == offset_of!(N, refcount));
-    assert!(offset_of!(W, header_bits) == offset_of!(N, header_bits));
-    assert!(offset_of!(W, payload) == offset_of!(N, payload));
-    assert!(offset_of!(W, payload_size) == offset_of!(N, payload_size));
-    assert!(offset_of!(W, drop_glue) == offset_of!(N, drop_glue));
-};
+// The envelope representation and lifecycle live in `crate::cow_envelope`.
+// This module retains its WASM allocator and C-ABI error reporting.
 
 wasm_no_mangle! {
-    /// WASM-side `hew_msg_envelope_new`. See native module for full docs.
+    /// Allocate a fresh COW envelope using the WASM mailbox allocator.
     ///
     /// # Safety
     ///
-    /// Same as the native variant.
+    /// `payload` must be a malloc-compatible allocation of `payload_size`
+    /// bytes (or null for zero bytes). Ownership transfers to the envelope.
     pub unsafe extern "C" fn hew_msg_envelope_new(
         payload: *mut c_void,
         payload_size: usize,
         drop_glue: Option<HewMsgEnvelopeDropFn>,
     ) -> *mut HewMsgEnvelope {
-        use std::sync::atomic::{AtomicU32, AtomicUsize};
-        let env = mailbox_malloc(size_of::<HewMsgEnvelope>()).cast::<HewMsgEnvelope>();
-        if env.is_null() {
-            return ptr::null_mut();
-        }
-        // SAFETY: env is non-null and we own it exclusively.
-        unsafe {
-            ptr::write(&raw mut (*env).refcount, AtomicUsize::new(1));
-            ptr::write(&raw mut (*env).header_bits, AtomicU32::new(0));
-            (*env).payload = payload;
-            (*env).payload_size = payload_size;
-            (*env).drop_glue = drop_glue;
-        }
-        env
+        // SAFETY: forwarded unchanged to the shared envelope lifecycle.
+        unsafe { crate::cow_envelope::new(payload, payload_size, drop_glue, mailbox_malloc) }
     }
 }
 
 wasm_no_mangle! {
-    /// WASM-side `hew_msg_envelope_clone_alias`.
+    /// Add an alias observer to a live COW envelope.
     ///
     /// # Safety
     ///
-    /// Same as the native variant.
+    /// `env` must be live and the caller must own one of its references.
     pub unsafe extern "C" fn hew_msg_envelope_clone_alias(
         env: *mut HewMsgEnvelope,
     ) -> *mut HewMsgEnvelope {
-        use std::sync::atomic::Ordering;
         if env.is_null() {
             set_last_error("hew_msg_envelope_clone_alias: env is null");
             return ptr::null_mut();
         }
-        // SAFETY: env is live; refcount + header_bits are atomics.
-        unsafe {
-            let prev = (*env).refcount.fetch_add(1, Ordering::Relaxed);
-            debug_assert!(prev >= 1, "clone_alias on a released envelope");
-            (*env).header_bits.fetch_or(HEW_MSG_ENVELOPE_ALIAS_ACTIVE, Ordering::Relaxed);
-        }
-        env
+        // SAFETY: the C ABI contract requires a live envelope.
+        unsafe { crate::cow_envelope::clone_alias(env) }
     }
 }
 
 wasm_no_mangle! {
-    /// WASM-side `hew_msg_envelope_release`.
+    /// Release one live COW envelope observer.
     ///
     /// # Safety
     ///
-    /// Same as the native variant.
+    /// `env` must be null or live and the caller must own one reference.
     pub unsafe extern "C" fn hew_msg_envelope_release(env: *mut HewMsgEnvelope) {
-        use std::sync::atomic::Ordering;
-        if env.is_null() {
-            return;
-        }
-        // SAFETY: env is live; refcount is atomic.
-        unsafe {
-            let prev = (*env).refcount.fetch_sub(1, Ordering::AcqRel);
-            debug_assert!(prev >= 1, "release on a zero-count envelope");
-            if prev == 1 {
-                let bits = (*env).header_bits.load(Ordering::Acquire);
-                header_validate(bits);
-                if let Some(drop_fn) = (*env).drop_glue {
-                    if !(*env).payload.is_null() {
-                        drop_fn((*env).payload);
-                    }
-                }
-                if !(*env).payload.is_null() {
-                    libc::free((*env).payload);
-                }
-                libc::free(env.cast());
-            }
-        }
+        // SAFETY: a null pointer is explicitly accepted by the shared lifecycle.
+        unsafe { crate::cow_envelope::release(env) }
     }
 }
 
 wasm_no_mangle! {
-    /// WASM-side `hew_msg_envelope_payload_ptr`.
+    /// Borrow a COW envelope payload pointer for read-only access.
     ///
     /// # Safety
     ///
-    /// Same as the native variant.
+    /// `env` must be null or live. The result remains valid only while the
+    /// caller owns a reference and must not mutate or free the payload.
     pub unsafe extern "C" fn hew_msg_envelope_payload_ptr(
         env: *mut HewMsgEnvelope,
     ) -> *mut c_void {
-        if env.is_null() {
-            return ptr::null_mut();
-        }
-        // SAFETY: env is live; payload is stable for the envelope's lifetime.
-        unsafe { (*env).payload }
+        // SAFETY: a null pointer is explicitly accepted by the shared lifecycle.
+        unsafe { crate::cow_envelope::payload_ptr(env) }
     }
 }
 
 wasm_no_mangle! {
-    /// WASM-side `hew_msg_envelope_fork_for_write`.
+    /// Fork a COW envelope into a private writable payload copy.
     ///
     /// # Safety
     ///
-    /// Same as the native variant.
+    /// `env` must be live and the caller transfers one owned reference to this
+    /// call. On success, that reference is replaced by the returned envelope.
     pub unsafe extern "C" fn hew_msg_envelope_fork_for_write(
         env: *mut HewMsgEnvelope,
     ) -> *mut HewMsgEnvelope {
-        use std::sync::atomic::Ordering;
         if env.is_null() {
             set_last_error("hew_msg_envelope_fork_for_write: env is null");
             return ptr::null_mut();
         }
-        // SAFETY: env is live; alias contract is read-only on payload.
-        // Snapshot `header_bits` so reserved/contract bits (`SHARED_FROZEN`,
-        // `CAPABILITY_TRANSFER`, γ/δ reserved) survive the fork.
-        let (payload_size, drop_glue, src_payload, src_bits) = unsafe {
-            (
-                (*env).payload_size,
-                (*env).drop_glue,
-                (*env).payload,
-                (*env).header_bits.load(Ordering::Relaxed),
-            )
-        };
-
-        let new_payload = if payload_size > 0 && !src_payload.is_null() {
-            let buf = mailbox_malloc(payload_size);
-            if buf.is_null() {
-                return ptr::null_mut();
-            }
-            // SAFETY: `buf` is fresh; src is readable for payload_size bytes.
-            unsafe { libc::memcpy(buf, src_payload, payload_size) };
-            buf
-        } else {
-            ptr::null_mut()
-        };
-
-        // SAFETY: standard envelope-new path, mirroring native.
-        let forked = unsafe { hew_msg_envelope_new(new_payload, payload_size, drop_glue) };
-        if forked.is_null() {
-            if !new_payload.is_null() {
-                // SAFETY: we allocated `new_payload` above and never published it.
-                unsafe { libc::free(new_payload) };
-            }
-            return ptr::null_mut();
-        }
-        // Preserve reserved/contract bits from the source (everything
-        // except `ALIAS_ACTIVE`) and set `FORKED` on the new envelope.
-        let inherited_bits = (src_bits & !HEW_MSG_ENVELOPE_ALIAS_ACTIVE) | HEW_MSG_ENVELOPE_FORKED;
-        // SAFETY: forked is a live envelope we just created.
-        unsafe {
-            (*forked).header_bits.fetch_or(inherited_bits, Ordering::Relaxed);
-        }
-        // SAFETY: caller transferred their reference into this call.
-        unsafe { hew_msg_envelope_release(env) };
-        forked
+        // SAFETY: the C ABI contract transfers one live envelope reference.
+        unsafe { crate::cow_envelope::fork_for_write(env, mailbox_malloc) }
     }
 }
 

--- a/scripts/structural-authority-audit.py
+++ b/scripts/structural-authority-audit.py
@@ -2234,6 +2234,50 @@ def test_build_authority_findings(ast_grep: Path, root: Path) -> tuple[list[str]
     return findings, len(scanned)
 
 
+def cow_envelope_definition_findings(root: Path) -> list[str]:
+    """Keep the COW envelope representation and lifecycle single-sourced."""
+    core_path = root / "hew-runtime/src/cow_envelope.rs"
+    wrapper_paths = (
+        root / "hew-runtime/src/mailbox.rs",
+        root / "hew-runtime/src/mailbox_wasm.rs",
+    )
+    if not core_path.exists() and not any(path.exists() for path in wrapper_paths):
+        # The audit self-tests construct focused fixture roots that do not carry
+        # the runtime. A partial real surface is still rejected below.
+        return []
+    try:
+        core = core_path.read_text(encoding="utf-8")
+        wrappers = {
+            path.relative_to(root).as_posix(): path.read_text(encoding="utf-8")
+            for path in wrapper_paths
+        }
+    except OSError as error:
+        return [f"COW envelope authority inputs are unreadable: {error}"]
+
+    failures: list[str] = []
+    representation = r"(?m)^#\[repr\(C\)\]\s*$\n^pub struct HewMsgEnvelope\b"
+    if len(re.findall(representation, core)) != 1:
+        failures.append(
+            "COW envelope core must define exactly one #[repr(C)] HewMsgEnvelope"
+        )
+    for path, source in wrappers.items():
+        if re.search(representation, source):
+            failures.append(f"{path} must re-export, not define, HewMsgEnvelope")
+
+    operations = ("new", "clone_alias", "release", "payload_ptr", "fork_for_write")
+    for operation in operations:
+        definition = rf"(?m)^pub unsafe fn {operation}\s*\("
+        if len(re.findall(definition, core)) != 1:
+            failures.append(f"COW envelope core must define `{operation}` exactly once")
+        delegation = f"crate::cow_envelope::{operation}"
+        for path, source in wrappers.items():
+            if source.count(delegation) != 1:
+                failures.append(
+                    f"{path} must delegate `{operation}` to the shared COW envelope core exactly once"
+                )
+    return failures
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -2326,6 +2370,7 @@ def main() -> int:
     failures.extend(poisoned_findings)
     build_findings, build_trees = test_build_authority_findings(ast_grep, root)
     failures.extend(build_findings)
+    failures.extend(cow_envelope_definition_findings(root))
     if failures:
         print(
             "structural authority inventory changed; review every explicit form/path target:",


### PR DESCRIPTION
Summary:
- Make cow_envelope the single implementation of the ABI-stable COW envelope representation and lifecycle.
- Retain native and WASM mailbox modules as thin ABI wrappers with their existing allocator hooks and target-specific null-error behavior.
- Remove the mirrored WASM layout assertion because both targets now use the same Rust type.

Validation:
- cargo fmt --all -- --check
- cargo clippy -p hew-runtime --tests -- -D warnings
- cargo test -p hew-runtime --lib --no-fail-fast (2,438 passed)
- cargo check -p hew-runtime --target wasm32-wasip1
- git diff --check