### PR TITLE
fix(fuzz): fail oracle on positive fixture rejection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -624,7 +624,7 @@ fuzz-oracle: hew-native
 		$(PYTHON) scripts/fuzz/run-oracle.py --hew "$(DEBUG_DIR)/hew" --timeout 30; \
 	fi
 
-# Oracle self-tests: four independently-failable checks that prove the
+# Oracle self-tests: five independently-failable checks that prove the
 # harness has teeth (flags real crashes), honours the ratchet contract
 # (unexpected-pass and unexpected-fail both fail closed), and refuses to
 # report PASS over a candidate set below its floor.

--- a/scripts/fuzz/expected-reject.txt
+++ b/scripts/fuzz/expected-reject.txt
@@ -1,0 +1,49 @@
+# Positive-corpus expected-rejection ratchet
+#
+# WHY: these exact positive fixtures are currently rejected by `hew check` or
+# cannot build as standalone programs. The genuine compiler defects are being
+# burned down by the ownership lanes; helper/library fixtures remain here only
+# while the oracle cannot prove them clean without a standalone entry point.
+# WHEN: remove an entry as soon as that fixture passes the full oracle pipeline.
+# WHAT replaces it: nothing. This shrink-only list reaches zero.
+#
+# Paths are exact and relative to the repository root. Do not add reject-corpus
+# or known-bug repro inputs here; those belong in their dedicated corpora.
+
+tests/vertical-slice/accept/arith.hew
+tests/vertical-slice/accept/consume_param_transfer_builder.hew
+tests/vertical-slice/accept/cross_module_fn_value/helpers.hew
+tests/vertical-slice/accept/cross_module_fn_value_shadow/helpers.hew
+tests/vertical-slice/accept/cross_module_generic_fn_value/helpers.hew
+tests/vertical-slice/accept/cross_module_generic_fn_value/main.hew
+tests/vertical-slice/accept/cross_module_private_enum/errors.hew
+tests/vertical-slice/accept/dir_module_peer_span_identity/zoo/cat.hew
+tests/vertical-slice/accept/dir_module_peer_span_identity/zoo/cnt.hew
+tests/vertical-slice/accept/dir_module_peer_span_identity/zoo/dog.hew
+tests/vertical-slice/accept/dir_module_peer_span_identity/zoo/num.hew
+tests/vertical-slice/accept/dir_module_peer_span_identity/zoo/zoo.hew
+tests/vertical-slice/accept/dir_module_trait_default/greeting/dog.hew
+tests/vertical-slice/accept/dir_module_trait_default/greeting/greeting.hew
+tests/vertical-slice/accept/file_import_trait_default_local_type_lib.hew
+tests/vertical-slice/accept/file_import_trait_default_method_lib.hew
+tests/vertical-slice/accept/file_import_trait_impl_lib.hew
+tests/vertical-slice/accept/flat_file_import_bare_fn_call_lib.hew
+tests/vertical-slice/accept/generic_display_xmod_lib.hew
+tests/vertical-slice/accept/generic_record_box.hew
+tests/vertical-slice/accept/greeting.hew
+tests/vertical-slice/accept/imported_actor_msg_discriminants_lib.hew
+tests/vertical-slice/accept/imported_fn_local_shadow/m.hew
+tests/vertical-slice/accept/imported_generics_resolve/lib.hew
+tests/vertical-slice/accept/imported_shadow_errmod.hew
+tests/vertical-slice/accept/let_record_destructure_selective_import_module.hew
+tests/vertical-slice/accept/lib/math.hew
+tests/vertical-slice/accept/local_fn_msg_actor_method_allowed.hew
+tests/vertical-slice/accept/module_method_shadow/util.hew
+tests/vertical-slice/accept/positive_record_remote_send.hew
+tests/vertical-slice/accept/qualified_call_reachability/src/runner/math.hew
+tests/vertical-slice/accept/qualified_call_reachability/src/runner/native_loop.hew
+tests/vertical-slice/accept/receive_gen_fn_owned_enum_yield.hew
+tests/vertical-slice/accept/receive_gen_fn_owned_record_yield.hew
+tests/vertical-slice/accept/receive_gen_fn_record_stream_break.hew
+tests/vertical-slice/accept/sink_i64_typed.hew
+tests/vertical-slice/accept/vec_into_iter_typeck.hew

