### PR TITLE
fix(ci): publish ratcheted Hew failures as skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,7 @@ jobs:
           --shard-count 4
 
       - name: Require every shard to complete
+        id: require-every-shard
         if: always()
         env:
           BUILD_RESULT: ${{ needs.compiled-hew-linux.result }}
@@ -324,11 +325,17 @@ jobs:
           done
 
       - name: List the independent full suite inventory
+        id: full-inventory
         run: |
           "${{ runner.temp }}/compiled-hew-artifact/compiled-hew/debug/hew" \
             test tests/hew --list > "${{ runner.temp }}/compiled-hew-full.txt"
 
       - name: Assert shard union and Hew ratchet
+        id: hew-ratchet
+        if: >-
+          always() &&
+          steps.require-every-shard.outcome == 'success' &&
+          steps.full-inventory.outcome == 'success'
         run: >-
           make test-hew-ratchet
           HEW_SHARD_REPORT_DIR="${{ runner.temp }}/compiled-hew-reports"
@@ -336,17 +343,31 @@ jobs:
           HEW_SHARD_COUNT=4
 
       - name: Assert shard union and O2 differential
+        id: o2-differential
+        if: >-
+          always() &&
+          steps.require-every-shard.outcome == 'success' &&
+          steps.full-inventory.outcome == 'success'
         run: >-
           make test-o2-differential
           HEW_SHARD_REPORT_DIR="${{ runner.temp }}/compiled-hew-reports"
           HEW_FULL_INVENTORY="${{ runner.temp }}/compiled-hew-full.txt"
           HEW_SHARD_COUNT=4
 
+      - name: Finalize compiled Hew JUnit reports
+        if: always()
+        run: >-
+          python3 scripts/compiled-hew-shards.py finalize
+          --reports-dir "${{ runner.temp }}/compiled-hew-reports"
+          --output-dir "${{ runner.temp }}/compiled-hew-published"
+          --full-inventory "${{ runner.temp }}/compiled-hew-full.txt"
+          --prerequisites-succeeded "${{ steps.hew-ratchet.outcome == 'success' && steps.o2-differential.outcome == 'success' }}"
+
       - name: Upload compiled Hew test reports
         if: always()
         uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         with:
-          report_paths: "${{ runner.temp }}/compiled-hew-reports/hew-*-shard-*.xml"
+          report_paths: "${{ runner.temp }}/compiled-hew-published/*.xml"
           check_name: Compiled Hew Test Results
 
   # ─────────────────────────────────────────────────────────────────────────

--- a/scripts/compiled-hew-shards.py
+++ b/scripts/compiled-hew-shards.py
@@ -7,15 +7,22 @@ import argparse
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 from typing import NoReturn
+import xml.etree.ElementTree as ET
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
 from corpus_nonempty import assert_nonempty  # noqa: E402
-from hew_junit import FAILURE_KINDS, JUnitError, parse as parse_hew_junit  # noqa: E402
+from hew_junit import (  # noqa: E402
+    FAILURE_KINDS,
+    JUnitError,
+    JUnitReport,
+    parse as parse_hew_junit,
+)
 
 
 PARTITION_RE = re.compile(r"^hash:([1-9][0-9]*)/([1-9][0-9]*)$")
@@ -126,6 +133,123 @@ def report_failures(reports_dir: Path, shard_count: int) -> None:
                     f"test={identity} kind={testcase.failure_kind}\n"
                     f"assertion:\n{diagnostic}"
                 )
