### PR TITLE
refactor(cli): group hew --help by audience and move internal commands under hew tool

### DIFF
--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -33,8 +33,8 @@ flowchart TD
 
 **Current v0.5 inspection commands:**
 
-- `hew compile --dump-mir raw|checked|elab <file.hew>` — inspect the MIR ladder without LLVM emission
-- `hew compile --emit-dir <dir> <file.hew>` — write LLVM/object/WASM artefacts for the Rust codegen path
+- `hew tool compile --dump-mir raw|checked|elab <file.hew>` — inspect the MIR ladder without LLVM emission
+- `hew tool compile --emit-dir <dir> <file.hew>` — write LLVM/object/WASM artefacts for the Rust codegen path
 - `hew machine diagram [--format mermaid|graphviz|json] <file.hew>` — render machine declarations
 - `hew machine list <file.hew>` — list machines, states, and events
 

--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -24,8 +24,8 @@ compiler configuration nor a compatibility contract. The cutover contract in
 
 Hew v0.5 compiles through an explicit sequence of representations. Each layer
 has a distinct owner, verifier or diagnostic class, and an eventual
-deterministic text dump. Today the CLI exposes `hew compile --dump-sir` and
-`hew compile --dump-mir raw|checked|elab`; AST/HIR dumps are planned cutover
+deterministic text dump. Today the CLI exposes `hew tool compile --dump-sir` and
+`hew tool compile --dump-mir raw|checked|elab`; AST/HIR dumps are planned cutover
 tooling, not current commands.
 
 **Status convention:** this document defines the required final architecture.
@@ -101,7 +101,7 @@ compile / run / build / debug / test / watch --run / eval
 Target choice begins no earlier than the MIR/LLVM boundary. Native, Wasm, and
 embedded builds are target outputs; ORC JIT is an execution mode over the same
 verified LLVM IR, not a second middle end. Inspection modes may intentionally
-stop after a layer. [current] `hew compile --dump-sir` and `--dump-mir
+stop after a layer. [current] `hew tool compile --dump-sir` and `--dump-mir
 raw|checked|elab` do so today; AST/HIR inspection exits are planned. No
 execution mode may skip, duplicate, or substitute semantic lowering.
 
@@ -407,7 +407,7 @@ Optimization-safety verifier ledger:
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Constant-CFG region discard | Every newly unreachable block has no value or ownership use carrying a drop obligation and no operation with a `MayTrap` edge. | `optimize_cfg` proves ordinary structural verification accepts a folded candidate with a discarded trapping arm, while the discard-safety verifier rejects it and leaves the original function unchanged. |
 
-**Dump:** `hew compile --dump-sir`.
+**Dump:** `hew tool compile --dump-sir`.
 
 ### 2.5 Raw MIR (`hew-mir::raw`)
 
@@ -487,7 +487,7 @@ an LLVM-specific backend.
 is dominated by its definition, every site has a chosen value-model operation
 (no "unclassified").
 
-**Dump:** [current] `hew compile --dump-mir raw`.
+**Dump:** [current] `hew tool compile --dump-mir raw`.
 
 #### Current raw coroutine substrate
 
@@ -519,7 +519,7 @@ value-cost language (see §4.3).
 at <span> but read at <span>", "two mutations alias the same value", "affine
 resource `c` would be shared across an actor send — consume or materialize".
 
-**Dump:** [current] `hew compile --dump-mir checked` (annotation overlay: `// read-share`,
+**Dump:** [current] `hew tool compile --dump-mir checked` (annotation overlay: `// read-share`,
 `// move (last use)`, `// ensure-unique → mutate`, `// materialize`, etc.).
 
 ---
@@ -547,7 +547,7 @@ tables.
 no `Drop` of a moved-out place; cleanup-block dominance; coroutine frame-slot
 type matches yield value-class; DecisionMap is total and SiteIds are stable.
 
