### PR TITLE
fix(lsp): round-trip paths through file URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "tower-lsp-server",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/hew-lsp/Cargo.toml
+++ b/hew-lsp/Cargo.toml
@@ -24,6 +24,7 @@ tower-lsp-server = "0.21.1"
 tokio = { version = "1", features = ["full"] }
 serde_json.workspace = true
 dashmap = "6.2.1"
+url = "2"
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -14,8 +14,8 @@ use tower_lsp_server::lsp_types::{
     Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, Location,
     NumberOrString, Uri as Url,
 };
-use tower_lsp_server::UriExt;
 
+use super::uri::FileUriExt;
 #[cfg(test)]
 use super::UriParse;
 use super::{DiagnosticMap, DiagnosticSource, DocumentState};

--- a/hew-lsp/src/server/handlers/text_sync.rs
+++ b/hew-lsp/src/server/handlers/text_sync.rs
@@ -6,8 +6,8 @@ use tower_lsp_server::lsp_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     InitializeParams, InitializeResult, MessageType, ServerCapabilities,
 };
-use tower_lsp_server::UriExt;
 
+use super::super::uri::FileUriExt;
 use super::super::{
     build_server_capabilities, close_document_and_dependents, normalize_workspace_root,
     HewLanguageServer,

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -5,6 +5,7 @@ mod convert;
 mod handlers;
 mod hierarchy;
 mod navigation;
+mod uri;
 mod workspace;
 
 #[cfg(test)]
@@ -32,6 +33,7 @@ use self::navigation::{
     collect_import_items, find_cross_file_definition, find_definition_in_ast,
     find_stdlib_definition, plan_workspace_rename,
 };
+use self::uri::FileUriExt;
 #[cfg(test)]
 use self::workspace::collect_workspace_symbols;
 use self::workspace::{build_code_lenses, collect_project_workspace_symbols};
@@ -105,7 +107,6 @@ use tower_lsp_server::lsp_types::{
     TypeHierarchyItem, TypeHierarchyPrepareParams, TypeHierarchySubtypesParams,
     TypeHierarchySupertypesParams,
 };
-use tower_lsp_server::UriExt;
 use tower_lsp_server::{Client, LanguageServer};
 
 // ── Semantic token types ─────────────────────────────────────────────
@@ -3442,15 +3443,27 @@ machine Traffic {
         }
     }
 
