### PR TITLE
test: add Hewbers compiler regressions

### DIFF
--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -15,3 +15,14 @@
 # the ratchet: a known compiler refusal cannot silently become a hung,
 # unstartable, or crashing binary under the same test identity.
 #
+# Priority-1 upstream reductions from Goobers-Hew.  Each is intentionally an
+# executable desired-behaviour test: remove its row when the failure is fixed.
+# #3173 currently refuses indirect owned call scrutinees with E_NOT_YET_IMPLEMENTED.
+tests/hew/call_scrutinee_indirect_ownership_test.hew::indirect_owned_result_call_scrutinee_preserves_payload compile
+# #3173 cannot attach an imported actor protocol descriptor and then reports the
+# unresolved imported child/handler as E_NOT_YET_IMPLEMENTED.
+tests/hew/imported_supervisor_child_layout_test.hew::imported_actor_is_a_supervised_child compile
+# #3173 reports the ownership-generation lowering invariant as E_MIR_ICE.
+tests/hew/journal_first_symlink_ownership_test.hew::scans_regular_path_components compile
+# #3173 reports the ownership-generation lowering invariant as E_MIR_ICE.
+tests/hew/json_value_loop_reassign_test.hew::reassigns_json_resource_builder_in_loop compile

--- a/tests/hew/call_scrutinee_indirect_ownership_test.hew
+++ b/tests/hew/call_scrutinee_indirect_ownership_test.hew
@@ -1,0 +1,21 @@
+//! An indirect call that returns an owned Result preserves its payload when
+//! used as a match scrutinee.
+
+import std.testing;
+
+fn make(value: string) -> Result<string, string> {
+    Ok(value)
+}
+
+fn inspect() -> i64 {
+    let f = make;
+    match f("payload") {
+        .Ok(value) => value.len(),
+        .Err(_) => 0,
+    }
+}
+
+#[test]
+fn indirect_owned_result_call_scrutinee_preserves_payload() {
+    testing.assert_eq(inspect(), 7);
+}

--- a/tests/hew/claims_vec_allocation_test.hew
+++ b/tests/hew/claims_vec_allocation_test.hew
@@ -1,0 +1,37 @@
+//! A `Vec` of the claim-projection record used by the operator path allocates
+//! its real record element size and retains each owned string field.
+
+import std.string;
+
+import std.testing;
+
+type ClaimView {
+    item: string;
+    run_id: string;
+    fence: i64;
+    expires_at: i64;
+    lifecycle_state: string;
+    checkpoint: i64;
+    exact_head_verifying: bool;
+}
+
+fn active_claims() -> Vec<ClaimView> {
+    let claims: Vec<ClaimView> = Vec.new();
+    for n in 0 .. 4 {
+        claims.push(ClaimView { item: "gitea:owner:repo:issue:" + string.from_int(n), run_id: "run-" + string.from_int(n), fence: n + 1, expires_at: 9000 + n, lifecycle_state: "Completed", checkpoint: n, exact_head_verifying: n == 2 });
+    }
+    claims
+}
+
+#[test]
+fn claim_projection_vec_allocates_and_preserves_fields() {
+    let claims = active_claims();
+    testing.assert_eq(claims.len(), 4);
+    testing.assert_eq_str(claims[3].item, "gitea:owner:repo:issue:3");
+    testing.assert_eq_str(claims[3].run_id, "run-3");
+    testing.assert_eq(claims[3].fence, 4);
+    testing.assert_eq(claims[3].expires_at, 9003);
+    testing.assert_eq_str(claims[3].lifecycle_state, "Completed");
+    testing.assert_eq(claims[3].checkpoint, 3);
+    testing.assert_true(claims[2].exact_head_verifying);
+}

--- a/tests/hew/imported_supervisor_child_layout_test.hew
+++ b/tests/hew/imported_supervisor_child_layout_test.hew
@@ -1,0 +1,23 @@
+//! A supervisor must lower an actor child whose declaration arrived through a
+//! file import, including its concrete layout and message dispatch.
+
+import "imported_supervisor_child_support/worker.hew";
+
+import std.testing;
+
+supervisor ImportedWorkerPool {
+    strategy: one_for_one;
+    intensity: 1 within 60s;
+
+    child worker: ImportedWorker(id: 17);
+}
+
+#[test]
+fn imported_actor_is_a_supervised_child() {
+    let sup = spawn ImportedWorkerPool;
+    match await sup.worker.identify() {
+        .Ok(id) => testing.assert_eq(id, 17),
+        .Err(_) => testing.assert_true(false),
+    }
+    supervisor_stop(sup);
+}

