### PR TITLE
docs(pr): trim pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,12 +16,3 @@
 <!-- Name specific new or modified tests. No pass counts — CI handles that.
      For test-only PRs, describe what's now covered that wasn't before.
      For changes with no new tests, explain why (e.g., "covered by existing E2E"). -->
-
-## Quality Checklist
-
-- [ ] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
-- [ ] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
-- [ ] New allocations have cleanup paths for sync, async, and actor shutdown contexts
-- [ ] Serialization changes include round-trip encode/decode tests
-- [ ] New runtime behavior has native/WASM execution coverage where supported; intentional WASM limitations have a typed manifest disposition and a focused diagnostic test; new `hew_*` exports are classified in `scripts/jit-symbol-classification.toml`
-- [ ] No duplicated logic — checked for existing helpers before adding new ones


### PR DESCRIPTION
## Why

The default pull-request form mixed required change context with a generic process checklist.

## What

Keep only the Why, What, and Test sections and their guidance comments.

## Test

- `git diff --check`
- verified the rendered template has only Why, What, and Test headings