### PR TITLE
fix(types): narrow needless range loop lint span

### DIFF
--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -54,6 +54,36 @@ fn run_check(source: &str, extra_args: &[&str]) -> Output {
         .expect("failed to spawn hew check")
 }
 
+/// Run `hew check` on a program importing a directory module assembled from
+/// `journal.hew` and `recovery.hew`. Only the peer file contains a lint.
+fn run_directory_module_check() -> Output {
+    let dir = tempdir();
+    let journal_dir = dir.path().join("journal");
+    std::fs::create_dir(&journal_dir).unwrap();
+    std::fs::write(
+        dir.path().join("main.hew"),
+        "import journal;\n\nfn main() {}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        journal_dir.join("journal.hew"),
+        "pub fn open() {\n    println(\"journal primary\");\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        journal_dir.join("recovery.hew"),
+        "pub fn recover() {\n    let names: Vec<string> = Vec.new();\n    for i in 0..names.len() {\n        let _ = names[i];\n    }\n}\n",
+    )
+    .unwrap();
+
+    Command::new(hew_binary())
+        .arg("check")
+        .arg(dir.path().join("main.hew"))
+        .current_dir(repo_root())
+        .output()
+        .expect("failed to spawn hew check")
+}
+
 fn stderr_of(output: &Output) -> String {
     strip_ansi(&String::from_utf8_lossy(&output.stderr))
 }
@@ -90,6 +120,26 @@ fn needless_range_loop_warning_points_at_loop_header() {
     assert!(
         !stderr.contains("unrelated after loop"),
         "the warning must not point at the following statement:\n{stderr}"
+    );
+}
+
+#[test]
+fn directory_module_lint_points_at_peer_file() {
+    let output = run_directory_module_check();
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "a lint warning must not fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("recovery.hew:3:9:")
+            && stderr.contains("3 |     for i in 0..names.len() {")
+            && stderr.contains("the loop variable `i` is only used to index `names`"),
+        "the lint must render against the peer file that owns its span:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("journal.hew:") && !stderr.contains("journal primary"),
+        "the primary module file is a negative control for attribution:\n{stderr}"
     );
 }
 

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -21,6 +21,11 @@ const NEEDLESS: &str = "fn main() {\n\
      }\n\
      }\n";
 
+/// A needless range loop followed by another statement. The later statement
+/// is a negative control for the diagnostic span: it must not be rendered as
+/// the source of the loop warning.
+const NEEDLESS_FOLLOWED_BY_STATEMENT: &str = "fn main() {\n    let xs: Vec<i64> = Vec.new();\n    for i in 0..xs.len() {\n        let _ = xs[i];\n    }\n    println(\"unrelated after loop\");\n}\n";
+
 /// The same program with an in-source allow directive on the line above.
 const NEEDLESS_SUPPRESSED: &str = "fn main() {\n\
      let xs: Vec<i64> = Vec.new();\n\
@@ -64,6 +69,27 @@ fn lint_warning_renders_by_default() {
     assert!(
         stderr.contains("warning:") && stderr.contains(LINT_MESSAGE),
         "expected the needless_range_loop warning to render:\n{stderr}"
+    );
+}
+
+#[test]
+fn needless_range_loop_warning_points_at_loop_header() {
+    let output = run_check(NEEDLESS_FOLLOWED_BY_STATEMENT, &[]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "a lint warning must not fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("prog.hew:3:9:")
+            && stderr.contains("3 |     for i in 0..xs.len() {")
+            && stderr.contains("|         ^^^^^^^^^^^^^^^^^\n")
+            && stderr.contains(LINT_MESSAGE),
+        "the needless_range_loop warning must point at the loop header:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("unrelated after loop"),
+        "the warning must not point at the following statement:\n{stderr}"
     );
 }
 

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -257,15 +257,16 @@ impl Default for LintLevels {
     }
 }
 
-/// Per-compilation source text, keyed by module, for in-source suppression.
+/// Per-compilation source text, keyed by diagnostic routing identity, for
+/// in-source suppression.
 ///
 /// The checker only carries byte-offset [`Span`]s, not source text, so the
 /// front end hands it the program's source(s) through
 /// [`super::Checker::set_lint_sources`] before [`super::Checker::check_program`].
 /// A lint then resolves the `// hew:allow(...)` directive on (or above) the line
 /// of its finding's span. `root` is the entry source the user compiled;
