### PR TITLE
fix(types): reject identity comparison on record values

### DIFF
--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -5072,7 +5072,7 @@ The methods `.try_to_i8()`, `.try_to_i16()`, `.try_to_i32()`, `.try_to_i64()`, `
 7. Bitwise XOR: `^`
 8. Bitwise OR: `|`
 9. Relational: `<`, `<=`, `>`, `>=`
-10. Equality: `==`, `!=`, `is` (`is` = reference identity on heap handles; `expr is TypeName` = static-only type check; rejected on string/scalars/records/tuples; regex matching is via `Pattern.is_match`)
+10. Equality: `==`, `!=`, `is` (`is` = reference identity on heap handles; `expr is TypeName` = static-only type check; rejected with `E_IS_VALUE_TYPE` on scalars, `string`, tuples, and `type Name { ... }` record declarations — records are copy-on-write values with no pointer identity, so `==` is the comparison for them; regex matching is via `Pattern.is_match`)
 11. Logical AND: `&&`
 12. Logical OR: `||`
 13. Range: `..`, `..=` (only lowered inside `for` loop iterables; standalone range value expressions are not lowered)

--- a/hew-cli/tests/is_value_type_reject_e2e.rs
+++ b/hew-cli/tests/is_value_type_reject_e2e.rs
@@ -1,0 +1,130 @@
+//! End-to-end coverage for `is` on a value type (#3108).
+//!
+//! `is` is reference identity on heap handles. A `type Point { ... }`
+//! declaration is a copy-on-write value under the v0.5 value model
+//! (`docs/v05/ownership.md`), so it has no identity to compare. The checker
+//! owns that answer: `hew check` must report `E_IS_VALUE_TYPE` at the `is`
+//! expression.
+//!
+//! Before the fix the checker admitted the program and it died later in the
+//! codegen front with a span-less
+//! `E_CODEGEN_FRONT_FAIL_CLOSED: … IdentityCompare lhs must be a pointer or
+//! integer value` — a compiler-invariant message, not a user diagnostic. This
+//! file pins both halves: the user-facing rejection appears, and the
+//! fail-closed backstop never surfaces.
+
+mod support;
+
+use std::process::{Command, Output};
+
+use support::{hew_binary, repo_root, strip_ansi, tempdir};
+
+/// Two records compared with `is` — the repro from #3108.
+const RECORD_IS: &str = "type Point {\n\
+     x: i64;\n\
+     y: i64;\n\
+     }\n\
+     \n\
+     fn main() {\n\
+     let p = Point { x: 1, y: 2 };\n\
+     let q = Point { x: 1, y: 2 };\n\
+     let same: bool = p is q;\n\
+     println(same);\n\
+     }\n";
+
+/// The same program written with `==`, the operator the diagnostic points at.
+const RECORD_EQ: &str = "type Point {\n\
+     x: i64;\n\
+     y: i64;\n\
+     }\n\
+     \n\
+     fn main() {\n\
+     let p = Point { x: 1, y: 2 };\n\
+     let q = Point { x: 1, y: 2 };\n\
+     let same: bool = p == q;\n\
+     println(same);\n\
+     }\n";
+
+/// Negative control: `is` on a heap handle stays accepted end to end, so the
+/// rejection above is about the value class and not about `is` itself.
+const VEC_IS: &str = "fn main() {\n\
+     let v1: Vec<i64> = Vec.new();\n\
+     let v2: Vec<i64> = Vec.new();\n\
+     let same: bool = v1 is v2;\n\
+     println(same);\n\
+     }\n";
+
+fn run_check(source: &str) -> Output {
+    let dir = tempdir();
+    let path = dir.path().join("main.hew");
+    std::fs::write(&path, source).unwrap();
+
+    Command::new(hew_binary())
+        .arg("check")
+        .arg(&path)
+        .current_dir(repo_root())
+        .output()
+        .expect("failed to spawn hew check")
+}
+
+#[test]
+fn is_on_a_record_is_rejected_by_the_checker() {
+    let output = run_check(RECORD_IS);
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains("E_IS_VALUE_TYPE"),
+        "expected `hew check` to reject `p is q` with E_IS_VALUE_TYPE; got:\n{stderr}"
+    );
+    assert!(!output.status.success(), "expected a non-zero exit");
+}
+
+#[test]
+fn is_on_a_record_never_reaches_the_codegen_front_backstop() {
+    // The regression under test: the checker used to pass this program
+    // through, and the only thing the user saw was a span-less
+    // compiler-invariant message from the codegen front.
+    let output = run_check(RECORD_IS);
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        !stderr.contains("E_CODEGEN_FRONT_FAIL_CLOSED"),
+        "the codegen-front fail-closed must be unreachable for `is` on a record; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn is_rejection_points_at_the_users_source_line() {
+    // A user diagnostic carries a location; the fail-closed message it
+    // replaces carried none.
+    let output = run_check(RECORD_IS);
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr
+            .lines()
+            .any(|line| line.contains("main.hew:") && line.contains("E_IS_VALUE_TYPE")),
+        "expected the E_IS_VALUE_TYPE diagnostic to be attributed to main.hew; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn structural_equality_on_the_same_record_is_accepted() {
+    // Negative control for the diagnostic's advice: `==` really is the way to
+    // compare two records, so the suggestion is not a dead end.
+    let output = run_check(RECORD_EQ);
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "`==` on two records must check clean; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn is_on_a_heap_handle_is_still_accepted() {
+    // Negative control for the rejection: `is` on a `Vec` handle is identity
+    // comparison with a real answer and must keep checking clean.
+    let output = run_check(VEC_IS);
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "`is` on two `Vec` handles must check clean; got:\n{stderr}"
+    );
+}

