### PR TITLE
Preserve imported actor identity through supervision

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -2967,6 +2967,8 @@ pub fn lower_program_with_mono_cap(
             .filter_map(|(_, (item, _))| match item {
                 Item::TypeDecl(decl) => Some(decl.name.clone()),
                 Item::Record(decl) => Some(decl.name.clone()),
+                Item::Actor(decl) => Some(decl.name.clone()),
+                Item::Supervisor(decl) => Some(decl.name.clone()),
                 _ => None,
             }),
     );
@@ -3003,6 +3005,12 @@ pub fn lower_program_with_mono_cap(
                 let event = machine_event_surface_type(&decl.name);
                 ctx.file_import_root_type_aliases
                     .insert(event.clone(), format!("{module_full_path}.{event}"));
+            }
+            Item::Actor(decl) => {
+                ctx.file_import_root_type_aliases.insert(
+                    decl.name.clone(),
+                    format!("{module_full_path}.{}", decl.name),
+                );
             }
             _ => {}
         }
@@ -13391,15 +13399,6 @@ impl LowerCtx {
     ) -> HirActorDecl {
         let previous_rewrites = self.imported_fn_rewrites.replace(rewrites.clone());
         let mut lowered = self.lower_actor(decl, span, Some(module_full_path));
-        lowered.defining_module = Some(module_full_path.to_string());
-        // `lower_actor` attached checker side-tables under the bare name
-        // (the root-actor identity). A module actor's checker identity is
-        // the dotted `qualified_name()`; re-attach the descriptor and the
-        // cycle-capability flag from the qualified keys so two same-named
-        // actors carry their own protocol (distinct msg_ids) and cycle flag.
-        let qualified = lowered.qualified_name();
-        lowered.protocol_descriptor = self.actor_protocol_descriptors.get(&qualified).cloned();
-        lowered.cycle_capable = self.cycle_capable_actors.contains(&qualified);
         // Owner-qualify each receive handler's return type to the declaring
         // module (`testffi.Result`) ONLY when the returned record's bare name
         // genuinely collides across modules — the same collision the MIR
@@ -14257,9 +14256,27 @@ impl LowerCtx {
                     static_slot += 1;
                     idx
                 };
+                let child_ty = self
+                    .canonical_supervisor_child_ty(&child.actor_type)
+                    .unwrap_or_else(|| {
+                        self.diagnostics.push(
+                            HirDiagnostic::new(
+                                HirDiagnosticKind::CheckerBoundaryViolation {
+                                    name: child.actor_type.clone(),
+                                    reason: "supervisor child has no lexical actor authority"
+                                        .to_string(),
+                                },
+                                child.span.clone(),
+                                "a dotted supervisor child must resolve through the checker's \
+                                 exact module binding",
+                            )
+                            .with_source_module(self.current_module_name.clone()),
+                        );
+                        format!("<invalid-supervisor-child:{}>", child.actor_type)
+                    });
                 HirSupervisorChild {
                     name: child.name.clone(),
-                    ty: self.canonical_supervisor_child_ty(&child.actor_type),
+                    ty: child_ty,
                     restart_policy: child.restart.map(|r| match r {
                         RestartPolicy::Permanent => HirRestartPolicy::Permanent,
                         RestartPolicy::Transient => HirRestartPolicy::Transient,
@@ -15147,41 +15164,20 @@ impl LowerCtx {
 
         let (methods, lifecycle_hooks) = self.partition_actor_methods(&decl.methods, &state_fields);
 
-        // Checker side-tables key a module actor under its module-short
-        // identity (`"{module_leaf}.{Actor}"`, matching the checker's
-        // `current_module_short()` fn_sigs prefix); only genuine root actors
-        // are keyed bare. A FILE-imported actor lowers through this root path
-        // — `flatten_file_import_items` (hew-compile) splices it into
-        // `program.items` AFTER type-checking, so its HIR identity stays
-        // root/bare — but the checker validated it as a module-graph item and
-        // published its protocol descriptor under the module-short key. The
-        // third pass sets `current_module_name` to the originating module's
-        // dotted path for spliced items (root items lower with it unset), so
-        // resolve the descriptor and the cycle-capability flag under the
-        // module-short key first and fall back to the bare root key. Without
-        // the module-scoped lookup every spliced multi-handler actor lost its
-        // descriptor and MIR collapsed all message-kind discriminants onto one
-        // fabricated tag — LLVM rejected the dispatch switch with "Duplicate
-        // integer as switch case". MIR no longer fabricates a discriminant, so
-        // that regression now surfaces as a hard
-        // `ActorProtocolDescriptorMissing` instead; this lookup is still what
-        // keeps a correct program from tripping it. Package-module actors overwrite
-        // both fields in `lower_imported_actor` with the same qualified keys,
-        // so this lookup is identity-preserving for them.
-        let module_scoped_key = self
-            .current_module_name
-            .as_deref()
-            .map(hew_types::short_name)
-            .map(|leaf| format!("{leaf}.{}", decl.name));
-        let protocol_descriptor = module_scoped_key
-            .as_deref()
-            .and_then(|key| self.actor_protocol_descriptors.get(key))
-            .or_else(|| self.actor_protocol_descriptors.get(&decl.name))
+        // Checker actor side-tables and every downstream layout registry share
+        // the declaration's complete nominal identity. File-import flattening
+        // supplies `decl_module` from the original module graph; root actors
+        // use the bare name. Never retry a module actor by leaf name because
+        // two nested modules may legitimately export the same actor leaf.
+        let actor_identity = decl_module.map_or_else(
+            || decl.name.clone(),
+            |module| format!("{module}.{}", decl.name),
+        );
+        let protocol_descriptor = self
+            .actor_protocol_descriptors
+            .get(&actor_identity)
             .cloned();
-        let cycle_capable = module_scoped_key
-            .as_deref()
-            .is_some_and(|key| self.cycle_capable_actors.contains(key))
-            || self.cycle_capable_actors.contains(&decl.name);
+        let cycle_capable = self.cycle_capable_actors.contains(&actor_identity);
 
         HirActorDecl {
             id: self.ids.item(),
@@ -24371,15 +24367,67 @@ impl LowerCtx {
     /// `NotYetImplemented`. Resolve the `alias.Type` prefix through
     /// `module_import_bindings` — the same table the checker's spawn resolution
     /// uses — so a supervisor-child handle carries the same identity a spawn
-    /// handle does. A bare root-actor spelling has no module prefix and is
-    /// returned unchanged.
-    fn canonical_supervisor_child_ty(&self, raw: &str) -> String {
-        match raw.split_once('.') {
-            Some((module_binding, member)) => {
-                self.imported_module_member_key(module_binding, member)
-            }
-            None => raw.to_string(),
+    /// handle does. Bare spellings follow lexical authority: a current-scope
+    /// declaration wins, then the checker's exact named/aliased import binding,
+    /// then a flattened file-import identity. No globally loaded leaf-name
+    /// fallback participates.
+    fn canonical_supervisor_child_ty(&self, raw: &str) -> Option<String> {
+        if let Some((module_binding, member)) = raw.split_once('.') {
+            let owner = self.module_import_bindings.get(&(
+                self.current_module_name.clone(),
+                self.current_module_idx,
+                module_binding.to_string(),
+            ))?;
+            let canonical = format!("{owner}.{member}");
+            return self
+                .actor_type_names
+                .contains(&canonical)
+                .then_some(canonical);
         }
+        // A flattened file import is syntactically present in the root item
+        // stream, so it also appears root-visible. Its explicit source-owner
+        // alias must therefore be checked before the ordinary current-scope
+        // declaration rung.
+        if self.current_module_name.is_none() {
+            if let Some(canonical) = self.file_import_root_type_aliases.get(raw) {
+                return self
+                    .actor_type_names
+                    .contains(canonical)
+                    .then(|| canonical.clone());
+            }
+        }
+        // A supervisor inside an imported module may name an actor declared in
+        // that same file by its local spelling. The checker supplies the exact
+        // set of actor identities, so qualify only an exact owner/name member;
+        // do not infer an owner by scanning globally loaded leaf names.
+        if let Some(module_full_path) = self.current_module_name.as_deref() {
+            let local_actor = format!("{module_full_path}.{raw}");
+            if self.actor_type_names.contains(&local_actor) {
+                return Some(local_actor);
+            }
+        }
+        let current_module_is_file_import = self
+            .current_module_name
+            .as_deref()
+            .is_some_and(|module| self.file_import_module_names.contains(module));
+        if self.current_scope_declares_source_type(raw, current_module_is_file_import) {
+            return Some(self.canonical_current_module_record_name(raw));
+        }
+        if let Some(canonical) = self
+            .import_type_name_aliases
+            .get(&(
+                self.current_module_name.clone(),
+                self.current_module_idx,
+                raw.to_string(),
+            ))
+            .cloned()
+        {
+            return self
+                .actor_type_names
+                .contains(&canonical)
+                .then_some(canonical);
+        }
+        Some(raw.to_string())
     }
 
     /// Whether bare `name` is authored by the scope currently being lowered.
@@ -37324,6 +37372,63 @@ impl Widget {
         assert_eq!(
             ctx.imported_module_member_key("codec", "MAX_READS"),
             "std.net.http.codec.MAX_READS"
+        );
+    }
+
+    #[test]
+    fn supervisor_child_identity_uses_exact_import_owner_and_keeps_root_bare() {
+        let mut ctx = LowerCtx::new(
+            &TypeCheckOutput::default(),
+            MONOMORPHISATION_REGISTRY_CAP,
+            TargetArch::host(),
+        );
+        ctx.module_import_bindings.insert(
+            (None, 0, "left_worker".to_string()),
+            "services.left.worker".to_string(),
+        );
+        ctx.module_import_bindings.insert(
+            (None, 0, "right_worker".to_string()),
+            "services.right.worker".to_string(),
+        );
+        ctx.file_import_root_type_aliases.insert(
+            "FlatWorker".to_string(),
+            "support.nested.worker.FlatWorker".to_string(),
+        );
+        ctx.actor_type_names.extend([
+            "services.left.worker.Worker".to_string(),
+            "services.right.worker.Worker".to_string(),
+            "support.nested.worker.FlatWorker".to_string(),
+        ]);
+
+        assert_eq!(
+            ctx.canonical_supervisor_child_ty("left_worker.Worker"),
+            Some("services.left.worker.Worker".to_string()),
+            "a qualified module import must retain the complete checker owner"
+        );
+        assert_eq!(
+            ctx.canonical_supervisor_child_ty("right_worker.Worker"),
+            Some("services.right.worker.Worker".to_string()),
+            "same-leaf actors in nested modules must remain distinct"
+        );
+        assert_ne!(
+            ctx.canonical_supervisor_child_ty("left_worker.Worker"),
+            ctx.canonical_supervisor_child_ty("right_worker.Worker"),
+            "canonicalization must never retry a nested actor by leaf name"
+        );
+        assert_eq!(
+            ctx.canonical_supervisor_child_ty("FlatWorker"),
+            Some("support.nested.worker.FlatWorker".to_string()),
+            "a flattened actor's bare surface must project to its declaration owner"
+        );
+        assert_eq!(
+            ctx.canonical_supervisor_child_ty("RootWorker"),
+            Some("RootWorker".to_string()),
+            "a genuine root actor must keep its bare identity"
+        );
+        assert_eq!(
+            ctx.canonical_supervisor_child_ty("services.left.worker.Worker"),
+            None,
+            "a raw canonical path without a lexical module root must fail closed"
         );
     }
 

--- a/hew-hir/tests/concurrency.rs
+++ b/hew-hir/tests/concurrency.rs
@@ -23,6 +23,8 @@ mod actor_send_gates;
 mod actor_state_lock_lower;
 #[path = "concurrency/cancellation_token_lower.rs"]
 mod cancellation_token_lower;
+#[path = "concurrency/imported_supervisor_child_identity.rs"]
+mod imported_supervisor_child_identity;
 #[path = "concurrency/spawn_qualified_identity.rs"]
 mod spawn_qualified_identity;
 #[path = "concurrency/supervisor_child_accessor_gates.rs"]

--- a/hew-hir/tests/concurrency/imported_supervisor_child_identity.rs
+++ b/hew-hir/tests/concurrency/imported_supervisor_child_identity.rs
@@ -1,0 +1,406 @@
+//! File-imported actor identity at the supervisor boundary.
+
+use std::path::PathBuf;
+
+use hew_hir::{lower_program_host_target, HirActorDecl, HirItem, HirSupervisorDecl, ResolutionCtx};
+use hew_parser::ast::{ImportDecl, ImportName, ImportSpec, Item, Program};
+use hew_parser::module::{Module, ModuleGraph, ModuleId};
+use hew_types::{module_registry::ModuleRegistry, Checker, TypeCheckOutput};
+
+const WORKER_MODULE: &str = "imported_supervisor_child_support.worker";
+const NAMED_WORKER_MODULE: &str = "services.workers";
+
+fn file_import_program(
+    imported_src: &str,
+    root_src: &str,
+) -> (Program, Vec<hew_parser::ast::Spanned<Item>>) {
+    let imported = hew_parser::parse(imported_src);
+    assert!(
+        imported.errors.is_empty(),
+        "imported parse errors: {:#?}",
+        imported.errors
+    );
+    let root = hew_parser::parse(root_src);
+    assert!(
+        root.errors.is_empty(),
+        "root parse errors: {:#?}",
+        root.errors
+    );
+
+    let imported_items: Vec<_> = imported
+        .program
+        .items
+        .into_iter()
+        .filter(|(item, _)| !matches!(item, Item::Import(_)))
+        .collect();
+    let worker_path = PathBuf::from("/virtual/imported_supervisor_child_support/worker.hew");
+    let mut root_items = root.program.items;
+    let import = root_items
+        .iter_mut()
+        .find_map(|(item, _)| match item {
+            Item::Import(import) if import.file_path.is_some() => Some(import),
+            _ => None,
+        })
+        .expect("root file import");
+    import.resolved_items = Some(imported_items.clone());
+    import.resolved_item_source_paths = vec![worker_path.clone(); imported_items.len()];
+    import.resolved_source_paths = vec![worker_path.clone()];
+
+    let worker_id = ModuleId::new(WORKER_MODULE.split('.').map(str::to_string).collect());
+    let root_id = ModuleId::root();
+    let worker_module = Module {
+        id: worker_id.clone(),
+        items: imported_items.clone(),
+        imports: Vec::new(),
+        source_paths: vec![worker_path],
+        doc: None,
+    };
+    let root_module = Module {
+        id: root_id.clone(),
+        items: root_items.clone(),
+        imports: Vec::new(),
+        source_paths: Vec::new(),
+        doc: None,
+    };
+    let mut graph = ModuleGraph::new(root_id.clone());
+    graph.add_module(worker_module).expect("add worker module");
+    graph.add_module(root_module).expect("add root module");
+    graph.topo_order = vec![worker_id, root_id];
+
+    (
+        Program {
+            items: root_items,
+            module_graph: Some(graph),
+            module_doc: root.program.module_doc,
+        },
+        imported_items,
+    )
+}
+
+fn lower_file_import(
+    imported_src: &str,
+    root_src: &str,
+) -> (hew_hir::LowerOutput, TypeCheckOutput) {
+    lower_file_import_with(imported_src, root_src, |_| {})
+}
+
+fn lower_file_import_with(
+    imported_src: &str,
+    root_src: &str,
+    prepare_checked: impl FnOnce(&mut TypeCheckOutput),
+) -> (hew_hir::LowerOutput, TypeCheckOutput) {
+    let (mut program, imported_items) = file_import_program(imported_src, root_src);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let mut tc_output = checker.check_program(&program);
+    prepare_checked(&mut tc_output);
+    // `hew-compile` performs this source-order splice after checking. HIR sees
+    // both the checker-authored module graph and the flattened tail entries.
+    program.items.extend(imported_items);
+    let lowered = lower_program_host_target(&program, &tc_output, &ResolutionCtx);
+    (lowered, tc_output)
+}
+
+fn actor_import_program(
+    spec: Option<ImportSpec>,
+    module_alias: Option<&str>,
+    root_tail: &str,
+) -> Program {
+    let imported = hew_parser::parse(
+        "pub actor Worker {\n\
+         \x20   let id: i64;\n\
+         \x20   receive fn identify() -> i64 { id }\n\
+         }\n",
+    );
+    assert!(imported.errors.is_empty(), "{:#?}", imported.errors);
+    let root = hew_parser::parse(root_tail);
+    assert!(root.errors.is_empty(), "{:#?}", root.errors);
+
+    let import_item = (
+        Item::Import(ImportDecl {
+            path: NAMED_WORKER_MODULE.split('.').map(str::to_string).collect(),
+            spec,
+            selection_trailing_comma: false,
+            module_alias: module_alias.map(str::to_string),
+            file_path: None,
+            resolved_items: Some(imported.program.items.clone()),
+            resolved_item_source_paths: Vec::new(),
+            resolved_source_paths: Vec::new(),
+        }),
+        0..0,
+    );
+    let worker_id = ModuleId::new(NAMED_WORKER_MODULE.split('.').map(str::to_string).collect());
+    let root_id = ModuleId::root();
+    let mut root_items = vec![import_item];
+    root_items.extend(root.program.items.clone());
+    let mut graph = ModuleGraph::new(root_id.clone());
+    graph
+        .add_module(Module {
+            id: worker_id.clone(),
+            items: imported.program.items,
+            imports: Vec::new(),
+            source_paths: Vec::new(),
+            doc: None,
+        })
+        .expect("add named worker module");
+    graph
+        .add_module(Module {
+            id: root_id.clone(),
+            items: root_items.clone(),
+            imports: Vec::new(),
+            source_paths: Vec::new(),
+            doc: None,
+        })
+        .expect("add root module");
+    graph.topo_order = vec![worker_id, root_id];
+
+    Program {
+        items: root_items,
+        module_graph: Some(graph),
+        module_doc: root.program.module_doc,
+    }
+}
+
+fn named_import_program(alias: Option<&str>, root_tail: &str) -> Program {
+    actor_import_program(
+        Some(ImportSpec::Names(vec![ImportName {
+            name: "Worker".to_string(),
+            alias: alias.map(str::to_string),
+        }])),
+        None,
+        root_tail,
+    )
+}
+
+fn lower_named_import(
+    alias: Option<&str>,
+    root_tail: &str,
+) -> (hew_hir::LowerOutput, TypeCheckOutput) {
+    let program = named_import_program(alias, root_tail);
+    let mut type_checker = Checker::new(ModuleRegistry::new(vec![]));
+    let checked = type_checker.check_program(&program);
+    let lowered = lower_program_host_target(&program, &checked, &ResolutionCtx);
+    (lowered, checked)
+}
+
+fn lower_whole_module_import(root_tail: &str) -> (hew_hir::LowerOutput, TypeCheckOutput) {
+    let program = actor_import_program(None, None, root_tail);
+    let mut type_checker = Checker::new(ModuleRegistry::new(vec![]));
+    let checked = type_checker.check_program(&program);
+    let lowered = lower_program_host_target(&program, &checked, &ResolutionCtx);
+    (lowered, checked)
+}
+
+fn actor<'a>(output: &'a hew_hir::LowerOutput, name: &str) -> &'a HirActorDecl {
+    output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            HirItem::Actor(actor) if actor.name == name => Some(actor),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("missing actor `{name}`"))
+}
+
+fn supervisor<'a>(output: &'a hew_hir::LowerOutput, name: &str) -> &'a HirSupervisorDecl {
+    output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            HirItem::Supervisor(supervisor) if supervisor.name == name => Some(supervisor),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("missing supervisor `{name}`"))
+}
+
+#[test]
+fn file_imported_supervisor_child_and_protocol_share_full_actor_identity() {
+    let (output, checked) = lower_file_import(
+        "pub actor ImportedWorker {\n\
+         \x20   let id: i64;\n\
+         \x20   receive fn identify() -> i64 { id }\n\
+         }\n",
+        "import \"imported_supervisor_child_support/worker.hew\";\n\
+         supervisor ImportedWorkerPool {\n\
+         \x20   child worker: ImportedWorker(id: 17);\n\
+         }\n",
+    );
+    assert!(
+        checked.errors.is_empty(),
+        "type errors: {:#?}",
+        checked.errors
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "HIR diagnostics: {:#?}",
+        output.diagnostics
+    );
+
+    let imported = actor(&output, "ImportedWorker");
+    let expected = format!("{WORKER_MODULE}.ImportedWorker");
+    assert_eq!(imported.qualified_name(), expected);
+    let descriptor = imported
+        .protocol_descriptor
+        .as_ref()
+        .expect("file-imported handler must retain its checker descriptor");
+    assert_eq!(descriptor.actor_name, expected);
+
+    let pool = supervisor(&output, "ImportedWorkerPool");
+    assert_eq!(pool.children.len(), 1);
+    assert_eq!(pool.children[0].ty, imported.qualified_name());
+}
+
+#[test]
+fn file_imported_actor_cycle_capability_uses_full_checker_identity() {
+    let expected = format!("{WORKER_MODULE}.CyclicImported");
+    let (output, checked) = lower_file_import_with(
+        "pub actor CyclicImported {\n\
+         \x20   let peer: LocalPid<CyclicImported>;\n\
+         }\n\
+         pub actor AcyclicImported {\n\
+         \x20   let value: i64;\n\
+         }\n",
+        "import \"imported_supervisor_child_support/worker.hew\";\n\
+         actor RootAcyclic {\n\
+         \x20   let value: i64;\n\
+         }\n",
+        |checked| {
+            assert!(checked.cycle_capable_actors.contains(&expected));
+            // File imports also expose a bare compatibility alias. Keep only
+            // the checker's full nominal key so this oracle cannot pass through
+            // the historical leaf/bare fallback in HIR lowering.
+            checked
+                .cycle_capable_actors
+                .retain(|actor| actor == &expected);
+        },
+    );
+    assert!(
+        checked.errors.is_empty(),
+        "type errors: {:#?}",
+        checked.errors
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "HIR diagnostics: {:#?}",
+        output.diagnostics
+    );
+
+    assert!(checked.cycle_capable_actors.contains(&expected));
+    assert_eq!(checked.cycle_capable_actors.len(), 1);
+
+    let cyclic = actor(&output, "CyclicImported");
+    assert_eq!(cyclic.qualified_name(), expected);
+    assert!(cyclic.cycle_capable);
+    assert!(!actor(&output, "AcyclicImported").cycle_capable);
+    assert!(!actor(&output, "RootAcyclic").cycle_capable);
+}
+
+#[test]
+fn named_and_aliased_supervisor_children_use_the_imported_actor_identity() {
+    for (alias, binding) in [(None, "Worker"), (Some("Renamed"), "Renamed")] {
+        let source =
+            format!("supervisor App {{ child worker: {binding}(id: 17) restart: temporary; }}");
+        let (output, checked) = lower_named_import(alias, &source);
+        assert!(
+            checked.errors.is_empty(),
+            "`{binding}` type errors: {:#?}",
+            checked.errors
+        );
+        assert!(
+            output.diagnostics.is_empty(),
+            "`{binding}` HIR diagnostics: {:#?}",
+            output.diagnostics
+        );
+        assert_eq!(
+            checked
+                .import_type_name_aliases
+                .iter()
+                .find(|((_, _, published), _)| published == binding)
+                .map(|(_, identity)| identity.as_str()),
+            Some("services.workers.Worker")
+        );
+        assert_eq!(
+            supervisor(&output, "App").children[0].ty,
+            "services.workers.Worker"
+        );
+    }
+}
+
+#[test]
+fn whole_module_supervisor_child_uses_the_imported_actor_identity() {
+    let (output, checked) = lower_whole_module_import(
+        "supervisor App { child worker: workers.Worker(id: 17) restart: temporary; }",
+    );
+    assert!(checked.errors.is_empty(), "{:#?}", checked.errors);
+    assert!(output.diagnostics.is_empty(), "{:#?}", output.diagnostics);
+    assert_eq!(
+        supervisor(&output, "App").children[0].ty,
+        "services.workers.Worker"
+    );
+}
+
+#[test]
+fn selected_alias_does_not_authorize_a_raw_canonical_actor_path_in_hir() {
+    let (output, checked) = lower_named_import(
+        Some("Renamed"),
+        "supervisor App { child worker: services.workers.Worker restart: temporary; }",
+    );
+    assert!(checked.errors.iter().any(|error| {
+        matches!(
+            error.kind,
+            hew_types::error::TypeErrorKind::SupervisorError {
+                subkind: hew_types::error::SupervisorErrorKind::UnknownChildActor
+            }
+        )
+    }));
+    let diagnostic = output
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                &diagnostic.kind,
+                hew_hir::HirDiagnosticKind::CheckerBoundaryViolation { name, reason }
+                    if name == "services.workers.Worker"
+                        && reason == "supervisor child has no lexical actor authority"
+            )
+        })
+        .expect("forced HIR lowering must fail closed at the checker boundary");
+    assert!(diagnostic.note.contains("exact module binding"));
+}
+
+#[test]
+fn file_imported_supervisor_resolves_its_same_file_actor_by_exact_owner() {
+    let (output, checked) = lower_file_import(
+        "pub actor Worker {\n\
+         \x20   let id: i64;\n\
+         \x20   receive fn identify() -> i64 { id }\n\
+         }\n\
+         pub supervisor Inner {\n\
+         \x20   child worker: Worker(id: 23) restart: temporary;\n\
+         }\n",
+        "import \"imported_supervisor_child_support/worker.hew\";",
+    );
+    assert!(checked.errors.is_empty(), "{:#?}", checked.errors);
+    assert!(output.diagnostics.is_empty(), "{:#?}", output.diagnostics);
+    assert_eq!(
+        supervisor(&output, "Inner").children[0].ty,
+        format!("{WORKER_MODULE}.Worker")
+    );
+}
+
+#[test]
+fn root_actor_keeps_authority_over_same_leaf_named_import_in_hir() {
+    let (output, checked) = lower_named_import(
+        None,
+        "actor Worker { receive fn identify() -> i64 { 9 } }\n\
+         supervisor App { child worker: Worker restart: temporary; }",
+    );
+    assert!(checked.errors.is_empty(), "{:#?}", checked.errors);
+    assert!(output.diagnostics.is_empty(), "{:#?}", output.diagnostics);
+    assert_eq!(supervisor(&output, "App").children[0].ty, "Worker");
+    assert!(output.module.items.iter().any(|item| matches!(
+        item,
+        HirItem::Actor(actor) if actor.name == "Worker" && actor.defining_module.is_none()
+    )));
+}

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -788,12 +788,11 @@ pub struct ActorLayout {
     /// Actor type name.
     pub name: String,
     /// Defining-module identity carried verbatim from
-    /// `HirActorDecl::defining_module`. `None` for root-program actors
-    /// (including file-import spliced ones); `Some(module_short)` for actors
-    /// exported by a package module. This is the discriminator that makes
-    /// qualified layout keys and qualified symbol mangling possible — layout
-    /// keys and all `mangle_actor_*` symbols still derive from the bare
-    /// `name` until the qualified re-key lands on top of this carrier.
+    /// `HirActorDecl::defining_module`. `None` for root-program actors;
+    /// `Some(module)` for imported actors, including file-import items spliced
+    /// into the root program after checking. `name` already carries the actor's
+    /// qualified registry key; this field preserves its declaration owner
+    /// separately without recovering identity from that presentation string.
     pub defining_module: Option<String>,
     /// Actor state field names in declaration order.
     pub state_field_names: Vec<String>,

--- a/hew-mir/tests/actor/supervisor_lowering.rs
+++ b/hew-mir/tests/actor/supervisor_lowering.rs
@@ -11,9 +11,12 @@
 //! destination, and init-args are rejected with `NotYetImplemented`.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use hew_hir::{lower_program, HirDiagnosticKind, ResolutionCtx};
 use hew_mir::{lower_hir_module, FunctionCallConv, Instr, MirDiagnosticKind, Place, Terminator};
+use hew_parser::ast::{ImportDecl, ImportName, ImportSpec, Item, Program};
+use hew_parser::module::{Module, ModuleGraph, ModuleId};
 use hew_types::{module_registry::ModuleRegistry, BuiltinType, Checker, ResolvedTy};
 
 /// Lower a Hew source program to MIR, asserting no parse or HIR diagnostics.
@@ -42,6 +45,260 @@ fn lower_module_from_source(source: &str) -> hew_mir::IrPipeline {
         hir.diagnostics
     );
     lower_hir_module(&hir.module)
+}
+
+/// Mirror `hew-compile`'s file-import order: type-check the module graph, then
+/// splice the imported declarations into the root source-order stream for HIR.
+fn lower_file_imported_supervisor_to_mir() -> hew_mir::IrPipeline {
+    lower_file_imported_program_to_mir(
+        "pub actor ImportedWorker {\n\
+         \x20   let id: i64;\n\
+         \x20   receive fn identify() -> i64 { id }\n\
+         }\n",
+        "import \"imported_supervisor_child_support/worker.hew\";\n\
+         supervisor ImportedWorkerPool {\n\
+         \x20   child worker: ImportedWorker(id: 17);\n\
+         }\n",
+    )
+}
+
+fn lower_file_imported_program_to_mir(
+    imported_source: &str,
+    root_source: &str,
+) -> hew_mir::IrPipeline {
+    let imported = hew_parser::parse(imported_source);
+    assert!(imported.errors.is_empty(), "{:#?}", imported.errors);
+    let root = hew_parser::parse(root_source);
+    assert!(root.errors.is_empty(), "{:#?}", root.errors);
+
+    let imported_items: Vec<_> = imported
+        .program
+        .items
+        .into_iter()
+        .filter(|(item, _)| !matches!(item, Item::Import(_)))
+        .collect();
+    let worker_path = PathBuf::from("/virtual/imported_supervisor_child_support/worker.hew");
+    let mut root_items = root.program.items;
+    let import = root_items
+        .iter_mut()
+        .find_map(|(item, _)| match item {
+            Item::Import(import) if import.file_path.is_some() => Some(import),
+            _ => None,
+        })
+        .expect("root file import");
+    import.resolved_items = Some(imported_items.clone());
+    import.resolved_item_source_paths = vec![worker_path.clone(); imported_items.len()];
+    import.resolved_source_paths = vec![worker_path.clone()];
+
+    let worker_id = ModuleId::new(vec![
+        "imported_supervisor_child_support".to_string(),
+        "worker".to_string(),
+    ]);
+    let root_id = ModuleId::root();
+    let mut graph = ModuleGraph::new(root_id.clone());
+    graph
+        .add_module(Module {
+            id: worker_id.clone(),
+            items: imported_items.clone(),
+            imports: Vec::new(),
+            source_paths: vec![worker_path],
+            doc: None,
+        })
+        .expect("add worker module");
+    graph
+        .add_module(Module {
+            id: root_id.clone(),
+            items: root_items.clone(),
+            imports: Vec::new(),
+            source_paths: Vec::new(),
+            doc: None,
+        })
+        .expect("add root module");
+    graph.topo_order = vec![worker_id, root_id];
+
+    let mut program = Program {
+        items: root_items,
+        module_graph: Some(graph),
+        module_doc: root.program.module_doc,
+    };
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&program);
+    assert!(
+        tc_output.errors.is_empty(),
+        "type errors: {:#?}",
+        tc_output.errors
+    );
+    program.items.extend(imported_items);
+    let hir = lower_program(
+        &program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(
+        hir.diagnostics.is_empty(),
+        "HIR diagnostics: {:#?}",
+        hir.diagnostics
+    );
+    lower_hir_module(&hir.module)
+}
+
+fn lower_named_imported_supervisor_to_mir(
+    alias: Option<&str>,
+    binding: &str,
+) -> hew_mir::IrPipeline {
+    let imported = hew_parser::parse(
+        "pub actor Worker {\n\
+         \x20   let id: i64;\n\
+         \x20   receive fn identify() -> i64 { id }\n\
+         }\n",
+    );
+    assert!(imported.errors.is_empty(), "{:#?}", imported.errors);
+    let root = hew_parser::parse(&format!(
+        "supervisor App {{ child worker: {binding}(id: 17) restart: temporary; }}"
+    ));
+    assert!(root.errors.is_empty(), "{:#?}", root.errors);
+    let module_path = ["services", "workers"];
+    let import_item = (
+        Item::Import(ImportDecl {
+            path: module_path.iter().map(ToString::to_string).collect(),
+            spec: Some(ImportSpec::Names(vec![ImportName {
+                name: "Worker".to_string(),
+                alias: alias.map(str::to_string),
+            }])),
+            selection_trailing_comma: false,
+            module_alias: None,
+            file_path: None,
+            resolved_items: Some(imported.program.items.clone()),
+            resolved_item_source_paths: Vec::new(),
+            resolved_source_paths: Vec::new(),
+        }),
+        0..0,
+    );
+    let worker_id = ModuleId::new(module_path.iter().map(ToString::to_string).collect());
+    let root_id = ModuleId::root();
+    let mut root_items = vec![import_item];
+    root_items.extend(root.program.items);
+    let mut graph = ModuleGraph::new(root_id.clone());
+    graph
+        .add_module(Module {
+            id: worker_id.clone(),
+            items: imported.program.items,
+            imports: Vec::new(),
+            source_paths: Vec::new(),
+            doc: None,
+        })
+        .expect("add named worker module");
+    graph
+        .add_module(Module {
+            id: root_id.clone(),
+            items: root_items.clone(),
+            imports: Vec::new(),
+            source_paths: Vec::new(),
+            doc: None,
+        })
+        .expect("add root module");
+    graph.topo_order = vec![worker_id, root_id];
+    let program = Program {
+        items: root_items,
+        module_graph: Some(graph),
+        module_doc: root.program.module_doc,
+    };
+    let mut type_checker = Checker::new(ModuleRegistry::new(vec![]));
+    let checked = type_checker.check_program(&program);
+    assert!(checked.errors.is_empty(), "{:#?}", checked.errors);
+    let hir = lower_program(
+        &program,
+        &checked,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(hir.diagnostics.is_empty(), "{:#?}", hir.diagnostics);
+    lower_hir_module(&hir.module)
+}
+
+#[test]
+fn file_imported_supervisor_child_uses_its_actor_layout_key() {
+    let pipeline = lower_file_imported_supervisor_to_mir();
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "MIR diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    let actor = pipeline
+        .actor_layouts
+        .iter()
+        .find(|actor| actor.name.ends_with(".ImportedWorker"))
+        .expect("imported actor layout");
+    let child = pipeline
+        .supervisor_layouts
+        .iter()
+        .find(|supervisor| supervisor.name == "ImportedWorkerPool")
+        .and_then(|supervisor| supervisor.children.first())
+        .expect("imported supervisor child layout");
+    assert_eq!(
+        child.actor_name, actor.name,
+        "supervisor child and actor layout must use the same complete identity key"
+    );
+    assert_eq!(
+        actor.name,
+        "imported_supervisor_child_support.worker.ImportedWorker"
+    );
+}
+
+#[test]
+fn named_and_aliased_supervisor_children_match_the_imported_actor_layout_key() {
+    for (alias, binding) in [(None, "Worker"), (Some("Renamed"), "Renamed")] {
+        let pipeline = lower_named_imported_supervisor_to_mir(alias, binding);
+        assert!(
+            pipeline.diagnostics.is_empty(),
+            "`{binding}` MIR diagnostics: {:#?}",
+            pipeline.diagnostics
+        );
+        let actor = pipeline
+            .actor_layouts
+            .iter()
+            .find(|actor| actor.name == "services.workers.Worker")
+            .expect("named-imported actor layout");
+        let child = pipeline
+            .supervisor_layouts
+            .iter()
+            .find(|supervisor| supervisor.name == "App")
+            .and_then(|supervisor| supervisor.children.first())
+            .expect("named-imported supervisor child");
+        assert_eq!(child.actor_name, actor.name);
+    }
+}
+
+#[test]
+fn file_imported_supervisor_child_matches_its_same_file_actor_layout_key() {
+    let pipeline = lower_file_imported_program_to_mir(
+        "pub actor Worker {\n\
+         \x20   let id: i64;\n\
+         \x20   receive fn identify() -> i64 { id }\n\
+         }\n\
+         pub supervisor Inner {\n\
+         \x20   child worker: Worker(id: 23) restart: temporary;\n\
+         }\n",
+        "import \"imported_supervisor_child_support/worker.hew\";",
+    );
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "MIR diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    let actor = pipeline
+        .actor_layouts
+        .iter()
+        .find(|actor| actor.name == "imported_supervisor_child_support.worker.Worker")
+        .expect("same-file actor layout");
+    let child = pipeline
+        .supervisor_layouts
+        .iter()
+        .find(|supervisor| supervisor.name.ends_with("Inner"))
+        .and_then(|supervisor| supervisor.children.first())
+        .expect("same-file supervisor child");
+    assert_eq!(child.actor_name, actor.name);
 }
 
 /// Lower a Hew source program to MIR, permitting HIR diagnostics for

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -71,6 +71,9 @@ impl Checker {
     /// Validate a `supervisor` declaration at the structural level.
     ///
     /// Checks:
+    /// - Every child type resolves lexically to an actor
+    ///   (`E_SUPERVISOR_UNKNOWN_CHILD_ACTOR` /
+    ///   `E_SUPERVISOR_CHILD_NOT_SUPERVISABLE`).
     /// - Duplicate child names (`E_SUPERVISOR_DUPLICATE_CHILD`).
     /// - `wired_to` keys each reference a declared sibling (`E_SUPERVISOR_WIRED_TO_UNKNOWN_SIBLING`).
     /// - `wired_to` sibling ref type matches the dependent actor's init param type
@@ -96,30 +99,33 @@ impl Checker {
             }
         }
 
-        // ── 1. Duplicate child names ─────────────────────────────────────────
+        // ── 1. Child actor identity ──────────────────────────────────────────
+        self.check_supervisor_child_actor_types(sd, span);
+
+        // ── 2. Duplicate child names ─────────────────────────────────────────
         self.check_supervisor_duplicate_children(sd, span);
 
-        // ── 2. Strategy / pool consistency ──────────────────────────────────
+        // ── 3. Strategy / pool consistency ──────────────────────────────────
         self.check_supervisor_strategy_pool(sd, span);
 
-        // ── 3. wired_to key resolution + type compatibility ──────────────────
+        // ── 4. wired_to key resolution + type compatibility ──────────────────
         self.check_supervisor_wired_to(sd, span);
 
-        // ── 4. Dependency cycle detection ────────────────────────────────────
+        // ── 5. Dependency cycle detection ────────────────────────────────────
         self.check_supervisor_wired_to_cycles(sd, span);
 
-        // ── 5. Permanent children must not have owned-heap state fields ──────
+        // ── 6. Permanent children must not have owned-heap state fields ──────
         self.check_supervisor_permanent_owned_heap(sd, span);
 
-        // ── 6. Intensity restart-budget sanity ──────────────────────────────
+        // ── 7. Intensity restart-budget sanity ──────────────────────────────
         self.check_supervisor_intensity(sd, span);
 
-        // ── 7. Children must not declare #[every] periodic handlers ──────────
+        // ── 8. Children must not declare #[every] periodic handlers ──────────
         self.check_supervisor_periodic_children(sd, span);
 
-        // ── 8. Type-check child init-arg expressions against the config
+        // ── 9. Type-check child init-arg expressions against the config
         //       params, then validate the resolved arg types (byte-copy wall).
-        //       Step 8 binds `sd.params` (the construction-time config params,
+        //       Step 9 binds `sd.params` (the construction-time config params,
         //       `supervisor App(config: T)`) in a fresh scope and synthesises
         //       the type of each child init-arg EXPRESSION so a `config.field`
         //       read resolves through the config struct's record layout and
@@ -131,6 +137,66 @@ impl Checker {
         //       BitCopy wall now validates (a scalar `config.field` passes; an
         //       owned one is still walled until the owned init thunk lands).
         self.check_supervisor_init_args(sd, span);
+    }
+
+    /// Resolve every child through lexical actor authority before HIR/MIR.
+    ///
+    /// This is the fail-closed boundary for unsupported spellings: package
+    /// actors must arrive through a whole-module qualifier or an exact
+    /// named/aliased binding. Merely loading another module that exports the
+    /// same leaf never grants authority, and a local non-actor declaration
+    /// shadows an import instead of silently selecting the foreign actor.
+    fn check_supervisor_child_actor_types(&mut self, sd: &SupervisorDecl, span: &Span) {
+        for child in &sd.children {
+            let child_span = if child.span.is_empty() {
+                span.clone()
+            } else {
+                child.span.clone()
+            };
+            let Some(identity) = self.resolve_supervisor_child_type(&child.actor_type) else {
+                self.errors.push(TypeError::new(
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::UnknownChildActor,
+                    },
+                    child_span,
+                    format!(
+                        "E_SUPERVISOR_UNKNOWN_CHILD_ACTOR: supervisor `{}` child `{}` references \
+                         unknown actor `{}`; import a public actor into this scope or qualify it \
+                         through a module binding",
+                        sd.name, child.name, child.actor_type
+                    ),
+                ));
+                continue;
+            };
+            match self.type_defs.get(&identity) {
+                Some(type_def) if type_def.kind == TypeDefKind::Actor => {}
+                None if self.supervisor_children.contains_key(&identity) => {}
+                Some(_) => self.errors.push(TypeError::new(
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::ChildNotSupervisable,
+                    },
+                    child_span,
+                    format!(
+                        "E_SUPERVISOR_CHILD_NOT_SUPERVISABLE: supervisor `{}` child `{}` names \
+                         `{}`; the selected declaration `{identity}` is neither an actor nor a \
+                         supervisor",
+                        sd.name, child.name, child.actor_type
+                    ),
+                )),
+                None => self.errors.push(TypeError::new(
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::UnknownChildActor,
+                    },
+                    child_span,
+                    format!(
+                        "E_SUPERVISOR_UNKNOWN_CHILD_ACTOR: supervisor `{}` child `{}` references \
+                         unknown actor `{}`; import a public actor into this scope or qualify it \
+                         through a module binding",
+                        sd.name, child.name, child.actor_type
+                    ),
+                )),
+            }
+        }
     }
 
     /// Bind the supervisor's construction-time config params in scope, type-

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2682,23 +2682,75 @@ impl Checker {
     /// finds no `receive fn` and every wall keyed on the actor identity silently
     /// skips.
     ///
-    /// Resolve the dotted `alias.Type` spelling through `module_import_bindings`
-    /// (via `resolve_module_type`) to the exact source owner — mirroring the
-    /// `spawn module.Actor(...)` path in `resolve_spawn_target`, so a
-    /// supervisor-child handle carries the same identity a spawn handle does. A
-    /// bare root-actor spelling (`Account`) and any spelling that does not
-    /// resolve to a module-exported actor are returned unchanged, so root/flat
-    /// programs are a no-op by construction.
-    pub(super) fn canonical_supervisor_child_type(&self, raw: &str) -> String {
+    /// Resolve dotted module bindings and bare named/aliased import bindings
+    /// through the same lexical facts ordinary type resolution consumes. A
+    /// declaration authored in the current scope wins before an import, and a
+    /// bare import resolves only when that exact binding published one source
+    /// identity. There is deliberately no scan over globally loaded exports.
+    pub(super) fn resolve_supervisor_child_type(&self, raw: &str) -> Option<String> {
         if let Some((module_short, type_name)) = raw.split_once('.') {
-            if let Some(td) = self
+            return self
                 .resolve_module_type(module_short, type_name)
-                .filter(|td| td.kind == TypeDefKind::Actor)
+                .map(|td| td.name);
+        }
+
+        if self.supervisor_children.contains_key(raw) {
+            return Some(raw.to_string());
+        }
+
+        // A supervisor declared inside a non-root module shares that module's
+        // nominal scope with its actors. Resolve only the exact owner-qualified
+        // actor declaration; never search another loaded module by leaf name.
+        // This rung precedes selected imports so a same-file actor retains
+        // lexical authority over an imported binding with the same spelling.
+        if let Some(owner) = self.current_module_identity() {
+            let local_actor = format!("{owner}.{raw}");
+            if self
+                .type_defs
+                .get(&local_actor)
+                .is_some_and(|type_def| type_def.kind == TypeDefKind::Actor)
             {
-                return td.name;
+                return Some(local_actor);
             }
         }
-        raw.to_string()
+
+        if self.local_type_defs.contains(raw) || self.source_type_defs.contains(raw) {
+            let local = self.declaration_identity(raw);
+            if self.type_defs.contains_key(&local) {
+                return Some(local);
+            }
+            if self.type_defs.contains_key(raw) {
+                return Some(raw.to_string());
+            }
+            // A flattened file import is root-visible in the source sets but
+            // its compatibility leaf key is retired after registration. Fall
+            // through to the exact published bare binding below; a genuine
+            // current-scope declaration returned from one of the two keys.
+        }
+
+        // Root actors and flattened file-import actors both publish an exact
+        // root-surface key. This is not a leaf search: the key exists only
+        // because that spelling was registered into the current root scope.
+        if self.current_module_identity().is_none() && self.type_defs.contains_key(raw) {
+            return Some(raw.to_string());
+        }
+
+        if let Some(identity) = self.published_bare_type_qualified(raw) {
+            if let Some(owner) = self.unqualified_to_module.get(&(
+                self.current_module.clone(),
+                self.current_module_idx,
+                raw.to_string(),
+            )) {
+                self.mark_module_owner_bindings_used(owner);
+            }
+            return Some(identity);
+        }
+        None
+    }
+
+    pub(super) fn canonical_supervisor_child_type(&self, raw: &str) -> String {
+        self.resolve_supervisor_child_type(raw)
+            .unwrap_or_else(|| raw.to_string())
     }
 
     /// Resolve a `(module, type, variant)` triple to its `VariantDef`, gated on

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -11546,6 +11546,16 @@ impl Checker {
                         continue;
                     }
                     self.register_actor_base(ad, Some(module_short));
+                    if ad.visibility.is_pub() {
+                        if let Some(binding) = import_spec.bare_binding(&ad.name) {
+                            self.publish_stdlib_hew_type_binding(
+                                module_short,
+                                binding,
+                                format!("{module_full_path}.{}", ad.name),
+                                import_spec,
+                            );
+                        }
+                    }
                 }
                 // Register pub consts from C-backed stdlib modules that also
                 // ship Hew source (e.g. `std::misc::log` with `pub const JSON`).
@@ -11778,6 +11788,16 @@ impl Checker {
                                 publication,
                             );
                         }