-/// `modules` maps a non-root module's dotted name (the same key
-/// [`LintCtx::source_module`] carries) to that module's source.
+/// `modules` maps a non-root module's dotted name, or an assembled peer file's
+/// path token, to that source (the same key [`LintCtx::source_module`] carries).
 #[derive(Debug, Clone, Default)]
 pub struct LintSources {
     root: Option<String>,
@@ -284,9 +285,9 @@ impl LintSources {
         self.root = Some(source);
     }
 
-    /// Install a non-root module's source, keyed by its dotted module name
-    /// (e.g. `"std.net.http"`), matching the `source_module` tag the lint
-    /// sweep stamps onto that module's diagnostics.
+    /// Install a non-root source, keyed by its dotted module name (e.g.
+    /// `"std.net.http"`) or assembled peer-file path, matching the
+    /// `source_module` tag the lint sweep stamps onto its diagnostics.
     pub fn set_module(&mut self, module: String, source: String) {
         self.modules.insert(module, source);
     }

--- a/hew-types/src/check/lints/needless_range_loop.rs
+++ b/hew-types/src/check/lints/needless_range_loop.rs
@@ -50,8 +50,8 @@ pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut 
 // ── candidate discovery ──────────────────────────────────────────────
 
 fn find_in_block(ctx: &LintCtx, levels: &LintLevels, block: &Block, out: &mut Vec<TypeError>) {
-    for (stmt, span) in &block.stmts {
-        find_in_stmt(ctx, levels, stmt, span, out);
+    for (stmt, _) in &block.stmts {
+        find_in_stmt(ctx, levels, stmt, out);
     }
     if let Some(trailing) = &block.trailing_expr {
         find_in_expr(ctx, levels, &trailing.0, out);
@@ -62,13 +62,7 @@ fn find_in_block(ctx: &LintCtx, levels: &LintLevels, block: &Block, out: &mut Ve
     clippy::too_many_lines,
     reason = "statement visitor enumerates every block-bearing stmt shape"
 )]
-fn find_in_stmt(
-    ctx: &LintCtx,
-    levels: &LintLevels,
-    stmt: &Stmt,
-    span: &hew_parser::ast::Span,
-    out: &mut Vec<TypeError>,
-) {
+fn find_in_stmt(ctx: &LintCtx, levels: &LintLevels, stmt: &Stmt, out: &mut Vec<TypeError>) {
     match stmt {
         Stmt::For {
             is_await,
@@ -78,7 +72,7 @@ fn find_in_stmt(
             ..
         } => {
             // Test this loop, then descend so nested range loops are found too.
-            try_flag(ctx, levels, *is_await, pattern, iterable, body, span, out);
+            try_flag(ctx, levels, *is_await, pattern, iterable, body, out);
             find_in_expr(ctx, levels, &iterable.0, out);
             find_in_block(ctx, levels, body, out);
         }
@@ -154,7 +148,7 @@ fn find_in_else(
     out: &mut Vec<TypeError>,
 ) {
     if let Some(if_stmt) = &else_block.if_stmt {
-        find_in_stmt(ctx, levels, &if_stmt.0, &if_stmt.1, out);
+        find_in_stmt(ctx, levels, &if_stmt.0, out);
     }
     if let Some(block) = &else_block.block {
         find_in_block(ctx, levels, block, out);
@@ -245,7 +239,6 @@ fn find_in_expr(ctx: &LintCtx, levels: &LintLevels, expr: &Expr, out: &mut Vec<T
 
 /// If this `for` loop is `for i in 0 .. coll.len()` over a lintable collection
 /// `coll`, run the precision scan and emit when the rewrite is valid.
-#[allow(clippy::too_many_arguments, reason = "destructured `Stmt::For` fields")]
 fn try_flag(
     ctx: &LintCtx,
     levels: &LintLevels,
@@ -253,7 +246,6 @@ fn try_flag(
     pattern: &Spanned<Pattern>,
     iterable: &Spanned<Expr>,
     body: &Block,
-    for_span: &hew_parser::ast::Span,
     out: &mut Vec<TypeError>,
 ) {
     if is_await {
@@ -319,7 +311,7 @@ fn try_flag(
     ctx.emit(
         levels,
         LintId::NeedlessRangeLoop,
-        for_span,
+        &(pattern.1.start..iterable.1.end),
         format!("the loop variable `{idx}` is only used to index `{coll}`"),
         format!("iterate the collection directly: `for {elem} in {coll} {{ … }}`"),
         out,

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -1913,11 +1913,11 @@ impl Checker {
     /// Run the semantic lint sweep over every function/method body in the
     /// program and collect findings into `out`.
     ///
-    /// Read-only over checker state (`&self`): it scans each module's raw source
+    /// Read-only over checker state (`&self`): it scans each source file
     /// once, walks each item's bodies, builds a [`lints::LintCtx`] carrying the
-    /// resolved-type facts, and tags each finding with the right `module_idx` /
-    /// `source_module`. The module
-    /// walk mirrors `classify_closure_escapes` and the body-check loop in
+    /// resolved-type facts, and tags each finding with the right per-file
+    /// `module_idx` / `source_module`. The module walk mirrors
+    /// `classify_closure_escapes` and the body-check loop in
     /// [`Checker::check_program`] (root items at index 0, then each non-root
     /// module in topo order at a 1-based index, with the same dotted module
     /// name `record_type` stamped onto its spans) so [`SpanKey`] lookups hit
@@ -1970,15 +1970,34 @@ impl Checker {
                     .as_ref()
                     .and_then(|indices| indices.module_base(mod_id))
                     .unwrap_or_default();
-                if let Some(source) = self.lint_sources.source_for(Some(&module_name)) {
-                    self.lint_source(source, module_base, Some(&module_name), levels, out);
+                for (source_idx, source_path) in module.source_paths.iter().enumerate() {
+                    let source_module = if source_idx == 0 {
+                        module_name.clone()
+                    } else {
+                        source_path.display().to_string()
+                    };
+                    let module_idx = span_indices
+                        .as_ref()
+                        .and_then(|indices| indices.path_index(source_path))
+                        .unwrap_or(module_base);
+                    if let Some(source) = self.lint_sources.source_for(Some(&source_module)) {
+                        self.lint_source(source, module_idx, Some(&source_module), levels, out);
+                    }
                 }
                 for (item_idx, (item, _)) in module.items.iter().enumerate() {
                     let module_idx = span_indices
                         .as_ref()
                         .and_then(|indices| indices.item_index(mod_id, item_idx))
                         .unwrap_or(module_base);
-                    self.lint_item(item, module_idx, Some(&module_name), levels, out);
+                    let item_source = program
+                        .module_graph
+                        .as_ref()
+                        .and_then(|mg| mg.item_source(mod_id, item_idx))
+                        .or_else(|| module.source_paths.first());
+                    let source_module = self
+                        .item_file_routing_token(Some(&module_name), item_source)
+                        .unwrap_or_else(|| module_name.clone());
+                    self.lint_item(item, module_idx, Some(&source_module), levels, out);
                 }
             }
         }


### PR DESCRIPTION
## Why

`needless_range_loop` diagnostics had two independent accuracy problems. The warning reused a whole-statement span even though it describes only the loop header, and lint diagnostics from a peer file in a directory-assembled module lost that file identity and rendered against the module's first source file.

## What

Build the lint span from the loop binding through the iterable expression so unrelated body and following statements are excluded. During the post-typecheck lint sweep, resolve every item and raw-source scan through the module graph's per-file source table and span-index namespace, then carry that source routing token on the diagnostic. Add end-to-end negative controls for both a following statement and a lint-free primary module file.

## Test

The CLI lint end-to-end suite covers the narrowed header and verifies that a loop in `recovery.hew` renders with that file's path, line, and source while excluding `journal.hew`. The `hew-types` lint-focused suite passes, formatting is clean, and workspace clippy passes with warnings denied.
