### PR TITLE
canonicalize constant CFGs in SIR

### DIFF
--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -395,6 +395,12 @@ arity/types; entry parameter initialization; and operation-specific semantic
 invariants. The module SIR → MIR pipeline verifies at module scope before it
 can construct representation or storage.
 
+Optimization-safety verifier ledger:
+
+| Rewrite | Required proof | Counterfactual evidence |
+| --- | --- | --- |
+| Constant-CFG region discard | Every newly unreachable block has no value or ownership use carrying a drop obligation and no operation with a `MayTrap` edge. | `optimize_cfg` proves ordinary structural verification accepts a folded candidate with a discarded trapping arm, while the discard-safety verifier rejects it and leaves the original function unchanged. |
+
 **Dump:** `hew compile --dump-sir`.
 
 ### 2.5 Raw MIR (`hew-mir::raw`)

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -411,18 +411,34 @@ fn report_strict_sir_missing_body(
 }
 
 fn lower_verified_hir_to_sir(module: &hew_hir::HirModule) -> Result<hew_sir::LoweredModule, ()> {
-    let sir = hew_sir::lower_module(module);
+    let mut sir = hew_sir::lower_module(module);
     let diagnostics = hew_sir::verify_module(&sir.module);
     if !diagnostics.is_empty() {
-        for diagnostic in diagnostics {
-            eprintln!(
-                "SIR verifier error in `{}`: {:?}",
-                diagnostic.function, diagnostic.kind
-            );
-        }
+        render_sir_diagnostics("verifier", diagnostics);
+        return Err(());
+    }
+    if let Err(error) = hew_sir::canonicalize_module_constant_cfg(&mut sir.module) {
+        let (stage, diagnostics) = match error {
+            hew_sir::SirOptimizationError::InvalidInput(diagnostics) => {
+                ("canonicalization input verifier", diagnostics)
+            }
+            hew_sir::SirOptimizationError::InvalidOutput(diagnostics) => {
+                ("canonicalization output verifier", diagnostics)
+            }
+        };
+        render_sir_diagnostics(stage, diagnostics);
         return Err(());
     }
     Ok(sir)
+}
+
+fn render_sir_diagnostics(stage: &str, diagnostics: Vec<hew_sir::SirDiagnostic>) {
+    for diagnostic in diagnostics {
+        eprintln!(
+            "SIR {stage} error in `{}`: {:?}",
+            diagnostic.function, diagnostic.kind
+        );
+    }
 }
 
 /// File frontend plus verified HIR, shared by SIR inspection and every
@@ -515,18 +531,7 @@ fn lower_file_to_sir(
         eprintln!("Error: {error}");
     })?;
     let verified = lower_file_to_verified_hir(input_path, &target, options)?;
-    let sir = hew_sir::lower_module(&verified.lower_output.module);
-    let diagnostics = hew_sir::verify_module(&sir.module);
-    if !diagnostics.is_empty() {
-        for diagnostic in diagnostics {
-            eprintln!(
-                "SIR verifier error in `{}`: {:?}",
-                diagnostic.function, diagnostic.kind
-            );
-        }
-        return Err(());
-    }
-    Ok(sir)
+    lower_verified_hir_to_sir(&verified.lower_output.module)
 }
 
 fn lower_file_to_mir_with_options(

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -3135,3 +3135,117 @@ mod embedded_stdlib_tests {
         ));
     }
 }
+
+/// Driver-boundary coverage for the single canonical SIR module shared by
+/// inspection, shadow evidence, and strict lowering.
+///
+/// Keep this at the private driver boundary rather than making production
+/// reports carry pass statistics solely for test observability.  The report
+/// already retains the exact SIR module passed into each SIR-backed lane.
+#[cfg(test)]
+mod sir_driver_tests {
+    use super::{compile, lower_verified_hir_to_pipeline, target, SirLaneRealization};
+    use hew_hir::{lower_program_host_target, ResolutionCtx};
+    use hew_sir::{SemOpKind, SemTerminator};
+    use hew_types::{module_registry::ModuleRegistry, Checker};
+
+    const DIRECT_CONSTANT_CFG: &str = r"
+        fn main() -> i64 {
+            if true {
+                0
+            } else {
+                1
+            }
+        }
+    ";
+
+    #[test]
+    fn shadow_and_strict_receive_the_same_canonical_sir_module() {
+        let parsed = hew_parser::parse(DIRECT_CONSTANT_CFG);
+        assert!(
+            parsed.errors.is_empty(),
+            "constant CFG fixture must parse: {:#?}",
+            parsed.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(Vec::new()));
+        let type_check = checker.check_program(&parsed.program);
+        assert!(
+            type_check.errors.is_empty(),
+            "constant CFG fixture must type-check: {:#?}",
+            type_check.errors
+        );
+        let lowered = lower_program_host_target(&parsed.program, &type_check, &ResolutionCtx);
+        assert!(
+            lowered.diagnostics.is_empty(),
+            "constant CFG fixture must lower to HIR: {:#?}",
+            lowered.diagnostics
+        );
+        let target = target::TargetSpec::from_requested(None)
+            .expect("host target must be available to the driver test");
+
+        let (shadow_pipeline, shadow_report) = lower_verified_hir_to_pipeline(
+            &lowered.module,
+            &type_check,
+            &target,
+            compile::SirMode::Shadow,
+        )
+        .expect("shadow lane must accept the scalar constant CFG");
+        let shadow_report = shadow_report.expect("shadow lane must retain its SIR report");
+        assert!(matches!(
+            &shadow_report.realization,
+            SirLaneRealization::Shadow(_)
+        ));
+
+        let (strict_pipeline, strict_report) = lower_verified_hir_to_pipeline(
+            &lowered.module,
+            &type_check,
+            &target,
+            compile::SirMode::Lower,
+        )
+        .expect("strict lane must accept the scalar constant CFG");
+        let strict_report = strict_report.expect("strict lane must retain its SIR report");
+        assert!(matches!(
+            &strict_report.realization,
+            SirLaneRealization::Strict { .. }
+        ));
+
+        // The shadow artifact intentionally remains legacy MIR, whereas the
+        // strict artifact is SIR-owned. The retained semantic input must be
+        // identical in both cases: it is the canonical CFG passed to the
+        // candidate bridge or strict component, not an inspector-only copy.
+        assert_eq!(shadow_report.sir.module, strict_report.sir.module);
+        let main = shadow_report
+            .sir
+            .module
+            .functions
+            .iter()
+            .find(|function| function.name == "main")
+            .expect("constant CFG fixture must retain its SIR main body");
+        assert!(
+            matches!(&main.blocks[0].terminator, SemTerminator::Goto(_)),
+            "the direct constant branch must be canonicalized before both lanes: {main:#?}"
+        );
+        assert!(
+            main.blocks
+                .iter()
+                .all(|block| !matches!(&block.terminator, SemTerminator::Branch { .. })),
+            "canonical SIR must contain no remaining branch for a direct constant: {main:#?}"
+        );
+        assert!(
+            main.blocks
+                .iter()
+                .flat_map(|block| &block.ops)
+                .all(|operation| { !matches!(&operation.kind, SemOpKind::ConstI64(1)) }),
+            "the unselected arm must be compacted before the SIR-backed lanes: {main:#?}"
+        );
+
+        assert!(
+            shadow_pipeline
+                .raw_mir
+                .iter()
+                .any(|function| function.name == "main"),
+            "shadow must retain the established main body as its emitted artifact"
+        );
+        assert_eq!(strict_pipeline.raw_mir.len(), 1);
+    }
+}

--- a/hew-cli/tests/sir_shadow_e2e.rs
+++ b/hew-cli/tests/sir_shadow_e2e.rs
@@ -925,6 +925,14 @@ fn sir_canonicalizes_direct_constant_cfg_before_strict_lowering() {
         "the unreachable source arm must be gone from canonical SIR:\n{main}",
     );
 
+    let shadow = raw_mir_dump(&source, Some("--sir-shadow"));
+    assert_success(&shadow, "canonical SIR shadow evidence must succeed");
+    assert!(
+        String::from_utf8_lossy(&shadow.stderr).contains("SIR shadow: verified"),
+        "shadow must consume the same verified canonical SIR module:\n{}",
+        describe_output(&shadow),
+    );
+
     let lowered = raw_mir_dump(&source, Some("--sir-lower"));
     assert_success(&lowered, "canonical strict SIR raw dump must succeed");
     let lowered_stderr = String::from_utf8_lossy(&lowered.stderr);

--- a/hew-cli/tests/sir_shadow_e2e.rs
+++ b/hew-cli/tests/sir_shadow_e2e.rs
@@ -106,6 +106,19 @@ fn main() -> i64 {
 }
 ";
 
+/// The first SIR optimization proof: both semantic branch arms are initially
+/// present, but the direct `true` condition lets SIR retain only the selected
+/// CFG edge before any Raw MIR representation is chosen.
+const CONSTANT_CFG_CANONICALIZATION: &str = r"
+fn main() -> i64 {
+    if true {
+        0
+    } else {
+        1
+    }
+}
+";
+
 const REACHABLE_UNSUPPORTED_CALL: &str = r"
 fn main() -> i64 {
     effectful()
@@ -885,6 +898,64 @@ fn sir_dump_preserves_short_circuit_control_flow() {
     assert!(
         !or_body.contains("Binary { op: Or"),
         "|| must not survive as an eager SIR binary operation:\n{or_body}",
+    );
+}
+
+/// `--dump-sir`, shadow evidence, and strict lowering must all consume the
+/// same canonical semantic CFG. This proves the first actual SIR pass is not
+/// an inspector-only transformation or a second compiler lane.
+#[test]
+fn sir_canonicalizes_direct_constant_cfg_before_strict_lowering() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("sir_constant_cfg.hew");
+    fs::write(&source, CONSTANT_CFG_CANONICALIZATION).expect("write constant SIR CFG fixture");
+
+    let inspected = sir_dump(&source);
+    assert_success(&inspected, "canonical SIR inspection must succeed");
+    let dump = String::from_utf8_lossy(&inspected.stdout);
+    let main = function_section(&dump, "main");
+    assert!(
+        main.contains("goto") && !main.contains("branch"),
+        "a direct constant branch must become one semantic edge:\n{main}",
+    );
+    assert!(
+        !main.contains("const 1"),
+        "the unreachable source arm must be gone from canonical SIR:\n{main}",
+    );
+
+    let lowered = raw_mir_dump(&source, Some("--sir-lower"));
+    assert_success(&lowered, "canonical strict SIR raw dump must succeed");
+    let lowered_stderr = String::from_utf8_lossy(&lowered.stderr);
+    assert!(
+        lowered_stderr.contains("no legacy MIR bodies were lowered"),
+        "strict canonicalization must remain on the SIR body path:\n{}",
+        describe_output(&lowered),
+    );
+
+    let mut compile = Command::new(hew_binary());
+    compile
+        .arg("compile")
+        .arg("--sir-lower")
+        .arg("--emit-dir")
+        .arg(dir.path())
+        .arg(&source)
+        .current_dir(repo_root());
+    let compiled = support::run_bounded_command(compile, "compile canonical constant SIR CFG");
+    assert_success(
+        &compiled,
+        "canonical SIR CFG must compile through Raw/Checked/Elaborated MIR and LLVM",
+    );
+
+    let binary = hew_testutil::compiled_binary_path(dir.path(), "sir_constant_cfg");
+    let executed = support::run_bounded_command(
+        Command::new(&binary),
+        format!("run canonical constant SIR CFG {}", binary.display()),
+    );
+    assert_success(
+        &executed,
+        "canonical SIR CFG executable must preserve behavior",
     );
 }
 

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -4289,10 +4289,21 @@ pub(super) fn validate_ownership_events(checked: &CheckedMirFunction) -> Vec<Mir
                     }),
                 }
             }