+                    }
+                }
+                Item::Actor(ad) if ad.visibility.is_pub() => {
+                    if let Some(binding) = publication.bare_binding(&ad.name) {
+                        self.publish_stdlib_hew_type_binding(
+                            module_short,
+                            binding,
+                            format!("{module_full_path}.{}", ad.name),
+                            publication,
+                        );
                     }
                 }
                 _ => {}
@@ -12953,6 +12973,19 @@ impl Checker {
                             .unwrap_or_else(|| ad.name.clone());
                         let source_identity = format!("{module_full_path}.{}", ad.name);
                         self.record_published_bare_type(&binding_name, &source_identity);
+                        // Supervisor declarations retain their source spelling
+                        // through parsing. Publish the same exact lexical
+                        // binding fact every other named/glob type import gives
+                        // HIR, so a child named by either `Worker` or an `as`
+                        // alias reaches the actor's declaration-owned key.
+                        self.import_type_name_aliases.insert(
+                            (
+                                self.current_module.clone(),
+                                self.current_module_idx,
+                                binding_name.clone(),
+                            ),
+                            source_identity,
+                        );
                         self.unqualified_to_module.insert(
                             (
                                 self.current_module.clone(),

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -16,6 +16,27 @@ fn selected_import(names: &[&str]) -> ImportSpec {
     )
 }
 
+fn parsed_import_items(source: &str) -> Vec<Spanned<Item>> {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "import fixture parse errors: {:#?}",
+        parsed.errors
+    );
+    parsed.program.items
+}
+
+fn selected_actor_import(path: &[&str], alias: Option<&str>, actor_source: &str) -> ImportDecl {
+    make_user_import(
+        path,
+        Some(ImportSpec::Names(vec![ImportName {
+            name: "Worker".to_string(),
+            alias: alias.map(str::to_string),
+        }])),
+        parsed_import_items(actor_source),
+    )
+}
+
 #[test]
 fn colliding_import_publishes_none_of_its_other_bindings() {
     let first = make_user_import(
@@ -706,6 +727,199 @@ fn imported_actor_i32_uses_exact_module_binding_and_owner() {
             .map(|sig| &sig.return_type),
         Some(&Ty::I32)
     );
+}
+
+#[test]
+fn supervisor_actor_named_and_aliased_imports_publish_exact_identity() {
+    for (alias, binding) in [(None, "Worker"), (Some("Renamed"), "Renamed")] {
+        let import = selected_actor_import(
+            &["services", "workers"],
+            alias,
+            "pub actor Worker { receive fn identify() -> i64 { 17 } }",
+        );
+        let supervisor = hew_parser::parse(&format!(
+            "supervisor App {{ child worker: {binding} restart: temporary; }}"
+        ));
+        assert!(supervisor.errors.is_empty(), "{:#?}", supervisor.errors);
+        let mut items = vec![(Item::Import(import), 0..1)];
+        items.extend(supervisor.program.items);
+        let output = check_items(items);
+
+        assert!(
+            output.errors.is_empty(),
+            "`{binding}` supervisor child must typecheck: {:#?}",
+            output.errors
+        );
+        assert_eq!(
+            output
+                .import_type_name_aliases
+                .iter()
+                .find(|((_, _, published), _)| published == binding)
+                .map(|(_, identity)| identity.as_str()),
+            Some("services.workers.Worker"),
+            "the actor import binding must publish its declaration-owned identity"
+        );
+    }
+}
+
+#[test]
+fn supervisor_actor_whole_module_import_uses_exact_identity() {
+    let import = make_user_import(
+        &["support", "worker"],
+        None,
+        parsed_import_items("pub actor Worker { receive fn identify() -> i64 { 17 } }"),
+    );
+    let supervisor =
+        hew_parser::parse("supervisor App { child worker: worker.Worker restart: temporary; }");
+    assert!(supervisor.errors.is_empty(), "{:#?}", supervisor.errors);
+    let mut items = vec![(Item::Import(import), 0..1)];
+    items.extend(supervisor.program.items);
+    let output = check_items(items);
+
+    assert!(
+        output.errors.is_empty(),
+        "a whole-module binding must authorize its exact actor: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn selected_actor_alias_does_not_authorize_unbound_canonical_path() {
+    let import = selected_actor_import(
+        &["support", "worker"],
+        Some("Renamed"),
+        "pub actor Worker { receive fn identify() -> i64 { 17 } }",
+    );
+    let supervisor = hew_parser::parse(
+        "supervisor App { child worker: support.worker.Worker restart: temporary; }",
+    );
+    assert!(supervisor.errors.is_empty(), "{:#?}", supervisor.errors);
+    let mut items = vec![(Item::Import(import), 0..1)];
+    items.extend(supervisor.program.items);
+    let output = check_items(items);
+
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "the unsupported spelling must stop at one checker diagnostic: {:#?}",
+        output.errors
+    );
+    let error = &output.errors[0];
+    assert!(matches!(
+        error.kind,
+        TypeErrorKind::SupervisorError {
+            subkind: SupervisorErrorKind::UnknownChildActor
+        }
+    ));
+    assert!(error
+        .message
+        .starts_with("E_SUPERVISOR_UNKNOWN_CHILD_ACTOR:"));
+    assert!(
+        !output.errors.iter().any(|error| matches!(
+            error.kind,
+            TypeErrorKind::SupervisorError {
+                subkind: SupervisorErrorKind::ChildNotSupervisable
+            }
+        )),
+        "an unbound module root is unknown, not an alternate declaration: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn local_actor_shadows_same_leaf_import_for_supervisor_child() {
+    let import = selected_actor_import(
+        &["foreign", "workers"],
+        None,
+        "pub actor Worker { let label: string; }",
+    );
+    let root = hew_parser::parse(
+        "actor Worker { receive fn identify() -> i64 { 9 } }\n\
+         supervisor App { child worker: Worker; }",
+    );
+    assert!(root.errors.is_empty(), "{:#?}", root.errors);
+    let mut items = vec![(Item::Import(import), 0..1)];
+    items.extend(root.program.items);
+    let output = check_items(items);
+
+    assert!(
+        output.errors.is_empty(),
+        "the local actor must win over the imported same-leaf binding: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn local_non_actor_shadow_is_not_replaced_by_imported_actor() {
+    let import = selected_actor_import(
+        &["foreign", "workers"],
+        None,
+        "pub actor Worker { receive fn identify() -> i64 { 17 } }",
+    );
+    let root = hew_parser::parse(
+        "type Worker { value: i64; }\n\
+         supervisor App { child worker: Worker; }",
+    );
+    assert!(root.errors.is_empty(), "{:#?}", root.errors);
+    let mut items = vec![(Item::Import(import), 0..1)];
+    items.extend(root.program.items);
+    let output = check_items(items);
+
+    assert!(output.errors.iter().any(|error| matches!(
+        error.kind,
+        TypeErrorKind::SupervisorError {
+            subkind: SupervisorErrorKind::ChildNotSupervisable
+        }
+    )));
+    assert!(!output.errors.iter().any(|error| matches!(
+        error.kind,
+        TypeErrorKind::SupervisorError {
+            subkind: SupervisorErrorKind::UnknownChildActor
+        }
+    )));
+}
+
+#[test]
+fn colliding_actor_import_bindings_stop_before_supervisor_lowering() {
+    let left = selected_actor_import(
+        &["left", "workers"],
+        None,
+        "pub actor Worker { receive fn identify() -> i64 { 1 } }",
+    );
+    let right = selected_actor_import(
+        &["right", "workers"],
+        None,
+        "pub actor Worker { receive fn identify() -> i64 { 2 } }",
+    );
+    let supervisor = hew_parser::parse("supervisor App { child worker: Worker; }");
+    assert!(supervisor.errors.is_empty(), "{:#?}", supervisor.errors);
+    let mut items = vec![(Item::Import(left), 0..1), (Item::Import(right), 2..3)];
+    items.extend(supervisor.program.items);
+    let output = check_items(items);
+
+    assert!(output
+        .errors
+        .iter()
+        .any(|error| error.kind == TypeErrorKind::ImportBindingCollision));
+    assert!(!output.errors.iter().any(|error| {
+        matches!(
+            error.kind,
+            TypeErrorKind::SupervisorError {
+                subkind: SupervisorErrorKind::UnknownChildActor
+            }
+        )
+    }));
+}
+
+#[test]
+fn unknown_supervisor_child_actor_is_rejected_before_mir() {
+    let output = check_source("supervisor App { child missing: Missing; }");
+    assert!(output.errors.iter().any(|error| matches!(
+        error.kind,
+        TypeErrorKind::SupervisorError {
+            subkind: SupervisorErrorKind::UnknownChildActor
+        }
+    )));
 }
 
 #[test]

--- a/hew-types/src/check/tests/supervisor.rs
+++ b/hew-types/src/check/tests/supervisor.rs
@@ -5,6 +5,20 @@
 pub(super) use super::*;
 
 #[test]
+fn nested_supervisor_remains_a_valid_child_target() {
+    let output = check_source(
+        "actor Worker { receive fn ping() {} }\n\
+         supervisor Inner { child worker: Worker; }\n\
+         supervisor Root { child inner: Inner; }",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "a nested supervisor is a supervisable child target: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn supervisor_permanent_owned_heap_rejects_vec_field() {
     let output = check_source(
         r"

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -565,6 +565,12 @@ impl std::error::Error for TypeError {}
 /// cannot silently collapse into an existing one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SupervisorErrorKind {
+    /// `E_SUPERVISOR_UNKNOWN_CHILD_ACTOR`: a child type does not resolve to a
+    /// declaration in the supervisor's lexical scope.
+    UnknownChildActor,
+    /// `E_SUPERVISOR_CHILD_NOT_SUPERVISABLE`: a child type resolves to a
+    /// declaration that is neither an actor nor a nested supervisor.
+    ChildNotSupervisable,
     /// `E_SUPERVISOR_POOL_COUNT_MISSING`: a `pool` child omits the required
     /// `count:` argument.
     PoolCountMissing,
@@ -608,6 +614,8 @@ impl SupervisorErrorKind {
     #[must_use]
     pub fn as_kind_str(self) -> &'static str {
         match self {
+            Self::UnknownChildActor => "SupervisorUnknownChildActor",
+            Self::ChildNotSupervisable => "SupervisorChildNotSupervisable",
             Self::PoolCountMissing => "SupervisorPoolCountMissing",
             Self::PoolCountType => "SupervisorPoolCountType",
             Self::PoolCountNonPositive => "SupervisorPoolCountNonPositive",

--- a/scripts/fuzz/expected-reject.txt
+++ b/scripts/fuzz/expected-reject.txt
@@ -35,6 +35,7 @@ tests/vertical-slice/accept/imported_actor_msg_discriminants_lib.hew
 tests/vertical-slice/accept/imported_fn_local_shadow/m.hew
 tests/vertical-slice/accept/imported_generics_resolve/lib.hew
 tests/vertical-slice/accept/imported_shadow_errmod.hew
+tests/vertical-slice/accept/imported_supervisor_child_identity_support/worker.hew
 tests/vertical-slice/accept/let_record_destructure_selective_import_module.hew
 tests/vertical-slice/accept/lib/math.hew
 tests/vertical-slice/accept/local_fn_msg_actor_method_allowed.hew

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -19,8 +19,5 @@
 # executable desired-behaviour test: remove its row when the failure is fixed.
 # #3173 currently refuses indirect owned call scrutinees with E_NOT_YET_IMPLEMENTED.
 tests/hew/call_scrutinee_indirect_ownership_test.hew::indirect_owned_result_call_scrutinee_preserves_payload compile
-# #3173 cannot attach an imported actor protocol descriptor and then reports the
-# unresolved imported child/handler as E_NOT_YET_IMPLEMENTED.
-tests/hew/imported_supervisor_child_layout_test.hew::imported_actor_is_a_supervised_child compile
 # #3173 reports the ownership-generation lowering invariant as E_MIR_ICE.
 tests/hew/json_value_loop_reassign_test.hew::reassigns_json_resource_builder_in_loop compile

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -35,7 +35,7 @@ checker-hir-fact-relation	checker-relation-use	hew-hir/src/lower.rs	7	stage-2	re
 checker-hir-fact-relation	checker-relation-use	hew-types/src/check/expressions.rs	11	stage-2	real checker/HIR produced-value carrier inventory
 checker-hir-fact-relation	checker-relation-use	hew-types/src/check/mod.rs	15	stage-2	real checker/HIR produced-value carrier inventory
 checker-hir-fact-relation	checker-relation-variant	hew-types/src/check/types.rs	6	stage-2	real checker/HIR produced-value carrier inventory
-checker-hir-fact-relation	hir-publication-consumer	hew-hir/src/lower.rs	373	stage-2	reviewed checker-to-HIR fact reads, including the new method_call_rewrites read that routes generic wire facade calls through the checker-selected WireCodec lowering
+checker-hir-fact-relation	hir-publication-consumer	hew-hir/src/lower.rs	371	stage-2	reviewed checker-to-HIR fact reads, including the new method_call_rewrites read that routes generic wire facade calls through the checker-selected WireCodec lowering
 checker-hir-fact-relation	hir-publication-consumer	hew-hir/src/node.rs	5	stage-2	real checker/HIR produced-value carrier inventory
 checker-hir-fact-relation	hir-relation-consumer	hew-hir/src/verify.rs	8	stage-2	real checker/HIR produced-value carrier inventory
 checker-hir-fact-relation	hir-relation-consumer	hew-mir/src/lower/ownership.rs	4	stage-2	real checker/HIR produced-value carrier inventory

--- a/tests/hew/imported_same_file_supervisor_support/worker.hew
+++ b/tests/hew/imported_same_file_supervisor_support/worker.hew
@@ -1,0 +1,14 @@
+//! A file-owned supervisor must resolve a bare child against an actor declared
+//! in that same file module before the declarations are flattened at HIR.
+
+pub actor Worker {
+    let id: i64;
+
+    receive fn identify() -> i64 {
+        id
+    }
+}
+
+pub supervisor Inner {
+    child worker: Worker(id: 23) restart: temporary;
+}

--- a/tests/hew/imported_same_file_supervisor_support/worker.hew
+++ b/tests/hew/imported_same_file_supervisor_support/worker.hew
@@ -9,6 +9,8 @@ pub actor Worker {
     }
 }
 
-pub supervisor Inner {
+supervisor Inner {
+    strategy: one_for_one;
+
     child worker: Worker(id: 23) restart: temporary;
 }

--- a/tests/hew/imported_same_file_supervisor_test.hew
+++ b/tests/hew/imported_same_file_supervisor_test.hew
@@ -1,0 +1,8 @@
+//! File-imported supervisors retain their own module as lexical actor authority.
+
+import "imported_same_file_supervisor_support/worker.hew";
+#[test]
+fn imported_supervisor_runs_its_same_file_actor() {
+    let sup = spawn Inner;
+    supervisor_stop(sup);
+}

--- a/tests/hew/imported_supervisor_named_binding_support/worker.hew
+++ b/tests/hew/imported_supervisor_named_binding_support/worker.hew
@@ -1,0 +1,7 @@
+pub actor Worker {
+    let id: i64;
+
+    receive fn identify() -> i64 {
+        id
+    }
+}

--- a/tests/hew/imported_supervisor_named_binding_test.hew
+++ b/tests/hew/imported_supervisor_named_binding_test.hew
@@ -1,0 +1,31 @@
+//! Named and aliased actor imports must retain their declaration identity when
+//! used as supervised children.
+
+import tests.hew.imported_supervisor_named_binding_support.worker.{Worker};
+import tests.hew.imported_supervisor_named_binding_support.worker.{Worker as Renamed};
+import std.testing;
+
+supervisor DirectPool {
+    child worker: Worker(id: 31) restart: temporary;
+}
+
+supervisor AliasedPool {
+    child worker: Renamed(id: 47) restart: temporary;
+}
+
+#[test]
+fn named_and_aliased_actors_run_as_supervised_children() {
+    let direct = spawn DirectPool;
+    match await direct.worker.identify() {
+        .Ok(id) => testing.assert_eq(id, 31),
+        .Err(_) => testing.assert_true(false),
+    }
+    supervisor_stop(direct);
+
+    let aliased = spawn AliasedPool;
+    match await aliased.worker.identify() {
+        .Ok(id) => testing.assert_eq(id, 47),
+        .Err(_) => testing.assert_true(false),
+    }
+    supervisor_stop(aliased);
+}

--- a/tests/hew/imported_supervisor_named_binding_test.hew
+++ b/tests/hew/imported_supervisor_named_binding_test.hew
@@ -2,14 +2,20 @@
 //! used as supervised children.
 
 import tests.hew.imported_supervisor_named_binding_support.worker.{Worker};
+
 import tests.hew.imported_supervisor_named_binding_support.worker.{Worker as Renamed};
+
 import std.testing;
 
 supervisor DirectPool {
+    strategy: one_for_one;
+
     child worker: Worker(id: 31) restart: temporary;
 }
 
 supervisor AliasedPool {
+    strategy: one_for_one;
+
     child worker: Renamed(id: 47) restart: temporary;
 }
 
@@ -21,7 +27,6 @@ fn named_and_aliased_actors_run_as_supervised_children() {
         .Err(_) => testing.assert_true(false),
     }
     supervisor_stop(direct);
-
     let aliased = spawn AliasedPool;
     match await aliased.worker.identify() {
         .Ok(id) => testing.assert_eq(id, 47),

--- a/tests/vertical-slice/accept/imported_supervisor_child_identity.hew
+++ b/tests/vertical-slice/accept/imported_supervisor_child_identity.hew
@@ -1,0 +1,25 @@
+//! A file import exposes its actor in the root surface while preserving the
+//! complete declaration identity used by actor and supervisor MIR layouts.
+
+import "imported_supervisor_child_identity_support/worker.hew";
+
+supervisor ImportedWorkerPool {
+    strategy: one_for_one;
+    intensity: 1 within 60s;
+
+    child worker: ImportedWorker(id: 17);
+}
+
+fn main() -> i64 {
+    let sup = spawn ImportedWorkerPool;
+    match await sup.worker.identify() {
+        .Ok(id) => {
+            supervisor_stop(sup);
+            id
+        },
+        .Err(_) => {
+            supervisor_stop(sup);
+            1
+        },
+    }
+}

--- a/tests/vertical-slice/accept/imported_supervisor_child_identity_support/worker.hew
+++ b/tests/vertical-slice/accept/imported_supervisor_child_identity_support/worker.hew
@@ -1,0 +1,7 @@
+pub actor ImportedWorker {
+    let id: i64;
+
+    receive fn identify() -> i64 {
+        id
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1746,6 +1746,11 @@ grep -qF 'select arm source must be actor.method(args)' "${reject_output}"
 # main returns 42 after bootstrap completes successfully.
 run_accept_expect_status "supervisor_basic" 42
 
+# A file-imported actor keeps its complete declaration identity through HIR,
+# actor-layout construction, and the supervisor child table. Exit 17 proves
+# handler dispatch resolves against that same layout key at runtime.
+run_accept_expect_status "imported_supervisor_child_identity" 17
+
 # Supervisor normal-return cleanup: main returns 42 with a live top-level
 # supervisor and three registered child specs. The native cleanup tail must not
 # use the supervisor-incompatible idle drain or overwrite the return value.


### PR DESCRIPTION
## Why

Imported actors could lose their declaration-owned identity at supervision boundaries. File-imported actors looked up protocol descriptors and cycle facts under a shortened key, while supervisor children retained source spellings that did not always match MIR actor-layout keys. Supported programs then reached MIR as unknown actors or handlers and reported `E_NOT_YET_IMPLEMENTED`.

Supervisor child spellings also need lexical authority: selecting `Worker as Renamed` must not authorize an unrelated raw `support.worker.Worker` path merely because that declaration is loaded globally.

Progresses #3189.

## What

- **checker**: resolves supervisor child actors through exact current-module declarations, whole-module bindings, or selected named/aliased bindings; unbound dotted roots fail early as `SupervisorUnknownChildActor`
- **HIR**: preserves the full declaration owner for imported actor protocol descriptors, cycle capability, and supervisor child identities; forced lowering without checker-owned authority fails closed
- **MIR**: keeps actor-layout and supervisor-child keys aligned without adding a leaf-name fallback
- **tests**: covers file, qualified, named, aliased, same-file supervisor, root-shadow, same-leaf, ambiguity, and cycle-capable identity cases; removes the recovered imported-supervisor row from the Hew-suite ledger

The same-file runtime fixture verifies that an imported supervisor starts and stops its child successfully. Imported-supervisor child accessor typing is outside this change and is not claimed here.

## Test

- `cargo test -p hew-types check::tests::imports`
- `cargo test -p hew-types check::tests::supervisor`
- `cargo test -p hew-hir --test concurrency`
- `cargo test -p hew-mir --test actor`
- O0/O2 execution of `imported_supervisor_child_layout_test.hew`, `imported_supervisor_named_binding_test.hew`, and `imported_same_file_supervisor_test.hew`
- O0/O2 compile and execution of the `imported_supervisor_child_identity` vertical fixture with its expected status
- `scripts/corpus-ratchet.sh hew-suite`
- `cargo test -p hew-parser --test fmt_roundtrip_corpus every_hew_file_roundtrips_through_formatter -- --exact`
- `make fuzz-oracle`
- `make structural-lint`
- `cargo clippy -p hew-types -p hew-hir -p hew-mir --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
