### PR TITLE
Report the actor and handler when an actor crashes

### DIFF
--- a/hew-runtime/src/crash.rs
+++ b/hew-runtime/src/crash.rs
@@ -162,13 +162,22 @@ fn push_crash_report_to(log: &PoisonSafe<VecDeque<CrashReport>>, report: CrashRe
 }
 
 /// Record a logical actor failure caught by the scheduler's language-unwind
-/// boundary.
+/// boundary, and report it once on stderr.
 ///
 /// Logical failures do not carry hardware `siginfo_t`; the typed Hew trap code
 /// occupies `signal`, matching the historical recovery report and the public
 /// `CrashReport`/observe schema. The scheduler supplies the message type when a
-/// mailbox node backs the activation; resumed continuations use zero.
-pub(crate) fn record_logical_crash(actor_id: u64, code: i32, msg_type: i32) {
+/// mailbox node backs the activation; resumed continuations use zero, and
+/// `dispatch_ptr` is the crashing actor's dispatch function as a `usize` (zero
+/// when the activation has none) — the key both context registries are stamped
+/// with at startup.
+pub(crate) fn record_logical_crash(actor_id: u64, code: i32, msg_type: i32, dispatch_ptr: usize) {
+    push_logical_crash_report(actor_id, code, msg_type);
+    emit_crash_diagnostic(actor_id, code, msg_type, dispatch_ptr);
+}
+
+/// Put one logical failure in the crash log without reporting it.
+fn push_logical_crash_report(actor_id: u64, code: i32, msg_type: i32) {
     let report = CrashReport {
         actor_id,
         actor_pid: actor_id,
@@ -183,12 +192,41 @@ pub(crate) fn record_logical_crash(actor_id: u64, code: i32, msg_type: i32) {
     push_crash_report(report);
 }
 
+/// Write the single user-facing line for a logical actor crash.
+///
+/// This is the only stderr writer on the crash path. `emit_crash_diagnostic_sig_safe`
+/// went with the siglongjmp recovery tier; the unwind path that replaced it stamps
+/// the trap code, suppresses the typed `HewPanic` message in the panic hook and
+/// records the crash silently, so an unsupervised crash reached the user as exit 1
+/// with nothing written at all. `record_logical_crash` is the one funnel every
+/// logical crash passes through, which is why the line is written here rather than
+/// at either scheduler catch site — one crash, one line.
+///
+/// Context is resolved from the registries codegen stamps at startup: the
+/// fully-qualified handler name when `(dispatch_ptr, msg_type)` is registered,
+/// otherwise the actor's type name. Both degrade to a named actor, never to the
+/// opaque `msg_type=-N` form the retired diagnostic printed.
+fn emit_crash_diagnostic(actor_id: u64, code: i32, msg_type: i32, dispatch_ptr: usize) {
+    use crate::profiler::actor_registry;
+
+    let context = actor_registry::handler_name_by_ptr(dispatch_ptr, msg_type)
+        .unwrap_or_else(|| actor_registry::lookup_dispatch_type_by_ptr_owned(dispatch_ptr));
+    let reason = match crate::internal::types::ExitReason::from_error_code(code) {
+        crate::internal::types::ExitReason::Signal(signal) => format!("Signal({signal})"),
+        named => named.trap_kind_name().to_owned(),
+    };
+    eprintln!("hew: actor crash in {context} (actor {actor_id}): {reason}");
+}
+
 /// Record a fault-injected crash in the global crash log.
 ///
 /// Uses `signal = -1` so injected failures remain distinguishable from typed
-/// logical traps and hardware signals.
+/// logical traps and hardware signals. Deliberately silent: a deterministic
+/// simulation hook is the harness asking for a crash, not a program fault the
+/// user has to diagnose, and the injecting frame has already released the actor
+/// it would name.
 pub(crate) fn record_injected_crash(actor_id: u64) {
-    record_logical_crash(actor_id, -1, 0);
+    push_logical_crash_report(actor_id, -1, 0);
 }
 
 // ── Monotonic timestamp utility ─────────────────────────────────────────

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -2463,7 +2463,7 @@ unsafe fn resume_suspended_activation(actor: *mut HewActor) {
                 .downcast_ref::<crate::actor::HewPanic>()
                 .map_or(101, |panic| panic.code);
             crate::util::quarantine_panic_payload(payload);
-            crate::crash::record_logical_crash(a.id, code, 0);
+            crate::crash::record_logical_crash(a.id, code, 0, a.dispatch.map_or(0, |f| f as usize));
             // SAFETY: catch_unwind proves the resumed stack is dead; this
             // activation still exclusively owns actor and resume_context.
             unsafe { resume_crash_recovery(actor, &raw mut resume_context, code) };
@@ -3625,7 +3625,12 @@ fn activate_queued_actor(actor: *mut HewActor) {
                             .map_or(101, |panic| panic.code);
                         set_last_error("actor dispatch panicked");
                         crate::util::quarantine_panic_payload(panic_payload);
-                        crate::crash::record_logical_crash(a.id, code, msg_ref.msg_type);
+                        crate::crash::record_logical_crash(
+                            a.id,
+                            code,
+                            msg_ref.msg_type,
+                            a.dispatch.map_or(0, |f| f as usize),
+                        );
                         // SAFETY: this scheduler frame exclusively owns the
                         // active actor and has completed stack cleanup.
                         unsafe {

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -2158,7 +2158,12 @@ unsafe fn activate_actor_wasm(actor: *mut HewActor) {
                         a.actor_state
                             .store(HewActorState::Crashed as i32, Ordering::Release);
                     }
-                    crate::crash::record_logical_crash(a.id, code, msg_ref.msg_type);
+                    crate::crash::record_logical_crash(
+                        a.id,
+                        code,
+                        msg_ref.msg_type,
+                        a.dispatch.map_or(0, |f| f as usize),
+                    );
                     crate::util::quarantine_panic_payload(panic_payload);
                 // SAFETY: normal dispatch return matches the scope opened
                 // immediately before handler entry.

--- a/tests/vertical-slice/accept/crash_actor_context_diagnostic.hew
+++ b/tests/vertical-slice/accept/crash_actor_context_diagnostic.hew
@@ -2,14 +2,15 @@
 // diagnostic, not emit an opaque msg_type integer.
 //
 // The Crasher actor traps in its `on_trigger` handler via an out-of-bounds Vec
-// index (hardware fault — SIGILL on x86_64, SIGTRAP on aarch64/macOS). The
-// signal handler longjmps back to the scheduler, which calls
-// handle_crash_recovery_impl. The diagnostic must include the actor type name
-// "Crasher" (resolved from the dispatch-fn registry populated by codegen at
-// startup), not the opaque "msg_type=-N" format.
+// index. `hew_trap_with_code` stamps the trap code on the actor and unwinds a
+// typed `HewPanic` through the generated LLVM cleanup pads; the scheduler
+// catches it and funnels it into `crash::record_logical_crash`, which writes
+// the one diagnostic line. The context must be resolved from the dispatch-fn
+// registry codegen populates at startup ("Crasher::on_trigger", or at minimum
+// the actor type name "Crasher"), never the opaque "msg_type=-N" format.
 //
 // A sleep after the send gives the scheduler time to deliver the message and
-// run the crash recovery path before the process exits.
+// run the crash path before the process exits.
 //
 // run.sh asserts:
 //   1. Exit is 1 after the unsupervised actor crash settles.

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -146,31 +146,16 @@ run_actor_bounds_trap_fixture() {
     local expected_diagnostic="$2"
     local expected_actor="${3:-}"
     local expected_status="${4:-1}"
-    local known_missing_actor_issue="${5:-}"
     run_accept_expect_status "${fixture}" "${expected_status}"
     if ! grep -qF -- "${expected_diagnostic}" "${stderr_output}"; then
         echo "${fixture}: missing expected actor panic diagnostic: ${expected_diagnostic}" >&2
         cat "${stderr_output}" >&2
         exit 1
     fi
-    if [[ -n "${known_missing_actor_issue}" ]] &&
-        ! grep -qF -- "${expected_actor}" "${stderr_output}"; then
-        if [[ "$(cat "${stderr_output}")" != "${expected_diagnostic}" ]]; then
-            echo "${fixture}: #${known_missing_actor_issue} changed from the exact context-free diagnostic" >&2
-            cat "${stderr_output}" >&2
-            exit 1
-        fi
-        echo "KNOWN ${fixture} (#${known_missing_actor_issue}: missing actor crash context)"
-        return
-    fi
     if [[ -n "${expected_actor}" ]] &&
         ! grep -qF -- "${expected_actor}" "${stderr_output}"; then
         echo "${fixture}: missing expected actor context: ${expected_actor}" >&2
         cat "${stderr_output}" >&2
-        exit 1
-    fi
-    if [[ -n "${known_missing_actor_issue}" ]]; then
-        echo "${fixture}: #${known_missing_actor_issue} is fixed; remove this known-failure ratchet" >&2
         exit 1
     fi
     if grep -qF -- 'hew: trap in main context' "${stderr_output}"; then
@@ -2325,21 +2310,19 @@ run_accept_expect_status "std_panic_wrappers_success" 0
 run_accept_expect_trap "crash_main_context_diagnostic"
 grep -q 'hew: trap in main context' "${stderr_output}"
 
-# F4.3's desired contract names `Crasher::on_trigger` rather than an opaque
-# message type. #3126 currently exits 1 with empty stderr; this shrink-only
-# ratchet admits exactly that missing diagnostic and rejects any other output
-# (including the desired context, which means the ledger can be removed).
+# F4.3: an actor crash must name the function/context in the diagnostic, not
+# emit an opaque msg_type integer. The fixture spawns an actor that traps in
+# its handler; `crash::record_logical_crash` resolves the handler name from the
+# dispatch-fn registry ("Crasher::on_trigger") rather than printing
+# "msg_type=-N". The unsupervised crash must also report exit 1 after main's
+# sleep gives the diagnostic time to settle.
 run_accept_expect_status "crash_actor_context_diagnostic" 1
-if grep -q 'Crasher' "${stderr_output}"; then
-    echo "crash_actor_context_diagnostic: #3126 is fixed; remove this known-failure ratchet" >&2
-    exit 1
-fi
-if [[ -s "${stderr_output}" ]]; then
-    echo "crash_actor_context_diagnostic: #3126 changed from the exact empty-stderr failure" >&2
+grep -q 'Crasher' "${stderr_output}"
+if grep -q 'msg_type=-' "${stderr_output}"; then
+    echo "crash_actor_context_diagnostic: stderr still contains opaque msg_type=-N format" >&2
     cat "${stderr_output}" >&2
     exit 1
 fi
-echo "KNOWN crash_actor_context_diagnostic (#3126: missing local actor crash context)"
 
 # Runtime FFI bounds checks inside actor dispatch must crash only the actor, not
 # the scheduler. Each fixture sends a crashing message and then proves actor
@@ -2350,74 +2333,62 @@ run_actor_bounds_trap_fixture \
     "vec_set_oob_actor_isolated" \
     "PANIC: Vec.set() index 99 out of bounds (len 1)" \
     "VecSetCrasher" \
-    0 \
-    3126
+    0
 run_actor_bounds_trap_fixture \
     "vec_pop_empty_actor_isolated" \
     "PANIC: Vec.pop() on an empty vector" \
     "VecPopCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "vec_remove_oob_actor_isolated" \
     "PANIC: Vec.remove() index 99 out of bounds (len 1)" \
     "VecRemoveCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "vec_remove_layout_oob_actor_isolated" \
     "PANIC: Vec.remove() index 99 out of bounds (len 1)" \
     "VecRemoveLayoutCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "bytes_index_oob_actor_isolated" \
     "PANIC: bytes[i] index 99 out of bounds (len 1)" \
     "BytesIndexCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "bytes_slice_oob_actor_isolated" \
     "PANIC: bytes slice range 0..99 out of bounds (len 2)" \
     "BytesSliceCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "bytes_pop_empty_actor_isolated" \
     "PANIC: bytes.pop() on an empty buffer" \
     "BytesPopCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "bytes_set_oob_actor_isolated" \
     "PANIC: bytes.set() index 99 out of bounds (len 1)" \
     "BytesSetCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "string_index_oob_actor_isolated" \
     "PANIC: string[i] index 99 out of bounds (len 3)" \
     "StringIndexCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "string_slice_oob_actor_isolated" \
     "PANIC: string slice range 1..99 out of bounds (len 5)" \
     "StringSliceCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "deque_pop_front_empty_actor_isolated" \
     "PANIC: Deque.pop_front() on an empty deque" \
     "DequePopFrontCrasher" \
-    1 \
-    3126
+    1
 run_actor_bounds_trap_fixture \
     "deque_pop_back_empty_actor_isolated" \
     "PANIC: Deque.pop_back() on an empty deque" \
     "DequePopBackCrasher" \
-    1 \
-    3126
+    1
 
 run_accept_expect_status "directory_module_call" 7
 


### PR DESCRIPTION
## Why

An unsupervised local actor crash exited 1 with nothing on stderr, so nobody could tell which actor or handler had died. `emit_crash_diagnostic_sig_safe` was the only writer on that path and it went with the siglongjmp recovery tier in bd0fff0ef; the unwind path that replaced it stamps the trap code, suppresses the typed `HewPanic` message in the panic hook (so a caught actor crash does not look like a process abort) and records the crash into the crash log and observe counters. Nothing left writes a line, and `record_unrecovered_actor_fault` flips the exit status to 1 silently.

## What

- **runtime**: `crash::record_logical_crash` now writes the one user-facing line. Every logical actor crash already funnels through it - both scheduler catch sites, native and WASM - so the line lands exactly once per crash without either catch site growing its own writer. It takes the crashing actor's dispatch pointer and resolves context from the registries codegen stamps at startup: the fully-qualified handler name from `handler_name_by_ptr`, falling back to the actor type name from `lookup_dispatch_type_by_ptr_owned`. Neither path can reach the retired opaque `msg_type=-N` form. Report-building splits out as `push_logical_crash_report` so fault injection - a simulation hook, not a program fault - stays silent.
- **e2e**: the gate carried a shrink-only ratchet admitting the empty stderr, both for `crash_actor_context_diagnostic` and for the twelve actor bounds-trap fixtures. It goes, along with `run_actor_bounds_trap_fixture`'s `known_missing_actor_issue` parameter, and those fixtures assert the actor context directly again. The `crash_actor_context_diagnostic` header comment still described the deleted siglongjmp architecture; it now describes the unwind path it actually exercises.

Output for the fixture:

```
hew: actor crash in Crasher::on_trigger (actor 1): IndexOutOfBounds
```

## Test

`tests/vertical-slice/accept/crash_actor_context_diagnostic.hew` and its `run.sh` assertions were already in-tree, ratcheted to the empty-stderr failure. The ratchet is gone and the fixture passes on its real contract; so do the twelve actor bounds-trap fixtures, which were ratcheted the same way and now match on `VecSetCrasher::boom`, `BytesSliceCrasher::boom` and the rest.

`make test-vertical-slice` is green end to end on this branch (exit 0), and `make lint` is clean. `make test` fails only on IDs that also fail on the same command at `origin/main` (`bdf5412fa`) - see the ID-diff comment below.

Fixes #3126
