### PR TITLE
fix(cli): give hew run and hew debug a sweepable temp home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,7 @@ dependencies = [
  "clap_complete",
  "dirs",
  "fd-lock",
+ "filetime",
  "finl_unicode",
  "hew-analysis",
  "hew-codegen-rs",
@@ -1794,6 +1795,7 @@ dependencies = [
  "tempfile",
  "toml",
  "wasmparser 0.252.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/hew-cli/Cargo.toml
+++ b/hew-cli/Cargo.toml
@@ -46,8 +46,15 @@ wasmparser = "0.252.0"
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+  "Win32_Foundation",
+  "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 fd-lock.workspace = true
+filetime = "0.2"
 hew-testutil = { path = "../hew-testutil" }
 object = "0.39"
 finl_unicode = { version = "=1.4.0", default-features = false, features = [

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -43,6 +43,7 @@ mod platform;
 mod playground;
 mod process;
 mod router;
+mod run_temp;
 #[cfg(unix)]
 mod signal;
 mod target;
@@ -1717,7 +1718,7 @@ fn compile_temp_wasi_module(
             std::process::exit(1);
         });
 
-    let tmp_dir = tempfile::tempdir().unwrap_or_else(|e| {
+    let tmp_dir = run_temp::create_hew_run_temp_dir().unwrap_or_else(|e| {
         eprintln!("Error: cannot create temp dir: {e}");
         std::process::exit(1);
     });
@@ -1827,7 +1828,7 @@ fn compile_temp_artifact(
 }
 
 fn create_debug_temp_artifact(target: &target::ExecutionTarget) -> CompiledTempExecutable {
-    let tmp_dir = tempfile::tempdir().unwrap_or_else(|e| {
+    let tmp_dir = run_temp::create_hew_run_temp_dir().unwrap_or_else(|e| {
         eprintln!("Error: cannot create temp dir: {e}");
         std::process::exit(1);
     });
@@ -1840,7 +1841,7 @@ fn create_debug_temp_artifact(target: &target::ExecutionTarget) -> CompiledTempE
 }
 
 fn create_run_temp_artifact(target: &target::ExecutionTarget) -> CompiledTempExecutable {
-    let tmp_dir = tempfile::tempdir().unwrap_or_else(|e| {
+    let tmp_dir = run_temp::create_hew_run_temp_dir().unwrap_or_else(|e| {
         eprintln!("Error: cannot create temp dir: {e}");
         std::process::exit(1);
     });
@@ -1858,6 +1859,12 @@ fn cmd_run(a: &args::RunArgs) {
     // compile the program runs normally and its own stdout is preserved — no
     // empty array is emitted so program output is never corrupted.
     diagnostic_json::set_output_format(a.format.into());
+
+    // Second cleanup authority for #3132: RAII drop is the fast path for a
+    // normal exit, but a killed `hew run` never reaches it. This best-effort
+    // sweep removes stale `hew-run` artifact dirs left by earlier kills
+    // before this run creates its own; it never fails the run itself.
+    run_temp::sweep_on_startup();
 
     // No input, or a directory: the manifest names the entry point. Resolution
     // happens before any path reaches the compiler, so a directory is never
@@ -2157,6 +2164,10 @@ fn cmd_check_run(a: &args::CheckArgs) -> i32 {
 }
 
 fn cmd_debug(a: &args::DebugArgs) {
+    // See the matching comment in `cmd_run`: best-effort second cleanup
+    // authority for #3132, never fails the debug session.
+    run_temp::sweep_on_startup();
+
     let input = a.input.display().to_string();
     let options = a.to_compile_options();
     let target = resolve_debug_target(options.target.as_deref());

--- a/hew-cli/src/run_temp.rs
+++ b/hew-cli/src/run_temp.rs
@@ -115,10 +115,10 @@ fn pid_is_alive(pid: u32) -> bool {
 #[cfg(windows)]
 fn pid_is_alive(pid: u32) -> bool {
     use windows_sys::Win32::Foundation::{
-        CloseHandle, GetLastError, ERROR_INVALID_PARAMETER, HANDLE,
+        CloseHandle, GetLastError, ERROR_INVALID_PARAMETER, HANDLE, STILL_ACTIVE,
     };
     use windows_sys::Win32::System::Threading::{
-        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE,
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
     };
 
     // SAFETY: `OpenProcess` is called with a plain integer pid and no

--- a/hew-cli/src/run_temp.rs
+++ b/hew-cli/src/run_temp.rs
@@ -112,16 +112,32 @@ fn pid_is_alive(pid: u32) -> bool {
     std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
-// WHY: no dependency-light way to query pid liveness on Windows — the
-// `sysinfo` crate pulls a full process-table scan for one boolean, which is
-// heavy for a startup sweep.
-// WHEN: revisit if Windows leak reports show STALE_AGE alone isn't bounding
-// growth tightly enough.
-// WHAT: a real check would call `OpenProcess` + `GetExitCodeProcess` (or
-// `GetProcessTimes`) via `windows-sys`, behind this same function signature.
-#[cfg(not(unix))]
-fn pid_is_alive(_pid: u32) -> bool {
-    true // unknown liveness treated as alive; STALE_AGE is the sole sweep signal
+#[cfg(windows)]
+fn pid_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_INVALID_PARAMETER, HANDLE,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE,
+    };
+
+    // SAFETY: `OpenProcess` is called with a plain integer pid and no
+    // pointers; the returned handle (if any) is closed below before this
+    // function returns on every path.
+    let handle: HANDLE = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        // ERROR_INVALID_PARAMETER: no process with this pid exists - dead.
+        // Anything else (e.g. access denied): the process exists but we
+        // can't query it - treat as alive, mirroring the Unix EPERM case.
+        return unsafe { GetLastError() } != ERROR_INVALID_PARAMETER;
+    }
+    let mut exit_code: u32 = 0;
+    // SAFETY: `handle` was just returned non-null by `OpenProcess` above and
+    // is closed unconditionally after this call.
+    let got_exit_code = unsafe { GetExitCodeProcess(handle, &mut exit_code) };
+    unsafe { CloseHandle(handle) };
+    // If we couldn't read the exit code, don't guess dead - treat as alive.
+    got_exit_code == 0 || exit_code == STILL_ACTIVE as u32
 }
 
 #[cfg(test)]
@@ -161,9 +177,15 @@ mod tests {
         let root = tempfile::tempdir().expect("create sweep-test root");
         let old_dir = root.path().join(format!("{}-old", std::process::id()));
         std::fs::create_dir(&old_dir).expect("create aged entry");
+        // `std::fs::File::open` + `set_modified` fails on Windows for a
+        // directory target (`PermissionDenied`, os error 5): opening a
+        // directory as a plain file handle doesn't grant the attribute-write
+        // access needed to change its mtime there. `filetime::set_file_mtime`
+        // uses the platform-correct call for a directory (on Windows, an
+        // explicit `FILE_FLAG_BACKUP_SEMANTICS` open), so it works on every
+        // supported OS.
         let old_mtime = SystemTime::now() - (STALE_AGE + Duration::from_mins(1));
-        std::fs::File::open(&old_dir)
-            .and_then(|f| f.set_modified(old_mtime))
+        filetime::set_file_mtime(&old_dir, filetime::FileTime::from_system_time(old_mtime))
             .expect("backdate aged entry's mtime");
 
         sweep_stale_run_dirs(root.path());

--- a/hew-cli/src/run_temp.rs
+++ b/hew-cli/src/run_temp.rs
@@ -1,0 +1,190 @@
+//! Owned, sweepable temp storage for `hew run` / `hew debug` compiled
+//! artifacts (#3132).
+//!
+//! Before this module, `hew run` and `hew debug` compiled into a bare
+//! `tempfile::tempdir()` and relied on its RAII `Drop` as the only cleanup
+//! authority. Every normal exit path drops the artifact first, but nothing
+//! survives `SIGKILL` or an uncaught fatal signal — and test harnesses kill
+//! `hew run` routinely through timeouts and watchdogs. The leaked
+//! directories landed at unnamed `/tmp/.tmpXXXXXX` paths that nothing could
+//! recognise or sweep.
+//!
+//! Artifacts now live under a recognisable, owned home:
+//! `$TMPDIR/hew-run/<pid>-<rand>/`. `hew run` and `hew debug` startup
+//! opportunistically sweeps that home (bounded work, no daemon): an entry
+//! whose pid no longer exists is removed unconditionally, and any entry
+//! older than [`STALE_AGE`] is removed regardless of pid state, so pid reuse
+//! or a platform without a liveness check still bounds disk growth. A live
+//! pid is always skipped. RAII drop stays the fast path for a normal exit;
+//! the sweep is the second cleanup authority that survives a kill.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Directory name under the system temp root that owns every `hew run` /
+/// `hew debug` compiled artifact.
+const HEW_RUN_DIR_NAME: &str = "hew-run";
+
+/// An entry older than this is swept on startup even if its pid still looks
+/// alive — it defends against pid reuse, and on a platform where liveness
+/// can't be checked (see `pid_is_alive` below) it is the *only* signal that
+/// ever removes anything.
+const STALE_AGE: Duration = Duration::from_hours(6);
+
+/// Root directory owning every `hew run` / `hew debug` artifact:
+/// `$TMPDIR/hew-run`. Uses `std::env::temp_dir()`, which honours
+/// `TMPDIR`/`TMP`/`TEMP` — the same convention `hew_temp_dir()`
+/// (`hew-runtime/src/env.rs`) exposes to compiled Hew programs.
+pub fn hew_run_root() -> PathBuf {
+    std::env::temp_dir().join(HEW_RUN_DIR_NAME)
+}
+
+/// Create a fresh, recognisably-named temp dir under [`hew_run_root`] for
+/// this process's compiled artifact: `<pid>-<rand>`.
+pub fn create_hew_run_temp_dir() -> std::io::Result<tempfile::TempDir> {
+    let root = hew_run_root();
+    std::fs::create_dir_all(&root)?;
+    tempfile::Builder::new()
+        .prefix(&format!("{}-", std::process::id()))
+        .tempdir_in(&root)
+}
+
+/// Best-effort startup sweep for `hew run` / `hew debug`. Never panics and
+/// never surfaces an error to the caller: a sweep failure (unreadable
+/// entry, permission denied, root missing) must not block the compile-and-run
+/// the user is waiting on.
+pub fn sweep_on_startup() {
+    sweep_stale_run_dirs(&hew_run_root());
+}
+
+/// Remove stale entries directly under `root`. Every per-entry I/O error is
+/// swallowed; a single unreadable or unremovable entry does not stop the
+/// sweep from considering the rest.
+fn sweep_stale_run_dirs(root: &Path) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return; // no hew-run dir yet, or unreadable - nothing to sweep
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let name = entry.file_name();
+        let dead_pid = name
+            .to_str()
+            .and_then(leading_pid)
+            .is_some_and(|pid| !pid_is_alive(pid));
+        let stale = entry_age(&entry, now).is_some_and(|age| age > STALE_AGE);
+        if dead_pid || stale {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+/// Parse the leading `<pid>` off a `<pid>-<rand>` directory name. Any other
+/// shape (no hyphen, non-numeric prefix) yields `None`, and such an entry is
+/// then only ever swept by [`STALE_AGE`] — an unrecognised name is not
+/// evidence of a dead process.
+fn leading_pid(dir_name: &str) -> Option<u32> {
+    dir_name.split('-').next()?.parse().ok()
+}
+
+fn entry_age(entry: &std::fs::DirEntry, now: SystemTime) -> Option<Duration> {
+    let modified = entry.metadata().ok()?.modified().ok()?;
+    now.duration_since(modified).ok()
+}
+
+/// Cross-platform pid-liveness check.
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    let Ok(pid) = libc::pid_t::try_from(pid) else {
+        return false; // does not fit a real pid_t - cannot be a live process
+    };
+    // SAFETY: signal 0 sends nothing; it only asks the kernel whether `pid`
+    // exists and is visible to us.
+    let result = unsafe { libc::kill(pid, 0) };
+    if result == 0 {
+        return true;
+    }
+    // EPERM: the process exists but is owned by another user - still alive.
+    // ESRCH (no such process), or anything else: treat as dead; STALE_AGE is
+    // the backstop for any state `kill(2)` cannot resolve.
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+// WHY: no dependency-light way to query pid liveness on Windows — the
+// `sysinfo` crate pulls a full process-table scan for one boolean, which is
+// heavy for a startup sweep.
+// WHEN: revisit if Windows leak reports show STALE_AGE alone isn't bounding
+// growth tightly enough.
+// WHAT: a real check would call `OpenProcess` + `GetExitCodeProcess` (or
+// `GetProcessTimes`) via `windows-sys`, behind this same function signature.
+#[cfg(not(unix))]
+fn pid_is_alive(_pid: u32) -> bool {
+    true // unknown liveness treated as alive; STALE_AGE is the sole sweep signal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pid value no live process on Linux (default `pid_max` 32768, or the
+    /// raised distro default of a few million) or macOS (`pid_max` 99999)
+    /// will ever hold, so `pid_is_alive` reliably reports it dead without
+    /// racing a real process.
+    const SURELY_DEAD_PID: u32 = 999_999_999;
+
+    #[test]
+    fn sweep_removes_dead_pid_entry_and_keeps_live_pid_entry() {
+        let root = tempfile::tempdir().expect("create sweep-test root");
+        let dead_dir = root.path().join(format!("{SURELY_DEAD_PID}-abcd1234"));
+        let live_dir = root.path().join(format!("{}-abcd1234", std::process::id()));
+        std::fs::create_dir(&dead_dir).expect("create dead-pid entry");
+        std::fs::create_dir(&live_dir).expect("create live-pid entry");
+
+        sweep_stale_run_dirs(root.path());
+
+        assert!(
+            !dead_dir.exists(),
+            "dead-pid entry must be swept: {}",
+            dead_dir.display()
+        );
+        assert!(
+            live_dir.exists(),
+            "live-pid entry must be kept: {}",
+            live_dir.display()
+        );
+    }
+
+    #[test]
+    fn sweep_removes_entry_older_than_stale_age_even_with_live_pid() {
+        let root = tempfile::tempdir().expect("create sweep-test root");
+        let old_dir = root.path().join(format!("{}-old", std::process::id()));
+        std::fs::create_dir(&old_dir).expect("create aged entry");
+        let old_mtime = SystemTime::now() - (STALE_AGE + Duration::from_mins(1));
+        std::fs::File::open(&old_dir)
+            .and_then(|f| f.set_modified(old_mtime))
+            .expect("backdate aged entry's mtime");
+
+        sweep_stale_run_dirs(root.path());
+
+        assert!(
+            !old_dir.exists(),
+            "an entry older than STALE_AGE must be swept even under a live pid: {}",
+            old_dir.display()
+        );
+    }
+
+    #[test]
+    fn sweep_on_missing_root_is_a_silent_noop() {
+        let parent = tempfile::tempdir().expect("create sweep-test parent");
+        let missing_root = parent.path().join("hew-run-does-not-exist");
+
+        // Must not panic and must leave nothing behind - this is the shape of
+        // the very first `hew run` on a machine, before any artifact has
+        // ever been created.
+        sweep_stale_run_dirs(&missing_root);
+
+        assert!(!missing_root.exists());
+    }
+}

--- a/hew-cli/src/run_temp.rs
+++ b/hew-cli/src/run_temp.rs
@@ -14,9 +14,9 @@
 //! opportunistically sweeps that home (bounded work, no daemon): an entry
 //! whose pid no longer exists is removed unconditionally, and any entry
 //! older than [`STALE_AGE`] is removed regardless of pid state, so pid reuse
-//! or a platform without a liveness check still bounds disk growth. A live
-//! pid is always skipped. RAII drop stays the fast path for a normal exit;
-//! the sweep is the second cleanup authority that survives a kill.
+//! still bounds disk growth. A live pid is always skipped. RAII drop stays
+//! the fast path for a normal exit; the sweep is the second cleanup
+//! authority that survives a kill.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -26,9 +26,8 @@ use std::time::{Duration, SystemTime};
 const HEW_RUN_DIR_NAME: &str = "hew-run";
 
 /// An entry older than this is swept on startup even if its pid still looks
-/// alive — it defends against pid reuse, and on a platform where liveness
-/// can't be checked (see `pid_is_alive` below) it is the *only* signal that
-/// ever removes anything.
+/// alive — it defends against pid reuse and against any state
+/// `pid_is_alive` below can't resolve to a confident dead.
 const STALE_AGE: Duration = Duration::from_hours(6);
 
 /// Root directory owning every `hew run` / `hew debug` artifact:

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -202,6 +202,48 @@ fn run_program_with_simple_arithmetic_succeeds() {
     assert_eq!(String::from_utf8_lossy(&output.stdout), "3\n");
 }
 
+/// #3132: `hew run`'s compiled artifact lives under `$TMPDIR/hew-run/<pid>-
+/// <rand>/` and RAII drop removes it on a normal exit. Points the child's
+/// temp root at an isolated directory (via TMPDIR/TMP/TEMP so the check
+/// holds on both the Unix and Windows temp-dir lookup) and asserts nothing
+/// remains under `hew-run/` once the process has exited cleanly.
+#[test]
+fn run_normal_exit_leaves_no_hew_run_artifact_dir_behind() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let path = dir.path().join("trivial_run.hew");
+    std::fs::write(&path, "fn main() {\n    println(1);\n}\n").unwrap();
+
+    let tmp_root = support::tempdir();
+    let mut command = Command::new(hew_binary());
+    command
+        .arg("run")
+        .arg(&path)
+        .current_dir(dir.path())
+        .env("TMPDIR", tmp_root.path())
+        .env("TMP", tmp_root.path())
+        .env("TEMP", tmp_root.path());
+    let output = support::run_bounded_command(command, "hew run trivial (artifact-cleanup proof)");
+
+    assert!(
+        output.status.success(),
+        "hew run should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let hew_run_dir = tmp_root.path().join("hew-run");
+    let leftover: Vec<_> = std::fs::read_dir(&hew_run_dir)
+        .map(|entries| entries.flatten().map(|e| e.path()).collect())
+        .unwrap_or_default();
+    assert!(
+        leftover.is_empty(),
+        "a normal exit must leave no artifact dir behind under {}: {leftover:?}",
+        hew_run_dir.display()
+    );
+}
+
 #[test]
 fn qualified_variant_tuple_payload_binds_nested_values() {
     require_codegen();


### PR DESCRIPTION
## Why

`hew run` and `hew debug` built compiled artifacts into a bare `tempfile::tempdir()` and relied on its RAII drop as the only cleanup authority. A `SIGKILL` or an uncaught fatal signal never reaches that drop, and test harnesses kill `hew run` routinely through timeouts and watchdogs. The leaked directories landed at unnamed `/tmp/.tmpXXXXXX` paths that nothing could recognise or sweep, and on a development machine they accumulated until the tmpfs quota was exhausted.

## What

- **cli**: run/debug/WASI-run artifacts now live under `$TMPDIR/hew-run/<pid>-<rand>/` (`hew-cli/src/run_temp.rs`) instead of a bare `tempdir()`
- **cli**: `hew run` and `hew debug` startup opportunistically sweeps that directory — an entry whose pid no longer exists is removed, and any entry older than six hours is removed regardless of pid state (the sole signal on a platform without a liveness check). A live pid is always skipped, and the sweep is best-effort: it never fails the run it's piggybacking on
- RAII drop stays the fast path for a normal exit; the startup sweep is the second cleanup authority that survives a kill

## Test

- `hew-cli/src/run_temp.rs` unit tests: `sweep_removes_dead_pid_entry_and_keeps_live_pid_entry`, `sweep_removes_entry_older_than_stale_age_even_with_live_pid`, `sweep_on_missing_root_is_a_silent_noop`
- `hew-cli/tests/run_e2e.rs::run_normal_exit_leaves_no_hew_run_artifact_dir_behind` — runs a trivial program through `hew run` with an isolated `TMPDIR`/`TMP`/`TEMP` and asserts nothing remains under `hew-run/` afterward