--- a/scripts/fuzz/oracle-selftest.sh
+++ b/scripts/fuzz/oracle-selftest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# oracle-selftest.sh — Four independently-failable validation tests for
+# oracle-selftest.sh — Five independently-failable validation tests for
 # scripts/fuzz/run-oracle.py.
 #
 # Test 1 (oracle-flags-a-known-crash):
@@ -21,7 +21,12 @@
 #   over nothing, and a corpus override with no declared minimum must be
 #   refused outright rather than defaulting to a floor of zero.
 #
-# All four must pass for the self-test to succeed.
+# Test 5 (oracle-ratchets-positive-rejections):
+#   An unlisted positive rejection must fail, the exact listed rejection must
+#   pass, and replacing that fixture with a clean program while it remains
+#   listed must fail as an unexpected pass.
+#
+# All five must pass for the self-test to succeed.
 
 set -euo pipefail
 
@@ -66,7 +71,10 @@ run_counterfactual() {
 }
 
 pass() { echo "PASS $1"; }
-fail() { echo "FAIL $1: $2" >&2; exit 1; }
+fail() {
+    echo "FAIL $1: $2" >&2
+    exit 1
+}
 
 # ---------------------------------------------------------------------------
 # Shared crash fixture: a checker-valid program that aborts at runtime.
@@ -90,11 +98,11 @@ CRASH_SOURCE='fn main() {
 # ---------------------------------------------------------------------------
 T1_DIR="${TMPDIR_BASE}/t1_regressions"
 mkdir -p "${T1_DIR}"
-printf '%s' "${CRASH_SOURCE}" > "${T1_DIR}/crash_fixture.hew"
+printf '%s' "${CRASH_SOURCE}" >"${T1_DIR}/crash_fixture.hew"
 
 # Create a matching expected-failures file that does NOT list crash_fixture.hew.
 T1_EF="${TMPDIR_BASE}/t1_expected_failures.txt"
-printf '# empty\n' > "${T1_EF}"
+printf '# empty\n' >"${T1_EF}"
 
 echo "--- Test 1: oracle-flags-a-known-crash ---"
 # Oracle must exit 1 (unexpected failure — crash not listed in expected-failures).
@@ -105,8 +113,8 @@ run_counterfactual "t1-known-crash" python3 "${ORACLE}" \
     --regressions-dir "${T1_DIR}" \
     --expected-failures "${T1_EF}" \
     --vertical-slice-dir "${EMPTY_DIR}" \
-    --min-candidates 1 \
-    || rc=$?
+    --min-candidates 1 ||
+    rc=$?
 if [[ "${rc}" -ne 1 ]]; then
     fail "oracle-flags-a-known-crash" "expected oracle exit 1, got ${rc}"
 fi
@@ -121,8 +129,8 @@ run_counterfactual "t1-report" python3 "${ORACLE}" \
     --expected-failures "${T1_EF}" \
     --vertical-slice-dir "${EMPTY_DIR}" \
     --min-candidates 1 \
-    --report "${T1_REPORT}" \
-    || rc=$?
+    --report "${T1_REPORT}" ||
+    rc=$?
 
 # The JSON report must contain runtime-abort or runtime-crash for the fixture.
 if ! python3 -c "
@@ -147,11 +155,11 @@ echo "--- Test 2: oracle-honours-expected-failure ---"
 
 T2_DIR="${TMPDIR_BASE}/t2_regressions"
 mkdir -p "${T2_DIR}"
-printf '%s' "${CRASH_SOURCE}" > "${T2_DIR}/crash_fixture.hew"
+printf '%s' "${CRASH_SOURCE}" >"${T2_DIR}/crash_fixture.hew"
 
 # 2a: crash_fixture.hew IS listed — oracle must exit 0 (known gap tolerated).
 T2_EF="${TMPDIR_BASE}/t2_expected_failures.txt"
-printf 'crash_fixture.hew  # known crash; issue: #test\n' > "${T2_EF}"
+printf 'crash_fixture.hew  # known crash; issue: #test\n' >"${T2_EF}"
 
 rc=0
 run_counterfactual "t2a-listed-crash" python3 "${ORACLE}" \
@@ -160,11 +168,11 @@ run_counterfactual "t2a-listed-crash" python3 "${ORACLE}" \
     --regressions-dir "${T2_DIR}" \
     --expected-failures "${T2_EF}" \
     --vertical-slice-dir "${EMPTY_DIR}" \
