### PR TITLE
test(types): accept nominal identity comparisons

### DIFF
--- a/hew-cli/tests/resource_marker_applicability_reject.rs
+++ b/hew-cli/tests/resource_marker_applicability_reject.rs
@@ -1,9 +1,8 @@
 //! Ownership-marker applicability must fail in the parser before checking.
 //!
-//! A `record` has no `ResourceMarker` field. Before this regression, placing
-//! `#[resource]` on one silently discarded the marker, so the clone below
-//! reached HIR as an ordinary copyable record. The CLI must now stop at the
-//! attribute and retain the source span in its rendered diagnostic.
+//! A type alias has no `ResourceMarker` field. The CLI must stop at an
+//! ownership marker applied to one and retain the source span in its rendered
+//! diagnostic.
 
 mod support;
 
@@ -12,25 +11,18 @@ use std::process::Command;
 use support::{hew_binary, strip_ansi};
 
 #[test]
-fn ownership_marker_on_record_fails_closed_before_hir() {
+fn ownership_marker_on_type_alias_fails_closed_before_hir() {
     let fixture = support::tempdir();
-    let source = fixture.path().join("resource_record_marker.hew");
+    let source = fixture.path().join("resource_alias_marker.hew");
     std::fs::write(
         &source,
         r"#[resource]
-type Token { id: i64 }
+type Metres = i64;
 
-impl Token {
-    fn close(self) {}
-}
-
-fn main() {
-    let t = Token { id: 1 };
-    let _copy = t.clone();
-}
+fn main() {}
 ",
     )
-    .expect("write resource-record fixture");
+    .expect("write resource-alias fixture");
 
     let output = Command::new(hew_binary())
         .args(["check", source.to_str().expect("fixture path is UTF-8")])
@@ -40,7 +32,7 @@ fn main() {
 
     assert!(
         !output.status.success(),
-        "ownership marker on record must stop before HIR; stdout: {}\nstderr: {}",
+        "ownership marker on type alias must stop before HIR; stdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
@@ -48,7 +40,7 @@ fn main() {
     assert!(
         stderr.contains("E_RESOURCE_MARKER_TARGET")
             && stderr.contains("#[resource]")
-            && stderr.contains("resource_record_marker.hew:1:1")
+            && stderr.contains("resource_alias_marker.hew:1:1")
             && stderr.contains("^^^^^^^^^^^"),
         "CLI must render the ownership-marker error at its source attribute:\n{stderr}"
     );

--- a/hew-codegen-rs/tests/exec/hashmap_keys_values_exec.rs
+++ b/hew-codegen-rs/tests/exec/hashmap_keys_values_exec.rs
@@ -250,7 +250,7 @@ fn hashmap_keys_bytes_rejected_by_key_branch_with_one_exact_diagnostic() {
     );
     assert_single_check_error_with_exact_diagnostic(
         &output,
-        "`HashMap<bytes, i64>.keys()` is not yet supported: projecting key type `bytes` into an owned `Vec` is not lowered; supported projection key types are scalar primitives, `string`, and Copy record/enum types",
+        "`bytes` cannot be used as a HashMap key yet: duplicate-key insertion cannot release the caller-owned bytes key on the overwrite path; use `string` or a supported fixed-width key",
     );
 }
 

--- a/hew-types/tests/coverage/is_allowance.rs
+++ b/hew-types/tests/coverage/is_allowance.rs
@@ -5,7 +5,7 @@
 //! * Allowed: machines, actors/actor refs, `Vec`/`HashMap`/`HashSet`, `bytes`,
 //!   user `type Foo { ... }` declarations.
 //! * Rejected with `E_IS_VALUE_TYPE`: scalars (`i64`, `bool`, `char`, floats),
-//!   `string`, `record` instances, tuples.
+//!   `string`, and tuples.
 //! * Cross-type mismatches collapse into `TypeErrorKind::Mismatch`.
 //! * Move/consumed-self follows the existing use-after-move rule (plan §D-D4).
 //!
@@ -168,7 +168,7 @@ fn is_result_typed_as_bool() {
 }
 
 // ---------------------------------------------------------------------------
-// REJECTED: scalars, string, record, tuples (E_IS_VALUE_TYPE)
+// REJECTED: scalars, string, tuples (E_IS_VALUE_TYPE)
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -207,21 +207,6 @@ fn string_is_string_rejected() {
                 let _eq: bool = a is b;
             }
         "#,
-    );
-}
-
-#[test]
-fn record_is_record_rejected() {
-    assert_has_e_is_value_type(
-        r"
-            type Point { x: i64, y: i64 }
-
-            fn main() {
-                let p = Point { x: 1, y: 2 };
-                let q = Point { x: 1, y: 2 };
-                let _eq: bool = p is q;
-            }
-        ",
     );
 }
 


### PR DESCRIPTION
## Why

Three tests still described diagnostics from before HashMap key validation, ownership markers, and nominal type declarations changed. Their expectations no longer matched the compiler paths users reach today.

## What

- Pin the bytes HashMap case to the earlier key-ownership diagnostic while preserving its exactly-one-error contract.
- Exercise ownership-marker applicability with a type alias, while retaining nominal type declarations as the legal control.
- Treat nominal type values as identity-bearing under `is`; scalar values remain rejected with `E_IS_VALUE_TYPE`.

## Test

Updated `hashmap_keys_bytes_rejected_by_key_branch_with_one_exact_diagnostic` and `ownership_marker_on_type_alias_fails_closed_before_hir`, and removed the stale `record_is_record_rejected`. `ownership_markers_on_nominal_types_still_check_clean`, `user_type_decl_is_user_type_decl_accepted`, and `int_is_int_rejected` provide the behavioural controls. Verified with the `hew-types` coverage suite, `cargo fmt`, and the exact JSON Clippy gate.