+
+
+def update_junit_totals(root: ET.Element) -> None:
+    root.set("tests", str(sum(1 for _ in root.iter("testcase"))))
+    root.set("failures", str(sum(1 for _ in root.iter("failure"))))
+    root.set("skipped", str(sum(1 for _ in root.iter("skipped"))))
+    for suite in root.iter("testsuite"):
+        suite.set("tests", str(sum(1 for _ in suite.iter("testcase"))))
+        suite.set("failures", str(sum(1 for _ in suite.iter("failure"))))
+        suite.set("skipped", str(sum(1 for _ in suite.iter("skipped"))))
+
+
+def write_finalization_failure(output_dir: Path, message: str) -> None:
+    root = ET.Element("testsuites", tests="1", failures="1", skipped="0")
+    suite = ET.SubElement(
+        root,
+        "testsuite",
+        name="compiled-hew-finalization",
+        tests="1",
+        failures="1",
+        skipped="0",
+    )
+    testcase = ET.SubElement(
+        suite,
+        "testcase",
+        classname="compiled-hew-finalization",
+        name="report-authority",
+    )
+    failure = ET.SubElement(testcase, "failure", type="launch", message=message)
+    failure.text = message
+    ET.ElementTree(root).write(
+        output_dir / "compiled-hew-finalization.xml",
+        encoding="unicode",
+        xml_declaration=True,
+    )
+
+
+def finalize_reports(
+    reports_dir: Path,
+    output_dir: Path,
+    full_inventory: Path,
+    expected_failures_path: Path,
+    prerequisites_succeeded: bool,
+) -> int:
+    """Prepare the JUnit input for GitHub after raw aggregate gates finish."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    reports = sorted(reports_dir.glob("hew-*-shard-*.xml"))
+    for report in reports:
+        shutil.copy2(report, output_dir / report.name)
+
+    if not prerequisites_succeeded:
+        write_finalization_failure(
+            output_dir,
+            "compiled-Hew raw ratchet or differential gate did not succeed",
+        )
+        return 1
+
+    try:
+        full = set(read_inventory(full_inventory))
+        expected = expected_failures(expected_failures_path, full)
+        actual: dict[str, str] = {}
+        parsed_reports: list[tuple[Path, JUnitReport]] = []
+        for report in reports:
+            parsed = parse_hew_junit(report, REPO_ROOT)
+            parsed_reports.append((report, parsed))
+            if "hew-o0-" not in report.name:
+                continue
+            for testcase in parsed.testcases:
+                identity = normalized_identity(testcase.classname, testcase.name)
+                if identity in actual:
+                    die(f"finalization report has duplicate identity: {identity}")
+                if testcase.failure_kind is not None:
+                    actual[identity] = testcase.failure_kind
+        if set(actual) != set(expected):
+            die("finalization failure set differs from the ratchet")
+        for identity, expected_kind in expected.items():
+            if actual[identity] != expected_kind:
+                die(f"finalization failure kind differs from the ratchet: {identity}")
+
+        for source, parsed in parsed_reports:
+            root = ET.parse(source).getroot()
+            for testcase in root.iter("testcase"):
+                identity = normalized_identity(
+                    testcase.get("classname", ""), testcase.get("name", "")
+                )
+                if identity not in expected:
+                    continue
+                failure = testcase.find("failure")
+                if failure is None or failure.get("type") != expected[identity]:
+                    die(f"finalization cannot normalize expected failure: {identity}")
+                message = failure.get("message", "")
+                text = failure.text or ""
+                testcase.remove(failure)
+                skipped = ET.SubElement(testcase, "skipped")
+                skipped.set(
+                    "message",
+                    f"expected {expected[identity]} failure"
+                    + (f": {message}" if message else ""),
+                )
+                skipped.text = text
+            update_junit_totals(root)
+            ET.ElementTree(root).write(
+                output_dir / source.name,
+                encoding="unicode",
+                xml_declaration=True,
+            )
+    except (JUnitError, SystemExit, ET.ParseError) as error:
+        message = (
+            "compiled-Hew report finalization rejected its ratchet inputs; "
+            "see workflow stderr"
+            if isinstance(error, SystemExit)
+            else str(error)
+        )
+        write_finalization_failure(output_dir, message)
+        print(f"compiled-hew-shards: finalization failed: {message}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def run_command(
@@ -275,7 +399,6 @@ def aggregate(
     o0, o2 = load_shards(reports_dir, full, shard_count)
     label = "hew-suite-tests" if mode == "ratchet" else "o2-differential-outcomes"
     assert_nonempty(label, len(full), context="union of compiled-Hew shards")
-
     if mode == "ratchet":
         expected = expected_failures(expected_failures_path, full)
         actual = {
@@ -342,6 +465,20 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     report_parser = subcommands.add_parser("report")
     report_parser.add_argument("--reports-dir", type=Path, required=True)
     report_parser.add_argument("--shard-count", type=int, required=True)
+    finalize_parser = subcommands.add_parser("finalize")
+    finalize_parser.add_argument("--reports-dir", type=Path, required=True)
+    finalize_parser.add_argument("--output-dir", type=Path, required=True)
+    finalize_parser.add_argument("--full-inventory", type=Path, required=True)
+    finalize_parser.add_argument(
+        "--expected-failures",
+        type=Path,
+        default=REPO_ROOT / "scripts" / "hew-suite-expected-failures.txt",
+    )
+    finalize_parser.add_argument(
+        "--prerequisites-succeeded",
+        choices=("true", "false"),
+        required=True,
+    )
     return parser.parse_args(argv)
 
 
@@ -356,6 +493,14 @@ def main(argv: list[str]) -> int:
             args.full_inventory,
             args.shard_count,
             args.expected_failures,
+        )
+    elif args.action == "finalize":
+        return finalize_reports(
+            args.reports_dir,
+            args.output_dir,
+            args.full_inventory,
+            args.expected_failures,
+            args.prerequisites_succeeded == "true",
         )
     else:
         report_failures(args.reports_dir, args.shard_count)

--- a/scripts/lib/hew_junit.py
+++ b/scripts/lib/hew_junit.py
@@ -107,8 +107,19 @@ def parse(path: Path, identity_root: Path | None = None) -> JUnitReport:
             )
         identities.add(identity)
 
-        failure = element.find("failure")
-        is_skipped = element.find("skipped") is not None
+        failure_elements = element.findall("failure")
+        skipped_elements = element.findall("skipped")
+        if (
+            len(failure_elements) > 1
+            or len(skipped_elements) > 1
+            or (failure_elements and skipped_elements)
+        ):
+            raise JUnitError(
+                f"JUnit testcase has non-exclusive outcomes: "
+                f"{path}: {classname}::{name}"
+            )
+        failure = failure_elements[0] if failure_elements else None
+        is_skipped = bool(skipped_elements)
         if failure is not None:
             outcome = "FAILED"
             failure_kind = failure.get("type", "")
@@ -148,6 +159,30 @@ def parse(path: Path, identity_root: Path | None = None) -> JUnitReport:
             f"JUnit summary disagrees with testcase elements: {path}: "
             f"declared={declared_totals} counted={counted}"
         )
+    for suite in root.iter("testsuite"):
+        try:
+            declared_suite_totals = (
+                int(suite.get("tests", "")),
+                int(suite.get("failures", "")),
+                int(suite.get("skipped", "")),
+            )
+        except ValueError as error:
+            raise JUnitError(
+                f"JUnit testsuite has non-integer summary attributes: {path}: "
+                f"{suite.get('name', '<unnamed>')}"
+            ) from error
+        suite_testcases = tuple(suite.iter("testcase"))
+        counted_suite_totals = (
+            len(suite_testcases),
+            sum(testcase.find("failure") is not None for testcase in suite_testcases),
+            sum(testcase.find("skipped") is not None for testcase in suite_testcases),
+        )
+        if declared_suite_totals != counted_suite_totals:
+            raise JUnitError(
+                f"JUnit testsuite summary disagrees with testcase elements: {path}: "
+                f"{suite.get('name', '<unnamed>')}: "
+                f"declared={declared_suite_totals} counted={counted_suite_totals}"
+            )
     return JUnitReport(
         testcases=tuple(testcases),
         tests=declared,

--- a/scripts/tests/test_compiled_hew_shards.py
+++ b/scripts/tests/test_compiled_hew_shards.py
@@ -13,6 +13,7 @@ import xml.etree.ElementTree as ET
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "compiled-hew-shards.py"
+JUNIT = ROOT / "scripts" / "lib" / "hew_junit.py"
 COUNT = 41
 SHARDS = 4
 
@@ -125,6 +126,184 @@ class CompiledHewShardTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         return result
+
+    def finalize(
+        self, prerequisites_succeeded: bool
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        output = self.root / "published"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "finalize",
+                "--reports-dir",
+                str(self.reports),
+                "--output-dir",
+                str(output),
+                "--full-inventory",
+                str(self.full_path),
+                "--expected-failures",
+                str(self.expected),
+                "--prerequisites-succeeded",
+                str(prerequisites_succeeded).lower(),
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return result, output
+
+    def test_finalization_skips_matching_failures_and_preserves_diagnostics(
+        self,
+    ) -> None:
+        values = self.full[0::SHARDS]
+        tracked = values[0]
+        self.expected.write_text(f"{tracked} runtime\n", encoding="utf-8")
+        for label in ("o0", "o2"):
+            write_junit(
+                self.reports / f"hew-{label}-shard-1.xml",
+                values,
+                failed={tracked},
+            )
+
+        result, published = self.finalize(True)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        root = ET.parse(published / "hew-o0-shard-1.xml").getroot()
+        self.assertEqual(root.get("failures"), "0")
+        self.assertEqual(root.get("skipped"), "1")
+        self.assertIsNone(root.find(".//failure"))
+        skipped = root.find(".//skipped")
+        self.assertEqual(
+            skipped.get("message"), "expected runtime failure: forced assertion"
+        )
+        self.assertEqual(skipped.text, "forced diagnostic text")
+        self.assertEqual(
+            ET.parse(self.reports / "hew-o0-shard-1.xml").getroot().get("failures"),
+            "1",
+        )
+        action_read = subprocess.run(
+            [sys.executable, str(JUNIT), str(published / "hew-o0-shard-1.xml")],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertEqual(action_read.returncode, 0, action_read.stderr)
+        self.assertIn("__SUMMARY__\t11\t0\t1", action_read.stdout)
+
+    def test_failed_prerequisite_keeps_raw_reports_and_adds_visible_failure(
+        self,
+    ) -> None:
+        result, published = self.finalize(False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue((published / "hew-o0-shard-1.xml").is_file())
+        finalization = ET.parse(published / "compiled-hew-finalization.xml").getroot()
+        self.assertEqual(finalization.get("failures"), "1")
+        self.assertIsNotNone(finalization.find(".//failure"))
+
+    def test_finalization_refuses_mismatched_expected_failure_kind(self) -> None:
+        values = self.full[0::SHARDS]
+        tracked = values[0]
+        self.expected.write_text(f"{tracked} compile\n", encoding="utf-8")
+        for label in ("o0", "o2"):
+            write_junit(
+                self.reports / f"hew-{label}-shard-1.xml",
+                values,
+                failed={tracked},
+                failure_kind="runtime",
+            )
+
+        result, published = self.finalize(True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("failure kind differs", result.stderr)
+        failure = ET.parse(published / "compiled-hew-finalization.xml").find(
+            ".//failure"
+        )
+        self.assertIsNotNone(failure)
+        self.assertIn("rejected its ratchet inputs", failure.get("message"))
+
+    def test_finalization_publishes_a_failure_when_raw_junit_is_malformed(self) -> None:
+        (self.reports / "hew-o0-shard-1.xml").write_text(
+            "<testsuites><testcase", encoding="utf-8"
+        )
+
+        result, published = self.finalize(True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("malformed JUnit report", result.stderr)
+        self.assertIsNotNone(
+            ET.parse(published / "compiled-hew-finalization.xml").find(".//failure")
+        )
+
+    def test_finalization_publishes_a_failure_when_expected_failure_is_missing(
+        self,
+    ) -> None:
+        tracked = self.full[0]
+        self.expected.write_text(f"{tracked} runtime\n", encoding="utf-8")
+
+        result, published = self.finalize(True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("failure set differs", result.stderr)
+        self.assertIsNotNone(
+            ET.parse(published / "compiled-hew-finalization.xml").find(".//failure")
+        )
+
+    def test_unexpected_pass_prerequisite_failure_keeps_raw_and_adds_red_verdict(
+        self,
+    ) -> None:
+        tracked = self.full[0]
+        self.expected.write_text(f"{tracked} runtime\n", encoding="utf-8")
+
+        result, published = self.finalize(False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(
+            ET.parse(published / "hew-o0-shard-1.xml").getroot().get("failures"),
+            "0",
+        )
+        self.assertIsNotNone(
+            ET.parse(published / "compiled-hew-finalization.xml").find(".//failure")
+        )
+
+    def test_finalization_publishes_a_failure_when_inventory_is_empty(self) -> None:
+        self.full_path.write_text("", encoding="utf-8")
+
+        result, published = self.finalize(True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("inventory is empty", result.stderr)
+        self.assertIsNotNone(
+            ET.parse(published / "compiled-hew-finalization.xml").find(".//failure")
+        )
+
+    def test_raw_junit_nonexclusive_outcomes_fail_aggregate(self) -> None:
+        path = self.reports / "hew-o0-shard-1.xml"
+        tree = ET.parse(path)
+        testcase = tree.find(".//testcase")
+        ET.SubElement(testcase, "failure", type="runtime")
+        ET.SubElement(testcase, "skipped")
+        tree.getroot().set("failures", "1")
+        tree.getroot().set("skipped", "1")
+        tree.find(".//testsuite").set("failures", "1")
+        tree.find(".//testsuite").set("skipped", "1")
+        tree.write(path, encoding="unicode", xml_declaration=True)
+
+        result = self.aggregate("ratchet", expect=1)
+        self.assertIn("non-exclusive outcomes", result.stderr)
+
+    def test_raw_junit_testsuite_summary_mismatch_fails_aggregate(self) -> None:
+        path = self.reports / "hew-o0-shard-1.xml"
+        tree = ET.parse(path)
+        tree.find(".//testsuite").set("failures", "1")
+        tree.write(path, encoding="unicode", xml_declaration=True)
+
+        result = self.aggregate("ratchet", expect=1)
+        self.assertIn("testsuite summary disagrees", result.stderr)
 
     def test_complete_disjoint_union_passes_both_gates(self) -> None:
         self.assertIn("ratchet passed", self.aggregate("ratchet").stdout)


### PR DESCRIPTION
Why

#3180 added intentional compiled-Hew failures under an exact ratchet. The execution and aggregate gates pass, but the reporting action reads the raw failure elements and leaves main with a red Compiled Hew Test Results check.

What

- Keep raw shard XML authoritative through execution, ratchet, and O0/O2 differential gates.
- Finalize publication only after both aggregate gates succeed, rendering exact same-kind expected failures as skipped while retaining their diagnostics.
- Emit a synthetic failing JUnit verdict whenever a prerequisite, report, inventory, failure set, or failure kind is invalid.
- Reject ambiguous testcase outcomes and inconsistent per-suite JUnit totals.

Test

- make test-build-harness
- make o2-differential-selftest
- make lint
- Ruff format/check and git diff --check
- Replayed run 33356581000 exact hosted artifacts: 1,414 raw tests, four expected failures per O0/O2, raw ratchet and differential green, published as eight visible skips and zero failures
- Independent fail-closed review GO with adversarial malformed, missing, unexpected-pass/fail, wrong-kind, and differential-divergence probes