### PR TITLE
fix(mir): publish ownership transfers for consuming calls

### DIFF
--- a/hew-cli/tests/consuming_call_owner_transfer_e2e.rs
+++ b/hew-cli/tests/consuming_call_owner_transfer_e2e.rs
@@ -1,0 +1,138 @@
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use support::{describe_output, hew_binary, repo_root, require_codegen, run_bounded_command};
+
+const STREAM_PAIR_SOURCE: &str = r#"
+import std.stream;
+
+fn main() {
+    let (text_sink, text_input) = stream.pipe(2);
+    text_sink.send("text-frame");
+    text_sink.close();
+    match text_input.try_recv() {
+        .Some(frame) => {
+            if frame != "text-frame" {
+                panic("stream text payload changed");
+            }
+        },
+        .None => panic("stream text frame missing"),
+    }
+
+    let (bytes_sink, bytes_input) = stream.bytes_pipe(2);
+    bytes_sink.send(b"ok");
+    bytes_sink.close();
+    match bytes_input.try_recv() {
+        .Some(frame) => {
+            if frame.len() != 2 {
+                panic("stream bytes payload changed");
+            }
+        },
+        .None => panic("stream bytes frame missing"),
+    }
+    println("stream-owner-transfer-ok");
+}
+"#;
+
+const CHANNEL_PAIR_SOURCE: &str = r#"
+import std.channel.channel;
+
+fn main() {
+    let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(1);
+    tx.send("channel-frame");
+    tx.close();
+    match rx.try_recv() {
+        .Some(frame) => {
+            if frame != "channel-frame" {
+                panic("channel payload changed");
+            }
+        },
+        .None => panic("channel frame missing"),
+    }
+    println("channel-owner-transfer-ok");
+}
+"#;
+
+const TCP_SPLIT_SOURCE: &str = r#"
+import std.net;
+import std.stream.{Sink, Stream};
+
+fn main() {
+    let listener = net.listen("127.0.0.1:0");
+    let port = listener.local_port();
+    let peer = net.connect(f"127.0.0.1:{port as i64}");
+    let server = listener.accept();
+    let (input, sink): (Stream<bytes>, Sink<bytes>) = server.into_stream_sink();
+    sink.close();
+    input.close();
+    peer.close();
+    listener.close();
+    println("tcp-split-owner-transfer-ok");
+}
+"#;
+
+fn selected_hew_binary() -> PathBuf {
+    std::env::var_os("HEW_BIN").map_or_else(hew_binary, PathBuf::from)
+}
+
+fn run_case(name: &str, source: &str) -> Output {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("consuming-owner-transfer-{name}-"))
+        .tempdir()
+        .expect("create owner-transfer test directory");
+    let path = dir.path().join(format!("{name}.hew"));
+    std::fs::write(&path, source).expect("write owner-transfer Hew source");
+    let mut command = Command::new(selected_hew_binary());
+    command.arg("run").arg(&path).current_dir(repo_root());
+    run_bounded_command(command, format!("hew run {}", path.display()))
+}
+
+#[test]
+fn consumed_pair_carriers_run_to_clean_exit_with_sentinels() {
+    require_codegen();
+
+    let cases = [
+        (
+            "stream-pair",
+            STREAM_PAIR_SOURCE,
+            "stream-owner-transfer-ok",
+        ),
+        (
+            "channel-pair",
+            CHANNEL_PAIR_SOURCE,
+            "channel-owner-transfer-ok",
+        ),
+        ("tcp-split", TCP_SPLIT_SOURCE, "tcp-split-owner-transfer-ok"),
+    ];
+    let outputs: Vec<_> = cases
+        .iter()
+        .map(|(name, source, sentinel)| (*name, *sentinel, run_case(name, source)))
+        .collect();
+
+    let mut failures = Vec::new();
+    for (name, sentinel, output) in outputs {
+        if !output.status.success() {
+            failures.push(format!(
+                "{name} must exit in the success class; status: {}:\n{}",
+                output.status,
+                describe_output(&output)
+            ));
+            continue;
+        }
+        let stdout = String::from_utf8(output.stdout).expect("Hew stdout must be UTF-8");
+        if !stdout.lines().any(|line| line == sentinel) {
+            failures.push(format!(
+                "{name} must print sentinel `{sentinel}`; stdout:\n{stdout}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "consuming-call owner-transfer runtime failures:\n\n{}",
+        failures.join("\n\n")
+    );
+}

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -2994,11 +2994,12 @@ impl Builder {
                         } else if self.vec_iter_drop_flags.contains_key(id) {
                             // Updated above even when a value-producing
                             // if/match arm retained HIR Read intent.
-                        } else if let Some(flag) = self.affine_release_flags.get(id).copied() {
-                            self.instructions.push(Instr::ConstI64 {
-                                dest: flag,
-                                value: 1,
-                            });
+                        } else if self.affine_release_flags.contains_key(id) {
+                            self.set_owned_local_consumed(
+                                *id,
+                                None,
+                                super::DischargeSite::BindingMoved,
+                            );
                         } else if let Some(flag) = self.collection_drop_flags.get(id).copied() {
                             // #2418 — an owned collection local with a
                             // path-sensitive drop-flag is KEPT in

--- a/hew-mir/tests/consuming_call_owner_transfer.rs
+++ b/hew-mir/tests/consuming_call_owner_transfer.rs
@@ -1,0 +1,207 @@
+use std::collections::HashSet;
+
+use hew_hir::{lower_program, BindingId, ResolutionCtx};
+use hew_mir::{
+    lower_hir_module, CheckedMirFunction, Instr, IrPipeline, MirStatement, OwnerId, OwnershipEvent,
+    Place, Terminator,
+};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+const CONSUMING_EXTERN_SOURCE: &str = r#"
+#[resource]
+type Conn { id: i64 }
+
+impl Conn {
+    fn close(self) {}
+}
+
+extern "C" {
+    fn consume_conn(consume conn: Conn);
+}
+
+fn run() {
+    let conn = Conn { id: 7 };
+    unsafe { consume_conn(conn) };
+}
+
+fn main() {
+    run();
+}
+"#;
+
+fn named_binding(function: &CheckedMirFunction, name: &str) -> BindingId {
+    function
+        .blocks
+        .iter()
+        .flat_map(|block| &block.statements)
+        .find_map(|statement| match statement {
+            MirStatement::Bind {
+                binding,
+                name: candidate,
+                ..
+            } if candidate == name => Some(*binding),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("the owned {name} binding must be present"))
+}
+
+fn guarded_owner(function: &CheckedMirFunction, binding: BindingId) -> OwnerId {
+    function
+        .blocks
+        .iter()
+        .flat_map(|block| &block.instructions)
+        .find_map(|instruction| match instruction {
+            Instr::OwnershipEvent(OwnershipEvent::Guard { owner, .. })
+                if owner.binding == binding =>
+            {
+                Some(*owner)
+            }
+            _ => None,
+        })
+        .expect("the owned binding must publish a guarded owner generation")
+}
+
+fn consuming_call_continuation(function: &CheckedMirFunction, expected_callee: &str) -> u32 {
+    function
+        .blocks
+        .iter()
+        .find_map(|block| match &block.terminator {
+            Terminator::Call {
+                callee, args, next, ..
+            } if callee == expected_callee => {
+                assert_eq!(args.len(), 1, "consuming extern must have one argument");
+                Some(*next)
+            }
+            _ => None,
+        })
+        .expect("run must contain the consuming extern call")
+}
+
+fn terminal_transfer_source(function: &CheckedMirFunction, expected_owner: OwnerId) -> Place {
+    let transfers: Vec<Place> = function
+        .blocks
+        .iter()
+        .flat_map(|block| &block.instructions)
+        .filter_map(|instruction| match instruction {
+            Instr::OwnershipEvent(OwnershipEvent::Transfer {
+                owner,
+                from,
+                to: None,
+                to_owner: None,
+                to_ty: None,
+            }) if *owner == expected_owner => Some(*from),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        transfers.len(),
+        1,
+        "the consuming call must publish exactly one terminal owner transfer"
+    );
+    transfers[0]
+}
+
+fn assert_no_release_after(
+    function: &CheckedMirFunction,
+    continuation: u32,
+    owner: OwnerId,
+    owner_place: Place,
+) {
+    let mut pending = vec![continuation];
+    let mut reachable = HashSet::new();
+    while let Some(block_id) = pending.pop() {
+        if !reachable.insert(block_id) {
+            continue;
+        }
+        let block = function
+            .blocks
+            .iter()
+            .find(|block| block.id == block_id)
+            .unwrap_or_else(|| panic!("reachable block bb{block_id} must exist"));
+        pending.extend(block.successors());
+    }
+
+    for block in function
+        .blocks
+        .iter()
+        .filter(|block| reachable.contains(&block.id))
+    {
+        assert!(
+            block.instructions.iter().all(|instruction| !matches!(
+                instruction,
+                Instr::OwnershipEvent(OwnershipEvent::Release {
+                    owner: released,
+                    ..
+                }) if *released == owner
+            )),
+            "scope exit must not release the transferred owner in bb{}: {:#?}",
+            block.id,
+            block.instructions
+        );
+        assert!(
+            block.instructions.iter().all(|instruction| !matches!(
+                instruction,
+                Instr::Drop { place, .. } if *place == owner_place
+            )),
+            "scope exit must not drop the transferred owner slot in bb{}: {:#?}",
+            block.id,
+            block.instructions
+        );
+    }
+}
+
+fn lower_clean_to_checked_mir(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(
+        tc_output.errors.is_empty(),
+        "type errors: {:#?}",
+        tc_output.errors
+    );
+    let hir = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(
+        hir.diagnostics.is_empty(),
+        "HIR diagnostics: {:#?}",
+        hir.diagnostics
+    );
+    lower_hir_module(&hir.module)
+}
+
+#[test]
+fn consuming_owned_call_publishes_terminal_transfer_before_scope_exit() {
+    let pipeline = lower_clean_to_checked_mir(CONSUMING_EXTERN_SOURCE);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "the ownership transfer must pass MIR validation: {:#?}",
+        pipeline.diagnostics
+    );
+
+    let run = pipeline
+        .checked_mir
+        .iter()
+        .find(|function| function.name == "run")
+        .expect("run must reach Checked MIR");
+    assert!(
+        run.checks.is_empty(),
+        "the consuming call must pass Checked-MIR ownership validation: {:#?}",
+        run.checks
+    );
+
+    let binding = named_binding(run, "conn");
+    let owner = guarded_owner(run, binding);
+    let continuation = consuming_call_continuation(run, "consume_conn");
+    let owner_place = terminal_transfer_source(run, owner);
+    assert_no_release_after(run, continuation, owner, owner_place);
+}


### PR DESCRIPTION
## Summary

A consuming call on an owned `#[resource]` binding published no terminal ownership
transfer, so scope-exit lowering emitted a second, unguarded release. That is a double
free, and it reaches users through the most ordinary shapes in the language.

On current `main`:

```
$ hew run examples/v05/surfaces/typed_streams.hew
hew: fatal synchronous hardware fault          # exit 139
```

```
$ make mqtt-broker-e2e
mqtt-broker-e2e: FAIL: malformed Remaining Length was not rejected
hew: fatal synchronous hardware fault
```

The MQTT parser is never reached. Six input shapes were tried — empty connection,
truncated, fifth continuation, oversized, zero-body, and a **fully valid CONNECT** — and
all six faulted with no parser log emitted. Opening the connection is sufficient. This is
not a missing bounds check: `read_varint_len` checks `i < data.len()` before indexing and
the emitted LLVM retains that branch.

`Builder::lower_value`'s consumed `BindingRef` handling set
`affine_release_flags[binding] = 1` directly. `ownership.rs` documents
`set_owned_local_consumed` as the mandatory consume chokepoint, which publishes the flag,
the terminal `OwnershipEvent::Transfer`, and the disposition together;
`materialize_explicit_scope_exits` reads that event to decide whether the owner still
needs releasing. Setting the flag alone left the transfer invisible to it.

The fix routes that site through the chokepoint. Eleven lines in `expr.rs`; the rest of
the diff is regression coverage.

Every other site that touches `affine_release_flags` was audited and is correct:
`mod.rs:5276` and `ownership.rs:1228`/`:1286` pair the flag with exact transfer
operations, `:3633`/`:3670` are the chokepoints themselves, `:4727` is allocation, and
`:5322` is aggregate ingress and explicitly not a dataflow terminal. This was one bypass,
not a pattern.

## Impact

Any service using `Connection::into_stream_sink` could be killed by a remote peer on its
first accepted connection. `std.stream`'s `try_pipe`, `try_bytes_pipe` and
`StreamPair::close`, the `ChannelPair` construction in `std/channel/channel.hew`, and
compiler-generated receive-generator channels share the shape and fault with no
networking involved.

## Verification

After the fix:

```
$ hew run examples/v05/surfaces/typed_streams.hew
recv frame-0
recv frame-1
recv frame-2
drained 3 frames                               # exit 0
```

- `make mqtt-broker-e2e` — passes, including the malformed Remaining Length rejection it was written to check. The broker both survives the packet and rejects it.
- `cargo test -p hew-mir --lib` — 929/929
- Receive-generator channel example — exit 0, output `1 2 3`
- `cargo fmt --all -- --check`, `git diff --check` — clean

Each new regression was confirmed to **fail without the fix**, which is what makes them
regression tests rather than assertions that happen to pass:

| Regression | Without the fix |
| --- | --- |
| Checked-MIR terminal transfer | terminal transfer count `0`, expected `1` |
| Stream pipe / bytes pipe | exit 1, sentinel absent |
| Channel pair | exit 1, sentinel absent |
| TCP split | exit 139, fatal synchronous hardware fault |

The Checked-MIR assertion sits at the layer the defect actually lives at; the runtime
cases assert on exit-code class and a sentinel line rather than golden stdout.

## Out of scope

The selected nextest gate stops at `mutable_direct_record_transfer_then_overwrite_uses_only_overwrite_flag`
with `DischargeAuthorityDrift`. That failure reproduces identically with this lowering fix
reversed, so it is pre-existing and unrelated; it is not addressed here.

Fixing this by removing the explicit free from `examples/mqtt_broker.hew` or the stdlib
wrapper was rejected — it would mask the compiler defect and leave every other consumer of
the shape broken.
