### PR TITLE
fix(types): require Option for optional wire fields

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -3132,11 +3132,9 @@ fn main() {
 
 Each field carries a `@N` tag — a stable wire identifier that must never be
 reused, even if the field is later removed (HEW-SPEC-2026.md §7.2). A field
-can also be marked `optional`, which only affects wire-decode behaviour (a
-missing field decodes without error); the field's Hew-level type stays the
-bare element type, not `Option<T>` — see
-[`examples/playground/types/wire_types.hew`](../examples/playground/types/wire_types.hew)
-for that form.
+marked `optional` must have type `Option<T>`; the marker admits only a value
+that can represent absence. This admission rule does not itself define
+encode/decode presence behaviour.
 
 `e.to_json()` and `TypeName.from_json(text)` round-trip a wire type through
 JSON; the latter is a call on the type name itself rather than a source

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -4201,7 +4201,7 @@ Hew introduces `wire` definitions for network-serializable data.
 A `#[wire] type` / `#[wire] enum`:
 
 - has stable field tags (numeric IDs)
-- has explicit optionality/defaults
+- permits `optional` fields only when their declared type resolves to `Option<T>`
 - supports forward/backward compatibility checks
 
 ### 7.2 Compatibility rules (normative)
@@ -4252,12 +4252,14 @@ Hew wire types map to MessagePack formats as follows:
 
 A `#[wire]` type is encoded as a MessagePack **map**. Field numbers are used as map keys (as MessagePack integers), and values are encoded according to the table above.
 
+<!-- Executable optional-field presence support lands in #3179/#3182. -->
+<!-- doctest: skip -->
 ```hew
 #[wire]
 type User {
     id: u64 @1;
     name: string @2;
-    email: string @3 optional;
+    email: Option<string> @3 optional;
 }
 
 // User { id: 42, name: "alice", email: Some("alice@example.com") } encodes as:
@@ -4295,11 +4297,13 @@ enum Status { Pending; Active; Completed; }
 
 Optional fields are represented using MessagePack **nil** for `None`:
 
+<!-- Executable optional-field presence support lands in #3179/#3182. -->
+<!-- doctest: skip -->
 ```hew
 #[wire]
 type Config {
     timeout_ms: u64 @1;
-    proxy_url: string @2 optional;
+    proxy_url: Option<string> @2 optional;
 }
 
 // Config { timeout_ms: 5000, proxy_url: None } encodes as:

--- a/examples/playground/types/wire_types.hew
+++ b/examples/playground/types/wire_types.hew
@@ -3,12 +3,12 @@
 
 // Wire types are schema-checked serialization contracts. Each field carries
 // an explicit tag (@1, @2, ...) so the binary encoding stays compatible as
-// the schema evolves. Optional fields may be added or omitted across versions.
+// the schema evolves. This playground example uses required fields only.
 #[wire]
 type UserMessage {
     name: string @1,
     age: i32 @2,
-    nickname: string @3 optional,
+    nickname: string @3,
 }
 
 fn main() {

--- a/hew-cli/tests/wire_check_e2e.rs
+++ b/hew-cli/tests/wire_check_e2e.rs
@@ -131,8 +131,8 @@ fn wire_check_rejects_field_repeatedness_change() {
 #[test]
 fn wire_check_warns_optional_to_required() {
     let output = run_wire_check(
-        "#[wire]\ntype Msg { name: String @1; }\n",
-        "#[wire]\ntype Msg { name: String @1 optional; }\n",
+        "#[wire]\ntype Msg { name: Option<string> @1; }\n",
+        "#[wire]\ntype Msg { name: Option<string> @1 optional; }\n",
     );
 
     assert!(
@@ -232,7 +232,7 @@ fn wire_check_rejects_removed_required_field() {
 fn wire_check_allows_removed_optional_field() {
     let stderr = assert_wire_check_ok(
         "#[wire]\ntype Msg { id: String @1; }\n",
-        "#[wire]\ntype Msg { id: String @1; tag: String @2 optional; }\n",
+        "#[wire]\ntype Msg { id: String @1; tag: Option<String> @2 optional; }\n",
     );
     assert!(
         !stderr.contains("removed"),

--- a/hew-cli/tests/wire_optional_option_admission_e2e.rs
+++ b/hew-cli/tests/wire_optional_option_admission_e2e.rs
@@ -1,0 +1,69 @@
+mod support;
+
+use std::process::Command;
+
+use support::{hew_binary, strip_ansi};
+
+#[test]
+fn wire_optional_field_without_option_fails_before_lowering() {
+    let fixture = support::tempdir();
+    let source = fixture.path().join("wire_optional_scalar.hew");
+    std::fs::write(
+        &source,
+        "#[wire]\ntype Message { body: string @1 optional }\n",
+    )
+    .expect("write wire fixture");
+
+    let output = Command::new(hew_binary())
+        .args(["check", source.to_str().expect("fixture path is UTF-8")])
+        .current_dir(fixture.path())
+        .output()
+        .expect("invoke hew check");
+
+    assert!(
+        !output.status.success(),
+        "a bare optional field must stop before lowering; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains("E_WIRE_OPTIONAL_REQUIRES_OPTION")
+            && stderr
+                .contains("wire field `body` is marked `optional` but must have type `Option<T>`")
+            && stderr.contains("wire_optional_scalar.hew:2:22"),
+        "CLI must render the semantic wire admission error at the field type:\n{stderr}"
+    );
+}
+
+#[test]
+fn wire_optional_option_counterfactual_controls_check_cleanly() {
+    let fixture = support::tempdir();
+    let source = fixture.path().join("wire_optional_controls.hew");
+    std::fs::write(
+        &source,
+        "#[wire]\ntype RequiredValue { body: string @1 }\n\
+         #[wire]\ntype RequiredOption { body: Option<string> @1 }\n\
+         #[wire]\ntype OptionalOption { body: Option<string> @1 optional }\n\
+         fn main() -> i64 {\n\
+             let _value = RequiredValue { body: \"required\" };\n\
+             let _required_option = RequiredOption { body: Some(\"present\") };\n\
+             let _optional_option = OptionalOption { body: None };\n\
+             0\n\
+         }\n",
+    )
+    .expect("write wire control fixture");
+
+    let output = Command::new(hew_binary())
+        .args(["check", source.to_str().expect("fixture path is UTF-8")])
+        .current_dir(fixture.path())
+        .output()
+        .expect("invoke hew check");
+
+    assert!(
+        output.status.success(),
+        "required T, required Option<T>, and optional Option<T> must remain valid; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -4567,7 +4567,7 @@ type Msg {
 #[wire]
 type Msg {
     id: i64 @1,
-    name: String @2 optional since 2,
+    name: Option<String> @2 optional since 2,
     tags: Vec<String> @3 repeated,
     reserved @4;
 }

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -2506,7 +2506,7 @@ fn parse_wire_struct_preserves_since_modifier() {
     let source = "\
 #[wire]
 type Msg {
-    added: String @2 optional since 2 json(\"added\"),
+    added: Option<String> @2 optional since 2 json(\"added\"),
 }
 ";
     let result = parse(source);
@@ -2554,7 +2554,7 @@ fn wire_struct_field_metadata_preserves_number_and_outer_naming_cases() {
 #[json(\"camelCase\")]
 #[yaml(\"snake_case\")]
 type Msg {
-    added: String @2 optional yaml(\"added_name\"),
+    added: Option<String> @2 optional yaml(\"added_name\"),
 }
 ";
     let result = parse(source);

--- a/hew-parser/tests/wire_diagnostics.rs
+++ b/hew-parser/tests/wire_diagnostics.rs
@@ -39,3 +39,19 @@ type Message {
         result.errors,
     );
 }
+
+#[test]
+fn optional_wire_field_remains_parser_permissive_for_alias_resolution() {
+    let result = parse(
+        r"#[wire]
+type Message {
+    body: MaybeText @1 optional,
+}",
+    );
+
+    assert!(
+        result.errors.is_empty(),
+        "the parser must not reject an alias before semantic Option<T> resolution: {:?}",
+        result.errors
+    );
+}

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -612,6 +612,10 @@ impl Checker {
         // alias maps exist) and before body checking + descriptor building (so
         // every member-derived consumer sees the corrected types).
         self.reresolve_member_types_after_imports(program);
+        // `optional` is a wire-schema admission marker, not an implicit
+        // default. Check it only after member re-resolution so aliases and
+        // imports have reached their semantic `Ty` identity.
+        self.validate_wire_optional_field_admission(program);
 
         // Build the actor protocol descriptor side-table BEFORE body checking.
         //

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2825,6 +2825,82 @@ impl Checker {
         self.suppress_undefined_type_report = prev_suppress;
     }
 
+    /// Admit `optional` wire fields only when their final semantic type is
+    /// `Option<T>`.
+    ///
+    /// This deliberately runs after [`Self::reresolve_member_types_after_imports`].
+    /// The parser cannot make this decision from syntax without rejecting a
+    /// valid alias, and the first registration pass predates import aliases.
+    /// Keeping this as the one checker-side gate means every later consumer
+    /// sees either an admitted `Option<T>` field or a hard type error.
+    pub(super) fn validate_wire_optional_field_admission(&mut self, program: &Program) {
+        if let Some(module_graph) = &program.module_graph {
+            for module_id in &module_graph.topo_order {
+                if *module_id == module_graph.root {
+                    continue;
+                }
+                let Some(module) = module_graph.modules.get(module_id) else {
+                    continue;
+                };
+                self.current_module = Some(module_id.path.join("."));
+                for (item, _) in &module.items {
+                    self.validate_type_decl_wire_optional_fields(item);
+                }
+            }
+        }
+
+        self.current_module = None;
+        for (item, _) in &program.items {
+            self.validate_type_decl_wire_optional_fields(item);
+        }
+        self.current_module_idx = 0;
+    }
+
+    fn validate_type_decl_wire_optional_fields(&mut self, item: &Item) {
+        let Item::TypeDecl(type_decl) = item else {
+            return;
+        };
+        let Some(wire) = &type_decl.wire else {
+            return;
+        };
+
+        let type_def_key = self.authoritative_type_def_key(&type_decl.name);
+        let Some(fields) = self
+            .type_defs
+            .get(&type_def_key)
+            .map(|type_def| type_def.fields.clone())
+        else {
+            return;
+        };
+
+        for metadata in wire.field_meta.iter().filter(|field| field.is_optional) {
+            let field_span = type_decl
+                .body
+                .iter()
+                .find_map(|item| match item {
+                    TypeBodyItem::Field { name, ty, .. } if name == &metadata.field_name => {
+                        Some(ty.1.clone())
+                    }
+                    _ => None,
+                })
+                .unwrap_or(0..0);
+            let resolved_ty = fields
+                .get(&metadata.field_name)
+                .map(|field_ty| self.normalize_for_use(field_ty));
+
+            if resolved_ty.as_ref().and_then(Ty::as_option).is_none() {
+                self.report_error(
+                    TypeErrorKind::WireOptionalFieldRequiresOption,
+                    &field_span,
+                    format!(
+                        "E_WIRE_OPTIONAL_REQUIRES_OPTION: wire field `{}` is marked `optional` but must have type `Option<T>`",
+                        metadata.field_name
+                    ),
+                );
+            }
+        }
+    }
+
     /// Seed `local_type_defs`/`source_type_defs` with the current scope's own
     /// type names so member re-resolution (a) treats them as locally-defined
     /// (no fresh-var injection) and (b) shadows any same-named import alias —

--- a/hew-types/src/check/tests/wire.rs
+++ b/hew-types/src/check/tests/wire.rs
@@ -292,3 +292,63 @@ fn wire_layout_json_name_override_preserved() {
         .expect("Cfg should have a wire layout entry");
     assert_eq!(entry.fields[0].json_name, Some("hostname".to_string()));
 }
+
+#[test]
+fn wire_optional_field_requires_semantic_option_type() {
+    let source = r"
+        #[wire]
+        type Invalid { value: string @1 optional }
+
+        #[wire]
+        type RequiredValue { value: string @1 }
+
+        #[wire]
+        type RequiredOption { value: Option<string> @1 }
+
+        #[wire]
+        type OptionalOption { value: Option<string> @1 optional }
+    ";
+    let output = check_source(source);
+    let error = output
+        .errors
+        .iter()
+        .find(|error| error.kind == TypeErrorKind::WireOptionalFieldRequiresOption)
+        .expect("bare optional field must be rejected");
+
+    assert_eq!(
+        error.message,
+        "E_WIRE_OPTIONAL_REQUIRES_OPTION: wire field `value` is marked `optional` but must have type `Option<T>`"
+    );
+    assert_eq!(error.span, 47..54);
+    assert_eq!(
+        output
+            .errors
+            .iter()
+            .filter(|error| error.kind == TypeErrorKind::WireOptionalFieldRequiresOption)
+            .count(),
+        1,
+        "required T, required Option<T>, and optional Option<T> are counterfactual controls: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn wire_optional_field_accepts_option_alias_after_resolution() {
+    let output = check_source(
+        r"
+        type MaybeText = Option<string>;
+
+        #[wire]
+        type Message { body: MaybeText @1 optional }
+        ",
+    );
+
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|error| error.kind == TypeErrorKind::WireOptionalFieldRequiresOption),
+        "an alias resolving to Option<T> must be admitted: {:#?}",
+        output.errors
+    );
+}

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -698,6 +698,12 @@ pub enum TypeErrorKind {
     InvalidSend,
     /// Operation not supported for this type
     InvalidOperation,
+    /// A `#[wire]` field marked `optional` does not resolve to `Option<T>`.
+    ///
+    /// This is an admission rule, rather than an encode/decode rule: wire
+    /// codecs may only rely on absence semantics after the field's Hew type
+    /// proves it can represent `None`.
+    WireOptionalFieldRequiresOption,
     /// A supervisor-declaration check failed. `subkind` names the specific
     /// `E_SUPERVISOR_*` diagnostic so JSON `code` / LSP `data.kind` consumers
     /// can differentiate the supervisor family instead of collapsing every
@@ -1415,6 +1421,7 @@ impl TypeErrorKind {
             Self::GenericLayoutCollision => "GenericLayoutCollision",
             Self::InvalidSend => "InvalidSend",
             Self::InvalidOperation => "InvalidOperation",
+            Self::WireOptionalFieldRequiresOption => "E_WIRE_OPTIONAL_REQUIRES_OPTION",
             Self::SupervisorError { subkind } => subkind.as_kind_str(),
             Self::ContextReaderOutsideHandler => "ContextReaderOutsideHandler",
             Self::ArityMismatch => "ArityMismatch",

--- a/tools/downstream/syntax-fixtures/syntax_test.hew
+++ b/tools/downstream/syntax-fixtures/syntax_test.hew
@@ -53,7 +53,7 @@ impl Drawable for Point {
 #[wire]
 type UserMessage {
     name: string @1,
-    age: u32 @2 optional,
+    age: Option<u32> @2 optional,
     email: string @3 deprecated,
 }
 


### PR DESCRIPTION
## Summary

- reject a `#[wire]` field marked `optional` unless its final resolved type is
  `Option<T>`
- keep the parser permissive so aliases resolving to `Option<T>` remain valid;
  the post-import type-checker gate is the semantic authority
- report stable `E_WIRE_OPTIONAL_REQUIRES_OPTION` at the field type and migrate
  positive examples/fixtures to `Option<T> optional`

This is the fail-closed admission slice of D300. It introduces no implicit
default and deliberately does not change codec presence or schema-compatibility
semantics. D300 remains open until JSON/YAML/CBOR and compatibility share the
full required/nullable/omissible contract.

## Validation

- `cargo test -p hew-parser --test wire_diagnostics` (3/3)
- `cargo test -p hew-types check::tests::wire::` (11/11)
- `cargo test -p hew-cli --test wire_optional_option_admission_e2e` (2/2)
- `cargo test -p hew-cli --test wire_check_e2e` (27/27)
- `cargo test -p hew-sandbox-wasm --test parity playground_sources_match_native_or_catalogued_divergence -- --exact` (1/1)
- `cargo fmt --all -- --check`
- `git diff --check`
- independent review: no P0-P2 findings

Counterfactual controls preserve required `T`, required `Option<T>`, optional
`Option<T>`, and aliases that semantically resolve to builtin `Option<T>`.