--- a/tests/hew/imported_supervisor_child_support/worker.hew
+++ b/tests/hew/imported_supervisor_child_support/worker.hew
@@ -1,0 +1,7 @@
+pub actor ImportedWorker {
+    let id: i64;
+
+    receive fn identify() -> i64 {
+        id
+    }
+}

--- a/tests/hew/journal_first_symlink_ownership_test.hew
+++ b/tests/hew/journal_first_symlink_ownership_test.hew
@@ -1,0 +1,33 @@
+//! The `first_symlink` loop must lower its owned path accumulator without
+//! violating the MIR discharge-authority invariant.
+
+import std.string;
+
+import std.testing;
+
+fn is_symlink(path: string) -> bool {
+    // The ownership-sensitive accumulator is independent of filesystem state.
+    false
+}
+
+fn first_symlink(root: string, rel_path: string) -> string {
+    if is_symlink(root) {
+        return root;
+    }
+    let parts = string.split(rel_path, "/");
+    var prefix = root;
+    for part in parts {
+        if part != "" {
+            prefix = prefix + "/" + part;
+            if is_symlink(prefix) {
+                return prefix;
+            }
+        }
+    }
+    ""
+}
+
+#[test]
+fn scans_regular_path_components() {
+    testing.assert_eq_str(first_symlink(".", "does-not-exist/child"), "");
+}

--- a/tests/hew/json_value_loop_reassign_test.hew
+++ b/tests/hew/json_value_loop_reassign_test.hew
@@ -1,0 +1,21 @@
+//! A resource-backed JSON array can be reassigned from its consuming builder
+//! result on every loop iteration.
+
+import std.encoding.json;
+
+import std.testing;
+
+fn rendered_count() -> string {
+    var values = json.array();
+    for n in 0 .. 3 {
+        values = values.push_int(n);
+    }
+    let rendered = values.stringify();
+    values.close();
+    rendered
+}
+
+#[test]
+fn reassigns_json_resource_builder_in_loop() {
+    testing.assert_eq_str(rendered_count(), "[0,1,2]");
+}

--- a/tests/hew/wire_json_unknown_field_behavior_test.hew
+++ b/tests/hew/wire_json_unknown_field_behavior_test.hew
@@ -1,0 +1,17 @@
+//! Default generated wire JSON decoding remains permissive for an unknown
+//! field, as specified for forward-compatible wire payloads.
+
+import std.testing;
+
+#[wire]
+type WireProbe {
+    name: string @1,
+}
+
+#[test]
+fn generated_wire_json_ignores_unknown_field_by_default() {
+    match WireProbe.from_json("{\"name\":\"known\",\"future\":true}") {
+        .Ok(probe) => testing.assert_eq_str(probe.name, "known"),
+        .Err(reason) => panic("permissive generated decode failed: " + reason),
+    }
+}


### PR DESCRIPTION
## Summary

- preserve four minimized dogfood compiler failures as executable desired-
  behavior tests with exact `compile` ratchet rows
- add two passing canaries for Vec record allocation and permissive unknown-field
  wire JSON decoding
- keep advisory/API findings out of the corpus when their contract is undecided

The retained failures cover an indirect owned-`Result` scrutinee, imported
supervisor-child layout publication, and the two generic loop-generation shapes
seen in journal path and JSON builder reassignment. The latter two are evidence
for #3120; they are not shape-specific fix requests.

The stale #3105 rows are not reintroduced, and the proposed
`Node.register(ChildRef)` test is excluded pending Q356's explicit role-lookup
contract.

## Validation

- focused JUnit run: 6 discovered tests
  - 4 expected compile failures with current `E_NOT_YET_IMPLEMENTED`, `E_MIR`,
    or `E_MIR_ICE` diagnostics
  - 2 passing executable canaries
- support worker checks but is not independently discovered as a test
- deterministic/local-only audit: no sleeps, process, filesystem, network, or
  platform dependency
- `git diff --check`
- two independent fixture reviews: no P0-P3 findings

The full local corpus exceeded a bounded five-minute run. Hosted CI's four
compiled-Hew shards and inventory/union ratchet are the exhaustive gate for this
PR.