-    --min-candidates 1 \
-    || rc=$?
+    --min-candidates 1 ||
+    rc=$?
 if [[ "${rc}" -ne 0 ]]; then
     fail "oracle-honours-expected-failure (2a: listed crash tolerated)" \
-         "expected oracle exit 0, got ${rc}"
+        "expected oracle exit 0, got ${rc}"
 fi
 
 # 2b: Remove crash_fixture.hew from disk while leaving it in expected-failures.
@@ -183,11 +191,11 @@ output="$(python3 "${ORACLE}" \
     2>&1)" || rc=$?
 if [[ "${rc}" -ne 1 ]]; then
     fail "oracle-honours-expected-failure (2b: missing-but-listed fails gate)" \
-         "expected oracle exit 1, got ${rc}; output: ${output}"
+        "expected oracle exit 1, got ${rc}; output: ${output}"
 fi
 if ! echo "${output}" | grep -q "expected-failing entry not found"; then
     fail "oracle-honours-expected-failure (2b: missing-but-listed fails gate)" \
-         "expected 'expected-failing entry not found' in output; got: ${output}"
+        "expected 'expected-failing entry not found' in output; got: ${output}"
 fi
 
 pass "oracle-honours-expected-failure"
@@ -200,10 +208,10 @@ echo "--- Test 3: oracle-passes-clean-program ---"
 T3_DIR="${TMPDIR_BASE}/t3_regressions"
 mkdir -p "${T3_DIR}"
 T3_EF="${TMPDIR_BASE}/t3_expected_failures.txt"
-printf '# empty\n' > "${T3_EF}"
+printf '# empty\n' >"${T3_EF}"
 
 # 3a: clean program with matching EXPECT — must exit 0, verdict clean.
-printf '// EXPECT: 7\nfn main() { println(7); }\n' > "${T3_DIR}/clean_fixture.hew"
+printf '// EXPECT: 7\nfn main() { println(7); }\n' >"${T3_DIR}/clean_fixture.hew"
 
 rc=0
 run_counterfactual "t3a-clean-program" python3 "${ORACLE}" \
@@ -212,15 +220,15 @@ run_counterfactual "t3a-clean-program" python3 "${ORACLE}" \
     --regressions-dir "${T3_DIR}" \
     --expected-failures "${T3_EF}" \
     --vertical-slice-dir "${EMPTY_DIR}" \
-    --min-candidates 1 \
-    || rc=$?
+    --min-candidates 1 ||
+    rc=$?
 if [[ "${rc}" -ne 0 ]]; then
     fail "oracle-passes-clean-program (3a: clean program passes)" \
-         "expected oracle exit 0, got ${rc}"
+        "expected oracle exit 0, got ${rc}"
 fi
 
 # 3b: mutate EXPECT to wrong value — must exit 1, verdict wrong-output.
-printf '// EXPECT: 8\nfn main() { println(7); }\n' > "${T3_DIR}/clean_fixture.hew"
+printf '// EXPECT: 8\nfn main() { println(7); }\n' >"${T3_DIR}/clean_fixture.hew"
 
 rc=0
 output=""
@@ -234,11 +242,11 @@ output="$(python3 "${ORACLE}" \
     2>&1)" || rc=$?
 if [[ "${rc}" -ne 1 ]]; then
     fail "oracle-passes-clean-program (3b: wrong EXPECT fails gate)" \
-         "expected oracle exit 1, got ${rc}; output: ${output}"
+        "expected oracle exit 1, got ${rc}; output: ${output}"
 fi
 if ! echo "${output}" | grep -q "wrong-output"; then
     fail "oracle-passes-clean-program (3b: wrong EXPECT fails gate)" \
-         "expected 'wrong-output' in output; got: ${output}"
+        "expected 'wrong-output' in output; got: ${output}"
 fi
 
 pass "oracle-passes-clean-program"
@@ -251,7 +259,7 @@ echo "--- Test 4: oracle-refuses-an-empty-candidate-set ---"
 T4_DIR="${TMPDIR_BASE}/t4"
 T4_EF="${TMPDIR_BASE}/t4_expected_failures.txt"
 mkdir -p "${T4_DIR}"
-printf '# empty\n' > "${T4_EF}"
+printf '# empty\n' >"${T4_EF}"
 
 rc=0
 output=""
