### PR TITLE
fix(release): install C++ driver in container builder

### DIFF
--- a/installers/docker/Dockerfile.release
+++ b/installers/docker/Dockerfile.release
@@ -29,14 +29,15 @@ COPY --from=llvm /opt/llvm-22 /opt/llvm-22
 
 # musl-dev: libc headers for static linking
 # clang: C/C++ compiler for crates and native link steps
-# gcc: crtbeginS.o and friends — clang links feature-test binaries against
+# gcc/g++: crtbeginS.o and friends plus the C++ driver used for the LLVM shim;
+#      clang links feature-test binaries against
 #      the GCC runtime files on Alpine (aws-lc-sys build probes need them)
 # linux-headers: linux/random.h for the aws-lc-sys getrandom feature probe
 # libffi-dev: llvm-config --system-libs includes -lffi; the static-pie link
 #      needs Alpine's libffi.a
 # zlib-static/zstd-static: compression libs for LLVM (static)
 RUN apk add --no-cache \
-    musl-dev clang gcc linux-headers libffi-dev \
+    musl-dev clang gcc g++ linux-headers libffi-dev \
     zlib-dev zlib-static zstd-dev zstd-static
 
 ENV LLVM_PREFIX=/opt/llvm-22


### PR DESCRIPTION
The rc2 downstream publisher reached the compiler image build and failed in `hew-codegen-rs` because `CXX=g++` is configured but Alpine only installed `gcc`. Install the matching `g++` package in the release builder. This is the sole failure from downstream publication run 33038058274; VS Code/LSP 1.5.1 published successfully.