### PR TITLE
fix(scripts): keep the C ABI surface generator parseable on older Python

### DIFF
--- a/scripts/generate-cabi-surface.py
+++ b/scripts/generate-cabi-surface.py
@@ -432,7 +432,8 @@ def static_source() -> dict[str, dict[str, dict[str, str]]]:
             symbol, type_name = match.groups()
             if not symbol.startswith(("hew_", "HEW_")):
                 continue
-            signature = f"static {symbol}: {re.sub(r'\\s+', ' ', type_name).strip()}"
+            collapsed_type = re.sub(r"\\s+", " ", type_name).strip()
+            signature = f"static {symbol}: {collapsed_type}"
             definitions[symbol] = (
                 signature,
                 f"{path.relative_to(ROOT)}:{line_at(source, match.start())}",


### PR DESCRIPTION
## Summary

`scripts/generate-cabi-surface.py` built a symbol signature by interpolating a
`re.sub` call containing a backslash directly inside an f-string. That syntax was
rejected until Python 3.12, so on an older interpreter the script raised a
`SyntaxError` at import and both `cabi-surface-check` and `ffi-ownership-ratchet`
failed before reading a single symbol:

```
signature = f"static {symbol}: {re.sub(r'\\s+', ' ', type_name).strip()}"
                                                                        ^
SyntaxError: f-string expression part cannot include a backslash
```

Hosted runners ship a newer interpreter and no workflow pins a Python version, so
the gates passed in CI and the break was invisible until someone ran `make
preflight` locally. macOS still ships 3.9 as the system interpreter, and the
release macOS validator runs 3.10.

The fix hoists the substitution into a local. The regex, the collapsed signature
text, and the generated surface are all unchanged.

## Verification

- `python3 scripts/generate-cabi-surface.py --check` passes on Python 3.9.6 (previously a `SyntaxError`) and on 3.13.12.
- `git status` after both runs shows no change to the generated surface — behaviour is identical, only the syntax moved.
- Every other Python source in `scripts/` and `.claude/scripts/` already parses under 3.10; this was the only file affected.

## Out of scope

No Python floor is declared or enforced here. No workflow pins `python-version`,
and the repository has one existing 3.10 compatibility gate
(`test-python310-toml-compat`) covering `tomllib` only. Deciding and enforcing a
supported-interpreter range is a separate question worth answering deliberately
rather than as a side effect of this fix.

The regex itself (`r"\\s+"`, which matches a literal backslash followed by `s`
rather than whitespace) is preserved exactly as written. It may well be a latent
bug, but changing it would alter the generated surface, so it is left alone here.