-            for (owner, place) in required {
-                if matched.contains(&owner) {
-                    continue;
-                }
+            let mut unmatched_required = required
+                .into_iter()
+                .filter(|(owner, _)| !matched.contains(owner))
+                .collect::<Vec<_>>();
+            // `ExactOwnerState` is a HashMap because ownership replay needs
+            // keyed mutation, but its randomized iteration order must not
+            // become diagnostic order. The binding SiteId is the diagnostic's
+            // source anchor; order those anchors as HIR encountered them, then
+            // use declaration/generation-based OwnerId for multiple owners at
+            // the same source site. Missing source metadata sorts last.
+            unmatched_required.sort_by_key(|(owner, _)| {
+                let site = binding_metadata.get(&owner.binding).map(|(_, site)| *site);
+                (site.is_none(), site.unwrap_or(SiteId(u32::MAX)), *owner)
+            });
+            for (owner, place) in unmatched_required {
                 let ty = owner_types
                     .get(&owner)
                     .map_or_else(|| "<unknown>".to_owned(), ToString::to_string);
@@ -7554,6 +7565,83 @@ fn missing_checked_owner_recipe_cannot_materialize_a_destructor() {
     assert!(validate_ownership_events(&checked)
         .iter()
         .any(|finding| matches!(finding, MirCheck::ObligationUnderReleased { .. })));
+}
+
+#[test]
+fn missing_owner_diagnostics_follow_source_binding_order() {
+    use crate::model::{OwnerId, OwnershipEvent};
+
+    let later_owner = OwnerId {
+        binding: BindingId(81),
+        generation: 0,
+    };
+    let earlier_owner = OwnerId {
+        binding: BindingId(82),
+        generation: 0,
+    };
+    let blocks = vec![BasicBlock {
+        id: ENTRY_BLOCK_ID,
+        statements: vec![
+            MirStatement::Bind {
+                binding: later_owner.binding,
+                name: "later".to_owned(),
+                site: SiteId(9),
+                ty: ResolvedTy::String,
+            },
+            MirStatement::Bind {
+                binding: earlier_owner.binding,
+                name: "earlier".to_owned(),
+                site: SiteId(3),
+                ty: ResolvedTy::String,
+            },
+        ],
+        // Deliberately mint in the opposite order from the source anchors.
+        instructions: vec![
+            Instr::OwnershipEvent(OwnershipEvent::Mint {
+                owner: later_owner,
+                place: Place::Local(1),
+                ty: ResolvedTy::String,
+            }),
+            Instr::OwnershipEvent(OwnershipEvent::Mint {
+                owner: earlier_owner,
+                place: Place::Local(2),
+                ty: ResolvedTy::String,
+            }),
+        ],
+        terminator: Terminator::Return,
+    }];
+    let checked = CheckedMirFunction {
+        name: "source_order".to_owned(),
+        return_ty: ResolvedTy::Unit,
+        blocks,
+        decisions: vec![],
+        checks: vec![],
+        cooperate_sites: vec![],
+        ownership_elaboration: Some(Box::new(ElaboratedMirFunction {
+            name: "source_order".to_owned(),
+            return_ty: ResolvedTy::Unit,
+            statements: vec![],
+            decisions: vec![],
+            blocks: vec![],
+            drop_plans: vec![(
+                ExitPath::Return {
+                    block: ENTRY_BLOCK_ID,
+                },
+                DropPlan::default(),
+            )],
+            coroutine: None,
+            lambda_captures: vec![],
+        })),
+    };
+
+    let sites = validate_ownership_events(&checked)
+        .into_iter()
+        .filter_map(|finding| match finding {
+            MirCheck::ObligationUnderReleased { site, .. } => Some(site),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(sites, [SiteId(3), SiteId(9)]);
 }
 
 #[test]

--- a/hew-sir/README.md
+++ b/hew-sir/README.md
@@ -1,8 +1,21 @@
 # Hew Semantic IR
 
 `hew-sir` is Hew's value-oriented semantic SSA intermediate representation.
-It sits between resolved HIR and the established ownership/layout MIR ladder.
+It sits between resolved HIR and the ownership/layout MIR ladder.
 
-The initial implementation is intentionally shadow-only: it verifies a small,
-pure subset of HIR and then leaves the existing HIR-to-MIR-to-LLVM pipeline as
-the authoritative producer of compiler artifacts.
+SIR owns semantic values, typed CFG, block arguments, direct-call identity,
+effect classification, and Hew-aware optimization. It deliberately does not
+own storage places, layout, ABI carriers, byte offsets, or LLVM operations.
+
+Migration uses `--sir-shadow` only as temporary differential evidence. Closed
+language domains selected with `--sir-lower` already produce Raw, Checked, and
+Elaborated MIR without legacy function-body lowering. The end state is one
+convergent body path:
+
+```text
+resolved + normalized HIR → SIR → Raw MIR → Checked MIR → Elaborated MIR → LLVM
+```
+
+Every SIR transformation verifies its input and output. Unsupported semantic
+surface is a compiler implementation gap, never permission to silently route a
+selected SIR body back through legacy lowering.

--- a/hew-sir/src/analysis.rs
+++ b/hew-sir/src/analysis.rs
@@ -1,6 +1,172 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::{BlockId, OpId, SemFunction, UseSite, ValueId};
+use crate::{BlockId, OpId, SemFunction, SuccessorSlot, UseSite, ValueId};
+
+/// Stable identity of one outgoing CFG edge in a semantic function.
+///
+/// The source block plus [`Self::slot`] identify an edge independently of its
+/// target. In particular, the two successor slots of a branch remain distinct
+/// even when both target the same block. `EdgeRef` is a snapshot identity over
+/// verified SIR: a transformation that changes a terminator must rebuild its
+/// [`CfgIndex`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EdgeRef {
+    pub source: BlockId,
+    pub slot: SuccessorSlot,
+}
+
+/// Deterministic control-flow facts for one semantic function.
+///
+/// `predecessors` and `successors` retain one [`EdgeRef`] per semantic edge,
+/// including duplicate edges. Their vectors are sorted by stable edge identity
+/// rather than relying on incidental allocation order. `edge_targets` records
+/// the target observed while indexing, so analyses can consume a coherent CFG
+/// snapshot without re-inspecting mutable terminators.
+///
+/// Reachability and reverse postorder contain only blocks that exist in the
+/// function. An edge to an unknown block remains visible in the index for
+/// diagnostics, but does not manufacture a reachable CFG node. Duplicate
+/// block identities are malformed SIR and must be rejected by the verifier
+/// before clients rely on `EdgeRef` as a unique semantic identity.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CfgIndex {
+    predecessors: BTreeMap<BlockId, Vec<EdgeRef>>,
+    successors: BTreeMap<BlockId, Vec<EdgeRef>>,
+    edge_targets: BTreeMap<EdgeRef, BlockId>,
+    reachable: BTreeSet<BlockId>,
+    reverse_postorder: Vec<BlockId>,
+}
+
+impl CfgIndex {
+    /// Return all incoming edges for `block` in stable edge-reference order.
+    #[must_use]
+    pub fn predecessors_of(&self, block: BlockId) -> &[EdgeRef] {
+        self.predecessors.get(&block).map_or(&[], Vec::as_slice)
+    }
+
+    /// Return all outgoing edges for `block` in stable successor-slot order.
+    #[must_use]
+    pub fn successors_of(&self, block: BlockId) -> &[EdgeRef] {
+        self.successors.get(&block).map_or(&[], Vec::as_slice)
+    }
+
+    /// Return the target captured for one indexed edge.
+    #[must_use]
+    pub fn edge_target(&self, edge: EdgeRef) -> Option<BlockId> {
+        self.edge_targets.get(&edge).copied()
+    }
+
+    /// Whether `block` is reachable from the function's declared entry block.
+    #[must_use]
+    pub fn is_reachable(&self, block: BlockId) -> bool {
+        self.reachable.contains(&block)
+    }
+
+    /// Return every block reachable from the function entry in stable block-ID
+    /// order.
+    #[must_use]
+    pub fn reachable(&self) -> &BTreeSet<BlockId> {
+        &self.reachable
+    }
+
+    /// Return the deterministic reverse-postorder traversal of reachable
+    /// blocks. DFS visits successors in [`SuccessorSlot`] order before
+    /// reversing its postorder.
+    #[must_use]
+    pub fn rpo(&self) -> &[BlockId] {
+        &self.reverse_postorder
+    }
+}
+
+/// Build the deterministic CFG facts for one semantic function.
+///
+/// The verifier remains authoritative for canonical, unique block identities
+/// and known successor targets. Consumers that transform SIR must verify first
+/// and rebuild the index after changing a terminator or block collection. An
+/// otherwise uniquely identified function with an unknown target can still be
+/// indexed for diagnostics, but duplicate block identities have no coherent
+/// `EdgeRef` meaning.
+#[must_use]
+pub fn build_cfg_index(function: &SemFunction) -> CfgIndex {
+    let mut index = CfgIndex::default();
+    let known_blocks = function
+        .blocks
+        .iter()
+        .map(|block| block.id)
+        .collect::<BTreeSet<_>>();
+
+    for block in &function.blocks {
+        index.predecessors.entry(block.id).or_default();
+        index.successors.entry(block.id).or_default();
+    }
+    for block in &function.blocks {
+        block.terminator.visit_successors_with_slots(|slot, edge| {
+            let edge_ref = EdgeRef {
+                source: block.id,
+                slot,
+            };
+            index.successors.entry(block.id).or_default().push(edge_ref);
+            index
+                .predecessors
+                .entry(edge.target)
+                .or_default()
+                .push(edge_ref);
+            index.edge_targets.insert(edge_ref, edge.target);
+        });
+    }
+    for edges in index.predecessors.values_mut() {
+        edges.sort_unstable();
+    }
+    for edges in index.successors.values_mut() {
+        edges.sort_unstable();
+    }
+
+    let mut postorder = Vec::new();
+    if known_blocks.contains(&function.entry) {
+        visit_reachable_postorder(
+            function.entry,
+            &known_blocks,
+            &index.successors,
+            &index.edge_targets,
+            &mut index.reachable,
+            &mut postorder,
+        );
+    }
+    postorder.reverse();
+    index.reverse_postorder = postorder;
+    index
+}
+
+fn visit_reachable_postorder(
+    block: BlockId,
+    known_blocks: &BTreeSet<BlockId>,
+    successors: &BTreeMap<BlockId, Vec<EdgeRef>>,
+    edge_targets: &BTreeMap<EdgeRef, BlockId>,
+    reachable: &mut BTreeSet<BlockId>,
+    postorder: &mut Vec<BlockId>,
+) {
+    if !reachable.insert(block) {
+        return;
+    }
+    if let Some(edges) = successors.get(&block) {
+        for edge in edges {
+            let Some(target) = edge_targets.get(edge).copied() else {
+                continue;
+            };
+            if known_blocks.contains(&target) {
+                visit_reachable_postorder(
+                    target,
+                    known_blocks,
+                    successors,
+                    edge_targets,
+                    reachable,
+                    postorder,
+                );
+            }
+        }
+    }
+    postorder.push(block);
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Dominators {
@@ -20,12 +186,7 @@ pub fn compute_dominators(function: &SemFunction) -> Dominators {
         .iter()
         .map(|b| b.id)
         .collect::<BTreeSet<_>>();
-    let mut predecessors: BTreeMap<BlockId, Vec<BlockId>> = BTreeMap::new();
-    for block in &function.blocks {
-        block
-            .terminator
-            .visit_successors(|edge| predecessors.entry(edge.target).or_default().push(block.id));
-    }
+    let cfg = build_cfg_index(function);
     let mut sets = function
         .blocks
         .iter()
@@ -45,18 +206,21 @@ pub fn compute_dominators(function: &SemFunction) -> Dominators {
             if block.id == function.entry {
                 continue;
             }
-            let mut next = predecessors
-                .get(&block.id)
-                .map_or_else(BTreeSet::new, |preds| {
-                    let mut result = all.clone();
-                    for pred in preds {
-                        result = result
-                            .intersection(sets.get(pred).expect("predecessor must be a block"))
-                            .copied()
-                            .collect();
-                    }
-                    result
-                });
+            let mut next = if cfg.predecessors_of(block.id).is_empty() {
+                BTreeSet::new()
+            } else {
+                let mut result = all.clone();
+                for predecessor in cfg.predecessors_of(block.id) {
+                    result = result
+                        .intersection(
+                            sets.get(&predecessor.source)
+                                .expect("predecessor must be a block"),
+                        )
+                        .copied()
+                        .collect();
+                }
+                result
+            };
             next.insert(block.id);
             if sets.get(&block.id) != Some(&next) {
                 sets.insert(block.id, next);
@@ -248,4 +412,185 @@ pub fn replace_all_uses(
     }
     *function = rewritten;
     Ok(replaced)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use hew_hir::ItemId;
+    use hew_types::{DefId, ResolvedTy};
+
+    use super::{build_cfg_index, EdgeRef};
+    use crate::{
+        BlockArg, BlockId, CallableId, Edge, FunctionSourceOrigin, Operand, SemBlock, SemFunction,
+        SemTerminator, SuccessorSlot, UseMode, ValueId,
+    };
+
+    fn read(value: u32) -> Operand {
+        Operand {
+            value: ValueId(value),
+            mode: UseMode::Read,
+        }
+    }
+
+    fn edge(target: u32) -> Edge {
+        Edge {
+            target: BlockId(target),
+            args: Vec::new(),
+        }
+    }
+
+    fn block(id: u32, terminator: SemTerminator) -> SemBlock {
+        SemBlock {
+            id: BlockId(id),
+            args: Vec::new(),
+            ops: Vec::new(),
+            terminator,
+        }
+    }
+
+    fn function(blocks: Vec<SemBlock>) -> SemFunction {
+        SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("cfg_index"),
+            name: "cfg_index".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: vec![BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::Bool,
+            }],
+            return_ty: ResolvedTy::Unit,
+            entry: BlockId(0),
+            blocks,
+        }
+    }
+
+    #[test]
+    fn successor_slots_preserve_duplicate_branch_edges_and_legacy_visitors() {
+        let mut terminator = SemTerminator::Branch {
+            condition: read(0),
+            then_target: edge(1),
+            else_target: edge(1),
+        };
+
+        let mut slotted = Vec::new();
+        terminator.visit_successors_with_slots(|slot, edge| slotted.push((slot, edge.target)));
+        assert_eq!(
+            slotted,
+            vec![
+                (SuccessorSlot(0), BlockId(1)),
+                (SuccessorSlot(1), BlockId(1)),
+            ]
+        );
+
+        let mut legacy = Vec::new();
+        terminator.visit_successors(|edge| legacy.push(edge.target));
+        assert_eq!(legacy, vec![BlockId(1), BlockId(1)]);
+
+        terminator
+            .successor_mut(SuccessorSlot(1))
+            .expect("branch else edge must own successor slot 1")
+            .target = BlockId(2);
+        terminator.visit_successors_with_slots_mut(|slot, edge| {
+            if slot == SuccessorSlot(0) {
+                edge.target = BlockId(3);
+            }
+        });
+        assert_eq!(
+            terminator
+                .successor(SuccessorSlot(0))
+                .map(|edge| edge.target),
+            Some(BlockId(3))
+        );
+        assert_eq!(
+            terminator
+                .successor(SuccessorSlot(1))
+                .map(|edge| edge.target),
+            Some(BlockId(2))
+        );
+        assert_eq!(terminator.successor(SuccessorSlot(2)), None);
+    }
+
+    #[test]
+    fn cfg_index_preserves_duplicate_edges_and_computes_stable_rpo() {
+        let function = function(vec![
+            block(
+                0,
+                SemTerminator::Branch {
+                    condition: read(0),
+                    then_target: edge(1),
+                    else_target: edge(1),
+                },
+            ),
+            block(1, SemTerminator::Goto(edge(2))),
+            block(
+                2,
+                SemTerminator::Branch {
+                    condition: read(0),
+                    then_target: edge(1),
+                    else_target: edge(3),
+                },
+            ),
+            block(3, SemTerminator::Return { value: None }),
+            block(4, SemTerminator::Return { value: None }),
+        ]);
+        assert!(crate::verify_function(&function).is_empty());
+
+        let index = build_cfg_index(&function);
+        let entry_then = EdgeRef {
+            source: BlockId(0),
+            slot: SuccessorSlot(0),
+        };
+        let entry_else = EdgeRef {
+            source: BlockId(0),
+            slot: SuccessorSlot(1),
+        };
+        let loop_back = EdgeRef {
+            source: BlockId(2),
+            slot: SuccessorSlot(0),
+        };
+        let exit = EdgeRef {
+            source: BlockId(2),
+            slot: SuccessorSlot(1),
+        };
+
+        assert_eq!(index.successors_of(BlockId(0)), &[entry_then, entry_else]);
+        assert_eq!(
+            index.predecessors_of(BlockId(1)),
+            &[entry_then, entry_else, loop_back]
+        );
+        assert_eq!(index.successors_of(BlockId(2)), &[loop_back, exit]);
+        assert_eq!(index.edge_target(entry_then), Some(BlockId(1)));
+        assert_eq!(index.edge_target(entry_else), Some(BlockId(1)));
+        assert_eq!(index.edge_target(exit), Some(BlockId(3)));
+        assert_eq!(
+            index.reachable,
+            BTreeSet::from([BlockId(0), BlockId(1), BlockId(2), BlockId(3)])
+        );
+        assert!(!index.is_reachable(BlockId(4)));
+        assert_eq!(
+            index.rpo(),
+            &[BlockId(0), BlockId(1), BlockId(2), BlockId(3)]
+        );
+        assert_eq!(index, build_cfg_index(&function));
+    }
+
+    #[test]
+    fn cfg_index_keeps_unknown_targets_for_diagnostics_without_reaching_them() {
+        let function = function(vec![block(0, SemTerminator::Goto(edge(9)))]);
+
+        let index = build_cfg_index(&function);
+        let unknown_edge = EdgeRef {
+            source: BlockId(0),
+            slot: SuccessorSlot(0),
+        };
+        assert_eq!(index.predecessors_of(BlockId(9)), &[unknown_edge]);
+        assert_eq!(index.edge_target(unknown_edge), Some(BlockId(9)));
+        assert_eq!(index.reachable, BTreeSet::from([BlockId(0)]));
+        assert!(!index.is_reachable(BlockId(9)));
+        assert_eq!(index.rpo(), &[BlockId(0)]);
+    }
 }

--- a/hew-sir/src/analysis.rs
+++ b/hew-sir/src/analysis.rs
@@ -206,15 +206,32 @@ pub fn compute_dominators(function: &SemFunction) -> Dominators {
             if block.id == function.entry {
                 continue;
             }
-            let mut next = if cfg.predecessors_of(block.id).is_empty() {
+            if !cfg.is_reachable(block.id) {
+                // No executable path reaches this block, so every known block
+                // vacuously dominates it. Leaving its initial `all` set intact
+                // keeps verifier-after-rewrite valid until the following CFG
+                // compaction removes the dead block.
+                continue;
+            }
+            // Dominance is a property of paths that can execute from the
+            // entry. A structurally present predecessor from an unreachable
+            // block must not invalidate a definition that dominates this
+            // reachable block on every executable path. This matters after
+            // CFG rewrites, where dead blocks can still point at a live join
+            // until compaction removes them.
+            let reachable_predecessors = cfg
+                .predecessors_of(block.id)
+                .iter()
+                .filter(|predecessor| cfg.is_reachable(predecessor.source));
+            let mut next = if reachable_predecessors.clone().next().is_none() {
                 BTreeSet::new()
             } else {
                 let mut result = all.clone();
-                for predecessor in cfg.predecessors_of(block.id) {
+                for predecessor in reachable_predecessors {
                     result = result
                         .intersection(
                             sets.get(&predecessor.source)
-                                .expect("predecessor must be a block"),
+                                .expect("reachable predecessor must be a block"),
                         )
                         .copied()
                         .collect();
@@ -421,7 +438,7 @@ mod tests {
     use hew_hir::ItemId;
     use hew_types::{DefId, ResolvedTy};
 
-    use super::{build_cfg_index, EdgeRef};
+    use super::{build_cfg_index, compute_dominators, EdgeRef};
     use crate::{
         BlockArg, BlockId, CallableId, Edge, FunctionSourceOrigin, Operand, SemBlock, SemFunction,
         SemTerminator, SuccessorSlot, UseMode, ValueId,
@@ -592,5 +609,36 @@ mod tests {
         assert_eq!(index.reachable, BTreeSet::from([BlockId(0)]));
         assert!(!index.is_reachable(BlockId(9)));
         assert_eq!(index.rpo(), &[BlockId(0)]);
+    }
+
+    #[test]
+    fn dominators_ignore_unreachable_predecessors_of_reachable_blocks() {
+        let mut function = function(vec![
+            block(0, SemTerminator::Goto(edge(1))),
+            block(
+                1,
+                SemTerminator::Return {
+                    value: Some(read(0)),
+                },
+            ),
+            // This structural predecessor cannot execute from the entry and
+            // must not make the entry parameter appear non-dominating at
+            // bb1. CFG simplification commonly creates this shape briefly
+            // before compaction removes the dead block.
+            block(2, SemTerminator::Goto(edge(1))),
+        ]);
+        function.return_ty = ResolvedTy::Bool;
+
+        assert!(crate::verify_function(&function).is_empty());
+        let index = build_cfg_index(&function);
+        assert_eq!(index.reachable(), &BTreeSet::from([BlockId(0), BlockId(1)]));
+        assert_eq!(index.rpo(), &[BlockId(0), BlockId(1)]);
+        assert!(!index.is_reachable(BlockId(2)));
+
+        let dominators = compute_dominators(&function);
+        assert_eq!(
+            dominators.sets.get(&BlockId(1)),
+            Some(&BTreeSet::from([BlockId(0), BlockId(1)]))
+        );
     }
 }

--- a/hew-sir/src/lib.rs
+++ b/hew-sir/src/lib.rs
@@ -10,11 +10,12 @@ mod analysis;
 mod dump;
 mod lower;
 mod model;
+mod optimize;
 mod verify;
 
 pub use analysis::{
-    build_def_use, compute_dominators, replace_all_uses, replace_use, DefUseIndex, Dominators,
-    RewriteError,
+    build_cfg_index, build_def_use, compute_dominators, replace_all_uses, replace_use, CfgIndex,
+    DefUseIndex, Dominators, EdgeRef, RewriteError,
 };
 pub use dump::dump_sir;
 pub use lower::{lower_module, LoweredModule, SirLoweringStatus};
@@ -23,7 +24,11 @@ pub use model::{
     FunctionSourceOrigin, GenericTemplateId, OpId, Operand, OperandSlot, Provenance, SemAbiParam,
     SemBlock, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemGenericTemplate,
     SemModule, SemOp, SemOpKind, SemParamPassing, SemSignature, SemTerminator, SirInstanceKey,
-    UseMode, UseSite, ValueDef, ValueId,
+    SuccessorSlot, UseMode, UseSite, ValueDef, ValueId,
+};
+pub use optimize::{
+    canonicalize_constant_cfg, canonicalize_module_constant_cfg, CfgCanonicalizationReport,
+    SirOptimizationError,
 };
 pub use verify::{
     verify_function, verify_function_in_module, verify_module, SirDiagnostic, SirDiagnosticKind,

--- a/hew-sir/src/lib.rs
+++ b/hew-sir/src/lib.rs
@@ -31,5 +31,6 @@ pub use optimize::{
     SirOptimizationError,
 };
 pub use verify::{
-    verify_function, verify_function_in_module, verify_module, SirDiagnostic, SirDiagnosticKind,
+    verify_function, verify_function_in_module, verify_module, CfgDiscardSafetyReason,
+    SirDiagnostic, SirDiagnosticKind,
 };

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -103,6 +103,18 @@ pub struct Operand {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OperandSlot(pub u32);
 
+/// Stable position of an outgoing semantic CFG edge within one terminator.
+///
+/// A successor slot names the edge's *role*, rather than its target. This is
+/// important because a branch may legitimately carry two distinct edges to
+/// the same target block. The initial terminator vocabulary assigns slot `0`
+/// to a `goto` edge and slots `0` and `1` to the then and else edges of a
+/// branch, respectively. Future terminators with several resume edges must
+/// extend this deterministic ordinal convention instead of identifying an
+/// edge by its target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SuccessorSlot(pub u32);
+
 /// Concrete, deterministic identity of one semantic SSA use.
 ///
 /// A value's use site is either an operation operand, identified by its stable
@@ -799,36 +811,101 @@ impl SemTerminator {
         }
     }
 
-    /// Visit CFG successors without exposing terminator shape to each caller.
-    pub fn visit_successors(&self, mut visit: impl FnMut(&Edge)) {
+    /// Visit CFG successors together with their stable structural slots.
+    ///
+    /// A slot identifies one edge within this terminator, not the target
+    /// block. This preserves the distinction between duplicate edges such as
+    /// `branch %condition, bb1, bb1`, which later CFG rewrites must be able
+    /// to redirect independently.
+    pub fn visit_successors_with_slots(&self, mut visit: impl FnMut(SuccessorSlot, &Edge)) {
         match self {
             Self::Return { .. } | Self::Unreachable => {}
-            Self::Goto(edge) => visit(edge),
+            Self::Goto(edge) => visit(SuccessorSlot(0), edge),
             Self::Branch {
                 then_target,
                 else_target,
                 ..
             } => {
-                visit(then_target);
-                visit(else_target);
+                visit(SuccessorSlot(0), then_target);
+                visit(SuccessorSlot(1), else_target);
             }
         }
     }
 
-    /// Mutable counterpart to [`Self::visit_successors`].
-    pub fn visit_successors_mut(&mut self, mut visit: impl FnMut(&mut Edge)) {
+    /// Mutable counterpart to [`Self::visit_successors_with_slots`].
+    pub fn visit_successors_with_slots_mut(
+        &mut self,
+        mut visit: impl FnMut(SuccessorSlot, &mut Edge),
+    ) {
         match self {
             Self::Return { .. } | Self::Unreachable => {}
-            Self::Goto(edge) => visit(edge),
+            Self::Goto(edge) => visit(SuccessorSlot(0), edge),
             Self::Branch {
                 then_target,
                 else_target,
                 ..
             } => {
-                visit(then_target);
-                visit(else_target);
+                visit(SuccessorSlot(0), then_target);
+                visit(SuccessorSlot(1), else_target);
             }
         }
+    }
+
+    /// Return the edge at one stable successor slot, if this terminator owns
+    /// that slot.
+    ///
+    /// The slot is intentionally structural: callers can distinguish and
+    /// inspect duplicate edges without comparing targets.
+    #[must_use]
+    pub fn successor(&self, slot: SuccessorSlot) -> Option<&Edge> {
+        match self {
+            Self::Goto(edge) if slot == SuccessorSlot(0) => Some(edge),
+            Self::Branch {
+                then_target,
+                else_target,
+                ..
+            } => match slot.0 {
+                0 => Some(then_target),
+                1 => Some(else_target),
+                _ => None,
+            },
+            Self::Return { .. } | Self::Goto(_) | Self::Unreachable => None,
+        }
+    }
+
+    /// Mutable counterpart to [`Self::successor`].
+    #[must_use]
+    pub fn successor_mut(&mut self, slot: SuccessorSlot) -> Option<&mut Edge> {
+        match self {
+            Self::Goto(edge) if slot == SuccessorSlot(0) => Some(edge),
+            Self::Branch {
+                then_target,
+                else_target,
+                ..
+            } => match slot.0 {
+                0 => Some(then_target),
+                1 => Some(else_target),
+                _ => None,
+            },
+            Self::Return { .. } | Self::Goto(_) | Self::Unreachable => None,
+        }
+    }
+
+    /// Visit CFG successors without exposing terminator shape to each caller.
+    ///
+    /// This compatibility visitor deliberately delegates to
+    /// [`Self::visit_successors_with_slots`]. New CFG analyses should retain
+    /// the slot so they can distinguish duplicate edges.
+    pub fn visit_successors(&self, mut visit: impl FnMut(&Edge)) {
+        self.visit_successors_with_slots(|_, edge| visit(edge));
+    }
+
+    /// Mutable counterpart to [`Self::visit_successors`].
+    ///
+    /// This compatibility visitor deliberately delegates to
+    /// [`Self::visit_successors_with_slots_mut`].
+    pub fn visit_successors_mut(&mut self, mut visit: impl FnMut(&mut Edge)) {
+        self.visit_successors_with_slots_mut(|_, edge| visit(edge));
     }
 
     /// Human-readable role of one operand slot, for exact verifier

--- a/hew-sir/src/optimize.rs
+++ b/hew-sir/src/optimize.rs
@@ -58,7 +58,8 @@ pub fn canonicalize_constant_cfg(
     }
 
     let mut candidate = function.clone();
-    let report = canonicalize_verified_function(&mut candidate);
+    let report = canonicalize_verified_function(&mut candidate)
+        .map_err(SirOptimizationError::InvalidOutput)?;
     let diagnostics = verify_function(&candidate);
     if !diagnostics.is_empty() {
         return Err(SirOptimizationError::InvalidOutput(diagnostics));
@@ -87,11 +88,12 @@ pub fn canonicalize_module_constant_cfg(
     }
 
     let mut candidate = module.clone();
-    let reports = candidate
-        .functions
-        .iter_mut()
-        .map(|function| (function.callable, canonicalize_verified_function(function)))
-        .collect::<Vec<_>>();
+    let mut reports = Vec::with_capacity(candidate.functions.len());
+    for function in &mut candidate.functions {
+        let report = canonicalize_verified_function(function)
+            .map_err(SirOptimizationError::InvalidOutput)?;
+        reports.push((function.callable, report));
+    }
     let diagnostics = verify_module(&candidate);
     if !diagnostics.is_empty() {
         return Err(SirOptimizationError::InvalidOutput(diagnostics));
@@ -101,7 +103,9 @@ pub fn canonicalize_module_constant_cfg(
     Ok(reports)
 }
 
-fn canonicalize_verified_function(function: &mut SemFunction) -> CfgCanonicalizationReport {
+fn canonicalize_verified_function(
+    function: &mut SemFunction,
+) -> Result<CfgCanonicalizationReport, Vec<SirDiagnostic>> {
     let constants = direct_bool_constants(function);
     let initial_cfg = build_cfg_index(function);
     let mut folded_branches = 0;
@@ -134,13 +138,26 @@ fn canonicalize_verified_function(function: &mut SemFunction) -> CfgCanonicaliza
         }
     }
 
+    // Keep the verifier boundary at the actual CFG rewrite, not only at the
+    // public call boundary. This deliberately makes dead-block compaction a
+    // separate audited transformation: later passes can follow this shape
+    // without inventing a second validation convention.
+    let diagnostics = verify_function(function);
+    if !diagnostics.is_empty() {
+        return Err(diagnostics);
+    }
+
     let post_fold_cfg = build_cfg_index(function);
     let (removed_blocks, block_remap) = compact_unreachable(function, post_fold_cfg.reachable());
-    CfgCanonicalizationReport {
+    let diagnostics = verify_function(function);
+    if !diagnostics.is_empty() {
+        return Err(diagnostics);
+    }
+    Ok(CfgCanonicalizationReport {
         folded_branches,
         removed_blocks,
         block_remap,
-    }
+    })
 }
 
 fn direct_bool_constants(function: &SemFunction) -> BTreeMap<ValueId, bool> {

--- a/hew-sir/src/optimize.rs
+++ b/hew-sir/src/optimize.rs
@@ -1,0 +1,219 @@
+//! Small, verifier-backed SIR canonicalization passes.
+//!
+//! This module intentionally starts with CFG canonicalization rather than a
+//! general pass manager. Each transformation is transactional: malformed input
+//! is rejected before mutation, and the verifier must accept the complete
+//! result before it becomes visible to a caller.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    build_cfg_index, verify_function, verify_module, BlockId, CallableId, SemFunction, SemModule,
+    SemOpKind, SemTerminator, SirDiagnostic, ValueId,
+};
+
+/// Stable result facts from one constant-CFG canonicalization.
+///
+/// `removed_blocks` and `block_remap` refer to the input function's block
+/// identities. Value and operation identities are intentionally not remapped:
+/// they are semantic identities rather than vector positions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CfgCanonicalizationReport {
+    /// Number of direct constant boolean branches replaced with their selected
+    /// edge.
+    pub folded_branches: usize,
+    /// Former identities of blocks unreachable after branch folding.
+    pub removed_blocks: Vec<BlockId>,
+    /// Every retained former block identity and its canonical new identity.
+    pub block_remap: BTreeMap<BlockId, BlockId>,
+}
+
+/// A verifier boundary failure around a SIR optimization pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SirOptimizationError {
+    /// The caller supplied malformed SIR. No transformation was attempted.
+    InvalidInput(Vec<SirDiagnostic>),
+    /// A pass implementation violated a SIR invariant. The caller's original
+    /// SIR remains intact.
+    InvalidOutput(Vec<SirDiagnostic>),
+}
+
+/// Fold direct constant-boolean branches and compact unreachable blocks.
+///
+/// This function is suitable for local SIR construction tests. Inter-IR
+/// boundaries that need direct-call validation should use
+/// [`canonicalize_module_constant_cfg`] instead.
+///
+/// # Errors
+///
+/// Returns [`SirOptimizationError::InvalidInput`] when `function` is not
+/// valid SIR, or [`SirOptimizationError::InvalidOutput`] if the pass would
+/// produce invalid SIR. In either case, `function` is unchanged.
+pub fn canonicalize_constant_cfg(
+    function: &mut SemFunction,
+) -> Result<CfgCanonicalizationReport, SirOptimizationError> {
+    let diagnostics = verify_function(function);
+    if !diagnostics.is_empty() {
+        return Err(SirOptimizationError::InvalidInput(diagnostics));
+    }
+
+    let mut candidate = function.clone();
+    let report = canonicalize_verified_function(&mut candidate);
+    let diagnostics = verify_function(&candidate);
+    if !diagnostics.is_empty() {
+        return Err(SirOptimizationError::InvalidOutput(diagnostics));
+    }
+
+    *function = candidate;
+    Ok(report)
+}
+
+/// Canonicalize every verified SIR body in a module transactionally.
+///
+/// The module form preserves callable-table validation around direct calls and
+/// is the intended SIR-to-MIR pipeline boundary.
+///
+/// # Errors
+///
+/// Returns [`SirOptimizationError::InvalidInput`] when the module is not
+/// valid SIR, or [`SirOptimizationError::InvalidOutput`] if canonicalization
+/// would violate a module invariant. In either case, `module` is unchanged.
+pub fn canonicalize_module_constant_cfg(
+    module: &mut SemModule,
+) -> Result<Vec<(CallableId, CfgCanonicalizationReport)>, SirOptimizationError> {
+    let diagnostics = verify_module(module);
+    if !diagnostics.is_empty() {
+        return Err(SirOptimizationError::InvalidInput(diagnostics));
+    }
+
+    let mut candidate = module.clone();
+    let reports = candidate
+        .functions
+        .iter_mut()
+        .map(|function| (function.callable, canonicalize_verified_function(function)))
+        .collect::<Vec<_>>();
+    let diagnostics = verify_module(&candidate);
+    if !diagnostics.is_empty() {
+        return Err(SirOptimizationError::InvalidOutput(diagnostics));
+    }
+
+    *module = candidate;
+    Ok(reports)
+}
+
+fn canonicalize_verified_function(function: &mut SemFunction) -> CfgCanonicalizationReport {
+    let constants = direct_bool_constants(function);
+    let initial_cfg = build_cfg_index(function);
+    let mut folded_branches = 0;
+
+    for block in &mut function.blocks {
+        if !initial_cfg.is_reachable(block.id) {
+            continue;
+        }
+        let selected = match &block.terminator {
+            SemTerminator::Branch {
+                condition,
+                then_target,
+                else_target,
+            } => constants.get(&condition.value).map(|is_true| {
+                if *is_true {
+                    then_target.clone()
+                } else {
+                    else_target.clone()
+                }
+            }),
+            SemTerminator::Return { .. } | SemTerminator::Goto(_) | SemTerminator::Unreachable => {
+                None
+            }
+        };
+        if let Some(edge) = selected {
+            // Retain the whole selected edge: its forwarded values and their
+            // semantic ownership modes are part of the CFG meaning.
+            block.terminator = SemTerminator::Goto(edge);
+            folded_branches += 1;
+        }
+    }
+
+    let post_fold_cfg = build_cfg_index(function);
+    let (removed_blocks, block_remap) = compact_unreachable(function, post_fold_cfg.reachable());
+    CfgCanonicalizationReport {
+        folded_branches,
+        removed_blocks,
+        block_remap,
+    }
+}
+
+fn direct_bool_constants(function: &SemFunction) -> BTreeMap<ValueId, bool> {
+    let mut constants = BTreeMap::new();
+    for operation in function.blocks.iter().flat_map(|block| &block.ops) {
+        if let (SemOpKind::ConstBool(value), [result]) =
+            (&operation.kind, operation.results.as_slice())
+        {
+            constants.insert(result.id, *value);
+        }
+    }
+    constants
+}
+
+fn compact_unreachable(
+    function: &mut SemFunction,
+    reachable: &BTreeSet<BlockId>,
+) -> (Vec<BlockId>, BTreeMap<BlockId, BlockId>) {
+    let removed_blocks = function
+        .blocks
+        .iter()
+        .filter_map(|block| (!reachable.contains(&block.id)).then_some(block.id))
+        .collect::<Vec<_>>();
+
+    // Make the entry block `bb0` while retaining former order for all other
+    // reachable blocks. That gives deterministic dumps even for hand-built
+    // SIR whose entry started at a nonzero canonical block index.
+    let mut retained = Vec::with_capacity(function.blocks.len() - removed_blocks.len());
+    let entry = function.entry;
+    retained.extend(
+        function
+            .blocks
+            .iter()
+            .filter(|block| block.id == entry && reachable.contains(&block.id))
+            .cloned(),
+    );
+    retained.extend(
+        function
+            .blocks
+            .iter()
+            .filter(|block| block.id != entry && reachable.contains(&block.id))
+            .cloned(),
+    );
+
+    let block_remap = retained
+        .iter()
+        .enumerate()
+        .map(|(index, block)| {
+            (
+                block.id,
+                BlockId(
+                    u32::try_from(index)
+                        .expect("SIR block count exceeds the module-local ID range"),
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for block in &mut retained {
+        let former = block.id;
+        block.id = *block_remap
+            .get(&former)
+            .expect("every retained SIR block must have a canonical remap");
+        block.terminator.visit_successors_mut(|edge| {
+            edge.target = *block_remap
+                .get(&edge.target)
+                .expect("a verified reachable SIR edge must target a retained block");
+        });
+    }
+    function.entry = *block_remap
+        .get(&entry)
+        .expect("a verified SIR entry must be reachable");
+    function.blocks = retained;
+
+    (removed_blocks, block_remap)
+}

--- a/hew-sir/src/optimize.rs
+++ b/hew-sir/src/optimize.rs
@@ -7,6 +7,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::verify::verify_cfg_discard_safety;
 use crate::{
     build_cfg_index, verify_function, verify_module, BlockId, CallableId, SemFunction, SemModule,
     SemOpKind, SemTerminator, SirDiagnostic, ValueId,
@@ -106,6 +107,7 @@ pub fn canonicalize_module_constant_cfg(
 fn canonicalize_verified_function(
     function: &mut SemFunction,
 ) -> Result<CfgCanonicalizationReport, Vec<SirDiagnostic>> {
+    let before_folding = function.clone();
     let constants = direct_bool_constants(function);
     let initial_cfg = build_cfg_index(function);
     let mut folded_branches = 0;
@@ -143,6 +145,10 @@ fn canonicalize_verified_function(
     // separate audited transformation: later passes can follow this shape
     // without inventing a second validation convention.
     let diagnostics = verify_function(function);
+    if !diagnostics.is_empty() {
+        return Err(diagnostics);
+    }
+    let diagnostics = verify_cfg_discard_safety(&before_folding, function);
     if !diagnostics.is_empty() {
         return Err(diagnostics);
     }

--- a/hew-sir/src/verify.rs
+++ b/hew-sir/src/verify.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::OpId;
 use crate::{
@@ -134,6 +134,31 @@ pub enum SirDiagnosticKind {
         value: ValueId,
         block: BlockId,
     },
+    /// A CFG rewrite made a formerly executable block unreachable even though
+    /// discarding that region is not yet semantically safe.
+    UnsafeCfgDiscard {
+        block: BlockId,
+        reason: CfgDiscardSafetyReason,
+    },
+}
+
+/// The fail-closed reasons a CFG rewrite may not discard a reachable region.
+///
+/// The initial SIR domain is no-drop, but the ownership cases remain explicit
+/// here so widening that domain cannot silently make an existing CFG rewrite
+/// unsound. Each violation is a concrete verifier-ledger row rather than a
+/// prose-only precondition on the optimizer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CfgDiscardSafetyReason {
+    /// An operation in the discarded region may transfer control to a
+    /// language-visible trap.
+    MayTrap { op: OpId },
+    /// A block argument or operation result is not proven to be a no-drop
+    /// value in the currently admitted SIR value domain.
+    DropObligationValue { value: ValueId },
+    /// A move or consume in the discarded region transfers or discharges an
+    /// ownership obligation.
+    DropObligationUse { site: UseSite },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -208,6 +233,108 @@ pub fn verify_function_in_module(module: &SemModule, function: &SemFunction) -> 
 #[must_use]
 pub fn verify_function(function: &SemFunction) -> Vec<SirDiagnostic> {
     verify_function_with_context(function, None)
+}
+
+/// Verify the semantic precondition for discarding blocks during a CFG rewrite.
+///
+/// `rewritten` is the post-edge-rewrite, pre-compaction candidate, so both
+/// functions still use the same block identities. Only blocks reachable in
+/// `original` and newly unreachable in `rewritten` are examined. The rewrite
+/// fails closed if such a block contains a potentially trapping operation, a
+/// value outside the proven no-drop domain, or an ownership transfer/discharge.
+#[must_use]
+pub(crate) fn verify_cfg_discard_safety(
+    original: &SemFunction,
+    rewritten: &SemFunction,
+) -> Vec<SirDiagnostic> {
+    let original_cfg = crate::build_cfg_index(original);
+    let rewritten_cfg = crate::build_cfg_index(rewritten);
+    let discarded = original_cfg
+        .reachable()
+        .difference(rewritten_cfg.reachable())
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut diagnostics = Vec::new();
+
+    for block in &original.blocks {
+        if !discarded.contains(&block.id) {
+            continue;
+        }
+        for argument in &block.args {
+            if !is_initial_value_type(&argument.ty) {
+                diagnostics.push(cfg_discard_diag(
+                    original,
+                    block.id,
+                    CfgDiscardSafetyReason::DropObligationValue {
+                        value: argument.value,
+                    },
+                ));
+            }
+        }
+        for operation in &block.ops {
+            if operation.kind.effects().may_trap() {
+                diagnostics.push(cfg_discard_diag(
+                    original,
+                    block.id,
+                    CfgDiscardSafetyReason::MayTrap { op: operation.id },
+                ));
+            }
+            for result in &operation.results {
+                if !is_initial_value_type(&result.ty) {
+                    diagnostics.push(cfg_discard_diag(
+                        original,
+                        block.id,
+                        CfgDiscardSafetyReason::DropObligationValue { value: result.id },
+                    ));
+                }
+            }
+            operation.kind.visit_operands(|operand, use_| {
+                if matches!(use_.mode, UseMode::Move | UseMode::Consume) {
+                    diagnostics.push(cfg_discard_diag(
+                        original,
+                        block.id,
+                        CfgDiscardSafetyReason::DropObligationUse {
+                            site: UseSite::Operation {
+                                op: operation.id,
+                                operand,
+                                value: use_.value,
+                                mode: use_.mode,
+                            },
+                        },
+                    ));
+                }
+            });
+        }
+        block.terminator.visit_operands(|operand, use_| {
+            if matches!(use_.mode, UseMode::Move | UseMode::Consume) {
+                diagnostics.push(cfg_discard_diag(
+                    original,
+                    block.id,
+                    CfgDiscardSafetyReason::DropObligationUse {
+                        site: UseSite::Terminator {
+                            block: block.id,
+                            operand,
+                            value: use_.value,
+                            mode: use_.mode,
+                        },
+                    },
+                ));
+            }
+        });
+    }
+
+    diagnostics
+}
+
+fn cfg_discard_diag(
+    function: &SemFunction,
+    block: BlockId,
+    reason: CfgDiscardSafetyReason,
+) -> SirDiagnostic {
+    diag(
+        function,
+        SirDiagnosticKind::UnsafeCfgDiscard { block, reason },
+    )
 }
 
 #[allow(
@@ -1406,4 +1533,99 @@ fn uses_in_terminator(term: &SemTerminator) -> Vec<ValueId> {
     let mut uses = Vec::new();
     term.visit_operands(|_, operand| uses.push(operand.value));
     uses
+}
+
+#[cfg(test)]
+mod cfg_discard_safety_tests {
+    use super::{verify_cfg_discard_safety, CfgDiscardSafetyReason, SirDiagnosticKind};
+    use crate::{
+        BlockArg, BlockId, CallableId, Edge, FunctionSourceOrigin, Operand, SemBlock, SemFunction,
+        SemTerminator, UseMode, UseSite, ValueId,
+    };
+    use hew_hir::ItemId;
+    use hew_types::{DefId, ResolvedTy};
+
+    fn operand(value: u32, mode: UseMode) -> Operand {
+        Operand {
+            value: ValueId(value),
+            mode,
+        }
+    }
+
+    #[test]
+    fn records_a_discarded_ownership_discharge_as_a_drop_obligation() {
+        let original = SemFunction {
+            id: ItemId(0),
+            callable: CallableId(0),
+            declaration: DefId::for_test("discarded_drop_obligation"),
+            name: "discarded_drop_obligation".to_string(),
+            span: 0..0,
+            source_origin: FunctionSourceOrigin::Unknown,
+            params: vec![
+                BlockArg {
+                    value: ValueId(0),
+                    ty: ResolvedTy::Bool,
+                },
+                BlockArg {
+                    value: ValueId(1),
+                    ty: ResolvedTy::I64,
+                },
+            ],
+            return_ty: ResolvedTy::I64,
+            entry: BlockId(0),
+            blocks: vec![
+                SemBlock {
+                    id: BlockId(0),
+                    args: Vec::new(),
+                    ops: Vec::new(),
+                    terminator: SemTerminator::Branch {
+                        condition: operand(0, UseMode::Read),
+                        then_target: Edge {
+                            target: BlockId(1),
+                            args: Vec::new(),
+                        },
+                        else_target: Edge {
+                            target: BlockId(2),
+                            args: Vec::new(),
+                        },
+                    },
+                },
+                SemBlock {
+                    id: BlockId(1),
+                    args: Vec::new(),
+                    ops: Vec::new(),
+                    terminator: SemTerminator::Return {
+                        value: Some(operand(1, UseMode::Read)),
+                    },
+                },
+                SemBlock {
+                    id: BlockId(2),
+                    args: Vec::new(),
+                    ops: Vec::new(),
+                    terminator: SemTerminator::Return {
+                        value: Some(operand(1, UseMode::Consume)),
+                    },
+                },
+            ],
+        };
+        let mut rewritten = original.clone();
+        rewritten.blocks[0].terminator = SemTerminator::Goto(Edge {
+            target: BlockId(1),
+            args: Vec::new(),
+        });
+
+        let diagnostics = verify_cfg_discard_safety(&original, &rewritten);
+        assert!(diagnostics.iter().any(|diagnostic| matches!(
+            &diagnostic.kind,
+            SirDiagnosticKind::UnsafeCfgDiscard {
+                block: BlockId(2),
+                reason: CfgDiscardSafetyReason::DropObligationUse {
+                    site: UseSite::Terminator {
+                        mode: UseMode::Consume,
+                        ..
+                    }
+                }
+            }
+        )));
+    }
 }

--- a/hew-sir/tests/optimize_cfg.rs
+++ b/hew-sir/tests/optimize_cfg.rs
@@ -230,6 +230,67 @@ fn constant_branch_preserves_a_reachable_semantic_unreachable_endpoint() {
 }
 
 #[test]
+fn compaction_accepts_a_newly_dead_block_that_reads_an_entry_parameter() {
+    let mut function = function(
+        "dead_parameter_read",
+        vec![BlockArg {
+            value: ValueId(0),
+            ty: ResolvedTy::Bool,
+        }],
+        ResolvedTy::Bool,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![value(1, ResolvedTy::Bool)],
+                    kind: SemOpKind::ConstBool(true),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Branch {
+                    condition: read(1),
+                    then_target: Edge {
+                        target: BlockId(1),
+                        args: Vec::new(),
+                    },
+                    else_target: Edge {
+                        target: BlockId(2),
+                        args: Vec::new(),
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(read(0)),
+                },
+            },
+            // Folding bb0 makes this block unreachable before the pass's
+            // second structural stage removes it. Its entry-param use remains
+            // semantically valid during that verifier boundary.
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(read(0)),
+                },
+            },
+        ],
+    );
+    assert!(verify_function(&function).is_empty());
+
+    let report = canonicalize_constant_cfg(&mut function)
+        .expect("dead blocks may retain entry-value uses until compaction");
+    assert_eq!(report.removed_blocks, vec![BlockId(2)]);
+    assert_eq!(function.blocks.len(), 2);
+    assert!(verify_function(&function).is_empty());
+}
+
+#[test]
 fn compaction_remaps_reachable_self_loops() {
     let mut function = function(
         "loop_remap",
@@ -284,6 +345,135 @@ fn compaction_remaps_reachable_self_loops() {
             target: BlockId(1),
             ..
         })
+    ));
+    assert!(verify_function(&function).is_empty());
+}
+
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the explicit CFG construction and every remapped edge assertion keep this structural regression auditable"
+)]
+fn compaction_remaps_multiblock_loop_edges_after_dead_block_removal() {
+    let mut function = function(
+        "multiblock_loop_remap",
+        vec![BlockArg {
+            value: ValueId(0),
+            ty: ResolvedTy::Bool,
+        }],
+        ResolvedTy::Unit,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![value(1, ResolvedTy::Bool)],
+                    kind: SemOpKind::ConstBool(true),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Branch {
+                    condition: read(1),
+                    then_target: Edge {
+                        target: BlockId(2),
+                        args: Vec::new(),
+                    },
+                    else_target: Edge {
+                        target: BlockId(1),
+                        args: Vec::new(),
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return { value: None },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(3),
+                    args: Vec::new(),
+                }),
+            },
+            SemBlock {
+                id: BlockId(3),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Branch {
+                    condition: read(0),
+                    then_target: Edge {
+                        target: BlockId(2),
+                        args: Vec::new(),
+                    },
+                    else_target: Edge {
+                        target: BlockId(4),
+                        args: Vec::new(),
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(4),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return { value: None },
+            },
+        ],
+    );
+    assert!(verify_function(&function).is_empty());
+
+    let report = canonicalize_constant_cfg(&mut function)
+        .expect("a constant entry edge must compact a multiblock loop safely");
+    assert_eq!(report.removed_blocks, vec![BlockId(1)]);
+    assert_eq!(
+        report.block_remap,
+        [
+            (BlockId(0), BlockId(0)),
+            (BlockId(2), BlockId(1)),
+            (BlockId(3), BlockId(2)),
+            (BlockId(4), BlockId(3)),
+        ]
+        .into_iter()
+        .collect()
+    );
+    assert_eq!(
+        function
+            .blocks
+            .iter()
+            .map(|block| block.id)
+            .collect::<Vec<_>>(),
+        vec![BlockId(0), BlockId(1), BlockId(2), BlockId(3)]
+    );
+    assert!(matches!(
+        &function.blocks[0].terminator,
+        SemTerminator::Goto(Edge {
+            target: BlockId(1),
+            ..
+        })
+    ));
+    assert!(matches!(
+        &function.blocks[1].terminator,
+        SemTerminator::Goto(Edge {
+            target: BlockId(2),
+            ..
+        })
+    ));
+    assert!(matches!(
+        &function.blocks[2].terminator,
+        SemTerminator::Branch {
+            then_target: Edge {
+                target: BlockId(1),
+                ..
+            },
+            else_target: Edge {
+                target: BlockId(3),
+                ..
+            },
+            ..
+        }
     ));
     assert!(verify_function(&function).is_empty());
 }
@@ -390,6 +580,39 @@ fn duplicate_block_identity_is_rejected_before_cfg_indexing_or_mutation() {
 }
 
 #[test]
+fn noncanonical_unique_block_order_is_rejected_atomically() {
+    let mut function = function(
+        "noncanonical_unique_blocks",
+        Vec::new(),
+        ResolvedTy::Unit,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(2),
+                    args: Vec::new(),
+                }),
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return { value: None },
+            },
+        ],
+    );
+    let before = function.clone();
+
+    assert!(matches!(
+        canonicalize_constant_cfg(&mut function),
+        Err(SirOptimizationError::InvalidInput(_))
+    ));
+    assert_eq!(function, before);
+}
+
+#[test]
 fn compaction_canonicalizes_a_nonzero_entry_block() {
     let mut function = function(
         "nonzero_entry",
@@ -453,4 +676,41 @@ fn module_canonicalization_keeps_callable_validation_and_is_atomic() {
     assert_eq!(reports[0].0, CallableId(0));
     assert_eq!(reports[0].1.folded_branches, 1);
     assert!(verify_module(&module).is_empty());
+}
+
+#[test]
+fn module_canonicalization_rejects_an_invalid_body_atomically() {
+    let valid = false_same_target_diamond();
+    let invalid = function(
+        "invalid_module_body",
+        Vec::new(),
+        ResolvedTy::Unit,
+        vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: Vec::new(),
+            terminator: SemTerminator::Goto(Edge {
+                target: BlockId(1),
+                args: Vec::new(),
+            }),
+        }],
+    );
+    let mut invalid = invalid;
+    invalid.id = ItemId(1);
+    invalid.callable = CallableId(1);
+
+    let mut module = SemModule {
+        callables: vec![callable_for(&valid), callable_for(&invalid)],
+        generic_templates: Vec::new(),
+        root_unit_callables: Vec::new(),
+        entry_callable: None,
+        functions: vec![valid, invalid],
+    };
+    let before = module.clone();
+
+    assert!(matches!(
+        canonicalize_module_constant_cfg(&mut module),
+        Err(SirOptimizationError::InvalidInput(_))
+    ));
+    assert_eq!(module, before);
 }

--- a/hew-sir/tests/optimize_cfg.rs
+++ b/hew-sir/tests/optimize_cfg.rs
@@ -1,10 +1,11 @@
 use hew_hir::ItemId;
 use hew_sir::{
     canonicalize_constant_cfg, canonicalize_module_constant_cfg, verify_function, verify_module,
-    BlockArg, BlockId, CallableId, CallableInstance, CfgCanonicalizationReport, Edge,
-    EffectSummary, FunctionSourceOrigin, OpId, Operand, Provenance, SemAbiParam, SemBlock,
-    SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind,
-    SemParamPassing, SemSignature, SemTerminator, SirOptimizationError, UseMode, ValueDef, ValueId,
+    BlockArg, BlockId, CallableId, CallableInstance, CfgCanonicalizationReport,
+    CfgDiscardSafetyReason, Edge, EffectSummary, FunctionSourceOrigin, OpId, Operand, Provenance,
+    SemAbiParam, SemBlock, SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule,
+    SemOp, SemOpKind, SemParamPassing, SemSignature, SemTerminator, SirDiagnosticKind,
+    SirOptimizationError, UseMode, ValueDef, ValueId,
 };
 use hew_types::{DefId, ResolvedTy};
 
@@ -167,6 +168,150 @@ fn false_branch_keeps_the_selected_duplicate_target_edge_and_remaps_blocks() {
             if args == &vec![read(1)]
     ));
     assert_eq!(function.blocks[1].args[0].value, ValueId(4));
+}
+
+#[test]
+fn compaction_preserves_every_surviving_non_block_identity_and_fact() {
+    let mut function = false_same_target_diamond();
+    let before = function.clone();
+
+    let report = canonicalize_constant_cfg(&mut function)
+        .expect("verified duplicate-edge CFG must canonicalize");
+
+    assert_eq!(function.id, before.id);
+    assert_eq!(function.callable, before.callable);
+    assert_eq!(function.declaration, before.declaration);
+    assert_eq!(function.name, before.name);
+    assert_eq!(function.span, before.span);
+    assert_eq!(function.source_origin, before.source_origin);
+    assert_eq!(function.params, before.params);
+    assert_eq!(function.return_ty, before.return_ty);
+
+    for (former_id, canonical_id) in &report.block_remap {
+        let former = before
+            .blocks
+            .iter()
+            .find(|block| block.id == *former_id)
+            .expect("every remap source must name an input block");
+        let canonical = function
+            .blocks
+            .iter()
+            .find(|block| block.id == *canonical_id)
+            .expect("every remap target must name an output block");
+
+        // These equalities jointly cover block-argument and operation
+        // ValueIds, OpIds, types, provenance, operands, and UseModes.
+        assert_eq!(canonical.args, former.args);
+        assert_eq!(canonical.ops, former.ops);
+
+        let mut expected_terminator = if *former_id == BlockId(0) {
+            match &former.terminator {
+                SemTerminator::Branch { else_target, .. } => {
+                    SemTerminator::Goto(else_target.clone())
+                }
+                other => panic!("fixture entry must be a branch, found {other:?}"),
+            }
+        } else {
+            former.terminator.clone()
+        };
+        expected_terminator.visit_successors_mut(|edge| {
+            edge.target = report.block_remap[&edge.target];
+        });
+        assert_eq!(canonical.terminator, expected_terminator);
+    }
+}
+
+#[test]
+fn discard_safety_rejects_a_trapping_arm_that_structural_verification_accepts() {
+    let mut function = function(
+        "discarded_trap",
+        Vec::new(),
+        ResolvedTy::Unit,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![value(0, ResolvedTy::Bool)],
+                    kind: SemOpKind::ConstBool(true),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Branch {
+                    condition: read(0),
+                    then_target: Edge {
+                        target: BlockId(1),
+                        args: Vec::new(),
+                    },
+                    else_target: Edge {
+                        target: BlockId(2),
+                        args: Vec::new(),
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return { value: None },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: vec![
+                    SemOp {
+                        id: OpId(1),
+                        results: vec![value(1, ResolvedTy::I64)],
+                        kind: SemOpKind::ConstI64(1),
+                        provenance: Provenance::Synthesized,
+                    },
+                    SemOp {
+                        id: OpId(2),
+                        results: vec![value(2, ResolvedTy::I64)],
+                        kind: SemOpKind::ConstI64(0),
+                        provenance: Provenance::Synthesized,
+                    },
+                    SemOp {
+                        id: OpId(3),
+                        results: vec![value(3, ResolvedTy::I64)],
+                        kind: SemOpKind::Binary {
+                            op: hew_parser::ast::BinaryOp::Divide,
+                            lhs: read(1),
+                            rhs: read(2),
+                        },
+                        provenance: Provenance::Synthesized,
+                    },
+                ],
+                terminator: SemTerminator::Return { value: None },
+            },
+        ],
+    );
+    let before = function.clone();
+    assert!(verify_function(&function).is_empty());
+
+    // This is the counterfactual: the ordinary post-fold verifier alone sees
+    // valid SSA even though compaction would erase a MayTrap region.
+    let mut structurally_valid_but_unsafe = function.clone();
+    structurally_valid_but_unsafe.blocks[0].terminator = SemTerminator::Goto(Edge {
+        target: BlockId(1),
+        args: Vec::new(),
+    });
+    assert!(verify_function(&structurally_valid_but_unsafe).is_empty());
+
+    let error = canonicalize_constant_cfg(&mut function)
+        .expect_err("discarding a MayTrap arm must fail closed");
+    assert!(matches!(
+        error,
+        SirOptimizationError::InvalidOutput(diagnostics)
+            if diagnostics.iter().any(|diagnostic| matches!(
+                &diagnostic.kind,
+                SirDiagnosticKind::UnsafeCfgDiscard {
+                    block: BlockId(2),
+                    reason: CfgDiscardSafetyReason::MayTrap { op: OpId(3) },
+                }
+            ))
+    ));
+    assert_eq!(function, before);
 }
 
 #[test]

--- a/hew-sir/tests/optimize_cfg.rs
+++ b/hew-sir/tests/optimize_cfg.rs
@@ -1,0 +1,456 @@
+use hew_hir::ItemId;
+use hew_sir::{
+    canonicalize_constant_cfg, canonicalize_module_constant_cfg, verify_function, verify_module,
+    BlockArg, BlockId, CallableId, CallableInstance, CfgCanonicalizationReport, Edge,
+    EffectSummary, FunctionSourceOrigin, OpId, Operand, Provenance, SemAbiParam, SemBlock,
+    SemCallConv, SemCallable, SemCallableKind, SemFunction, SemModule, SemOp, SemOpKind,
+    SemParamPassing, SemSignature, SemTerminator, SirOptimizationError, UseMode, ValueDef, ValueId,
+};
+use hew_types::{DefId, ResolvedTy};
+
+fn read(value: u32) -> Operand {
+    Operand {
+        value: ValueId(value),
+        mode: UseMode::Read,
+    }
+}
+
+fn value(id: u32, ty: ResolvedTy) -> ValueDef {
+    ValueDef {
+        id: ValueId(id),
+        ty,
+    }
+}
+
+fn callable_for(function: &SemFunction) -> SemCallable {
+    SemCallable {
+        id: function.callable,
+        function: function.id,
+        declaration: function.declaration.clone(),
+        instance: CallableInstance::Monomorphic,
+        symbol: function.name.clone(),
+        source_origin: function.source_origin.clone(),
+        signature: SemSignature {
+            params: function
+                .params
+                .iter()
+                .map(|parameter| SemAbiParam {
+                    ty: parameter.ty.clone(),
+                    passing: SemParamPassing::ReadOnly,
+                    caller_visible_projection: false,
+                })
+                .collect(),
+            return_ty: function.return_ty.clone(),
+        },
+        call_conv: SemCallConv::Default,
+        kind: SemCallableKind::HewDirect,
+        effect_summary: EffectSummary::Unknown,
+    }
+}
+
+fn module(function: SemFunction) -> SemModule {
+    SemModule {
+        callables: vec![callable_for(&function)],
+        generic_templates: Vec::new(),
+        root_unit_callables: Vec::new(),
+        entry_callable: None,
+        functions: vec![function],
+    }
+}
+
+fn function(
+    name: &str,
+    params: Vec<BlockArg>,
+    return_ty: ResolvedTy,
+    blocks: Vec<SemBlock>,
+) -> SemFunction {
+    SemFunction {
+        id: ItemId(0),
+        callable: CallableId(0),
+        declaration: DefId::for_test(name),
+        name: name.to_string(),
+        span: 0..0,
+        source_origin: FunctionSourceOrigin::Unknown,
+        params,
+        return_ty,
+        entry: BlockId(0),
+        blocks,
+    }
+}
+
+fn false_same_target_diamond() -> SemFunction {
+    function(
+        "false_same_target_diamond",
+        vec![
+            BlockArg {
+                value: ValueId(0),
+                ty: ResolvedTy::I64,
+            },
+            BlockArg {
+                value: ValueId(1),
+                ty: ResolvedTy::I64,
+            },
+        ],
+        ResolvedTy::I64,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![value(2, ResolvedTy::Bool)],
+                    kind: SemOpKind::ConstBool(false),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Branch {
+                    condition: read(2),
+                    then_target: Edge {
+                        target: BlockId(2),
+                        args: vec![read(0)],
+                    },
+                    else_target: Edge {
+                        target: BlockId(2),
+                        args: vec![read(1)],
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(1),
+                    results: vec![value(3, ResolvedTy::I64)],
+                    kind: SemOpKind::ConstI64(99),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Return {
+                    value: Some(read(3)),
+                },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: vec![BlockArg {
+                    value: ValueId(4),
+                    ty: ResolvedTy::I64,
+                }],
+                ops: Vec::new(),
+                terminator: SemTerminator::Return {
+                    value: Some(read(4)),
+                },
+            },
+        ],
+    )
+}
+
+#[test]
+fn false_branch_keeps_the_selected_duplicate_target_edge_and_remaps_blocks() {
+    let mut function = false_same_target_diamond();
+    assert!(verify_function(&function).is_empty());
+
+    let report = canonicalize_constant_cfg(&mut function)
+        .expect("verified SIR must canonicalize successfully");
+    assert_eq!(
+        report,
+        CfgCanonicalizationReport {
+            folded_branches: 1,
+            removed_blocks: vec![BlockId(1)],
+            block_remap: [(BlockId(0), BlockId(0)), (BlockId(2), BlockId(1))]
+                .into_iter()
+                .collect(),
+        }
+    );
+    assert!(verify_function(&function).is_empty());
+    assert_eq!(function.blocks.len(), 2);
+    assert!(matches!(
+        &function.blocks[0].terminator,
+        SemTerminator::Goto(Edge { target: BlockId(1), args })
+            if args == &vec![read(1)]
+    ));
+    assert_eq!(function.blocks[1].args[0].value, ValueId(4));
+}
+
+#[test]
+fn constant_branch_preserves_a_reachable_semantic_unreachable_endpoint() {
+    let mut function = function(
+        "constant_to_unreachable",
+        Vec::new(),
+        ResolvedTy::Unit,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![value(0, ResolvedTy::Bool)],
+                    kind: SemOpKind::ConstBool(true),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Branch {
+                    condition: read(0),
+                    then_target: Edge {
+                        target: BlockId(2),
+                        args: Vec::new(),
+                    },
+                    else_target: Edge {
+                        target: BlockId(1),
+                        args: Vec::new(),
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return { value: None },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Unreachable,
+            },
+        ],
+    );
+    assert!(verify_function(&function).is_empty());
+
+    let report = canonicalize_constant_cfg(&mut function).expect("constant CFG must fold");
+    assert_eq!(report.removed_blocks, vec![BlockId(1)]);
+    assert!(matches!(
+        &function.blocks[0].terminator,
+        SemTerminator::Goto(Edge {
+            target: BlockId(1),
+            ..
+        })
+    ));
+    assert!(matches!(
+        &function.blocks[1].terminator,
+        SemTerminator::Unreachable
+    ));
+    assert!(verify_function(&function).is_empty());
+}
+
+#[test]
+fn compaction_remaps_reachable_self_loops() {
+    let mut function = function(
+        "loop_remap",
+        Vec::new(),
+        ResolvedTy::Unit,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![value(0, ResolvedTy::Bool)],
+                    kind: SemOpKind::ConstBool(true),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Branch {
+                    condition: read(0),
+                    then_target: Edge {
+                        target: BlockId(2),
+                        args: Vec::new(),
+                    },
+                    else_target: Edge {
+                        target: BlockId(1),
+                        args: Vec::new(),
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return { value: None },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(2),
+                    args: Vec::new(),
+                }),
+            },
+        ],
+    );
+    assert!(verify_function(&function).is_empty());
+
+    canonicalize_constant_cfg(&mut function).expect("loop CFG must canonicalize");
+    assert_eq!(function.blocks.len(), 2);
+    assert!(matches!(
+        &function.blocks[1].terminator,
+        SemTerminator::Goto(Edge {
+            target: BlockId(1),
+            ..
+        })
+    ));
+    assert!(verify_function(&function).is_empty());
+}
+
+#[test]
+fn dynamic_branch_is_a_byte_for_byte_noop() {
+    let mut function = function(
+        "dynamic_branch",
+        vec![BlockArg {
+            value: ValueId(0),
+            ty: ResolvedTy::Bool,
+        }],
+        ResolvedTy::I64,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Branch {
+                    condition: read(0),
+                    then_target: Edge {
+                        target: BlockId(1),
+                        args: Vec::new(),
+                    },
+                    else_target: Edge {
+                        target: BlockId(2),
+                        args: Vec::new(),
+                    },
+                },
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(0),
+                    results: vec![value(1, ResolvedTy::I64)],
+                    kind: SemOpKind::ConstI64(1),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Return {
+                    value: Some(read(1)),
+                },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: vec![SemOp {
+                    id: OpId(1),
+                    results: vec![value(2, ResolvedTy::I64)],
+                    kind: SemOpKind::ConstI64(2),
+                    provenance: Provenance::Synthesized,
+                }],
+                terminator: SemTerminator::Return {
+                    value: Some(read(2)),
+                },
+            },
+        ],
+    );
+    let before = function.clone();
+    assert!(verify_function(&function).is_empty());
+
+    let report = canonicalize_constant_cfg(&mut function).expect("dynamic CFG remains valid");
+    assert_eq!(report.folded_branches, 0);
+    assert!(report.removed_blocks.is_empty());
+    assert_eq!(function, before);
+}
+
+#[test]
+fn malformed_input_is_rejected_atomically() {
+    let mut function = function(
+        "missing_successor",
+        Vec::new(),
+        ResolvedTy::Unit,
+        vec![SemBlock {
+            id: BlockId(0),
+            args: Vec::new(),
+            ops: Vec::new(),
+            terminator: SemTerminator::Goto(Edge {
+                target: BlockId(1),
+                args: Vec::new(),
+            }),
+        }],
+    );
+    let before = function.clone();
+
+    assert!(matches!(
+        canonicalize_constant_cfg(&mut function),
+        Err(SirOptimizationError::InvalidInput(_))
+    ));
+    assert_eq!(function, before);
+}
+
+#[test]
+fn duplicate_block_identity_is_rejected_before_cfg_indexing_or_mutation() {
+    let mut function = false_same_target_diamond();
+    function.blocks[1].id = BlockId(0);
+    let before = function.clone();
+
+    assert!(matches!(
+        canonicalize_constant_cfg(&mut function),
+        Err(SirOptimizationError::InvalidInput(_))
+    ));
+    assert_eq!(function, before);
+}
+
+#[test]
+fn compaction_canonicalizes_a_nonzero_entry_block() {
+    let mut function = function(
+        "nonzero_entry",
+        Vec::new(),
+        ResolvedTy::Unit,
+        vec![
+            SemBlock {
+                id: BlockId(0),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Unreachable,
+            },
+            SemBlock {
+                id: BlockId(1),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Return { value: None },
+            },
+            SemBlock {
+                id: BlockId(2),
+                args: Vec::new(),
+                ops: Vec::new(),
+                terminator: SemTerminator::Goto(Edge {
+                    target: BlockId(1),
+                    args: Vec::new(),
+                }),
+            },
+        ],
+    );
+    function.entry = BlockId(2);
+    assert!(verify_function(&function).is_empty());
+
+    let report = canonicalize_constant_cfg(&mut function)
+        .expect("a valid nonzero entry must canonicalize successfully");
+    assert_eq!(report.folded_branches, 0);
+    assert_eq!(report.removed_blocks, vec![BlockId(0)]);
+    assert_eq!(
+        report.block_remap,
+        [(BlockId(1), BlockId(1)), (BlockId(2), BlockId(0))]
+            .into_iter()
+            .collect()
+    );
+    assert_eq!(function.entry, BlockId(0));
+    assert!(matches!(
+        &function.blocks[0].terminator,
+        SemTerminator::Goto(Edge {
+            target: BlockId(1),
+            ..
+        })
+    ));
+    assert!(verify_function(&function).is_empty());
+}
+
+#[test]
+fn module_canonicalization_keeps_callable_validation_and_is_atomic() {
+    let mut module = module(false_same_target_diamond());
+    assert!(verify_module(&module).is_empty());
+    let reports = canonicalize_module_constant_cfg(&mut module)
+        .expect("verified module must canonicalize as one transaction");
+    assert_eq!(reports.len(), 1);
+    assert_eq!(reports[0].0, CallableId(0));
+    assert_eq!(reports[0].1.folded_branches, 1);
+    assert!(verify_module(&module).is_empty());
+}

--- a/scripts/sir-shadow-corpus.sh
+++ b/scripts/sir-shadow-corpus.sh
@@ -22,7 +22,7 @@
 # Environment:
 #   HEW_BIN                    compiler binary (default: target/debug/hew)
 #   SIR_SHADOW_MIN_REALIZED    minimum total SIR→raw-MIR realizations (default: 2; may only raise)
-#   SIR_SHADOW_MIN_SUCCESSES   minimum successful baseline compilations (default: 16; may only raise)
+#   SIR_SHADOW_MIN_VERIFIED    minimum verified compiler outcomes (default: 16; may only raise)
 
 set -euo pipefail
 
@@ -35,13 +35,14 @@ source "$ROOT/scripts/lib/corpus-nonempty.sh"
 HEW_BIN="${HEW_BIN:-$ROOT/target/debug/hew}"
 DEFAULT_CORPUS="$ROOT/tests/ll-oracle/corpus"
 REALIZED_FLOOR=2
-SUCCESS_FLOOR=16
+VERIFIED_FLOOR=16
 MIN_REALIZED="${SIR_SHADOW_MIN_REALIZED:-$REALIZED_FLOOR}"
-MIN_SUCCESSES="${SIR_SHADOW_MIN_SUCCESSES:-$SUCCESS_FLOOR}"
+MIN_VERIFIED="${SIR_SHADOW_MIN_VERIFIED:-$VERIFIED_FLOOR}"
 # Repeat the established compile enough times to make randomized ownership-fact
-# emission fail closed without turning comparison into a set operation.  The
-# exact EdgeCarry sequence is compiler output and must remain byte-identical.
-DETERMINISM_RUNS=4
+# and diagnostic emission fail closed without turning either comparison into a
+# set operation.  Both streams are compiler output and must remain
+# byte-identical.
+DETERMINISM_RUNS=6
 
 usage() {
     cat <<'EOF'
@@ -53,7 +54,7 @@ arguments, runs every top-level .hew fixture in tests/ll-oracle/corpus.
 Environment:
   HEW_BIN                    compiler binary (default: target/debug/hew)
   SIR_SHADOW_MIN_REALIZED    minimum total SIR→raw-MIR realizations (default: 2; may only raise)
-  SIR_SHADOW_MIN_SUCCESSES   minimum successful baseline compilations (default: 16; may only raise)
+  SIR_SHADOW_MIN_VERIFIED    minimum verified compiler outcomes (default: 16; may only raise)
 EOF
 }
 
@@ -67,13 +68,13 @@ require_nonnegative_integer() {
 }
 
 require_nonnegative_integer SIR_SHADOW_MIN_REALIZED "$MIN_REALIZED"
-require_nonnegative_integer SIR_SHADOW_MIN_SUCCESSES "$MIN_SUCCESSES"
+require_nonnegative_integer SIR_SHADOW_MIN_VERIFIED "$MIN_VERIFIED"
 if (( MIN_REALIZED < REALIZED_FLOOR )); then
     echo "sir-shadow-corpus: SIR_SHADOW_MIN_REALIZED may not lower the committed floor $REALIZED_FLOOR" >&2
     exit 2
 fi
-if (( MIN_SUCCESSES < SUCCESS_FLOOR )); then
-    echo "sir-shadow-corpus: SIR_SHADOW_MIN_SUCCESSES may not lower the committed floor $SUCCESS_FLOOR" >&2
+if (( MIN_VERIFIED < VERIFIED_FLOOR )); then
+    echo "sir-shadow-corpus: SIR_SHADOW_MIN_VERIFIED may not lower the committed floor $VERIFIED_FLOOR" >&2
     exit 2
 fi
 
@@ -184,6 +185,7 @@ edge_carry_sequence() {
 
 failures=0
 successes=0
+verified_outcomes=0
 verified=0
 generic_templates=0
 hir_declarations=0
@@ -209,6 +211,14 @@ for index in "${!fixtures[@]}"; do
         "$HEW_BIN" compile --sir-shadow --dump-mir raw "$fixture" || shadow_status=$?
 
     fixture_failed=0
+    if [[ "$baseline_status" -ne 0 && "$baseline_status" -ne 1 ]]; then
+        echo "FAIL $label: baseline compiler exited abnormally with status $baseline_status" >&2
+        fixture_failed=1
+    fi
+    if [[ "$shadow_status" -ne 0 && "$shadow_status" -ne 1 ]]; then
+        echo "FAIL $label: SIR shadow compiler exited abnormally with status $shadow_status" >&2
+        fixture_failed=1
+    fi
     for ((run = 2; run <= DETERMINISM_RUNS; run++)); do
         repeated_out="$tmpdir/$index.baseline.$run.out"
         repeated_err="$tmpdir/$index.baseline.$run.err"
@@ -223,6 +233,10 @@ for index in "${!fixtures[@]}"; do
         fi
         if ! diff -u "$baseline_edges" "$repeated_edges"; then
             echo "FAIL $label: repeated compile $run reordered EdgeCarry facts" >&2
+            fixture_failed=1
+        fi
+        if ! diff -u "$baseline_err" "$repeated_err"; then
+            echo "FAIL $label: repeated compile $run changed diagnostic emission" >&2
             fixture_failed=1
         fi
     done
@@ -267,11 +281,19 @@ for index in "${!fixtures[@]}"; do
 
     if [[ "$fixture_failed" -ne 0 ]]; then
         failures=$((failures + 1))
+    else
+        # A normal diagnostic rejection is a verified compiler outcome, not a
+        # missing corpus execution. Its status, stdout, and exact stderr have
+        # all passed the same repeated-compile and shadow-parity assertions.
+        verified_outcomes=$((verified_outcomes + 1))
+        if [[ "$baseline_status" -eq 1 ]]; then
+            printf 'ok   %s  (deterministic diagnostic rejection)\n' "$label"
+        fi
     fi
 done
 
-if [[ "$successes" -lt "$MIN_SUCCESSES" ]]; then
-    echo "FAIL sir-shadow-corpus: only $successes successful baseline compilations; require $MIN_SUCCESSES" >&2
+if [[ "$verified_outcomes" -lt "$MIN_VERIFIED" ]]; then
+    echo "FAIL sir-shadow-corpus: only $verified_outcomes verified compiler outcomes; require $MIN_VERIFIED" >&2
     failures=$((failures + 1))
 fi
 if [[ "$realized" -lt "$MIN_REALIZED" ]]; then
@@ -284,4 +306,4 @@ if [[ "$failures" -ne 0 ]]; then
     exit 1
 fi
 
-echo "sir-shadow-corpus: OK (${#fixtures[@]} fixtures, $successes successful baseline compiles, SIR $verified monomorphic, $generic_templates template(s), $hir_declarations HIR declarations, $realized/$concrete_bodies concrete realized)"
+echo "sir-shadow-corpus: OK (${#fixtures[@]} fixtures, $verified_outcomes verified outcomes, $successes successful baseline compiles, SIR $verified monomorphic, $generic_templates template(s), $hir_declarations HIR declarations, $realized/$concrete_bodies concrete realized)"


### PR DESCRIPTION
## Summary

Semantic CFG canonicalization in SIR — slot-addressed edges, a deterministic CFG index with
predecessors, successors, reachability and RPO; constant-boolean branch folding to the
selected edge; unreachable-block compaction with canonical `BlockId` remapping. The
transformation runs once at the shared HIR→SIR boundary, so dump, shadow and strict all
consume the same canonical SIR.

Stacked on #3062, which carries the deterministic `EdgeCarry` emission this needs.

## A verifier rule that catches something real

Folding a constant branch discards the not-taken arm. If that arm contained a trapping
operation or a drop obligation, discarding it changes behaviour.

Each newly unreachable block must therefore contain neither a `MayTrap` operation nor a
potential drop obligation — ownership-bearing values, or `Move`/`Consume` uses. The
counterfactual proves this is not redundant: ordinary structural verification **accepts** a
folded candidate that discards a trapping arm, while the new rule rejects it as
`UnsafeCfgDiscard`. A separate test proves `Consume` counts as a drop obligation.

## Preservation, verified rather than asserted

`compaction_preserves_every_surviving_non_block_identity_and_fact` compares function
metadata, block arguments, complete operations, `ValueId`, `OpId`, types, provenance, edge
operands and `UseMode`. Apart from intended branch-to-goto folding and dead-block removal,
only block identities and edge targets are remapped.

Verification runs after folding **and** after compaction, on a private candidate.
Transactional atomicity is proven by cloning malformed inputs, requiring `InvalidInput`, and
comparing the whole value unchanged; unsafe trap-region rejection returns `InvalidOutput`
without mutation.

## A second nondeterminism, found by this work

`sir-shadow-verify` failed on `rc_weak_graph` — and SIR was not involved; that fixture
realizes 0 of 0 SIR bodies. Six ordinary compilations of the same input produced two
alternating stderr hashes: two ownership diagnostics swapping order between runs. Twelve
unfixed runs produced hashes `5d90fc52…` and `68b15bb6…`.

Same root object as the `EdgeCarry` fix — `ExactOwnerState` is a randomized `HashMap` — but a
**different consumer**: its unmatched owners were iterated directly into findings, whose
order survived into diagnostic projection.

Ordering is now by binding `SiteId`, then declaration/generation-based `OwnerId`, with
missing source metadata sorting last. That follows source-anchor order, which is how a reader
consumes diagnostics, and gives a semantic same-site tie-breaker.

Fixed at the **emission**, not the comparison. Sorting where the oracle reads would have
hidden it and left every build showing diagnostics in a different order.

### Output streams swept

The earlier `EdgeCarry` fix concluded no other fact kind carried the same exposure. That was
correct for what it measured — raw-MIR sequences — but its scope did not include stderr. All
streams re-checked across six runs, each now deterministic:

| Stream | Result |
| --- | --- |
| Text stdout/stderr | one hash |
| JSON diagnostics | one hash; positions stable at 7:23 then 9:14 |
| MIR raw / checked / elab dumps | one hash per stage |
| SIR dump and inspection report | one hash |
| SIR shadow report | one hash |
| Native compile artifact report | one hash; emits no manifest |

## Verification

- `sir-shadow-verify` — 16 fixtures, 16 verified outcomes including `rc_weak_graph`; 3/7 concrete SIR bodies realized
- New six-run diagnostic-order check — fails on run 2 without the fix, swapping 9:14 and 7:23
- Existing six-run `EdgeCarry` check — passes across the full corpus
- `cargo test -p hew-mir --lib` 934/934 · `-p hew-sir` 54/54
- Strict source→LLVM driver E2E 14/14, no legacy MIR bodies lowered
- `cargo fmt --all -- --check`, `git diff --check`, clippy `-D warnings` — clean

## Scope

No legacy path is deleted here — correct for this slice. SCCP, DCE, block-argument
elimination and Raw-MIR CFG values are later work. An out-of-domain body still fails
explicitly rather than reaching a legacy branch; disabled compilation is unchanged.

## Worth a follow-up

Two consumers of `ExactOwnerState` have now been canonicalized separately. The durable fix is
to make its iteration canonical at the source — an ordered map, or an accessor that is the
only way to iterate — so a third consumer cannot reintroduce this.
