### PR TITLE
fix(runtime): fail closed on a channel send the drain cannot complete

### DIFF
--- a/hew-cli/tests/channel_send_shutdown_e2e.rs
+++ b/hew-cli/tests/channel_send_shutdown_e2e.rs
@@ -1,0 +1,130 @@
+//! Executed regression for #3146: a blocking channel send that is still full
+//! when the runtime enters shutdown must fail closed with an attributed
+//! diagnostic instead of parking its handler until the drain deadline.
+//!
+//! The fixture spawns a periodic handler that sends into a one-slot channel
+//! whose only receiver is a `main` local that reads once and never closes. The
+//! third send finds the ring full and, before the fix, parked the scheduler
+//! worker inside the handler: the shutdown drain refuses to join a worker still
+//! in a handler, so the process died through the 5s drain timeout with nothing
+//! naming the channel or the actor.
+
+mod support;
+
+use std::fs;
+use std::process::Command;
+
+use support::{hew_binary, repo_root, require_codegen};
+
+/// A periodic handler filling a one-slot channel that `main` reads once.
+const FULL_SEND_AT_SHUTDOWN_SOURCE: &str = r#"import std.channel.channel;
+
+actor Pulse {
+    let ready: channel.Sender<i64>;
+    var count: i64 = 0;
+
+    #[every(1ms)]
+    receive fn tick() {
+        count += 1;
+        ready.send(count);
+    }
+}
+
+fn main() {
+    let (ready_tx, ready_rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(1);
+    let _p = spawn Pulse(ready: ready_tx, count: 0);
+    let _ = ready_rx.recv();
+    sleep(200ms);
+    println("main done");
+}
+"#;
+
+/// A send parked on a full channel when shutdown starts fails closed, naming
+/// the channel, rather than surfacing as an unattributed drain timeout.
+#[test]
+fn full_send_at_shutdown_fails_closed_with_named_channel() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("full_send_at_shutdown.hew");
+    fs::write(&source, FULL_SEND_AT_SHUTDOWN_SOURCE).expect("write full-send fixture");
+
+    let mut command = Command::new(hew_binary());
+    command.arg("run").arg(&source).current_dir(repo_root());
+    let output = support::run_bounded_command(command, "hew run full_send_at_shutdown");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stdout.contains("main done"),
+        "main must reach its end; stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        !stderr.contains("shutdown drain timed out"),
+        "a full send must not strand the drain; stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("channel send abandoned during shutdown"),
+        "the abandoned send must name itself; stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("capacity 1"),
+        "the diagnostic must name the channel's capacity; stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+}
+
+/// Negative control: backpressure under a live, draining receiver in the
+/// running phase still parks and resumes. A shutdown-phase check that fired
+/// while the runtime is running would turn this into a failure.
+#[test]
+fn full_send_with_draining_receiver_still_backpressures() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("full_send_backpressure.hew");
+    fs::write(
+        &source,
+        r#"import std.channel.channel;
+
+actor Pump {
+    let out: channel.Sender<i64>;
+
+    receive fn go(count: i64) {
+        for i in 0..count {
+            out.send(i);
+        }
+    }
+}
+
+fn main() {
+    let (tx, rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(1);
+    let pump = spawn Pump(out: tx);
+    pump.go(8);
+    var seen: i64 = 0;
+    for _i in 0..8 {
+        match rx.recv() {
+            .Some(_) => { seen += 1; },
+            .None => {},
+        }
+    }
+    println(f"seen {seen}");
+    rx.close();
+}
+"#,
+    )
+    .expect("write backpressure fixture");
+
+    let mut command = Command::new(hew_binary());
+    command.arg("run").arg(&source).current_dir(repo_root());
+    let output = support::run_bounded_command(command, "hew run full_send_backpressure");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "backpressure over a full channel must still complete; stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_eq!(stdout, "seen 8\n", "stderr:\n{stderr}");
+}

--- a/hew-runtime/src/channel_core.rs
+++ b/hew-runtime/src/channel_core.rs
@@ -33,6 +33,7 @@
 
 use std::collections::VecDeque;
 use std::sync::{Condvar, Mutex};
+use std::time::Duration;
 
 use hew_cabi::sink::TrySendResult;
 use hew_cabi::vec::{HewTypeOwnershipKind, HewVecElemLayout};
@@ -50,6 +51,11 @@ pub const STREAM_AWAIT_SUSPEND: i32 = 0;
 /// peer closed, or the ring had space). The caller MUST NOT suspend; it binds
 /// the result on the immediate edge.
 pub const STREAM_AWAIT_READY: i32 = 1;
+
+/// How often a thread blocked on a full ring re-reads the runtime's shutdown
+/// phase. Matches the shutdown drain's own poll cadence, so a send abandoned at
+/// the drain edge is observed within one drain tick.
+const SHUTDOWN_PHASE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// One parked peer (a consumer awaiting an item, or a producer blocked on a full
 /// ring). The core owns one in-flight ref on `slot`.
@@ -509,9 +515,21 @@ impl ChannelCore {
         STREAM_AWAIT_READY
     }
 
-    /// Blocking producer send (default callers). Parks the FOREIGN thread on the
+    /// Blocking producer send (default callers). Parks the calling thread on the
     /// condvar until the ring has space; silently discards after any terminal
-    /// close or producer fault.
+    /// close or producer fault; fails closed once the runtime drain begins.
+    ///
+    /// A send that is still full when the runtime reaches [`crate::shutdown::PHASE_DRAIN`]
+    /// can
+    /// never complete on its own terms: `main` has returned, the drain is
+    /// already counting down to abandoning in-flight work, and the drain
+    /// deliberately refuses to join a worker still inside a handler. Parking
+    /// through that window turns a producer's backpressure into an
+    /// unattributed `shutdown drain timed out` exit. The send instead fails
+    /// closed naming the channel's shape and the sending actor, which is the
+    /// same verdict the drain would reach later - deterministic, attributed, and
+    /// reached before the deadline instead of after it. Backpressure while the
+    /// runtime is running or quiescing is untouched.
     pub fn blocking_send(&self, item: Vec<u8>) {
         let consumer_wake;
         {
@@ -531,12 +549,35 @@ impl ChannelCore {
                     consumer_wake = inner.consumer.take();
                     break;
                 }
+                if crate::shutdown::hew_shutdown_phase() >= crate::shutdown::PHASE_DRAIN {
+                    let capacity = inner.capacity;
+                    let queued = inner.queue.len();
+                    let layout = inner.elem_layout;
+                    drop(inner);
+                    // Release the undeliverable envelope's owned heap before
+                    // aborting so the abandoned send is not also a leak.
+                    Self::drop_envelope(layout.as_ref(), item);
+                    Self::abort_send_abandoned_at_shutdown(capacity, queued);
+                }
                 #[cfg(test)]
                 self.rendezvous_before_wait();
-                inner = self
+                // SHORTCUT: poll the shutdown phase instead of being woken by
+                // it.
+                // WHY: shutdown publishes a phase, not a wake edge, and no
+                //   readiness source outside this core can notify this condvar.
+                // WHEN OBSOLETE: once `channel.send` has a suspending ramp of
+                //   its own (the `await_send` park already on this core) a
+                //   producer no longer holds a worker and the drain converges
+                //   without any phase probe.
+                // WHAT THE REAL FIX IS: lower `channel.Sender.send` in an
+                //   execution context through `await_send`, the way
+                //   `channel.Receiver.recv` already lowers through
+                //   `hew_channel_await_recv`.
+                let (guard, _timeout) = self
                     .cv
-                    .wait(inner)
+                    .wait_timeout(inner, SHUTDOWN_PHASE_POLL_INTERVAL)
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
+                inner = guard;
             }
         }
         if let Some(w) = consumer_wake {
@@ -710,6 +751,30 @@ impl ChannelCore {
         for item in discarded {
             Self::drop_envelope(layout.as_ref(), item);
         }
+    }
+
+    /// Fail closed on a send that the drain will never let complete: never a
+    /// silent park into the drain deadline. Named so the message identifies
+    /// the channel's shape and the sending actor.
+    ///
+    /// Aborts rather than panicking: the only callers reach this through the
+    /// `extern "C"` send entries, which are `nounwind`, so a panic here becomes
+    /// a double-panic abort with the real message buried. This is the same
+    /// fail-closed shape the sibling boundary uses
+    /// ([`crate::channel_common::abort_elem_witness`]).
+    fn abort_send_abandoned_at_shutdown(capacity: usize, queued: usize) -> ! {
+        let actor = crate::actor::hew_actor_current_id_silent();
+        let sender = if actor < 0 {
+            "outside any actor handler".to_string()
+        } else {
+            format!("in actor {actor}")
+        };
+        eprintln!(
+            "PANIC: channel send abandoned during shutdown: channel is full \
+             (capacity {capacity}, {queued} queued) and the runtime drain has \
+             begun, so this send {sender} can never complete"
+        );
+        std::process::abort();
     }
 
     /// Fail closed on an empty-and-faulted read: never a silent EOF.

--- a/hew-runtime/src/channel_wasm.rs
+++ b/hew-runtime/src/channel_wasm.rs
@@ -354,6 +354,17 @@ fn try_send_bytes(
     }
 }
 
+/// Native/wasm32 divergence on a full channel, stated in one place.
+///
+/// Both targets fail closed on a send that cannot complete, and neither ever
+/// drops the element silently. They differ in when "cannot complete" is
+/// decided: wasm32 has no send park at all, so a full ring is terminal on the
+/// spot; native parks for backpressure and fails closed only once the runtime
+/// drain has begun (`ChannelCore::blocking_send`), because until then a live
+/// receiver can still make room. wasm32 is therefore strictly stricter, and a
+/// program whose producers outrun their consumer traps here where native would
+/// have backpressured. The two converge when `channel.Sender.send` gains the
+/// cooperative suspending ramp its receiver counterpart already has.
 fn send_bytes(
     sender: &HewWasmChannelSender,
     bytes: Vec<u8>,

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -34,7 +34,7 @@ pub(crate) const PHASE_RUNNING: i32 = 0;
 /// Phase 1: No new spawns or messages accepted.
 const PHASE_QUIESCE: i32 = 1;
 /// Phase 2: Draining remaining messages with deadline.
-const PHASE_DRAIN: i32 = 2;
+pub(crate) const PHASE_DRAIN: i32 = 2;
 /// Phase 3: Force-terminating all actors.
 const PHASE_TERMINATE: i32 = 3;
 /// Shutdown complete.


### PR DESCRIPTION
## Why

A native actor handler that sends on a full channel whose receiver never closes blocks forever. The handler never returns to its loop top, and the shutdown drain deliberately refuses to join a worker still inside a handler, so the drain cannot converge: the process exits through `hew: shutdown drain timed out after 5s; abandoning in-flight work` with nothing naming the channel or the actor.

The mechanism, ground out on main's tip: `channel.Sender.send` lowers to `hew_channel_send_layout` -> `ChannelCore::blocking_send`, which parks the scheduler worker on the core's condvar. The only edge that wakes such a producer is the receiver's `close_stream`. In the reduced case that edge never fires before the drain deadline: the receiver's close runs at `main`'s exits, and `main` cannot reach an exit while the drain is waiting on the handler that is parked inside it. Closing the receiver by hand makes the same program run indefinitely, which isolates the park as the liveness defect rather than the close protocol.

## What

A send parked on a full ring now fails closed once the runtime reaches the drain phase, naming the channel's capacity, its queue depth, and the sending actor. That is the verdict the drain reaches five seconds later anyway, delivered deterministically and with attribution instead of as an anonymous timeout. Backpressure while the runtime is running or quiescing is untouched: a full ring with a receiver still draining it still parks and resumes.

- **runtime/channel**: `ChannelCore::blocking_send` reads the shutdown phase in its full-ring branch and fails closed at `PHASE_DRAIN` or later. The condvar wait becomes a bounded wait matching the drain's own poll cadence, marked as a shortcut with its WHY / WHEN obsolete / WHAT - shutdown publishes a phase, not a wake edge, and the real fix is a suspending ramp for `channel.Sender.send` like the one `channel.Receiver.recv` already has.
- **runtime/channel**: the native/wasm32 disposition on a full channel is stated once, at the wasm trap site. Both targets fail closed and neither drops the element silently; wasm32 has no send park at all, so it is strictly stricter than native, and the two converge when the suspending send ramp lands. `docs/sandbox-vm-divergences.md` is the sandbox VM's contract rather than the wasm32 runtime twin's, and carried no entry for this, so the statement lives beside the code it constrains.

`PHASE_DRAIN` becomes `pub(crate)` so the predicate is a named phase rather than a literal.

**#3147 is not fixed here and this PR does not close it.** The registration id the issue asks for has to be minted at `mailbox_await_send` and handed back through `hew_actor_await_send_by_id` / `hew_actor_detach_await_send_by_id` (`actor.rs`), `actor_await_send_pinned`, and `hew_supervisor_role_await_send` (`supervisor.rs`), then through the codegen suspend ramp (`suspend.rs`, `runtime_abi.rs`, `llvm.rs`) and the JIT symbol classification. Two of those files belong to other live lanes. No mailbox-local scheme substitutes: any identity read back through the slot pointer collapses to address identity the moment the allocation recycles, which is the case the issue's oracle is about. `ChannelCore::detach_consumer` and `detach_producer` are the same defect class and want the same treatment.

## Test

- `hew-cli/tests/channel_send_shutdown_e2e.rs::full_send_at_shutdown_fails_closed_with_named_channel` - the issue's reduced case, asserting the named diagnostic and the absence of the drain timeout. Fails on `origin/main`'s tip with `hew: shutdown drain timed out after 5s` after 6.5s; passes on this branch in 1.7s.
- `...::full_send_with_draining_receiver_still_backpressures` - the negative control: eight items through a one-slot channel with the handler parking between each receive. Passes on both, so the phase check cannot be firing while the runtime is running.

Fixes #3146

