### PR TITLE
fix(runtime): wake actors by incarnation instead of by address

### DIFF
--- a/docs/internal/waivers/runtime-unsafe-count-43907.md
+++ b/docs/internal/waivers/runtime-unsafe-count-43907.md
@@ -102,15 +102,15 @@ Remediation that must land with the merge: update
 .github/hew-runtime-unsafe-count.txt to total=43907. (Not done in this review â
 the reviewed worktree is read-only.)
 
-NOT waived, tracked as a follow-up lane, not a blocker: 11 enqueue_resume call
-sites still resolve pointer-only through with_live_actor â
-supervisor.rs:1838,2454; reactor.rs:1053,1147,1288,1315; await_cancel.rs:226;
-channel_core.rs:248; task_scope.rs:933,1118; reply_channel.rs:419;
-hew_node.rs:824. Residual defect is a wrong-incarnation wake (a replacement CAS'd
-SuspendedâRunnable with no readiness behind it â the fabricated-timeout path at
-scheduler.rs:1310-1315), NOT a use-after-free: with_live_actor never derefs an
-untracked pointer. Three of these carry SAFETY comments still asserting
-"enqueue_resume re-validates waiter.actor", which is now the weaker claim; update
-them when the sites are converted. Also: mailbox_detach_await_send
+The follow-up lane landed (#3069). Every readiness source now records an
+ActorIncarnation (actor id + never-reissued spawn_serial) at park time and wakes
+through scheduler::enqueue_resume_by_incarnation, which resolves the live
+incarnation, refuses a serial mismatch before touching the actor, and holds the
+pin across the enqueue. The pointer-only entry survives as the pub(crate)
+enqueue_resume_pinned, reachable in production only from that resolver, so the
+GROUP B reasoning above (id-keyed registry + pin across the wake) is now the
+whole-crate rule rather than one site's. The three SAFETY comments that asserted
+"enqueue_resume re-validates waiter.actor" are rewritten to the incarnation
+claim. Also: mailbox_detach_await_send
 (mailbox.rs:2926) still matches its waiter by slot ADDRESS, safe only because the
 detaching caller holds the creator ref â convention, not construction.

--- a/hew-runtime/src/await_cancel.rs
+++ b/hew-runtime/src/await_cancel.rs
@@ -14,6 +14,7 @@ use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
 
 use crate::actor::HewActor;
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::task_scope::{hew_cancel_token_release, hew_cancel_token_retain, HewCancellationToken};
 use crate::timer_wheel::{hew_timer_wheel_cancel, hew_timer_wheel_schedule_handle};
 use crate::timer_wheel::{HewTimerEntry, HewTimerWheel};
@@ -97,7 +98,10 @@ pub struct HewAwaitCancel {
     timer_entry: AtomicPtr<HewTimerEntry>,
     timer_generation: AtomicU64,
     timer_ref_held: AtomicBool,
-    actor: AtomicPtr<HewActor>,
+    /// The waiting actor's incarnation, set once at registration and never
+    /// rewritten. `ActorIncarnation::NONE` means the wait has no resumable
+    /// continuation (a sleep, or a foreign-thread waiter).
+    actor: ActorIncarnation,
     cleanup: HewAwaitCleanup,
     source: *mut c_void,
     /// Test-only per-instance final-free probe. When a test binds one via
@@ -220,11 +224,7 @@ unsafe fn await_cancel_finish(
             unsafe { cleanup(r.source, status as i32) };
         }
         if wake_actor {
-            let actor = r.actor.load(Ordering::Acquire);
-            if !actor.is_null() {
-                // SAFETY: enqueue_resume revalidates liveness before deref.
-                unsafe { crate::scheduler::enqueue_resume(actor, ptr::null_mut()) };
-            }
+            crate::scheduler::enqueue_resume_by_incarnation(r.actor);
         }
     }
 
@@ -269,7 +269,9 @@ pub unsafe extern "C" fn hew_await_cancel_new(
         timer_entry: AtomicPtr::new(ptr::null_mut()),
         timer_generation: AtomicU64::new(0),
         timer_ref_held: AtomicBool::new(false),
-        actor: AtomicPtr::new(actor),
+        // SAFETY: `actor`, when non-null, is the registering actor and is
+        // live for this call.
+        actor: unsafe { ActorIncarnation::of(actor) },
         cleanup,
         source,
         #[cfg(test)]

--- a/hew-runtime/src/channel_core.rs
+++ b/hew-runtime/src/channel_core.rs
@@ -38,6 +38,7 @@ use hew_cabi::sink::TrySendResult;
 use hew_cabi::vec::{HewTypeOwnershipKind, HewVecElemLayout};
 
 use crate::actor::HewActor;
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::read_slot::{
     hew_read_slot_free, read_slot_deposit_status, read_slot_retain, HewReadSlot, ReadStatus,
 };
@@ -53,9 +54,10 @@ pub const STREAM_AWAIT_READY: i32 = 1;
 /// One parked peer (a consumer awaiting an item, or a producer blocked on a full
 /// ring). The core owns one in-flight ref on `slot`.
 struct Waiter {
-    /// The parked-continuation actor, woken via `enqueue_resume`. Raw and
-    /// possibly-stale: `enqueue_resume` validates liveness, never this code.
-    actor: *mut HewActor,
+    /// The parked-continuation actor's incarnation, woken via
+    /// `enqueue_resume_by_incarnation`. Recorded at park time, when the actor
+    /// is live; if it dies before the wake the identity simply stops resolving.
+    actor: ActorIncarnation,
     /// The readiness slot; the core holds one retained ref while registered.
     slot: *mut HewReadSlot,
     /// A parked producer's pending item, enqueued by the drainer when space
@@ -232,7 +234,7 @@ impl ChannelCore {
     /// # Safety
     ///
     /// `w.slot` must be a slot the core holds an in-flight ref to (released
-    /// here); `w.actor` may be stale (`enqueue_resume` validates it).
+    /// here).
     #[allow(
         clippy::needless_pass_by_value,
         reason = "takes the Waiter by value to consume it: the wake releases the \
@@ -243,9 +245,7 @@ impl ChannelCore {
         // terminal status is the documented reactor-deposit contract.
         let do_wake = unsafe { read_slot_deposit_status(w.slot, ReadStatus::Data) };
         if do_wake {
-            // SAFETY: `enqueue_resume` re-validates `w.actor` under the registry
-            // lock; a freed actor drops the wake with no deref.
-            unsafe { crate::scheduler::enqueue_resume(w.actor, std::ptr::null_mut()) };
+            crate::scheduler::enqueue_resume_by_incarnation(w.actor);
         }
         // Release the core's in-flight ref (the single authority for it).
         // SAFETY: the core owned this ref; nothing else releases it.
@@ -278,6 +278,8 @@ impl ChannelCore {
         // Replace any prior (abandoned) consumer registration; a Stream<T> has a
         // single owner, so a live double-park cannot occur, but a stale slot from
         // a torn-down park must release its ref.
+        // SAFETY: `actor` is the awaiting actor, live for this registration.
+        let actor = unsafe { ActorIncarnation::of(actor) };
         if let Some(prev) = inner.consumer.replace(Waiter {
             actor,
             slot,
@@ -488,6 +490,9 @@ impl ChannelCore {
                 // Full ring: park the producer; it owns `item` across the suspend.
                 // SAFETY: caller holds the creator ref, so the slot is live.
                 unsafe { read_slot_retain(slot) };
+                // SAFETY: `actor` is the sending actor, live for this
+                // registration.
+                let actor = unsafe { ActorIncarnation::of(actor) };
                 inner.producers.push_back(Waiter {
                     actor,
                     slot,

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -13083,4 +13083,53 @@ mod tests {
         }
         crate::registry::hew_registry_clear();
     }
+
+    /// Wake-edge incarnation family: the wire reply table (#3069).
+    ///
+    /// A remote ask registers its parked caller by address. If that caller dies
+    /// and the allocator hands its box to the next spawn before the reply
+    /// arrives, the completion resolves an address that now belongs to a
+    /// different incarnation.
+    ///
+    /// `reincarnate` selects the stale case; `false` is the positive control
+    /// that proves this edge does wake the caller that registered.
+    fn run_node_reply_family(reincarnate: bool) {
+        use crate::scheduler::NoWorkerSchedulerForTest;
+        use crate::test_actor::{assert_not_woken, assert_woken, TrackedTestActor};
+
+        let sched = NoWorkerSchedulerForTest::install();
+        let victim = TrackedTestActor::install_parked();
+
+        let table = ReplyRoutingTable::new();
+        let key = ConnectionKey {
+            conn_mgr: 3069,
+            conn_id: 1,
+        };
+        let (request_id, _pending) = table.register_parked(key, victim.ptr());
+
+        if reincarnate {
+            victim.reincarnate_parked();
+        }
+
+        assert!(
+            table.complete(request_id, vec![0xEF]),
+            "the reply must resolve the registered request"
+        );
+
+        if reincarnate {
+            assert_not_woken(&sched, &victim, "node");
+        } else {
+            assert_woken(&sched, &victim, "node");
+        }
+    }
+
+    #[test]
+    fn node_reply_wake_does_not_resume_a_reused_address() {
+        run_node_reply_family(true);
+    }
+
+    #[test]
+    fn node_reply_wake_resumes_the_registering_incarnation() {
+        run_node_reply_family(false);
+    }
 }

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -7,15 +7,14 @@
     reason = "FFI entry-point module; SAFETY documented at fn signature."
 )]
 
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::lifetime::{PoisonSafe, PoisonSafeRw};
 use crate::util::{CondvarExt, MutexExt};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::ptr;
-use std::sync::atomic::{
-    AtomicBool, AtomicPtr, AtomicU16, AtomicU64, AtomicU8, AtomicUsize, Ordering,
-};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 
 use crate::set_last_error;
@@ -677,12 +676,13 @@ struct PendingReply {
     kind: PendingReplyKind,
     outcome: Mutex<Option<ReplyOutcome>>,
     cond: Condvar,
-    /// When non-null, the remote ask was issued by a SUSPENDABLE caller (NEW-5):
+    /// When set, the remote ask was issued by a SUSPENDABLE caller (NEW-5):
     /// the caller's coroutine has parked (or is about to park) on this reply and
-    /// the readiness source must RESUME it through the scheduler rather than
-    /// signal `cond`. Null for a blocking (condvar) caller. Set once at
-    /// registration; read on completion to pick the wake path.
-    parked_caller: AtomicPtr<crate::actor::HewActor>,
+    /// the readiness source must RESUME that exact incarnation through the
+    /// scheduler rather than signal `cond`. `ActorIncarnation::NONE` for a
+    /// blocking (condvar) caller. Set once at registration; read on completion
+    /// to pick the wake path.
+    parked_caller: ActorIncarnation,
 }
 
 /// Per-runtime reply routing table for correlating remote ask/reply pairs.
@@ -720,7 +720,9 @@ impl ReplyRoutingTable {
             kind,
             outcome: Mutex::new(None),
             cond: Condvar::new(),
-            parked_caller: AtomicPtr::new(parked_caller),
+            // SAFETY: `parked_caller`, when non-null, is the actor parking on
+            // this request and is live for this registration.
+            parked_caller: unsafe { ActorIncarnation::of(parked_caller) },
         });
         let mut map = self
             .pending
@@ -810,18 +812,10 @@ impl ReplyRoutingTable {
         *guard = Some(outcome);
         drop(guard);
 
-        let caller = pending.parked_caller.load(Ordering::Acquire);
-        if caller.is_null() {
+        if pending.parked_caller.is_none() {
             pending.cond.notify_one();
         } else {
-            // SAFETY: `caller` is the actor whose coroutine parked on this
-            // request. `enqueue_resume` re-confirms liveness against the live
-            // registry under lock and drops the wake for an actor already torn
-            // down, so a stale pointer from an abandoned ask is never
-            // dereferenced. `cont` is null: the parked continuation handle the
-            // suspend edge published is resumed in place (every readiness source
-            // passes null here).
-            unsafe { crate::scheduler::enqueue_resume(caller, ptr::null_mut()) };
+            crate::scheduler::enqueue_resume_by_incarnation(pending.parked_caller);
         }
     }
 
@@ -9488,13 +9482,13 @@ mod tests {
             conn_mgr: 101,
             conn_id: 21,
         };
-        // A dangling (untracked) actor pointer exercises the suspend wake path
-        // without a live actor: `enqueue_resume` re-confirms liveness against the
-        // live registry and drops the wake for an untracked pointer, so the
-        // completion still deposits the outcome the finish path drains.
-        let parked_actor = std::ptr::dangling_mut::<crate::actor::HewActor>();
+        // A tracked stub actor exercises the suspend wake path: the
+        // registration records its incarnation, and the completion resumes that
+        // incarnation instead of signalling the condvar.
+        let parked = crate::test_actor::TrackedTestActor::install_parked();
+        let parked_actor = parked.ptr();
         let (id, pending) = reply_table().register_parked(key, parked_actor);
-        assert_eq!(pending.parked_caller.load(Ordering::Acquire), parked_actor);
+        assert_eq!(pending.parked_caller, parked.incarnation());
         let handle = Arc::into_raw(pending).cast::<c_void>().cast_mut();
 
         assert!(reply_table().complete(id, Vec::new()));
@@ -9591,7 +9585,10 @@ mod tests {
             conn_mgr: 102,
             conn_id: 22,
         };
-        let parked_actor = std::ptr::dangling_mut::<crate::actor::HewActor>();
+        // A tracked stub actor: registration records the caller's incarnation,
+        // so the parked caller must be a real live actor, not a placeholder.
+        let parked = crate::test_actor::TrackedTestActor::install_parked();
+        let parked_actor = parked.ptr();
         let (id, pending) = reply_table().register_parked(key, parked_actor);
         let handle = Arc::into_raw(pending).cast::<c_void>().cast_mut();
 
@@ -9610,7 +9607,10 @@ mod tests {
             conn_mgr: 103,
             conn_id: 23,
         };
-        let parked_actor = std::ptr::dangling_mut::<crate::actor::HewActor>();
+        // A tracked stub actor: registration records the caller's incarnation,
+        // so the parked caller must be a real live actor, not a placeholder.
+        let parked = crate::test_actor::TrackedTestActor::install_parked();
+        let parked_actor = parked.ptr();
         let (_id, pending) = reply_table().register_parked(key, parked_actor);
         let handle = Arc::into_raw(pending).cast::<c_void>().cast_mut();
 
@@ -9632,7 +9632,10 @@ mod tests {
             conn_mgr: 104,
             conn_id: 24,
         };
-        let parked_actor = std::ptr::dangling_mut::<crate::actor::HewActor>();
+        // A tracked stub actor: registration records the caller's incarnation,
+        // so the parked caller must be a real live actor, not a placeholder.
+        let parked = crate::test_actor::TrackedTestActor::install_parked();
+        let parked_actor = parked.ptr();
         let (id, pending) = reply_table().register_parked(key, parked_actor);
         let handle = Arc::into_raw(pending).cast::<c_void>().cast_mut();
 

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -281,6 +281,14 @@ macro_rules! cabi_guard {
 pub(crate) mod lifetime;
 pub(crate) mod util;
 
+/// Shared stub actors for the wake-edge tests (#3069).
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) mod test_actor;
+
+/// Wake-edge incarnation tests, one readiness family each (#3069).
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod wake_incarnation_tests;
+
 /// CBOR wire envelope types — the Rust-native representation of the Hew wire
 /// protocol plus the fail-closed encode/decode helpers used by runtime
 /// transport paths.

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -572,6 +572,9 @@ pub(crate) struct ActorIncarnation {
     spawn_serial: u64,
 }
 
+// The whole surface is the native wake edge: wasm32 has its own cooperative
+// scheduler, reply channel and mailbox, and never resolves an incarnation.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 impl ActorIncarnation {
     /// No wake target.
     ///
@@ -617,10 +620,12 @@ impl ActorIncarnation {
         self.actor_id == 0
     }
 
+    /// The location-transparent actor id half of the pair.
     pub(crate) const fn actor_id(self) -> u64 {
         self.actor_id
     }
 
+    /// The never-reissued serial half of the pair.
     pub(crate) const fn spawn_serial(self) -> u64 {
         self.spawn_serial
     }

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -549,6 +549,106 @@ pub(crate) fn with_actor_send_by_identity<R>(
     Some(f(&pin))
 }
 
+/// The exact identity of one actor incarnation: the location-transparent `id`
+/// plus the never-reissued [`HewActor::spawn_serial`].
+///
+/// A readiness source that records a wake target records an ADDRESS when it
+/// keeps a `*mut HewActor`. Addresses are recycled: the allocator hands a freed
+/// actor box straight back to the next spawn, so a wake registered by one
+/// incarnation and fired after that incarnation died can resolve to whatever
+/// actor now occupies the address. The registry's pointer probe cannot tell the
+/// two apart — both are tracked-live — so the wake lands on the wrong
+/// incarnation and moves it `Suspended -> Runnable` with no readiness behind
+/// it.
+///
+/// `spawn_serial` is the discriminator that closes it. It comes from a
+/// monotonic allocator that refuses to wrap ([`crate::pid::MAX_ACTOR_SERIAL`]
+/// is a hard spawn failure, not a wrap), so no two incarnations in a process
+/// ever share one. Recording the pair and resolving it through
+/// [`with_live_incarnation`] makes a wake name an incarnation, not an address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ActorIncarnation {
+    actor_id: u64,
+    spawn_serial: u64,
+}
+
+impl ActorIncarnation {
+    /// No wake target.
+    ///
+    /// Actor id `0` is the runtime's invalid-actor sentinel (`hew_pid_make`
+    /// refuses to mint it), so it can never name a real incarnation. Sources
+    /// that park without an actor — a foreign thread, or an await registered
+    /// before the caller is known — record this.
+    pub(crate) const NONE: Self = Self {
+        actor_id: 0,
+        spawn_serial: 0,
+    };
+
+    /// Capture the incarnation of a live actor, or [`Self::NONE`] for null.
+    ///
+    /// # Safety
+    ///
+    /// `actor`, if non-null, must be live for the duration of this call. Every
+    /// caller records its own actor at park time, where that holds by
+    /// construction.
+    pub(crate) unsafe fn of(actor: *mut HewActor) -> Self {
+        if actor.is_null() {
+            return Self::NONE;
+        }
+        // SAFETY: caller guarantees `actor` is live for this read.
+        unsafe {
+            Self {
+                actor_id: (*actor).id,
+                spawn_serial: (*actor).spawn_serial,
+            }
+        }
+    }
+
+    /// Rebuild an incarnation from its two scalars (an ABI-boundary record).
+    pub(crate) const fn from_parts(actor_id: u64, spawn_serial: u64) -> Self {
+        Self {
+            actor_id,
+            spawn_serial,
+        }
+    }
+
+    /// Whether this records no target at all.
+    pub(crate) const fn is_none(self) -> bool {
+        self.actor_id == 0
+    }
+
+    pub(crate) const fn actor_id(self) -> u64 {
+        self.actor_id
+    }
+
+    pub(crate) const fn spawn_serial(self) -> u64 {
+        self.spawn_serial
+    }
+}
+
+/// Pin the exact incarnation named by `target` and run `f` while it is held.
+///
+/// Returns `None` — and runs nothing — when the incarnation is gone: the id is
+/// untracked, or it now resolves to a DIFFERENT incarnation (a serial
+/// mismatch). Dropping the call is the correct answer in both cases; the dead
+/// incarnation's continuation was destroyed by its own teardown.
+///
+/// The pin is the allocation lease: [`pin_actor_by_id`] takes it under the
+/// registry lock, and the free path drains `send_pin_count` to zero before
+/// reclaiming the box, so `f` cannot race the target into a free or an address
+/// reuse.
+// live on not(wasm32) — the scheduler wake edge; dead on wasm32.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub(crate) fn with_live_incarnation<R>(
+    target: ActorIncarnation,
+    f: impl FnOnce(&ActorPin) -> R,
+) -> Option<R> {
+    if target.is_none() {
+        return None;
+    }
+    with_actor_send_by_identity(target.actor_id, target.spawn_serial, f)
+}
+
 /// Resolve the per-actor-TYPE dispatch function pointer for a live actor id,
 /// returned as an opaque `*const c_void` codec-registry key.
 ///

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -30,6 +30,7 @@ use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 
 use crate::internal::types::{HewError, HewOverflowPolicy};
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::mailbox_header::{normalize_coalesce_fallback, Origin};
 use crate::read_slot::{
     hew_read_slot_free, read_slot_deposit_status, read_slot_retain, HewReadSlot, ReadStatus,
@@ -1409,15 +1410,9 @@ struct SlowPathQueue {
 /// cancellation, or close wins the registration race.
 #[derive(Debug)]
 struct BlockedSender {
-    sender: Option<BlockedSenderIncarnation>,
+    sender: ActorIncarnation,
     slot: *mut HewReadSlot,
     node: *mut HewMsgNode,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct BlockedSenderIncarnation {
-    actor_id: u64,
-    spawn_serial: u64,
 }
 
 // SAFETY: slots and nodes remain live under explicit retained ownership; the
@@ -2835,16 +2830,11 @@ pub(crate) unsafe fn mailbox_await_send(
     }
     // SAFETY: the caller owns the creator ref, so the slot is live to retain.
     unsafe { read_slot_retain(slot) };
-    let sender = if actor.is_null() {
-        None
-    } else {
-        // SAFETY: the caller guarantees the sender is live for registration.
-        let sender = unsafe { &*actor };
-        Some(BlockedSenderIncarnation {
-            actor_id: sender.id,
-            spawn_serial: sender.spawn_serial,
-        })
-    };
+    // SAFETY: the caller guarantees the sender is live for registration, so
+    // its incarnation can be captured here. Recording the incarnation rather
+    // than the pointer is what makes the later wake refuse a replacement actor
+    // that reused this allocation.
+    let sender = unsafe { ActorIncarnation::of(actor) };
     waiters.push_back(BlockedSender { sender, slot, node });
     MAILBOX_AWAIT_SEND_SUSPEND
 }
@@ -2910,7 +2900,7 @@ pub(crate) unsafe fn mailbox_send_with_reply_cooperative(
         return HewError::ErrActorStopped as i32;
     }
     waiters.push_back(BlockedSender {
-        sender: None,
+        sender: ActorIncarnation::NONE,
         slot: ptr::null_mut(),
         node,
     });
@@ -2955,20 +2945,10 @@ unsafe fn wake_blocked_sender(waiter: &BlockedSender, status: ReadStatus) {
     }
     // SAFETY: the waiter owns a retained live slot ref.
     let should_wake = unsafe { read_slot_deposit_status(waiter.slot, status) };
-    if should_wake {
-        if let Some(sender) = waiter.sender {
-            #[cfg(test)]
-            run_blocked_sender_pre_wake_hook(sender.actor_id);
-            let _ = crate::lifetime::live_actors::with_actor_send_by_identity(
-                sender.actor_id,
-                sender.spawn_serial,
-                |pin| {
-                    // SAFETY: the identity pin keeps this exact incarnation's
-                    // allocation live throughout the pointer-based resume edge.
-                    unsafe { crate::scheduler::enqueue_resume(pin.as_ptr(), ptr::null_mut()) };
-                },
-            );
-        }
+    if should_wake && !waiter.sender.is_none() {
+        #[cfg(test)]
+        run_blocked_sender_pre_wake_hook(waiter.sender.actor_id());
+        crate::scheduler::enqueue_resume_by_incarnation(waiter.sender);
     }
     // SAFETY: the waiter owns exactly one retained slot ref.
     unsafe { hew_read_slot_free(waiter.slot) };

--- a/hew-runtime/src/reactor.rs
+++ b/hew-runtime/src/reactor.rs
@@ -60,6 +60,7 @@ use crate::io_time::{
     hew_io_poller_new, hew_io_poller_poll_ready, hew_io_poller_register, hew_io_poller_stop,
     hew_io_poller_unregister, HewIoPoller, HEW_IO_ERROR, HEW_IO_HUP, HEW_IO_READ,
 };
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::lifetime::poison_safe::PoisonSafe;
 use crate::transport::{
     actor_ref_local_ptr, hew_actor_ref_is_alive, tcp_conn_raw_fd, tcp_conn_read_available,
@@ -151,6 +152,11 @@ struct Registration {
     /// Stable actor identity (`*mut HewActor` as `usize`) for
     /// `reactor_detach_actor` matching on actor teardown.
     actor_key: usize,
+    /// The owning actor's incarnation, captured while it was live at
+    /// registration. Every wake this registration fires names this
+    /// incarnation, so a replacement actor that inherits the allocation (or the
+    /// `actor_key`) is never resumed in its place.
+    actor: ActorIncarnation,
     /// The readiness action (auto-send vs resume — the D-3 seam).
     mode: RegMode,
     /// Set once a terminal close (`on_close` / EOF / error deposit) has been
@@ -174,6 +180,28 @@ struct Registration {
 // `reactor_detach_actor` on `hew_actor_free`) and the slot refcount, not by
 // this impl.
 unsafe impl Send for Registration {}
+
+impl Registration {
+    /// Build a registration, capturing the owning actor's incarnation while the
+    /// actor is still live.
+    ///
+    /// # Safety
+    ///
+    /// `actor_ref`'s local pointer, when non-null, must reference a live actor.
+    unsafe fn new(conn: c_int, actor_ref: HewActorRef, actor_key: usize, mode: RegMode) -> Self {
+        // SAFETY: forwarded from the caller's liveness guarantee.
+        let actor =
+            unsafe { ActorIncarnation::of(actor_ref_local_ptr(&actor_ref).cast::<HewActor>()) };
+        Self {
+            conn,
+            actor_ref,
+            actor_key,
+            actor,
+            mode,
+            closed: false,
+        }
+    }
+}
 
 impl Drop for Registration {
     /// SINGLE AUTHORITY for releasing everything a registration owns. A
@@ -607,6 +635,8 @@ struct ReadySnapshot {
     conn: c_int,
     actor_ref: HewActorRef,
     actor_local: *mut HewActor,
+    /// The registration's captured incarnation — the wake target.
+    actor: ActorIncarnation,
     mode: ReadyMode,
     already_closed: bool,
 }
@@ -751,6 +781,7 @@ fn handle_ready_fd(poller: *mut HewIoPoller, fd: c_int, events: c_int) {
             // snapshot so liveness can be checked after the lock is released.
             actor_ref: unsafe { std::ptr::read(std::ptr::addr_of!(reg.actor_ref)) },
             actor_local: actor_ref_local_ptr(&reg.actor_ref).cast::<HewActor>(),
+            actor: reg.actor,
             mode: match &reg.mode {
                 RegMode::AutoSend {
                     on_data_type,
@@ -1048,9 +1079,7 @@ fn handle_ready_resume(
     }
 
     if deposit.wake {
-        // SAFETY: `enqueue_resume` re-confirms liveness under the registry lock
-        // and only flips state + enqueues; a freed actor drops the wake.
-        unsafe { crate::scheduler::enqueue_resume(snap.actor_local, std::ptr::null_mut()) };
+        crate::scheduler::enqueue_resume_by_incarnation(snap.actor);
     }
     // One-shot: remove the registration. Dropping the `Registration` releases the
     // REGISTRATION-OWNED slot ref (the `Drop for Registration` single authority
@@ -1142,9 +1171,7 @@ fn handle_ready_accept(
     // checks the cancelled flag before publishing + waking.
     let wake = unsafe { crate::read_slot::read_slot_deposit_handle(read_slot, deposit_handle) };
     if wake {
-        // SAFETY: `enqueue_resume` re-confirms liveness under the registry lock
-        // and only flips state + enqueues; a freed actor drops the wake.
-        unsafe { crate::scheduler::enqueue_resume(snap.actor_local, std::ptr::null_mut()) };
+        crate::scheduler::enqueue_resume_by_incarnation(snap.actor);
     } else if deposit_handle != INVALID_CONNECTION_HANDLE {
         // Deposit FAILED on a real accepted connection: the suspended handler was
         // abandoned/cancelled (cancelled flag set, or a cancellation/deadline won
@@ -1268,7 +1295,7 @@ fn deliver_orphan_close(reg: &Registration) {
             }
         }
         RegMode::Resume { read_slot } => {
-            resume_with_status(actor_local, read_slot, crate::read_slot::ReadStatus::Error);
+            resume_with_status(reg.actor, read_slot, crate::read_slot::ReadStatus::Error);
         }
         RegMode::Accept { read_slot } => {
             // NEW-2: the accept registration never made it into the poller; wake
@@ -1282,10 +1309,8 @@ fn deliver_orphan_close(reg: &Registration) {
                     crate::read_slot::INVALID_CONNECTION_HANDLE,
                 )
             };
-            if should_wake && !actor_local.is_null() {
-                // SAFETY: `enqueue_resume` re-confirms liveness; a freed actor
-                // drops the wake.
-                unsafe { crate::scheduler::enqueue_resume(actor_local, std::ptr::null_mut()) };
+            if should_wake {
+                crate::scheduler::enqueue_resume_by_incarnation(reg.actor);
             }
         }
     }
@@ -1300,7 +1325,7 @@ fn deliver_orphan_close(reg: &Registration) {
 /// Does NOT release the reactor's slot ref — the caller drops the owning
 /// `Registration`, whose `Drop` impl is the single authority for that release.
 fn resume_with_status(
-    actor_local: *mut HewActor,
+    actor: ActorIncarnation,
     read_slot: *mut crate::read_slot::HewReadSlot,
     status: crate::read_slot::ReadStatus,
 ) {
@@ -1308,11 +1333,8 @@ fn resume_with_status(
     // `reactor_await_read`); the deposit checks the cancelled flag before
     // publishing.
     let should_wake = unsafe { crate::read_slot::read_slot_deposit_status(read_slot, status) };
-    if should_wake && !actor_local.is_null() {
-        // SAFETY: `enqueue_resume` does NOT trust the pointer — it re-confirms
-        // liveness under the registry lock and only flips state + enqueues; a
-        // freed actor drops the wake.
-        unsafe { crate::scheduler::enqueue_resume(actor_local, std::ptr::null_mut()) };
+    if should_wake {
+        crate::scheduler::enqueue_resume_by_incarnation(actor);
     }
 }
 
@@ -1532,15 +1554,17 @@ pub(crate) unsafe fn reactor_attach(
         }
     }
 
-    let reg = Registration {
-        conn,
-        actor_ref: snapshot,
-        actor_key,
-        mode: RegMode::AutoSend {
-            on_data_type,
-            on_close_type,
-        },
-        closed: false,
+    // SAFETY: `snapshot` names the actor registering this fd, live here.
+    let reg = unsafe {
+        Registration::new(
+            conn,
+            snapshot,
+            actor_key,
+            RegMode::AutoSend {
+                on_data_type,
+                on_close_type,
+            },
+        )
     };
     REACTOR_STATE.access(|state| {
         state.pending.push(Pending::Add { fd, reg });
@@ -1617,12 +1641,9 @@ pub(crate) unsafe fn reactor_await_read(
         unsafe { crate::read_slot::read_slot_retain(read_slot) };
         state.pending.push(Pending::Add {
             fd,
-            reg: Registration {
-                conn,
-                actor_ref: snapshot,
-                actor_key,
-                mode: RegMode::Resume { read_slot },
-                closed: false,
+            // SAFETY: `snapshot` names the awaiting actor, live here.
+            reg: unsafe {
+                Registration::new(conn, snapshot, actor_key, RegMode::Resume { read_slot })
             },
         });
         true
@@ -1698,14 +1719,11 @@ pub(crate) unsafe fn reactor_await_accept(
         unsafe { crate::read_slot::read_slot_retain(read_slot) };
         state.pending.push(Pending::Add {
             fd,
-            reg: Registration {
-                // The accept registration's `conn` field carries the LISTENER
-                // handle the fd belongs to.
-                conn: listener,
-                actor_ref: snapshot,
-                actor_key,
-                mode: RegMode::Accept { read_slot },
-                closed: false,
+            // The accept registration's `conn` field carries the LISTENER
+            // handle the fd belongs to.
+            // SAFETY: `snapshot` names the awaiting actor, live here.
+            reg: unsafe {
+                Registration::new(listener, snapshot, actor_key, RegMode::Accept { read_slot })
             },
         });
         true
@@ -2012,15 +2030,17 @@ pub(crate) fn inject_registration_for_test(
         state.conn_to_fd.insert(conn, fd);
         state.registry.insert(
             fd,
-            Registration {
-                conn,
-                actor_ref,
-                actor_key,
-                mode: RegMode::AutoSend {
-                    on_data_type: 1,
-                    on_close_type: 2,
-                },
-                closed: false,
+            // SAFETY: the caller passes a live (or remote) actor ref.
+            unsafe {
+                Registration::new(
+                    conn,
+                    actor_ref,
+                    actor_key,
+                    RegMode::AutoSend {
+                        on_data_type: 1,
+                        on_close_type: 2,
+                    },
+                )
             },
         );
     });
@@ -2043,13 +2063,8 @@ pub(crate) fn inject_resume_registration_for_test(
         state.conn_to_fd.insert(conn, fd);
         state.registry.insert(
             fd,
-            Registration {
-                conn,
-                actor_ref,
-                actor_key,
-                mode: RegMode::Resume { read_slot },
-                closed: false,
-            },
+            // SAFETY: the caller passes a live (or remote) actor ref.
+            unsafe { Registration::new(conn, actor_ref, actor_key, RegMode::Resume { read_slot }) },
         );
     });
 }
@@ -2071,13 +2086,8 @@ pub(crate) fn inject_accept_registration_for_test(
         state.conn_to_fd.insert(conn, fd);
         state.registry.insert(
             fd,
-            Registration {
-                conn,
-                actor_ref,
-                actor_key,
-                mode: RegMode::Accept { read_slot },
-                closed: false,
-            },
+            // SAFETY: the caller passes a live (or remote) actor ref.
+            unsafe { Registration::new(conn, actor_ref, actor_key, RegMode::Accept { read_slot }) },
         );
     });
 }
@@ -2126,10 +2136,13 @@ pub(crate) fn handle_ready_accept_for_test(
     read_slot: *mut crate::read_slot::HewReadSlot,
     hard_close: bool,
 ) {
+    // SAFETY: the caller passes a live (or remote) actor ref.
+    let actor = unsafe { ActorIncarnation::of(actor_ref_local_ptr(&actor_ref).cast::<HewActor>()) };
     let snap = ReadySnapshot {
         conn: listener_conn,
         actor_local: actor_ref_local_ptr(&actor_ref).cast::<HewActor>(),
         actor_ref,
+        actor,
         mode: ReadyMode::Accept { read_slot },
         already_closed: false,
     };
@@ -2192,15 +2205,17 @@ pub(crate) fn enqueue_pending_add_for_test(
     REACTOR_STATE.access(|state| {
         state.pending.push(Pending::Add {
             fd,
-            reg: Registration {
-                conn,
-                actor_ref,
-                actor_key,
-                mode: RegMode::AutoSend {
-                    on_data_type: 1,
-                    on_close_type: 2,
-                },
-                closed: false,
+            // SAFETY: the caller passes a live (or remote) actor ref.
+            reg: unsafe {
+                Registration::new(
+                    conn,
+                    actor_ref,
+                    actor_key,
+                    RegMode::AutoSend {
+                        on_data_type: 1,
+                        on_close_type: 2,
+                    },
+                )
             },
         });
     });
@@ -3570,12 +3585,14 @@ mod tests {
         REACTOR_STATE.access(|state| {
             state.pending.push(Pending::Add {
                 fd: 73,
-                reg: Registration {
-                    conn: 74,
-                    actor_ref: dead_actor_ref(),
-                    actor_key: KEY,
-                    mode: RegMode::Resume { read_slot: slot },
-                    closed: false,
+                // SAFETY: a remote ref carries no local actor pointer.
+                reg: unsafe {
+                    Registration::new(
+                        74,
+                        dead_actor_ref(),
+                        KEY,
+                        RegMode::Resume { read_slot: slot },
+                    )
                 },
             });
         });
@@ -3835,15 +3852,17 @@ mod tests {
             set_delivering_actor_for_test(KEY);
             state.registry.insert(
                 rfd,
-                Registration {
-                    conn: 601,
-                    actor_ref: dead_actor_ref(),
-                    actor_key: KEY,
-                    mode: RegMode::AutoSend {
-                        on_data_type: 1,
-                        on_close_type: 2,
-                    },
-                    closed: false,
+                // SAFETY: a remote ref carries no local actor pointer.
+                unsafe {
+                    Registration::new(
+                        601,
+                        dead_actor_ref(),
+                        KEY,
+                        RegMode::AutoSend {
+                            on_data_type: 1,
+                            on_close_type: 2,
+                        },
+                    )
                 },
             );
             // While we still hold the lock, the re-scrub cannot run and the

--- a/hew-runtime/src/read_slot.rs
+++ b/hew-runtime/src/read_slot.rs
@@ -7,12 +7,13 @@
 //! worker. When the reactor reports the fd ready it reads the available bytes,
 //! deposits the resulting `bytes` value (or an error/EOF status) into the slot,
 //! and wakes the parked continuation via
-//! `crate::scheduler::enqueue_resume(caller_actor, null)` (the same
+//! `crate::scheduler::enqueue_resume_by_incarnation(caller)` (the same
 //! source-agnostic waker the reply path uses). On the resume edge the handler
 //! takes the deposited result out of the slot and binds it.
 //!
 //! Unlike the reply channel there is NO condvar: the only consumer is a parked
-//! coroutine woken by `enqueue_resume`, never a blocked foreign thread. The slot
+//! coroutine woken by the incarnation-keyed wake edge, never a blocked foreign
+//! thread. The slot
 //! is a one-shot atomic cell plus a manual refcount that lets the abandon edge
 //! (handler freed while suspended) free the slot without racing a reactor that
 //! still holds a pointer to it on its `Registration`.

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -14,10 +14,11 @@ use crate::await_cancel::{
     hew_await_cancel_complete, hew_await_cancel_free, hew_await_cancel_retain,
 };
 use crate::await_cancel::{hew_await_cancel_status, AwaitCancelStatus, HewAwaitCancel};
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::util::{CondvarExt, MutexExt};
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
 
@@ -105,16 +106,23 @@ pub struct HewReplyChannel {
     /// is status-bearing: `hew_reply_channel_failure_kind` names WHY no value
     /// arrived instead of collapsing every failure into "null".
     fail_reason: AtomicI32,
-    /// The waiter-kind discriminator (W6.010). When non-null, the waiter is a
-    /// PARKED CONTINUATION belonging to this actor: a reply wakes it via
-    /// `scheduler::enqueue_resume(caller_actor, ..)` (the suspend edge owns the
-    /// `suspended_cont` handle; the FG3 two-phase park inside `enqueue_resume`
-    /// covers a reply that fires mid-park). When null (the default), the waiter
+    /// The waiter-kind discriminator (W6.010), as the caller's incarnation.
+    /// When set, the waiter is a PARKED CONTINUATION belonging to that exact
+    /// incarnation: a reply wakes it through
+    /// `scheduler::enqueue_resume_by_incarnation` (the suspend edge owns the
+    /// `suspended_cont` handle; the FG3 two-phase park inside the wake covers a
+    /// reply that fires mid-park). Actor id `0` (the default) means the waiter
     /// is a CONDVAR-blocked foreign/main thread woken by `cond.notify_one()`
-    /// (E6 — the foreign-thread ask path stays on the condvar). Set BEFORE the
+    /// (E6 - the foreign-thread ask path stays on the condvar). Set BEFORE the
     /// ask is submitted (so before any possible reply) by
     /// [`hew_reply_channel_set_parked_waiter`].
-    caller_actor: AtomicPtr<HewActor>,
+    ///
+    /// Two scalars rather than one field because the set lands after
+    /// construction: `caller_actor_id` is published last with `Release` and
+    /// read first with `Acquire`, so a reader that sees an id also sees the
+    /// serial that belongs to it.
+    caller_actor_id: AtomicU64,
+    caller_actor_serial: AtomicU64,
     /// Mutex protecting the condvar wait.
     lock: Mutex<()>,
     /// Condvar signalled by [`hew_reply`].
@@ -160,7 +168,8 @@ pub extern "C" fn hew_reply_channel_new() -> *mut HewReplyChannel {
         reply_drop_fn: AtomicPtr::new(ptr::null_mut()),
         allocation_failed: AtomicBool::new(false),
         fail_reason: AtomicI32::new(crate::internal::types::HEW_REPLY_FAIL_NONE),
-        caller_actor: AtomicPtr::new(ptr::null_mut()),
+        caller_actor_id: AtomicU64::new(0),
+        caller_actor_serial: AtomicU64::new(0),
         lock: Mutex::new(()),
         cond: Condvar::new(),
         await_cancel: AtomicPtr::new(ptr::null_mut()),
@@ -191,9 +200,16 @@ pub unsafe extern "C" fn hew_reply_channel_set_parked_waiter(
     if ch.is_null() {
         return;
     }
-    // SAFETY: caller guarantees `ch` is a live reply-channel reference.
+    // SAFETY: caller guarantees `ch` is a live reply-channel reference, and
+    // `actor` - when non-null - is the live actor parking on this ask.
     unsafe {
-        (*ch).caller_actor.store(actor, Ordering::Release);
+        let target = ActorIncarnation::of(actor);
+        (*ch)
+            .caller_actor_serial
+            .store(target.spawn_serial(), Ordering::Relaxed);
+        (*ch)
+            .caller_actor_id
+            .store(target.actor_id(), Ordering::Release);
     }
 }
 
@@ -390,15 +406,18 @@ unsafe fn publish_reply_from_sender_ref(
         };
 
         // Waiter-kind branch (W6.010, E5/E6). A parked-continuation waiter
-        // (`caller_actor` non-null) is woken by re-enqueuing its actor; the
+        // (`caller_actor` set) is woken by re-enqueuing its actor; the
         // resumed continuation reads the now-ready reply value from `ch` on its
         // resume edge. A condvar-blocked foreign/main thread (`caller_actor`
         // null — the default, E6) is woken by `cond.notify_one()`. The load is
         // Acquire-paired with the Release store in
         // `hew_reply_channel_set_parked_waiter`, which happens-before the ask
         // submission and therefore before any reply can fire.
-        let caller_actor = (*ch).caller_actor.load(Ordering::Acquire);
-        if caller_actor.is_null() {
+        let caller_actor = ActorIncarnation::from_parts(
+            (*ch).caller_actor_id.load(Ordering::Acquire),
+            (*ch).caller_actor_serial.load(Ordering::Relaxed),
+        );
+        if caller_actor.is_none() {
             // Foreign/main-thread condvar waiter (E6 — unchanged). A condvar
             // waiter re-checks its `ready`/`cancelled` predicate under the lock,
             // so a notify on the losing edge is harmless; it is left ungated.
@@ -411,12 +430,11 @@ unsafe fn publish_reply_from_sender_ref(
             // continuation handle is owned by the scheduler's suspend edge (the
             // `suspended_cont` slot); `enqueue_resume` reads the slot itself and
             // records a `pending_wake` if the reply fired in the FG3 park window
-            // (so a mid-park reply is never lost). The `cont` argument is unused
-            // by the resume edge (the slot is authoritative), so pass null.
-            // SAFETY: `caller_actor` references the live `HewActor` whose
-            // continuation is parked on this ask; the suspend edge keeps it
-            // alive until the resume reclaims the parked continuation.
-            crate::scheduler::enqueue_resume(caller_actor, ptr::null_mut());
+            // (so a mid-park reply is never lost). The wake names the
+            // caller's INCARNATION, so a reply arriving after that caller died
+            // - and after a new actor inherited its allocation - resolves to
+            // nothing and is dropped.
+            crate::scheduler::enqueue_resume_by_incarnation(caller_actor);
         }
         hew_reply_channel_free(ch);
     }

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -37,6 +37,7 @@ use crate::deque::{GlobalQueue, WorkDeque, WorkStealer};
 use crate::deterministic::hew_deterministic_set_seed;
 use crate::execution_context::HewExecutionContext;
 use crate::internal::types::{HewActorState, HewDispatchFn, HewSysDispatchFn};
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::lifetime::poison_safe::PoisonSafe;
 use crate::mailbox::{self, hew_mailbox_has_messages, hew_msg_node_free, HewMailbox};
 use crate::mailbox_header::{HewSysMsg, Origin};
@@ -1493,16 +1494,23 @@ fn assert_wake_routes_to_owning_runtime(actor_runtime_id: crate::runtime_id::Run
 /// enqueue is race-free: the actor is `Runnable` but not yet on the queue, so
 /// nothing can run it and re-park between the CAS and the consume.
 ///
+/// # Not a wake entry point
+///
+/// A pointer names an ADDRESS, and addresses are recycled, so this cannot be
+/// the edge a readiness source calls: the registry probe below proves the
+/// address is live, never that it still holds the incarnation that parked.
+/// Production reaches this only through [`enqueue_resume_by_incarnation`],
+/// which resolves an [`ActorIncarnation`] and holds a pin over the call. The
+/// scheduler's own unit tests call it directly to exercise the CAS and
+/// pending-wake discipline in isolation.
+///
 /// # Safety
 ///
-/// `actor`, if non-null, may reference a freed `HewActor` — this function does
-/// NOT trust the pointer to be live. It re-confirms liveness against the
-/// `LIVE_ACTORS` registry under the registry lock before dereferencing, so a
-/// stale pointer from an abandoned/late reply is rejected atomically rather than
-/// dereferenced. `cont`, if non-null, must be the continuation parked on
-/// `actor` (a `coro.begin` frame). The caller (a readiness source) owns the wake
-/// edge; the executor owns teardown.
-pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
+/// `actor`, if non-null, must be pinned live by the caller for the duration of
+/// this call. `cont`, if non-null, must be the continuation parked on `actor`
+/// (a `coro.begin` frame). The caller (a readiness source) owns the wake edge;
+/// the executor owns teardown.
+pub(crate) unsafe fn enqueue_resume_pinned(actor: *mut HewActor, cont: *mut c_void) {
     if actor.is_null() {
         return;
     }
@@ -1654,6 +1662,38 @@ pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
         assert_wake_routes_to_owning_runtime(actor_runtime_id);
         sched_enqueue_owned(entry);
     }
+}
+
+/// Wake the exact actor incarnation a readiness source parked.
+///
+/// This is the single wake edge every readiness source calls: the reactor, the
+/// reply slot, channels, task scopes, await-cancel, supervisor restart-await,
+/// the wire reply, and mailbox block-send admission.
+///
+/// The source records an [`ActorIncarnation`] at park time, not a pointer.
+/// Resolution here refuses two distinct failures and is silent about both,
+/// because dropping the wake is the correct answer to each:
+///
+/// - the id is untracked — the actor died and its own teardown already
+///   destroyed the continuation this wake would have resumed;
+/// - the id resolves but the `spawn_serial` differs — the address (or the id,
+///   after a 2^48 wrap that the spawn allocator refuses anyway) now belongs to
+///   a DIFFERENT incarnation. Waking it would CAS a stranger
+///   `Suspended -> Runnable` with no readiness behind it, and a suspending
+///   `select` resumed that way fabricates a timeout.
+///
+/// The refusal happens before any mutation of the resolved actor, so a stale
+/// wake cannot leave a `pending_wake` marker on the wrong incarnation either.
+/// The pin taken during resolution is held across the enqueue, so the target
+/// cannot die or have its address reused mid-call.
+pub(crate) fn enqueue_resume_by_incarnation(target: ActorIncarnation) {
+    let _ = crate::lifetime::live_actors::with_live_incarnation(target, |pin| {
+        // SAFETY: the pin keeps THIS incarnation's allocation live across the
+        // wake; the free path drains `send_pin_count` before reclaiming it.
+        // `cont` is null because the suspend edge owns the parked handle — the
+        // resume edge reads it from `suspended_cont`, never from here.
+        unsafe { enqueue_resume_pinned(pin.as_ptr(), std::ptr::null_mut()) };
+    });
 }
 
 /// Wake one parked worker.
@@ -4808,7 +4848,7 @@ mod tests {
         );
         // SAFETY: the hook runs on the test thread, which owns this allocation
         // exclusively while the mailbox resolves the removed waiter.
-        unsafe { crate::test_actor::reincarnate_parked_in_place(actor_ptr) };
+        let _ = unsafe { crate::test_actor::reincarnate_parked_in_place(actor_ptr) };
     }
 
     #[test]
@@ -4994,7 +5034,7 @@ mod tests {
 
         // SAFETY: actor is live (tracked) for this scope; sentinel handle is
         // never resumed.
-        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
 
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
@@ -5043,7 +5083,7 @@ mod tests {
 
         // SAFETY: `actor_ptr` is a stale (untracked) pointer; `enqueue_resume`
         // must reject it via the registry check rather than dereference it.
-        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
 
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
@@ -5238,7 +5278,7 @@ mod tests {
         let actor_ptr = actor.ptr();
 
         // SAFETY: actor is live (tracked); terminal so it is never resumed/enqueued.
-        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
 
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
@@ -5286,7 +5326,7 @@ mod tests {
             // SAFETY: actor is live (tracked) for this scope; the sentinel handle
             // is never resumed. The trap fires after the registry lock is
             // released, so it does not poison the live-actor registry.
-            unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+            unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
         }));
         assert!(
             trapped.is_err(),
@@ -5314,7 +5354,7 @@ mod tests {
 
         // SAFETY: actor is live (tracked); null slot means no handle is ever
         // resumed.
-        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
 
         assert!(
             crate::coro_exec::take_pending_wake(&actor),
@@ -5358,7 +5398,7 @@ mod tests {
 
         // SAFETY: actor is live (tracked); the sentinel handle is never resumed
         // (no worker thread exists under NoWorkerSchedulerForTest).
-        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
 
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
@@ -5414,7 +5454,7 @@ mod tests {
 
         // SAFETY: actor is live (tracked); the sentinel handle is never
         // resumed (no worker thread exists under NoWorkerSchedulerForTest).
-        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
 
         assert_eq!(
             sched.pop_global(),
@@ -5487,7 +5527,7 @@ mod tests {
         let _hook = EnqueueResumeCasFailHookGuard::install(park_completes_inside_cas_fail_gap);
         // SAFETY: actor is live (tracked); the sentinel handle is never
         // resumed (no worker thread exists under NoWorkerSchedulerForTest).
-        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
 
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
@@ -5600,7 +5640,7 @@ mod tests {
 
         // The reactor's resume-mode deposit + wake (what `handle_ready_resume`
         // does on `Data`): build an owned bytes value, deposit it into the slot,
-        // then `enqueue_resume(actor, null)`.
+        // then `enqueue_resume_pinned(actor, null)`.
         let slot = crate::read_slot::hew_read_slot_new();
         let payload = b"reactor-delivered-bytes";
         let payload_len = u32::try_from(payload.len()).expect("payload fits u32");
@@ -5610,7 +5650,7 @@ mod tests {
         let wake = unsafe { crate::read_slot::read_slot_deposit_data(slot, triple) };
         assert!(wake, "a non-cancelled deposit must signal a wake");
         // SAFETY: `actor_ptr` is live (tracked) for this scope.
-        unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        unsafe { enqueue_resume_pinned(actor_ptr, ptr::null_mut()) };
 
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
@@ -6502,7 +6542,7 @@ mod tests {
         // Wake #1: enqueue_resume → Runnable → activate → resume #1 (Pending) →
         // re-park as Suspended.
         // SAFETY: actor live; parked handle is the executor-owned frame.
-        unsafe { enqueue_resume(actor_ptr, parked_handle) };
+        unsafe { enqueue_resume_pinned(actor_ptr, parked_handle) };
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
             HewActorState::Runnable as i32,
@@ -6518,7 +6558,7 @@ mod tests {
         // Wake #2: enqueue_resume → activate → resume #2 (Ready) → destroy once →
         // settle to Idle (empty mailbox).
         // SAFETY: actor live; same parked handle.
-        unsafe { enqueue_resume(actor_ptr, parked_handle) };
+        unsafe { enqueue_resume_pinned(actor_ptr, parked_handle) };
         activate_actor(actor_ptr);
         assert_eq!(
             actor.actor_state.load(Ordering::Acquire),
@@ -6593,7 +6633,7 @@ mod tests {
         // still has the 2nd message, so the completed resume settles to Runnable
         // (not Idle) and is re-enqueued.
         // SAFETY: actor live; handle1 is the executor-owned frame.
-        unsafe { enqueue_resume(actor_ptr, handle1) };
+        unsafe { enqueue_resume_pinned(actor_ptr, handle1) };
         activate_actor(actor_ptr);
         assert!(
             actor.suspended_cont.load(Ordering::Acquire).is_null(),
@@ -6625,7 +6665,7 @@ mod tests {
 
         // Wake → resume(Ready) → destroy once → re-arm. Mailbox now empty → Idle.
         // SAFETY: actor live; handle2 is the executor-owned frame.
-        unsafe { enqueue_resume(actor_ptr, handle2) };
+        unsafe { enqueue_resume_pinned(actor_ptr, handle2) };
         activate_actor(actor_ptr);
         assert!(
             actor.suspended_cont.load(Ordering::Acquire).is_null(),
@@ -6734,7 +6774,7 @@ mod tests {
         // Wake it, then run the activation. It takes the resume-before-loop
         // path; the outline latches the stop; the poll reports `Pending`.
         // SAFETY: the actor is live (tracked) and `handle` is its parked frame.
-        unsafe { enqueue_resume(actor_ptr, handle) };
+        unsafe { enqueue_resume_pinned(actor_ptr, handle) };
         activate_actor(actor_ptr);
 
         assert_eq!(

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -4593,6 +4593,7 @@ pub unsafe extern "C" fn hew_sched_metrics_snapshot(out: *mut HewSchedMetrics) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_actor::{stub_actor, TrackedTestActor};
     use std::ptr;
     use std::sync::atomic::AtomicI32;
     use std::sync::Arc;
@@ -4797,97 +4798,6 @@ mod tests {
         }
     }
 
-    /// Helper: build a minimal `HewActor` with sensible defaults.
-    fn stub_actor() -> HewActor {
-        HewActor {
-            sched_link_next: AtomicPtr::new(ptr::null_mut()),
-            id: 1,
-            state: ptr::null_mut(),
-            state_size: 0,
-            dispatch: None,
-            mailbox: ptr::null_mut(),
-            actor_state: AtomicI32::new(HewActorState::Runnable as i32),
-            budget: AtomicI32::new(HEW_MSG_BUDGET),
-            init_state: ptr::null_mut(),
-            init_state_size: 0,
-            coalesce_key_fn: None,
-            terminate_fn: None,
-            state_drop_fn: None,
-            state_clone_fn: None,
-            terminate_called: AtomicBool::new(false),
-            terminate_finished: AtomicBool::new(false),
-            dispatch_active: AtomicBool::new(false),
-            error_code: AtomicI32::new(0),
-            supervisor: ptr::null_mut(),
-            supervisor_child_index: -1,
-            priority: AtomicI32::new(actor::HEW_PRIORITY_NORMAL),
-            reductions: AtomicI32::new(HEW_DEFAULT_REDUCTIONS),
-            idle_count: AtomicI32::new(0),
-            hibernation_threshold: AtomicI32::new(0),
-            hibernating: AtomicI32::new(0),
-            prof_messages_processed: AtomicU64::new(0),
-            prof_processing_time_ns: AtomicU64::new(0),
-            arena: std::ptr::null_mut(),
-            suspended_cont: AtomicPtr::new(std::ptr::null_mut()),
-            cont_tag: AtomicI32::new(crate::internal::types::ContTag::Empty as i32),
-            pending_wake: AtomicBool::new(false),
-            suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
-            suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
-            runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
-            runtime: ptr::null(),
-            send_pin_count: std::sync::atomic::AtomicU32::new(0),
-            gen_sink: AtomicPtr::new(std::ptr::null_mut()),
-            local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
-            spawn_serial: 1,
-            sys_dispatch: None,
-            state_drop_consumed: AtomicBool::new(false),
-            state_drop_borrowed: AtomicBool::new(false),
-            parked_ask_channel: AtomicPtr::new(std::ptr::null_mut()),
-        }
-    }
-
-    /// RAII guard that registers a stub actor in `LIVE_ACTORS` for the duration
-    /// of a test and untracks it on drop. `enqueue_resume` now confirms liveness
-    /// against `LIVE_ACTORS` before waking (the W6.010 caller-actor UAF guard),
-    /// so a wake-expecting test must present its stub as a LIVE actor. Each guard
-    /// assigns a unique `id` so concurrent tests do not collide in the
-    /// process-wide registry.
-    struct TrackedTestActor {
-        ptr: *mut HewActor,
-    }
-
-    impl TrackedTestActor {
-        fn install(mut actor: HewActor) -> Self {
-            actor.id = next_tracked_test_actor_id();
-            // Own the actor through a single raw pointer from `Box::into_raw`
-            // rather than storing a `Box` alongside a derived raw pointer: under
-            // Stacked Borrows, moving the `Box` (e.g. returning `Self`) retags and
-            // invalidates the pointee, so the saved raw tag would be stale. The
-            // `into_raw` pointer keeps valid provenance across the struct move and
-            // `Drop` reconstitutes the `Box` to free it exactly once.
-            let ptr: *mut HewActor = Box::into_raw(Box::new(actor));
-            // SAFETY: `ptr` is a freshly-boxed, fully-initialised actor.
-            assert!(unsafe { crate::lifetime::live_actors::track_actor(ptr) });
-            Self { ptr }
-        }
-
-        fn ptr(&self) -> *mut HewActor {
-            self.ptr
-        }
-
-        /// Untrack the actor WITHOUT freeing the box, modelling a caller actor
-        /// torn down before a late/orphan-retire reply fires. After this returns
-        /// `enqueue_resume(ptr)` must observe the actor as no longer live.
-        fn untrack(&self) {
-            crate::lifetime::live_actors::untrack_actor(self.ptr);
-        }
-    }
-
-    fn next_tracked_test_actor_id() -> u64 {
-        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
-        NEXT_ID.fetch_add(1, Ordering::Relaxed)
-    }
-
     static BLOCKED_SENDER_REINCARNATION: AtomicPtr<HewActor> = AtomicPtr::new(ptr::null_mut());
 
     fn reincarnate_blocked_sender_at_same_address() {
@@ -4896,52 +4806,9 @@ mod tests {
             !actor_ptr.is_null(),
             "blocked sender reincarnation target must be installed"
         );
-        assert!(crate::lifetime::live_actors::untrack_actor(actor_ptr));
-
-        let mut replacement = stub_actor();
-        replacement.id = next_tracked_test_actor_id();
-        replacement.spawn_serial = 2;
-        replacement
-            .actor_state
-            .store(HewActorState::Suspended as i32, Ordering::Release);
-        replacement.suspended_cont.store(
-            ptr::null_mut::<u8>().wrapping_add(1).cast(),
-            Ordering::Release,
-        );
-        replacement.cont_tag.store(
-            crate::internal::types::ContTag::Parked as i32,
-            Ordering::Release,
-        );
-
-        // SAFETY: the old incarnation is untracked and exclusively owned by
-        // this test. Destroying it returns this exact allocation to the test's
-        // one-slot pool; placement immediately reuses it for the replacement.
-        unsafe {
-            actor_ptr.drop_in_place();
-            actor_ptr.write(replacement);
-        }
-        // SAFETY: the replacement is fully initialized at `actor_ptr` and has
-        // a fresh identity distinct from the destroyed incarnation.
-        assert!(unsafe { crate::lifetime::live_actors::track_actor(actor_ptr) });
-    }
-
-    impl std::ops::Deref for TrackedTestActor {
-        type Target = HewActor;
-        fn deref(&self) -> &HewActor {
-            // SAFETY: `ptr` owns a live, boxed actor for the guard's lifetime.
-            unsafe { &*self.ptr }
-        }
-    }
-
-    impl Drop for TrackedTestActor {
-        fn drop(&mut self) {
-            // Idempotent: `untrack_actor` only removes a matching entry; a
-            // double-untrack (test already called `untrack`) is a no-op.
-            crate::lifetime::live_actors::untrack_actor(self.ptr);
-            // SAFETY: `ptr` came from `Box::into_raw` in `install`; reclaim the
-            // box so the actor is freed exactly once.
-            unsafe { drop(Box::from_raw(self.ptr)) };
-        }
+        // SAFETY: the hook runs on the test thread, which owns this allocation
+        // exclusively while the mailbox resolves the removed waiter.
+        unsafe { crate::test_actor::reincarnate_parked_in_place(actor_ptr) };
     }
 
     #[test]

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -22,6 +22,7 @@ use crate::internal::types::{
     HewActorState, HewDispatchFn, HewLifecycleFn, HewOnCrashFn, HewSysDispatchFn,
 };
 use crate::io_time::hew_now_ms;
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::mailbox;
 use crate::mailbox_header::HewSysMsg;
 use crate::pool::{HewActorPool, PoolStrategy};
@@ -1166,15 +1167,17 @@ fn finish_supervisor_reclamation(access: &ClosedSupervisorAccess) {
 /// slot. `notify_restart` fires every waiter exactly once per restart cycle,
 /// depositing readiness into `slot` and re-enqueuing `actor` on the scheduler.
 struct RestartAwaitWaiter {
-    /// The parked-continuation actor, woken via `enqueue_resume`. Raw and
-    /// possibly-stale: `enqueue_resume` re-validates liveness, never this code.
-    actor: *mut HewActor,
+    /// The parked-continuation actor's incarnation, woken via
+    /// `enqueue_resume_by_incarnation`. Captured at park time, when the actor is
+    /// live; a restart that recycles the awaiter's allocation cannot inherit
+    /// this wake.
+    actor: ActorIncarnation,
     /// The readiness slot; the observer holds one retained ref while registered.
     slot: *mut crate::read_slot::HewReadSlot,
 }
 
-// SAFETY: `actor` is re-validated under the registry lock by `enqueue_resume`;
-// `slot` is reference-counted. The waiter is only moved between the supervisor's
+// SAFETY: `actor` is a pair of scalars carrying no allocation; `slot` is
+// reference-counted. The waiter is only moved between the supervisor's
 // `restart_await_waiters` mutex and the firing path, both single-consumer.
 unsafe impl Send for RestartAwaitWaiter {}
 
@@ -1833,9 +1836,7 @@ fn wake_restart_await_waiters(sup: *mut HewSupervisor) {
             )
         };
         if do_wake {
-            // SAFETY: `enqueue_resume` re-validates `waiter.actor` under the
-            // registry lock; a freed actor drops the wake with no deref.
-            unsafe { crate::scheduler::enqueue_resume(waiter.actor, ptr::null_mut()) };
+            crate::scheduler::enqueue_resume_by_incarnation(waiter.actor);
         }
         // Release the observer's retained in-flight ref (the single authority).
         // SAFETY: the observer owned this ref; nothing else releases it.
@@ -2449,9 +2450,7 @@ unsafe fn stop_supervisor_owned(
             )
         };
         if do_wake {
-            // SAFETY: `enqueue_resume` re-validates the actor under the registry
-            // lock; a freed actor drops the wake with no deref.
-            unsafe { crate::scheduler::enqueue_resume(waiter.actor, ptr::null_mut()) };
+            crate::scheduler::enqueue_resume_by_incarnation(waiter.actor);
         }
         // SAFETY: the observer owned this ref; nothing else releases it.
         unsafe { crate::read_slot::hew_read_slot_free(waiter.slot) };
@@ -10116,6 +10115,8 @@ pub unsafe extern "C" fn hew_supervisor_restart_await_suspend(
     // out from under the abandon edge.
     // SAFETY: caller holds the creator ref, so the slot is live to retain.
     unsafe { crate::read_slot::read_slot_retain(slot) };
+    // SAFETY: `actor` is the awaiting actor, live for this registration.
+    let actor = unsafe { ActorIncarnation::of(actor) };
     waiters.push(RestartAwaitWaiter { actor, slot });
     drop(waiters);
     RESTART_AWAIT_SUSPEND

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -19,6 +19,7 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use crate::internal::types::{HewTaskError, HewTaskState};
+use crate::lifetime::live_actors::ActorIncarnation;
 use crate::rc::hew_rc_drop;
 use crate::util::{CondvarExt, MutexExt};
 
@@ -894,9 +895,11 @@ fn task_await_waiter_final_free_count_for_test() -> usize {
 /// task's completion observer owns one retained in-flight ref on `slot` and
 /// fires `wake` exactly once on `Done`.
 struct TaskAwaitWaiter {
-    /// The parked-continuation actor, woken via `enqueue_resume`. Raw and
-    /// possibly-stale: `enqueue_resume` re-validates liveness, never this code.
-    actor: *mut crate::actor::HewActor,
+    /// The parked-continuation actor's incarnation, woken via
+    /// `enqueue_resume_by_incarnation`. Recorded at park time, when the actor
+    /// is live; if it dies before completion the identity stops resolving and
+    /// the wake is dropped.
+    actor: ActorIncarnation,
     /// The readiness slot; the observer holds one retained ref while registered.
     slot: *mut crate::read_slot::HewReadSlot,
 }
@@ -928,9 +931,7 @@ unsafe extern "C" fn task_await_wake(ctx: *mut c_void) {
         crate::read_slot::read_slot_deposit_status(waiter.slot, crate::read_slot::ReadStatus::Data)
     };
     if do_wake {
-        // SAFETY: `enqueue_resume` re-validates `waiter.actor` under the registry
-        // lock; a freed actor drops the wake with no deref.
-        unsafe { crate::scheduler::enqueue_resume(waiter.actor, ptr::null_mut()) };
+        crate::scheduler::enqueue_resume_by_incarnation(waiter.actor);
     }
     // Release the observer's in-flight ref (the single authority for it).
     // SAFETY: the observer owned this ref; nothing else releases it.
@@ -974,6 +975,8 @@ pub unsafe extern "C" fn hew_task_await_suspend(
     // out from under the abandon edge.
     // SAFETY: caller holds the creator ref, so the slot is live to retain.
     unsafe { crate::read_slot::read_slot_retain(slot) };
+    // SAFETY: `actor` is the awaiting actor, live for this registration.
+    let actor = unsafe { ActorIncarnation::of(actor) };
     let waiter = Box::into_raw(Box::new(TaskAwaitWaiter { actor, slot }));
     let signal = t
         .done_signal
@@ -1050,9 +1053,9 @@ struct ScopeJoinWaiter {
     /// The shared first-ready arbiter (retained once for this waiter). The
     /// winning child observer calls `hew_await_cancel_complete` on it.
     reg: *mut crate::await_cancel::HewAwaitCancel,
-    /// The parked-continuation actor, woken via `enqueue_resume` when the join
-    /// wins. Raw and possibly-stale: `enqueue_resume` re-validates liveness.
-    actor: *mut crate::actor::HewActor,
+    /// The parked-continuation actor's incarnation, woken via
+    /// `enqueue_resume_by_incarnation` when the join wins.
+    actor: ActorIncarnation,
     /// Outstanding child observers not yet fired. The observer that decrements
     /// this to zero is the join winner.
     pending: AtomicUsize,
@@ -1111,12 +1114,7 @@ unsafe extern "C" fn scope_join_child_done(ctx: *mut c_void) {
         // box.
         let won = unsafe { crate::await_cancel::hew_await_cancel_complete(w.reg) != 0 };
         if won {
-            let actor = w.actor;
-            if !actor.is_null() {
-                // SAFETY: `enqueue_resume` re-validates `actor` liveness under the
-                // registry lock; a freed actor drops the wake with no deref.
-                unsafe { crate::scheduler::enqueue_resume(actor, ptr::null_mut()) };
-            }
+            crate::scheduler::enqueue_resume_by_incarnation(w.actor);
         }
     }
     // Release this observer's box ref (the last release reclaims the box).
@@ -1194,6 +1192,8 @@ pub unsafe extern "C" fn hew_task_scope_completion_observe(
     //     arbiter ref) before every observer is installed.
     // SAFETY: `reg` is live; retain the single box-owned arbiter ref.
     unsafe { crate::await_cancel::hew_await_cancel_retain(reg) };
+    // SAFETY: `actor` is the joining actor, live for this registration.
+    let actor = unsafe { ActorIncarnation::of(actor) };
     let waiter = Box::into_raw(Box::new(ScopeJoinWaiter {
         reg,
         actor,
@@ -5291,9 +5291,10 @@ mod tests {
                 "fresh slot must carry exactly the creator ref"
             );
 
-            // Park the awaiter with a null actor: `enqueue_resume` re-validates
-            // liveness and a cancelled slot suppresses the wake anyway, so no
-            // actor is needed to exercise the abandon teardown.
+            // Park the awaiter with a null actor: it records
+            // `ActorIncarnation::NONE`, which never resolves, and a cancelled
+            // slot suppresses the wake anyway, so no actor is needed to
+            // exercise the abandon teardown.
             let ret = hew_task_await_suspend(scope, task, ptr::null_mut(), slot);
             assert_eq!(
                 ret, TASK_AWAIT_SUSPEND,

--- a/hew-runtime/src/test_actor.rs
+++ b/hew-runtime/src/test_actor.rs
@@ -1,4 +1,4 @@
-//! Shared stub actors for the wake-edge tests.
+//! Shared stub actors for the wake-edge incarnation tests (#3069).
 //!
 //! Every readiness source records its wake target while the target actor is
 //! alive and fires it later, when the target may already be gone. The hazard
@@ -10,7 +10,7 @@
 //! allocator hook. It destroys the installed incarnation in place and
 //! placement-constructs a fresh one, with a fresh identity, at the exact same
 //! address, then re-tracks it. A wake recorded before the call and fired after
-//! it names an address that is live again and belongs to somebody else - the
+//! it names an address that is live again and belongs to somebody else — the
 //! precise state a supervisor restart or a spawn-after-free produces in
 //! production, minus the allocator's timing.
 
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU32, AtomicU64, 
 
 use crate::actor::{HewActor, HEW_DEFAULT_REDUCTIONS, HEW_MSG_BUDGET, HEW_PRIORITY_NORMAL};
 use crate::internal::types::{ContTag, HewActorState};
-use crate::lifetime::live_actors;
+use crate::lifetime::live_actors::{self, ActorIncarnation};
 use crate::scheduler::NoWorkerSchedulerForTest;
 
 /// Build a minimal `HewActor` with sensible defaults.
@@ -136,6 +136,12 @@ impl TrackedTestActor {
         self.ptr
     }
 
+    /// This actor's current incarnation identity.
+    pub(crate) fn incarnation(&self) -> ActorIncarnation {
+        // SAFETY: the guard owns a live, tracked actor.
+        unsafe { ActorIncarnation::of(self.ptr) }
+    }
+
     /// Untrack the actor WITHOUT freeing the box, modelling a caller torn down
     /// before a late reply fires. After this returns, a wake for the actor must
     /// observe it as no longer live.
@@ -144,25 +150,27 @@ impl TrackedTestActor {
     }
 
     /// Destroy this incarnation and construct a fresh, parked one at the SAME
-    /// address, tracked under a new identity.
+    /// address, tracked under a new identity. Returns the replacement's
+    /// incarnation.
     ///
     /// This is the deterministic form of the production race: a supervisor
     /// restart (or any spawn following a free) receiving the dead child's
     /// allocation back from the allocator.
-    pub(crate) fn reincarnate_parked(&self) {
+    pub(crate) fn reincarnate_parked(&self) -> ActorIncarnation {
         // SAFETY: the guard owns this allocation exclusively for its lifetime.
-        unsafe { reincarnate_parked_in_place(self.ptr) };
+        unsafe { reincarnate_parked_in_place(self.ptr) }
     }
 }
 
 /// Destroy the tracked incarnation at `actor` and construct a fresh, parked one
-/// at the SAME address, tracked under a new identity.
+/// at the SAME address, tracked under a new identity. Returns the replacement's
+/// incarnation.
 ///
 /// # Safety
 ///
 /// `actor` must be a tracked, fully initialised actor allocation the caller
 /// owns exclusively (no other thread may be inside a pin on it).
-pub(crate) unsafe fn reincarnate_parked_in_place(actor: *mut HewActor) {
+pub(crate) unsafe fn reincarnate_parked_in_place(actor: *mut HewActor) -> ActorIncarnation {
     assert!(
         live_actors::untrack_actor(actor),
         "the incarnation being replaced must still be tracked"
@@ -192,6 +200,8 @@ pub(crate) unsafe fn reincarnate_parked_in_place(actor: *mut HewActor) {
     // SAFETY: the replacement is fully initialised at `actor` and has a fresh
     // identity distinct from the destroyed incarnation.
     assert!(unsafe { live_actors::track_actor(actor) });
+    // SAFETY: as above — the replacement is live and tracked.
+    unsafe { ActorIncarnation::of(actor) }
 }
 
 impl std::ops::Deref for TrackedTestActor {

--- a/hew-runtime/src/test_actor.rs
+++ b/hew-runtime/src/test_actor.rs
@@ -1,0 +1,258 @@
+//! Shared stub actors for the wake-edge tests.
+//!
+//! Every readiness source records its wake target while the target actor is
+//! alive and fires it later, when the target may already be gone. The hazard
+//! these helpers reproduce is ADDRESS reuse: an actor box freed and handed
+//! straight back to the next spawn, so a wake recorded against the dead
+//! incarnation resolves to a live, unrelated one.
+//!
+//! [`TrackedTestActor::reincarnate_parked`] makes that deterministic without an
+//! allocator hook. It destroys the installed incarnation in place and
+//! placement-constructs a fresh one, with a fresh identity, at the exact same
+//! address, then re-tracks it. A wake recorded before the call and fired after
+//! it names an address that is live again and belongs to somebody else - the
+//! precise state a supervisor restart or a spawn-after-free produces in
+//! production, minus the allocator's timing.
+
+use std::ptr;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU32, AtomicU64, Ordering};
+
+use crate::actor::{HewActor, HEW_DEFAULT_REDUCTIONS, HEW_MSG_BUDGET, HEW_PRIORITY_NORMAL};
+use crate::internal::types::{ContTag, HewActorState};
+use crate::lifetime::live_actors;
+use crate::scheduler::NoWorkerSchedulerForTest;
+
+/// Build a minimal `HewActor` with sensible defaults.
+pub(crate) fn stub_actor() -> HewActor {
+    HewActor {
+        sched_link_next: AtomicPtr::new(ptr::null_mut()),
+        id: 1,
+        state: ptr::null_mut(),
+        state_size: 0,
+        dispatch: None,
+        mailbox: ptr::null_mut(),
+        actor_state: AtomicI32::new(HewActorState::Runnable as i32),
+        budget: AtomicI32::new(HEW_MSG_BUDGET),
+        init_state: ptr::null_mut(),
+        init_state_size: 0,
+        coalesce_key_fn: None,
+        terminate_fn: None,
+        state_drop_fn: None,
+        state_clone_fn: None,
+        terminate_called: AtomicBool::new(false),
+        terminate_finished: AtomicBool::new(false),
+        dispatch_active: AtomicBool::new(false),
+        error_code: AtomicI32::new(0),
+        supervisor: ptr::null_mut(),
+        supervisor_child_index: -1,
+        priority: AtomicI32::new(HEW_PRIORITY_NORMAL),
+        reductions: AtomicI32::new(HEW_DEFAULT_REDUCTIONS),
+        idle_count: AtomicI32::new(0),
+        hibernation_threshold: AtomicI32::new(0),
+        hibernating: AtomicI32::new(0),
+        prof_messages_processed: AtomicU64::new(0),
+        prof_processing_time_ns: AtomicU64::new(0),
+        arena: ptr::null_mut(),
+        suspended_cont: AtomicPtr::new(ptr::null_mut()),
+        cont_tag: AtomicI32::new(ContTag::Empty as i32),
+        pending_wake: AtomicBool::new(false),
+        suspended_reply_channel: AtomicPtr::new(ptr::null_mut()),
+        suspended_cancel_token: AtomicPtr::new(ptr::null_mut()),
+        runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+        runtime: ptr::null(),
+        send_pin_count: AtomicU32::new(0),
+        gen_sink: AtomicPtr::new(ptr::null_mut()),
+        local_pid_id: crate::lifetime::local_handles::HewLocalPidId::INVALID,
+        spawn_serial: 1,
+        sys_dispatch: None,
+        state_drop_consumed: AtomicBool::new(false),
+        state_drop_borrowed: AtomicBool::new(false),
+        parked_ask_channel: AtomicPtr::new(ptr::null_mut()),
+    }
+}
+
+/// Distinct ids for stub actors so tests sharing a registry cannot collide.
+fn next_stub_actor_id() -> u64 {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// A distinct `spawn_serial` per stub incarnation. Production allocates from
+/// the same kind of monotonic counter and never reissues; the tests need the
+/// same property so a reincarnation is provably a different incarnation.
+fn next_stub_spawn_serial() -> u64 {
+    static NEXT_SERIAL: AtomicU64 = AtomicU64::new(1);
+    NEXT_SERIAL.fetch_add(1, Ordering::Relaxed)
+}
+
+/// A stub actor tracked in the current runtime's liveness registry for the
+/// duration of a test, untracked and freed on drop.
+///
+/// The wake edges confirm liveness against the registry before waking, so a
+/// wake-expecting test must present its stub as a LIVE actor.
+pub(crate) struct TrackedTestActor {
+    ptr: *mut HewActor,
+}
+
+impl TrackedTestActor {
+    /// Track `actor` under a fresh identity.
+    pub(crate) fn install(mut actor: HewActor) -> Self {
+        actor.id = next_stub_actor_id();
+        actor.spawn_serial = next_stub_spawn_serial();
+        // Own the actor through a single raw pointer from `Box::into_raw`
+        // rather than storing a `Box` alongside a derived raw pointer: under
+        // Stacked Borrows, moving the `Box` (e.g. returning `Self`) retags and
+        // invalidates the pointee, so the saved raw tag would be stale. The
+        // `into_raw` pointer keeps valid provenance across the struct move and
+        // `Drop` reconstitutes the `Box` to free it exactly once.
+        let ptr: *mut HewActor = Box::into_raw(Box::new(actor));
+        // SAFETY: `ptr` is a freshly-boxed, fully-initialised actor.
+        assert!(unsafe { live_actors::track_actor(ptr) });
+        Self { ptr }
+    }
+
+    /// Track a stub actor already parked: `Suspended`, with a non-null
+    /// `suspended_cont` handle so a wake takes the direct-delivery arm rather
+    /// than the mid-park pending-wake arm.
+    pub(crate) fn install_parked() -> Self {
+        let installed = Self::install(stub_actor());
+        installed.park();
+        installed
+    }
+
+    /// Put this actor into the parked shape a readiness source expects.
+    fn park(&self) {
+        self.actor_state
+            .store(HewActorState::Suspended as i32, Ordering::Release);
+        self.suspended_cont.store(
+            ptr::null_mut::<u8>().wrapping_add(1).cast(),
+            Ordering::Release,
+        );
+        self.cont_tag
+            .store(ContTag::Parked as i32, Ordering::Release);
+    }
+
+    pub(crate) fn ptr(&self) -> *mut HewActor {
+        self.ptr
+    }
+
+    /// Untrack the actor WITHOUT freeing the box, modelling a caller torn down
+    /// before a late reply fires. After this returns, a wake for the actor must
+    /// observe it as no longer live.
+    pub(crate) fn untrack(&self) {
+        live_actors::untrack_actor(self.ptr);
+    }
+
+    /// Destroy this incarnation and construct a fresh, parked one at the SAME
+    /// address, tracked under a new identity.
+    ///
+    /// This is the deterministic form of the production race: a supervisor
+    /// restart (or any spawn following a free) receiving the dead child's
+    /// allocation back from the allocator.
+    pub(crate) fn reincarnate_parked(&self) {
+        // SAFETY: the guard owns this allocation exclusively for its lifetime.
+        unsafe { reincarnate_parked_in_place(self.ptr) };
+    }
+}
+
+/// Destroy the tracked incarnation at `actor` and construct a fresh, parked one
+/// at the SAME address, tracked under a new identity.
+///
+/// # Safety
+///
+/// `actor` must be a tracked, fully initialised actor allocation the caller
+/// owns exclusively (no other thread may be inside a pin on it).
+pub(crate) unsafe fn reincarnate_parked_in_place(actor: *mut HewActor) {
+    assert!(
+        live_actors::untrack_actor(actor),
+        "the incarnation being replaced must still be tracked"
+    );
+
+    let mut replacement = stub_actor();
+    replacement.id = next_stub_actor_id();
+    replacement.spawn_serial = next_stub_spawn_serial();
+    replacement
+        .actor_state
+        .store(HewActorState::Suspended as i32, Ordering::Release);
+    replacement.suspended_cont.store(
+        ptr::null_mut::<u8>().wrapping_add(1).cast(),
+        Ordering::Release,
+    );
+    replacement
+        .cont_tag
+        .store(ContTag::Parked as i32, Ordering::Release);
+
+    // SAFETY: the old incarnation is untracked and exclusively owned by the
+    // caller. Destroying it in place leaves the allocation owned and
+    // uninitialised; the write immediately reinitialises it.
+    unsafe {
+        actor.drop_in_place();
+        actor.write(replacement);
+    }
+    // SAFETY: the replacement is fully initialised at `actor` and has a fresh
+    // identity distinct from the destroyed incarnation.
+    assert!(unsafe { live_actors::track_actor(actor) });
+}
+
+impl std::ops::Deref for TrackedTestActor {
+    type Target = HewActor;
+    fn deref(&self) -> &HewActor {
+        // SAFETY: `ptr` owns a live, boxed actor for the guard's lifetime.
+        unsafe { &*self.ptr }
+    }
+}
+
+impl Drop for TrackedTestActor {
+    fn drop(&mut self) {
+        // Idempotent: `untrack_actor` only removes a matching entry, so a
+        // double-untrack (the test already called `untrack`) is a no-op.
+        live_actors::untrack_actor(self.ptr);
+        // SAFETY: `ptr` came from `Box::into_raw` in `install`; reclaim the box
+        // so the actor is freed exactly once.
+        unsafe { drop(Box::from_raw(self.ptr)) };
+    }
+}
+
+/// Assert the actor at `victim`'s address was NOT resumed by a stale wake: it
+/// stays parked, carries no pending-wake marker, and nothing reached the run
+/// queue.
+pub(crate) fn assert_not_woken(
+    sched: &NoWorkerSchedulerForTest,
+    victim: &TrackedTestActor,
+    family: &str,
+) {
+    assert_eq!(
+        victim.actor_state.load(Ordering::Acquire),
+        HewActorState::Suspended as i32,
+        "{family}: a wake registered by a dead incarnation must not resume the \
+         actor that later occupies its address"
+    );
+    assert!(
+        !crate::coro_exec::take_pending_wake(victim),
+        "{family}: a stale wake must not leave a pending-wake marker on the \
+         replacement either - the marker would fire on its next park"
+    );
+    assert_eq!(
+        sched.pop_global(),
+        None,
+        "{family}: a stale wake must not enqueue the replacement"
+    );
+}
+
+/// Assert the registering incarnation WAS resumed (the positive control).
+pub(crate) fn assert_woken(
+    sched: &NoWorkerSchedulerForTest,
+    victim: &TrackedTestActor,
+    family: &str,
+) {
+    assert_eq!(
+        victim.actor_state.load(Ordering::Acquire),
+        HewActorState::Runnable as i32,
+        "{family}: the registering incarnation must be resumed by its own wake"
+    );
+    assert_eq!(
+        sched.pop_global(),
+        Some(victim.ptr()),
+        "{family}: the woken actor must be enqueued exactly once"
+    );
+}

--- a/hew-runtime/src/wake_incarnation_tests.rs
+++ b/hew-runtime/src/wake_incarnation_tests.rs
@@ -1,0 +1,228 @@
+//! Wake-edge incarnation tests: one per readiness family (#3069).
+//!
+//! Every family here registers a wake target while the target actor is parked
+//! and fires it later. The registration is an ADDRESS, and addresses are
+//! recycled: the allocator hands a freed actor box straight back to the next
+//! spawn, so a wake recorded by an actor that has since died can resolve to a
+//! live, unrelated incarnation. The liveness probe on the wake edge cannot tell
+//! the two apart - both are tracked-live at the same address - so the stale
+//! wake moves a stranger `Suspended -> Runnable` with no readiness behind it,
+//! and a suspending `select` resumed that way fabricates a timeout.
+//!
+//! [`TrackedTestActor::reincarnate_parked`] forces that interleaving with no
+//! allocator hook and no threads: it destroys the registered incarnation in
+//! place and constructs a fresh, parked one at the same address under a new
+//! identity.
+//!
+//! Each family gets a pair. The negative asserts the replacement is untouched
+//! after a stale wake; the positive control asserts the same edge DOES wake the
+//! incarnation that actually registered, so the negative cannot be satisfied by
+//! a wake path that simply drops everything.
+
+use std::ptr;
+
+use crate::scheduler::NoWorkerSchedulerForTest;
+use crate::test_actor::{assert_not_woken, assert_woken, TrackedTestActor};
+
+// ── timer / deadline (await_cancel) ──────────────────────────────────────────
+
+/// Register the shared deadline arbiter against a parked actor, then fire the
+/// timeout arm.
+///
+/// `reincarnate` decides whether the registering incarnation dies (and has its
+/// address reused) before the timer fires.
+fn run_timer_family(reincarnate: bool) {
+    use crate::await_cancel::{
+        hew_await_cancel_cancel, hew_await_cancel_free, hew_await_cancel_new, AwaitCancelStatus,
+    };
+
+    let sched = NoWorkerSchedulerForTest::install();
+    let victim = TrackedTestActor::install_parked();
+
+    // SAFETY: `victim` is live and tracked; the registration takes no ownership
+    // of it.
+    let reg = unsafe { hew_await_cancel_new(victim.ptr(), None, ptr::null_mut()) };
+
+    if reincarnate {
+        victim.reincarnate_parked();
+    }
+
+    // The timer wheel's deadline arm: settle the wait as TimedOut and wake.
+    // SAFETY: `reg` is the live registration created above.
+    let ran = unsafe {
+        hew_await_cancel_cancel(
+            reg,
+            AwaitCancelStatus::TimedOut as i32,
+            /* wake_actor */ 1,
+        )
+    };
+    assert_eq!(ran, 1, "the timeout arm must win the one-shot arbiter");
+    // SAFETY: releases the creator reference taken by `hew_await_cancel_new`.
+    unsafe { hew_await_cancel_free(reg) };
+
+    if reincarnate {
+        assert_not_woken(&sched, &victim, "timer");
+    } else {
+        assert_woken(&sched, &victim, "timer");
+    }
+}
+
+#[test]
+fn timer_wake_does_not_resume_a_reused_address() {
+    run_timer_family(true);
+}
+
+#[test]
+fn timer_wake_resumes_the_registering_incarnation() {
+    run_timer_family(false);
+}
+
+// ── channel (typed stream pipe) ──────────────────────────────────────────────
+
+fn run_channel_family(reincarnate: bool) {
+    use crate::channel_core::{ChannelCore, STREAM_AWAIT_SUSPEND};
+    use crate::read_slot::{hew_read_slot_free, hew_read_slot_new};
+
+    let sched = NoWorkerSchedulerForTest::install();
+    let victim = TrackedTestActor::install_parked();
+
+    let core = ChannelCore::new(4);
+    let slot = hew_read_slot_new();
+    // SAFETY: `victim` is live and tracked; `slot` is freshly created and the
+    // test holds its creator reference.
+    let parked = unsafe { core.await_next(victim.ptr(), slot) };
+    assert_eq!(
+        parked, STREAM_AWAIT_SUSPEND,
+        "an empty, open pipe must park the consumer"
+    );
+
+    if reincarnate {
+        victim.reincarnate_parked();
+    }
+
+    // A producer send is the readiness edge: it queues the item and wakes the
+    // registered consumer.
+    core.blocking_send(vec![1, 2, 3, 4]);
+
+    if reincarnate {
+        assert_not_woken(&sched, &victim, "channel");
+    } else {
+        assert_woken(&sched, &victim, "channel");
+    }
+
+    // SAFETY: releases the test's creator reference on the slot.
+    unsafe { hew_read_slot_free(slot) };
+}
+
+#[test]
+fn channel_wake_does_not_resume_a_reused_address() {
+    run_channel_family(true);
+}
+
+#[test]
+fn channel_wake_resumes_the_registering_incarnation() {
+    run_channel_family(false);
+}
+
+// ── reply channel (suspending ask) ───────────────────────────────────────────
+
+fn run_reply_family(reincarnate: bool) {
+    use crate::reply_channel::{
+        hew_reply, hew_reply_channel_free, hew_reply_channel_new, hew_reply_channel_retain,
+        hew_reply_channel_set_parked_waiter,
+    };
+
+    let sched = NoWorkerSchedulerForTest::install();
+    let victim = TrackedTestActor::install_parked();
+
+    let ch = hew_reply_channel_new();
+    // SAFETY: `ch` is live; `victim` is the actor whose continuation parks on
+    // this ask.
+    unsafe { hew_reply_channel_set_parked_waiter(ch, victim.ptr()) };
+    // The callee side holds its own sender reference, consumed by `hew_reply`.
+    // SAFETY: `ch` is live and the test holds the waiter reference.
+    unsafe { hew_reply_channel_retain(ch) };
+
+    if reincarnate {
+        victim.reincarnate_parked();
+    }
+
+    let payload: i32 = 7;
+    // SAFETY: `ch` is live with a sender reference outstanding; `payload` is a
+    // live bit-copy value of the stated size.
+    let delivered =
+        unsafe { hew_reply(ch, (&raw const payload).cast_mut().cast(), size_of::<i32>()) };
+    assert!(delivered, "the reply must be delivered to the channel");
+
+    if reincarnate {
+        assert_not_woken(&sched, &victim, "reply");
+    } else {
+        assert_woken(&sched, &victim, "reply");
+    }
+
+    // SAFETY: releases the test's waiter reference (the last one).
+    unsafe { hew_reply_channel_free(ch) };
+}
+
+#[test]
+fn reply_wake_does_not_resume_a_reused_address() {
+    run_reply_family(true);
+}
+
+#[test]
+fn reply_wake_resumes_the_registering_incarnation() {
+    run_reply_family(false);
+}
+
+// ── task scope (await over a scope-owned child task) ─────────────────────────
+
+fn run_scope_family(reincarnate: bool) {
+    use crate::read_slot::{hew_read_slot_free, hew_read_slot_new};
+    use crate::task_scope::{
+        hew_task_await_suspend, hew_task_new, hew_task_scope_complete_task, hew_task_scope_destroy,
+        hew_task_scope_new, hew_task_scope_spawn, TASK_AWAIT_SUSPEND,
+    };
+
+    let sched = NoWorkerSchedulerForTest::install();
+    let victim = TrackedTestActor::install_parked();
+
+    // SAFETY: the test owns every scope/task/slot pointer exclusively.
+    unsafe {
+        let scope = hew_task_scope_new();
+        let task = hew_task_new();
+        hew_task_scope_spawn(scope, task);
+
+        let slot = hew_read_slot_new();
+        let parked = hew_task_await_suspend(scope, task, victim.ptr(), slot);
+        assert_eq!(
+            parked, TASK_AWAIT_SUSPEND,
+            "an outstanding child task must park the awaiting actor"
+        );
+
+        if reincarnate {
+            victim.reincarnate_parked();
+        }
+
+        // The child completes: the observer deposits readiness and wakes.
+        hew_task_scope_complete_task(scope, task);
+
+        if reincarnate {
+            assert_not_woken(&sched, &victim, "scope");
+        } else {
+            assert_woken(&sched, &victim, "scope");
+        }
+
+        hew_read_slot_free(slot);
+        hew_task_scope_destroy(scope);
+    }
+}
+
+#[test]
+fn scope_wake_does_not_resume_a_reused_address() {
+    run_scope_family(true);
+}
+
+#[test]
+fn scope_wake_resumes_the_registering_incarnation() {
+    run_scope_family(false);
+}


### PR DESCRIPTION
## Why

Eleven readiness sources in the runtime recorded their wake target as a raw
`*mut HewActor` and woke it through `enqueue_resume`, whose liveness probe
matched the ADDRESS against the live-actor registry. That proved the address was
tracked, never that it still held the incarnation that parked. An actor that
dies while a wake is registered against it hands its box back to the allocator,
so the next spawn - a supervisor restart, most often - can occupy the same
address, and the late wake moved that stranger `Suspended -> Runnable` with no
readiness behind it. A suspending `select` resumed that way reports a timeout
that never happened.

Now a wake names an incarnation. The wake resolves the live incarnation or is
dropped, and the resolution pin is held across the enqueue, so the target cannot
die or have its address recycled mid-call.

## What

- **runtime (`lifetime/live_actors`)**: `ActorIncarnation` - the actor id paired
  with its never-reissued `spawn_serial` - plus `with_live_incarnation`, which
  pins the exact incarnation or returns `None` on an untracked id or a serial
  mismatch.
- **runtime (`scheduler`)**: `enqueue_resume_by_incarnation` is the single wake
  edge. The refusal happens before any mutation of the resolved actor, so a
  stale wake cannot leave a `pending_wake` marker on the wrong incarnation
  either. The old `pub unsafe fn enqueue_resume` is gone; the pointer entry
  survives only as `pub(crate) enqueue_resume_pinned`, reachable in production
  solely through the resolver. There is no second wake path.
- **runtime (wake sources)**: `supervisor`, `task_scope`, `reactor`,
  `await_cancel`, `channel_core`, `reply_channel`, `hew_node` and `mailbox` all
  record an `ActorIncarnation` at park time, when the actor is provably live.
- **docs**: three SAFETY comments that asserted the old edge re-validated the
  waiter now state the incarnation rule, and the runtime-unsafe-count waiver
  records that its tracked follow-up landed.

WASM is untouched: `scheduler_wasm::enqueue_resume` is a separate cooperative
twin with no address-reuse hazard (single-threaded, no supervision), and
`wasm_parity_tests` still passes.

## Test

`hew-runtime/src/wake_incarnation_tests.rs` is new: one negative and one
positive control per readiness family - timer, channel, reply, scope - plus the
node pair in `hew_node`'s test module. `TrackedTestActor::reincarnate_parked`
(`hew-runtime/src/test_actor.rs`) forces the interleaving with no allocator hook
and no threads, by destroying the registered incarnation in place and
constructing a fresh parked one at the same address under a new identity. The
five negatives were committed failing against the pointer path and pass on the
registry; the positive controls prove the same edges still wake the incarnation
that registered, so the negatives cannot be satisfied by a wake path that drops
everything.

`hew_node`'s `parked_reply_*` tests stood a `dangling_mut` pointer in for the
parked caller, which only worked while nothing read it; they now install a
tracked stub, because registration reads the caller's identity.

## Not in this change

`mailbox_detach_await_send` (`hew-runtime/src/mailbox.rs:2916`) still finds the
registration to remove by read-slot ADDRESS. That is sound today because the
detaching caller holds the slot's creator reference for the whole call, so the
address cannot be recycled underneath it - construction by convention, which is
what the issue asks to replace. It is a separate signature change (the detach
entry takes no actor) with its own oracle, and it is not on the wake edge this
change is about. Worth a follow-up rather than a rider here.

Fixes #3069