-    /// Returns a `file://` URI for `posix_path` that is valid on the current
-    /// platform.  On Windows, `file:///project/foo` lacks a drive letter and
-    /// `Url::to_file_path()` returns `Err`; prefixing with `C:` makes it a
-    /// well-formed Windows file URI while leaving Unix paths unchanged.
+    /// Returns a file URI for `posix_path` that is valid on the current
+    /// platform. On Windows, the POSIX-shaped fixture path is placed on `C:`
+    /// before the platform-aware path conversion.
     fn make_test_uri(posix_path: &str) -> Url {
         #[cfg(windows)]
-        return Url::parse(&format!("file:///C:{posix_path}")).unwrap();
+        let path = PathBuf::from(format!("C:{posix_path}"));
         #[cfg(not(windows))]
-        return Url::parse(&format!("file://{posix_path}")).unwrap();
+        let path = PathBuf::from(posix_path);
+        Url::from_file_path(path).expect("test path should be an absolute file path")
+    }
+
+    #[test]
+    fn absolute_paths_round_trip_through_file_uris() {
+        for path in ["/project/plain.hew", "/project/naïve source.hew"] {
+            let uri = make_test_uri(path);
+            #[cfg(windows)]
+            let expected = PathBuf::from(format!("C:{path}"));
+            #[cfg(not(windows))]
+            let expected = PathBuf::from(path);
+            assert_eq!(uri.to_file_path().as_deref(), Some(expected.as_path()));
+        }
     }
 
     fn has_unresolved_import(documents: &DashMap<Url, DocumentState>, uri: &Url) -> bool {

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -7,11 +7,9 @@ use hew_parser::ParseResult;
 use tower_lsp_server::lsp_types::{
     DocumentLink, Location, PrepareRenameResponse, Range, TextEdit, Uri as Url, WorkspaceEdit,
 };
-use tower_lsp_server::UriExt;
 
+use super::uri::FileUriExt;
 use super::workspace::find_workspace_root_for_uri;
-#[cfg(test)]
-use super::UriParse;
 use super::{offset_range_to_lsp, span_to_range, DocumentState};
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -1682,9 +1680,10 @@ mod tests {
 
     fn make_test_uri(posix_path: &str) -> Url {
         #[cfg(windows)]
-        return Url::parse(&format!("file:///C:{posix_path}")).unwrap();
+        let path = std::path::PathBuf::from(format!("C:{posix_path}"));
         #[cfg(not(windows))]
-        return Url::parse(&format!("file://{posix_path}")).unwrap();
+        let path = std::path::PathBuf::from(posix_path);
+        Url::from_file_path(path).expect("test path should be an absolute file path")
     }
 
     fn first_named_import_match(

--- a/hew-lsp/src/server/uri.rs
+++ b/hew-lsp/src/server/uri.rs
@@ -1,0 +1,63 @@
+use std::borrow::Cow;
+use std::path::Path;
+use std::str::FromStr;
+
+use tower_lsp_server::lsp_types::Uri;
+
+/// Converts between LSP URIs and filesystem paths without interpolating paths
+/// into URI strings. Conversion remains fallible for paths or URIs that cannot
+/// be represented on the current platform.
+pub(super) trait FileUriExt: Sized {
+    fn from_file_path(path: impl AsRef<Path>) -> Option<Self>;
+
+    fn to_file_path(&self) -> Option<Cow<'_, Path>>;
+}
+
+impl FileUriExt for Uri {
+    fn from_file_path(path: impl AsRef<Path>) -> Option<Self> {
+        let file_url = url::Url::from_file_path(path).ok()?;
+        Self::from_str(file_url.as_str()).ok()
+    }
+
+    fn to_file_path(&self) -> Option<Cow<'_, Path>> {
+        let file_url = url::Url::parse(self.as_str()).ok()?;
+        if file_url.scheme() != "file" {
+            return None;
+        }
+        file_url.to_file_path().ok().map(Cow::Owned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn absolute_paths_round_trip_with_uri_encoding() {
+        let plain_path = std::env::temp_dir().join("hew-lsp-uri.hew");
+        let encoded_path = std::env::temp_dir().join("naïve Hew source.hew");
+
+        for path in [&plain_path, &encoded_path] {
+            let uri = Uri::from_file_path(path).expect("absolute path should become a file URI");
+            assert_eq!(uri.to_file_path().as_deref(), Some(path.as_path()));
+        }
+
+        let encoded_uri = Uri::from_file_path(&encoded_path).expect("absolute path should convert");
+        assert!(encoded_uri.as_str().contains("%20"));
+        assert!(Uri::from_file_path(PathBuf::from("relative.hew")).is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_drive_and_unc_paths_round_trip() {
+        for path in [
+            PathBuf::from(r"C:\Hew source\naïve.hew"),
+            PathBuf::from(r"\\server\Hew share\naïve.hew"),
+        ] {
+            let uri = Uri::from_file_path(&path).expect("absolute Windows path should convert");
+            assert_eq!(uri.to_file_path().as_deref(), Some(path.as_path()));
+        }
+    }
+}

--- a/hew-lsp/src/server/workspace.rs
+++ b/hew-lsp/src/server/workspace.rs
@@ -8,10 +8,10 @@ use hew_analysis::{util::compute_line_offsets, SymbolInfo};
 use hew_parser::ast::{Attribute, Item};
 use hew_parser::ParseResult;
 use tower_lsp_server::lsp_types::{CodeLens, Command, Location, SymbolInformation, Uri as Url};
-use tower_lsp_server::UriExt;
 
 use super::analysis::source_for_path;
 use super::convert::analysis_symbol_kind_to_lsp;
+use super::uri::FileUriExt;
 use super::{offset_range_to_lsp, span_to_range, DocumentState};
 
 // ── Code lens helpers ───────────────────────────────────────────────


### PR DESCRIPTION
## Why

When a workspace path contained a space or other URI-sensitive characters, hew-lsp interpolated the raw path into a `file://` string. The resulting invalid LSP URI could panic test helpers and caused production workspace scans, import navigation, and rename planning to omit unopened files.

## What

LSP file URI conversion now goes through a platform-aware path-to-URL implementation before constructing `lsp_types::Uri`, so path components are percent-encoded and conversion failures remain fallible. All server path conversion sites use the same implementation, including Windows drive and UNC path handling.

## Test

`absolute_paths_round_trip_through_file_uris`, `absolute_paths_round_trip_with_uri_encoding`, `windows_drive_and_unc_paths_round_trip`, `coverage_scanner_surface`, `plan_workspace_rename_disk_scan_skips_symlinked_directory`, and `importer_originated_rename_includes_unopened_definition_file_edits`.
