### PR TITLE
docs(guide): document silent reference-cycle leaks

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -977,6 +977,14 @@ is no `Weak.new()`; construction starts with `Option<Weak<T>>.None`, then uses
 `downgrade()` and `set()`. Strong `Rc` cycles leak. `Rc.new_cyclic`, direct
 deref/borrow access to the payload, and cross-actor transfer are not supported.
 
+> **Reference cycles leak silently.** Hew reclaims shared storage with reference
+> counts and has no cycle collector. A stored self-referential structure leaks
+> when a field owns a strong reference back to its own refcounted container:
+> every count in the cycle stays above zero after the outside owners disappear.
+> Hew emits no diagnostic and no runtime warning for this leak. Use `Weak<T>`
+> for local graph back-edges, as above, or redesign the structure as a tree or
+> DAG.
+
 ### Struct value param and returning a struct
 
 ```hew
@@ -1463,6 +1471,22 @@ fn main() {
 ```
 
 Spawn the dependency first, pass its `LocalPid<Dep>` into the dependent actor's spawn, store it in a field, and `await dep.method(...)` from a handler. Awaiting another actor yields `Result<R, AskError>` like any ask.
+
+### Avoid reference cycles in actor state
+
+Hew has no cycle collector and no weak reference for sendable strong handles.
+If one actor's state owns a strong handle to a second actor and the second
+actor's state owns a strong handle back, dropping every outside handle leaves
+both reference counts above zero. Both actors and every value reachable from
+their state then leak.
+
+The leak is silent: there is no compiler diagnostic and no runtime warning.
+Break the ownership cycle by storing a stable actor id and looking up a strong
+handle only when it is needed. For named local actors, store the non-owning
+`LocalPid<T>` shown above instead of a strong handle. Keep ownership flowing in
+one direction when neither form is available.
+
+Cycle collection is post-0.6.0 work (ORCA-style collection is the candidate).
 
 ### Timers and scheduling — sleep and sleep_until
 

--- a/docs/v05/ownership.md
+++ b/docs/v05/ownership.md
@@ -20,7 +20,7 @@ let b = perimeter(p);   // borrow again — legal, no clone needed
 println(p.describe());  // value-receiver chain — still legal
 ```
 
-Reaching for a second *independent, divergent* copy is a `clone`: `clone val`
+Reaching for a second _independent, divergent_ copy is a `clone`: `clone val`
 (prefix form, the natural spelling) or `val.clone()` (method form) — see below.
 `clone` is a cost operation, not an ownership keyword: you never need it to keep
 using a value after passing or sending it somewhere. Copy-on-write already keeps
@@ -31,7 +31,7 @@ your binding valid.
 The user-facing promise is simple: **you never free, annotate, or move — the
 compiler balances the books.**
 
-Under the hood, every live heap value carries exactly one *drop obligation*.
+Under the hood, every live heap value carries exactly one _drop obligation_.
 Creating a value — or retaining a share of one — mints an obligation; scope
 exit, consumption, or hand-off discharges it, recursively through everything the
 value owns. Sharing a value (reading a field out of a live composite, reading a
@@ -70,7 +70,7 @@ order:
 ## `clone x` — the eager-copy cost operation
 
 `clone` is not an ownership keyword. It is a stdlib **cost operation** that means
-"make an independent, eager copy of this value *now*" — the opposite of
+"make an independent, eager copy of this value _now_" — the opposite of
 copy-on-write's lazy, on-demand fork. `clone x` (prefix form, the natural and
 primary spelling) and `x.clone()` (method form) are equivalent:
 
@@ -155,7 +155,7 @@ model.
 ship after the first release: a `resource type` — a file, a socket, a unique
 handle — is never clonable, never implicitly shared, has a deterministic
 exactly-once destructor, and moves on send (the sender is invalidated, because a
-unique resource genuinely cannot exist in two places). That is the *one* place a
+unique resource genuinely cannot exist in two places). That is the _one_ place a
 surface move will ever return.
 
 At rc1 the feature is not yet user-visible; only the **seam** is reserved:
@@ -177,11 +177,11 @@ The entire ownership model rejects your program in exactly **three** places. Eac
 wall names the binding, its state, and the span that put it there, and each ships
 a one-line escape:
 
-| Wall | When it fires | Escape |
-|---|---|---|
-| mutation of a `let` | you mutate a value bound with `let` | declare it `var` |
-| clone of a non-cloneable | you `clone` a value with no copy path | restructure now; the `resource` lifecycle later |
-| send of a non-sendable | you send a resource-shaped value | use the owning-actor pattern; lifts when `resource` transfer ships |
+| Wall                     | When it fires                         | Escape                                                             |
+| ------------------------ | ------------------------------------- | ------------------------------------------------------------------ |
+| mutation of a `let`      | you mutate a value bound with `let`   | declare it `var`                                                   |
+| clone of a non-cloneable | you `clone` a value with no copy path | restructure now; the `resource` lifecycle later                    |
+| send of a non-sendable   | you send a resource-shaped value      | use the owning-actor pattern; lifts when `resource` transfer ships |
 
 There is no fourth wall. Use-after-send of a value is **not** an error (send takes
 a snapshot); use-after-call is **not** an error (calls borrow). The model has no
@@ -202,13 +202,11 @@ compare equal. This invariant holds even after COW splits a shared buffer.
 
 ## Reference cycles (Q321)
 
-Hew uses atomic reference counting without a cycle collector. Constructing
-reference cycles through actor state or stored self-referential structures will
-cause the involved values to leak (neither the cycle collector nor weak
-references exist yet).
-
-**Guideline:** design data structures as DAGs (trees, acyclic graphs). Cycles are a
-documented limitation for v0.5; future work will evaluate ORCA-style cycle collection.
+Hew reclaims shared storage by reference counting and has no cycle collector:
+a strong reference cycle through actor state or a stored self-referential
+structure leaks silently. Design data as trees or DAGs; see
+[Avoid reference cycles in actor state](../hew-language-guide.md#avoid-reference-cycles-in-actor-state)
+for the guidance and the cycle-collection status.
 
 ## Remaining work
 


### PR DESCRIPTION
## Why

Reference-count cycles can silently retain actor state and stored structures,
but the limitation is easy to miss where users learn those shapes.

## What

The language guide now calls out the actor-to-actor and self-referential
structure shapes that leak, states that no diagnostic or runtime warning is
emitted, and explains how to break cycles with `Weak`, `LocalPid`, stable-id
lookup, or acyclic ownership. The ownership contract links to that guidance
instead of duplicating it.

## Test

Rendered both changed Markdown files with Pandoc and checked the new callout,
heading, cross-reference, and the existing multi-line blockquotes around
`default { state }` and generic function values. Checked that the guide diff
contains only the two intended additive hunks and no removed `> ` continuation
lines. `make lint` reaches the documentation-aware gates but is blocked by the
unchanged `hew-fmt-check` baseline, which reports existing formatting drift in
eleven example programs.
