### PR TITLE
fix(release): make cargo-about setup idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,7 +469,9 @@ jobs:
       # ── Third-party license attribution ─────────────────────────────────
 
       - name: Install cargo-about
-        run: cargo install cargo-about --locked --features cli --version 0.9.0
+        run: |
+          cargo-about --version 2>/dev/null | grep -q ' 0.9.0$' || \
+            cargo install cargo-about --locked --features cli --version 0.9.0 --force
 
       - name: Generate THIRD-PARTY-LICENSES
         run: cargo about generate --workspace about.hbs -o THIRD-PARTY-LICENSES
@@ -888,7 +890,9 @@ jobs:
             --archive "target/${{ matrix.rust_target }}/release-lib/libhew.a"
 
       - name: Install cargo-about
-        run: cargo install cargo-about --locked --features cli --version 0.9.0
+        run: |
+          cargo-about --version 2>/dev/null | grep -q ' 0.9.0$' || \
+            cargo install cargo-about --locked --features cli --version 0.9.0 --force
 
       - name: Generate THIRD-PARTY-LICENSES
         run: cargo about generate --workspace about.hbs -o THIRD-PARTY-LICENSES
@@ -1058,7 +1062,8 @@ jobs:
               --archive cross-release-libs/x86_64-unknown-freebsd/libhew.a
 
             # ── Third-party license attribution ────────────────────────────
-            cargo install cargo-about --locked --features cli --version 0.9.0
+            cargo-about --version 2>/dev/null | grep -q ' 0.9.0$' || \
+              cargo install cargo-about --locked --features cli --version 0.9.0 --force
             cargo about generate --workspace about.hbs -o THIRD-PARTY-LICENSES
 
             # ── Package archive ────────────────────────────────────────────
@@ -1206,7 +1211,8 @@ jobs:
               --consumer-archive cross-release-libs/aarch64-unknown-freebsd/libhew_release_link_probe.a
 
             # ── Third-party license attribution ────────────────────────────
-            cargo install cargo-about --locked --features cli --version 0.9.0
+            cargo-about --version 2>/dev/null | grep -q ' 0.9.0$' || \
+              cargo install cargo-about --locked --features cli --version 0.9.0 --force
             cargo about generate --workspace about.hbs -o THIRD-PARTY-LICENSES
 
             # ── Package archive ────────────────────────────────────────────


### PR DESCRIPTION
Unblocks rc2 packaging on runners whose restored Cargo home already contains cargo-about. Reuse the pinned 0.9.0 binary when present; otherwise force-install that pinned version.