### PR TITLE
docs(spec): retire stale generator, harness, and THIR claims

### DIFF
--- a/docs/specs/HEW-FUTURE.md
+++ b/docs/specs/HEW-FUTURE.md
@@ -99,21 +99,20 @@ Edition 2026 ships supervisor strategies (`one_for_one`, `one_for_all`,
 hot-swap upgrades, dynamic strategy changes, supervisor introspection
 APIs — are deferred.
 
-### 1.6 Generators (`gen fn`, `async gen fn`, `receive gen fn`, `Lazy<T>`, `#[prefetch(N)]`)
+### 1.6 Generators (`Lazy<T>`, `#[prefetch(N)]`)
 
-**[Scalar-parameter + fn-typed-parameter forms live in v0.5 / remaining forms deferred]**
+**[`gen fn`, `async gen fn`, and `receive gen fn` live in v0.5 / remaining forms deferred]**
 
-Zero-parameter `gen fn` functions compile and run. The LLVM coroutine machinery,
-`yield`, `.next()`, and `for x in generator()` are all live. Parameterized `gen fn`
-with scalar parameters (e.g. `n: i64`) and fn-typed parameters are also live — the
-Cluster 1 parameter/capture lowering that unblocked these shipped and the
-`gen_fn_param_capture` and `gen_fn_fn_typed_param` vertical-slice fixtures pass.
+`gen fn` functions compile and run, including parameterized forms with scalar
+parameters (e.g. `n: i64`) and fn-typed parameters. The LLVM coroutine
+machinery, `yield`, `.next()`, and `for x in generator()` are all live.
+`async gen fn` returning `AsyncGenerator<Y>` consumed with `for await` is
+also live. `receive gen fn` on actors returning `Stream<Y>` backed by
+mailbox protocol (cross-actor streaming with natural backpressure) is live
+as well — the `receive_gen_fn_*` vertical-slice fixtures pass.
 
 Remaining deferred:
 
-- `async gen fn` returning `AsyncGenerator<Y>` with `for await`.
-- `receive gen fn` on actors returning `Stream<Y>` backed by mailbox
-  protocol (cross-actor streaming with natural backpressure).
 - `Lazy<T>` for memoised one-shot computations.
 - `#[prefetch(N)]` attribute as an optimisation hint on cross-actor
   generators.

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -4537,9 +4537,9 @@ AST                       — concrete syntax, no name resolution
     │  resolve
     ▼
 Resolved HIR              — names, scopes, capabilities resolved;
-    │  type check          stable BindingId / SiteId carriage
-    ▼
-THIR                      — every expression carries its concrete type;
+    │  type check          stable BindingId / SiteId carriage;
+    ▼                       every expression carries its concrete type
+SIR                       — semantic SSA: typed values, effects, CFG;
     │  lower               monomorphisation and trait-dispatch done
     ▼
 Raw MIR                   — real CFG, real Places, real terminators
@@ -4565,10 +4565,10 @@ Native object / WASM
   use site resolves to a binding or to a `NameNotFound` diagnostic.
   Capabilities (Send, Frozen, Copy) attach here. Module structure is
   fully resolved.
-- **THIR.** Every expression carries its concrete `Ty`. No `Ty::Var`
-  survives this stage — the boundary is fail-closed. Generic functions
-  are monomorphised at use sites; trait dispatch resolves to concrete
-  implementations; closure signatures are explicit; aggregate
+- **SIR.** Semantic SSA: typed values, effects, and the CFG. No `Ty::Var`
+  survives Resolved HIR — the boundary is fail-closed before SIR is built.
+  Generic functions are monomorphised at use sites; trait dispatch resolves
+  to concrete implementations; closure signatures are explicit; aggregate
   initialiser type arguments are carried.
 - **Raw MIR.** The function body is a control-flow graph of basic
   blocks with real terminators (`Goto`, `Branch`, `Return`, `Drop`,
@@ -4935,7 +4935,9 @@ summarises what is shipped and stable.
 - `PartitionPolicy::FailFast` and partition-detected-dead resolution for
   pending remote asks.
 - SWIM-based membership with quarantine and incarnation-gated readmission.
-- Two-process CI harness (13/13) as the distributed proving gate.
+- Two-process CI harness covering cross-node send/ask, monitor/link
+  semantics, partition handling, and SWIM membership as the distributed
+  proving gate.
 
 Authentication tokens and supervisor-capability enforcement are not yet
 runtime-enforced; see `HEW-DIST-SPEC.md` §rc1-notes for the current
@@ -5333,7 +5335,7 @@ If you want this to be directly executable as an engineering project, the next m
   normative — `dns`, `tls`, `quic`, `websocket`, `xml`/`yaml`/`toml`/`csv`,
   `regex`, `process`, `compress` — move to HEW-FUTURE.md §3.
 - **MIR ladder.** §8 (compilation model) is rewritten around the new IR
-  ladder: AST → Resolved HIR → THIR → Raw MIR → Checked MIR → Elaborated
+  ladder: AST → Resolved HIR → SIR → Raw MIR → Checked MIR → Elaborated
   MIR → LLVM IR via inkwell. The v0.4 Rust-frontend / C++ backend /
   MessagePack-AST pipeline is no longer the design.
 - **Deferred to next edition.** Generators (`async gen fn` /


### PR DESCRIPTION
## Why

`docs/specs/HEW-FUTURE.md` §1.6 still listed `async gen fn` / `AsyncGenerator<Y>`
and `receive gen fn` as deferred, but both ship and run today. HEW-SPEC-2026 §11
carried a fixed 13/13 test-count claim for the two-process distributed harness
that no longer matches the harness's actual case count. HEW-SPEC-2026 also
still described THIR in the IR ladder (§8.1 diagram, §8.1 bullet, and a
changelog note) after THIR was deleted from the compiler (#3131).

## What

- `HEW-FUTURE.md` §1.6: keeps only what is actually deferred (`Lazy<T>`,
  `#[prefetch(N)]`); states that `gen fn`, `async gen fn`, and
  `receive gen fn` ship.
- `HEW-SPEC-2026.md` §11: the harness bullet now describes what it covers
  (send/ask, monitor/link, partition handling, SWIM membership) instead of
  a case count.
- `HEW-SPEC-2026.md` §8.1: the IR ladder diagram and its stage bullet now
  name SIR instead of THIR, matching the current HIR → SIR → Raw/Checked/
  Elaborated MIR ladder (`docs/internal/v05-ir-ladder.md`). The changelog
  note describing the §8 rewrite is updated to match.

Both spec files are in `.prettierignore`; only the changed lines were
touched (`git diff --stat`: 20/19 across both files, no reflow).

## Test

- Ran a three-yield `async gen fn` consumed with `for await` against the
  release `hew` binary — compiles and prints the expected sequence.
- Ran `tests/vertical-slice/accept/receive_gen_fn_string_yield.hew` and
  diffed its output against `receive_gen_fn_string_yield.expected` — exact
  match.
- Counted test functions in `hew-cli/tests/distributed_two_process_e2e.rs`:
  21, not 13 — confirms the stale count.
- `grep -n -i thir docs/specs/HEW-SPEC-2026.md docs/specs/HEW-FUTURE.md` —
  no real THIR mentions remain (one incidental substring match in
  "a *thir*d path is").