@@ -265,11 +273,11 @@ output="$(python3 "${ORACLE}" \
     2>&1)" || rc=$?
 if [[ "${rc}" -ne 1 ]]; then
     fail "oracle-refuses-an-empty-candidate-set (4a: empty corpus fails gate)" \
-         "expected oracle exit 1, got ${rc}; output: ${output}"
+        "expected oracle exit 1, got ${rc}; output: ${output}"
 fi
 if ! echo "${output}" | grep -q "CORPUS MINIMUM"; then
     fail "oracle-refuses-an-empty-candidate-set (4a: empty corpus fails gate)" \
-         "expected 'CORPUS MINIMUM' in output; got: ${output}"
+        "expected 'CORPUS MINIMUM' in output; got: ${output}"
 fi
 
 # 4b: a corpus override with no declared minimum must be refused outright,
@@ -284,15 +292,111 @@ output="$(python3 "${ORACLE}" \
     2>&1)" || rc=$?
 if [[ "${rc}" -ne 1 ]]; then
     fail "oracle-refuses-an-empty-candidate-set (4b: undeclared corpus refused)" \
-         "expected oracle exit 1, got ${rc}; output: ${output}"
+        "expected oracle exit 1, got ${rc}; output: ${output}"
 fi
 if ! echo "${output}" | grep -q -- "--min-candidates"; then
     fail "oracle-refuses-an-empty-candidate-set (4b: undeclared corpus refused)" \
-         "expected '--min-candidates' in output; got: ${output}"
+        "expected '--min-candidates' in output; got: ${output}"
 fi
 
 pass "oracle-refuses-an-empty-candidate-set"
 
 # ---------------------------------------------------------------------------
+echo "--- Test 5: oracle-ratchets-positive-rejections ---"
+T5_VERTICAL="${TMPDIR_BASE}/t5_vertical"
+T5_REGRESSIONS="${TMPDIR_BASE}/t5_regressions"
+T5_EF="${TMPDIR_BASE}/t5_expected_failures.txt"
+T5_ER="${TMPDIR_BASE}/t5_expected_rejects.txt"
+T5_REPORT="${TMPDIR_BASE}/t5_report.json"
+mkdir -p "${T5_VERTICAL}" "${T5_REGRESSIONS}"
+printf '# empty\n' >"${T5_EF}"
+printf '# empty\n' >"${T5_ER}"
+printf 'fn main() { let value: i64 = "not-an-integer"; }\n' \
+    >"${T5_VERTICAL}/reject_fixture.hew"
+
+# 5a: A positive fixture rejected by the frontend and absent from the exact
+# rejection ratchet must fail closed.
+rc=0
+output="$(python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T5_REGRESSIONS}" \
+    --expected-failures "${T5_EF}" \
+    --expected-rejects "${T5_ER}" \
+    --vertical-slice-dir "${T5_VERTICAL}" \
+    --min-candidates 1 \
+    --report "${T5_REPORT}" \
+    2>&1)" || rc=$?
+if [[ "${rc}" -ne 1 ]]; then
+    fail "oracle-ratchets-positive-rejections (5a: unexpected reject fails)" \
+        "expected oracle exit 1, got ${rc}; output: ${output}"
+fi
+if [[ "${output}" != *"UNEXPECTED REJECTIONS (not in expected-reject.txt)"* ]]; then
+    fail "oracle-ratchets-positive-rejections (5a: unexpected reject fails)" \
+        "unexpected-rejection list was not printed; output: ${output}"
+fi
+if ! python3 -c "
+import json, sys
+r = json.load(open('${T5_REPORT}'))
+paths = [entry['path'] for entry in r['unexpected_rejects']]
+sys.exit(0 if paths == ['tests/vertical-slice/accept/reject_fixture.hew'] else 1)
+"; then
+    fail "oracle-ratchets-positive-rejections (5a: unexpected reject fails)" \
+        "report did not identify the exact unexpected rejection; output: ${output}"
+fi
+
+# 5b: Listing that exact fixture identity tolerates the known rejection.
+printf 'tests/vertical-slice/accept/reject_fixture.hew\n' >"${T5_ER}"
+rc=0
+run_counterfactual "t5b-listed-reject" python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T5_REGRESSIONS}" \
+    --expected-failures "${T5_EF}" \
+    --expected-rejects "${T5_ER}" \
+    --vertical-slice-dir "${T5_VERTICAL}" \
+    --min-candidates 1 ||
+    rc=$?
+if [[ "${rc}" -ne 0 ]]; then
+    fail "oracle-ratchets-positive-rejections (5b: listed reject passes)" \
+        "expected oracle exit 0, got ${rc}"
+fi
+
+# 5c (negative control): make the listed fixture clean. The stale entry must
+# fail in the opposite direction so the manifest can only shrink.
+printf '// EXPECT: 7\nfn main() { println(7); }\n' \
+    >"${T5_VERTICAL}/reject_fixture.hew"
+rc=0
+output="$(python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T5_REGRESSIONS}" \
+    --expected-failures "${T5_EF}" \
+    --expected-rejects "${T5_ER}" \
+    --vertical-slice-dir "${T5_VERTICAL}" \
+    --min-candidates 1 \
+    --report "${T5_REPORT}" \
+    2>&1)" || rc=$?
+if [[ "${rc}" -ne 1 ]]; then
+    fail "oracle-ratchets-positive-rejections (5c: stale reject fails)" \
+        "expected oracle exit 1, got ${rc}; output: ${output}"
+fi
+if [[ "${output}" != *"UNEXPECTED PASSES (listed in expected-reject.txt but passed)"* ]]; then
+    fail "oracle-ratchets-positive-rejections (5c: stale reject fails)" \
+        "unexpected-pass list was not printed; output: ${output}"
+fi
+if ! python3 -c "
+import json, sys
+r = json.load(open('${T5_REPORT}'))
+paths = [entry['path'] for entry in r['unexpected_reject_passes']]
+sys.exit(0 if paths == ['tests/vertical-slice/accept/reject_fixture.hew'] else 1)
+"; then
+    fail "oracle-ratchets-positive-rejections (5c: stale reject fails)" \
+        "report did not identify the exact unexpected pass; output: ${output}"
+fi
+
+pass "oracle-ratchets-positive-rejections"
+
+# ---------------------------------------------------------------------------
 echo ""
