### PR TITLE
fix(types): recheck defer moves on every exit

### DIFF
--- a/hew-cli/tests/defer_move_state_e2e.rs
+++ b/hew-cli/tests/defer_move_state_e2e.rs
@@ -1,0 +1,161 @@
+//! End-to-end coverage for move-state replay at defer materialization edges.
+
+mod support;
+
+use std::process::{Command, Output};
+
+use support::{hew_binary, strip_ansi};
+
+fn check_source(name: &str, source: &str) -> Output {
+    let fixture = support::tempdir();
+    let source_path = fixture.path().join(name);
+    std::fs::write(&source_path, source).expect("write Hew fixture");
+    Command::new(hew_binary())
+        .args(["check", source_path.to_str().expect("UTF-8 fixture path")])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew check must run")
+}
+
+const RESOURCE_DECL: &str = r"
+#[resource]
+type Conn {
+    fd: i64;
+}
+
+impl Conn {
+    fn id(self) -> i64 {
+        self.fd
+    }
+
+    fn close(self) {}
+}
+";
+
+#[test]
+fn defer_reads_recheck_unconditional_conditional_and_return_edges() {
+    let source = format!(
+        r#"{RESOURCE_DECL}
+fn unconditional() {{
+    let unconditional_conn = Conn {{ fd: 1 }};
+    defer println(f"{{unconditional_conn.id()}}");
+    unconditional_conn.close();
+}}
+
+fn conditional(take: bool) {{
+    let conditional_conn = Conn {{ fd: 2 }};
+    defer println(f"{{conditional_conn.id()}}");
+    if take {{
+        conditional_conn.close();
+    }}
+}}
+
+fn early_return(leave: bool) {{
+    let return_conn = Conn {{ fd: 3 }};
+    defer println(f"{{return_conn.id()}}");
+    if leave {{
+        return_conn.close();
+        return;
+    }}
+    println("normal exit keeps return_conn live");
+}}
+
+fn main() {{}}
+"#
+    );
+    let output = check_source("defer_moved.hew", &source);
+    assert!(!output.status.success(), "moved defer captures must reject");
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    let bindings = ["unconditional_conn", "conditional_conn", "return_conn"];
+    let missing_diagnostics: Vec<_> = bindings
+        .iter()
+        .filter(|name| !stderr.contains(&format!("error: use of moved value `{name}`")))
+        .copied()
+        .collect();
+    assert!(
+        missing_diagnostics.is_empty(),
+        "missing inline-quality move diagnostics for {missing_diagnostics:?}:\n{stderr}"
+    );
+    for name in bindings {
+        assert!(
+            stderr.contains(&format!(
+                "duplicate `{name}` with `clone {name}` before the consuming use"
+            )),
+            "missing inline-quality help for {name}:\n{stderr}"
+        );
+    }
+    assert_eq!(
+        stderr.matches("note: value was consumed here").count(),
+        3,
+        "each materialization failure must point at its own consume edge:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("conditional_conn.close();"),
+        "conditional rejection must name the consuming branch:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("return_conn.close();"),
+        "return-edge rejection must name its consuming branch:\n{stderr}"
+    );
+}
+
+#[test]
+fn defer_reads_compile_when_every_materialization_edge_is_live() {
+    let source = format!(
+        r#"{RESOURCE_DECL}
+fn live_on_every_edge(leave: bool) {{
+    let edge_conn = Conn {{ fd: 1 }};
+    defer println(f"{{edge_conn.id()}}");
+    if leave {{
+        return;
+    }}
+    println("normal exit");
+}}
+
+fn resource_is_not_consumed() {{
+    let live_conn = Conn {{ fd: 2 }};
+    defer println(f"{{live_conn.id()}}");
+    println("body leaves resource live");
+}}
+
+fn main() {{
+    live_on_every_edge(true);
+    live_on_every_edge(false);
+    resource_is_not_consumed();
+}}
+"#
+    );
+    let output = check_source("defer_live.hew", &source);
+    assert!(
+        output.status.success(),
+        "live defer captures must compile:\n{}",
+        strip_ansi(&String::from_utf8_lossy(&output.stderr))
+    );
+}
+
+#[test]
+fn defer_registration_still_rejects_forward_references() {
+    let output = check_source(
+        "defer_forward.hew",
+        r#"fn main() {
+    defer println(f"{later}");
+    let later = 5;
+}
+"#,
+    );
+    assert!(
+        !output.status.success(),
+        "forward defer capture must reject"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains("error: undefined variable `later`"),
+        "registration must retain lexical scope checking:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("use of moved value"),
+        "forward-reference rejection must not be misreported as a move:\n{stderr}"
+    );
+}

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -1577,10 +1577,9 @@ struct Builder {
     /// `emit_pending_defers(scope_id)` drains and lowers them in LIFO
     /// (reverse registration) order at every exit from that scope.
     ///
-    /// Q205-B: bindings inside defer bodies resolve by lexical reference
-    /// at execution time — mutable vars observe their final value;
-    /// moved/consumed bindings are rejected by the move-checker at the
-    /// materialization site.
+    /// Q205-B: bindings inside defer bodies resolve at registration, while the
+    /// type checker replays their move-state checks on every materialization
+    /// edge. Lowering then reads live mutable bindings at execution time.
     pub(crate) pending_defers: HashMap<ScopeId, Vec<HirExpr>>,
     /// W3.031 Stage 1: per-binding `TraitObjectStorage` ledger for
     /// `dyn Trait` locals. Populated at the binding's introducing

--- a/hew-mir/src/lower/scope.rs
+++ b/hew-mir/src/lower/scope.rs
@@ -891,10 +891,9 @@ impl Builder {
     /// exit drains them permanently.
     ///
     /// Q205-B: mutable vars observe their final value at this program point
-    /// because the defer bodies are lowered inline here. Moved/consumed
-    /// bindings are caught by the MIR move-checker at the materialization
-    /// site — a use-after-move in the defer body produces a checker-stream
-    /// violation exactly as it would at a normal scope exit.
+    /// because the defer bodies are lowered inline here. The type checker's
+    /// defer replay validates captured bindings against this return edge's
+    /// move-state before HIR reaches this lowering step.
     pub(crate) fn emit_defers_for_return(&mut self) {
         // Walk from innermost scope to outermost (reverse of push order).
         for i in (0..self.active_scopes.len()).rev() {

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -8,6 +8,61 @@ use crate::builtin_names::BuiltinNamedType;
 use crate::BuiltinType;
 
 impl Checker {
+    /// Re-synthesize deferred bodies at one materialization edge while keeping
+    /// only move-state diagnostics. Registration already owns ordinary typing
+    /// and lexical-resolution errors; replay exists solely to apply the edge's
+    /// current ownership state and to thread effects through LIFO bodies.
+    fn recheck_materialized_defers(&mut self, defers: Vec<Spanned<Expr>>) {
+        for (body, span) in defers {
+            let error_mark = self.errors.len();
+            self.synthesize(&body, &span);
+            let replay_errors = self.errors.split_off(error_mark);
+            for error in replay_errors.into_iter().filter(|error| {
+                matches!(
+                    error.kind,
+                    TypeErrorKind::UseAfterMove | TypeErrorKind::UseAfterConsume
+                )
+            }) {
+                let duplicate = self.errors.iter().any(|existing| {
+                    existing.kind == error.kind
+                        && existing.span == error.span
+                        && existing.message == error.message
+                        && existing.notes == error.notes
+                        && existing.suggestions == error.suggestions
+                        && existing.source_module == error.source_module
+                });
+                if !duplicate {
+                    self.errors.push(error);
+                }
+            }
+        }
+    }
+
+    fn recheck_current_scope_defers(&mut self) {
+        self.recheck_materialized_defers(self.env.current_scope_defers());
+    }
+
+    fn recheck_return_edge_defers(&mut self) {
+        self.recheck_materialized_defers(self.env.return_edge_defers());
+    }
+
+    fn recheck_loop_edge_defers(&mut self, label: Option<&str>, span: &Span) {
+        let Some(defers) = self.env.loop_edge_defers(label) else {
+            self.errors.push(
+                TypeError::new(
+                    TypeErrorKind::InvalidOperation,
+                    span.clone(),
+                    "cannot determine deferred move-state for this loop exit",
+                )
+                .with_suggestion(
+                    "check that the loop label names an active enclosing loop".to_string(),
+                ),
+            );
+            return;
+        };
+        self.recheck_materialized_defers(defers);
+    }
+
     /// The declared type of an annotated `let`/`var`, given the annotation and
     /// the type synthesised for the initialiser.
     ///
@@ -383,6 +438,9 @@ impl Checker {
                 // If/Match arm bodies that flow to return can Ok-coerce.
                 self.tail_ok_armed = tail_ok_armed;
                 let ty = self.check_last_stmt_type(stmt, span, expected);
+                if !matches!(ty, Ty::Never) {
+                    self.recheck_current_scope_defers();
+                }
                 self.const_values = const_values_snapshot;
                 self.emit_scope_warnings();
                 return ty;
@@ -438,6 +496,9 @@ impl Checker {
         } else {
             Ty::Unit
         };
+        if !terminated && !matches!(ty, Ty::Never) {
+            self.recheck_current_scope_defers();
+        }
         self.const_values = const_values_snapshot;
         self.emit_scope_warnings();
         ty
@@ -515,44 +576,44 @@ impl Checker {
     /// The return *type* of the construct itself is always `Ty::Never` (a
     /// `return` diverges); callers assign that directly.
     pub(super) fn check_return_operand(&mut self, value: Option<&Spanned<Expr>>, span: &Span) {
-        let Some(expected) = self.current_return_type.clone() else {
-            return;
-        };
-        // Inside a gen{} body, `current_return_type` is shaped as
-        // `Generator<Y, R>`. A `return <expr>` targets the Return component R,
-        // not the full Generator type, so `return 1` inside gen{} unifies
-        // against i64 rather than Generator<Y, i64>.
-        let effective_expected = if self.in_generator {
-            let resolved = self.subst.resolve(&expected);
-            match resolved.as_generator() {
-                Some((_, ret)) => ret.clone(),
-                None => expected,
-            }
-        } else {
-            expected
-        };
-        // Guard: do not check against Ty::Error — it would silently suppress
-        // mismatch diagnostics in the returned expression. Synthesize the value
-        // instead so its own errors are still caught.
-        if matches!(self.subst.resolve(&effective_expected), Ty::Error) {
-            if let Some((val, vs)) = value {
-                self.synthesize(val, vs);
-            }
-        } else {
-            match value {
-                Some((val, vs)) => {
-                    self.check_against(val, vs, &effective_expected);
+        if let Some(expected) = self.current_return_type.clone() {
+            // Inside a gen{} body, `current_return_type` is shaped as
+            // `Generator<Y, R>`. A `return <expr>` targets the Return component R,
+            // not the full Generator type, so `return 1` inside gen{} unifies
+            // against i64 rather than Generator<Y, i64>.
+            let effective_expected = if self.in_generator {
+                let resolved = self.subst.resolve(&expected);
+                match resolved.as_generator() {
+                    Some((_, ret)) => ret.clone(),
+                    None => expected,
                 }
-                None if effective_expected != Ty::Unit => {
-                    self.errors.push(TypeError::return_type_mismatch(
-                        span.clone(),
-                        &effective_expected,
-                        &Ty::Unit,
-                    ));
+            } else {
+                expected
+            };
+            // Guard: do not check against Ty::Error — it would silently suppress
+            // mismatch diagnostics in the returned expression. Synthesize the value
+            // instead so its own errors are still caught.
+            if matches!(self.subst.resolve(&effective_expected), Ty::Error) {
+                if let Some((val, vs)) = value {
+                    self.synthesize(val, vs);
                 }
-                _ => {}
+            } else {
+                match value {
+                    Some((val, vs)) => {
+                        self.check_against(val, vs, &effective_expected);
+                    }
+                    None if effective_expected != Ty::Unit => {
+                        self.errors.push(TypeError::return_type_mismatch(
+                            span.clone(),
+                            &effective_expected,
+                            &Ty::Unit,
+                        ));
+                    }
+                    _ => {}
+                }
             }
         }
+        self.recheck_return_edge_defers();
         // M-4: a `return CrashAction::…;` inside a `#[on(crash)]` hook is now
         // fully wired (the MIR return boundary extracts the variant tag; the
         // supervisor honours it). The former fail-closed reject is removed; the
@@ -1551,7 +1612,9 @@ impl Checker {
                     self.loop_labels.push(lbl.clone());
                 }
                 self.loop_depth += 1;
+                self.env.enter_loop(label.as_deref());
                 self.check_block(body, None);
+                self.env.exit_loop();
                 self.loop_depth -= 1;
                 if label.is_some() {
                     self.loop_labels.pop();
@@ -1880,7 +1943,9 @@ impl Checker {
                     self.loop_labels.push(lbl.clone());
                 }
                 self.loop_depth += 1;
+                self.env.enter_loop(label.as_deref());
                 self.check_block(body, None);
+                self.env.exit_loop();
                 self.loop_depth -= 1;
                 if label.is_some() {
                     self.loop_labels.pop();
@@ -1911,7 +1976,9 @@ impl Checker {
                     self.loop_labels.push(lbl.clone());
                 }
                 self.loop_depth += 1;
+                self.env.enter_loop(label.as_deref());
                 self.check_block(body, None);
+                self.env.exit_loop();
                 self.loop_depth -= 1;
                 if label.is_some() {
                     self.loop_labels.pop();
@@ -1939,7 +2006,9 @@ impl Checker {
                     self.loop_labels.push(lbl.clone());
                 }
                 self.loop_depth += 1;
+                self.env.enter_loop(label.as_deref());
                 self.check_block(body, None);
+                self.env.exit_loop();
                 self.loop_depth -= 1;
                 if label.is_some() {
                     self.loop_labels.pop();
@@ -1965,6 +2034,9 @@ impl Checker {
                 if let Some((val_expr, val_span)) = value {
                     self.synthesize(val_expr, val_span);
                 }
+                if self.loop_depth > 0 {
+                    self.recheck_loop_edge_defers(label.as_deref(), span);
+                }
             }
             Stmt::Continue { label } => {
                 if self.loop_depth == 0 {
@@ -1982,13 +2054,30 @@ impl Checker {
                         ));
                     }
                 }
+                if self.loop_depth > 0 {
+                    self.recheck_loop_edge_defers(label.as_deref(), span);
+                }
             }
             Stmt::Match { scrutinee, arms } => {
                 let scr_ty = self.synthesize(&scrutinee.0, &scrutinee.1);
                 self.check_match_stmt(&scr_ty, arms, span);
             }
             Stmt::Defer(expr) => {
+                let ownership = self.env.ownership_snapshot();
                 self.synthesize(&expr.0, &expr.1);
+                self.env.restore_ownership(&ownership);
+                if !self.env.register_defer(*expr.clone()) {
+                    self.errors.push(
+                        TypeError::new(
+                            TypeErrorKind::InvalidOperation,
+                            span.clone(),
+                            "cannot register defer without an active lexical scope",
+                        )
+                        .with_suggestion(
+                            "place the defer inside a function or block scope".to_string(),
+                        ),
+                    );
+                }
             }
         }
     }

--- a/hew-types/src/env.rs
+++ b/hew-types/src/env.rs
@@ -4,7 +4,7 @@
 //! supporting let/var declarations and shadowing.
 
 use crate::ty::Ty;
-use hew_parser::ast::Span;
+use hew_parser::ast::{Expr, Span, Spanned};
 use std::collections::HashMap;
 
 /// Checker-local identity for a lexical binding.
@@ -220,6 +220,10 @@ pub enum ScopeWarningKind {
 #[derive(Debug, Clone, Default)]
 pub struct TypeEnv {
     scopes: Vec<HashMap<String, Binding>>,
+    /// Deferred bodies registered in each lexical scope, parallel to `scopes`.
+    deferred_scopes: Vec<Vec<Spanned<Expr>>>,
+    /// Lexical scope floors for active loops, paired with their optional labels.
+    loop_scope_floors: Vec<(Option<String>, usize)>,
     next_binding_id: u32,
 }
 
@@ -229,6 +233,8 @@ impl TypeEnv {
     pub fn new() -> Self {
         Self {
             scopes: vec![HashMap::new()],
+            deferred_scopes: vec![Vec::new()],
+            loop_scope_floors: Vec::new(),
             next_binding_id: 0,
         }
     }
@@ -245,6 +251,7 @@ impl TypeEnv {
     /// Push a new scope onto the stack.
     pub fn push_scope(&mut self) {
         self.scopes.push(HashMap::new());
+        self.deferred_scopes.push(Vec::new());
     }
 
     /// Pop the current scope from the stack.
@@ -253,6 +260,82 @@ impl TypeEnv {
     /// Panics if there are no scopes to pop.
     pub fn pop_scope(&mut self) {
         self.scopes.pop().expect("cannot pop empty scope stack");
+        self.deferred_scopes
+            .pop()
+            .expect("cannot pop empty defer-scope stack");
+    }
+
+    /// Register a deferred body in the current lexical scope.
+    ///
+    /// Returns `false` only if the environment's scope stacks are inconsistent;
+    /// callers turn that invariant failure into a fail-closed diagnostic.
+    pub fn register_defer(&mut self, body: Spanned<Expr>) -> bool {
+        let Some(scope) = self.deferred_scopes.last_mut() else {
+            return false;
+        };
+        scope.push(body);
+        true
+    }
+
+    /// Deferred bodies materialized by the current scope's normal exit, in
+    /// runtime order (innermost registration first).
+    #[must_use]
+    pub fn current_scope_defers(&self) -> Vec<Spanned<Expr>> {
+        self.deferred_scopes
+            .last()
+            .into_iter()
+            .flat_map(|scope| scope.iter().rev().cloned())
+            .collect()
+    }
+
+    /// Deferred bodies materialized by a function-return edge, in runtime
+    /// order: innermost scope first, LIFO within each scope.
+    #[must_use]
+    pub fn return_edge_defers(&self) -> Vec<Spanned<Expr>> {
+        self.deferred_scopes
+            .iter()
+            .rev()
+            .flat_map(|scope| scope.iter().rev().cloned())
+            .collect()
+    }
+
+    /// Record the lexical scope depth immediately before a loop body opens.
+    pub fn enter_loop(&mut self, label: Option<&str>) {
+        self.loop_scope_floors
+            .push((label.map(str::to_string), self.deferred_scopes.len()));
+    }
+
+    /// Retire the innermost loop boundary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no loop boundary is active, which indicates an unbalanced
+    /// checker traversal.
+    pub fn exit_loop(&mut self) {
+        self.loop_scope_floors
+            .pop()
+            .expect("cannot exit loop with no active loop boundary");
+    }
+
+    /// Deferred bodies materialized by a `break` or `continue` edge.
+    ///
+    /// An unlabeled edge targets the innermost loop. A labeled edge targets the
+    /// nearest active loop carrying that label. `None` fails closed when the
+    /// source checker cannot identify the loop boundary.
+    #[must_use]
+    pub fn loop_edge_defers(&self, label: Option<&str>) -> Option<Vec<Spanned<Expr>>> {
+        let (_, floor) = self
+            .loop_scope_floors
+            .iter()
+            .rev()
+            .find(|(candidate, _)| label.is_none() || candidate.as_deref() == label)?;
+        Some(
+            self.deferred_scopes[*floor..]
+                .iter()
+                .rev()
+                .flat_map(|scope| scope.iter().rev().cloned())
+                .collect(),
+        )
     }
 
     /// Define a variable in the current scope (synthetic, no source span — not warned about).
@@ -589,6 +672,9 @@ impl TypeEnv {
     )]
     pub fn pop_scope_with_warnings(&mut self) -> Vec<ScopeWarning> {
         let scope = self.scopes.pop().expect("cannot pop empty scope stack");
+        self.deferred_scopes
+            .pop()
+            .expect("cannot pop empty defer-scope stack");
         let mut warnings = Vec::new();
         for (name, binding) in &scope {
             let Some(span) = &binding.def_span else {


### PR DESCRIPTION
## Summary

A read of a consumed value is correctly rejected inline but was silently permitted inside a
`defer` block, where it read moved-from, zeroed storage.

On `main`:

```hew
let c = Conn { fd: 3 };
defer { println(f"DEFER reads {c.id()}"); }
c.close();
```
```
CLOSE fd=3
after explicit close
DEFER reads 0        <- exit 0, no diagnostic
```

The identical read written inline is a hard error:

```
error: use of moved value `c`
note: value was consumed here
```

Defer bodies were type-checked once at their registration point
(`hew-types/src/check/statements.rs`) and inlined at each exit edge
(`hew-mir/src/lower/scope.rs`), so the move-state at the materialization site was never
re-checked. The comment at `hew-mir/src/lower/mod.rs:1581-1583` asserted the opposite —
that moved or consumed bindings are rejected by the move-checker at the materialization
site. They were not; the comment is corrected here.

Each defer body is now re-checked against the move-state at every site where it
materializes.

## Behaviour

After the fix, the reported case:

```
d_moved.hew:18:36: error: use of moved value `c`
 18 |     defer { println(f"DEFER reads {c.id()}"); }
    |                                    ^
d_moved.hew:19:5: note: value was consumed here
 19 |     c.close();
    |     ^
  = help: duplicate `c` with `clone c` before the consuming use to keep the original usable
```

Same diagnostic quality as the inline path — binding named, consuming use pointed at, same
help text.

A consume on only one branch rejects that materialization edge and names the consuming
call inside that branch; the non-consuming sibling edge stays valid.

Registration-point *scoping* was already correct and is unchanged: a forward reference
(`defer { println(f"{x}") } let x = 5;`) still fails as `undefined variable`. Only the
move-*state* was stale.

## Verification

- Reported reproduction: exit 0 with `DEFER reads 0` before; exit 1 with the diagnostic above after.
- Focused regressions: 3 passed, 0 failed.
- `cargo check -p hew-types -p hew-mir -p hew-cli`: pass
- Formatter: 654 Hew sources clean; Rust formatting clean
- Workspace clippy with warnings denied: pass on both commits
- `git diff origin/main --check`: pass

Each regression was confirmed to fail without the fix:

| Shape | Without the fix |
| --- | --- |
| Unconditional consume | diagnostic absent |
| Conditional consume | only the lower-quality `E_MIR_CHECK`, no clone help |
| Early-return consume | diagnostic absent |
| Valid on every edge | compiled (must keep compiling) |
| Forward reference | rejected (must stay rejected) |
| Unconsumed resource | compiled (must keep compiling) |

## Scope

This closes the hole on the exit edges `defer` already runs on. Whether `defer` should also
run on trap, cancel and unwind edges is a separate open design question. This change makes
that work easier rather than harder: future exit kinds can reuse the same
materialization-edge replay with their own ownership state.

## Out of scope

Two pre-existing environment-coupling failures were observed and are not addressed here:
`test-build-harness` assumes `../../target/release-lib/hew` and rejects an external
`CARGO_TARGET_DIR`, and two `hew-types` library tests fail under an external target because
they cannot locate the development stdlib (2120 passed, 2 failed). The known
`dogfood-compile-measure` baseline mismatch on `main` is also unrelated.
