### PR TITLE
docs(release): record v0.6.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,89 @@
 
 ## [Unreleased]
 
-### Changed
+## [0.6.0-rc3] - 2026-08-31
 
-- **`panic()` in main context unwinds with cleanup.** A panic outside an actor
-  now runs the same drop obligations and `#[resource]` closes as a panic inside
-  one, instead of ending the process with them skipped. The panic status and the
-  message on stderr are unchanged.
+Hew v0.6.0-rc3 is the third release candidate for v0.6. Checked-MIR exit
+cleanup now derives from ownership replay, and the candidate settles several
+actor, wire, machine, and tooling contracts. It intentionally precedes
+remaining post-rc3 edge-owner, generator-ownership, and known-NYI work; an
+accepted-set change after this candidate requires rc4.
 
 ### Changed (breaking)
 
-- **Supervised actors use `ChildRef<T>` handles.** Named child and static-pool
-  accessors no longer return `LocalPid<T>`. A `ChildRef<T>` carries its
-  supervisor identity and child slot, so asks and tells re-resolve the current
-  incarnation after restarts and fail closed while the role is unavailable or
-  permanently stopped.
+- **Record declarations use `type`.** The `record` keyword is removed. Rewrite
+  `record Name { ... }` as `type Name { ... }`, and
+  `record Name(T, U);` as `type Name(T, U);`. (#3064)
+- **Bare variant expressions are errors.** Replace `Variant` with contextual
+  `.Variant` or `Type.Variant`; `hew fmt --migrate --root .` performs the
+  mechanical migration. (#3136)
+- **Supervised actors use `ChildRef<T>` handles.** Named supervised actor-child
+  and static actor-pool member accessors no longer return `LocalPid<T>`: they
+  return `ChildRef<T>`. Nested-supervisor accessors remain `LocalPid<Sub>`. A
+  `ChildRef<T>` carries its supervisor identity and child slot, so asks and
+  tells re-resolve the current incarnation after restarts and fail closed while
+  the role is unavailable or permanently stopped. (#3062)
+- **Optional wire fields must be `Option<T>`.** Change
+  `field: T @N optional` to `field: Option<T> @N optional`; the marker no
+  longer supplies an implicit default. (#3178)
+- **Some fire-and-forget actor calls are result-bearing.** Calls to an actor
+  with `drop_new`, `drop_old`, `fail`, or `coalesce` mailbox policy return
+  `Result<(), SendError>`; handle `MessageLost` when policy discarded,
+  replaced, or coalesced work, and `Full` for `fail`. Unbounded and bounded
+  `block` mailboxes retain the unit-typed cooperative send surface. A
+  `coalesce` fallback cannot be `block`; choose `drop_new`, `drop_old`, or
+  `fail`, or make `block` the top-level overflow policy.
+- **Record values have structural equality, not identity.** `is` is rejected
+  for a record value; use `==`. Ownership markers on tuple-form product
+  declarations are likewise rejected because that form cannot preserve the
+  marker. Use a named `type` or enum for a resource or linear declaration.
+  (#3103, #3133)
+
+### Changed — ownership and compiler correctness
+
+- **Checked-MIR exit cleanup derives from ownership replay.** Direct
+  consuming calls hand their cleanup obligation to the callee on both normal
+  and unwind paths, composite-result joins end the arm owner before publishing
+  the result owner, and checked MIR rejects overlapping exact owners for one
+  place. The retired builder-ledger and per-exit admission paths can no longer
+  disagree with the replay that validates the plan. (#3173)
+- **Ownership-state replay work is bounded and checked.** A memo keyed by the
+  replay inputs avoids repeated whole-function derivations, debug and test
+  builds validate cached answers against fresh replay, and MIR cost gates hold
+  both per-body work and growth with program size. (#3177)
+
+### Changed — wire format
+
+- **Optional wire fields must resolve to `Option<T>`.** The optional marker is
+  an admission rule after aliases and imports resolve; it does not introduce an
+  implicit default. Update a marked field whose type is not `Option<T>`. (#3178)
+- **Wire key presence is distinct from an `Option` value.** CBOR and text
+  codecs carry required or optional field presence independently from a null
+  `Option` encoding, reject presence-compatibility flips, and fail closed when
+  required metadata or keys are absent. (#3182, fixes #3179)
+
+### Fixed — runtime, machine, and tooling correctness
+
+- **Native main-context panics unwind with cleanup.** Native targets run the
+  same drop obligations and `#[resource]` closes as actor panics before exit.
+  `wasm32` main-context panic cleanup remains divergent while portable WASM
+  exception handling is unavailable (#3155; wasm32 follow-up #3150).
+- **Crash and wake paths retain their live incarnation.** Crash reclamation is
+  the sole owner of an abandoned coroutine frame, crash reports identify the
+  actor and handler, and readiness wakes resolve an actor incarnation instead
+  of a reused address. A channel send whose drain cannot complete fails closed.
+- **Imported machines resolve as declared.** Contextual variants in an imported
+  machine body work, package imports export both a machine and its event
+  companion, and event payload types participate in derived-marker checks.
+- **Every compiler host uses one session.** CLI, LSP, WASM, and fuzzing agree on
+  lowering and backend-front checks; LSP paths round-trip through file URIs,
+  and `hew run`/`hew debug` use a sweepable temporary home. (#3166)
+
+### Validation
+
+- **Multi-module compiler regressions are covered.** The regression corpus
+  exercises indirect ownership, imported supervised-child layouts, first-path
+  symlink ownership, collection reassignment, and wire JSON behaviour. (#3180)
 
 ## [0.6.0-rc2] - 2026-08-24
 

--- a/docs/releases/v0.6.0-rc3.md
+++ b/docs/releases/v0.6.0-rc3.md
@@ -1,0 +1,100 @@
+# Hew v0.6.0-rc3
+
+Hew v0.6.0-rc3 is the third release candidate for v0.6.0. It is not the final
+v0.6.0 release. Checked-MIR exit cleanup now derives from ownership replay, and
+this candidate settles several language and runtime contracts around records,
+actors, wire fields, and imported machines.
+
+## Supported in this candidate
+
+- **Records use `type`.** The `record` declaration keyword is removed. Rewrite
+  `record Name { ... }` as `type Name { ... }`, and
+  `record Name(T, U);` as `type Name(T, U);`.
+- **Variants use a dotted expression form.** Bare variants in expression
+  position are rejected. Use contextual `.Variant` or `Type.Variant`; run
+  `hew fmt --migrate --root .` to perform the source migration.
+- **Supervised children use restart-aware handles.** Named supervised
+  actor-child and static actor-pool member accessors return `ChildRef<T>`, not
+  `LocalPid<T>`. Nested-supervisor accessors remain `LocalPid<Sub>`. The child
+  handle carries the supervisor identity and child slot, so calls resolve the
+  current incarnation after a restart and fail closed while the role is
+  unavailable or stopped. (#3062)
+- **Mailbox policy is visible in the actor call type.** An unbounded or bounded
+  `block` mailbox has the ordinary unit-typed cooperative send surface. A
+  `drop_new`, `drop_old`, `fail`, or `coalesce` policy returns
+  `Result<(), SendError>`: `MessageLost` reports discarded, replaced, or
+  coalesced work, and `Full` reports a `fail` policy rejection.
+- **Wire presence is explicit.** A field declared `optional` must have type
+  `Option<T>`: migrate `field: T @N optional` to
+  `field: Option<T> @N optional`. Required and optional key presence is
+  independent of an `Option` null value across CBOR and text codecs. Missing
+  required metadata or keys fail closed, and compatibility cannot flip field
+  presence.
+- **Ownership cleanup has one checked source.** Checked MIR derives exit cleanup
+  from the ownership-event replay it validates. Consuming calls transfer cleanup
+  on normal and unwind paths, and a composite-result join ends an arm owner
+  before the result owner begins. Owner-state replay is memoized and guarded by
+  fresh-replay and cost checks.
+- **Imported machine and compiler-host paths agree.** Imported machine bodies
+  resolve contextual variants, package imports expose machines and their event
+  companions, and their event payloads participate in marker derivation. CLI,
+  LSP, WASM, and fuzzing use one compiler session; the LSP preserves file URIs,
+  while `hew run` and `hew debug` use a sweepable temporary home.
+- **Crash and channel paths fail closed.** Crash reclamation remains the sole
+  owner of an abandoned coroutine frame, actor crash reports identify the actor
+  and handler, wakeups are tied to an actor incarnation rather than an address,
+  and a channel send fails when its drain cannot complete.
+- **Native main-context panics clean up.** On native targets, `panic()` in
+  `main` unwinds through the generated cleanup path before the process exits.
+  This does not yet extend to wasm32: without portable WASM exception handling,
+  a non-actor panic there still exits without cleanup (#3155; wasm32 follow-up
+  #3150).
+
+## Deliberate refusals and candidate limits
+
+These cases fail closed rather than compiling to an unowned or
+platform-dependent result.
+
+- `is` is not defined for record values; use structural `==`. Ownership markers
+  on tuple-form product declarations are rejected; use a named `type` or enum
+  when the declaration needs a resource or linear contract.
+- `#[resource]` and `#[linear]` values cannot be stored in machine-state
+  payloads until machine lifecycle release is wired. Keep the resource outside
+  the machine and pass a handle through transitions.
+- A borrowed element of a live collection cannot be returned, explicitly
+  closed, or transferred into another owner. Read through the borrow or move an
+  independently owned value instead.
+- An ownership transfer that would require an unproven inline-composite
+  field-drop pairing is rejected. Keep the composite owned at its original
+  scope or move the composite as a whole.
+- An `optional` wire field whose type is not `Option<T>`, a missing required
+  wire key, or a required/optional compatibility flip is rejected. A null
+  `Option` value is not a substitute for key presence.
+- A `coalesce` mailbox cannot use `block` as its fallback. Choose `drop_new`,
+  `drop_old`, or `fail`, or declare `block` as the top-level overflow policy.
+- On `wasm32-wasi`, the bounded nonblocking channel slice remains available:
+  `channel.new`, sender `send`/clone/close, and receiver `try_recv`/close.
+  Blocking receiver operations and unsupported I/O streams remain compile-time
+  refusals rather than silently emulated capabilities.
+
+## Candidate boundary and validation
+
+rc3 intentionally precedes remaining post-rc3 edge-owner,
+generator-ownership, and known-NYI work. It does not claim those ownership
+surfaces are complete. Promotion still requires an exercised published
+candidate and release qualification. Any later change that materially alters
+the set or meaning of accepted programs requires rc4 rather than being silently
+folded into v0.6.0.
+
+Validation includes multi-module compiler regressions for indirect ownership,
+imported supervised-child layouts, first-path symlink ownership, collection
+reassignment, and wire JSON behaviour.
+
+## Candidate publication
+
+Publication remains staged. The signed tag publishes platform assets and
+checksums first. npm consumers are then published manually through
+`.github/workflows/publish-npm-packages.yml`; npm publication is not inferred
+from the tag. Before tagging, the release process validates the versioned
+playground image against the exact clean Hew candidate and records its registry
+digest as release evidence. Homebrew intentionally skips prerelease tags.


### PR DESCRIPTION
## Summary

- move the complete post-rc2 user-visible changes into the v0.6.0-rc3 changelog
- add the rc3 release record with migrations, fail-closed candidate limits, and staged publication guidance
- state the post-rc3 ownership and zero-NYI boundary without claiming C2 or final work has landed

## Validation

- independent release-record review: GO with no P0, P1, or P2 findings
- workspace version: 0.6.0-rc3
- release filename/title and fresh Unreleased section checked
- legacy path syntax lint and diff check pass
- signed clean commit rebased on merged PR #3184

## Candidate discipline

This record must merge through normal CI before the immutable rc3 candidate SHA is captured. The tag remains held until fresh main CI, local parity/artifact/ASan evidence, the cross-platform release gate, and the playground digest/signing handoff all qualify that same SHA.