### PR TITLE
refactor(compile): route every host through one compiler session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
  "hew-lexer",
  "hew-mir",
  "hew-parser",
+ "hew-sir",
  "hew-types",
  "serde",
  "tempfile",
@@ -1862,6 +1863,7 @@ version = "0.6.0-rc2"
 dependencies = [
  "dashmap",
  "hew-analysis",
+ "hew-compile",
  "hew-hir",
  "hew-lexer",
  "hew-mir",
@@ -2090,6 +2092,7 @@ name = "hew-wasm"
 version = "0.6.0-rc2"
 dependencies = [
  "hew-analysis",
+ "hew-compile",
  "hew-hir",
  "hew-lexer",
  "hew-mir",

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -287,23 +287,19 @@ fn lower_verified_hir_to_pipeline(
 ) -> Result<(hew_mir::IrPipeline, Option<SirLaneReport>), ()> {
     match sir_mode {
         compile::SirMode::Disabled => {
-            let mut pipeline =
-                hew_mir::lower_hir_module_with_facts(module, mir_pointer_width(target));
-            pipeline.attach_lowering_facts(tco);
-            Ok((pipeline, None))
+            let output = compiler_session(target).lower_hir_module(module, tco);
+            Ok((output.pipeline, None))
         }
         compile::SirMode::Lower => {
             let sir = lower_verified_hir_to_sir(module)?;
-            let component = hew_mir::lower_entry_component(&sir.module).map_err(|error| {
+            let session = compiler_session(target);
+            let component = session.lower_sir_module(&sir.module).map_err(|error| {
                 eprintln!("SIR strict lowering failed: {error}");
                 report_strict_sir_missing_body(module, &sir, error.missing_body);
             })?;
             let callables = component.callables().to_vec();
             let pipeline = component.into_pipeline();
-            if let Err(error) = hew_codegen_rs::validate_codegen_front_for_triple(
-                &pipeline,
-                target.normalized_triple(),
-            ) {
+            if let Some(error) = session.check_pipeline(&pipeline) {
                 eprintln!("SIR strict backend-front validation failed: {error}");
                 return Err(());
             }
@@ -596,6 +592,17 @@ fn mir_pointer_width(target: &target::TargetSpec) -> hew_mir::PointerWidth {
     }
 }
 
+fn compiler_session(target: &target::TargetSpec) -> hew_compile::Session {
+    hew_compile::Session::new(
+        hew_compile::SessionTarget {
+            hir_arch: hir_target_arch(target),
+            pointer_width: mir_pointer_width(target),
+            codegen_triple: Some(target.normalized_triple().to_string()),
+        },
+        hew_compile::DiagnosticPolicy::default(),
+    )
+}
+
 /// `true` when `input` is a compiler-owned, import-only stdlib substrate in a
 /// Hew source checkout. Recognised by canonical path shape plus an enclosing
 /// checkout root, so lookalike external paths cannot skip deep gates.
@@ -657,11 +664,9 @@ fn run_check_deep_gates(
         return Err(());
     }
 
-    let mut pipeline =
-        hew_mir::lower_hir_module_with_facts(&lower_output.module, mir_pointer_width(target));
-    // Clone checker-authored layout-fact lifecycle into the pipeline
-    // (see the matching invocation in `check_command`).
-    pipeline.attach_lowering_facts(tco);
+    let output = compiler_session(target).lower_hir_module(&lower_output.module, tco);
+    let codegen_error = output.codegen_error;
+    let pipeline = output.pipeline;
     if render_pipeline_mir_diagnostics(
         &state.program,
         &state.source,
@@ -677,7 +682,7 @@ fn run_check_deep_gates(
     // only after the codegen-front gate has had its say.
     let lint_denied = render_pipeline_mir_lints(&state.source, input, &pipeline, levels);
 
-    if let Err(error) = hew_codegen_rs::validate_codegen_front(&pipeline) {
+    if let Some(error) = codegen_error {
         diagnostic::render_codegen_front_diagnostic(&error, Some((state.source.as_str(), input)));
         return Err(());
     }
@@ -703,9 +708,9 @@ fn build_explain_cow_pipeline(
     if !lowered.diagnostics.is_empty() {
         return None;
     }
-    let mut pipeline =
-        hew_mir::lower_hir_module_with_facts(&lowered.module, mir_pointer_width(target));
-    pipeline.attach_lowering_facts(tco);
+    let pipeline = compiler_session(target)
+        .lower_hir_module(&lowered.module, tco)
+        .pipeline;
     // Advisory diagnostics (obligation under-release leaks) are non-blocking; the
     // explain-cow view is still valid, so proceed unless a hard error is present.
     pipeline.diagnostics.is_empty().then_some(pipeline)

--- a/hew-compile/Cargo.toml
+++ b/hew-compile/Cargo.toml
@@ -15,7 +15,7 @@ hew-lexer = { path = "../hew-lexer" }
 hew-hir = { path = "../hew-hir" }
 hew-mir = { path = "../hew-mir" }
 hew-sir = { path = "../hew-sir" }
-hew-codegen-rs = { path = "../hew-codegen-rs" }
+hew-codegen-rs = { path = "../hew-codegen-rs", optional = true }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 serde.workspace = true
@@ -24,6 +24,19 @@ toml.workspace = true
 [dev-dependencies]
 hew-types = { path = "../hew-types", features = ["test"] }
 tempfile.workspace = true
+
+[features]
+default = ["codegen"]
+# Native LLVM backend-front verification (`Session::check_pipeline`). Off by
+# default for browser-hosted consumers (hew-wasm) that only need the MIR
+# pipeline for lints and never touch a codegen result -- WHY: linking
+# hew-codegen-rs pulls in inkwell/llvm-sys, which needs system LLVM to even
+# compile. WHEN this can go away: never as a default off-switch, but if
+# hew-codegen-rs itself drops native LLVM the split is moot. WHAT the real
+# boundary is: hew-wasm is documented analysis-only (no native codegen), so
+# this feature keeps that boundary honest at the dependency graph level while
+# `Session` and its MIR lowering stay the single authority every host shares.
+codegen = ["dep:hew-codegen-rs"]
 
 [lints]
 workspace = true

--- a/hew-compile/Cargo.toml
+++ b/hew-compile/Cargo.toml
@@ -13,14 +13,15 @@ categories = ["compilers"]
 [dependencies]
 hew-lexer = { path = "../hew-lexer" }
 hew-hir = { path = "../hew-hir" }
+hew-mir = { path = "../hew-mir" }
+hew-sir = { path = "../hew-sir" }
+hew-codegen-rs = { path = "../hew-codegen-rs" }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 serde.workspace = true
 toml.workspace = true
 
 [dev-dependencies]
-hew-codegen-rs = { path = "../hew-codegen-rs" }
-hew-mir = { path = "../hew-mir" }
 hew-types = { path = "../hew-types", features = ["test"] }
 tempfile.workspace = true
 

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -135,6 +135,13 @@ impl Session {
     }
 
     /// Lower already verified HIR through the complete build check set.
+    ///
+    /// The MIR lowering below runs unconditionally for every host: it is the
+    /// one pipeline every `Session` produces, which is what keeps wasm and
+    /// native lint output identical. The native LLVM backend-front check
+    /// (`check_pipeline`) layers on top of that when the `codegen` feature is
+    /// compiled in; hosts that build without it (hew-wasm) still get the
+    /// exact same pipeline, just without a codegen verdict they never read.
     #[must_use]
     pub fn lower_hir_module(
         &self,
@@ -143,9 +150,11 @@ impl Session {
     ) -> SessionOutput {
         let mut pipeline = hew_mir::lower_hir_module_with_facts(module, self.target.pointer_width);
         pipeline.attach_lowering_facts(tco);
+        #[cfg(feature = "codegen")]
         let codegen_error = self.check_pipeline(&pipeline);
         SessionOutput {
             pipeline,
+            #[cfg(feature = "codegen")]
             codegen_error,
         }
     }
@@ -164,6 +173,7 @@ impl Session {
         hew_mir::lower_entry_component(module)
     }
 
+    #[cfg(feature = "codegen")]
     #[must_use]
     pub fn check_pipeline(
         &self,
@@ -182,6 +192,7 @@ impl Session {
 #[derive(Debug)]
 pub struct SessionOutput {
     pub pipeline: hew_mir::IrPipeline,
+    #[cfg(feature = "codegen")]
     pub codegen_error: Option<hew_codegen_rs::CodegenError>,
 }
 
@@ -2739,6 +2750,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "codegen")]
     #[test]
     fn remote_pid_lookup_annotation_reaches_mir_with_its_builtin_carrier() {
         let dir = tempfile::tempdir().expect("create temp dir");

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -55,6 +55,136 @@ pub struct FrontendOptions {
     pub lint_levels: hew_types::LintLevels,
 }
 
+/// Target facts that must stay coupled while a source is lowered.
+///
+/// This deliberately contains only facts passed by existing hosts: the HIR
+/// architecture, MIR pointer width, and optional backend target triple.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionTarget {
+    pub hir_arch: hew_hir::TargetArch,
+    pub pointer_width: hew_mir::PointerWidth,
+    pub codegen_triple: Option<String>,
+}
+
+impl SessionTarget {
+    #[must_use]
+    pub fn native() -> Self {
+        Self {
+            hir_arch: hew_hir::TargetArch::host(),
+            pointer_width: hew_mir::PointerWidth::Bits64,
+            codegen_triple: None,
+        }
+    }
+
+    #[must_use]
+    pub fn wasm32() -> Self {
+        Self {
+            // WHY: the browser sandbox supports actors and machines even
+            // though the wasm codegen target rejects them. WHEN: the browser
+            // executes the same wasm substrate as native builds. REAL FIX:
+            // use TargetArch::Wasm32 here and remove this analysis-only split.
+            hir_arch: hew_hir::TargetArch::X86_64,
+            pointer_width: hew_mir::PointerWidth::Bits32,
+            codegen_triple: None,
+        }
+    }
+}
+
+/// The fixed compiler check set. Hosts cannot select a narrower subset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CheckSet {
+    #[default]
+    Build,
+}
+
+/// Policy used when exposing diagnostics produced by a compilation session.
+#[derive(Debug, Clone, Default)]
+pub struct DiagnosticPolicy {
+    pub warnings_as_errors: bool,
+    pub lint_levels: hew_types::LintLevels,
+}
+
+/// The sole authority for HIR verification, MIR lowering, and backend-front
+/// checks. Every host enters through this type with its target facts explicit.
+#[derive(Debug, Clone)]
+pub struct Session {
+    pub target: SessionTarget,
+    pub checks: CheckSet,
+    pub diagnostic_policy: DiagnosticPolicy,
+}
+
+impl Session {
+    #[must_use]
+    pub fn new(target: SessionTarget, diagnostic_policy: DiagnosticPolicy) -> Self {
+        Self {
+            target,
+            checks: CheckSet::Build,
+            diagnostic_policy,
+        }
+    }
+
+    #[must_use]
+    pub fn from_frontend_options(target: SessionTarget, options: &FrontendOptions) -> Self {
+        Self::new(
+            target,
+            DiagnosticPolicy {
+                warnings_as_errors: options.warnings_as_errors,
+                lint_levels: options.lint_levels.clone(),
+            },
+        )
+    }
+
+    /// Lower already verified HIR through the complete build check set.
+    #[must_use]
+    pub fn lower_hir_module(
+        &self,
+        module: &hew_hir::HirModule,
+        tco: &hew_types::TypeCheckOutput,
+    ) -> SessionOutput {
+        let mut pipeline = hew_mir::lower_hir_module_with_facts(module, self.target.pointer_width);
+        pipeline.attach_lowering_facts(tco);
+        let codegen_error = self.check_pipeline(&pipeline);
+        SessionOutput {
+            pipeline,
+            codegen_error,
+        }
+    }
+
+    /// Lower the strict SIR lane through this same session authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`hew_mir::SirMirLoweringError`] when the entry point's
+    /// component cannot be closed over the SIR module (for example a
+    /// missing callable body).
+    pub fn lower_sir_module(
+        &self,
+        module: &hew_sir::SemModule,
+    ) -> Result<hew_mir::SirMirComponent, hew_mir::SirMirLoweringError> {
+        hew_mir::lower_entry_component(module)
+    }
+
+    #[must_use]
+    pub fn check_pipeline(
+        &self,
+        pipeline: &hew_mir::IrPipeline,
+    ) -> Option<hew_codegen_rs::CodegenError> {
+        match self.target.codegen_triple.as_deref() {
+            Some(triple) => {
+                hew_codegen_rs::validate_codegen_front_for_triple(pipeline, triple).err()
+            }
+            None => hew_codegen_rs::validate_codegen_front(pipeline).err(),
+        }
+    }
+}
+
+/// Checked MIR and the backend-front result produced by [`Session`].
+#[derive(Debug)]
+pub struct SessionOutput {
+    pub pipeline: hew_mir::IrPipeline,
+    pub codegen_error: Option<hew_codegen_rs::CodegenError>,
+}
+
 #[derive(Debug, Clone)]
 pub enum FrontendDiagnosticKind {
     Message(FrontendMessageDiagnostic),

--- a/hew-lsp/Cargo.toml
+++ b/hew-lsp/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 tracing.workspace = true
 hew-analysis = { path = "../hew-analysis" }
+hew-compile = { path = "../hew-compile" }
 hew-hir = { path = "../hew-hir" }
 hew-lexer = { path = "../hew-lexer" }
 hew-mir = { path = "../hew-mir" }

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -963,8 +963,13 @@ pub(super) fn analyze_document(
     // unconditional-ERROR HIR mapping above.
     if hir_diagnostics.is_empty() {
         if let Some(hir_module) = hir_module.as_ref() {
-            let mir_lint_diagnostics =
-                build_mir_lint_lsp_diagnostics(uri, source, &line_offsets, hir_module);
+            let mir_lint_diagnostics = build_mir_lint_lsp_diagnostics(
+                uri,
+                source,
+                &line_offsets,
+                hir_module,
+                type_output.as_ref().expect("HIR requires type checking"),
+            );
             merge_diagnostics(&mut diagnostics_by_uri, &mir_lint_diagnostics);
         }
     }
@@ -1274,20 +1279,24 @@ fn collect_hir_diagnostics(
 ///
 /// # Panics
 ///
-/// Never. MIR lowering can reject code the checker accepted, and
-/// [`hew_mir::lower_hir_module_with_facts`] reports that through
-/// `IrPipeline::diagnostics`, which this function ignores entirely: a lowering
-/// failure degrades silently to "no MIR lints" and leaves the already-computed
-/// HIR diagnostics untouched.
+/// Never. The shared compiler session owns MIR lowering and all build checks;
+/// this presentation layer only chooses how its lint findings are rendered.
 fn build_mir_lint_lsp_diagnostics(
     root_uri: &Url,
     root_source: &str,
     root_line_offsets: &[usize],
     hir_module: &hew_hir::HirModule,
+    tco: &TypeCheckOutput,
 ) -> DiagnosticMap {
     let mut diagnostics_by_uri = DiagnosticMap::new();
 
-    let pipeline = hew_mir::lower_hir_module_with_facts(hir_module, hew_mir::PointerWidth::Bits64);
+    // The LSP has no target selector, so it uses the same native target facts
+    // as a default `hew build`. The session fixes the check set to Build.
+    let session = hew_compile::Session::new(
+        hew_compile::SessionTarget::native(),
+        hew_compile::DiagnosticPolicy::default(),
+    );
+    let pipeline = session.lower_hir_module(hir_module, tco).pipeline;
     // `pipeline.diagnostics` (the hard `E_MIR_*` move/init errors) are
     // deliberately dropped: the CLI is the gate for those, and surfacing them
     // here would turn a lowering failure into a user-visible editor error.
@@ -2683,10 +2692,50 @@ mod tests {
             hir_diagnostics.is_empty(),
             "fixture must lower cleanly: {hir_diagnostics:?}"
         );
-        build_mir_lint_lsp_diagnostics(&uri, source, &line_offsets, &module)
+        build_mir_lint_lsp_diagnostics(&uri, source, &line_offsets, &module, &type_output)
             .get(&uri)
             .cloned()
             .unwrap_or_default()
+    }
+
+    #[test]
+    fn lsp_and_build_session_report_the_same_mir_lints() {
+        let uri = Url::parse("file:///session_agreement.hew").unwrap();
+        let parse_result = hew_parser::parse(MIR_DEAD_STORE);
+        let mut checker = Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+        let tco = checker.check_program(&parse_result.program);
+        let (hir_diagnostics, module) = collect_hir_diagnostics(&parse_result.program, &tco);
+        assert!(hir_diagnostics.is_empty(), "fixture must lower cleanly");
+
+        let build = hew_compile::Session::new(
+            hew_compile::SessionTarget::native(),
+            hew_compile::DiagnosticPolicy::default(),
+        )
+        .lower_hir_module(&module, &tco);
+        let lsp = build_mir_lint_lsp_diagnostics(
+            &uri,
+            MIR_DEAD_STORE,
+            &compute_line_offsets(MIR_DEAD_STORE),
+            &module,
+            &tco,
+        );
+        let lsp_codes = lsp
+            .get(&uri)
+            .into_iter()
+            .flatten()
+            .filter_map(|diagnostic| match &diagnostic.code {
+                Some(NumberOrString::String(code)) => Some(code.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let build_codes = build
+            .pipeline
+            .lint_warnings
+            .iter()
+            .map(|warning| warning.lint.as_str().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(lsp_codes, build_codes);
     }
 
     #[test]

--- a/hew-parser/fuzz/Cargo.toml
+++ b/hew-parser/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ hew-lexer = { path = "../../hew-lexer" }
 hew-parser = { path = ".." }
 hew-types = { path = "../../hew-types" }
 hew-hir = { path = "../../hew-hir" }
+hew-compile = { path = "../../hew-compile" }
 hew-mir = { path = "../../hew-mir" }
 
 [[bin]]

--- a/hew-parser/fuzz/fuzz_targets/fuzz_mir.rs
+++ b/hew-parser/fuzz/fuzz_targets/fuzz_mir.rs
@@ -3,7 +3,6 @@
 mod support;
 
 use hew_hir::{lower_program_host_target, verify_hir, ResolutionCtx};
-use hew_mir::lower_hir_module;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -28,6 +27,10 @@ fuzz_target!(|data: &[u8]| {
             return;
         }
 
-        let _ = lower_hir_module(&hir.module);
+        let _ = hew_compile::Session::new(
+            hew_compile::SessionTarget::native(),
+            hew_compile::DiagnosticPolicy::default(),
+        )
+        .lower_hir_module(&hir.module, &type_check);
     }
 });

--- a/hew-parser/fuzz/fuzz_targets/support.rs
+++ b/hew-parser/fuzz/fuzz_targets/support.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use hew_hir::{lower_program_host_target, verify_hir, ResolutionCtx};
-use hew_mir::{lower_hir_module, IrPipeline};
+use hew_mir::IrPipeline;
 use hew_parser::Severity;
 use hew_types::module_registry::{build_module_search_paths, ModuleRegistry};
 use hew_types::Checker;
@@ -45,7 +45,14 @@ pub fn parse_check_lower(source: &str) -> Option<IrPipeline> {
         return None;
     }
 
-    Some(lower_hir_module(&hir.module))
+    Some(
+        hew_compile::Session::new(
+            hew_compile::SessionTarget::native(),
+            hew_compile::DiagnosticPolicy::default(),
+        )
+        .lower_hir_module(&hir.module, &type_check)
+        .pipeline,
+    )
 }
 
 #[allow(dead_code)]

--- a/hew-wasm/Cargo.toml
+++ b/hew-wasm/Cargo.toml
@@ -27,6 +27,7 @@ wasm-opt = ["-O1", "--enable-bulk-memory"]
 
 [dependencies]
 hew-analysis = { path = "../hew-analysis" }
+hew-compile = { path = "../hew-compile" }
 hew-hir = { path = "../hew-hir" }
 hew-lexer = { path = "../hew-lexer" }
 hew-mir = { path = "../hew-mir" }

--- a/hew-wasm/Cargo.toml
+++ b/hew-wasm/Cargo.toml
@@ -27,7 +27,7 @@ wasm-opt = ["-O1", "--enable-bulk-memory"]
 
 [dependencies]
 hew-analysis = { path = "../hew-analysis" }
-hew-compile = { path = "../hew-compile" }
+hew-compile = { path = "../hew-compile", default-features = false }
 hew-hir = { path = "../hew-hir" }
 hew-lexer = { path = "../hew-lexer" }
 hew-mir = { path = "../hew-mir" }

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -539,13 +539,19 @@ struct AnalyzedSource {
 /// Lower to MIR and collect the MIR-stage lint findings, applying the same
 /// suppression policy the CLI's `render_pipeline_mir_lints` applies.
 ///
-/// Degrades silently to an empty vector on any lowering trouble: MIR lowering
-/// can reject code the checker accepted, and those hard `E_MIR_*` diagnostics
-/// (`IrPipeline::diagnostics`) are deliberately dropped here rather than being
-/// promoted into browser-visible errors. The playground's authority for hard
-/// errors stays at the parse/check/HIR stages.
-fn collect_mir_lints(source: &str, hir_module: &hew_hir::HirModule) -> Vec<hew_mir::MirLint> {
-    let pipeline = hew_mir::lower_hir_module_with_facts(hir_module, hew_mir::PointerWidth::Bits32);
+/// Degrades silently to an empty vector on any lowering trouble. The shared
+/// session still runs the build check set at wasm32 pointer width; this browser
+/// renderer retains its historical warning-only presentation policy.
+fn collect_mir_lints(
+    source: &str,
+    hir_module: &hew_hir::HirModule,
+    tco: &hew_types::TypeCheckOutput,
+) -> Vec<hew_mir::MirLint> {
+    let session = hew_compile::Session::new(
+        hew_compile::SessionTarget::wasm32(),
+        hew_compile::DiagnosticPolicy::default(),
+    );
+    let pipeline = session.lower_hir_module(hir_module, tco).pipeline;
     let levels = hew_types::LintLevels::default();
     pipeline
         .lint_warnings
@@ -635,7 +641,7 @@ fn parse_and_type_check(source: &str) -> AnalyzedSource {
             // skipping it also keeps the added browser cost off every buffer
             // that is mid-edit and already erroring.
             if diags.is_empty() {
-                mir_lints = collect_mir_lints(source, &lower_output.module);
+                mir_lints = collect_mir_lints(source, &lower_output.module, &tco);
             }
             diags
         } else {
@@ -2318,6 +2324,42 @@ mod tests {
         assert!(
             !diags.iter().any(|d| d["kind"] == "dead_store"),
             "hew:allow must suppress the playground surfacing too: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn wasm_session_uses_build_checks_at_wasm32_width() {
+        let parsed = hew_parser::parse(MIR_DEAD_STORE);
+        let mut checker = hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(
+            hew_types::module_registry::build_module_search_paths(),
+        ));
+        let tco = checker.check_program(&parsed.program);
+        let hir = hew_hir::lower_program(
+            &parsed.program,
+            &tco,
+            &hew_hir::ResolutionCtx,
+            hew_hir::TargetArch::X86_64,
+        );
+        let wasm = hew_compile::Session::new(
+            hew_compile::SessionTarget::wasm32(),
+            hew_compile::DiagnosticPolicy::default(),
+        );
+        let build = hew_compile::Session::new(
+            hew_compile::SessionTarget::native(),
+            hew_compile::DiagnosticPolicy::default(),
+        );
+
+        assert_eq!(wasm.checks, build.checks);
+        assert_eq!(wasm.target.pointer_width, hew_mir::PointerWidth::Bits32);
+        assert_eq!(
+            wasm.lower_hir_module(&hir.module, &tco)
+                .pipeline
+                .lint_warnings,
+            build
+                .lower_hir_module(&hir.module, &tco)
+                .pipeline
+                .lint_warnings,
+            "wasm must run the build check set while retaining its own ABI width"
         );
     }
 }


### PR DESCRIPTION
## Why

The CLI, LSP, wasm host, and MIR fuzz harness each called
`hew_mir::lower_hir_module_with_facts` (or `lower_entry_component`) directly,
choosing their own pointer width and running the backend-front check in
slightly different ways. That let a host drift from what `hew build`
actually checks.

## What

- **hew-compile**: adds `Session`, built from an explicit `SessionTarget`
  (HIR arch, MIR pointer width, optional codegen triple), a fixed
  `CheckSet::Build`, and a `DiagnosticPolicy`. `Session::lower_hir_module`
  and `Session::lower_sir_module` are the only entry points that lower HIR
  or strict SIR to MIR and run the backend-front check.
- **hew-cli**: the normal, SIR, check, and explain paths all build a
  `Session` via `compiler_session` and go through it instead of calling
  `hew_mir`/`hew_codegen_rs` directly.
- **hew-lsp**: the MIR-lint pass now lowers through a native-target
  `Session` rather than calling `lower_hir_module_with_facts` itself.
- **hew-wasm**: the browser host lowers through `SessionTarget::wasm32()`,
  which expresses the 32-bit pointer width as session state rather than a
  separate lowering path; it keeps its own warning-only presentation
  policy on top.
- **hew-parser fuzz**: `support.rs` and `fuzz_mir.rs` both go through the
  same `Session` instead of calling `hew_mir::lower_hir_module` directly.

## Test

- `hew-lsp::server::analysis::tests::lsp_and_build_session_report_the_same_mir_lints`
  asserts the LSP's MIR-lint codes equal the build session's on the same
  fixture.
- `hew-wasm::tests::wasm_session_uses_build_checks_at_wasm32_width` asserts
  the wasm session's lint warnings equal the native build session's despite
  the different pointer width.
- Both were mutated to inject a mismatch and confirmed to fail before being
  restored, so neither is vacuous.
- `make lint` and `make test` pass on the rebased branch; `make test`'s
  failing-ID set is identical to the `origin/main` baseline at the same
  commit (bdf5412fa), so this change introduces no new failures.

Fixes #3089
