### PR TITLE
fix(release): build tagged source with recovery recipe

### DIFF
--- a/.github/workflows/publish-release-downstreams.yml
+++ b/.github/workflows/publish-release-downstreams.yml
@@ -62,9 +62,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Checkout recovery recipe
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Checkout immutable release source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: ${{ inputs.release_tag }}
+          path: release-source
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
@@ -74,7 +78,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
-          context: .
+          context: release-source
           file: installers/docker/Dockerfile.release
           platforms: linux/amd64,linux/arm64
           push: true


### PR DESCRIPTION
The rc2 recovery publisher correctly validated the release tag, but its Docker job also checked out that immutable tag as the entire build workspace. That prevented merged recovery fixes to `installers/docker/Dockerfile.release` from taking effect. Keep the workflow checkout as the recovery recipe, check out the immutable release tag under `release-source`, and use that directory strictly as the Docker build context. The resulting compiler remains rc2 source while the recovery Dockerfile can supply the missing Alpine `g++` dependency.