### PR TITLE
ci: make ratchet recoveries non-blocking

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -93,6 +93,10 @@ jobs:
             rustup run 1.96.0 rustc --version | grep -q '^rustc 1\.96\.0 '
             rustup target list --toolchain 1.96.0 --installed | grep -qx wasm32-wasip1
             export MAKE=gmake
+            # The scheduled FreeBSD run is the accounting authority for
+            # FreeBSD-scoped nextest ledger entries. Manual runs retain the
+            # PR-friendly recovery-reporting behavior.
+            export RATCHET_STRICT_RECOVERIES="${{ github.event_name == 'schedule' && '1' || '0' }}"
             /usr/local/llvm22/bin/llvm-config --version
             command -v gdb || command -v lldb || {
               echo "No debugger found: install the FreeBSD gdb package or LLVM's lldb package" >&2

--- a/.github/workflows/nightly-ratchet-accounting.yml
+++ b/.github/workflows/nightly-ratchet-accounting.yml
@@ -1,0 +1,215 @@
+name: Nightly ratchet accounting
+
+on:
+  schedule:
+    # Offset from the sanitizer and coverage nightlies so the heavyweight
+    # compiler build does not contend with their runner provisioning.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+env:
+  LLVM_VERSION: "22.1.5"
+  WASMTIME_VERSION: "v47.0.2"
+  CARGO_TERM_COLOR: always
+  RATCHET_STRICT_RECOVERIES: "1"
+  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+
+jobs:
+  account-linux:
+    name: Strict global ratchet accounting (Linux)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Free runner disk
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/share/swift || true
+          sudo docker system prune -af >/dev/null 2>&1 || true
+          df -h /
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gdb libssl-dev pkg-config mold zlib1g-dev libzstd-dev
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        uses: ./.github/actions/setup-llvm
+        with:
+          version: ${{ env.LLVM_VERSION }}
+
+      - uses: ./.github/actions/setup-rust-build
+        with:
+          targets: "wasm32-unknown-unknown, wasm32-wasip1"
+          tools: nextest@0.9.120
+          cache-shared-key: nightly-ratchet-accounting
+
+      - name: Install wasmtime
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          WASMTIME_DIR="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          WASMTIME_ROOT="${RUNNER_TEMP}/wasmtime"
+          mkdir -p "${WASMTIME_ROOT}"
+          .github/scripts/retry-download.sh \
+            gh release download "$WASMTIME_VERSION" --repo bytecodealliance/wasmtime \
+            --pattern "${WASMTIME_DIR}.tar.xz" --dir "${RUNNER_TEMP}" --clobber
+          tar -xJf "${RUNNER_TEMP}/${WASMTIME_DIR}.tar.xz" -C "${WASMTIME_ROOT}"
+          echo "${WASMTIME_ROOT}/${WASMTIME_DIR}" >> "$GITHUB_PATH"
+          "${WASMTIME_ROOT}/${WASMTIME_DIR}/wasmtime" --version
+
+      - name: Account for global expected-failure ledgers
+        run: make ratchet-accounting
+
+      - name: Upload ratchet JUnit reports
+        if: always()
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+        with:
+          report_paths: "{target/nextest/ci/ratchet.xml,target/hew-test-reports/hew-suite-ratchet.xml}"
+          check_name: Nightly Ratchet Accounting
+          fail_on_failure: true
+          fail_on_parse_error: true
+          require_tests: true
+
+  # Platform-scoped nextest rows are checked on their native hosts. Keep this
+  # in sync with the ledger selectors: adding a new platform-specific selector
+  # requires a scheduled strict job for that platform.
+  account-macos-nextest:
+    name: Strict nextest accounting (macOS arm64)
+    runs-on: macos-14
+    # This intentionally includes the oracle binaries excluded from ordinary
+    # hosted macOS CI; full native ledger authority needs their outcomes.
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - uses: ./.github/actions/setup-rust-build
+        with:
+          targets: "aarch64-apple-darwin, x86_64-apple-darwin, wasm32-wasip1"
+          tools: nextest@0.9.120
+          cache-shared-key: nightly-ratchet-accounting-macos
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        uses: ./.github/actions/setup-llvm
+        with:
+          version: ${{ env.LLVM_VERSION }}
+
+      - name: Set macOS deployment target
+        run: echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
+
+      - name: Install wasmtime
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          WASMTIME_DIR="wasmtime-${WASMTIME_VERSION}-aarch64-macos"
+          WASMTIME_ROOT="${RUNNER_TEMP}/wasmtime"
+          mkdir -p "${WASMTIME_ROOT}"
+          .github/scripts/retry-download.sh \
+            gh release download "$WASMTIME_VERSION" --repo bytecodealliance/wasmtime \
+            --pattern "${WASMTIME_DIR}.tar.xz" --dir "${RUNNER_TEMP}" --clobber
+          tar -xJf "${RUNNER_TEMP}/${WASMTIME_DIR}.tar.xz" -C "${WASMTIME_ROOT}"
+          echo "${WASMTIME_ROOT}/${WASMTIME_DIR}" >> "$GITHUB_PATH"
+          "${WASMTIME_ROOT}/${WASMTIME_DIR}/wasmtime" --version
+
+      - name: Account for macOS nextest ledger entries
+        run: make ratchet-accounting-nextest
+
+      - name: Upload nextest ratchet report
+        if: always()
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+        with:
+          report_paths: target/nextest/ci/ratchet.xml
+          check_name: Nightly macOS Nextest Ratchet Accounting
+          fail_on_failure: true
+          fail_on_parse_error: true
+          require_tests: true
+
+  account-windows-nextest:
+    name: Strict nextest accounting (Windows)
+    runs-on: windows-2022
+    timeout-minutes: 120
+    env:
+      # aws-lc-sys needs NASM for its Windows MSVC bootstrap. The prebuilt
+      # assembly path is the regular Windows suite's documented prerequisite.
+      AWS_LC_SYS_PREBUILT_NASM: "1"
+      # Windows LLVM/codegen compilation reaches its memory envelope with two
+      # concurrent jobs; this matches the regular Windows full-suite gate.
+      CARGO_BUILD_JOBS: "2"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Setup MSVC environment
+        uses: ./.github/actions/setup-msvc
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        uses: ./.github/actions/setup-llvm
+        with:
+          version: ${{ env.LLVM_VERSION }}
+
+      - uses: ./.github/actions/setup-rust-build
+        with:
+          targets: wasm32-wasip1
+          tools: nextest@0.9.120
+          cache-shared-key: nightly-ratchet-accounting-windows
+
+      - name: Install GNU Make
+        shell: pwsh
+        run: choco install make --yes --no-progress
+
+      - name: Install wasmtime
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $dir = "wasmtime-${env:WASMTIME_VERSION}-x86_64-windows"
+          $archive = Join-Path $env:RUNNER_TEMP "$dir.zip"
+          $root = Join-Path $env:RUNNER_TEMP "wasmtime"
+          gh release download "${env:WASMTIME_VERSION}" --repo bytecodealliance/wasmtime --pattern "$dir.zip" --dir $env:RUNNER_TEMP --clobber
+          if ($LASTEXITCODE -ne 0) { throw "downloading $dir.zip from bytecodealliance/wasmtime failed" }
+          Expand-Archive -Path $archive -DestinationPath $root -Force
+          $wasmtimeBin = Join-Path $root $dir
+          $wasmtimeExe = Join-Path $wasmtimeBin "wasmtime.exe"
+          if (-not (Test-Path -LiteralPath $wasmtimeExe)) { throw "wasmtime.exe not found at $wasmtimeExe" }
+          Add-Content -Path $env:GITHUB_PATH -Value $wasmtimeBin
+          & $wasmtimeExe --version
+          if ($LASTEXITCODE -ne 0) { throw "wasmtime installed but --version exited $LASTEXITCODE" }
+          $wasmLd = Get-Command wasm-ld -ErrorAction SilentlyContinue
+          if (-not $wasmLd) { throw "wasm-ld not found on PATH" }
+          & $wasmLd.Source --version
+          if ($LASTEXITCODE -ne 0) { throw "wasm-ld --version exited $LASTEXITCODE" }
+
+      - name: Account for Windows nextest ledger entries
+        shell: bash
+        run: make SHELL=bash ratchet-accounting-nextest
+
+      - name: Upload nextest ratchet report
+        if: always()
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+        with:
+          report_paths: target/nextest/ci/ratchet.xml
+          check_name: Nightly Windows Nextest Ratchet Accounting
+          fail_on_failure: true
+          fail_on_parse_error: true
+          require_tests: true

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks help shell-script-lint actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
-.PHONY: test test-strict macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
+.PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
 .PHONY: test-ownership-balance-corpus test-ownership-balance-runner-selftest
 .PHONY: stdlib-user-build-clean
 .PHONY: clean install uninstall verify-ffi ffi-ownership-ratchet-record test-verify-ffi test-cabi-surface cabi-surface cabi-surface-check
@@ -238,6 +238,8 @@ endif
 NEXTEST_JUNIT := $(CARGO_TARGET_ROOT)/nextest/ci/junit.xml
 NEXTEST_RATCHET_JUNIT := $(CARGO_TARGET_ROOT)/nextest/ci/ratchet.xml
 NEXTEST_FAILURE_LEDGER := scripts/nextest-expected-failures.tsv
+RATCHET_STRICT_RECOVERIES ?= 0
+RATCHET_STRICT_RECOVERIES_ARG := $(if $(filter 1 true yes,$(RATCHET_STRICT_RECOVERIES)),--strict-recoveries,)
 
 ifndef NEXTEST_PLATFORM
 ifeq ($(OS),Windows_NT)
@@ -698,9 +700,9 @@ fuzz-corpus:
 FUZZ_ORACLE_FULL ?=
 fuzz-oracle: hew-native
 	@if [ -n "$(FUZZ_ORACLE_FULL)" ]; then \
-		$(PYTHON) scripts/fuzz/run-oracle.py --hew "$(DEBUG_DIR)/hew" --full --timeout 30; \
+		$(PYTHON) scripts/fuzz/run-oracle.py --hew "$(DEBUG_DIR)/hew" --full --timeout 30 $(RATCHET_STRICT_RECOVERIES_ARG); \
 	else \
-		$(PYTHON) scripts/fuzz/run-oracle.py --hew "$(DEBUG_DIR)/hew" --timeout 30; \
+		$(PYTHON) scripts/fuzz/run-oracle.py --hew "$(DEBUG_DIR)/hew" --timeout 30 $(RATCHET_STRICT_RECOVERIES_ARG); \
 	fi
 
 # Oracle self-tests: five independently-failable checks that prove the
@@ -978,11 +980,24 @@ test: test-artifacts ## Test: run the ratcheted Rust workspace test suite
 			--ledger "$(NEXTEST_FAILURE_LEDGER)" \
 			--output "$(NEXTEST_RATCHET_JUNIT)" \
 			--platform "$(NEXTEST_PLATFORM)" \
-			--runner-exit "$$status" $(NEXTEST_RATCHET_INVENTORY_ARGS)
+			--runner-exit "$$status" $(NEXTEST_RATCHET_INVENTORY_ARGS) $(RATCHET_STRICT_RECOVERIES_ARG)
 
 test-strict: test-artifacts ## Test: run the Rust workspace test suite with no known failures
 	@rm -f "$(NEXTEST_JUNIT)" "$(NEXTEST_RATCHET_JUNIT)" "$(NEXTEST_FULL_INVENTORY)" "$(NEXTEST_SELECTED_INVENTORY)"
 	$(TEST_RUN_ENV) cargo nextest run $(NEXTEST_WORKSPACE_ARGS)
+
+# Scheduled ledger authority. Each family runs independently so a red first
+# family cannot suppress reports from the later ledgers.
+ratchet-accounting: ## Check: strict expected-failure ledger accounting
+	RATCHET_STRICT_RECOVERIES=1 RATCHET_ACCOUNTING_MAKE="$(MAKE)" scripts/ratchet-accounting.sh
+
+# Platform-scoped nextest ledger entries receive their own scheduled jobs.
+# This target owns strict mode rather than relying on workflow environment.
+ratchet-accounting-nextest: ## Check: strict nextest expected-failure accounting
+	RATCHET_STRICT_RECOVERIES=1 $(MAKE) test
+
+test-ratchet-accounting-runner: ## Test: accounting runner executes all families after failures
+	TMPDIR="$${TMPDIR:-/tmp}" scripts/tests/test_ratchet_accounting_runner.sh
 
 # Canonical local macOS memory authority. This is deliberately named as a local
 # authority, not a CI `test-*` gate: hosted macOS processes cannot grant
@@ -1158,10 +1173,10 @@ test-runtime-unit:
 #
 # These targets run the suites through scripts/corpus-ratchet.sh, which
 # compares the set of failing tests against an exhaustive tracked-failures
-# list.  Any unexpected failure or unexpected
-# pass causes the gate to exit 1.  When the converging lanes land and the
-# tracked failures drop to zero, delete the list entries; the ratchets then
-# pass with no tracking overhead.
+# list. Unexpected failures fail every gate; recovered tracked failures are
+# reported in PRs and fail only when RATCHET_STRICT_RECOVERIES=1. When the
+# converging lanes land and tracked failures drop to zero, delete the list
+# entries; the ratchets then pass with no tracking overhead.
 #
 # HEW_O0_OUTCOMES_FILE, when set, wires the ratchet's O0 outcome capture into
 # test-o2-differential's O0 baseline so the differential gate does not re-run
@@ -1175,7 +1190,7 @@ test-hew-ratchet:
 	$(PYTHON) scripts/compiled-hew-shards.py aggregate --mode ratchet \
 		--reports-dir "$(HEW_SHARD_REPORT_DIR)" \
 		--full-inventory "$(HEW_FULL_INVENTORY)" \
-		--shard-count "$(HEW_SHARD_COUNT)"
+		--shard-count "$(HEW_SHARD_COUNT)" $(RATCHET_STRICT_RECOVERIES_ARG)
 
 # The shard-aggregate form reads reports; it builds nothing.
 else
@@ -1205,7 +1220,7 @@ test-core-matrix: hew-native
 	$(PYTHON) scripts/core-matrix-gen.py --out "$(CURDIR)/.tmp/core-matrix-regen"
 	diff -r tests/core-matrix/cells "$(CURDIR)/.tmp/core-matrix-regen"
 	@echo "==> Running the core matrix (primitive x operation)"
-	HEW_BIN="$(DEBUG_DIR)/hew" $(PYTHON) scripts/core-matrix.py
+	HEW_BIN="$(DEBUG_DIR)/hew" $(PYTHON) scripts/core-matrix.py $(RATCHET_STRICT_RECOVERIES_ARG)
 
 # Regen seam: driven only by an explicit
 # `make core-matrix-record`.

--- a/scripts/compiled-hew-shards.py
+++ b/scripts/compiled-hew-shards.py
@@ -176,6 +176,7 @@ def finalize_reports(
     full_inventory: Path,
     expected_failures_path: Path,
     prerequisites_succeeded: bool,
+    strict_recoveries: bool,
 ) -> int:
     """Prepare the JUnit input for GitHub after raw aggregate gates finish."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -194,22 +195,54 @@ def finalize_reports(
         full = set(read_inventory(full_inventory))
         expected = expected_failures(expected_failures_path, full)
         actual: dict[str, str] = {}
+        o0_outcomes: dict[str, str] = {}
+        o2_outcomes: dict[str, str] = {}
         parsed_reports: list[tuple[Path, JUnitReport]] = []
         for report in reports:
             parsed = parse_hew_junit(report, REPO_ROOT)
             parsed_reports.append((report, parsed))
-            if "hew-o0-" not in report.name:
-                continue
             for testcase in parsed.testcases:
                 identity = normalized_identity(testcase.classname, testcase.name)
-                if identity in actual:
-                    die(f"finalization report has duplicate identity: {identity}")
-                if testcase.failure_kind is not None:
-                    actual[identity] = testcase.failure_kind
-        if set(actual) != set(expected):
-            die("finalization failure set differs from the ratchet")
-        for identity, expected_kind in expected.items():
-            if actual[identity] != expected_kind:
+                outcome = testcase.failure_kind or testcase.outcome
+                if "hew-o0-" in report.name:
+                    if identity in o0_outcomes:
+                        die(
+                            f"finalization report has duplicate O0 identity: {identity}"
+                        )
+                    o0_outcomes[identity] = outcome
+                    if testcase.failure_kind is not None:
+                        actual[identity] = testcase.failure_kind
+                elif "hew-o2-" in report.name:
+                    if identity in o2_outcomes:
+                        die(
+                            f"finalization report has duplicate O2 identity: {identity}"
+                        )
+                    o2_outcomes[identity] = outcome
+        unexpected = set(actual) - set(expected)
+        recovered = {
+            identity
+            for identity in expected
+            if o0_outcomes.get(identity) == "ok" and o2_outcomes.get(identity) == "ok"
+        }
+        nonpassing = set(expected) - set(actual) - recovered
+        if unexpected:
+            die(f"finalization has untracked failures: {sorted(unexpected)[:5]}")
+        if recovered:
+            print(
+                "compiled-Hew recovery accounting: tracked failures now pass: "
+                + ", ".join(sorted(recovered)[:5]),
+                file=sys.stderr,
+            )
+            if strict_recoveries:
+                die("finalization found recoveries under strict accounting")
+        if nonpassing:
+            die(
+                "finalization expected entries did not PASS in both O0 and O2: "
+                f"{sorted(nonpassing)[:5]}"
+            )
+        for identity, actual_kind in actual.items():
+            expected_kind = expected[identity]
+            if actual_kind != expected_kind:
                 die(f"finalization failure kind differs from the ratchet: {identity}")
 
         for source, parsed in parsed_reports:
@@ -218,7 +251,7 @@ def finalize_reports(
                 identity = normalized_identity(
                     testcase.get("classname", ""), testcase.get("name", "")
                 )
-                if identity not in expected:
+                if identity not in actual:
                     continue
                 failure = testcase.find("failure")
                 if failure is None or failure.get("type") != expected[identity]:
@@ -392,6 +425,7 @@ def aggregate(
     full_inventory: Path,
     shard_count: int,
     expected_failures_path: Path,
+    strict_recoveries: bool,
 ) -> None:
     if shard_count < 2:
         die("shard count must be at least two")
@@ -406,15 +440,31 @@ def aggregate(
             for identity, outcome in o0.items()
             if outcome in FAILURE_KINDS
         }
-        if set(actual) != set(expected):
+        unexpected = set(actual) - set(expected)
+        recovered = {
+            identity
+            for identity in expected
+            if o0.get(identity) == "ok" and o2.get(identity) == "ok"
+        }
+        nonpassing = set(expected) - set(actual) - recovered
+        if unexpected:
+            die(f"O0 shard has untracked failures: unexpected={sorted(unexpected)[:5]}")
+        if recovered:
+            print(
+                "compiled-Hew recovery accounting: tracked failures now pass: "
+                + ", ".join(sorted(recovered)[:5]),
+                file=sys.stderr,
+            )
+            if strict_recoveries:
+                die("O0 shard found recoveries under strict accounting")
+        if nonpassing:
             die(
-                "O0 shard failure set differs from the ratchet: "
-                f"unexpected={sorted(set(actual) - set(expected))[:5]} "
-                f"now_passing={sorted(set(expected) - set(actual))[:5]}"
+                "O0 shard expected entries did not PASS in both O0 and O2: "
+                f"{sorted(nonpassing)[:5]}"
             )
         kind_differences = [
             f"{identity}: expected={expected[identity]} actual={actual[identity]}"
-            for identity in sorted(expected)
+            for identity in sorted(actual)
             if actual[identity] != expected[identity]
         ]
         if kind_differences:
@@ -454,6 +504,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     aggregate_parser.add_argument(
         "--mode", choices=("ratchet", "differential"), required=True
     )
+    aggregate_parser.add_argument("--strict-recoveries", action="store_true")
     aggregate_parser.add_argument("--reports-dir", type=Path, required=True)
     aggregate_parser.add_argument("--full-inventory", type=Path, required=True)
     aggregate_parser.add_argument("--shard-count", type=int, required=True)
@@ -474,6 +525,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         type=Path,
         default=REPO_ROOT / "scripts" / "hew-suite-expected-failures.txt",
     )
+    finalize_parser.add_argument("--strict-recoveries", action="store_true")
     finalize_parser.add_argument(
         "--prerequisites-succeeded",
         choices=("true", "false"),
@@ -493,6 +545,7 @@ def main(argv: list[str]) -> int:
             args.full_inventory,
             args.shard_count,
             args.expected_failures,
+            args.strict_recoveries,
         )
     elif args.action == "finalize":
         return finalize_reports(
@@ -501,6 +554,7 @@ def main(argv: list[str]) -> int:
             args.full_inventory,
             args.expected_failures,
             args.prerequisites_succeeded == "true",
+            args.strict_recoveries,
         )
     else:
         report_failures(args.reports_dir, args.shard_count)

--- a/scripts/core-matrix.py
+++ b/scripts/core-matrix.py
@@ -15,9 +15,9 @@ class the cell has TODAY:
     NYI-INTERNAL    rejected with compiler internals in the message
     CRASH           aborted, trapped, hung, or failed to link
 
-The gate fails on ANY drift in either direction: a PASS cell that stops
-passing is a regression, and a non-PASS cell that starts passing means the
-table is stale and must be updated (that is the ratchet).
+The gate fails on regressions. A non-PASS cell that starts passing is reported
+as a recovered truth-table entry in PR runs, and is made blocking only by
+--strict-recoveries in scheduled accounting.
 
 Usage:
     python3 scripts/core-matrix.py            # gate against matrix.tsv
@@ -205,6 +205,11 @@ def write_matrix(results):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--record", action="store_true")
+    ap.add_argument(
+        "--strict-recoveries",
+        action="store_true",
+        help="fail when a recorded non-PASS cell now passes",
+    )
     args = ap.parse_args()
 
     if not os.path.exists(HEW):
@@ -268,13 +273,14 @@ def main():
         for r in regressions:
             print(f"  {r}", file=sys.stderr)
     if fixes:
-        ok = False
         print(
-            "cells that now PASS -- update the truth table with --record:",
+            "RECOVERIES: cells now PASS -- update the truth table with --record:",
             file=sys.stderr,
         )
         for r in fixes:
             print(f"  {r}", file=sys.stderr)
+        if args.strict_recoveries:
+            ok = False
 
     counts = {}
     for klass, _ in results.values():

--- a/scripts/corpus-ratchet.sh
+++ b/scripts/corpus-ratchet.sh
@@ -3,9 +3,10 @@
 #
 # A corpus ratchet answers one question: does the set of things that FAIL right
 # now exactly equal the set recorded in an expected-failures file? A new failure
-# is a regression; a listed failure that now passes is an accepted fix nobody
-# recorded. Both are hard errors, so the tracked-failure list stays an honest
-# record of the system's failure models instead of decaying into an allowlist.
+# is a regression; a listed failure that now passes is a recovery that needs
+# its ledger row removed. Regressions are hard errors in every invocation.
+# Recoveries are reported but non-blocking in PR gates, and become hard errors
+# only when RATCHET_STRICT_RECOVERIES=1 (the scheduled ledger-accounting run).
 #
 # Four gates asked that question in four separate scripts:
 #
@@ -84,9 +85,10 @@ usage() {
     cat <<'EOF'
 Usage: scripts/corpus-ratchet.sh <corpus> [options]
 
-Run a corpus and assert its failing set exactly matches the tracked
-expected-failures list.  Exits 0 on an exact match, 1 on any deviation:
-an unexpected failure (regression) or an unexpected pass (unrecorded fix).
+Run a corpus and assert it has no failures outside the tracked
+expected-failures list. Exits 1 for a regression, infrastructure drift, or
+when a scheduled strict run finds a recovered entry still in the ledger.
+Ordinary PR runs report recovered entries and exit 0.
 
 Corpora:
   hew-suite    `hew test tests/hew/`               (make test-hew-ratchet)
@@ -204,6 +206,14 @@ done
 # Makefile with an explicit HEW_BIN, so the resolved default is the correct one
 # for every corpus and the literal is not preserved.
 HEW_BIN="${HEW_BIN_ARG:-${HEW_BIN:-$(cargo_debug_dir "$REPO_ROOT")/hew}}"
+RATCHET_STRICT_RECOVERIES="${RATCHET_STRICT_RECOVERIES:-0}"
+case "$RATCHET_STRICT_RECOVERIES" in
+0 | 1) ;;
+*)
+    echo "error: RATCHET_STRICT_RECOVERIES must be 0 or 1" >&2
+    exit 1
+    ;;
+esac
 
 require_hew_bin() {
     if [[ ! -f "$HEW_BIN" ]]; then
@@ -222,6 +232,13 @@ require_hew_bin() {
 # remains the ratchet identity; the second field is corpus-specific metadata.
 EXPECTED_STR=""
 ACTUAL_STR=""
+# The complete selected corpus, populated by each runner before outcome
+# comparison. An expected row absent here is an inventory/configuration error,
+# not evidence that a test recovered.
+RATCHET_INVENTORY_STR=""
+# Only an observed ordinary PASS may discharge an expected-failure row. An
+# ignored test or skipped doc fence remains a hard ledger/inventory defect.
+RATCHET_PASSED_STR=""
 EXPECTED_DIAGNOSTICS_STR=""
 EXPECTED_DIAGNOSTIC_CODE=""
 EXPECTED_FAILURE_KINDS_STR=""
@@ -337,6 +354,20 @@ set_difference() {
     printf '%s' "$out"
 }
 
+set_intersection() {
+    local present="$1"
+    local against="$2"
+    local entry
+    local out=""
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        if line_set_contains "$against" "$entry"; then
+            out="${out}${entry}"$'\n'
+        fi
+    done <<<"$present"
+    printf '%s' "$out"
+}
+
 count_set() {
     local set="$1"
     [[ -z "$set" ]] && {
@@ -377,15 +408,20 @@ record_expected_refusal_status() {
 
 # Compare EXPECTED_STR against ACTUAL_STR and exit with the gate's verdict.
 ratchet_verdict() {
-    local unexpected_failures unexpected_passes
-    local count_actual count_unexpected_fail count_unexpected_pass count_refusal_drift
+    local unexpected_failures recovered missing_expected nonpassing_expected
+    local count_actual count_unexpected_fail count_recovered count_missing_expected count_nonpassing_expected count_refusal_drift
     local entry status sorted_actual
 
     unexpected_failures="$(set_difference "$ACTUAL_STR" "$EXPECTED_STR")"
-    unexpected_passes="$(set_difference "$EXPECTED_STR" "$ACTUAL_STR")"
+    recovered="$(set_intersection "$EXPECTED_STR" "$RATCHET_PASSED_STR")"
+    missing_expected="$(set_difference "$EXPECTED_STR" "$RATCHET_INVENTORY_STR")"
+    nonpassing_expected="$(set_difference "$(set_difference "$EXPECTED_STR" "$ACTUAL_STR")" "$RATCHET_PASSED_STR")"
+    nonpassing_expected="$(set_difference "$nonpassing_expected" "$missing_expected")"
     count_actual="$(count_set "$ACTUAL_STR")"
     count_unexpected_fail="$(count_set "$unexpected_failures")"
-    count_unexpected_pass="$(count_set "$unexpected_passes")"
+    count_recovered="$(count_set "$recovered")"
+    count_missing_expected="$(count_set "$missing_expected")"
+    count_nonpassing_expected="$(count_set "$nonpassing_expected")"
     count_refusal_drift="$(count_set "$RATCHET_REFUSAL_DRIFT_STR")"
 
     RATCHET_EXTRA_FAIL_COUNT=0
@@ -393,8 +429,25 @@ ratchet_verdict() {
         "$RATCHET_EXTRA_FAIL_FN" detect
     fi
 
-    if ((count_unexpected_fail == 0 && count_unexpected_pass == 0 && \
+    if ((count_unexpected_fail == 0 && count_missing_expected == 0 && \
+        count_nonpassing_expected == 0 && \
         count_refusal_drift == 0 && RATCHET_EXTRA_FAIL_COUNT == 0)); then
+        if ((count_recovered > 0)); then
+            echo "${RATCHET_VERDICT_LABEL}: $count_recovered tracked failure(s) now PASS — ledger cleanup required:"
+            while IFS= read -r entry; do
+                [[ -z "$entry" ]] && continue
+                echo "  NOW-PASSES: $entry"
+            done <<<"$recovered"
+            echo ""
+            printf '%s\n' "$RATCHET_NOWPASS_HELP"
+            echo ""
+            if ((RATCHET_STRICT_RECOVERIES == 1)); then
+                echo "==> ${RATCHET_VERDICT_LABEL}: FAILED (strict recovery accounting)"
+                exit 1
+            fi
+            echo "==> ${RATCHET_VERDICT_LABEL}: PASSED (recoveries reported)"
+            exit 0
+        fi
         if ((count_actual == 0)); then
             ((RATCHET_ALL_PASS_LEADING_BLANK == 1)) && echo ""
             echo "${RATCHET_INDENT}${RATCHET_ALL_PASS_TEXT}"
@@ -430,14 +483,36 @@ ratchet_verdict() {
         echo ""
     fi
 
-    if ((count_unexpected_pass > 0)); then
-        echo "$RATCHET_FAIL_PREFIX: $count_unexpected_pass listed failure(s) now PASS — remove from list:"
+    if ((count_missing_expected > 0)); then
+        echo "$RATCHET_FAIL_PREFIX: $count_missing_expected expected entry/entries absent from the selected corpus:"
+        while IFS= read -r entry; do
+            [[ -z "$entry" ]] && continue
+            echo "  MISSING-EXPECTED: $entry"
+        done <<<"$missing_expected"
+        echo ""
+        echo "  This is an inventory or fixture-removal error, not a recovered test."
+        echo ""
+    fi
+
+    if ((count_recovered > 0)); then
+        echo "${RATCHET_VERDICT_LABEL}: $count_recovered tracked failure(s) now PASS — ledger cleanup required:"
         while IFS= read -r entry; do
             [[ -z "$entry" ]] && continue
             echo "  NOW-PASSES: $entry"
-        done <<<"$unexpected_passes"
+        done <<<"$recovered"
         echo ""
         printf '%s\n' "$RATCHET_NOWPASS_HELP"
+        echo ""
+    fi
+
+    if ((count_nonpassing_expected > 0)); then
+        echo "$RATCHET_FAIL_PREFIX: $count_nonpassing_expected expected entry/entries did not produce PASS or the pinned failure:"
+        while IFS= read -r entry; do
+            [[ -z "$entry" ]] && continue
+            echo "  NONPASS-EXPECTED: $entry"
+        done <<<"$nonpassing_expected"
+        echo ""
+        echo "  Skipped or otherwise nonterminal entries cannot be treated as recoveries."
         echo ""
     fi
 
@@ -494,7 +569,7 @@ run_hew_suite() {
     read_expected_failures
 
     mkdir -p "$(dirname "$junit_output")"
-    STDERR_FILE="$(mktemp /tmp/hew-suite-ratchet-stderr.XXXXXX)"
+    STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/hew-suite-ratchet-stderr.XXXXXX")"
     fresh_report="${junit_output}.new.$$"
     trap 'rm -f "$STDERR_FILE" "${fresh_report:-}"' EXIT
     rc=0
@@ -550,8 +625,10 @@ run_hew_suite() {
     fi
 
     while IFS=$'\t' read -r status identity failure_kind; do
-        [[ "$status" == "FAILED" ]] || continue
         [[ -n "$identity" ]] || continue
+        RATCHET_INVENTORY_STR="${RATCHET_INVENTORY_STR}${identity}"$'\n'
+        [[ "$status" == "ok" ]] && RATCHET_PASSED_STR="${RATCHET_PASSED_STR}${identity}"$'\n'
+        [[ "$status" == "FAILED" ]] || continue
         ACTUAL_STR="${ACTUAL_STR}${identity}"$'\n'
         if line_set_contains "$EXPECTED_STR" "$identity"; then
             if ! find_expected_failure_kind "$identity"; then
@@ -632,12 +709,15 @@ run_stdlib() {
     while IFS= read -r -d $'\0' f; do
         total=$((total + 1))
         relpath="${f#"$REPO_ROOT"/}"
+        RATCHET_INVENTORY_STR="${RATCHET_INVENTORY_STR}${relpath}"$'\n'
         check_output=""
         check_status=0
         check_output="$("$HEW_BIN" check "$f" 2>&1)" || check_status=$?
         if ((check_status != 0)); then
             ACTUAL_STR="${ACTUAL_STR}${relpath}"$'\n'
             record_expected_refusal_status "$relpath" "$check_status"
+        else
+            RATCHET_PASSED_STR="${RATCHET_PASSED_STR}${relpath}"$'\n'
         fi
         bare_variants=""
         if bare_variants="$(
@@ -781,6 +861,7 @@ run_hew_corpus() {
     corpus_nonempty_assert "hew-corpus-check-files" "$total" || exit 1
 
     for f in "${swept[@]}"; do
+        RATCHET_INVENTORY_STR="${RATCHET_INVENTORY_STR}${f}"$'\n'
         check_index=$((check_index + 1))
         check_log="$HEW_CORPUS_TMPDIR/check-$check_index.log"
         status=0
@@ -807,6 +888,8 @@ run_hew_corpus() {
                     HEW_CORPUS_DIAGNOSTIC_DRIFT="${HEW_CORPUS_DIAGNOSTIC_DRIFT}${f}"$'\t'"${status}"$'\t'"${expected_code}"$'\t'"${actual_codes}"$'\n'
                 fi
             fi
+        else
+            RATCHET_PASSED_STR="${RATCHET_PASSED_STR}${f}"$'\n'
         fi
     done
 
@@ -1047,6 +1130,7 @@ run_doc_fences() {
 
     for ((idx = 0; idx < total_fences; idx++)); do
         fence_id="${DOC_FENCE_IDS[$idx]}"
+        RATCHET_INVENTORY_STR="${RATCHET_INVENTORY_STR}${fence_id}"$'\n'
         is_skip="${DOC_FENCE_SKIPPED[$idx]}"
         outfile="$DOC_FENCE_OUTDIR/${fence_id}.hew"
 
@@ -1067,6 +1151,7 @@ run_doc_fences() {
 
         if [[ "$check_rc" == "0" ]]; then
             pass=$((pass + 1))
+            RATCHET_PASSED_STR="${RATCHET_PASSED_STR}${fence_id}"$'\n'
         else
             fail=$((fail + 1))
             ACTUAL_STR="${ACTUAL_STR}${fence_id}"$'\n'

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -3,7 +3,8 @@
 # These fences currently fail `hew check`. Each entry is tracked here so new
 # failures are always caught, while this known-failing backlog does not block
 # the gate. Remove an entry when the underlying fence is fixed; a fence that
-# was failing but now passes is a ratchet-forward and requires a list update.
+# now passes is reported in PR gates and fails scheduled strict accounting
+# until its list entry is removed.
 #
 # Format: <fence-id> <cksum>  # <root-cause category>: <one-line description>
 #

--- a/scripts/fuzz/oracle-selftest.sh
+++ b/scripts/fuzz/oracle-selftest.sh
@@ -8,9 +8,10 @@
 #   classifies the crash as clean, this test goes red.
 #
 # Test 2 (oracle-honours-expected-failure):
-#   The same crashing program, listed in expected-failures.txt, must be
-#   tolerated (exit 0).  Then, with the file removed while still listed, the
-#   oracle must exit 1 with "expected-failing entry not found".
+#   The same crashing program, listed with its exact runtime-crash class, must
+#   be tolerated. A mismatched class and a missing file must fail closed. A
+#   listed fixture that becomes clean reports recovery in PR mode and fails
+#   under strict accounting.
 #
 # Test 3 (oracle-passes-clean-program):
 #   A program with // EXPECT: 7 must exit 0 with verdict clean.  Mutating
@@ -24,7 +25,7 @@
 # Test 5 (oracle-ratchets-positive-rejections):
 #   An unlisted positive rejection must fail, the exact listed rejection must
 #   pass, and replacing that fixture with a clean program while it remains
-#   listed must fail as an unexpected pass.
+#   listed reports recovery in normal mode and fails strict accounting.
 #
 # All five must pass for the self-test to succeed.
 
@@ -37,7 +38,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${ROOT}/scripts/lib/cargo-output-dir.sh"
 HEW="${HEW_BIN:-$(cargo_debug_dir "${ROOT}")/hew}"
 ORACLE="${ROOT}/scripts/fuzz/run-oracle.py"
-TMPDIR_BASE="$(mktemp -d /tmp/hew-oracle-selftest.XXXXXX)"
+TMPDIR_BASE="$(mktemp -d "${TMPDIR:-/tmp}/hew-oracle-selftest.XXXXXX")"
 trap 'rm -rf "${TMPDIR_BASE}"' EXIT
 
 # Empty directory passed as --vertical-slice-dir so the self-tests only run
@@ -157,9 +158,9 @@ T2_DIR="${TMPDIR_BASE}/t2_regressions"
 mkdir -p "${T2_DIR}"
 printf '%s' "${CRASH_SOURCE}" >"${T2_DIR}/crash_fixture.hew"
 
-# 2a: crash_fixture.hew IS listed — oracle must exit 0 (known gap tolerated).
+# 2a: crash_fixture.hew is listed with its observed class — tolerate it.
 T2_EF="${TMPDIR_BASE}/t2_expected_failures.txt"
-printf 'crash_fixture.hew  # known crash; issue: #test\n' >"${T2_EF}"
+printf 'crash_fixture.hew runtime-crash  # known crash; issue: #test\n' >"${T2_EF}"
 
 rc=0
 run_counterfactual "t2a-listed-crash" python3 "${ORACLE}" \
@@ -175,10 +176,8 @@ if [[ "${rc}" -ne 0 ]]; then
         "expected oracle exit 0, got ${rc}"
 fi
 
-# 2b: Remove crash_fixture.hew from disk while leaving it in expected-failures.
-# Oracle must exit 1 with "expected-failing entry not found".
-rm "${T2_DIR}/crash_fixture.hew"
-
+# 2b: Pinning a different failure class is drift, not a tolerated failure.
+printf 'crash_fixture.hew timeout  # deliberately wrong class\n' >"${T2_EF}"
 rc=0
 output=""
 output="$(python3 "${ORACLE}" \
@@ -188,14 +187,68 @@ output="$(python3 "${ORACLE}" \
     --expected-failures "${T2_EF}" \
     --vertical-slice-dir "${EMPTY_DIR}" \
     --min-candidates 1 \
+    --report "${TMPDIR_BASE}/t2_drift_report.json" \
     2>&1)" || rc=$?
-if [[ "${rc}" -ne 1 ]]; then
-    fail "oracle-honours-expected-failure (2b: missing-but-listed fails gate)" \
-        "expected oracle exit 1, got ${rc}; output: ${output}"
+if [[ "${rc}" -ne 1 || "${output}" != *"EXPECTED FAILURE CLASS DRIFT"* ]]; then
+    fail "oracle-honours-expected-failure (2b: class drift fails gate)" \
+        "expected class-drift failure; output: ${output}"
 fi
-if ! echo "${output}" | grep -q "expected-failing entry not found"; then
-    fail "oracle-honours-expected-failure (2b: missing-but-listed fails gate)" \
-        "expected 'expected-failing entry not found' in output; got: ${output}"
+if ! python3 -c "
+import json, sys
+r = json.load(open('${TMPDIR_BASE}/t2_drift_report.json'))
+d = r['expected_failure_class_drifts']
+sys.exit(0 if len(d) == 1 and d[0]['expected_classification'] == 'timeout' and d[0]['observed_classification'] == 'runtime-crash' else 1)
+"; then
+    fail "oracle-honours-expected-failure (2b: class drift fails gate)" \
+        "JSON report did not preserve expected and observed classes"
+fi
+
+# 2c: A listed fixture absent from selection is an inventory error, not recovery.
+printf 'crash_fixture.hew runtime-crash  # known crash; issue: #test\n' >"${T2_EF}"
+rm "${T2_DIR}/crash_fixture.hew"
+rc=0
+output="$(python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T2_DIR}" \
+    --expected-failures "${T2_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    --min-candidates 1 \
+    2>&1)" || rc=$?
+if [[ "${rc}" -ne 1 || "${output}" != *"expected failure absent from corpus"* ]]; then
+    fail "oracle-honours-expected-failure (2c: missing-but-listed fails gate)" \
+        "expected missing-entry failure; output: ${output}"
+fi
+
+# 2d/2e: Only a genuinely clean fixture recovers. PR mode reports it; strict
+# accounting rejects the stale ledger entry.
+printf '// EXPECT: 7\nfn main() { println(7); }\n' >"${T2_DIR}/crash_fixture.hew"
+rc=0
+output="$(python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T2_DIR}" \
+    --expected-failures "${T2_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    --min-candidates 1 \
+    2>&1)" || rc=$?
+if [[ "${rc}" -ne 0 || "${output}" != *"NOW-PASSES: crash_fixture.hew"* ]]; then
+    fail "oracle-honours-expected-failure (2d: clean recovery reports)" \
+        "expected nonblocking clean recovery; output: ${output}"
+fi
+rc=0
+output="$(python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T2_DIR}" \
+    --expected-failures "${T2_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    --min-candidates 1 \
+    --strict-recoveries \
+    2>&1)" || rc=$?
+if [[ "${rc}" -ne 1 || "${output}" != *"NOW-PASSES: crash_fixture.hew"* ]]; then
+    fail "oracle-honours-expected-failure (2e: strict clean recovery fails)" \
+        "expected strict clean recovery failure; output: ${output}"
 fi
 
 pass "oracle-honours-expected-failure"
@@ -362,8 +415,8 @@ if [[ "${rc}" -ne 0 ]]; then
         "expected oracle exit 0, got ${rc}"
 fi
 
-# 5c (negative control): make the listed fixture clean. The stale entry must
-# fail in the opposite direction so the manifest can only shrink.
+# 5c: make the listed fixture clean. Normal PR mode reports the stale entry
+# without blocking; scheduled strict accounting rejects it.
 printf '// EXPECT: 7\nfn main() { println(7); }\n' \
     >"${T5_VERTICAL}/reject_fixture.hew"
 rc=0
@@ -377,13 +430,17 @@ output="$(python3 "${ORACLE}" \
     --min-candidates 1 \
     --report "${T5_REPORT}" \
     2>&1)" || rc=$?
-if [[ "${rc}" -ne 1 ]]; then
-    fail "oracle-ratchets-positive-rejections (5c: stale reject fails)" \
-        "expected oracle exit 1, got ${rc}; output: ${output}"
+if [[ "${rc}" -ne 0 ]]; then
+    fail "oracle-ratchets-positive-rejections (5c: recovery reports in PR mode)" \
+        "expected oracle exit 0, got ${rc}; output: ${output}"
 fi
 if [[ "${output}" != *"UNEXPECTED PASSES (listed in expected-reject.txt but passed)"* ]]; then
-    fail "oracle-ratchets-positive-rejections (5c: stale reject fails)" \
+    fail "oracle-ratchets-positive-rejections (5c: recovery reports in PR mode)" \
         "unexpected-pass list was not printed; output: ${output}"
+fi
+if [[ "${output}" != *"NOW-PASSES: tests/vertical-slice/accept/reject_fixture.hew"* ]]; then
+    fail "oracle-ratchets-positive-rejections (5c: recovery reports in PR mode)" \
+        "exact recovery identity was not printed; output: ${output}"
 fi
 if ! python3 -c "
 import json, sys
@@ -391,8 +448,29 @@ r = json.load(open('${T5_REPORT}'))
 paths = [entry['path'] for entry in r['unexpected_reject_passes']]
 sys.exit(0 if paths == ['tests/vertical-slice/accept/reject_fixture.hew'] else 1)
 "; then
-    fail "oracle-ratchets-positive-rejections (5c: stale reject fails)" \
+    fail "oracle-ratchets-positive-rejections (5c: recovery reports in PR mode)" \
         "report did not identify the exact unexpected pass; output: ${output}"
+fi
+
+rc=0
+output="$(python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T5_REGRESSIONS}" \
+    --expected-failures "${T5_EF}" \
+    --expected-rejects "${T5_ER}" \
+    --vertical-slice-dir "${T5_VERTICAL}" \
+    --min-candidates 1 \
+    --strict-recoveries \
+    --report "${T5_REPORT}" \
+    2>&1)" || rc=$?
+if [[ "${rc}" -ne 1 ]]; then
+    fail "oracle-ratchets-positive-rejections (5c: strict recovery fails)" \
+        "expected oracle exit 1, got ${rc}; output: ${output}"
+fi
+if [[ "${output}" != *"NOW-PASSES: tests/vertical-slice/accept/reject_fixture.hew"* ]]; then
+    fail "oracle-ratchets-positive-rejections (5c: strict recovery fails)" \
+        "strict output did not preserve the exact recovery identity; output: ${output}"
 fi
 
 pass "oracle-ratchets-positive-rejections"

--- a/scripts/fuzz/run-oracle.py
+++ b/scripts/fuzz/run-oracle.py
@@ -28,17 +28,18 @@ The harness asserts exact stdout match and (if present) exit code.
 Files without these annotations: clean = build-0 + run-0 within bounds.
 
 Ratchet (--regressions mode):
-  tests/fuzz-oracle/expected-failures.txt lists bare filenames from the
-  ratcheted candidate sources (vertical-slice or regressions) that are KNOWN
-  to fail, each annotated with # <root-cause>; issue: #NNNN.
-  - A listed file that PASSES   → unexpected-pass → gate failure.
-  - An unlisted file that FAILS → unexpected-fail → gate failure.
+  tests/fuzz-oracle/expected-failures.txt pins bare filenames from the
+  ratcheted candidate sources (vertical-slice or regressions) to one exact
+  failure classification, each annotated with # <root-cause>; issue: #NNNN.
+  - A listed file observed clean          → recovery report (strict fails).
+  - A listed file with another fail class → class drift → gate failure.
+  - An unlisted file that FAILS           → unexpected-fail → gate failure.
 
 Positive-corpus rejection ratchet:
   scripts/fuzz/expected-reject.txt lists exact repo-relative paths from
   tests/vertical-slice/accept that are currently rejected by the frontend or
   cannot build as standalone programs.
-  - A listed file that stops being rejected → unexpected-pass → gate failure.
+  - A listed file that stops being rejected → recovery report (strict accounting fails).
   - An unlisted file that is rejected       → unexpected-reject → gate failure.
   In --full mode the ratchet is NOT applied to cargo-fuzz corpus files (they
   are raw bytes; classification is advisory only).
@@ -521,15 +522,75 @@ def collect_candidates(
 # ---------------------------------------------------------------------------
 
 
-def _load_expected_failures(expected_failures_path: Path) -> set[str]:
-    """Parse expected-failures.txt and return the set of bare filenames listed."""
+KNOWN_FAILURE_CLASSES = frozenset(
+    {
+        "frontend-reject",
+        "nyi-codegen",
+        "build-ice",
+        "runtime-crash",
+        "runtime-abort",
+        "timeout",
+        "output-cap",
+        "wrong-output",
+    }
+)
+
+
+def _load_expected_failures(expected_failures_path: Path) -> dict[str, str]:
+    """Parse exact `<filename> <failure-class>` expected-failure entries."""
     if not expected_failures_path.exists():
+        return {}
+    expected: dict[str, str] = {}
+    for line_number, line in enumerate(
+        expected_failures_path.read_text().splitlines(), 1
+    ):
+        stripped = line.split("#")[0].strip()
+        if not stripped:
+            continue
+        fields = stripped.split()
+        if len(fields) != 2:
+            raise ValueError(
+                f"{expected_failures_path}:{line_number}: expected "
+                "'<filename> <failure-class>'"
+            )
+        name, classification = fields
+        if Path(name).name != name or not name.endswith(".hew"):
+            raise ValueError(
+                f"{expected_failures_path}:{line_number}: expected a bare .hew filename: {name}"
+            )
+        if classification not in KNOWN_FAILURE_CLASSES:
+            raise ValueError(
+                f"{expected_failures_path}:{line_number}: unsupported failure class "
+                f"{classification!r}"
+            )
+        if name in expected:
+            raise ValueError(
+                f"{expected_failures_path}:{line_number}: duplicate expected failure: {name}"
+            )
+        expected[name] = classification
+    return expected
+
+
+def _load_expected_rejects(expected_rejects_path: Path) -> set[str]:
+    """Parse exact positive-corpus rejection identities."""
+    if not expected_rejects_path.exists():
         return set()
     expected: set[str] = set()
-    for line in expected_failures_path.read_text().splitlines():
-        stripped = line.split("#")[0].strip()
-        if stripped:
-            expected.add(stripped)
+    for line_number, line in enumerate(
+        expected_rejects_path.read_text().splitlines(), 1
+    ):
+        identity = line.split("#")[0].strip()
+        if not identity:
+            continue
+        if len(identity.split()) != 1:
+            raise ValueError(
+                f"{expected_rejects_path}:{line_number}: expected one fixture identity"
+            )
+        if identity in expected:
+            raise ValueError(
+                f"{expected_rejects_path}:{line_number}: duplicate expected rejection: {identity}"
+            )
+        expected.add(identity)
     return expected
 
 
@@ -602,6 +663,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--full",
         action="store_true",
         help="Also scan cargo-fuzz corpus (source 1). Default: regressions mode only.",
+    )
+    p.add_argument(
+        "--strict-recoveries",
+        action="store_true",
+        help="fail when an expected failure or rejection now passes",
     )
     p.add_argument(
         "--min-candidates",
@@ -716,8 +782,12 @@ def main() -> int:
         vertical_slice_dir=args.vertical_slice_dir,
     )
 
-    expected_failure_names = _load_expected_failures(expected_failures_path)
-    expected_reject_paths = _load_expected_failures(expected_rejects_path)
+    try:
+        expected_failures = _load_expected_failures(expected_failures_path)
+        expected_reject_paths = _load_expected_rejects(expected_rejects_path)
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
 
     # Floor the ratcheted candidate set. Both gate conditions below are searches
     # over the collected candidates: an empty collection yields no unexpected
@@ -752,8 +822,10 @@ def main() -> int:
     all_verdicts: list[Verdict] = []
     unexpected_fails: list[Verdict] = []
     unexpected_passes: list[Verdict] = []
+    expected_failure_class_drifts: list[tuple[str, str, Verdict]] = []
     unexpected_rejects: list[tuple[str, Verdict]] = []
     unexpected_reject_passes: list[tuple[str, Verdict]] = []
+    missing_expected_entries: list[str] = []
     seen_reject_paths: set[str] = set()
 
     with tempfile.TemporaryDirectory(prefix="hew-oracle-") as tmpdir:
@@ -785,8 +857,15 @@ def main() -> int:
 
                 if apply_ratchet:
                     name = src.name
-                    is_expected_fail = name in expected_failure_names
-                    if (
+                    expected_class = expected_failures.get(name)
+                    if expected_class is not None:
+                        if not verdict.is_fail:
+                            unexpected_passes.append(verdict)
+                        elif verdict.classification != expected_class:
+                            expected_failure_class_drifts.append(
+                                (name, expected_class, verdict)
+                            )
+                    elif (
                         reject_ratchet_root is not None
                         and verdict.classification == "frontend-reject"
                     ):
@@ -798,10 +877,8 @@ def main() -> int:
                         seen_reject_paths.add(identity)
                         if identity not in expected_reject_paths:
                             unexpected_rejects.append((identity, verdict))
-                    elif verdict.is_fail and not is_expected_fail:
+                    elif verdict.is_fail:
                         unexpected_fails.append(verdict)
-                    elif not verdict.is_fail and is_expected_fail:
-                        unexpected_passes.append(verdict)
 
                     if reject_ratchet_root is not None:
                         identity = _fixture_identity(
@@ -844,23 +921,17 @@ def main() -> int:
     all_candidate_names = {p.name for p in regressions} | {
         p.name for p in vertical_slice
     }
-    for name in sorted(expected_failure_names):
+    for name in sorted(expected_failures):
         if name not in all_candidate_names:
-            ghost = Verdict(
-                regressions_dir / name,
-                "clean",  # "passed" in the sense of not being present
-                "expected-failing entry not found in regressions corpus",
+            missing_expected_entries.append(
+                f"expected failure absent from corpus: {name}"
             )
-            unexpected_passes.append(ghost)
 
     for identity in sorted(expected_reject_paths - seen_reject_paths):
         if not any(path == identity for path, _ in unexpected_reject_passes):
-            ghost = Verdict(
-                repo_root / identity,
-                "clean",
-                "expected-reject entry not found in positive corpus",
+            missing_expected_entries.append(
+                f"expected rejection absent from corpus: {identity}"
             )
-            unexpected_reject_passes.append((identity, ghost))
 
     # Summary.
     print()
@@ -878,6 +949,12 @@ def main() -> int:
         print(floor_error, file=sys.stderr)
         gate_ok = False
 
+    if missing_expected_entries:
+        print("\nEXPECTED ENTRIES MISSING FROM CORPUS:")
+        for entry in missing_expected_entries:
+            print(f"  {entry}")
+        gate_ok = False
+
     if unexpected_fails:
         print("\nUNEXPECTED FAILURES (not in expected-failures.txt):")
         for v in unexpected_fails:
@@ -887,11 +964,22 @@ def main() -> int:
             print(f"  UNEXPECTED: {v.path.name}  {v.classification}  {v.detail}")
         gate_ok = False
 
+    if expected_failure_class_drifts:
+        print("\nEXPECTED FAILURE CLASS DRIFT:")
+        for name, expected_class, verdict in expected_failure_class_drifts:
+            detail = f"  {verdict.detail}" if verdict.detail else ""
+            print(
+                f"  CLASS-DRIFT: {name}  expected={expected_class} "
+                f"observed={verdict.classification}{detail}"
+            )
+        gate_ok = False
+
     if unexpected_passes:
         print("\nUNEXPECTED PASSES (listed in expected-failures.txt but passed):")
         for v in unexpected_passes:
             print(f"  NOW-PASSES: {v.path.name}  {v.detail}")
-        gate_ok = False
+        if args.strict_recoveries:
+            gate_ok = False
 
     if unexpected_rejects:
         print("\nUNEXPECTED REJECTIONS (not in expected-reject.txt):")
@@ -905,7 +993,8 @@ def main() -> int:
         for identity, verdict in unexpected_reject_passes:
             detail = f"  {verdict.detail}" if verdict.detail else ""
             print(f"  NOW-PASSES: {identity}{detail}")
-        gate_ok = False
+        if args.strict_recoveries:
+            gate_ok = False
 
     if gate_ok:
         print("ORACLE gate: PASS")
@@ -939,7 +1028,21 @@ def main() -> int:
                 for v in unexpected_fails
             ],
             "unexpected_passes": [
-                {"path": str(v.path), "detail": v.detail} for v in unexpected_passes
+                {
+                    "path": str(v.path),
+                    "expected_classification": expected_failures[v.path.name],
+                    "detail": v.detail,
+                }
+                for v in unexpected_passes
+            ],
+            "expected_failure_class_drifts": [
+                {
+                    "path": name,
+                    "expected_classification": expected_class,
+                    "observed_classification": verdict.classification,
+                    "detail": verdict.detail,
+                }
+                for name, expected_class, verdict in expected_failure_class_drifts
             ],
             "unexpected_rejects": [
                 {
@@ -953,6 +1056,7 @@ def main() -> int:
                 {"path": identity, "detail": verdict.detail}
                 for identity, verdict in unexpected_reject_passes
             ],
+            "missing_expected_entries": missing_expected_entries,
         }
         args.report.write_text(json.dumps(report, indent=2))
         print(f"Report written to {args.report}")

--- a/scripts/hew-corpus-expected-failures.txt
+++ b/scripts/hew-corpus-expected-failures.txt
@@ -6,9 +6,10 @@
 #
 #   <path> [E_DIAGNOSTIC_CODE]  # classification and issue
 #
-# The gate exits 1 on any UNEXPECTED failure (not in this list), UNEXPECTED
-# PASS (listed here but now compiles — delete the entry), or changed diagnostic
-# for an entry that records one. Pin codes, not diagnostic prose.
+# The gate exits 1 on any UNEXPECTED failure (not in this list), changed
+# diagnostic for an entry that records one, or inventory/outcome drift. A
+# listed entry that now compiles is reported in PR gates and fails scheduled
+# strict accounting until removed. Pin codes, not diagnostic prose.
 #
 # Classification categories:
 #   deferred-nyi    — Feature not yet implemented in the compiler (select/channel,

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -2,13 +2,13 @@
 #
 # Known failing tests in tests/hew/.
 # The ratchet (scripts/corpus-ratchet.sh hew-suite) enforces:
-#   - Every test listed here MUST fail (unexpected pass = gate failure).
+#   - Every test listed here that now passes is reported for ledger cleanup.
 #   - Every test NOT listed here MUST pass (unexpected failure = gate failure).
 #
 # This is a tracked-failure list, not a waiver. An entry earns its place by
 # naming the defect class that keeps it red; nothing lands here to make the
-# gate green. Remove an entry the moment its class is fixed — the ratchet
-# fails on an unexpected pass precisely so a fix cannot go unnoticed.
+# gate green. Remove an entry the moment its class is fixed — PR gates report
+# that recovery and scheduled strict accounting fails until it is recorded.
 #
 # Format: <source-path>::<test_function_name> <failure-kind>  # root cause
 # Failure kinds are compile, runtime, timeout, and launch. The kind is part of

--- a/scripts/nextest-expected-failures.tsv
+++ b/scripts/nextest-expected-failures.tsv
@@ -1,9 +1,13 @@
 # platform<TAB>outcome<TAB>suite<TAB>test<TAB>reason
 #
 # Ordinary CI may carry a narrowly identified compiler defect while its fix is
-# developed. Entries compare in both directions: a pass, disappearance, changed
-# outcome, or unlisted failure makes the ratchet fail. Signals and setup errors
-# cannot be accepted. Release gates do not read this file.
+# developed. PR gates report an entry that now passes; scheduled strict
+# accounting requires its removal. Changed outcomes, unlisted failures,
+# disappearance, signals, and setup errors remain blocking. Release gates do
+# not read this file. If a multi-platform entry recovers on only a subset,
+# replace its selector with the exact remaining failing platforms (or split it
+# into platform-specific rows); never delete the row wholesale until every
+# selected platform has recovered.
 freebsd	failure	hew-cli::extern_ownership_double_release_e2e	resource_payload_beside_an_interpolated_string_closes_exactly_once	#3106 keeps resource Result match authorities consistent
 linux,macos,freebsd	failure	hew-cli::measured_os_io_string_retention_canary	shipped_os_io_wrappers_emit_all_measured_calls_and_caller_releases	#3079 derives unwind cleanup from exact live owner states
 *	failure	hew-cli::branch_divergent_return_drop_ir	returned_result_branch_releases_only_the_nonreturned_string_sibling	#3118 releases branch-local siblings on normal edges

--- a/scripts/ratchet-accounting.sh
+++ b/scripts/ratchet-accounting.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Execute every strict expected-failure ledger family, retaining evidence from
+# later families even if an earlier ledger reports stale accounting.
+
+set -uo pipefail
+
+if [[ "${RATCHET_STRICT_RECOVERIES:-}" != "1" ]]; then
+    echo "error: ratchet accounting requires RATCHET_STRICT_RECOVERIES=1" >&2
+    exit 2
+fi
+
+make_command="${RATCHET_ACCOUNTING_MAKE:-${MAKE:-make}}"
+families=(
+    test
+    test-hew-ratchet
+    test-core-matrix
+    test-stdlib-ratchet
+    test-doc-examples
+    fuzz-oracle
+    hew-check-all
+)
+
+failed=0
+for family in "${families[@]}"; do
+    echo "==> Ratchet accounting: ${family}"
+    if "${make_command}" "${family}"; then
+        echo "==> Ratchet accounting: ${family}: PASSED"
+    else
+        status=$?
+        echo "==> Ratchet accounting: ${family}: FAILED (exit ${status})" >&2
+        failed=1
+    fi
+done
+
+if ((failed)); then
+    echo "==> Ratchet accounting: FAILED (one or more families failed)" >&2
+    exit 1
+fi
+echo "==> Ratchet accounting: PASSED"

--- a/scripts/stdlib-expected-failures.txt
+++ b/scripts/stdlib-expected-failures.txt
@@ -5,9 +5,9 @@
 #
 # Ratchet rules:
 #   - Any NEW failure not listed here causes the gate to exit 1.
-#   - Any listed failure that NOW PASSES causes the gate to exit 1.
+#   - A listed failure that now passes is reported in PR gates and fails
+#     scheduled strict accounting until its entry is removed.
 #   - Delete an entry when the underlying issue is fixed.
 #   - Never add an entry to hide a regression; fix the code instead.
 #
 # Captured: 2026-06-10 on release/v0.5.0-pre-history-polish (575e022d)
-

--- a/scripts/tests/test_compiled_hew_shards.py
+++ b/scripts/tests/test_compiled_hew_shards.py
@@ -28,14 +28,16 @@ def write_junit(
     path: Path,
     identities: list[str],
     failed: set[str] | None = None,
+    skipped: set[str] | None = None,
     failure_kind: str = "runtime",
 ) -> None:
     failed = failed or set()
+    skipped = skipped or set()
     root = ET.Element(
         "testsuites",
         tests=str(len(identities)),
         failures=str(len(failed)),
-        skipped="0",
+        skipped=str(len(skipped)),
     )
     suite = ET.SubElement(
         root,
@@ -43,7 +45,7 @@ def write_junit(
         name="generated",
         tests=str(len(identities)),
         failures=str(len(failed)),
-        skipped="0",
+        skipped=str(len(skipped)),
     )
     for value in identities:
         classname, name = value.rsplit("::", 1)
@@ -58,6 +60,8 @@ def write_junit(
             failure.text = "forced diagnostic text"
             system_out = ET.SubElement(testcase, "system-out")
             system_out.text = "forced fixture output"
+        elif value in skipped:
+            ET.SubElement(testcase, "skipped")
     ET.ElementTree(root).write(path, encoding="unicode", xml_declaration=True)
 
 
@@ -83,23 +87,28 @@ class CompiledHewShardTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temporary.cleanup()
 
-    def aggregate(self, mode: str, expect: int = 0) -> subprocess.CompletedProcess[str]:
+    def aggregate(
+        self, mode: str, expect: int = 0, strict_recoveries: bool = False
+    ) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            "aggregate",
+            "--mode",
+            mode,
+            "--reports-dir",
+            str(self.reports),
+            "--full-inventory",
+            str(self.full_path),
+            "--shard-count",
+            str(SHARDS),
+            "--expected-failures",
+            str(self.expected),
+        ]
+        if strict_recoveries:
+            command.append("--strict-recoveries")
         result = subprocess.run(
-            [
-                sys.executable,
-                str(SCRIPT),
-                "aggregate",
-                "--mode",
-                mode,
-                "--reports-dir",
-                str(self.reports),
-                "--full-inventory",
-                str(self.full_path),
-                "--shard-count",
-                str(SHARDS),
-                "--expected-failures",
-                str(self.expected),
-            ],
+            command,
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,
@@ -239,19 +248,36 @@ class CompiledHewShardTests(unittest.TestCase):
             ET.parse(published / "compiled-hew-finalization.xml").find(".//failure")
         )
 
-    def test_finalization_publishes_a_failure_when_expected_failure_is_missing(
+    def test_recovery_is_nonblocking_and_strict_accounting_rejects_it(
         self,
     ) -> None:
         tracked = self.full[0]
         self.expected.write_text(f"{tracked} runtime\n", encoding="utf-8")
 
+        result = self.aggregate("ratchet")
+        self.assertIn("recovery accounting", result.stderr)
+
+        strict = self.aggregate("ratchet", expect=1, strict_recoveries=True)
+        self.assertIn("recoveries under strict accounting", strict.stderr)
+
         result, published = self.finalize(True)
 
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("failure set differs", result.stderr)
-        self.assertIsNotNone(
-            ET.parse(published / "compiled-hew-finalization.xml").find(".//failure")
-        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse((published / "compiled-hew-finalization.xml").exists())
+
+    def test_skipped_expected_failure_is_not_a_recovery(self) -> None:
+        values = self.full[0::SHARDS]
+        tracked = values[0]
+        self.expected.write_text(f"{tracked} runtime\n", encoding="utf-8")
+        for label in ("o0", "o2"):
+            write_junit(
+                self.reports / f"hew-{label}-shard-1.xml",
+                values,
+                skipped={tracked},
+            )
+
+        result = self.aggregate("ratchet", expect=1)
+        self.assertIn("did not PASS in both O0 and O2", result.stderr)
 
     def test_unexpected_pass_prerequisite_failure_keeps_raw_and_adds_red_verdict(
         self,
@@ -363,7 +389,7 @@ class CompiledHewShardTests(unittest.TestCase):
         values = self.full[0::SHARDS]
         write_junit(self.reports / "hew-o0-shard-1.xml", values, failed={values[0]})
         result = self.aggregate("ratchet", expect=1)
-        self.assertIn("failure set differs", result.stderr)
+        self.assertIn("untracked failures", result.stderr)
 
     def test_expected_failure_is_an_exact_path_qualified_identity(self) -> None:
         values = self.full[0::SHARDS]

--- a/scripts/tests/test_doc_ratchet_membership.sh
+++ b/scripts/tests/test_doc_ratchet_membership.sh
@@ -140,10 +140,12 @@ run_harness() {
     local expected_file="$1"
     local fail_file="$2"
     local call_log="$3"
+    local strict_recoveries="${4:-0}"
 
     HARNESS_STATUS=0
     HARNESS_OUTPUT="$({
-        HEW_FAIL_IDS="$fail_file" \
+        RATCHET_STRICT_RECOVERIES="$strict_recoveries" \
+            HEW_FAIL_IDS="$fail_file" \
             HEW_CALL_LOG="$call_log" \
             "$HARNESS" doc-fences \
             --expected-failures "$expected_file" \
@@ -296,7 +298,8 @@ assert_contains "$HARNESS_OUTPUT" \
     "OUTCOME DRIFT: $first_failure (exit 139, expected structured diagnostic exit 1)" \
     "abnormal tracked-refusal outcome names the exact fence and status"
 
-# Mutation 1: a listed failure now passes and must be rejected.
+# Mutation 1: a listed failure now passes. PR mode reports it without blocking;
+# strict ledger accounting rejects it.
 first_failure=""
 while IFS= read -r fence_id; do
     [[ -z "$fence_id" ]] && continue
@@ -308,13 +311,34 @@ while IFS= read -r fence_id; do
 done <"$BASELINE_FAIL_IDS"
 
 run_harness "$BASELINE_EXPECTED" "$NOW_PASS_IDS" /dev/null
-if [[ "$HARNESS_STATUS" -ne 0 ]]; then
-    pass "now-pass mutation is rejected"
+if [[ "$HARNESS_STATUS" -eq 0 ]]; then
+    pass "now-pass mutation is reported without blocking"
 else
-    fail "now-pass mutation was accepted"
+    fail "now-pass mutation unexpectedly blocked a PR-mode run"
 fi
 assert_contains "$HARNESS_OUTPUT" "NOW-PASSES: $first_failure" \
     "now-pass mutation names the exact fence"
+
+run_harness "$BASELINE_EXPECTED" "$NOW_PASS_IDS" /dev/null 1
+if [[ "$HARNESS_STATUS" -ne 0 ]]; then
+    pass "strict now-pass mutation is rejected"
+else
+    fail "strict now-pass mutation was accepted"
+fi
+
+# Mutation 1b: a ledger row that is absent from the selected corpus is not a
+# recovery. It must fail closed even in ordinary PR mode.
+MISSING_EXPECTED="$TMP_ROOT/expected-missing-entry.txt"
+cp "$BASELINE_EXPECTED" "$MISSING_EXPECTED"
+printf 'missing-fence 1\n' >>"$MISSING_EXPECTED"
+run_harness "$MISSING_EXPECTED" "$BASELINE_FAIL_IDS" /dev/null
+if [[ "$HARNESS_STATUS" -ne 0 ]]; then
+    pass "missing expected entry is rejected"
+else
+    fail "missing expected entry was treated as a recovery"
+fi
+assert_contains "$HARNESS_OUTPUT" "MISSING-EXPECTED: missing-fence" \
+    "missing expected entry names the absent identity"
 
 # Mutation 2: a previously passing fence fails and must be rejected.
 cp "$BASELINE_FAIL_IDS" "$NEW_FAILURE_IDS"

--- a/scripts/tests/test_hew_suite_runner.py
+++ b/scripts/tests/test_hew_suite_runner.py
@@ -23,6 +23,7 @@ def run(
     *,
     emit_o0_outcomes: Path | None = None,
     ambient_opt_level: str | None = None,
+    strict_recoveries: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     command = [
         "bash",
@@ -40,6 +41,7 @@ def run(
         "HEW_BIN": str(compiler),
         "HEW_TESTS_DIR": str(fixtures),
         "HEW_JUNIT_STUB_MODE": mode,
+        "RATCHET_STRICT_RECOVERIES": "1" if strict_recoveries else "0",
     }
     if ambient_opt_level is not None:
         environment["HEW_OPT_LEVEL"] = ambient_opt_level
@@ -65,6 +67,14 @@ def make_fixture(work: Path) -> tuple[Path, Path]:
         '    printf \'%s\\n\' \'<testsuites tests="1" failures="0" skipped="0"><testsuite name="sample.hew" tests="1" failures="0" skipped="0"><testcase classname="sample.hew" name="sample"/></testsuite></testsuites>\'\n'
         '    [ "$HEW_JUNIT_STUB_MODE" = pass ] && exit 0\n'
         "    exit 1\n"
+        "    ;;\n"
+        "  skipped)\n"
+        '    printf \'%s\\n\' \'<testsuites tests="1" failures="0" skipped="1"><testsuite name="sample.hew" tests="1" failures="0" skipped="1"><testcase classname="sample.hew" name="sample"><skipped/></testcase></testsuite></testsuites>\'\n'
+        "    exit 0\n"
+        "    ;;\n"
+        "  other-pass)\n"
+        '    printf \'%s\\n\' \'<testsuites tests="1" failures="0" skipped="0"><testsuite name="sample.hew" tests="1" failures="0" skipped="0"><testcase classname="sample.hew" name="other"/></testsuite></testsuites>\'\n'
+        "    exit 0\n"
         "    ;;\n"
         "  failure)\n"
         '    printf \'%s\\n\' \'<testsuites tests="1" failures="1" skipped="0"><testsuite name="sample.hew" tests="1" failures="1" skipped="0"><testcase classname="sample.hew" name="sample"><failure type="compile" message="assertion failed">diagnostic</failure></testcase></testsuite></testsuites>\'\n'
@@ -134,11 +144,51 @@ def test_failure_kind_drift_fails_the_ratchet_without_matching_text() -> None:
                 report,
                 f"failure-kind-drift-{actual_kind}",
             )
-
             assert result.returncode != 0
             assert f"expected=compile actual={actual_kind}" in result.stdout, (
                 result.stdout + result.stderr
             )
+
+
+def test_recovery_is_nonblocking_in_pr_mode_and_strict_in_accounting() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        fixtures, compiler = make_fixture(work)
+        expected = work / "expected.txt"
+        expected.write_text("sample.hew::sample compile\n", encoding="utf-8")
+        report = work / "report.xml"
+
+        recovery = run(compiler, fixtures, expected, report, "pass")
+        assert recovery.returncode == 0, recovery.stdout + recovery.stderr
+        assert "NOW-PASSES: sample.hew::sample" in recovery.stdout
+
+        strict = run(
+            compiler,
+            fixtures,
+            expected,
+            report,
+            "pass",
+            strict_recoveries=True,
+        )
+        assert strict.returncode != 0
+        assert "NOW-PASSES: sample.hew::sample" in strict.stdout
+
+
+def test_skips_and_missing_identities_are_not_recoveries() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        fixtures, compiler = make_fixture(work)
+        expected = work / "expected.txt"
+        expected.write_text("sample.hew::sample compile\n", encoding="utf-8")
+        report = work / "report.xml"
+
+        skipped = run(compiler, fixtures, expected, report, "skipped")
+        assert skipped.returncode != 0
+        assert "NONPASS-EXPECTED: sample.hew::sample" in skipped.stdout
+
+        absent = run(compiler, fixtures, expected, report, "other-pass")
+        assert absent.returncode != 0
+        assert "MISSING-EXPECTED: sample.hew::sample" in absent.stdout
 
 
 def test_duplicate_failure_identities_are_rejected() -> None:
@@ -226,6 +276,8 @@ def test_runner_status_must_agree_before_report_is_published() -> None:
 if __name__ == "__main__":
     test_valid_failure_report_and_status_one_reach_the_ratchet()
     test_failure_kind_drift_fails_the_ratchet_without_matching_text()
+    test_recovery_is_nonblocking_in_pr_mode_and_strict_in_accounting()
+    test_skips_and_missing_identities_are_not_recoveries()
     test_duplicate_failure_identities_are_rejected()
     test_pass_and_failure_path_aliases_are_rejected()
     test_o0_handoff_ignores_ambient_optimization_level()

--- a/scripts/tests/test_ratchet_accounting_runner.sh
+++ b/scripts/tests/test_ratchet_accounting_runner.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Counterfactuals for scripts/ratchet-accounting.sh's keep-going contract.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="${ROOT}/scripts/ratchet-accounting.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hew-ratchet-accounting-test.XXXXXX")"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+FAKE_MAKE="${TMP_ROOT}/fake-make"
+LOG="${TMP_ROOT}/families.log"
+cat >"${FAKE_MAKE}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>"${RATCHET_ACCOUNTING_TEST_LOG}"
+if [[ "$1" == "test" || "$1" == "test-doc-examples" ]]; then
+    exit 1
+fi
+EOF
+chmod +x "${FAKE_MAKE}"
+
+status=0
+output="$(RATCHET_STRICT_RECOVERIES=1 \
+    RATCHET_ACCOUNTING_MAKE="${FAKE_MAKE}" \
+    RATCHET_ACCOUNTING_TEST_LOG="${LOG}" \
+    "${RUNNER}" 2>&1)" || status=$?
+if [[ "${status}" -ne 1 ]]; then
+    echo "FAIL: runner must fail only after executing all families (got ${status})" >&2
+    exit 1
+fi
+
+expected=$'test\ntest-hew-ratchet\ntest-core-matrix\ntest-stdlib-ratchet\ntest-doc-examples\nfuzz-oracle\nhew-check-all'
+actual="$(cat "${LOG}")"
+if [[ "${actual}" != "${expected}" ]]; then
+    echo "FAIL: runner skipped or reordered a family" >&2
+    printf 'expected:\n%s\nactual:\n%s\n' "${expected}" "${actual}" >&2
+    exit 1
+fi
+if [[ "${output}" != *"test-doc-examples: FAILED"* || "${output}" != *"hew-check-all: PASSED"* ]]; then
+    echo "FAIL: runner did not retain later-family evidence" >&2
+    exit 1
+fi
+
+echo "PASS: accounting runner executes and reports every family after failures"

--- a/tests/fuzz-oracle/README.md
+++ b/tests/fuzz-oracle/README.md
@@ -34,14 +34,17 @@ visible for fail-closed classification.
 
 ## Ratchet: expected-failures.txt
 
-`expected-failures.txt` lists candidate filenames that are **known to fail**,
-each annotated with a tracking issue. Candidates may come from the
+`expected-failures.txt` pins each candidate filename to its exact known failure
+classification, with a tracking issue. Candidates may come from the
 vertical-slice or regression corpus.
 
 **Gate behaviour:**
 
-- A listed candidate that **passes** → `unexpected-pass` → gate failure.
-  This forces the entry to be removed and a positive guard to be added.
+- A listed candidate that fails with a **different class** → class drift → gate
+  failure. A tracked runtime crash cannot silently become a timeout, frontend
+  rejection, abort, or compiler failure.
+- A listed candidate observed **clean** → recovery report in PRs and strict
+  accounting failure until its entry is removed.
 - An unlisted candidate that **fails** → `unexpected-fail` → gate failure.
   This forces the failure to be registered (or fixed).
 
@@ -57,8 +60,8 @@ nested helper fixtures and same-named files cannot collide.
 
 - An unlisted positive fixture that is rejected is an `unexpected-reject` and
   fails the gate.
-- A listed fixture that stops being rejected is an `unexpected-pass` and fails
-  the gate until its entry is removed.
+- A listed fixture that stops being rejected is reported as recovery in normal
+  PR runs. Scheduled strict accounting fails until its entry is removed.
 
 Remove an entry as soon as its fixture passes. Nothing replaces it: intentional
 negative and known-bug inputs belong in the reject and repro corpora instead.
@@ -68,14 +71,15 @@ negative and known-bug inputs belong in the reject and repro corpora instead.
 1. Minimise the failing program (manually, or with a future `a3-fuzz-minimize`
    tool) until it is the smallest program that reproduces the failure.
 2. Add it to `regressions/` with a descriptive filename.
-3. Add an entry to `expected-failures.txt` with a tracking issue.
-4. Run `make fuzz-oracle` to confirm the oracle classifies it as expected-fail.
+3. Add an entry to `expected-failures.txt` with the observed failure class and
+   a tracking issue.
+4. Run `make fuzz-oracle` to confirm the oracle classifies it exactly as pinned.
 5. Commit both files together.
 
 When the underlying fix lands:
 
-1. Leave the entry in place and run `make fuzz-oracle`; it must report the
-   clean execution as an unexpected pass.
+1. Leave the entry in place and run `make fuzz-oracle`; it reports the clean
+   execution as recovery. Scheduled strict accounting fails until cleanup.
 2. Remove the entry from `expected-failures.txt`.
 3. Add, update, or restore the vertical-slice invocation that guards the fixed
    behaviour.

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -1,13 +1,17 @@
 # tests/fuzz-oracle/expected-failures.txt
 #
-# Ratcheted vertical-slice and regression-corpus entries that are KNOWN to fail.
+# Ratcheted vertical-slice and regression-corpus entries that are KNOWN to fail
+# with the exact class pinned in column two.
 # The oracle enforces (in regressions mode):
-#   - Every filename listed here MUST fail (unexpected pass = gate failure →
-#     forces updating this file to promote the gap to a positive guard).
+#   - Every listed fixture must keep its pinned failure class. A class drift
+#     fails closed in every run; only an observed `clean` outcome is recovery.
+#   - A clean recovery is reported in PR mode and fails strict accounting.
 #   - Every regression file NOT listed here MUST pass (unexpected failure =
 #     gate failure).
 #
-# Format: <filename>  # <root-cause>; issue: #NNNN
+# Format: <filename> <failure-class>  # <root-cause>; issue: #NNNN
+# Failure classes are frontend-reject, nyi-codegen, build-ice, runtime-crash,
+# runtime-abort, timeout, output-cap, and wrong-output.
 # Filenames are bare (no path prefix); they match the oracle's candidate set.
 #
 # When a fix lands for an entry here, REMOVE the entry and add, update, or
@@ -24,41 +28,41 @@
 # Intentional aborts/traps: fixtures in tests/vertical-slice/accept/ that are
 # designed to trap or abort at runtime as their correctness proof.  Listed here
 # so the oracle gate does not treat them as unexpected failures.  The ratchet
-# fires in BOTH directions: if any of these starts passing (no longer traps),
-# that is a regression.
+# reports a clean recovery in PRs and fails strict accounting until cleanup;
+# a different non-clean class remains a blocking semantic drift.
 
-assert_eq_fail.hew       # intentional abort: assert_eq(2+2, 5) → SIGABRT; tests assertion failure propagation
-join_branch_trap.hew     # intentional abort: join branch trap propagates as SIGABRT (HEW-SPEC-2026 §4.11.2)
-string_slice_oob_panics.hew  # intentional abort: out-of-bounds string slice calls libc::abort()
-bytes_index_oob_traps.hew    # intentional abort: out-of-bounds bytes index b[i] calls libc::abort() → SIGABRT (signal 6)
-bytes_pop_empty_traps.hew    # intentional abort: empty bytes.pop() calls libc::abort() → SIGABRT
-bytes_set_oob_traps.hew      # intentional abort: out-of-bounds bytes.set() calls libc::abort() → SIGABRT
-string_index_oob_traps.hew   # intentional abort: out-of-bounds string index s[i] calls libc::abort() → SIGABRT (signal 6)
-vec_set_oob_traps.hew        # intentional abort: out-of-bounds Vec.set() calls libc::abort() → SIGABRT (signal 6)
-vec_pop_empty_traps.hew      # intentional abort: empty Vec.pop() calls libc::abort() → SIGABRT (signal 6)
-vec_remove_oob_traps.hew     # intentional abort: out-of-bounds Vec.remove() calls libc::abort() → SIGABRT (signal 6)
-deque_pop_front_empty_traps.hew  # intentional abort: empty Deque.pop_front() routes through runtime_bounds_trap → std::process::abort() (no main-context actor recovery frame) → SIGABRT (signal 6)
-deque_pop_back_empty_traps.hew   # intentional abort: empty Deque.pop_back() routes through runtime_bounds_trap → std::process::abort() (no main-context actor recovery frame) → SIGABRT (signal 6)
+assert_eq_fail.hew runtime-crash       # intentional abort: assert_eq(2+2, 5) → SIGABRT; tests assertion failure propagation
+join_branch_trap.hew runtime-crash     # intentional abort: join branch trap propagates as SIGABRT (HEW-SPEC-2026 §4.11.2)
+string_slice_oob_panics.hew runtime-crash  # intentional abort: out-of-bounds string slice calls libc::abort()
+bytes_index_oob_traps.hew runtime-crash    # intentional abort: out-of-bounds bytes index b[i] calls libc::abort() → SIGABRT (signal 6)
+bytes_pop_empty_traps.hew runtime-crash    # intentional abort: empty bytes.pop() calls libc::abort() → SIGABRT
+bytes_set_oob_traps.hew runtime-crash      # intentional abort: out-of-bounds bytes.set() calls libc::abort() → SIGABRT
+string_index_oob_traps.hew runtime-crash   # intentional abort: out-of-bounds string index s[i] calls libc::abort() → SIGABRT (signal 6)
+vec_set_oob_traps.hew runtime-crash        # intentional abort: out-of-bounds Vec.set() calls libc::abort() → SIGABRT (signal 6)
+vec_pop_empty_traps.hew runtime-crash      # intentional abort: empty Vec.pop() calls libc::abort() → SIGABRT (signal 6)
+vec_remove_oob_traps.hew runtime-crash     # intentional abort: out-of-bounds Vec.remove() calls libc::abort() → SIGABRT (signal 6)
+deque_pop_front_empty_traps.hew runtime-crash  # intentional abort: empty Deque.pop_front() routes through runtime_bounds_trap → std::process::abort() (no main-context actor recovery frame) → SIGABRT (signal 6)
+deque_pop_back_empty_traps.hew runtime-crash   # intentional abort: empty Deque.pop_back() routes through runtime_bounds_trap → std::process::abort() (no main-context actor recovery frame) → SIGABRT (signal 6)
 # Arch-dependent trap signals: SIGILL (132) on x86_64 Linux, SIGTRAP (133) on aarch64/macOS.
-isize_div_by_zero_traps.hew  # intentional trap: isize / 0 → DivideByZero signal (SIGILL x86_64 / SIGTRAP aarch64)
-isize_shift_oob_traps.hew    # intentional trap: isize << 64 → ShiftOutOfRange signal (SIGILL x86_64 / SIGTRAP aarch64)
-vec_element_width_oob_traps.hew  # intentional trap: Vec<i8> index at len → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
-vec_index_assign_oob_traps.hew   # intentional trap: Vec<i64> OOB write v[1] on 1-element vec → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
-vec_index_oob_traps.hew          # intentional trap: Vec<i64> read v[10] on 3-element vec → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
-vec_enum_index_oob_traps.hew     # intentional trap: Vec<enum> read v[i] past end → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
-hashmap_index_absent_traps.hew       # intentional trap: HashMap<string,i64> read m["absent"] on missing key → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
-hashmap_enum_index_absent_traps.hew  # intentional trap: HashMap<string,enum> read m["absent"] on missing key → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
-crash_main_context_diagnostic.hew  # intentional trap: OOB Vec index in main context → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64) + "hew: trap in main context" stderr diagnostic (F1.3)
-wire_cbor_decode_malformed_traps.hew  # intentional trap: decoding malformed CBOR (0xFF filler bytes) through the wire body codec fails closed → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
-wire_cbor_enum_oob_tag_traps.hew  # intentional trap: decoding an out-of-range enum variant tag (well-formed CBOR, unknown tag) through the wire body codec fails closed → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
-wire_cbor_narrow_int_over_range_traps.hew  # intentional trap: decoding a CBOR integer outside a fixed-width field's range (i8 from 300) through the wire body codec fails closed rather than truncating → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
-wire_cbor_enum_arity_mismatch_traps.hew  # intentional trap: decoding an enum payload whose arity exceeds the target variant (Pair(i64) from {1:[10,20]}) through the wire body codec fails closed rather than dropping the surplus → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
-wire_cbor_missing_required_value_traps.hew  # intentional trap: a required scalar rejects an absent CBOR map key → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
-wire_cbor_missing_required_option_traps.hew  # intentional trap: a required Option rejects an absent CBOR map key instead of inferring optional presence from its value shape → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
-wire_cbor_null_required_value_traps.hew  # intentional trap: a required scalar rejects a present CBOR null value → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
-int_negate_runtime_min_traps.hew  # intentional trap: negating a runtime i32::MIN value (-n for non-literal n; literal -<digits> folds at compile time) → IntegerOverflow signal (SIGILL x86_64 / SIGTRAP aarch64)
-receive_gen_fn_fault_trap.hew  # intentional abort: a receive-gen producer that traps mid-stream fault-closes the stream so the consumer observes the fault on its next resume → SIGABRT (signal 6)
-receive_gen_fn_teardown_fault.hew  # intentional abort: a receive-gen producer torn down (actor stopped) while its stream is live and parked fault-closes the stream so the consumer observes the fault → SIGABRT (signal 6)
+isize_div_by_zero_traps.hew runtime-crash  # intentional trap: isize / 0 → DivideByZero signal (SIGILL x86_64 / SIGTRAP aarch64)
+isize_shift_oob_traps.hew runtime-crash    # intentional trap: isize << 64 → ShiftOutOfRange signal (SIGILL x86_64 / SIGTRAP aarch64)
+vec_element_width_oob_traps.hew runtime-crash  # intentional trap: Vec<i8> index at len → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+vec_index_assign_oob_traps.hew runtime-crash   # intentional trap: Vec<i64> OOB write v[1] on 1-element vec → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+vec_index_oob_traps.hew runtime-crash          # intentional trap: Vec<i64> read v[10] on 3-element vec → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+vec_enum_index_oob_traps.hew runtime-crash     # intentional trap: Vec<enum> read v[i] past end → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+hashmap_index_absent_traps.hew runtime-crash       # intentional trap: HashMap<string,i64> read m["absent"] on missing key → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+hashmap_enum_index_absent_traps.hew runtime-crash  # intentional trap: HashMap<string,enum> read m["absent"] on missing key → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+crash_main_context_diagnostic.hew runtime-crash  # intentional trap: OOB Vec index in main context → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64) + "hew: trap in main context" stderr diagnostic (F1.3)
+wire_cbor_decode_malformed_traps.hew runtime-crash  # intentional trap: decoding malformed CBOR (0xFF filler bytes) through the wire body codec fails closed → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
+wire_cbor_enum_oob_tag_traps.hew runtime-crash  # intentional trap: decoding an out-of-range enum variant tag (well-formed CBOR, unknown tag) through the wire body codec fails closed → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
+wire_cbor_narrow_int_over_range_traps.hew runtime-crash  # intentional trap: decoding a CBOR integer outside a fixed-width field's range (i8 from 300) through the wire body codec fails closed rather than truncating → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
+wire_cbor_enum_arity_mismatch_traps.hew runtime-crash  # intentional trap: decoding an enum payload whose arity exceeds the target variant (Pair(i64) from {1:[10,20]}) through the wire body codec fails closed rather than dropping the surplus → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
+wire_cbor_missing_required_value_traps.hew runtime-crash  # intentional trap: a required scalar rejects an absent CBOR map key → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
+wire_cbor_missing_required_option_traps.hew runtime-crash  # intentional trap: a required Option rejects an absent CBOR map key instead of inferring optional presence from its value shape → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
+wire_cbor_null_required_value_traps.hew runtime-crash  # intentional trap: a required scalar rejects a present CBOR null value → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
+int_negate_runtime_min_traps.hew runtime-crash  # intentional trap: negating a runtime i32::MIN value (-n for non-literal n; literal -<digits> folds at compile time) → IntegerOverflow signal (SIGILL x86_64 / SIGTRAP aarch64)
+receive_gen_fn_fault_trap.hew runtime-crash  # intentional abort: a receive-gen producer that traps mid-stream fault-closes the stream so the consumer observes the fault on its next resume → SIGABRT (signal 6)
+receive_gen_fn_teardown_fault.hew runtime-crash  # intentional abort: a receive-gen producer torn down (actor stopped) while its stream is live and parked fault-closes the stream so the consumer observes the fault → SIGABRT (signal 6)
 
 # Actor-isolated crash fixtures (`*_actor_isolated.hew`). Each crashes ONE
 # unsupervised actor and then proves an independent probe actor still answers:
@@ -70,14 +74,14 @@ receive_gen_fn_teardown_fault.hew  # intentional abort: a receive-gen producer t
 # so they are registered here for the same reason as the sibling trap fixtures:
 # the failure is the fixture's correctness proof, and a fixture that stopped
 # reporting it would be the regression.
-bytes_index_oob_actor_isolated.hew       # intentional actor crash: out-of-bounds bytes index inside a receive handler; probe survives, process exits 1
-bytes_pop_empty_actor_isolated.hew       # intentional actor crash: empty bytes.pop() inside a receive handler; probe survives, process exits 1
-bytes_set_oob_actor_isolated.hew         # intentional actor crash: out-of-bounds bytes.set() inside a receive handler; probe survives, process exits 1
-bytes_slice_oob_actor_isolated.hew       # intentional actor crash: out-of-bounds bytes slice inside a receive handler; probe survives, process exits 1
-deque_pop_back_empty_actor_isolated.hew  # intentional actor crash: empty Deque.pop_back() inside a receive handler; probe survives, process exits 1
-deque_pop_front_empty_actor_isolated.hew # intentional actor crash: empty Deque.pop_front() inside a receive handler; probe survives, process exits 1
-string_index_oob_actor_isolated.hew      # intentional actor crash: out-of-bounds string index inside a receive handler; probe survives, process exits 1
-string_slice_oob_actor_isolated.hew      # intentional actor crash: out-of-bounds string slice inside a receive handler; probe survives, process exits 1
-vec_pop_empty_actor_isolated.hew         # intentional actor crash: empty Vec.pop() inside a receive handler; probe survives, process exits 1
-vec_remove_layout_oob_actor_isolated.hew # intentional actor crash: out-of-bounds Vec.remove() on a layout-carrying element type inside a receive handler; probe survives, process exits 1
-vec_remove_oob_actor_isolated.hew        # intentional actor crash: out-of-bounds Vec.remove() inside a receive handler; probe survives, process exits 1
+bytes_index_oob_actor_isolated.hew runtime-abort       # intentional actor crash: out-of-bounds bytes index inside a receive handler; probe survives, process exits 1
+bytes_pop_empty_actor_isolated.hew runtime-abort       # intentional actor crash: empty bytes.pop() inside a receive handler; probe survives, process exits 1
+bytes_set_oob_actor_isolated.hew runtime-abort         # intentional actor crash: out-of-bounds bytes.set() inside a receive handler; probe survives, process exits 1
+bytes_slice_oob_actor_isolated.hew runtime-abort       # intentional actor crash: out-of-bounds bytes slice inside a receive handler; probe survives, process exits 1
+deque_pop_back_empty_actor_isolated.hew runtime-abort  # intentional actor crash: empty Deque.pop_back() inside a receive handler; probe survives, process exits 1
+deque_pop_front_empty_actor_isolated.hew runtime-abort # intentional actor crash: empty Deque.pop_front() inside a receive handler; probe survives, process exits 1
+string_index_oob_actor_isolated.hew runtime-abort      # intentional actor crash: out-of-bounds string index inside a receive handler; probe survives, process exits 1
+string_slice_oob_actor_isolated.hew runtime-abort      # intentional actor crash: out-of-bounds string slice inside a receive handler; probe survives, process exits 1
+vec_pop_empty_actor_isolated.hew runtime-abort         # intentional actor crash: empty Vec.pop() inside a receive handler; probe survives, process exits 1
+vec_remove_layout_oob_actor_isolated.hew runtime-abort # intentional actor crash: out-of-bounds Vec.remove() on a layout-carrying element type inside a receive handler; probe survives, process exits 1
+vec_remove_oob_actor_isolated.hew runtime-abort        # intentional actor crash: out-of-bounds Vec.remove() inside a receive handler; probe survives, process exits 1

--- a/xtask/src/nextest_ratchet.rs
+++ b/xtask/src/nextest_ratchet.rs
@@ -16,6 +16,7 @@ struct Options {
     output: PathBuf,
     platform: String,
     runner_exit: i32,
+    strict_recoveries: bool,
     full_inventory: Option<PathBuf>,
     selected_inventory: Option<PathBuf>,
 }
@@ -145,12 +146,13 @@ type Expected = (Outcome, String);
 #[derive(Debug, Default)]
 struct Evaluation {
     matched: Vec<(Identity, String)>,
+    recoveries: Vec<String>,
     failures: Vec<String>,
     errors: Vec<String>,
 }
 
 impl Evaluation {
-    fn exact(&self) -> bool {
+    fn blocking(&self) -> bool {
         self.failures.is_empty() && self.errors.is_empty()
     }
 }
@@ -244,26 +246,32 @@ pub(super) fn run(args: &[String]) -> Result<()> {
             ..Evaluation::default()
         },
     };
-    write_report(&options.output, &evaluation)?;
-    if evaluation.exact() {
+    write_report(&options.output, &evaluation, options.strict_recoveries)?;
+    if evaluation.blocking() && (!options.strict_recoveries || evaluation.recoveries.is_empty()) {
         println!(
             "nextest ratchet: {} known non-pass outcome(s) matched",
             evaluation.matched.len()
         );
+        for recovery in &evaluation.recoveries {
+            println!("nextest recovery accounting: {recovery}");
+        }
         Ok(())
     } else {
-        Err(evaluation
+        let mut failures = evaluation
             .failures
             .iter()
             .chain(&evaluation.errors)
             .cloned()
-            .collect::<Vec<_>>()
-            .join("\n"))
+            .collect::<Vec<_>>();
+        if options.strict_recoveries {
+            failures.extend(evaluation.recoveries.iter().cloned());
+        }
+        Err(failures.join("\n"))
     }
 }
 
 fn usage() -> &'static str {
-    "usage: cargo run -p xtask -- nextest-ratchet --junit <raw.xml> --ledger <ledger.tsv> --output <ratchet.xml> --platform <name> --runner-exit <code> [--full-inventory <nextest-list.json> --selected-inventory <nextest-list.json>]"
+    "usage: cargo run -p xtask -- nextest-ratchet --junit <raw.xml> --ledger <ledger.tsv> --output <ratchet.xml> --platform <name> --runner-exit <code> [--full-inventory <nextest-list.json> --selected-inventory <nextest-list.json>] [--strict-recoveries]"
 }
 
 fn parse_options(args: &[String]) -> Result<Options> {
@@ -280,8 +288,16 @@ fn parse_options(args: &[String]) -> Result<Options> {
                 | "--runner-exit"
                 | "--full-inventory"
                 | "--selected-inventory"
+                | "--strict-recoveries"
         ) {
             return Err(format!("unknown nextest-ratchet option: {flag}"));
+        }
+        if flag == "--strict-recoveries" {
+            if values.insert(flag, "true").is_some() {
+                return Err(format!("duplicate option: {flag}"));
+            }
+            index += 1;
+            continue;
         }
         let value = args
             .get(index + 1)
@@ -305,6 +321,7 @@ fn parse_options(args: &[String]) -> Result<Options> {
         runner_exit: get("--runner-exit")?
             .parse()
             .map_err(|_| "--runner-exit must be an integer".to_string())?,
+        strict_recoveries: values.contains_key("--strict-recoveries"),
         full_inventory: values
             .get("--full-inventory")
             .map(|value| PathBuf::from(*value)),
@@ -731,17 +748,19 @@ fn evaluate(
         }
         let Some(actual) = case.outcome.ledger_name() else {
             if let Some((outcome, reason)) = wanted {
-                result.failures.push(format!(
-                    "expected {} {} ({}) but it {}",
-                    outcome.ledger_name().unwrap(),
-                    identity.label(),
-                    reason,
-                    if case.outcome == Outcome::Skipped {
-                        "was skipped"
-                    } else {
-                        "passed"
-                    }
-                ));
+                if case.outcome == Outcome::Passed {
+                    result.recoveries.push(format!(
+                        "tracked {} now passes: {} ({reason})",
+                        outcome.ledger_name().unwrap(),
+                        identity.label(),
+                    ));
+                } else {
+                    result.failures.push(format!(
+                        "expected {} {} ({reason}) but it was skipped",
+                        outcome.ledger_name().unwrap(),
+                        identity.label(),
+                    ));
+                }
             }
             continue;
         };
@@ -784,14 +803,18 @@ fn evaluate(
     result
 }
 
-fn write_report(path: &Path, evaluation: &Evaluation) -> Result<()> {
+fn write_report(path: &Path, evaluation: &Evaluation, strict_recoveries: bool) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .map_err(|error| format!("create {}: {error}", parent.display()))?;
     }
-    let failures = usize::from(!evaluation.failures.is_empty() && evaluation.errors.is_empty());
+    let failures = usize::from(
+        (!evaluation.failures.is_empty()
+            || (strict_recoveries && !evaluation.recoveries.is_empty()))
+            && evaluation.errors.is_empty(),
+    );
     let errors = usize::from(!evaluation.errors.is_empty());
-    let skipped = evaluation.matched.len();
+    let skipped = evaluation.matched.len() + evaluation.recoveries.len();
     let tests = 1 + skipped;
     let mut xml = format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites name=\"nextest-ratchet\" tests=\"{tests}\" failures=\"{failures}\" errors=\"{errors}\" skipped=\"{skipped}\">\n  <testsuite name=\"nextest-ratchet\" tests=\"{tests}\" failures=\"{failures}\" errors=\"{errors}\" skipped=\"{skipped}\">\n"
@@ -802,11 +825,11 @@ fn write_report(path: &Path, evaluation: &Evaluation) -> Result<()> {
         messages.extend(evaluation.failures.iter().cloned());
         Some(("error", "ratchet error", messages.join("\n")))
     } else if failures > 0 {
-        Some((
-            "failure",
-            "ratchet mismatch",
-            evaluation.failures.join("\n"),
-        ))
+        let mut messages = evaluation.failures.clone();
+        if strict_recoveries {
+            messages.extend(evaluation.recoveries.iter().cloned());
+        }
+        Some(("failure", "ratchet mismatch", messages.join("\n")))
     } else {
         None
     };
@@ -823,6 +846,13 @@ fn write_report(path: &Path, evaluation: &Evaluation) -> Result<()> {
             xml,
             "    <testcase name=\"{}\" classname=\"nextest-ratchet\"><skipped message=\"{}\"/></testcase>",
             escape(&identity.label()), escape(reason)
+        );
+    }
+    for recovery in &evaluation.recoveries {
+        let _ = writeln!(
+            xml,
+            "    <testcase name=\"recovered ledger entry\" classname=\"nextest-ratchet\"><skipped message=\"{}\"/></testcase>",
+            escape(recovery)
         );
     }
     xml.push_str("  </testsuite>\n</testsuites>\n");
@@ -880,7 +910,7 @@ mod tests {
     }
 
     #[test]
-    fn exact_failure_matches_and_unexpected_pass_does_not() {
+    fn exact_failure_matches_and_recovery_is_reported_without_blocking() {
         let report = scan(&xml(
             "<testcase name=\"test\"><failure type=\"test failure with exit code 1\"/></testcase>",
             1,
@@ -890,11 +920,13 @@ mod tests {
         ))
         .unwrap();
         let exact = evaluate(&report, ledger("failure"), 100, None);
-        assert!(exact.exact());
+        assert!(exact.blocking());
         assert_eq!(exact.matched.len(), 1);
 
         let pass = scan(&xml("<testcase name=\"test\"/>", 1, 0, 0, 0)).unwrap();
-        assert!(!evaluate(&pass, ledger("failure"), 0, None).exact());
+        let recovery = evaluate(&pass, ledger("failure"), 0, None);
+        assert!(recovery.blocking());
+        assert_eq!(recovery.recoveries.len(), 1);
     }
 
     #[test]
@@ -909,8 +941,8 @@ mod tests {
         .unwrap();
         let changed = evaluate(&report, ledger("failure"), 100, None);
         assert!(changed.failures[0].contains("changed from failure to timeout"));
-        assert!(!evaluate(&report, BTreeMap::new(), 100, None).exact());
-        assert!(!evaluate(&report, ledger("timeout"), 0, None).exact());
+        assert!(!evaluate(&report, BTreeMap::new(), 100, None).blocking());
+        assert!(!evaluate(&report, ledger("timeout"), 0, None).blocking());
     }
 
     #[test]
@@ -1001,7 +1033,7 @@ mod tests {
         )
         .unwrap();
         let filtered = FilteredInventories::new(full.clone(), selected).unwrap();
-        assert!(evaluate(&report, ledger("failure"), 0, Some(&filtered)).exact());
+        assert!(evaluate(&report, ledger("failure"), 0, Some(&filtered)).blocking());
 
         let stale_inventories = FilteredInventories::new(BTreeSet::new(), BTreeSet::new()).unwrap();
         let stale = evaluate(&report, ledger("failure"), 0, Some(&stale_inventories));
@@ -1013,7 +1045,7 @@ mod tests {
             missing.failures[0].contains("expected failure is absent"),
             "a selected test missing from JUnit must not be mistaken for a filter exclusion"
         );
-        assert!(!evaluate(&report, ledger("failure"), 0, None).exact());
+        assert!(!evaluate(&report, ledger("failure"), 0, None).blocking());
     }
 
     #[test]
@@ -1025,14 +1057,16 @@ mod tests {
         )
         .unwrap();
         let available = FilteredInventories::new(full.clone(), full).unwrap();
-        assert!(!evaluate(&pass, ledger("failure"), 0, Some(&available)).exact());
+        let recovery = evaluate(&pass, ledger("failure"), 0, Some(&available));
+        assert!(recovery.blocking());
+        assert_eq!(recovery.recoveries.len(), 1);
 
         let unrelated = scan(&xml("<testcase name=\"selected\"/>", 1, 0, 0, 0)).unwrap();
         for testcase in [("test", true, "matches"), ("test", false, "mismatch")] {
             let unavailable =
                 parse_inventory(&inventory(&[testcase], 1), "counterfactual").unwrap();
             let inventories = FilteredInventories::new(unavailable.clone(), unavailable).unwrap();
-            assert!(!evaluate(&unrelated, ledger("failure"), 0, Some(&inventories)).exact());
+            assert!(!evaluate(&unrelated, ledger("failure"), 0, Some(&inventories)).blocking());
         }
     }
 
@@ -1080,7 +1114,7 @@ mod tests {
             ..Evaluation::default()
         };
         let path = std::env::temp_dir().join(format!("hew-ratchet-{}.xml", std::process::id()));
-        write_report(&path, &evaluation).unwrap();
+        write_report(&path, &evaluation, false).unwrap();
         let report = scan(&fs::read_to_string(&path).unwrap()).unwrap();
         fs::remove_file(path).unwrap();
         assert_eq!(report.counts.tests, 2);


### PR DESCRIPTION
Summary

- Treat a pinned non-pass outcome that becomes an observed PASS as a reported, non-blocking recovery in ordinary PR ratchets.
- Keep new failures, failure-class drift, skipped or missing tests, malformed evidence, inventory drift, and infrastructure errors blocking.
- Add strict scheduled accounting for every global ratchet family and native nextest coverage on Linux, macOS, Windows, and FreeBSD.
- Pin fuzz expected failures to exact semantic classes so only a clean recovery is non-blocking.

Validation

- Independent review: GO, no P0-P3 findings.
- Production fuzz oracle: 774 candidates; 698 clean; 34 expected frontend rejects; 11 runtime-abort and 31 runtime-crash entries matched.
- Ratchet runner counterfactual, fuzz/doc/Hew selftests, 24 compiled-shard tests, 10 nextest-ratchet tests, core matrix normal/strict, actionlint, shell lint, formatting, and signature checks passed.

The scheduled macOS full-inventory job is new and retains a 180-minute operational envelope; its first hosted execution remains the operational validation.