### PR TITLE
fix(mir): make consuming call handoffs unwind-safe

### DIFF
--- a/hew-cli/tests/affine_resource_carrier_boundaries.rs
+++ b/hew-cli/tests/affine_resource_carrier_boundaries.rs
@@ -551,6 +551,19 @@ fn consuming_a_resource_from_a_reusable_closure_fails_closed() {
 fn channel_handle_clone_terminals_match_runtime_semantics() {
     assert_exact_runtime("channel_sender_clone", CHANNEL_SENDER_CLONE_BODY, "1\n");
     let sender_mir = raw_mir("channel_sender_clone", CHANNEL_SENDER_CLONE_BODY);
+    let channel_ctor = function(
+        &sender_mir,
+        "fn std$channel$try_new(i64) -> Result<(Sender, Receiver), string>",
+    );
+    let (_, after_pair_free) = channel_ctor
+        .split_once("call hew_channel_pair_free")
+        .expect("channel construction must discharge its transient pair through the extern ABI");
+    assert!(
+        after_pair_free.contains("neutralize_payload _13 [CallDischargeConsume]")
+            && !after_pair_free.contains("drop _13 ty=std.channel.ChannelPair"),
+        "a consuming extern must neutralize the pair on its normal successor; \
+         its source slot cannot remain armed for ChannelPair::close:\n{channel_ctor}"
+    );
     assert!(
         sender_mir.contains("call hew_vec_clone_owned(")
             && sender_mir.contains("call hew_vec_push_owned_move(")

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -358,6 +358,39 @@ fn toml_encoding_round_trips_under_wasi() {
 }
 
 #[test]
+fn json_value_implicit_close_runs_once_under_wasi() {
+    require_wasi_runner();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("json_implicit_close_wasi.hew");
+    fs::write(
+        &source,
+        r#"import std.encoding.json;
+
+fn main() {
+    let value = json.null();
+    println("json-implicit-close-ok");
+}
+"#,
+    )
+    .expect("write JSON implicit-close WASI source");
+
+    let output = run_wasi_example(&source);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "JSON's implicit resource close must not recursively re-close its discharged FFI value\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_eq!(
+        stdout.as_ref(),
+        "json-implicit-close-ok\n",
+        "stderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn wasm_channel_send_full_traps_instead_of_dropping() {
     require_wasi_runner();
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -23735,16 +23735,21 @@ fn projection_neutralize_transferee(instr: &Instr) -> Option<Place> {
     }
 }
 
-/// Whether an interior-write marker is the exact handoff that consumes the
-/// whole registered owner. The source slot is neutral after this instruction,
-/// so refreshing its crash snapshot would mint a second owner beside the
-/// transferee.
-fn helper_whole_owner_was_transferred(instr: &Instr, owner: Place) -> bool {
+/// Whether an interior-write marker neutralizes the exact whole registered
+/// owner.
+///
+/// A named transferee is not required for the source lifecycle to end: a
+/// `CallDischargeConsume` records that the callee already released the value
+/// and deliberately has no successor owner. Once the whole source slot is
+/// zeroed, refreshing its typed crash snapshot would resurrect cleanup
+/// authority for a value that no longer exists. Projection neutralizes do not
+/// match the whole-local `owner`, so aggregates with live sibling fields still
+/// refresh normally.
+fn helper_whole_owner_was_neutralized(instr: &Instr, owner: Place) -> bool {
     matches!(
         instr,
         Instr::NeutralizePayloadSlot {
             place,
-            transferee: Some(_),
             ..
         } if *place == owner
     )
@@ -36627,7 +36632,7 @@ fn lower_function<'ctx>(
             // escrow can never retain the moved-out pointer concurrently.
             for place in interior_owner_writes {
                 if !deferred_interior_owner_arms.contains(&place)
-                    && !helper_whole_owner_was_transferred(instr, place)
+                    && !helper_whole_owner_was_neutralized(instr, place)
                 {
                     emit_helper_crash_cleanup_arm_after_write(&fn_ctx, place)?;
                 }

--- a/hew-codegen-rs/src/llvm_tests.rs
+++ b/hew-codegen-rs/src/llvm_tests.rs
@@ -10996,7 +10996,7 @@ fn helper_crash_cleanup_consumed_guard_proof_is_conservative() {
 }
 
 #[test]
-fn whole_owner_neutralize_transfers_crash_cleanup_authority() {
+fn whole_owner_neutralize_ends_source_crash_cleanup_authority() {
     use hew_mir::model::NeutralizeAuthority;
 
     let instr = Instr::NeutralizePayloadSlot {
@@ -11004,18 +11004,32 @@ fn whole_owner_neutralize_transfers_crash_cleanup_authority() {
         transferee: Some(Place::Local(1)),
         authority: NeutralizeAuthority::WholeCarrierConsume,
     };
-    assert!(helper_whole_owner_was_transferred(&instr, Place::Local(0)));
-    assert!(!helper_whole_owner_was_transferred(&instr, Place::Local(1)));
+    assert!(helper_whole_owner_was_neutralized(&instr, Place::Local(0)));
+    assert!(!helper_whole_owner_was_neutralized(&instr, Place::Local(1)));
 
-    let no_transferee = Instr::NeutralizePayloadSlot {
+    let discharged_without_transferee = Instr::NeutralizePayloadSlot {
         place: Place::Local(0),
         transferee: None,
-        authority: NeutralizeAuthority::WholeCarrierConsume,
+        authority: NeutralizeAuthority::CallDischargeConsume,
     };
-    assert!(!helper_whole_owner_was_transferred(
-        &no_transferee,
+    assert!(helper_whole_owner_was_neutralized(
+        &discharged_without_transferee,
         Place::Local(0)
     ));
+
+    let projected = Instr::NeutralizePayloadSlot {
+        place: Place::EnumVariant {
+            local: 0,
+            variant_idx: 0,
+            field_idx: 0,
+        },
+        transferee: None,
+        authority: NeutralizeAuthority::MoveOutArmConsume,
+    };
+    assert!(
+        !helper_whole_owner_was_neutralized(&projected, Place::Local(0)),
+        "neutralizing one payload must retain cleanup for the aggregate's live siblings"
+    );
 }
 
 #[test]

--- a/hew-mir/src/lower/assign.rs
+++ b/hew-mir/src/lower/assign.rs
@@ -205,7 +205,7 @@ impl Builder {
                 }
                 owns_source
             } else {
-                self.consume_typed_produced_value_owner_into_actor_state(value.site, src)
+                self.consume_typed_produced_value_owner_at_terminal_boundary(value.site, src)
             };
             if transferred {
                 self.push_instr(Instr::NeutralizePayloadSlot {

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -13,11 +13,12 @@ use super::{
     mangle_layout_key, mangle_machine_step, monomorphic_user_record_key, numeric_method_op,
     numeric_method_signedness, option_payload_ty, runtime_symbol_for_call_expr, signed_min_value,
     ty_is_closure_pair, ty_is_generator_handle, ty_is_indirect_enum, ty_is_stream_handle,
-    unary_op_label, unresolved_fn_sig_reason, user_record_layout_key, ActorStateLoadMode, BinaryOp,
-    BindingId, Builder, BuiltinType, ChildKind, ClosurePairRhs, CmpPred, Disposition,
-    FailClosedReason, FieldOffset, FloatWidth, HashMap, HashSet, HirExpr, HirExprKind, HirLiteral,
-    HirStmtKind, HirVarSelfMethodTarget, Instr, IntArithOp, IntSignedness, IntentKind,
-    MirDiagnostic, MirDiagnosticKind, MirStatement, NumericMethodFamily, Place,
+    unary_op_label, unresolved_fn_sig_reason, user_record_layout_key, ActorStateLoadMode,
+    AffineCallConsumeCandidate, BinaryOp, BindingId, Builder, BuiltinType, ChildKind,
+    ClosurePairRhs, CmpPred, Disposition, FailClosedReason, FieldOffset, FloatWidth, HashMap,
+    HashSet, HirExpr, HirExprKind, HirLiteral, HirStmtKind, HirVarSelfMethodTarget, Instr,
+    IntArithOp, IntSignedness, IntentKind, MirDiagnostic, MirDiagnosticKind, MirStatement,
+    NumericMethodFamily, PendingAffineCallConsumeArg, PendingAffineCallConsumeSite, Place,
     ProjectedPayloadOrigin, ProjectedPayloadRejectReason, ReleaseSymbolVerdict, ResolvedRef,
     ResolvedTy, RuntimeCallContext, SiteId, SuspendKind, Terminator, TrapKind, UnaryOp, ValueClass,
     VecElementRelease, FOR_ITER_CURSOR_NAME_PREFIX, SENTINEL_RECV_GEN_COMPANION_BINDING,
@@ -2995,11 +2996,26 @@ impl Builder {
                             // Updated above even when a value-producing
                             // if/match arm retained HIR Read intent.
                         } else if self.affine_release_flags.contains_key(id) {
-                            self.set_owned_local_consumed(
-                                *id,
-                                None,
-                                super::DischargeSite::BindingMoved,
-                            );
+                            if self.deferred_affine_call_consume_sites.contains(&expr.site) {
+                                // The typed call contract adopts this affine
+                                // argument only if the invoke returns normally.
+                                // Keep its guard and OwnerId live in this block
+                                // so unwind cleanup retains the caller's value;
+                                // the finalized call-site fact commits both in
+                                // the normal successor. The checker-visible
+                                // `Use { Consume }` above remains unchanged.
+                                self.set_owned_local_consumed_post_lowering(
+                                    *id,
+                                    None,
+                                    super::DischargeSite::CallArgumentTransfer,
+                                );
+                            } else {
+                                self.set_owned_local_consumed(
+                                    *id,
+                                    None,
+                                    super::DischargeSite::BindingMoved,
+                                );
+                            }
                         } else if let Some(flag) = self.collection_drop_flags.get(id).copied() {
                             // #2418 — an owned collection local with a
                             // path-sensitive drop-flag is KEPT in
@@ -6001,8 +6017,29 @@ impl Builder {
                     if move_ingress && self.reject_opaque_foreign_collection_ingress(arg) {
                         return None;
                     }
-                    let arg_place =
-                        self.lower_method_arg_value(arg, is_vec_element_store || move_ingress)?;
+                    // Catalogued runtime collection sinks adopt a consuming
+                    // payload only after the invoke returns normally. Keep an
+                    // affine binding's guard and OwnerId live while lowering
+                    // this exact argument site; `splice_normal_call_ownership_commits`
+                    // remains the single normal-edge transfer authority. A
+                    // direct Hew consuming parameter does not enter this path
+                    // and continues to transfer before invoke.
+                    let runtime_defers_affine_consume =
+                        runtime_authority_for_collection(*target_family, &callee).is_some_and(
+                            |family| {
+                                family.arg_consume_verdict(arg_index + 1)
+                                    == hew_types::runtime_call::ConsumeVerdict::ProvenConsume
+                            },
+                        );
+                    if runtime_defers_affine_consume {
+                        self.deferred_affine_call_consume_sites.insert(arg.site);
+                    }
+                    let lowered_arg =
+                        self.lower_method_arg_value(arg, is_vec_element_store || move_ingress);
+                    if runtime_defers_affine_consume {
+                        self.deferred_affine_call_consume_sites.remove(&arg.site);
+                    }
+                    let arg_place = lowered_arg?;
                     arg_places.push(arg_place);
                     if move_ingress
                         && !self.retain_caller_borrowed_cow_collection_ingress(arg, arg_place)
@@ -9387,6 +9424,74 @@ impl Builder {
         )
     }
 
+    /// Resolve affine arguments whose declared extern contract adopts the value
+    /// only on normal return. Direct Hew consuming parameters own their values
+    /// from function entry and therefore use ordinary pre-invoke binding
+    /// transfer instead of this deferred protocol.
+    fn affine_call_consume_candidates(
+        &mut self,
+        callee_symbol: &str,
+        callee_item: Option<hew_hir::ItemId>,
+        hir_args: &[hew_hir::HirExpr],
+    ) -> Vec<AffineCallConsumeCandidate> {
+        let mut candidates = Vec::new();
+        for (index, arg) in hir_args.iter().enumerate() {
+            let HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(binding),
+                ..
+            } = &arg.kind
+            else {
+                continue;
+            };
+            let use_intent = self.binding_ref_use_intent(arg);
+            if use_intent == IntentKind::Discharge {
+                continue;
+            }
+            let Some(guard) = self.affine_release_flags.get(binding).copied() else {
+                continue;
+            };
+            if callee_item.is_some()
+                || !self
+                    .call_scrutinee_provenance
+                    .extern_table
+                    .extern_param_is_consume(callee_symbol, index)
+            {
+                continue;
+            }
+            if use_intent != IntentKind::Consume {
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::NotYetImplemented {
+                        construct: "typed affine call consume without checker Consume intent"
+                            .to_string(),
+                        site: arg.site,
+                    },
+                    note: "the checker use and physical normal-edge handoff must share one consume authority"
+                        .to_string(),
+                });
+                continue;
+            }
+            candidates.push(AffineCallConsumeCandidate {
+                index,
+                binding: *binding,
+                guard,
+                site: arg.site,
+            });
+        }
+        candidates
+    }
+
+    fn activate_affine_call_consume_sites(&mut self, candidates: &[AffineCallConsumeCandidate]) {
+        self.deferred_affine_call_consume_sites
+            .extend(candidates.iter().map(|candidate| candidate.site));
+    }
+
+    fn deactivate_affine_call_consume_sites(&mut self, candidates: &[AffineCallConsumeCandidate]) {
+        for candidate in candidates {
+            self.deferred_affine_call_consume_sites
+                .remove(&candidate.site);
+        }
+    }
+
     /// Lower a direct call using the checker/HIR-projected authority. The
     /// `Extern` variant is the capability to read an audited FFI parameter
     /// contract; it does not select a specialised codegen ABI.
@@ -9433,10 +9538,21 @@ impl Builder {
         if self.reject_opaque_foreign_call_arg_transfers(callee_item, hir_args) {
             return None;
         }
-        // Lower each argument left-to-right.  If any fails to produce a
-        // Place, fail the whole call — argument diagnostics already capture
-        // the root cause.
-        let arg_places = self.lower_direct_call_args(callee_symbol, callee_item, hir_args)?;
+        // Keep declared-extern affine consumes caller-owned through the call.
+        // Their exact HIR sites preserve `Use { Consume }` while deferring the
+        // guard, physical neutralization, and `OwnerId` commit to the normal
+        // successor. Direct Hew consumes take the ordinary binding path: the
+        // caller transfers before invoke and the callee owns from entry.
+        let pending_affine_consumes =
+            self.affine_call_consume_candidates(callee_symbol, callee_item, hir_args);
+        self.activate_affine_call_consume_sites(&pending_affine_consumes);
+
+        // Lower each argument left-to-right. If any fails to produce a Place,
+        // fail the whole call after retiring the transient site context —
+        // argument diagnostics already capture the root cause.
+        let lowered_args = self.lower_direct_call_args(callee_symbol, callee_item, hir_args);
+        self.deactivate_affine_call_consume_sites(&pending_affine_consumes);
+        let arg_places = lowered_args?;
 
         // Allocate a destination local for the return value, unless the
         // callee is declared Unit-returning or divergent. Never-returning
@@ -9504,6 +9620,22 @@ impl Builder {
         if !proven_borrow_args.is_empty() {
             self.proven_borrow_call_args
                 .insert(self.current_block_id, proven_borrow_args);
+        }
+        if !pending_affine_consumes.is_empty() {
+            let args = pending_affine_consumes
+                .into_iter()
+                .map(|candidate| PendingAffineCallConsumeArg {
+                    index: candidate.index,
+                    binding: candidate.binding,
+                    source: arg_places[candidate.index],
+                    guard: candidate.guard,
+                    site: candidate.site,
+                })
+                .collect();
+            let replaced = self
+                .pending_affine_call_consumes
+                .insert(self.current_block_id, PendingAffineCallConsumeSite { args });
+            debug_assert!(replaced.is_none(), "one call terminator per basic block");
         }
         self.note_owned_call_site(callee_item, hir_args, &arg_places);
         let authority = if matches!(ret_ty, ResolvedTy::Never) {

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -13,14 +13,14 @@ use super::{
     mangle_layout_key, mangle_machine_step, monomorphic_user_record_key, numeric_method_op,
     numeric_method_signedness, option_payload_ty, runtime_symbol_for_call_expr, signed_min_value,
     ty_is_closure_pair, ty_is_generator_handle, ty_is_indirect_enum, ty_is_stream_handle,
-    unary_op_label, unresolved_fn_sig_reason, user_record_layout_key, ActorStateLoadMode,
-    AffineCallConsumeCandidate, BinaryOp, BindingId, Builder, BuiltinType, ChildKind,
-    ClosurePairRhs, CmpPred, Disposition, FailClosedReason, FieldOffset, FloatWidth, HashMap,
-    HashSet, HirExpr, HirExprKind, HirLiteral, HirStmtKind, HirVarSelfMethodTarget, Instr,
-    IntArithOp, IntSignedness, IntentKind, MirDiagnostic, MirDiagnosticKind, MirStatement,
-    NumericMethodFamily, PendingAffineCallConsumeArg, PendingAffineCallConsumeSite, Place,
-    ProjectedPayloadOrigin, ProjectedPayloadRejectReason, ReleaseSymbolVerdict, ResolvedRef,
-    ResolvedTy, RuntimeCallContext, SiteId, SuspendKind, Terminator, TrapKind, UnaryOp, ValueClass,
+    unary_op_label, unresolved_fn_sig_reason, user_record_layout_key, ActorStateLoadMode, BinaryOp,
+    BindingId, Builder, BuiltinType, ChildKind, ClosurePairRhs, CmpPred, Disposition,
+    FailClosedReason, FieldOffset, FloatWidth, HashMap, HashSet, HirExpr, HirExprKind, HirLiteral,
+    HirStmtKind, HirVarSelfMethodTarget, Instr, IntArithOp, IntSignedness, IntentKind,
+    MirDiagnostic, MirDiagnosticKind, MirStatement, NumericMethodFamily,
+    PendingAffineCallConsumeArg, PendingAffineCallConsumeSite, Place, ProjectedPayloadOrigin,
+    ProjectedPayloadRejectReason, ReleaseSymbolVerdict, ResolvedRef, ResolvedTy,
+    RuntimeCallContext, SiteId, SuspendKind, Terminator, TrapKind, UnaryOp, ValueClass,
     VecElementRelease, FOR_ITER_CURSOR_NAME_PREFIX, SENTINEL_RECV_GEN_COMPANION_BINDING,
 };
 #[cfg(test)]
@@ -9422,74 +9422,6 @@ impl Builder {
                 .map(crate::CallAuthority::Runtime)
                 .unwrap_or_default(),
         )
-    }
-
-    /// Resolve affine arguments whose declared extern contract adopts the value
-    /// only on normal return. Direct Hew consuming parameters own their values
-    /// from function entry and therefore use ordinary pre-invoke binding
-    /// transfer instead of this deferred protocol.
-    fn affine_call_consume_candidates(
-        &mut self,
-        callee_symbol: &str,
-        callee_item: Option<hew_hir::ItemId>,
-        hir_args: &[hew_hir::HirExpr],
-    ) -> Vec<AffineCallConsumeCandidate> {
-        let mut candidates = Vec::new();
-        for (index, arg) in hir_args.iter().enumerate() {
-            let HirExprKind::BindingRef {
-                resolved: ResolvedRef::Binding(binding),
-                ..
-            } = &arg.kind
-            else {
-                continue;
-            };
-            let use_intent = self.binding_ref_use_intent(arg);
-            if use_intent == IntentKind::Discharge {
-                continue;
-            }
-            let Some(guard) = self.affine_release_flags.get(binding).copied() else {
-                continue;
-            };
-            if callee_item.is_some()
-                || !self
-                    .call_scrutinee_provenance
-                    .extern_table
-                    .extern_param_is_consume(callee_symbol, index)
-            {
-                continue;
-            }
-            if use_intent != IntentKind::Consume {
-                self.diagnostics.push(MirDiagnostic {
-                    kind: MirDiagnosticKind::NotYetImplemented {
-                        construct: "typed affine call consume without checker Consume intent"
-                            .to_string(),
-                        site: arg.site,
-                    },
-                    note: "the checker use and physical normal-edge handoff must share one consume authority"
-                        .to_string(),
-                });
-                continue;
-            }
-            candidates.push(AffineCallConsumeCandidate {
-                index,
-                binding: *binding,
-                guard,
-                site: arg.site,
-            });
-        }
-        candidates
-    }
-
-    fn activate_affine_call_consume_sites(&mut self, candidates: &[AffineCallConsumeCandidate]) {
-        self.deferred_affine_call_consume_sites
-            .extend(candidates.iter().map(|candidate| candidate.site));
-    }
-
-    fn deactivate_affine_call_consume_sites(&mut self, candidates: &[AffineCallConsumeCandidate]) {
-        for candidate in candidates {
-            self.deferred_affine_call_consume_sites
-                .remove(&candidate.site);
-        }
     }
 
     /// Lower a direct call using the checker/HIR-projected authority. The

--- a/hew-mir/src/lower/facts.rs
+++ b/hew-mir/src/lower/facts.rs
@@ -1181,6 +1181,7 @@ pub(super) fn compute_param_ownership(
     ParamOwnershipFacts {
         produced_value_facts: HashMap::new(),
         param_consume,
+        true_receiver_methods,
         borrow_arg_sites,
         proven_borrow_arg_sites,
         call_param_consume,

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -410,6 +410,28 @@ struct PendingOwnedCallSite {
     args: Vec<PendingOwnedCallArg>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct AffineCallConsumeCandidate {
+    index: usize,
+    binding: BindingId,
+    guard: Place,
+    site: SiteId,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingAffineCallConsumeArg {
+    index: usize,
+    binding: BindingId,
+    source: Place,
+    guard: Place,
+    site: SiteId,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PendingAffineCallConsumeSite {
+    args: Vec<PendingAffineCallConsumeArg>,
+}
+
 #[derive(Debug, Clone)]
 enum OwnedCarrierNeutralizeTarget {
     Whole(Place),
@@ -499,6 +521,19 @@ struct Builder {
     /// into an owning sink. Resolved after CFG construction so liveness and
     /// projection taint choose snapshot versus last-use transfer.
     pending_owned_call_args: HashMap<u32, PendingOwnedCallSite>,
+    /// Affine whole-local arguments whose declared extern contract consumes the
+    /// value only after the call returns normally. The HIR `Use { Consume }`
+    /// remains in the call block for move checking, while these facts defer
+    /// physical neutralization and the owner transfer to `next`, leaving the
+    /// same owner live for caller-side unwind cleanup.
+    pending_affine_call_consumes: HashMap<u32, PendingAffineCallConsumeSite>,
+    /// HIR argument sites whose affine consume commits on the normal call edge:
+    /// either a declared-extern site recorded in `pending_affine_call_consumes`
+    /// or a catalogued runtime `ProvenConsume` site finalized by
+    /// `splice_normal_call_ownership_commits`. Binding-ref lowering consults
+    /// this exact-site set so a nested expression cannot accidentally defer a
+    /// different consume of the same binding.
+    deferred_affine_call_consume_sites: HashSet<SiteId>,
     /// Callee-side parameters admitted by the same carrier summary. Every
     /// terminal path receives the inverse snapshot drop.
     owned_carrier_params: Vec<OwnedCarrierParam>,
@@ -3977,6 +4012,11 @@ pub(crate) struct ParamOwnershipFacts {
     /// drop. Only affine `Named { builtin: None }` resource params ever appear;
     /// non-resource and builtin-handle params are absent.
     param_consume: HashMap<(hew_hir::ItemId, usize), bool>,
+    /// Impl/trait functions whose parameter zero is a source-level receiver.
+    /// Associated functions remain ordinary at index zero. Direct-call
+    /// lowering uses this identity to keep a fluent receiver's existing owner
+    /// lineage distinct from a non-receiver consuming parameter handoff.
+    true_receiver_methods: HashSet<hew_hir::ItemId>,
     /// `SiteId`s of free-call arguments whose target parameter is a resource
     /// BORROW. At the single `MirStatement::Use` emission point such an arg's
     /// over-stamped `Consume` intent is downgraded to a borrowing `Read`, so the
@@ -7219,6 +7259,7 @@ fn splice_body_ownership_releases(
     }
     splice_opaque_extern_string_argument_handoffs(blocks, builder);
     splice_normal_call_ownership_commits(blocks, builder);
+    splice_affine_call_argument_consumes(blocks, builder);
     splice_retained_field_aggregate_commits(blocks, builder);
     finalize_string_local_share_intents(&mut *blocks, builder);
     splice_escaped_record_sibling_field_drops(blocks, builder);
@@ -7442,8 +7483,22 @@ fn splice_normal_call_ownership_commits(blocks: &mut [BasicBlock], builder: &mut
                 to_ty: None,
             });
             if !successor.instructions.contains(&event) {
-                shift_instr_spans_on_insert(&mut builder.instr_spans, next, 0);
-                successor.instructions.insert(0, event);
+                let mut operations = Vec::new();
+                if let Some(flag) = builder.affine_release_flags.get(&binding).copied() {
+                    operations.push(Instr::ConstI64 {
+                        dest: flag,
+                        value: 1,
+                    });
+                }
+                operations.push(event);
+                for (index, operation) in operations.into_iter().enumerate() {
+                    shift_instr_spans_on_insert(
+                        &mut builder.instr_spans,
+                        next,
+                        u32::try_from(index).unwrap_or(u32::MAX),
+                    );
+                    successor.instructions.insert(index, operation);
+                }
             }
         }
         // A source-level consuming argument already authored the checker
@@ -7585,6 +7640,264 @@ fn splice_normal_call_ownership_commits(blocks: &mut [BasicBlock], builder: &mut
         }
         builder.set_owned_local_consumed_post_lowering(
             owner.binding,
+            None,
+            DischargeSite::CallArgumentTransfer,
+        );
+    }
+}
+
+struct AffineCallConsumeCommit {
+    next: u32,
+    owner: crate::model::OwnerId,
+    place: Place,
+    guard: Place,
+}
+
+/// Commit a declared-extern affine argument only after the extern returns
+/// normally. Lowering preserved the checker `Use { Consume }` in the call
+/// block but deliberately left the `OwnerId` and guard live, so the caller can
+/// clean up an extern that unwinds before accepting ownership. A Hew callee is
+/// different: its consuming parameter owns the value from function entry, so
+/// ordinary binding lowering transfers the caller owner before the invoke.
+fn splice_affine_call_argument_consumes(blocks: &mut [BasicBlock], builder: &mut Builder) {
+    let pending = std::mem::take(&mut builder.pending_affine_call_consumes);
+    if pending.is_empty() {
+        return;
+    }
+    let commits = collect_affine_call_consume_commits(blocks, builder, pending);
+    apply_affine_call_consume_commits(blocks, builder, commits);
+}
+
+struct AffineCallConsumeResolution<'a> {
+    blocks: &'a [BasicBlock],
+    owner_exits: &'a HashMap<u32, drop_plan::ExactOwnerState>,
+    predecessors: &'a HashMap<u32, Vec<u32>>,
+    guards: &'a HashMap<crate::model::OwnerId, Place>,
+}
+
+fn reject_affine_call_consume(
+    builder: &mut Builder,
+    site: SiteId,
+    construct: impl Into<String>,
+    note: impl Into<String>,
+) {
+    builder.diagnostics.push(MirDiagnostic {
+        kind: MirDiagnosticKind::NotYetImplemented {
+            construct: construct.into(),
+            site,
+        },
+        note: note.into(),
+    });
+}
+
+fn collect_affine_call_consume_commits(
+    blocks: &[BasicBlock],
+    builder: &mut Builder,
+    pending: HashMap<u32, PendingAffineCallConsumeSite>,
+) -> Vec<AffineCallConsumeCommit> {
+    let (_, owner_exits) = drop_plan::exact_owner_states(blocks);
+    let mut predecessors = HashMap::<u32, Vec<u32>>::new();
+    for block in blocks {
+        for successor in block.successors() {
+            predecessors.entry(successor).or_default().push(block.id);
+        }
+    }
+    let guards = blocks
+        .iter()
+        .flat_map(|block| &block.instructions)
+        .filter_map(|instruction| match instruction {
+            Instr::OwnershipEvent(crate::model::OwnershipEvent::Guard { owner, flag, .. }) => {
+                Some((*owner, *flag))
+            }
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+    let resolution = AffineCallConsumeResolution {
+        blocks,
+        owner_exits: &owner_exits,
+        predecessors: &predecessors,
+        guards: &guards,
+    };
+    let mut pending = pending.into_iter().collect::<Vec<_>>();
+    pending.sort_by_key(|(block_id, _)| *block_id);
+    let mut commits = Vec::new();
+    for (block_id, site) in pending {
+        for commit in resolve_affine_call_consume_site(&resolution, builder, block_id, site) {
+            if !commits.iter().any(|existing: &AffineCallConsumeCommit| {
+                existing.next == commit.next
+                    && existing.owner == commit.owner
+                    && existing.place == commit.place
+            }) {
+                commits.push(commit);
+            }
+        }
+    }
+    commits
+}
+
+fn resolve_affine_call_consume_site(
+    resolution: &AffineCallConsumeResolution<'_>,
+    builder: &mut Builder,
+    block_id: u32,
+    site: PendingAffineCallConsumeSite,
+) -> Vec<AffineCallConsumeCommit> {
+    let site_id = site.args.first().map_or(SiteId(0), |arg| arg.site);
+    let Some(block) = resolution.blocks.iter().find(|block| block.id == block_id) else {
+        reject_affine_call_consume(
+            builder,
+            site_id,
+            format!("pending affine call consume without basic block bb{block_id}"),
+            "typed call-argument ownership facts must resolve before Checked MIR",
+        );
+        return Vec::new();
+    };
+    let Terminator::Call { args, next, .. } = &block.terminator else {
+        reject_affine_call_consume(
+            builder,
+            site_id,
+            "affine call consume without call terminator",
+            "typed call-argument ownership facts must terminate at their recorded call",
+        );
+        return Vec::new();
+    };
+    if resolution.predecessors.get(next).map(Vec::as_slice) != Some(&[block_id]) {
+        reject_affine_call_consume(
+            builder,
+            site_id,
+            "affine call consume with shared normal successor",
+            format!(
+                "normal-edge ownership commits require bb{next} to be dedicated to bb{block_id}; incoming blocks are {:?}",
+                resolution.predecessors.get(next).cloned().unwrap_or_default()
+            ),
+        );
+        return Vec::new();
+    }
+    let Some(state) = resolution.owner_exits.get(&block_id) else {
+        for arg in &site.args {
+            reject_affine_call_consume(
+                builder,
+                arg.site,
+                "affine call consume without exact predecessor ownership",
+                "the caller must retain one exact owner through the call's unwind edge",
+            );
+        }
+        return Vec::new();
+    };
+    site.args
+        .into_iter()
+        .filter_map(|arg| {
+            resolve_affine_call_consume_arg(builder, args, *next, state, resolution.guards, arg)
+        })
+        .collect()
+}
+
+fn resolve_affine_call_consume_arg(
+    builder: &mut Builder,
+    args: &[Place],
+    next: u32,
+    state: &drop_plan::ExactOwnerState,
+    guards: &HashMap<crate::model::OwnerId, Place>,
+    arg: PendingAffineCallConsumeArg,
+) -> Option<AffineCallConsumeCommit> {
+    let Some(argument) = args.get(arg.index).copied() else {
+        reject_affine_call_consume(
+            builder,
+            arg.site,
+            "affine call consume argument index is absent",
+            "the typed parameter contract must align with the emitted call ABI",
+        );
+        return None;
+    };
+    if argument != arg.source {
+        reject_affine_call_consume(
+            builder,
+            arg.site,
+            "affine call consume source changed before finalization",
+            "the call-argument owner must be resolved at its exact emitted place",
+        );
+        return None;
+    }
+    let mut owners = state
+        .iter()
+        .filter_map(|(owner, place)| {
+            (owner.binding == arg.binding && *place == argument).then_some((*owner, *place))
+        })
+        .collect::<Vec<_>>();
+    owners.sort_by_key(|(owner, _)| *owner);
+    let [(owner, place)] = owners.as_slice() else {
+        reject_affine_call_consume(
+            builder,
+            arg.site,
+            "affine call consume without one exact live owner",
+            format!(
+                "binding {:?} must retain one owner at {argument:?} through the unwind edge; found {owners:?}",
+                arg.binding
+            ),
+        );
+        return None;
+    };
+    if guards.get(owner).copied() != Some(arg.guard) {
+        reject_affine_call_consume(
+            builder,
+            arg.site,
+            "affine call consume without its exact live guard",
+            format!(
+                "owner {owner:?} must retain guard {:?} through the unwind edge; found {:?}",
+                arg.guard,
+                guards.get(owner)
+            ),
+        );
+        return None;
+    }
+    Some(AffineCallConsumeCommit {
+        next,
+        owner: *owner,
+        place: *place,
+        guard: arg.guard,
+    })
+}
+
+fn apply_affine_call_consume_commits(
+    blocks: &mut [BasicBlock],
+    builder: &mut Builder,
+    commits: Vec<AffineCallConsumeCommit>,
+) {
+    for commit in commits {
+        let Some(successor) = blocks.iter_mut().find(|block| block.id == commit.next) else {
+            continue;
+        };
+        let event = Instr::OwnershipEvent(crate::model::OwnershipEvent::Transfer {
+            owner: commit.owner,
+            from: commit.place,
+            to: None,
+            to_owner: None,
+            to_ty: None,
+        });
+        if successor.instructions.contains(&event) {
+            continue;
+        }
+        let operations = [
+            Instr::ConstI64 {
+                dest: commit.guard,
+                value: 1,
+            },
+            Instr::NeutralizePayloadSlot {
+                place: commit.place,
+                transferee: None,
+                authority: crate::model::NeutralizeAuthority::CallDischargeConsume,
+            },
+            event,
+        ];
+        for (offset, operation) in operations.into_iter().enumerate() {
+            shift_instr_spans_on_insert(
+                &mut builder.instr_spans,
+                commit.next,
+                u32::try_from(offset).unwrap_or(u32::MAX),
+            );
+            successor.instructions.insert(offset, operation);
+        }
+        builder.set_owned_local_consumed_post_lowering(
+            commit.owner.binding,
             None,
             DischargeSite::CallArgumentTransfer,
         );
@@ -13410,6 +13723,14 @@ pub(crate) fn lower_function(
     debug_assert!(
         builder.pending_owned_call_args.is_empty(),
         "checked MIR cannot retain unresolved owned call-carrier arguments"
+    );
+    debug_assert!(
+        builder.pending_affine_call_consumes.is_empty(),
+        "checked MIR cannot retain unresolved affine call-consume arguments"
+    );
+    debug_assert!(
+        builder.deferred_affine_call_consume_sites.is_empty(),
+        "checked MIR cannot retain an active affine call-consume lowering context"
     );
     assert_eq!(
         builder.param_boundary_modes.len(),

--- a/hew-mir/src/lower/move_value.rs
+++ b/hew-mir/src/lower/move_value.rs
@@ -233,6 +233,12 @@ impl Builder {
                     && !self.ty_is_machine(&owned_ty)
                     && self
                         .param_ownership
+                        .param_consume
+                        .get(&(callee_item, index))
+                        .copied()
+                        != Some(true)
+                    && self
+                        .param_ownership
                         .call_param_owned_carrier
                         .get(&(callee_item, index))
                         .copied()
@@ -939,11 +945,44 @@ impl Builder {
                     });
                 let target_is_owned_carrier = callee_item.is_some_and(|item| {
                     self.param_ownership
-                        .call_param_owned_carrier
+                        .param_consume
+                        .get(&(item, index))
+                        .copied()
+                        != Some(true)
+                        && self
+                            .param_ownership
+                            .call_param_owned_carrier
+                            .get(&(item, index))
+                            .copied()
+                            == Some(true)
+                });
+                let target_is_affine_consume = callee_item.is_some_and(|item| {
+                    self.param_ownership
+                        .param_consume
                         .get(&(item, index))
                         .copied()
                         == Some(true)
+                        && !(index == 0
+                            && self.param_ownership.true_receiver_methods.contains(&item))
                 });
+                if target_is_affine_consume {
+                    // Keep projections on the ordinary move funnel: a loaded
+                    // resource field must neutralize its root-relative carrier
+                    // slot before the callee adopts it. The funnel also keeps
+                    // reusable closure captures fail-closed.
+                    let value = self.lower_value_for_move(arg)?;
+                    // A named binding emitted its guard + terminal Transfer
+                    // during ordinary BindingRef lowering. A fresh rvalue has
+                    // a synthetic produced-value owner instead; end that exact
+                    // generation here so the consuming callee owns the copied
+                    // parameter from entry and caller unwind never closes it.
+                    // The receiver exclusion is load-bearing: its slot can
+                    // appear in `param_consume` because the method returns or
+                    // otherwise forwards `self`, while the call-site receiver's
+                    // owner lineage continues through the result.
+                    self.consume_typed_produced_value_owner_at_terminal_boundary(arg.site, value);
+                    return Some(value);
+                }
                 if is_move && target_is_owned_carrier {
                     if self.reject_capture_env_whole_escape_expr(arg) {
                         return None;

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -1259,16 +1259,18 @@ impl Builder {
         operations
     }
 
-    /// Move a freshly published owner into actor-state storage, which is
-    /// outside the MIR `Place` domain.
+    /// Move a freshly published owner across a terminal boundary whose new
+    /// owner is outside this MIR frame's `Place` domain: actor-state storage
+    /// or a direct Hew callee's consuming parameter.
     ///
     /// The typed publication site selects the exact provisional `OwnerId`. The
-    /// terminal event is emitted beside the physical state store, so unwind
-    /// before the store retains frame cleanup while normal continuation ends
-    /// the local generation. Returning whether an owner was found lets the
-    /// caller null only a source that actually transferred; borrowed and
-    /// bit-copy publications remain untouched.
-    pub(crate) fn consume_typed_produced_value_owner_into_actor_state(
+    /// caller chooses the semantic boundary: actor-state lowering emits the
+    /// event after its non-unwinding store, while direct-call lowering emits it
+    /// immediately before invoke so the callee owns cleanup on both return and
+    /// unwind. Returning whether an owner was found lets the caller null only a
+    /// source that actually transferred; borrowed and bit-copy publications
+    /// remain untouched.
+    pub(crate) fn consume_typed_produced_value_owner_at_terminal_boundary(
         &mut self,
         site: SiteId,
         source: Place,

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -6,11 +6,11 @@ use super::{
     hir_expr_contains_synthetic_vec_get_clone, local_is_rewritten_after_current_iteration,
     machine_layout_ty_matches, monomorphic_user_record_key, named_type_marker, ty_is_closure_pair,
     ty_is_heap_owning_enum_composite, ty_is_local_collection_handle, user_record_layout_key,
-    vec_iter_record_layout_key, ActiveIterationOwner, BasicBlock, BindingId, Builder, BuiltinType,
-    ClosurePairIngress, CmpPred, DecisionFact, DischargeSite, Disposition, FieldLoadClass,
-    FieldOffset, HashMap, HashSet, HirBinding, HirBlock, HirExpr, HirExprKind,
-    HirProducedValueRelation, HirStmtKind, Instr, IntentKind, LayoutClass, MirDiagnostic,
-    MirDiagnosticKind, MirStatement, OwnedCarrierNeutralizeTarget, OwnedLocalEntry,
+    vec_iter_record_layout_key, ActiveIterationOwner, AffineCallConsumeCandidate, BasicBlock,
+    BindingId, Builder, BuiltinType, ClosurePairIngress, CmpPred, DecisionFact, DischargeSite,
+    Disposition, FieldLoadClass, FieldOffset, HashMap, HashSet, HirBinding, HirBlock, HirExpr,
+    HirExprKind, HirProducedValueRelation, HirStmtKind, Instr, IntentKind, LayoutClass,
+    MirDiagnostic, MirDiagnosticKind, MirStatement, OwnedCarrierNeutralizeTarget, OwnedLocalEntry,
     OwnerMintOrigin, OwnerMintWarrant, OwnershipCtx, OwnershipDecision, Place, PlaceProvenance,
     ProducedValueOwnership, Projection, ResolvedRef, ResolvedTy, ResourceMarker, SiteId, Strategy,
     Terminator, ValueClass, ValueOwnership, ValueProvenance, SYNTHETIC_CALL_SCRUTINEE_NAME,
@@ -153,6 +153,80 @@ pub(super) fn returned_aggregate_consumes_source(
 }
 
 impl Builder {
+    /// Resolve affine arguments whose declared extern contract adopts the value
+    /// only on normal return. Direct Hew consuming parameters own their values
+    /// from function entry and therefore use ordinary pre-invoke binding
+    /// transfer instead of this deferred protocol.
+    pub(super) fn affine_call_consume_candidates(
+        &mut self,
+        callee_symbol: &str,
+        callee_item: Option<hew_hir::ItemId>,
+        hir_args: &[hew_hir::HirExpr],
+    ) -> Vec<AffineCallConsumeCandidate> {
+        let mut candidates = Vec::new();
+        for (index, arg) in hir_args.iter().enumerate() {
+            let HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(binding),
+                ..
+            } = &arg.kind
+            else {
+                continue;
+            };
+            let use_intent = self.binding_ref_use_intent(arg);
+            if use_intent == IntentKind::Discharge {
+                continue;
+            }
+            let Some(guard) = self.affine_release_flags.get(binding).copied() else {
+                continue;
+            };
+            if callee_item.is_some()
+                || !self
+                    .call_scrutinee_provenance
+                    .extern_table
+                    .extern_param_is_consume(callee_symbol, index)
+            {
+                continue;
+            }
+            if use_intent != IntentKind::Consume {
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::NotYetImplemented {
+                        construct: "typed affine call consume without checker Consume intent"
+                            .to_string(),
+                        site: arg.site,
+                    },
+                    note: "the checker use and physical normal-edge handoff must share one consume authority"
+                        .to_string(),
+                });
+                continue;
+            }
+            candidates.push(AffineCallConsumeCandidate {
+                index,
+                binding: *binding,
+                guard,
+                site: arg.site,
+            });
+        }
+        candidates
+    }
+
+    pub(super) fn activate_affine_call_consume_sites(
+        &mut self,
+        candidates: &[AffineCallConsumeCandidate],
+    ) {
+        self.deferred_affine_call_consume_sites
+            .extend(candidates.iter().map(|candidate| candidate.site));
+    }
+
+    pub(super) fn deactivate_affine_call_consume_sites(
+        &mut self,
+        candidates: &[AffineCallConsumeCandidate],
+    ) {
+        for candidate in candidates {
+            self.deferred_affine_call_consume_sites
+                .remove(&candidate.site);
+        }
+    }
+
     pub(crate) fn emit_scope_exit_marker<I>(&mut self, scopes: I)
     where
         I: IntoIterator<Item = hew_hir::ScopeId>,

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -1567,6 +1567,10 @@ pub struct ExternContractTable {
     /// would not. Both keys are therefore checked, and either one claims the
     /// callee for the extern contract.
     decl_ids: HashSet<hew_hir::ItemId>,
+    /// Parameter positions carrying an explicit source `consume` contract.
+    /// Extern call sites use endpoint names today, so this shares the
+    /// name-plus-index identity used by the call boundary.
+    consuming_params: HashSet<(String, usize)>,
 }
 
 impl ExternContractTable {
@@ -1584,6 +1588,14 @@ impl ExternContractTable {
     #[must_use]
     pub fn is_extern_id(&self, id: hew_hir::ItemId) -> bool {
         self.decl_ids.contains(&id)
+    }
+
+    /// True when the declared extern parameter at `index` is explicitly
+    /// `consume`. This is distinct from the result and borrowing contracts:
+    /// it authorizes a terminal caller-to-ABI ownership transfer.
+    #[must_use]
+    pub fn extern_param_is_consume(&self, name: &str, index: usize) -> bool {
+        self.consuming_params.contains(&(name.to_owned(), index))
     }
 
     /// True when `name` is a declared extern whose RETURN carries an audited
@@ -1817,6 +1829,7 @@ pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContrac
     let mut foreign_names: HashSet<String> = HashSet::new();
     let mut borrowing_arg_names: HashSet<String> = HashSet::new();
     let mut audited_domestic_return_names: HashSet<String> = HashSet::new();
+    let mut consuming_params: HashSet<(String, usize)> = HashSet::new();
     let pointer_free_records = PointerFreeRecords::from_module(module);
     let type_decls: HashMap<&str, &hew_hir::HirTypeDecl> = module
         .items
@@ -1830,6 +1843,11 @@ pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContrac
         if let hew_hir::HirItem::ExternFn(ef) = item {
             names.insert(ef.name.clone());
             decl_ids.insert(ef.id);
+            for (index, consumes) in ef.param_consume.iter().copied().enumerate() {
+                if consumes {
+                    consuming_params.insert((ef.name.clone(), index));
+                }
+            }
             if !ef.provenance.is_stdlib() {
                 foreign_decl_ids.insert(ef.id);
                 foreign_names.insert(ef.name.clone());
@@ -1878,6 +1896,7 @@ pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContrac
         borrowing_arg_names,
         audited_domestic_return_names,
         decl_ids,
+        consuming_params,
     }
 }
 
@@ -6452,6 +6471,7 @@ mod extern_ownership_opacity {
     fn host_bytes() -> bytes;
     fn host_len(s: string) -> i64;
     fn host_sink(s: string);
+    fn host_take(consume s: string);
 }
 fn hew_mk() -> string { "x" }
 fn main() {}
@@ -6464,12 +6484,35 @@ fn main() {}
     #[test]
     fn every_declared_extern_is_recognised_as_extern() {
         let t = table();
-        for name in ["host_string", "host_bytes", "host_len", "host_sink"] {
+        for name in [
+            "host_string",
+            "host_bytes",
+            "host_len",
+            "host_sink",
+            "host_take",
+        ] {
             assert!(t.is_extern_name(name), "`{name}` must be a known extern");
         }
         assert!(
             !t.is_extern_name("hew_mk"),
             "a Hew-bodied function is not an extern"
+        );
+    }
+
+    #[test]
+    fn explicit_extern_consume_is_parameter_specific() {
+        let t = table();
+        assert!(
+            t.extern_param_is_consume("host_take", 0),
+            "the declared consume parameter must retain its terminal ABI contract"
+        );
+        assert!(
+            !t.extern_param_is_consume("host_sink", 0),
+            "an ordinary extern parameter must not acquire a consume contract"
+        );
+        assert!(
+            !t.extern_param_is_consume("host_take", 1),
+            "consume contracts are parameter-indexed"
         );
     }
 

--- a/hew-mir/tests/consuming_call_owner_transfer.rs
+++ b/hew-mir/tests/consuming_call_owner_transfer.rs
@@ -1,9 +1,7 @@
-use std::collections::HashSet;
-
-use hew_hir::{lower_program, BindingId, ResolutionCtx};
+use hew_hir::{lower_program, BindingId, IntentKind, ResolutionCtx};
 use hew_mir::{
-    lower_hir_module, CheckedMirFunction, Instr, IrPipeline, MirStatement, OwnerId, OwnershipEvent,
-    Place, Terminator,
+    lower_hir_module, CheckedMirFunction, Instr, IrPipeline, MirStatement, NeutralizeAuthority,
+    OwnerId, OwnershipEvent, Place, Terminator,
 };
 use hew_types::module_registry::ModuleRegistry;
 use hew_types::Checker;
@@ -30,6 +28,36 @@ fn main() {
 }
 "#;
 
+const CONSUMING_DIRECT_PANIC_SOURCE: &str = r#"
+#[resource]
+type Conn { id: i64 }
+
+impl Conn {
+    fn close(self) {}
+}
+
+fn explode() {
+    panic("boom");
+}
+
+fn consume_then_panic(consume conn: Conn) {
+    explode();
+}
+
+fn run() {
+    let conn = Conn { id: 7 };
+    consume_then_panic(conn);
+}
+
+fn run_fresh() {
+    consume_then_panic(Conn { id: 8 });
+}
+
+fn main() {
+    run();
+}
+"#;
+
 fn named_binding(function: &CheckedMirFunction, name: &str) -> BindingId {
     function
         .blocks
@@ -46,23 +74,60 @@ fn named_binding(function: &CheckedMirFunction, name: &str) -> BindingId {
         .unwrap_or_else(|| panic!("the owned {name} binding must be present"))
 }
 
-fn guarded_owner(function: &CheckedMirFunction, binding: BindingId) -> OwnerId {
+fn guarded_owner(function: &CheckedMirFunction, binding: BindingId) -> (OwnerId, Place) {
     function
         .blocks
         .iter()
         .flat_map(|block| &block.instructions)
         .find_map(|instruction| match instruction {
-            Instr::OwnershipEvent(OwnershipEvent::Guard { owner, .. })
+            Instr::OwnershipEvent(OwnershipEvent::Guard { owner, flag, .. })
                 if owner.binding == binding =>
             {
-                Some(*owner)
+                Some((*owner, *flag))
             }
             _ => None,
         })
         .expect("the owned binding must publish a guarded owner generation")
 }
 
-fn consuming_call_continuation(function: &CheckedMirFunction, expected_callee: &str) -> u32 {
+fn owner_at_place(function: &CheckedMirFunction, expected_place: Place) -> OwnerId {
+    function
+        .blocks
+        .iter()
+        .flat_map(|block| &block.instructions)
+        .find_map(|instruction| match instruction {
+            Instr::OwnershipEvent(OwnershipEvent::Mint { owner, place, .. })
+                if *place == expected_place =>
+            {
+                Some(*owner)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("{expected_place:?} must mint an owner"))
+}
+
+fn guarded_owner_at_place(
+    function: &CheckedMirFunction,
+    expected_place: Place,
+) -> (OwnerId, Place) {
+    let owner = owner_at_place(function, expected_place);
+    let flag = function
+        .blocks
+        .iter()
+        .flat_map(|block| &block.instructions)
+        .find_map(|instruction| match instruction {
+            Instr::OwnershipEvent(OwnershipEvent::Guard {
+                owner: guarded,
+                flag,
+                ..
+            }) if *guarded == owner => Some(*flag),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("owner {owner:?} must publish a guard"));
+    (owner, flag)
+}
+
+fn consuming_call_edge(function: &CheckedMirFunction, expected_callee: &str) -> (u32, Place, u32) {
     function
         .blocks
         .iter()
@@ -70,85 +135,235 @@ fn consuming_call_continuation(function: &CheckedMirFunction, expected_callee: &
             Terminator::Call {
                 callee, args, next, ..
             } if callee == expected_callee => {
-                assert_eq!(args.len(), 1, "consuming extern must have one argument");
-                Some(*next)
+                let [argument] = args.as_slice() else {
+                    panic!("consuming extern must have one argument: {args:?}");
+                };
+                Some((block.id, *argument, *next))
             }
             _ => None,
         })
         .expect("run must contain the consuming extern call")
 }
 
-fn terminal_transfer_source(function: &CheckedMirFunction, expected_owner: OwnerId) -> Place {
-    let transfers: Vec<Place> = function
+fn assert_call_block_retains_owner(
+    function: &CheckedMirFunction,
+    call_block_id: u32,
+    binding: BindingId,
+    owner: OwnerId,
+    flag: Place,
+) {
+    let call_block = function
         .blocks
         .iter()
-        .flat_map(|block| &block.instructions)
-        .filter_map(|instruction| match instruction {
-            Instr::OwnershipEvent(OwnershipEvent::Transfer {
-                owner,
-                from,
-                to: None,
-                to_owner: None,
-                to_ty: None,
-            }) if *owner == expected_owner => Some(*from),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(
-        transfers.len(),
-        1,
-        "the consuming call must publish exactly one terminal owner transfer"
+        .find(|block| block.id == call_block_id)
+        .expect("consuming call block must exist");
+    assert!(
+        call_block.statements.iter().any(|statement| matches!(
+            statement,
+            MirStatement::Use {
+                binding: used,
+                intent: IntentKind::Consume,
+                ..
+            } if *used == binding
+        )),
+        "the source-level consuming argument must remain a checker Consume use: {:#?}",
+        call_block.statements
     );
-    transfers[0]
+    assert!(
+        call_block.instructions.iter().all(|instruction| !matches!(
+            instruction,
+            Instr::ConstI64 { dest, value: 1 } if *dest == flag
+        ) && !matches!(
+            instruction,
+            Instr::OwnershipEvent(OwnershipEvent::Transfer {
+                owner: transferred,
+                ..
+            }) if *transferred == owner
+        )),
+        "the call block must retain its guarded owner for the unwind edge: {:#?}",
+        call_block.instructions
+    );
 }
 
-fn assert_no_release_after(
+fn unwind_drops<'a>(
+    function: &'a CheckedMirFunction,
+    expected_callee: &str,
+) -> &'a [hew_mir::ElabDrop] {
+    function
+        .ownership_elaboration
+        .as_ref()
+        .expect("Checked MIR must retain ownership elaboration")
+        .drop_plans
+        .iter()
+        .find_map(|(exit, plan)| {
+            matches!(
+                exit,
+                hew_mir::ExitPath::Unwind { callee, .. } if callee == expected_callee
+            )
+            .then_some(plan.drops.as_slice())
+        })
+        .unwrap_or_else(|| panic!("{expected_callee} must publish an unwind cleanup plan"))
+}
+
+fn assert_call_block_transfers_owner(
+    function: &CheckedMirFunction,
+    call_block_id: u32,
+    binding: BindingId,
+    owner: OwnerId,
+    owner_place: Place,
+    flag: Place,
+) {
+    let call_block = function
+        .blocks
+        .iter()
+        .find(|block| block.id == call_block_id)
+        .expect("consuming call block must exist");
+    assert!(
+        call_block.statements.iter().any(|statement| matches!(
+            statement,
+            MirStatement::Use {
+                binding: used,
+                intent: IntentKind::Consume,
+                ..
+            } if *used == binding
+        )),
+        "the direct consuming argument must remain a checker Consume use: {:#?}",
+        call_block.statements
+    );
+    let exact_transfers = call_block
+        .instructions
+        .windows(2)
+        .filter(|window| {
+            matches!(
+                window,
+                [
+                    Instr::ConstI64 { dest, value: 1 },
+                    Instr::OwnershipEvent(OwnershipEvent::Transfer {
+                        owner: transferred,
+                        from,
+                        to: None,
+                        to_owner: None,
+                        to_ty: None,
+                    }),
+                ] if *dest == flag && *transferred == owner && *from == owner_place
+            )
+        })
+        .count();
+    assert_eq!(
+        exact_transfers, 1,
+        "a direct Hew consume must transfer caller ownership before invoke: {:#?}",
+        call_block.instructions
+    );
+    assert!(
+        call_block.instructions.iter().all(|instruction| !matches!(
+            instruction,
+            Instr::NeutralizePayloadSlot {
+                authority: NeutralizeAuthority::CallDischargeConsume,
+                ..
+            }
+        )),
+        "a direct Hew parameter slot, not caller-side neutralization, owns the value"
+    );
+}
+
+fn assert_exact_normal_edge_commit(
     function: &CheckedMirFunction,
     continuation: u32,
     owner: OwnerId,
     owner_place: Place,
+    flag: Place,
 ) {
-    let mut pending = vec![continuation];
-    let mut reachable = HashSet::new();
-    while let Some(block_id) = pending.pop() {
-        if !reachable.insert(block_id) {
-            continue;
-        }
-        let block = function
-            .blocks
-            .iter()
-            .find(|block| block.id == block_id)
-            .unwrap_or_else(|| panic!("reachable block bb{block_id} must exist"));
-        pending.extend(block.successors());
-    }
-
-    for block in function
+    let continuation_block = function
         .blocks
         .iter()
-        .filter(|block| reachable.contains(&block.id))
-    {
-        assert!(
-            block.instructions.iter().all(|instruction| !matches!(
-                instruction,
-                Instr::OwnershipEvent(OwnershipEvent::Release {
-                    owner: released,
-                    ..
-                }) if *released == owner
-            )),
-            "scope exit must not release the transferred owner in bb{}: {:#?}",
-            block.id,
-            block.instructions
-        );
-        assert!(
-            block.instructions.iter().all(|instruction| !matches!(
-                instruction,
-                Instr::Drop { place, .. } if *place == owner_place
-            )),
-            "scope exit must not drop the transferred owner slot in bb{}: {:#?}",
-            block.id,
-            block.instructions
-        );
-    }
+        .find(|block| block.id == continuation)
+        .expect("consuming call continuation must exist");
+    let exact_commits = continuation_block
+        .instructions
+        .windows(3)
+        .filter(|window| {
+            matches!(
+                window,
+                [
+                    Instr::ConstI64 { dest, value: 1 },
+                    Instr::NeutralizePayloadSlot {
+                        place,
+                        transferee: None,
+                        authority: NeutralizeAuthority::CallDischargeConsume,
+                    },
+                    Instr::OwnershipEvent(OwnershipEvent::Transfer {
+                        owner: transferred,
+                        from,
+                        to: None,
+                        to_owner: None,
+                        to_ty: None,
+                    }),
+                ] if *dest == flag
+                    && *place == owner_place
+                    && *transferred == owner
+                    && *from == owner_place
+            )
+        })
+        .count();
+    assert_eq!(
+        exact_commits, 1,
+        "the normal edge must contain exactly one guard/neutralize/transfer commit: {:#?}",
+        continuation_block.instructions
+    );
+}
+
+fn assert_unwind_retains_owner(
+    function: &CheckedMirFunction,
+    expected_callee: &str,
+    owner: OwnerId,
+    owner_place: Place,
+    flag: Place,
+) {
+    let unwind_drops = unwind_drops(function, expected_callee);
+    assert!(
+        unwind_drops.iter().any(|drop| {
+            drop.place == owner_place
+                && drop
+                    .guard
+                    .is_some_and(|guard| guard.owner == owner && guard.flag == flag)
+        }),
+        "the unwind edge must retain the exact guarded caller owner: {unwind_drops:#?}"
+    );
+}
+
+fn assert_unwind_excludes_owner(
+    function: &CheckedMirFunction,
+    expected_callee: &str,
+    owner: OwnerId,
+    owner_place: Place,
+) {
+    let unwind_drops = unwind_drops(function, expected_callee);
+    assert!(
+        unwind_drops.iter().all(|drop| {
+            drop.place != owner_place
+                && drop.guard.is_none_or(|guard| guard.owner != owner)
+        }),
+        "the caller transferred ownership before entry and must not drop it on unwind: {unwind_drops:#?}"
+    );
+}
+
+fn assert_callee_unwind_drops_param(
+    function: &CheckedMirFunction,
+    expected_callee: &str,
+    owner: OwnerId,
+    param_place: Place,
+    flag: Place,
+) {
+    let unwind_drops = unwind_drops(function, expected_callee);
+    assert!(
+        unwind_drops.iter().any(|drop| {
+            drop.place == param_place
+                && drop
+                    .guard
+                    .is_some_and(|guard| guard.owner == owner && guard.flag == flag)
+        }),
+        "the consuming callee must drop its exact guarded parameter on unwind: {unwind_drops:#?}"
+    );
 }
 
 fn lower_clean_to_checked_mir(source: &str) -> IrPipeline {
@@ -180,7 +395,7 @@ fn lower_clean_to_checked_mir(source: &str) -> IrPipeline {
 }
 
 #[test]
-fn consuming_owned_call_publishes_terminal_transfer_before_scope_exit() {
+fn declared_extern_consume_commits_only_on_normal_return() {
     let pipeline = lower_clean_to_checked_mir(CONSUMING_EXTERN_SOURCE);
     assert!(
         pipeline.diagnostics.is_empty(),
@@ -200,8 +415,106 @@ fn consuming_owned_call_publishes_terminal_transfer_before_scope_exit() {
     );
 
     let binding = named_binding(run, "conn");
-    let owner = guarded_owner(run, binding);
-    let continuation = consuming_call_continuation(run, "consume_conn");
-    let owner_place = terminal_transfer_source(run, owner);
-    assert_no_release_after(run, continuation, owner, owner_place);
+    let (owner, flag) = guarded_owner(run, binding);
+    let (call_block_id, owner_place, continuation) = consuming_call_edge(run, "consume_conn");
+    assert_call_block_retains_owner(run, call_block_id, binding, owner, flag);
+    assert_exact_normal_edge_commit(run, continuation, owner, owner_place, flag);
+    assert_unwind_retains_owner(run, "consume_conn", owner, owner_place, flag);
+}
+
+#[test]
+fn direct_hew_consume_transfers_before_invoke_and_callee_owns_unwind() {
+    let pipeline = lower_clean_to_checked_mir(CONSUMING_DIRECT_PANIC_SOURCE);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "direct consuming ownership must pass MIR validation: {:#?}",
+        pipeline.diagnostics
+    );
+
+    let run = pipeline
+        .checked_mir
+        .iter()
+        .find(|function| function.name == "run")
+        .expect("run must reach Checked MIR");
+    assert!(
+        run.checks.is_empty(),
+        "the direct consuming call must pass Checked-MIR ownership validation: {:#?}",
+        run.checks
+    );
+    let binding = named_binding(run, "conn");
+    let (transferred_owner, transfer_guard) = guarded_owner(run, binding);
+    let (call_block_id, owner_place, _) = consuming_call_edge(run, "consume_then_panic");
+    assert_call_block_transfers_owner(
+        run,
+        call_block_id,
+        binding,
+        transferred_owner,
+        owner_place,
+        transfer_guard,
+    );
+    assert_unwind_excludes_owner(run, "consume_then_panic", transferred_owner, owner_place);
+
+    let run_fresh = pipeline
+        .checked_mir
+        .iter()
+        .find(|function| function.name == "run_fresh")
+        .expect("fresh-value caller must reach Checked MIR");
+    assert!(
+        run_fresh.checks.is_empty(),
+        "the fresh consuming call must pass Checked-MIR ownership validation: {:#?}",
+        run_fresh.checks
+    );
+    let (fresh_call_block_id, fresh_owner_place, _) =
+        consuming_call_edge(run_fresh, "consume_then_panic");
+    let fresh_owner = owner_at_place(run_fresh, fresh_owner_place);
+    let fresh_call_block = run_fresh
+        .blocks
+        .iter()
+        .find(|block| block.id == fresh_call_block_id)
+        .expect("fresh consuming call block must exist");
+    assert_eq!(
+        fresh_call_block
+            .instructions
+            .iter()
+            .filter(|instruction| matches!(
+                instruction,
+                Instr::OwnershipEvent(OwnershipEvent::Transfer {
+                    owner,
+                    from,
+                    to: None,
+                    to_owner: None,
+                    to_ty: None,
+                }) if *owner == fresh_owner && *from == fresh_owner_place
+            ))
+            .count(),
+        1,
+        "a fresh direct consume must terminal-transfer its produced owner before invoke: {:#?}",
+        fresh_call_block.instructions
+    );
+    assert_unwind_excludes_owner(
+        run_fresh,
+        "consume_then_panic",
+        fresh_owner,
+        fresh_owner_place,
+    );
+
+    let callee = pipeline
+        .checked_mir
+        .iter()
+        .find(|function| function.name == "consume_then_panic")
+        .expect("consuming callee must reach Checked MIR");
+    assert!(
+        callee.checks.is_empty(),
+        "the consuming callee must pass Checked-MIR ownership validation: {:#?}",
+        callee.checks
+    );
+    let param_place = Place::Local(0);
+    let (param_owner, entry_drop_guard) = guarded_owner_at_place(callee, param_place);
+    assert_callee_unwind_drops_param(
+        callee,
+        "explode",
+        param_owner,
+        param_place,
+        entry_drop_guard,
+    );
 }

--- a/hew-mir/tests/lowering_expr/vertical.rs
+++ b/hew-mir/tests/lowering_expr/vertical.rs
@@ -745,11 +745,9 @@ fn checked_mir_rejects_second_resource_close() {
     );
 }
 
-/// Assert the Checked-MIR discharge protocol around a consuming call. The
-/// caller retains the guarded release authority on the unwind edge; only the
-/// successful continuation arms the guard, applies the call-kind's exact slot
-/// neutralization policy, and retires the owner. Normal call/return paths
-/// therefore carry no competing close.
+/// Assert the Checked-MIR discharge protocol around a consuming receiver. The
+/// caller retains its guarded owner on unwind; only a successful close commits
+/// the transfer and leaves no competing caller-side return cleanup.
 #[expect(
     clippy::too_many_lines,
     reason = "the test helper pins one complete Checked-MIR owner lifecycle and every exit edge"
@@ -758,7 +756,6 @@ fn assert_resource_call_discharge_paths_are_exact(
     pipeline: &hew_mir::IrPipeline,
     function_name: &str,
     callee_name: &str,
-    neutralizes_slot: bool,
 ) {
     let checked = pipeline
         .checked_mir
@@ -800,55 +797,32 @@ fn assert_resource_call_discharge_paths_are_exact(
         .iter()
         .find(|block| block.id == continuation)
         .expect("call continuation block present");
-    let exact_discharge = if neutralizes_slot {
-        continuation_block.instructions.windows(3).any(|window| {
-            matches!(
-                window,
-                [
-                    Instr::ConstI64 { dest, value: 1 },
-                    Instr::NeutralizePayloadSlot {
-                        place,
-                        transferee: None,
-                        authority: hew_mir::NeutralizeAuthority::CallDischargeConsume,
-                    },
-                    Instr::OwnershipEvent(hew_mir::OwnershipEvent::Transfer {
-                        owner: transfer_owner,
-                        from,
-                        to: None,
-                        to_owner: None,
-                        to_ty: None,
-                    }),
-                ] if *dest == flag
-                    && *place == argument
-                    && *transfer_owner == owner
-                    && *from == argument
-            )
-        })
-    } else {
-        continuation_block.instructions.windows(2).any(|window| {
-            matches!(
-                window,
-                [
-                    Instr::ConstI64 { dest, value: 1 },
-                    Instr::OwnershipEvent(hew_mir::OwnershipEvent::Transfer {
-                        owner: transfer_owner,
-                        from,
-                        to: None,
-                        to_owner: None,
-                        to_ty: None,
-                    }),
-                ] if *dest == flag && *transfer_owner == owner && *from == argument
-            )
-        }) && continuation_block.instructions.iter().all(|instruction| {
-            !matches!(
-                instruction,
-                Instr::NeutralizePayloadSlot { place, .. } if *place == argument
-            )
-        })
-    };
+    let exact_discharge = continuation_block.instructions.windows(3).any(|window| {
+        matches!(
+            window,
+            [
+                Instr::ConstI64 { dest, value: 1 },
+                Instr::NeutralizePayloadSlot {
+                    place,
+                    transferee: None,
+                    authority: hew_mir::NeutralizeAuthority::CallDischargeConsume,
+                },
+                Instr::OwnershipEvent(hew_mir::OwnershipEvent::Transfer {
+                    owner: transfer_owner,
+                    from,
+                    to: None,
+                    to_owner: None,
+                    to_ty: None,
+                }),
+            ] if *dest == flag
+                && *place == argument
+                && *transfer_owner == owner
+                && *from == argument
+        )
+    });
     assert!(
         exact_discharge,
-        "only the successful continuation may discharge the caller owner: {:?}",
+        "only the successful continuation may discharge the receiver owner: {:?}",
         continuation_block.instructions
     );
 
@@ -934,7 +908,7 @@ fn explicit_resource_close_suppresses_scope_exit_drop() {
         "a single explicit close must type-check cleanly: {:?}",
         p.diagnostics
     );
-    assert_resource_call_discharge_paths_are_exact(&p, "serve", "Conn::close", true);
+    assert_resource_call_discharge_paths_are_exact(&p, "serve", "Conn::close");
 }
 
 /// A `#[resource]` value that is NEVER explicitly closed keeps its scope-exit
@@ -1281,26 +1255,6 @@ fn direct_string_resource_move_has_only_resource_flag_authority() {
     );
 }
 
-/// Duplicate source-shape control for the release-flag protocol: even an
-/// unconditional close keeps unwind cleanup until the call succeeds. The
-/// continuation then performs the exact discharge and leaves no return drop.
-#[test]
-fn unconditional_resource_close_emits_no_scope_exit_drop() {
-    let p = lower_source(
-        r"
-        #[resource]
-        type Conn { id: i64 }
-        impl Conn { fn close(self) { } }
-        fn serve() {
-            let c = Conn { id: 1 };
-            c.close();
-        }
-    ",
-    );
-    assert!(p.diagnostics.is_empty(), "{:?}", p.diagnostics);
-    assert_resource_call_discharge_paths_are_exact(&p, "serve", "Conn::close", true);
-}
-
 /// A never-closed `#[resource]` earns its implicit scope-exit close, and that
 /// close is FLAG-GUARDED too — the same exactly-once machinery the
 /// conditional case rides, so a never-closed resource on a `MaybeConsumed`
@@ -1345,37 +1299,6 @@ fn never_closed_resource_keeps_flag_guarded_scope_exit_drop() {
          must carry a path-sensitive drop-flag guard: {:?}",
         serve.drop_plans
     );
-}
-
-/// #1941 — a `#[resource]` moved BY VALUE into an ordinary free function is an
-/// ownership transfer into the callee (Hew has no by-reference parameters):
-/// the callee owns and closes it after the call succeeds, so the caller's
-/// binding transitions to `Consumed` and earns no normal scope-exit close.
-/// Until that success edge, the unwind plan retains the caller's guarded
-/// cleanup. Before the fix the argument
-/// lowered `IntentKind::Read`, the caller stayed `Live`, and the caller's
-/// implicit drop double-closed what the callee already closed.
-#[test]
-fn value_move_into_free_fn_consumes_caller_binding() {
-    let p = lower_source(
-        r"
-        #[resource]
-        type Conn { id: i64 }
-        impl Conn { fn close(self) { } }
-        fn sink(c: Conn) { c.close(); }
-        fn run() {
-            let c = Conn { id: 1 };
-            sink(c);
-        }
-    ",
-    );
-    assert!(
-        p.diagnostics.is_empty(),
-        "a clean by-value move of a resource into a consumer must type-check: \
-         {:?}",
-        p.diagnostics
-    );
-    assert_resource_call_discharge_paths_are_exact(&p, "run", "sink", false);
 }
 
 /// #1941 negative — reading a `#[resource]` after moving it by value into a


### PR DESCRIPTION
## Summary

- distinguish direct Hew, declared-extern, and catalogued runtime consuming-call ownership contracts
- transfer direct Hew consume arguments before invoke so the callee owns normal and unwind cleanup from entry, including fresh rvalues and projected resource fields
- retain declared extern and runtime collection consume owners in the caller through invoke, then commit their guard, physical neutralization, and terminal transfer only on the normal successor
- keep fluent receivers on their existing discharge lineage and consuming parameters out of the separate owned-carrier protocol
- prevent stale/double cleanup across JSON, TOML, YAML, channel, and runtime collection resource handoffs

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- all-target Clippy with `-D warnings` for `hew-mir`, `hew-codegen-rs`, and `hew-cli`
- direct/extern Checked-MIR ownership suite (2/2), including fresh-owner transfer and unwind exclusion
- resource projection transfer, reusable-closure rejection, associated/static parameter-zero, runtime collection exactly-once, and post-transfer reuse oracles
- affine resource carrier boundary suite (9 passed, 1 macOS-only ignored)
- native TOML fresh/fluent resource fixture (exit 0, output `8`)
- TOML and JSON WASI execution regressions
- focused resource-close vertical suite (8/8) and direct-consume negative regression (1/1)

The exact `generator_in_local_tuple_not_extracted_keeps_source_drop` double-free remains red, but it is already identified by test ID and signature in the measured `main` baseline under generator extraction/reaggregation authority. It is not introduced by this branch.