-**Dump:** [current] `hew compile --dump-mir elab` (includes explicit drop / cleanup-block section
+**Dump:** [current] `hew tool compile --dump-mir elab` (includes explicit drop / cleanup-block section
 and DecisionMap).
 
 ---
@@ -573,7 +573,7 @@ legalization; instruction selection; or machine policy.
 unsupported MIR constructs, missing locals, unresolved runtime symbols, and
 LLVM verifier failures.
 
-**Dump:** textual `.ll` plus any requested MIR dump (`hew compile
+**Dump:** textual `.ll` plus any requested MIR dump (`hew tool compile
 --dump-mir raw|checked|elab`).
 
 ---
@@ -844,7 +844,7 @@ the Checked MIR and Elaborated MIR stages.
 
 ## 7. Building the v0.5 spine
 
-At hard cutover, `hew compile` runs the v0.5 Rust
+At hard cutover, `hew tool compile` runs the v0.5 Rust
 HIR/SIR/MIR/codegen-rs path. The backend is a normal Cargo dependency of `hew`;
 no retired C++ backend build step is involved:
 

--- a/docs/internal/v05-type-descriptor-contract.md
+++ b/docs/internal/v05-type-descriptor-contract.md
@@ -16,7 +16,7 @@ are wire-rejected or handled as composites.
 
 - monomorphisation symbol mangling (replaces ad-hoc per-call-site string building)
 - `PrimitiveWireKind::Nested(name)` carriage on the wire
-- IR dump identity in `hew compile --dump-sir` / `--dump-mir <stage>`
+- IR dump identity in `hew tool compile --dump-sir` / `--dump-mir <stage>`
 
 ## Fail-closed rules
 

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -68,6 +68,11 @@ impl SirModeArgs {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Compile a .hew file through the v0.5 IR ladder.
+    ///
+    /// Superseded by `hew tool compile`. Kept as a hidden alias so the
+    /// Makefile, release scripts, and the bare `hew <file>.hew` fallback keep
+    /// working while they migrate.
+    #[command(hide = true)]
     Compile(CompileArgs),
     /// Compile and run a .hew file.
     Run(RunArgs),
@@ -96,7 +101,13 @@ pub enum Command {
     /// Scaffold a manifest-first project (`hew.toml` + starter source + merged `.gitignore`).
     Init(InitArgs),
     /// Curated playground example tools.
+    ///
+    /// Superseded by `hew tool playground-verify`. Kept as a hidden alias so
+    /// CI keeps working while it migrates.
+    #[command(hide = true)]
     Playground(PlaygroundCommand),
+    /// Compiler-internal tools.
+    Tool(ToolCommand),
     /// Print shell completion script.
     Completions(CompletionsArgs),
     /// Print version info.
@@ -927,6 +938,29 @@ pub struct PlaygroundVerifyArgs {
     /// Per-example execution timeout (`500ms`, `30s`, `1m`; bare integers mean seconds).
     #[arg(long, default_value = "30", value_name = "DURATION")]
     pub timeout: String,
+}
+
+// ---------------------------------------------------------------------------
+// Tool
+// ---------------------------------------------------------------------------
+
+/// The compiler-internal surface: harnesses the compiler team drives, not
+/// commands a Hew program's author reaches for. Keeping them behind one
+/// namespace lets the public help stay about building and shipping code.
+#[derive(Debug, Args)]
+pub struct ToolCommand {
+    #[command(subcommand)]
+    pub command: ToolSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ToolSubcommand {
+    /// Compile a .hew file through the v0.5 IR ladder.
+    Compile(CompileArgs),
+    /// Compile and run each runnable playground example and verify its stdout
+    /// against the checked-in `.expected` file.
+    #[command(name = "playground-verify")]
+    PlaygroundVerify(PlaygroundVerifyArgs),
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-cli/src/help.rs
+++ b/hew-cli/src/help.rs
@@ -1,0 +1,268 @@
+//! The audience-grouped `hew --help` listing.
+//!
+//! clap renders every subcommand under one flat `Commands:` heading, which put
+//! the seventeen package and registry commands beside `hew build`. The command
+//! set is grouped here instead: the listing is generated from clap's own
+//! metadata - names, visibility, and the `about` line each subcommand already
+//! carries - and installed as the literal part of a help template, so a
+//! description is written in exactly one place and the help cannot drift from
+//! the parser.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use clap::Command;
+
+/// Width the generated listing wraps to.
+///
+/// WHY: clap's own default when stdout is not a terminal, which is what the
+/// help tests and every piped invocation see. WHEN: replace this with the live
+/// terminal width once the listing is rendered at print time rather than baked
+/// into the template string. WHAT: a real solution asks clap for `term_w`,
+/// which is private to its help renderer today.
+const LISTING_WIDTH: usize = 100;
+
+/// Indent before a command name.
+const INDENT: &str = "  ";
+
+/// Minimum gap between the longest command name and the descriptions.
+const GAP: usize = 2;
+
+/// Heading commands land under when no group claims them.
+///
+/// A command is never dropped from the help because someone forgot to file it;
+/// it surfaces here instead, and `unfiled_commands_are_empty` fails.
+const UNFILED_HEADING: &str = "Other";
+
+/// Audience groups, in the order they are listed, and the commands in each.
+///
+/// Membership is stated once here rather than on the variants because clap 4.6
+/// has no per-subcommand `help_heading`: `Command::help_heading` groups
+/// arguments only, and subcommands render under a single heading.
+const COMMAND_GROUPS: &[(&str, &[&str])] = &[
+    (
+        "Build and run",
+        &["run", "build", "debug", "watch", "eval", "init"],
+    ),
+    (
+        "Code quality",
+        &["check", "test", "fmt", "doc", "wire", "machine"],
+    ),
+    (
+        "Packages",
+        &[
+            "add", "remove", "install", "update", "outdated", "tree", "list", "search", "info",
+            "publish",
+        ],
+    ),
+    (
+        "Registry account",
+        &[
+            "login",
+            "logout",
+            "key",
+            "namespace",
+            "yank",
+            "deprecate",
+            "index",
+        ],
+    ),
+    (
+        "Tooling",
+        &["tool", "lsp", "observe", "completions", "version"],
+    ),
+];
+
+/// The `hew` command with the grouped help installed.
+///
+/// Parsing goes through this rather than `Cli::command()` so `--help` and the
+/// parser can never describe different command sets.
+pub(crate) fn hew_command() -> Command {
+    let command = <crate::args::Cli as clap::CommandFactory>::command();
+    let template = help_template(&command);
+    command.help_template(template)
+}
+
+/// Build the help template: clap's own layout with the flat `{all-args}`
+/// command list replaced by the grouped listing as literal text.
+///
+/// Literal template text is emitted verbatim, so the two-column alignment
+/// survives; `{before-help}` would be re-wrapped by clap and lose it.
+fn help_template(command: &Command) -> String {
+    let styles = command.get_styles();
+    let header = styles.get_header();
+
+    let mut ungrouped: BTreeMap<&str, &Command> = command
+        .get_subcommands()
+        .filter(|sub| !sub.is_hide_set())
+        .map(|sub| (sub.get_name(), sub))
+        .collect();
+
+    let mut groups: Vec<(&str, Vec<&Command>)> = Vec::new();
+    for (heading, names) in COMMAND_GROUPS {
+        let members: Vec<&Command> = names
+            .iter()
+            .filter_map(|name| ungrouped.remove(name))
+            .collect();
+        if !members.is_empty() {
+            groups.push((heading, members));
+        }
+    }
+    if !ungrouped.is_empty() {
+        groups.push((UNFILED_HEADING, ungrouped.into_values().collect()));
+    }
+
+    let name_column = groups
+        .iter()
+        .flat_map(|(_, members)| members.iter())
+        .map(|sub| sub.get_name().chars().count())
+        .max()
+        .unwrap_or(0)
+        + GAP;
+
+    let mut template = String::from("{before-help}{about-with-newline}\n{usage-heading} {usage}\n");
+    for (heading, members) in &groups {
+        let _ = write!(template, "\n{header}{heading}:{header:#}\n");
+        for sub in members {
+            push_entry(&mut template, sub, name_column, styles);
+        }
+    }
+    let _ = write!(template, "\n{header}Options:{header:#}\n");
+    template.push_str("{options}{after-help}");
+    template
+}
+
+/// Write one `  name    description` row, wrapped and hanging-indented.
+fn push_entry(out: &mut String, sub: &Command, name_column: usize, styles: &clap::builder::Styles) {
+    let literal = styles.get_literal();
+    let name = sub.get_name();
+    let about = sub.get_about().map(ToString::to_string).unwrap_or_default();
+
+    let indent = INDENT.len() + name_column;
+    out.push_str(INDENT);
+    let _ = write!(out, "{literal}{name}{literal:#}");
+    if about.is_empty() {
+        out.push('\n');
+        return;
+    }
+    out.push_str(&" ".repeat(name_column - name.chars().count()));
+
+    for (index, line) in wrap(&about, LISTING_WIDTH.saturating_sub(indent))
+        .into_iter()
+        .enumerate()
+    {
+        if index > 0 {
+            out.push_str(&" ".repeat(indent));
+        }
+        out.push_str(&line);
+        out.push('\n');
+    }
+}
+
+/// Greedy word wrap. Descriptions are single-line prose, so word boundaries are
+/// the only break points needed.
+fn wrap(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.chars().count() + 1 + word.chars().count() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hew_command, COMMAND_GROUPS, LISTING_WIDTH, UNFILED_HEADING};
+
+    fn rendered_help() -> String {
+        hew_command().render_help().to_string()
+    }
+
+    fn visible_command_names() -> Vec<String> {
+        hew_command()
+            .get_subcommands()
+            .filter(|sub| !sub.is_hide_set())
+            .map(|sub| sub.get_name().to_string())
+            .collect()
+    }
+
+    /// The generated listing only - clap owns the usage and options sections.
+    fn listing_lines(help: &str) -> Vec<&str> {
+        let start = help
+            .find("\nBuild and run:\n")
+            .expect("grouped listing should be present");
+        let end = start
+            + help[start..]
+                .find("\nOptions:\n")
+                .expect("options section should follow the listing");
+        help[start..end].lines().collect()
+    }
+
+    /// The point of the change: a reader scanning `hew --help` sees five
+    /// audiences instead of one flat list.
+    #[test]
+    fn help_lists_commands_under_audience_headings() {
+        let help = rendered_help();
+        for (heading, _) in COMMAND_GROUPS {
+            assert!(
+                help.contains(&format!("\n{heading}:\n")),
+                "`{heading}:` heading missing from help:\n{help}"
+            );
+        }
+        assert!(
+            !help.contains("\nCommands:\n"),
+            "the flat command list should be gone:\n{help}"
+        );
+    }
+
+    /// Fail-closed control for the group table: a command added to the parser
+    /// and forgotten here still reaches the help, and this test says so.
+    #[test]
+    fn every_visible_command_is_filed_under_exactly_one_group() {
+        let visible = visible_command_names();
+        assert!(!visible.is_empty(), "no visible subcommands to file");
+
+        for name in &visible {
+            let groups: Vec<&str> = COMMAND_GROUPS
+                .iter()
+                .filter(|(_, names)| names.contains(&name.as_str()))
+                .map(|(heading, _)| *heading)
+                .collect();
+            assert_eq!(
+                groups.len(),
+                1,
+                "`{name}` is filed under {groups:?}, expected exactly one group"
+            );
+        }
+
+        let help = rendered_help();
+        assert!(
+            !help.contains(&format!("\n{UNFILED_HEADING}:\n")),
+            "unfiled commands reached the help:\n{help}"
+        );
+    }
+
+    /// A long description wraps under its own column rather than running off
+    /// the page or breaking the two-column alignment.
+    #[test]
+    fn help_listing_wraps_within_the_listing_width() {
+        let help = rendered_help();
+        for line in listing_lines(&help) {
+            assert!(
+                line.chars().count() <= LISTING_WIDTH,
+                "line exceeds the listing width: {line:?}"
+            );
+        }
+    }
+}

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1,8 +1,6 @@
 //! `hew` — the Hew programming language compiler driver.
 //!
 //! ```text
-//! hew compile file.hew [--emit-dir DIR] [--dump-mir raw|elab] [--target wasm32-unknown-unknown]
-//!                                  # Run the v0.5 IR ladder and emit native or WASM
 //! hew run [file.hew|DIR] [-- args...]
 //!                                  # Compile and run a package or explicit file
 //! hew debug file.hew [-- args...]  # Compile through v0.5 native codegen and launch a debugger
@@ -20,7 +18,8 @@
 //! hew fmt --check file.hew         # Check formatting (CI mode)
 //! hew init [name] [--lib|--actor]  # Scaffold a manifest-first project (hew.toml + source)
 //! hew add <pkg> / hew install / …  # Package-manager commands (see hew --help)
-//! hew playground verify            # Verify runnable playground examples
+//! hew tool compile file.hew        # Run the v0.5 IR ladder and emit native or WASM
+//! hew tool playground-verify       # Verify runnable playground examples
 //! hew completions <shell>          # Print shell completion script
 //! hew version                      # Print version info
 //! hew observe [args...]             # Launch the TUI actor observer (delegates to hew-observe)
@@ -34,6 +33,7 @@ mod diagnostic_json;
 mod doc;
 mod eval;
 mod explain_cow;
+mod help;
 mod jit;
 mod link;
 mod machine;

--- a/hew-cli/src/playground.rs
+++ b/hew-cli/src/playground.rs
@@ -71,13 +71,7 @@ enum EntryOutcome {
 // ---------------------------------------------------------------------------
 
 /// Run the `hew playground verify` subcommand.
-pub fn cmd_playground(args: &crate::args::PlaygroundCommand) {
-    match &args.command {
-        crate::args::PlaygroundSubcommand::Verify(verify_args) => cmd_verify(verify_args),
-    }
-}
-
-fn cmd_verify(args: &crate::args::PlaygroundVerifyArgs) {
+pub fn cmd_playground_verify(args: &crate::args::PlaygroundVerifyArgs) {
     let timeout = crate::util::parse_timeout(&args.timeout).unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -1,9 +1,9 @@
 use std::ffi::OsString;
 use std::path::Path;
 
-use clap::Parser;
+use clap::FromArgMatches;
 
-use crate::args::{self, Cli, Command};
+use crate::args::{self, Cli, Command, ToolSubcommand};
 
 pub(crate) trait CommandDispatcher {
     fn compile(&mut self, args: &args::CompileArgs);
@@ -19,7 +19,7 @@ pub(crate) trait CommandDispatcher {
     fn machine(&mut self, args: &args::MachineCommand);
     fn fmt(&mut self, args: &args::FmtArgs);
     fn init(&mut self, args: &args::InitArgs);
-    fn playground(&mut self, args: &args::PlaygroundCommand);
+    fn playground_verify(&mut self, args: &args::PlaygroundVerifyArgs);
     fn completions(&mut self, args: &args::CompletionsArgs);
     fn version(&mut self);
     fn help(&mut self);
@@ -83,8 +83,8 @@ impl CommandDispatcher for MainCommandDispatcher {
         crate::cmd_init(args);
     }
 
-    fn playground(&mut self, args: &args::PlaygroundCommand) {
-        crate::playground::cmd_playground(args);
+    fn playground_verify(&mut self, args: &args::PlaygroundVerifyArgs) {
+        crate::playground::cmd_playground_verify(args);
     }
 
     fn completions(&mut self, args: &args::CompletionsArgs) {
@@ -98,7 +98,7 @@ impl CommandDispatcher for MainCommandDispatcher {
     fn help(&mut self) {
         // No subcommand — shouldn't normally happen since clap shows help,
         // but handle gracefully.
-        let _ = <Cli as clap::CommandFactory>::command().print_help();
+        let _ = crate::help::hew_command().print_help();
         eprintln!();
         std::process::exit(1);
     }
@@ -135,7 +135,13 @@ pub(crate) fn dispatch_command(command: Option<&Command>, dispatcher: &mut impl 
         Some(Command::Machine(args)) => dispatcher.machine(args),
         Some(Command::Fmt(args)) => dispatcher.fmt(args),
         Some(Command::Init(args)) => dispatcher.init(args),
-        Some(Command::Playground(args)) => dispatcher.playground(args),
+        Some(Command::Playground(args)) => match &args.command {
+            args::PlaygroundSubcommand::Verify(verify) => dispatcher.playground_verify(verify),
+        },
+        Some(Command::Tool(tool)) => match &tool.command {
+            ToolSubcommand::Compile(args) => dispatcher.compile(args),
+            ToolSubcommand::PlaygroundVerify(args) => dispatcher.playground_verify(args),
+        },
         Some(Command::Completions(args)) => dispatcher.completions(args),
         Some(Command::Version) => dispatcher.version(),
         Some(Command::Observe(args)) => dispatcher.observe(args),
@@ -150,13 +156,20 @@ where
     I: IntoIterator<Item = OsString>,
 {
     let raw_args: Vec<OsString> = args.into_iter().collect();
-    match Cli::try_parse_from(raw_args.clone()) {
+    match parse_from(raw_args.clone()) {
         Ok(cli) => Ok(cli),
         Err(error) => match compile_fallback_args(&raw_args) {
-            Some(fallback_args) => Cli::try_parse_from(fallback_args),
+            Some(fallback_args) => parse_from(fallback_args),
             None => Err(error),
         },
     }
+}
+
+/// Parse through [`crate::help::hew_command`] rather than `Cli::try_parse_from`
+/// so the command that answers `--help` is the command that parses.
+fn parse_from(args: Vec<OsString>) -> Result<Cli, clap::Error> {
+    let matches = crate::help::hew_command().try_get_matches_from(args)?;
+    Cli::from_arg_matches(&matches)
 }
 
 fn compile_fallback_args(raw_args: &[OsString]) -> Option<Vec<OsString>> {
@@ -251,6 +264,59 @@ mod tests {
             compile_fallback_args(&[OsString::from("hew"), OsString::from("version")]),
             None
         );
+    }
+
+    /// The `hew tool compile` spelling must be the same parse as the old
+    /// top-level one, flags and all - the move is a rename of the surface, not
+    /// a change to the harness.
+    #[test]
+    fn tool_compile_parses_identically_to_the_hidden_compile_alias() {
+        let argv = ["--dump-mir", "raw", "sample.hew"];
+
+        let namespaced = parse_compile(["hew", "tool", "compile"].into_iter().chain(argv));
+        let alias = parse_compile(["hew", "compile"].into_iter().chain(argv));
+
+        assert_eq!(format!("{namespaced:?}"), format!("{alias:?}"));
+        assert_eq!(namespaced.dump_mir.as_deref(), Some("raw"));
+        assert_eq!(namespaced.input, PathBuf::from("sample.hew"));
+    }
+
+    /// The old spellings still parse for the Makefile and the release scripts,
+    /// and the negative control is that a reader is not offered them: the help
+    /// never says `playground`.
+    #[test]
+    fn hidden_aliases_parse_but_are_absent_from_the_help() {
+        let alias = try_parse_cli_with_compile_fallback(
+            ["hew", "playground", "verify"]
+                .into_iter()
+                .map(OsString::from),
+        )
+        .expect("`hew playground verify` should still parse");
+        assert!(matches!(
+            alias.command,
+            Some(crate::args::Command::Playground(_))
+        ));
+
+        let help = crate::help::hew_command().render_help().to_string();
+        assert!(
+            !help.contains("playground"),
+            "the retired spelling should not be offered in help:\n{help}"
+        );
+    }
+
+    fn parse_compile<'a>(argv: impl Iterator<Item = &'a str>) -> CompileArgs {
+        let cli = try_parse_cli_with_compile_fallback(argv.map(OsString::from))
+            .expect("compile arguments should parse");
+        match cli.command {
+            Some(crate::args::Command::Compile(compile)) => compile,
+            Some(crate::args::Command::Tool(tool)) => match tool.command {
+                crate::args::ToolSubcommand::Compile(compile) => compile,
+                crate::args::ToolSubcommand::PlaygroundVerify(_) => {
+                    panic!("expected a compile command, got playground-verify")
+                }
+            },
+            other => panic!("expected a compile command, got {other:?}"),
+        }
     }
 
     #[test]
@@ -350,6 +416,28 @@ mod tests {
         dispatch_command(Some(&command), &mut dispatcher);
 
         assert_eq!(dispatcher.calls, vec!["wire"]);
+    }
+
+    #[test]
+    fn dispatch_command_routes_tool_namespace_to_the_same_handlers() {
+        let command = crate::args::Command::Tool(crate::args::ToolCommand {
+            command: crate::args::ToolSubcommand::Compile(CompileArgs {
+                input: PathBuf::from("sample.hew"),
+                emit_dir: None,
+                emit_llvm: false,
+                dump_mir: None,
+                sir: SirModeArgs::default(),
+                dump_sir: false,
+                target: None,
+                opt_level: "0".to_string(),
+                format: crate::args::DiagnosticFormat::Text,
+            }),
+        });
+        let mut dispatcher = RecordingDispatcher::default();
+
+        dispatch_command(Some(&command), &mut dispatcher);
+
+        assert_eq!(dispatcher.calls, vec!["compile:sample.hew"]);
     }
 
     #[test]
@@ -455,8 +543,8 @@ mod tests {
             self.calls.push("init".to_string());
         }
 
-        fn playground(&mut self, _args: &crate::args::PlaygroundCommand) {
-            self.calls.push("playground".to_string());
+        fn playground_verify(&mut self, _args: &crate::args::PlaygroundVerifyArgs) {
+            self.calls.push("playground-verify".to_string());
         }
 
         fn completions(&mut self, args: &CompletionsArgs) {


### PR DESCRIPTION
## Why

`hew --help` listed thirty-eight commands under one flat `Commands:` heading, so
the seventeen package and registry commands sat beside `hew build`, `hew compile`
advertised the IR-ladder harness (`--dump-mir`, `--dump-sir`, `--emit-dir`) as
something a Hew author would reach for, and `hew playground` was a CI
example-verifier wearing a user command's name. The help now opens on five
audiences, and the harness lives behind `hew tool`.

## What

- **cli**: the top-level help is grouped - build and run, code quality, packages,
  registry account, tooling. clap 4.6 has no per-subcommand `help_heading`
  (`Command::help_heading` groups arguments; subcommands all render under one
  heading), so `hew-cli/src/help.rs` generates the listing from clap's own
  metadata - names, visibility, and the `about` each subcommand already carries -
  and installs it as the literal part of a help template. Descriptions stay on
  their variants, and parsing goes through the same `Command` that answers
  `--help`, so the two cannot describe different command sets.
- **cli**: `hew tool compile` and `hew tool playground-verify` are the spellings
  for the internal surface. The old `hew compile` and `hew playground verify`
  remain as hidden aliases (`hide = true`) - they parse, they do not appear in
  help or in the generated completions - so the Makefile and the release scripts
  keep working until they migrate. The bare `hew <file>.hew` fallback is
  unchanged.
- **docs**: `docs/internal/v05-ir-ladder.md`,
  `docs/internal/v05-type-descriptor-contract.md`, and `docs/diagrams.md` name
  `hew tool compile` for the IR dumps.

User-facing behaviour of every public command is unchanged: no flag moved, no
output changed.

`docs/` and `README.md` carry no `adze` references. The four remaining mentions
are `CHANGELOG.md` entries for releases that really did ship a binary by that
name, so they are left as the release record.

## Test

`hew-cli` unit tests, all behavioural against the real clap command:

- `help::tests::help_lists_commands_under_audience_headings` - each audience
  heading is present and the flat `Commands:` list is gone.
- `help::tests::every_visible_command_is_filed_under_exactly_one_group` -
  fail-closed control on the group table: a command added to the parser and left
  out of the table still reaches the help, under `Other:`, and this fails.
- `help::tests::help_listing_wraps_within_the_listing_width` - long descriptions
  wrap under their own column instead of running off the page.
- `router::tests::tool_compile_parses_identically_to_the_hidden_compile_alias` -
  `hew tool compile --dump-mir raw sample.hew` and the old spelling produce the
  same `CompileArgs`.
- `router::tests::hidden_aliases_parse_but_are_absent_from_the_help` -
  `hew playground verify` still parses; the negative control is that the rendered
  help contains no `playground`.
- `router::tests::dispatch_command_routes_tool_namespace_to_the_same_handlers` -
  the namespaced command reaches the same handler as the alias.