--- a/hew-hir/tests/lowering_core/is_type_pattern_lowering.rs
+++ b/hew-hir/tests/lowering_core/is_type_pattern_lowering.rs
@@ -62,18 +62,23 @@ fn walk_expr<'a>(expr: &'a HirExpr, out: &mut Vec<&'a HirExpr>) {
 
 #[test]
 fn is_type_pattern_lowers_to_bool_true_literal() {
-    // `holder is Holder` where `holder: Holder` is a user `type` decl —
+    // `holder is Holder` where `holder: Holder` is a user `enum` decl —
     // the checker has recorded the static type-pattern match, so HIR
     // lowers the comparison to a `Bool(true)` literal. Any `else` branch
     // gated on the negation is therefore dead at the HIR level.
+    //
+    // The receiver is an enum rather than a `type Foo { ... }` record
+    // because `is` on a record is rejected by the checker (#3108), and a
+    // rejected program records no type-pattern entry to read here.
     let output = lower(
         r"
-        pub type Holder {
-            v: i64;
+        pub enum Holder {
+            One;
+            Two;
         }
 
         fn main() {
-            let holder = Holder { v: 1 };
+            let holder = Holder.One;
             let _eq: bool = holder is Holder;
         }
         ",
@@ -118,13 +123,14 @@ fn is_value_pattern_lowers_to_identity_compare() {
     // runtime `IdentityCompare` form, NOT to a literal.
     let output = lower(
         r"
-        pub type Holder {
-            v: i64;
+        pub enum Holder {
+            One;
+            Two;
         }
 
         fn main() {
-            let a = Holder { v: 1 };
-            let b = Holder { v: 2 };
+            let a = Holder.One;
+            let b = Holder.Two;
             let _eq: bool = a is b;
         }
         ",

--- a/hew-lsp/tests/fixtures/v05_is_operator.hew
+++ b/hew-lsp/tests/fixtures/v05_is_operator.hew
@@ -1,5 +1,6 @@
-type Payload {
-    value: i32;
+enum Payload {
+    First;
+    Second;
 }
 
 fn is_probe() -> i32 {

--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -1605,13 +1605,13 @@ fn main() {
 
     #[test]
     fn is_operator_is_reserved_runtime_feature() {
+        // The operands are `Vec` handles, not a record: `is` on a record is a
+        // checker rejection (E_IS_VALUE_TYPE, #3108), and this test is about
+        // the sandbox profile reserving the operator, not about the value
+        // model. A record receiver would never reach the profile check.
         assert_profile_rejection(
             r#"
-type Node {
-    value: i64;
-}
-
-fn same(left: Node, right: Node) -> bool {
+fn same(left: Vec<i64>, right: Vec<i64>) -> bool {
     left is right
 }
 

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -638,7 +638,10 @@ const CONSTRUCTS: &[Construct] = &[
     },
     Construct {
         id: "identity comparison (`is`)",
-        probe: "type Node { value: i64; }\nfn same(a: Node, b: Node) -> bool { a is b }\nfn main() {\n    println(\"x\");\n}\n",
+        // `Vec` handles, not a record: `is` on a record is a checker rejection
+        // (E_IS_VALUE_TYPE, #3108) and would never reach the profile check,
+        // which is what this row pins.
+        probe: "fn same(a: Vec<i64>, b: Vec<i64>) -> bool { a is b }\nfn main() {\n    println(\"x\");\n}\n",
         coverage: Coverage::RejectedByProfile {
             diagnostic_kind: "reserved_runtime_feature",
         },

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -746,11 +746,11 @@ impl Checker {
 
             // Identity comparison: `lhs is rhs` (slice D-2).
             //
-            // Allowed receivers per plan §D-D2: machines, actors/actor refs,
-            // heap-backed `Vec`/`HashMap`/`HashSet`/`bytes`, and user `type`
-            // declarations (`TypeDefKind::Struct`/`Enum`, both Rc-backed in
-            // the runtime). Rejected with `E_IS_VALUE_TYPE`: scalars, `String`,
-            // `record` types, tuples, ranges, fn/closures.
+            // Allowed receivers: machines, actors/actor refs, heap-backed
+            // `Vec`/`HashMap`/`HashSet`/`bytes`, and user `enum` declarations.
+            // Rejected with `E_IS_VALUE_TYPE`: scalars, `String`, `type
+            // Foo { ... }` record declarations, `record` types, tuples,
+            // ranges, fn/closures.
             //
             // Result is always `bool`. Cross-class mismatches (e.g.
             // `LocalPid<T> is Vec<int>`) collapse into a single
@@ -9598,10 +9598,15 @@ impl Checker {
         let lhs_ok = self.is_identity_capable(&lhs_resolved);
         let rhs_ok = self.is_identity_capable(&rhs_resolved);
 
+        // One rejection per `is` expression when both operands resolve to the
+        // same value type: two carets carrying a byte-identical message about
+        // one type reads as two separate bugs. Operands of *different* value
+        // types still get one diagnostic each, since each names its own type.
+        let same_value_type = !lhs_ok && !rhs_ok && lhs_resolved == rhs_resolved;
         if !lhs_ok {
             self.report_is_value_type(&lhs.1, &lhs_resolved);
         }
-        if !rhs_ok {
+        if !rhs_ok && !same_value_type {
             self.report_is_value_type(&rhs.1, &rhs_resolved);
         }
 
@@ -9657,10 +9662,13 @@ impl Checker {
         let lhs_ok = self.is_identity_capable(&lhs_resolved);
         let rhs_ok = self.is_identity_capable(&rhs_resolved);
 
+        // Same de-duplication as the value form: `a is i64` where `a: i64`
+        // names one type, so it gets one diagnostic.
+        let same_value_type = !lhs_ok && !rhs_ok && lhs_resolved == rhs_resolved;
         if !lhs_ok {
             self.report_is_value_type(&lhs.1, &lhs_resolved);
         }
-        if !rhs_ok {
+        if !rhs_ok && !same_value_type {
             self.report_is_value_type(&rhs.1, &rhs_resolved);
         }
 
@@ -9720,9 +9728,10 @@ impl Checker {
             TypeErrorKind::InvalidOperation,
             span,
             format!(
-                "`is` requires an identity-bearing operand; `{}` is a value type \
-                 (E_IS_VALUE_TYPE) — use `==` for value comparison; `is` checks \
-                 identity for heap-backed types only",
+                "`is` compares identity, and `{}` is a value type \
+                 (E_IS_VALUE_TYPE) — use `==` to compare it by value; `is` \
+                 applies to handles such as actor references and \
+                 `Vec`/`HashMap`/`HashSet`",
                 ty.user_facing()
             ),
         );
@@ -9737,10 +9746,10 @@ impl Checker {
     ///   `LocalPid<T>`.
     /// * Heap-backed collections: `Vec<T>`, `HashMap<K,V>`, `HashSet<T>`.
     /// * `bytes`.
-    /// * User `type Foo { ... }` declarations (`TypeDefKind::Struct` and
-    ///   `TypeDefKind::Enum`), which are Rc-backed in the runtime.
+    /// * User `enum` declarations (`TypeDefKind::Enum`).
     ///
-    /// Returns `false` for value types: scalars, `String`, `record` types,
+    /// Returns `false` for value types: scalars, `String`, `type Foo { ... }`
+    /// record declarations (`TypeDefKind::Struct`), `record` types,
     /// tuples, arrays, slices, ranges, durations, functions, closures, and
     /// trait objects. Caller is responsible for handling `Ty::Var` / `Ty::Error`
     /// before invoking this predicate.
@@ -9761,16 +9770,24 @@ impl Checker {
                 if builtin.is_some_and(BuiltinType::is_collection) {
                     return true;
                 }
-                // User type declarations: machines, actors, and user
-                // `type Foo { ... }` (Struct/Enum, Rc-backed). `Record` is
-                // explicitly rejected as a value type.
+                // A `type Foo { ... }` record declaration
+                // (`TypeDefKind::Struct`) is not identity-capable: under the
+                // v0.5 value model a record is a copy-on-write value with
+                // structural `==` and no pointer identity
+                // (`docs/v05/ownership.md`), and the codegen front has no
+                // `IdentityCompare` lowering for its representation. The
+                // checker owns that answer, so the codegen-front legality
+                // check stays an unreachable backstop (#3108).
+                //
+                // Machines, actors and enums stay in the set: only the record
+                // answer is settled here. `is` on an `enum` or `machine` value
+                // still reaches the codegen-front check today; whether they are
+                // value-class too is a separate language decision, tracked as
+                // follow-up on #3108.
                 if let Some(td) = self.type_defs.get(name) {
                     return matches!(
                         td.kind,
-                        TypeDefKind::Machine
-                            | TypeDefKind::Actor
-                            | TypeDefKind::Struct
-                            | TypeDefKind::Enum
+                        TypeDefKind::Machine | TypeDefKind::Actor | TypeDefKind::Enum
                     );
                 }
                 false

--- a/hew-types/tests/coverage/is_allowance.rs
+++ b/hew-types/tests/coverage/is_allowance.rs
@@ -1,11 +1,15 @@
 //! Identity-comparison (`is`) allowance set and value-type rejection (slice D-2).
 //!
-//! Covers the checker rule from plan §D-D2:
+//! Covers the checker rule (HEW-SPEC-2026 §operator precedence, entry 10):
+//! `is` is reference identity on heap *handles*, never on values.
 //!
-//! * Allowed: machines, actors/actor refs, `Vec`/`HashMap`/`HashSet`, `bytes`,
-//!   user `type Foo { ... }` declarations.
+//! * Allowed: machines, actors/actor refs, `Vec`/`HashMap`/`HashSet`, `bytes`.
 //! * Rejected with `E_IS_VALUE_TYPE`: scalars (`i64`, `bool`, `char`, floats),
-//!   `string`, and tuples.
+//!   `string`, tuples, and user `type Foo { ... }` record declarations.
+//!   Records are copy-on-write values under the v0.5 value model
+//!   (`docs/v05/ownership.md` — structural `==`, no pointer identity), so the
+//!   checker is the last word on them; the codegen-front `IdentityCompare`
+//!   legality check is an unreachable backstop, not a user diagnostic (#3108).
 //! * Cross-type mismatches collapse into `TypeErrorKind::Mismatch`.
 //! * Move/consumed-self follows the existing use-after-move rule (plan §D-D4).
 //!
@@ -127,20 +131,132 @@ fn bytes_is_bytes_accepted() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// REJECTED: user `type Foo { ... }` records are values, not handles (#3108)
+// ---------------------------------------------------------------------------
+
+/// A `type Foo { ... }` declaration is a copy-on-write *value* under the v0.5
+/// value model, so `p is q` has no identity to compare. Before #3108 the
+/// checker admitted it and the program died in the codegen front with a
+/// span-less `E_CODEGEN_FRONT_FAIL_CLOSED`; the checker must be the last word.
 #[test]
-fn user_type_decl_is_user_type_decl_accepted() {
-    // `type Foo { ... }` declares a heap-backed Struct in the runtime; `is`
-    // is valid (plan §D-D2).
-    assert_clean(
+fn record_type_is_record_type_rejected() {
+    assert_has_e_is_value_type(
         r"
-            type Holder {
-                v: i64;
+            type Point {
+                x: i64;
             }
 
             fn main() {
-                let p = Holder { v: 1 };
-                let q = Holder { v: 1 };
+                let p = Point { x: 1 };
+                let q = Point { x: 1 };
                 let _eq: bool = p is q;
+            }
+        ",
+    );
+}
+
+/// One mistake, one diagnostic: `p is q` on two `Point` values is a single
+/// misuse of the operator, so the two operands must not each raise a
+/// byte-identical rejection.
+#[test]
+fn record_type_rejection_is_reported_once_per_expression() {
+    let output = typecheck_isolated(
+        r"
+            type Point {
+                x: i64;
+            }
+
+            fn main() {
+                let p = Point { x: 1 };
+                let q = Point { x: 1 };
+                let _eq: bool = p is q;
+            }
+        ",
+    );
+    let count = output
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("E_IS_VALUE_TYPE"))
+        .count();
+    assert_eq!(
+        count, 1,
+        "expected exactly one E_IS_VALUE_TYPE, got: {:#?}",
+        output.errors
+    );
+}
+
+/// Counter-case for the de-duplication above: two *different* value types each
+/// name their own type, so each still earns its own diagnostic. Without this
+/// the de-duplication could silently collapse to "report the LHS only".
+#[test]
+fn distinct_value_type_operands_are_each_reported() {
+    let output = typecheck_isolated(
+        r#"
+            fn main() {
+                let a: i64 = 1;
+                let b: string = "x";
+                let _eq: bool = a is b;
+            }
+        "#,
+    );
+    let count = output
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("E_IS_VALUE_TYPE"))
+        .count();
+    assert_eq!(
+        count, 2,
+        "expected one E_IS_VALUE_TYPE per distinct value type, got: {:#?}",
+        output.errors
+    );
+}
+
+/// The diagnostic has to be actionable: it names the offending type and points
+/// at `==`, the operator that does compare two records.
+#[test]
+fn record_type_rejection_names_the_type_and_suggests_equality() {
+    let output = typecheck_isolated(
+        r"
+            type Point {
+                x: i64;
+            }
+
+            fn main() {
+                let p = Point { x: 1 };
+                let q = Point { x: 1 };
+                let _eq: bool = p is q;
+            }
+        ",
+    );
+    let named = output
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("E_IS_VALUE_TYPE"))
+        .filter(|e| e.message.contains("Point") && e.message.contains("`==`"))
+        .count();
+    assert!(
+        named > 0,
+        "expected an E_IS_VALUE_TYPE naming `Point` and `==`, got: {:#?}",
+        output.errors
+    );
+}
+
+/// Negative control for the rejection: `==` on the very same record is the
+/// supported comparison and must stay clean, so the diagnostic's advice is
+/// truthful rather than a dead end.
+#[test]
+fn record_type_structural_equality_still_accepted() {
+    assert_clean(
+        r"
+            type Point {
+                x: i64;
+            }
+
+            fn main() {
+                let p = Point { x: 1 };
+                let q = Point { x: 1 };
+                let _eq: bool = p == q;
             }
         ",
     );
@@ -266,22 +382,20 @@ fn vec_int_is_vec_string_rejected_as_mismatch() {
 
 #[test]
 fn is_after_actor_send_reads_sender_snapshot_source() {
-    let src = r#"
-        type Payload { data: string; }
-
+    let src = r"
         actor SnapshotSink {
             let _id: i64;
-            receive fn consume(p: Payload) {}
+            receive fn consume(p: bytes) {}
         }
 
         fn main() {
             let s = spawn SnapshotSink(_id: 0);
-            let h = Payload { data: "hello" };
-            let q = Payload { data: "world" };
+            let h = bytes.new();
+            let q = bytes.new();
             s.consume(h);
             let _eq: bool = h is q;
         }
-    "#;
+    ";
     let output = typecheck_isolated(src);
     assert!(output.errors.is_empty(), "{:#?}", output.errors);
 }
@@ -293,19 +407,20 @@ fn is_after_actor_send_reads_sender_snapshot_source() {
 #[test]
 fn is_type_pattern_static_tautology_emits_redundant_is_warning() {
     // Static-tautology: `holder is Holder` where `holder: Holder` is a
-    // user `type` declaration. The checker records the type-pattern in
+    // user `enum` declaration. The checker records the type-pattern in
     // `is_type_patterns`, HIR lowers it to `HirLiteral::Bool(true)`, and
     // any `else` branch gated on the negation is dead. A `RedundantIs`
     // warning surfaces this so the user is told before they wonder why
     // their else-branch never runs.
     let output = common::typecheck_isolated(
         r"
-            type Holder {
-                v: i64;
+            enum Holder {
+                One;
+                Two;
             }
 
             fn main() {
-                let holder = Holder { v: 1 };
+                let holder = Holder.One;
                 let _eq: bool = holder is Holder;
             }
         ",
@@ -325,16 +440,18 @@ fn is_type_pattern_with_distinct_types_emits_no_redundant_is_warning() {
     // flag the Mismatch (and not the static-tautology warning).
     let output = common::typecheck_isolated(
         r"
-            type Holder {
-                v: i64;
+            enum Holder {
+                One;
+                Two;
             }
 
-            type Other {
-                w: i64;
+            enum Other {
+                Three;
+                Four;
             }
 
             fn main() {
-                let holder = Holder { v: 1 };
+                let holder = Holder.One;
                 let _eq: bool = holder is Other;
             }
         ",
@@ -375,12 +492,13 @@ fn is_type_pattern_requires_identifier_lhs_emits_invalid_operation() {
     // doesn't fire first.
     let output = common::typecheck_isolated(
         r"
-            type Holder {
-                v: i64;
+            enum Holder {
+                One;
+                Two;
             }
 
             fn make() -> Holder {
-                Holder { v: 1 }
+                Holder.One
             }
 
             fn main() {


### PR DESCRIPTION
## Why

`p is q` on a `type Point { x: i64; y: i64; }` declaration passed the type
checker and then died in the codegen front with

```
E_CODEGEN_FRONT_FAIL_CLOSED: codegen-front validation failed: fail-closed: IdentityCompare lhs must be a pointer or integer value
```

with no source location and no remedy. That is a compiler-invariant message,
not a user diagnostic. The checker's identity-allowance predicate claimed
`type Foo { ... }` declarations were Rc-backed and therefore identity-bearing;
under the v0.5 value model (`docs/v05/ownership.md`) a record is a
copy-on-write value with structural `==` and no pointer identity, which is
exactly why the codegen front has no `IdentityCompare` lowering for its
representation.

## What

- **types**: `is_identity_capable` no longer admits `TypeDefKind::Struct`, so
  `is` on a record is rejected at the use site with `E_IS_VALUE_TYPE`. The
  checker is the last word; the codegen-front legality check becomes an
  unreachable backstop. Machines, actors and enums stay in the allowance set —
  only the record answer is settled here.
- **types**: the rejection reports once per `is` expression when both operands
  are the same value type. Two carets carrying a byte-identical message about
  one type read as two separate bugs; operands of different value types still
  get one diagnostic each.
- **types**: the message names the offending type and points at `==`, the
  operator that does compare two records, instead of talking about
  "heap-backed types".
- **spec**: the `is` entry in the operator-precedence table now names record
  declarations among the rejected operands and says why.
- **hir / lsp / sandbox**: four fixtures used a record receiver the checker now
  rejects, and move to a receiver that still reaches the behaviour they pin —
  the HIR type-pattern vertical and the LSP `is` fixture to an enum, and the
  sandbox profile's `is` rejection and its parity-ratchet row to `Vec` handles,
  so the sandbox's own reserved-feature rejection is still what fires.

## Test

- `hew-cli::is_value_type_reject_e2e` — the issue's repro through `hew check`:
  the rejection appears, it is attributed to the user's source line, and
  `E_CODEGEN_FRONT_FAIL_CLOSED` never surfaces. Negative controls in the same
  file: `==` on the same two records checks clean, and `is` on two `Vec`
  handles still checks clean.
- `hew-types::coverage is_allowance` — `record_type_is_record_type_rejected`,
  `record_type_rejection_names_the_type_and_suggests_equality`,
  `record_type_rejection_is_reported_once_per_expression`,
  `distinct_value_type_operands_are_each_reported` (counter-case for the
  de-duplication), and `record_type_structural_equality_still_accepted`. The
  existing actor-ref / `Vec` / `HashMap` / `HashSet` / `bytes` acceptances are
  unchanged.