-echo "oracle-selftest: all 4 tests PASS"
+echo "oracle-selftest: all 5 tests PASS"

--- a/scripts/fuzz/run-oracle.py
+++ b/scripts/fuzz/run-oracle.py
@@ -10,7 +10,7 @@ Exit 0: no unexpected failures.
 Exit 1: at least one unexpected failure (or a ratchet violation).
 
 Classification taxonomy (fail-closed):
-  frontend-reject  parse error OR check non-zero              → not a failure
+  frontend-reject  check non-zero OR non-runnable build       → FAIL
   clean            build exit 0 AND binary exit 0 (or EXIT:)  → pass
   nyi-codegen      build non-zero with NYI/MIR/CODEGEN marker → FAIL
   build-ice        build output contains Rust panic marker     → FAIL
@@ -33,6 +33,13 @@ Ratchet (--regressions mode):
   to fail, each annotated with # <root-cause>; issue: #NNNN.
   - A listed file that PASSES   → unexpected-pass → gate failure.
   - An unlisted file that FAILS → unexpected-fail → gate failure.
+
+Positive-corpus rejection ratchet:
+  scripts/fuzz/expected-reject.txt lists exact repo-relative paths from
+  tests/vertical-slice/accept that are currently rejected by the frontend or
+  cannot build as standalone programs.
+  - A listed file that stops being rejected → unexpected-pass → gate failure.
+  - An unlisted file that is rejected       → unexpected-reject → gate failure.
   In --full mode the ratchet is NOT applied to cargo-fuzz corpus files (they
   are raw bytes; classification is advisory only).
 """
@@ -101,7 +108,7 @@ class Verdict:
 
     @property
     def is_fail(self) -> bool:
-        return self.classification not in ("frontend-reject", "clean")
+        return self.classification != "clean"
 
 
 @dataclass
@@ -122,7 +129,7 @@ class OracleStats:
 
     @property
     def total_fail(self) -> int:
-        return sum(self.fails.values())
+        return self.frontend_reject + sum(self.fails.values())
 
 
 # ---------------------------------------------------------------------------
@@ -526,6 +533,11 @@ def _load_expected_failures(expected_failures_path: Path) -> set[str]:
     return expected
 
 
+def _fixture_identity(src: Path, corpus_root: Path, prefix: Path) -> str:
+    """Return the stable manifest identity for a corpus fixture."""
+    return (prefix / src.relative_to(corpus_root)).as_posix()
+
+
 # ---------------------------------------------------------------------------
 # Report
 # ---------------------------------------------------------------------------
@@ -570,6 +582,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Expected-failures list. Default: <regressions-dir>/../expected-failures.txt.",
+    )
+    p.add_argument(
+        "--expected-rejects",
+        type=Path,
+        default=None,
+        help=(
+            "Expected positive-corpus rejections. Default: "
+            "<repo-root>/scripts/fuzz/expected-reject.txt."
+        ),
     )
     p.add_argument(
         "--vertical-slice-dir",
@@ -678,6 +699,12 @@ def main() -> int:
     expected_failures_path: Path = args.expected_failures or (
         regressions_dir.parent / "expected-failures.txt"
     )
+    if args.expected_rejects is not None:
+        expected_rejects_path = args.expected_rejects
+    elif args.vertical_slice_dir is not None:
+        expected_rejects_path = args.vertical_slice_dir.parent / "expected-reject.txt"
+    else:
+        expected_rejects_path = script_dir / "expected-reject.txt"
 
     # Detect HEW_STD: honour env if set, else use repo std/.
     hew_std: Optional[str] = os.environ.get("HEW_STD") or str(repo_root / "std")
@@ -690,6 +717,7 @@ def main() -> int:
     )
 
     expected_failure_names = _load_expected_failures(expected_failures_path)
+    expected_reject_paths = _load_expected_failures(expected_rejects_path)
 
     # Floor the ratcheted candidate set. Both gate conditions below are searches
     # over the collected candidates: an empty collection yields no unexpected
@@ -724,6 +752,9 @@ def main() -> int:
     all_verdicts: list[Verdict] = []
     unexpected_fails: list[Verdict] = []
     unexpected_passes: list[Verdict] = []
+    unexpected_rejects: list[tuple[str, Verdict]] = []
+    unexpected_reject_passes: list[tuple[str, Verdict]] = []
+    seen_reject_paths: set[str] = set()
 
     with tempfile.TemporaryDirectory(prefix="hew-oracle-") as tmpdir:
         workdir = Path(tmpdir)
@@ -733,6 +764,7 @@ def main() -> int:
             label: str,
             apply_ratchet: bool,
             strict_exit: bool = True,
+            reject_ratchet_root: Optional[Path] = None,
         ) -> None:
             if not files or floor_error is not None:
                 return
@@ -754,10 +786,34 @@ def main() -> int:
                 if apply_ratchet:
                     name = src.name
                     is_expected_fail = name in expected_failure_names
-                    if verdict.is_fail and not is_expected_fail:
+                    if (
+                        reject_ratchet_root is not None
+                        and verdict.classification == "frontend-reject"
+                    ):
+                        identity = _fixture_identity(
+                            src,
+                            reject_ratchet_root,
+                            Path("tests/vertical-slice/accept"),
+                        )
+                        seen_reject_paths.add(identity)
+                        if identity not in expected_reject_paths:
+                            unexpected_rejects.append((identity, verdict))
+                    elif verdict.is_fail and not is_expected_fail:
                         unexpected_fails.append(verdict)
                     elif not verdict.is_fail and is_expected_fail:
                         unexpected_passes.append(verdict)
+
+                    if reject_ratchet_root is not None:
+                        identity = _fixture_identity(
+                            src,
+                            reject_ratchet_root,
+                            Path("tests/vertical-slice/accept"),
+                        )
+                        if (
+                            identity in expected_reject_paths
+                            and verdict.classification != "frontend-reject"
+                        ):
+                            unexpected_reject_passes.append((identity, verdict))
 
         # Source 1: cargo-fuzz corpus (full mode only, no ratchet).
         _process_group(fuzz_corpus, "cargo-fuzz corpus", apply_ratchet=False)
@@ -773,6 +829,10 @@ def main() -> int:
             "vertical-slice/accept",
             apply_ratchet=True,
             strict_exit=False,
+            reject_ratchet_root=(
+                args.vertical_slice_dir
+                or repo_root / "tests" / "vertical-slice" / "accept"
+            ),
         )
 
         # Source 3: regression corpus (ratchet enforced, strict exit required).
@@ -792,6 +852,15 @@ def main() -> int:
                 "expected-failing entry not found in regressions corpus",
             )
             unexpected_passes.append(ghost)
+
+    for identity in sorted(expected_reject_paths - seen_reject_paths):
+        if not any(path == identity for path, _ in unexpected_reject_passes):
+            ghost = Verdict(
+                repo_root / identity,
+                "clean",
+                "expected-reject entry not found in positive corpus",
+            )
+            unexpected_reject_passes.append((identity, ghost))
 
     # Summary.
     print()
@@ -822,6 +891,20 @@ def main() -> int:
         print("\nUNEXPECTED PASSES (listed in expected-failures.txt but passed):")
         for v in unexpected_passes:
             print(f"  NOW-PASSES: {v.path.name}  {v.detail}")
+        gate_ok = False
+
+    if unexpected_rejects:
+        print("\nUNEXPECTED REJECTIONS (not in expected-reject.txt):")
+        for identity, verdict in unexpected_rejects:
+            detail = f"  {verdict.detail}" if verdict.detail else ""
+            print(f"  UNEXPECTED-REJECT: {identity}{detail}")
+        gate_ok = False
+
+    if unexpected_reject_passes:
+        print("\nUNEXPECTED PASSES (listed in expected-reject.txt but passed):")
+        for identity, verdict in unexpected_reject_passes:
+            detail = f"  {verdict.detail}" if verdict.detail else ""
+            print(f"  NOW-PASSES: {identity}{detail}")
         gate_ok = False
 
     if gate_ok:
@@ -857,6 +940,18 @@ def main() -> int:
             ],
             "unexpected_passes": [
                 {"path": str(v.path), "detail": v.detail} for v in unexpected_passes
+            ],
+            "unexpected_rejects": [
+                {
+                    "path": identity,
+                    "classification": verdict.classification,
+                    "detail": verdict.detail,
+                }
+                for identity, verdict in unexpected_rejects
+            ],
+            "unexpected_reject_passes": [
+                {"path": identity, "detail": verdict.detail}
+                for identity, verdict in unexpected_reject_passes
             ],
         }
         args.report.write_text(json.dumps(report, indent=2))

--- a/tests/fuzz-oracle/README.md
+++ b/tests/fuzz-oracle/README.md
@@ -6,6 +6,8 @@ Every checker-valid Hew program (one that passes `hew check`) must also
 compile and run cleanly. This oracle verifies that invariant continuously:
 
 - For each `.hew` file in the candidate set, run `hew check`.
+- Reject any positive-corpus fixture that does not pass `hew check` unless its
+  exact path is temporarily ratcheted in `scripts/fuzz/expected-reject.txt`.
 - If checker-valid, compile to a native binary (`hew build -o`) and execute it
   **directly** (not `hew run`, which masks signals — see below).
 - Classify the outcome fail-closed. Anything not provably clean is a failure
@@ -45,6 +47,21 @@ vertical-slice or regression corpus.
 
 The ratchet fires in both directions so a confirmed gap that silently reverts
 is caught the day it re-emerges.
+
+## Ratchet: expected-reject.txt
+
+`scripts/fuzz/expected-reject.txt` is a separate, shrink-only ratchet for
+positive accept fixtures that the frontend rejects or that cannot currently
+build as standalone programs. Entries are exact repository-relative paths, so
+nested helper fixtures and same-named files cannot collide.
+
+- An unlisted positive fixture that is rejected is an `unexpected-reject` and
+  fails the gate.
+- A listed fixture that stops being rejected is an `unexpected-pass` and fails
+  the gate until its entry is removed.
+
+Remove an entry as soon as its fixture passes. Nothing replaces it: intentional
+negative and known-bug inputs belong in the reject and repro corpora instead.
 
 ## How to add a regression
 


### PR DESCRIPTION
## Why

The deterministic fuzz oracle treated frontend rejection of positive accept fixtures as a non-failure, allowing fixtures to stop checking or building while the merge gate remained green.

## What

Frontend rejection is now a failing verdict. A shrink-only exact-path ratchet records the current positive-corpus rejections and fails in both directions when an unlisted fixture is rejected or a listed fixture stops being rejected. The oracle report and documentation now expose the same fail-closed contract.

## Test

`make fuzz-oracle-selftest` exercises unexpected rejection, an expected listed rejection, and the stale-entry unexpected-pass negative control. `make fuzz-oracle` verifies the complete deterministic corpus. `make lint` runs formatting, structural checks, generated-surface checks, and workspace test clippy with warnings denied.
