### PR TITLE
fix(mir): deduplicate discarded-result release

### DIFF
--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -10917,6 +10917,19 @@ fn deduplicate_ownership_spines(blocks: &mut [BasicBlock], builder: &mut Builder
         let mut seen = Vec::<Instr>::new();
         let mut removals = Vec::new();
         for (index, instruction) in block.instructions.iter().enumerate() {
+            if index > 0
+                && matches!(
+                    instruction,
+                    Instr::OwnershipEvent(crate::model::OwnershipEvent::Release { .. })
+                )
+                && block.instructions[index - 1] == *instruction
+            {
+                // The first event ends this exact owner generation, so an
+                // immediately repeated release can only be a duplicated
+                // logical half of the same physical cleanup.
+                removals.push(index);
+                continue;
+            }
             if relocation_duplicates_prior_adoption(block, index) {
                 removals.push(index);
                 if let Some(neutralize) = duplicate_neutralize_before_relocation(block, index) {


### PR DESCRIPTION
Fixes the rc2 Linux ARM clean-room release blocker. Discarded owned string results could receive one physical drop followed by the same logical Release twice; the second event necessarily names an already-ended generation. The ownership-spine canonicalizer now removes only immediately adjacent identical Release events.\n\nVerified with the exact release clean-room source (`installers/docker/test-stdlib.hew`) and formatting.