### PR TITLE
fix(mir): canonicalize edge carry emission order

### DIFF
--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -9006,11 +9006,17 @@ fn materialize_explicit_goto_edge_carries(blocks: &mut [BasicBlock], builder: &m
                 _ => None,
             })
             .collect::<HashSet<_>>();
-        let carries = exit
+        let mut carries = exit
             .iter()
             .filter(|(owner, place)| !existing.contains(&(**owner, **place)))
             .map(|(owner, place)| (*owner, *place))
             .collect::<Vec<_>>();
+        // `ExactOwnerState` is a HashMap because transfer replay needs keyed
+        // mutation, but its randomized iteration order must not become MIR
+        // instruction order. OwnerId follows source binding declaration order
+        // and then the binding's ownership generation, so it is the semantic
+        // order for the exact generations carried across this source edge.
+        carries.sort_by_key(|(owner, _)| *owner);
         for (owner, place) in carries {
             let insert_at = block.instructions.len();
             block.instructions.push(Instr::OwnershipEvent(

--- a/scripts/sir-shadow-corpus.sh
+++ b/scripts/sir-shadow-corpus.sh
@@ -36,6 +36,10 @@ HEW_BIN="${HEW_BIN:-$ROOT/target/debug/hew}"
 DEFAULT_CORPUS="$ROOT/tests/ll-oracle/corpus"
 MIN_REALIZED="${SIR_SHADOW_MIN_REALIZED:-1}"
 MIN_SUCCESSES="${SIR_SHADOW_MIN_SUCCESSES:-1}"
+# Repeat the established compile enough times to make randomized ownership-fact
+# emission fail closed without turning comparison into a set operation.  The
+# exact EdgeCarry sequence is compiler output and must remain byte-identical.
+DETERMINISM_RUNS=4
 
 usage() {
     cat <<'EOF'
@@ -163,6 +167,11 @@ run_compile() {
     return "$status"
 }
 
+edge_carry_sequence() {
+    local output_path="$1"
+    sed -n '/ownership EdgeCarry/p' "$output_path"
+}
+
 failures=0
 successes=0
 verified=0
@@ -176,6 +185,7 @@ for index in "${!fixtures[@]}"; do
     label="${fixture#"$ROOT"/}"
     baseline_out="$tmpdir/$index.baseline.out"
     baseline_err="$tmpdir/$index.baseline.err"
+    baseline_edges="$tmpdir/$index.baseline.edges"
     shadow_out="$tmpdir/$index.shadow.out"
     shadow_err="$tmpdir/$index.shadow.err"
     normalized_shadow_err="$tmpdir/$index.shadow.normalized.err"
@@ -183,11 +193,30 @@ for index in "${!fixtures[@]}"; do
     baseline_status=0
     run_compile "$baseline_out" "$baseline_err" \
         "$HEW_BIN" compile --dump-mir raw "$fixture" || baseline_status=$?
+    edge_carry_sequence "$baseline_out" >"$baseline_edges"
     shadow_status=0
     run_compile "$shadow_out" "$shadow_err" \
         "$HEW_BIN" compile --sir-shadow --dump-mir raw "$fixture" || shadow_status=$?
 
     fixture_failed=0
+    for ((run = 2; run <= DETERMINISM_RUNS; run++)); do
+        repeated_out="$tmpdir/$index.baseline.$run.out"
+        repeated_err="$tmpdir/$index.baseline.$run.err"
+        repeated_edges="$tmpdir/$index.baseline.$run.edges"
+        repeated_status=0
+        run_compile "$repeated_out" "$repeated_err" \
+            "$HEW_BIN" compile --dump-mir raw "$fixture" || repeated_status=$?
+        edge_carry_sequence "$repeated_out" >"$repeated_edges"
+        if [[ "$baseline_status" -ne "$repeated_status" ]]; then
+            echo "FAIL $label: repeated compile $run changed exit status from $baseline_status to $repeated_status" >&2
+            fixture_failed=1
+        fi
+        if ! diff -u "$baseline_edges" "$repeated_edges"; then
+            echo "FAIL $label: repeated compile $run reordered EdgeCarry facts" >&2
+            fixture_failed=1
+        fi
+    done
+
     if [[ "$baseline_status" -ne "$shadow_status" ]]; then
         echo "FAIL $label: exit status baseline=$baseline_status shadow=$shadow_status" >&2
         fixture_failed=1


### PR DESCRIPTION
## Summary

The compiler emitted ownership `EdgeCarry` facts in a different order on different runs of
the same input. Forty pre-fix compiles produced **37 distinct `EdgeCarry` sequences** for
`rc_weak_lifecycle` and 6 for `r4_runtime_abi`.

`ExactOwnerState` (`hew-mir/src/lower/drop_plan.rs`) is a randomized `HashMap`, and
`materialize_explicit_goto_edge_carries` (`hew-mir/src/lower/mod.rs`) iterated it directly,
appending facts in bucket order.

This surfaced through `sir-shadow-verify`, but it is **not a SIR defect**. The parity
failure was between two runs of the ordinary *legacy* path; the shadow oracle merely
noticed. Hew is deterministic by design, so an input producing different fact sequences
across runs is a defect on its own terms.

## Fix

Facts are ordered by `OwnerId` — source binding declaration identity, then ownership
generation — sorted at the emission boundary. That is a meaningful key rather than a
convenient one: it derives from declaration order, not from iteration accident.

Both paths emit it. Ordinary lowering canonicalizes before the Raw/Checked MIR freeze;
shadow mode builds that same pipeline and clones it before SIR replacements. Independent
ordinary and `--sir-shadow` invocations are now byte-identical.

Deliberately **not** fixed by sorting at the comparison site. That would make the oracle
lenient and leave the nondeterminism in the compiler.

## Verification

- Repeated-compile determinism regression: fails on compile 2 for both fixtures without the fix; passes 2 fixtures × 4 compiles with it
- `sir-shadow-verify`: full corpus 15/15; `rc_weak_lifecycle` and `r4_runtime_abi` pass individually
- `cargo test -p hew-mir --lib` — 929 passed
- `cargo test -p hew-sir` — 31 passed
- Shell script lint — 54 scripts
- `cargo fmt --all -- --check`, `git diff --check` — clean

**No other fact kind carries the same exposure.** Removing `EdgeCarry` lines left one
identical non-`EdgeCarry` raw-MIR sequence across all 40 pre-fix runs for each fixture.

## Why it matters beyond SIR

This is slice S0b of the compiler-core modernization, and a precondition for judging
#3039's `r4_layout` and replaying the SIR CFG work. But the determinism defect stands
independently: any consumer comparing two compilations — a golden fixture, a differential
oracle, a reproducible-build check — could have been derailed by it.
