### PR TITLE
fix(parser): reject ownership markers on tuple types

### DIFF
--- a/hew-parser/src/parser/items.rs
+++ b/hew-parser/src/parser/items.rs
@@ -327,11 +327,8 @@ impl Parser<'_> {
         let supports_resource_marker = match self.peek_at(target_pos) {
             Some(Token::Enum | Token::Indirect) => true,
             Some(Token::Type) => {
-                !self
-                    .tokens
-                    .get(target_pos + 1)
-                    .is_some_and(|(token, _)| Self::is_ident_token(token))
-                    || !matches!(self.tokens.get(target_pos + 2), Some((Token::Equal, _)))
+                !self.is_type_alias_lookahead_at(target_pos)
+                    && !self.is_tuple_type_lookahead_at(target_pos)
             }
             _ => false,
         };
@@ -760,24 +757,28 @@ impl Parser<'_> {
     }
 
     pub(crate) fn is_type_alias_lookahead(&self) -> bool {
+        self.is_type_alias_lookahead_at(self.pos)
+    }
+
+    fn is_type_alias_lookahead_at(&self, start: usize) -> bool {
         // Check for `type Name =` or `type Name<...> =` (Name can be a
         // contextual keyword). A body declaration starts with `{` instead.
-        if !matches!(self.tokens.get(self.pos), Some((Token::Type, _)))
+        if !matches!(self.tokens.get(start), Some((Token::Type, _)))
             || !self
                 .tokens
-                .get(self.pos + 1)
+                .get(start + 1)
                 .is_some_and(|(tok, _)| Self::is_ident_token(tok))
         {
             return false;
         }
-        if matches!(self.tokens.get(self.pos + 2), Some((Token::Equal, _))) {
+        if matches!(self.tokens.get(start + 2), Some((Token::Equal, _))) {
             return true;
         }
-        if !matches!(self.tokens.get(self.pos + 2), Some((Token::Less, _))) {
+        if !matches!(self.tokens.get(start + 2), Some((Token::Less, _))) {
             return false;
         }
         let mut depth = 0usize;
-        for (index, (token, _)) in self.tokens.iter().enumerate().skip(self.pos + 2) {
+        for (index, (token, _)) in self.tokens.iter().enumerate().skip(start + 2) {
             match token {
                 Token::Less => depth += 1,
                 Token::Greater => depth = depth.saturating_sub(1),
@@ -793,15 +794,19 @@ impl Parser<'_> {
 
     /// Check for `type Name(...)` (including generic names) without consuming.
     pub(crate) fn is_tuple_type_lookahead(&self) -> bool {
-        if !matches!(self.tokens.get(self.pos), Some((Token::Type, _)))
+        self.is_tuple_type_lookahead_at(self.pos)
+    }
+
+    fn is_tuple_type_lookahead_at(&self, start: usize) -> bool {
+        if !matches!(self.tokens.get(start), Some((Token::Type, _)))
             || !self
                 .tokens
-                .get(self.pos + 1)
+                .get(start + 1)
                 .is_some_and(|(tok, _)| Self::is_ident_token(tok))
         {
             return false;
         }
-        let mut index = self.pos + 2;
+        let mut index = start + 2;
         if matches!(self.tokens.get(index), Some((Token::Less, _))) {
             let mut depth = 0usize;
             while let Some((token, _)) = self.tokens.get(index) {

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -3748,11 +3748,53 @@ fn unmarked_type_has_no_resource_marker() {
 }
 
 #[test]
+fn resource_marker_rejects_tuple_type_without_affecting_supported_targets() {
+    let unsupported_source = "#[resource]\ntype Pair(i64);";
+    let unsupported = parse(unsupported_source);
+    assert_eq!(
+        unsupported.errors.len(),
+        1,
+        "tuple-form ownership marker must produce one diagnostic: {:?}",
+        unsupported.errors
+    );
+    assert!(
+        unsupported.errors[0]
+            .message
+            .contains("E_RESOURCE_MARKER_TARGET"),
+        "tuple-form ownership marker must use the target diagnostic: {:?}",
+        unsupported.errors
+    );
+    assert_eq!(
+        &unsupported_source[unsupported.errors[0].span.clone()],
+        "#[resource]",
+        "ownership-marker diagnostic must point at its attribute"
+    );
+
+    let supported_source = r"
+#[resource] type Named { x: i64; }
+#[resource] enum E { A; }
+";
+    let supported = parse(supported_source);
+    assert!(
+        supported.errors.is_empty(),
+        "supported ownership-marker targets must remain valid: {:?}",
+        supported.errors
+    );
+    assert_eq!(supported.program.items.len(), 2);
+    for (item, _) in &supported.program.items {
+        let Item::TypeDecl(decl) = item else {
+            panic!("expected ownership-bearing type declaration, got {item:?}");
+        };
+        assert_eq!(decl.resource_marker, ResourceMarker::Resource);
+    }
+}
+
+#[test]
 fn resource_markers_reject_unsupported_top_level_items_in_every_visibility_form() {
     let source = r"
-#[resource] record PrivateRecord { id: i64 }
-#[linear] pub record PublicRecord { id: i64 }
-#[resource] package record PackageRecord { id: i64 }
+#[resource] type PrivateTuple(i64);
+#[linear] pub type PublicTuple(i64);
+#[resource] package type PackageTuple(i64);
 
 #[linear] fn private_fn() {}
 #[resource] pub fn public_fn() {}
@@ -3770,7 +3812,7 @@ fn resource_markers_reject_unsupported_top_level_items_in_every_visibility_form(
 #[linear] pub type PublicAlias = i64;
 #[resource] package type PackageAlias = i64;
 
-#[linear] impl PrivateRecord { fn close(self) {} }
+#[linear] impl PrivateTuple { fn close(self) {} }
 ";
     let result = parse(source);
     let marker_errors: Vec<_> = result

--- a/hew-parser/tests/fmt_totality.rs
+++ b/hew-parser/tests/fmt_totality.rs
@@ -353,10 +353,10 @@ fn fmt_totality_item_machine() {
     );
 }
 
-/// `Item::Record` — named form.
+/// `Item::Record` — tuple form.
 #[test]
 fn fmt_totality_item_record() {
-    assert_roundtrip("record Point { x: i64, y: i64 }\n");
+    assert_roundtrip("type Point(i64, i64);\n");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Ownership markers on tuple-form product declarations parsed successfully even though their `RecordDecl` representation cannot store a `ResourceMarker`, silently discarding the ownership contract.

## What

The parser now rejects `#[resource]` and `#[linear]` on tuple-form `type` declarations with `E_RESOURCE_MARKER_TARGET` at the attribute. Named `type` and `enum` declarations remain valid ownership-marker targets. Parser applicability and formatter-totality fixtures now use the current `type` product syntax instead of removed literal `record` syntax.

## Test

- `resource_marker_rejects_tuple_type_without_affecting_supported_targets`
- `resource_markers_reject_unsupported_top_level_items_in_every_visibility_form`
- `fmt_totality_item_record`
