### PR TITLE
docs(examples): refresh current Hew idioms

### DIFF
--- a/examples/algos/coin_change.hew
+++ b/examples/algos/coin_change.hew
@@ -1,5 +1,7 @@
 // Minimum Coins to Make Change
 // Coins: [1, 5, 10, 25], Amount: 30 -> 2 (25 + 5)
+const INF: i32 = 999999;
+
 fn main() {
     let coins: Vec<i32> = Vec.new();
     coins.push(1);
@@ -8,7 +10,6 @@ fn main() {
     coins.push(25);
     let num_coins = coins.len();
     let amount = 30;
-    let INF = 999999;
     let dp: Vec<i32> = Vec.new();
     dp.push(0);
     for i in 1 .. amount + 1 {

--- a/examples/algos/dijkstra.hew
+++ b/examples/algos/dijkstra.hew
@@ -2,9 +2,10 @@
 // Weighted graph (5 nodes):
 //   0->1(4), 0->2(1), 1->3(1), 2->1(2), 2->3(5), 3->4(3)
 // Expected distances from 0: [0, 3, 1, 4, 7]
+const INF: i32 = 999999;
+
 fn main() {
     let num_nodes = 5;
-    let INF = 999999;
     // Weighted adjacency list
     let adj_nodes: Vec<i32> = Vec.new();
     let adj_weights: Vec<i32> = Vec.new();

--- a/examples/algos/floyd_warshall.hew
+++ b/examples/algos/floyd_warshall.hew
@@ -6,9 +6,10 @@
 //   [10, 0, 2, 3]
 //   [8, 11, 0, 1]
 //   [7, 10, 12, 0]
+const INF: i32 = 999999;
+
 fn main() {
     let n = 4;
-    let INF = 999999;
     // Initialize distance matrix (flat n*n)
     let dist: Vec<i32> = Vec.new();
     for i in 0 .. n * n {

--- a/examples/algos/matrix_chain.hew
+++ b/examples/algos/matrix_chain.hew
@@ -1,6 +1,8 @@
 // Matrix Chain Multiplication
 // Dimensions: [10, 30, 5, 60] -> minimum operations = 4500
 // Matrices: A1(10x30), A2(30x5), A3(5x60)
+const INF: i32 = 999999;
+
 fn main() {
     let dims: Vec<i32> = Vec.new();
     dims.push(10);
@@ -8,7 +10,6 @@ fn main() {
     dims.push(5);
     dims.push(60);
     let n = dims.len() - 1;
-    let INF = 999999;
     // dp[i][j] = min cost to multiply matrices i..j (0-indexed)
     // Flat array: n x n
     let dp: Vec<i32> = Vec.new();

--- a/examples/chat_client.hew
+++ b/examples/chat_client.hew
@@ -1,48 +1,52 @@
-//! Status: aspirational (Hew roadmap: v0.7+ distributed Node API and transport stabilization)
-//! Description: Chat Client example.
+//! Status: runnable (local TCP; start `examples/chat_server.hew` on port 9000)
+//! Description: TCP chat client with independently owned stream/sink halves.
 //!
-//! A connection is a `#[resource]` with exactly one owner. Handing it to the
-//! link actor transfers it, so the actor — not `main` — drives BOTH
-//! directions: `pump` awaits inbound frames, `say` writes outbound lines.
-//! `main` owns the terminal and forwards typed lines as messages.
+//! A connection is a `#[resource]` with exactly one owner. Splitting it gives
+//! the reader actor and `main` independently owned halves: the actor awaits
+//! inbound TCP chunks while `main` forwards terminal input to the outbound
+//! sink. Closing the sink after `/quit` flushes the disconnect marker; reader
+//! completion reports the peer's terminal state, but `main` remains blocked on
+//! stdin until the user enters `/quit`. Runtime teardown then closes the
+//! actor-owned stream half. The distributed Node API is a separate roadmap
+//! surface; this example uses the stable local TCP API.
 
-import std.net.{Connection};
+import std.channel.channel;
 
 import std.io;
 
+import std.net;
+
 import std.os;
 
-extern "C" {
-    fn hew_bytes_to_string(data: bytes) -> string;
-}
+import std.stream;
 
-actor ChatLink {
-    let conn: Connection;
-
-    /// Inbound pump. `await conn.read()` suspends the handler on the reactor
-    /// instead of blocking a scheduler worker, so `say` messages still
-    /// dispatch while this loop waits for the next frame.
-    receive fn pump(unused: i32) {
-        var running = true;
-        while running {
-            let msg_bytes = await conn.read();
-            let msg = unsafe {
-                hew_bytes_to_string(msg_bytes)
-            };
-            if msg.contains("__HEW_TCP_DISCONNECT__") {
-                println("[client] server disconnected");
-                running = false;
-            } else {
-                println(msg);
+actor ChatReader {
+    let input: stream.Stream<bytes>;
+    let done: channel.Sender<string>;
+    /// The terminal path publishes completion and returns. `main` remains in
+    /// its stdin loop until `/quit`, then closes the sink, waits for this
+    /// status, and exits; runtime teardown closes both handles exactly once.
+    receive fn pump() {
+        var reading = true;
+        while reading {
+            match await input.recv() {
+                .Some(chunk) => {
+                    let msg = chunk.to_string();
+                    if msg.contains("__HEW_TCP_DISCONNECT__") {
+                        done.send("[client] server acknowledged disconnect");
+                        reading = false;
+                    } else {
+                        println(msg);
+                    }
+                },
+                .None => {
+                    // The duplex stream surface reports one terminal `None`
+                    // for peer EOF or a transport read failure; do not claim
+                    // one cause when that public API does not expose it.
+                    done.send("[client] server stream ended");
+                    reading = false;
+                },
             }
-        }
-    }
-
-    /// Outbound write. Only this actor touches the connection.
-    receive fn say(line: string) {
-        match conn.write_string(line) {
-            .Ok(_) => {},
-            .Err(_) => println("[client] send failed"),
         }
     }
 }
@@ -60,7 +64,12 @@ fn main() {
     let addr = f"127.0.0.1:{port}";
     let connect_timeout_sec: i64 = 5;
     let connect_timeout_usec: i64 = 0;
-    let conn = net.connect_timeout(addr, connect_timeout_sec, connect_timeout_usec);
+    let conn = match net.try_connect_timeout(addr, connect_timeout_sec, connect_timeout_usec) {
+        .Ok(conn) => conn,
+        .Err(err) => {
+            panic(f"[client] connect to {addr} failed: {net.net_error_message(err)}");
+        },
+    };
     match conn.set_read_timeout(-1) {
         .Ok(_) => {},
         .Err(_) => {
@@ -71,15 +80,24 @@ fn main() {
     println("=== Hew TCP Chat Client ===");
     println(f"Connected to {addr}");
     println("Type messages and press Enter. Type /quit to exit.");
-    let link = spawn ChatLink(conn: conn);
-    link.pump(0);
+    let (input, output) = conn.into_stream_sink();
+    let (done_tx, done_rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(1);
+    let reader = spawn ChatReader(input: input, done: done_tx);
+    reader.pump();
     loop {
         let line = io.read_line();
         if line.contains("/quit") {
-            println("[client] disconnected");
+            // Sink close drains the queued protocol marker before publishing
+            // EOF to the peer, so `/quit` cannot race ahead of disconnect.
+            output.send("__HEW_TCP_DISCONNECT__".to_bytes());
             break;
         }
-        link.say(f"{name}: {line}");
+        output.send(f"{name}: {line}".to_bytes());
     }
-    sleep(50ms);
+    output.close();
+    match done_rx.recv() {
+        .Some(message) => println(message),
+        .None => println("[client] reader closed without a status message"),
+    }
+    done_rx.close();
 }

--- a/examples/chat_server.hew
+++ b/examples/chat_server.hew
@@ -1,4 +1,4 @@
-//! Status: aspirational (Hew roadmap: v0.7+ distributed Node API and transport stabilization)
+//! Status: runnable (local TCP; distributed Node API remains roadmap)
 //! Description: TCP Chat Server — idiomatic Hew actor-based design.
 
 // TCP Chat Server — idiomatic Hew actor-based design.
@@ -25,8 +25,8 @@ actor ChatRoom {
         println(f"{name} joined the chat");
     }
     receive fn unregister(name: string) {
-        var new_handlers: Vec<LocalPid<ClientHandler>> = Vec.new();
-        var new_names: Vec<string> = Vec.new();
+        let new_handlers: Vec<LocalPid<ClientHandler>> = Vec.new();
+        let new_names: Vec<string> = Vec.new();
         for i in 0 .. names.len() {
             if names[i] != name {
                 new_handlers.push(handlers[i]);
@@ -51,30 +51,47 @@ actor ClientHandler {
     let name: string;
     let room: LocalPid<ChatRoom>;
     receive fn start(unused: i32) {
-        let _ = conn.write_string(f"[server] welcome {name}");
+        match conn.write_string(f"[server] welcome {name}") {
+            .Ok(_) => {},
+            .Err(err) => println(f"[server] welcome write failed: {net.write_error_message(err)}"),
+        }
         var running = true;
         while running {
-            let data = conn.read_string();
-            if data.contains("__HEW_TCP_DISCONNECT__") {
-                room.unregister(name.clone());
-                // The connection belongs to this actor's lifetime, not to this
-                // handler: `deliver` stays reachable for as long as the actor
-                // lives, and a broadcast already in flight when the client
-                // disconnects would write to a closed socket. Leaving the
-                // socket in state lets the actor's teardown close it exactly
-                // once, after the last message that could touch it.
-                running = false;
-            } else {
-                let line = f"{name.clone()}: {data}";
-                println(line);
-                room.broadcast(name.clone(), line);
+            match conn.try_read_string() {
+                .Ok(data) => {
+                    if data.is_empty() {
+                        room.unregister(name);
+                        running = false;
+                    } else if data.contains("__HEW_TCP_DISCONNECT__") {
+                        room.unregister(name);
+                        match conn.write_string("__HEW_TCP_DISCONNECT__") {
+                            .Ok(_) => {},
+                            .Err(err) => println(f"[server] disconnect write failed: {net.write_error_message(err)}"),
+                        }
+                        running = false;
+                    } else {
+                        let line = f"{name}: {data}";
+                        println(line);
+                        // ChatRoom uses the default unbounded mailbox, so this unit
+                        // send has no SendError result to discard or handle.
+                        room.broadcast(name, line);
+                    }
+                },
+                .Err(err) => {
+                    println(f"[server] client read failed: {net.net_error_message(err)}");
+                    room.unregister(name);
+                    running = false;
+                },
             }
         }
     }
     receive fn deliver(msg: string) {
         // A slow or disconnected client surfaces as Err here; this demo drops
         // the message rather than applying per-client flow control.
-        let _ = conn.write_string(msg);
+        match conn.write_string(msg) {
+            .Ok(_) => {},
+            .Err(err) => println(f"[server] client write failed: {net.write_error_message(err)}"),
+        }
     }
 }
 
@@ -85,17 +102,20 @@ fn main() {
         port = os.args(1);
     }
     let addr = f"0.0.0.0:{port}";
-    let listener = net.listen(addr);
+    let listener = match net.try_listen(addr) {
+        .Ok(listener) => listener,
+        .Err(err) => panic(f"[server] listen on {addr} failed: {net.net_error_message(err)}"),
+    };
     println("=== Hew TCP Chat Server ===");
     println(f"Listening on {addr}");
     let handlers: Vec<LocalPid<ClientHandler>> = Vec.new();
     let names: Vec<string> = Vec.new();
     let room = spawn ChatRoom(handlers: handlers, names: names);
     var next_id: i32 = 1;
-    var accepting = 1;
-    while accepting == 1 {
+    loop {
         let conn = listener.accept();
         let handler = spawn ClientHandler(conn: conn, name: f"client-{next_id}", room: room);
+        // The default unbounded mailbox makes this a lossless unit send.
         room.register(handler, f"client-{next_id}");
         handler.start(0);
         next_id = next_id + 1;

--- a/examples/chat_service.hew
+++ b/examples/chat_service.hew
@@ -1,4 +1,4 @@
-//! Status: aspirational (Hew roadmap: v0.7+ distributed Node API and transport stabilization)
+//! Status: runnable (local actor path; distributed Node API is native-only)
 //! Description: Distributed chat service — idiomatic Hew networked actors
 
 // Distributed chat service — idiomatic Hew networked actors
@@ -7,9 +7,10 @@
 //   Server node: ChatRoom actor manages connected users
 //   Client node: connects, looks up "room", sends messages
 //
-// The actor code is identical whether local or distributed.
-// Node.start/shutdown/register/lookup typecheck today. Node.connect is
-// runtime-only for now (not a typechecker builtin yet).
+// This runnable path keeps the actor and client on one native process. The
+// Node API is also available for a distributed deployment: start, shutdown,
+// register, connect, and typed lookup are native-only, and lookup returns a
+// Result<RemotePid<T>, LookupError>.
 actor ChatRoom {
     let users: Vec<string>;
     let messages: Vec<string>;
@@ -28,10 +29,8 @@ actor ChatRoom {
     receive fn history() -> i64 {
         let total = messages.len();
         println(f"[room] {total} messages total");
-        var i = 0;
-        while i < total {
-            println(f"  {messages[i]}");
-            i = i + 1;
+        for msg in messages {
+            println(f"  {msg}");
         }
         total
     }
@@ -48,18 +47,22 @@ fn main() {
     // ── Client side (same process for now) ───────────────────
     // In a distributed setup:
     //   Node.start("0.0.0.0:9001");
-    //   Node.connect("127.0.0.1:9000");  // runtime API, not a typechecker builtin yet
-    //   let room = Node.lookup("room");
+    //   Node.connect("127.0.0.1:9000");
+    //   let found: Result<RemotePid<ChatRoom>, LookupError> = Node.lookup("room");
 
-    // These calls are location-transparent — identical syntax
-    // whether room is local or on a remote node:
+    // These are direct calls on the local actor. They are lossless unit sends
+    // for ChatRoom's unbounded mailbox; a RemotePid uses its typed send/ask
+    // methods and returns a Result that callers must handle.
     room.enter("alice");
     room.enter("bob");
     room.say("alice", "hello everyone!");
     room.say("bob", "hey alice!");
     room.say("alice", "how is the weather?");
     room.exit_room("bob");
-    let _ = await room.history();
+    match await room.history() {
+        .Ok(_) => {},
+        .Err(_) => panic("chat history request failed"),
+    }
     // Node.shutdown();
     println("[main] chat demo complete");
 }

--- a/examples/concurrent_counter.hew
+++ b/examples/concurrent_counter.hew
@@ -11,8 +11,7 @@ actor Counter {
     receive fn increment(n: i64) {
         count = count + n;
     }
-    receive fn print_total() -> i64 {
-        println(count);
+    receive fn total() -> i64 {
         count
     }
 }
@@ -22,5 +21,9 @@ fn main() {
     c.increment(10);
     c.increment(20);
     c.increment(12);
-    let _ = await c.print_total();
+    let result = await c.total();
+    match result {
+        .Ok(total) => println(total),
+        .Err(_) => println("ask failed"),
+    }
 }

--- a/examples/fibonacci.hew
+++ b/examples/fibonacci.hew
@@ -1,8 +1,7 @@
 //! Status: runnable
-//! Description: Fibonacci across actors - Hew language example
+//! Description: Recursive Fibonacci with a plain function - Hew language example
 
-// Fibonacci across actors - Hew language example
-// Computes Fibonacci numbers using actor message passing
+// Recursive Fibonacci with a plain function - Hew language example
 fn fibonacci(n: i32) -> i32 {
     if n <= 1 {
         n

--- a/examples/http_json_demo.hew
+++ b/examples/http_json_demo.hew
@@ -30,7 +30,7 @@
 // fetches; it never frees the parent passed by the caller.
 import std.net.http.http_client;
 
-import std.encoding.json.{Value};
+import std.encoding.json.{self, Value};
 
 // Fetch a URL and return the body string, or None on transport failure.
 fn fetch(url: string) -> Option<string> {
@@ -71,11 +71,8 @@ fn main() {
                     slideshow.free(); // free before root
                     root.free(); // outermost last
                 },
-                .Err(_) => {
-                    // Err(ParseError.Invalid(msg)) is accepted by `hew check`
-                    // but fails at runtime with an undeclared-variable
-                    // error. Use `Err(_)` and a static message instead.
-                    println("json parse failed");
+                .Err(ParseError.Invalid(msg)) => {
+                    println(f"json parse failed: {msg}");
                 },
             }
         },

--- a/examples/lambda_actor_factory.hew
+++ b/examples/lambda_actor_factory.hew
@@ -1,4 +1,4 @@
-//! Status: aspirational (Hew roadmap: actor/supervisor codegen-rs runtime parity)
+//! Status: runnable
 //! Description: Lambda Actor Factory Pattern Example
 
 // Lambda Actor Factory Pattern Example
@@ -31,7 +31,10 @@ fn run_multiplier(factor: i64, value: i64) {
     let worker = actor |x: i64| {
         println(f"{factor} * {x} = {x * factor}");
     };
-    worker.send(value);
+    match worker.send(value) {
+        .Ok(_) => {},
+        .Err(_) => panic("multiplier actor rejected its input"),
+    }
     await worker.close();
     return;
 }
@@ -41,7 +44,10 @@ fn run_string_processor(tag: string, value: i64) {
     let worker = actor |x: i64| {
         println(f"[{tag}] {x}");
     };
-    worker.send(value);
+    match worker.send(value) {
+        .Ok(_) => {},
+        .Err(_) => panic("string processor actor rejected its input"),
+    }
     await worker.close();
     return;
 }
@@ -57,8 +63,14 @@ fn run_conditional_processor(check_even: bool, first: i64, second: i64) {
         }
         // else: don't print anything
     };
-    worker.send(first);
-    worker.send(second);
+    match worker.send(first) {
+        .Ok(_) => {},
+        .Err(_) => panic("conditional actor rejected its first input"),
+    }
+    match worker.send(second) {
+        .Ok(_) => {},
+        .Err(_) => panic("conditional actor rejected its second input"),
+    }
     await worker.close();
     return;
 }
@@ -71,7 +83,10 @@ fn run_factory_maker(base: i64, offset: i64) {
         // In a real implementation, this might create and return another actor
         // but that would require more complex type system support
     };
-    worker.send(offset);
+    match worker.send(offset) {
+        .Ok(_) => {},
+        .Err(_) => panic("factory actor rejected its input"),
+    }
     await worker.close();
     return;
 }

--- a/examples/lambda_actor_pipeline.hew
+++ b/examples/lambda_actor_pipeline.hew
@@ -1,4 +1,4 @@
-//! Status: aspirational (Hew roadmap: actor/supervisor codegen-rs runtime parity)
+//! Status: runnable
 //! Description: Lambda Actor Pipeline Example
 
 // Lambda Actor Pipeline Example
@@ -16,7 +16,10 @@ fn main() {
         print("Doubled: ");
         print(doubled);
         print(" -> ");
-        printer.send(doubled);
+        match printer.send(doubled) {
+            .Ok(_) => {},
+            .Err(_) => panic("doubler could not send to printer"),
+        }
     };
     // First stage - adder that sends to doubler
     let adder = actor |x: i32| {
@@ -24,16 +27,25 @@ fn main() {
         print("Added 5: ");
         print(added);
         print(" -> ");
-        doubler.send(added);
+        match doubler.send(added) {
+            .Ok(_) => {},
+            .Err(_) => panic("adder could not send to doubler"),
+        }
     };
     // Start the pipeline
     println("Starting pipeline with input: 10");
-    adder.send(10); // 10 + 5 = 15, then 15 * 2 = 30
+    match adder.send(10) {
+        .Ok(_) => {},
+        .Err(_) => panic("pipeline rejected input 10"),
+    }
     sleep(100ms);
 
     // Another pipeline run
     println("Starting pipeline with input: 3");
-    adder.send(3); // 3 + 5 = 8, then 8 * 2 = 16
+    match adder.send(3) {
+        .Ok(_) => {},
+        .Err(_) => panic("pipeline rejected input 3"),
+    }
     sleep(100ms);
 
     // More complex pipeline - 3 stage transformation
@@ -42,14 +54,32 @@ fn main() {
     };
     let squarer = actor |x: i32| {
         let squared = x * x;
-        formatter.send(squared);
+        match formatter.send(squared) {
+            .Ok(_) => {},
+            .Err(_) => panic("squarer could not send to formatter"),
+        }
     };
     let incrementer = actor |x: i32| {
-        squarer.send(x + 1);
+        match squarer.send(x + 1) {
+            .Ok(_) => {},
+            .Err(_) => panic("incrementer could not send to squarer"),
+        }
     };
     println("Complex pipeline: increment -> square -> format");
-    incrementer.send(4); // 4+1=5, 5*5=25, format 25
-    incrementer.send(9); // 9+1=10, 10*10=100, format 100
+    match incrementer.send(4) { // 4+1=5, 5*5=25, format 25
+        .Ok(_) => {},
+        .Err(_) => panic("complex pipeline rejected input 4"),
+    }
+    match incrementer.send(9) { // 9+1=10, 10*10=100, format 100
+        .Ok(_) => {},
+        .Err(_) => panic("complex pipeline rejected input 9"),
+    }
     sleep(100ms);
+    await adder.close();
+    await doubler.close();
+    await printer.close();
+    await incrementer.close();
+    await squarer.close();
+    await formatter.close();
     println("=== Pipeline Done ===");
 }

--- a/examples/lambda_actors.hew
+++ b/examples/lambda_actors.hew
@@ -1,4 +1,4 @@
-//! Status: aspirational (Hew roadmap: actor/supervisor codegen-rs runtime parity)
+//! Status: runnable
 //! Description: Basic lambda actor
 
 fn main() {
@@ -8,7 +8,10 @@ fn main() {
     let doubler = actor |x: i64| {
         println(x * 2);
     };
-    doubler.send(21);
+    match doubler.send(21) {
+        .Ok(_) => {},
+        .Err(_) => panic("doubler actor rejected its input"),
+    }
     await doubler.close();
 
     // Multiple lambda actors running concurrently
@@ -22,10 +25,22 @@ fn main() {
         println(f"Plus 10: {x + 10}");
     };
     // Send to all concurrently
-    printer.send(100);
-    multiplier.send(7);
-    adder.send(5);
-    printer.send(200);
+    match printer.send(100) {
+        .Ok(_) => {},
+        .Err(_) => panic("printer actor rejected its first input"),
+    }
+    match multiplier.send(7) {
+        .Ok(_) => {},
+        .Err(_) => panic("multiplier actor rejected its input"),
+    }
+    match adder.send(5) {
+        .Ok(_) => {},
+        .Err(_) => panic("adder actor rejected its input"),
+    }
+    match printer.send(200) {
+        .Ok(_) => {},
+        .Err(_) => panic("printer actor rejected its second input"),
+    }
     await printer.close();
     await multiplier.close();
     await adder.close();
@@ -35,16 +50,28 @@ fn main() {
         let scoped_actor = actor |msg: i64| {
             println(f"Scoped: {msg}");
         };
-        scoped_actor.send(42);
+        match scoped_actor.send(42) {
+            .Ok(_) => {},
+            .Err(_) => panic("scoped actor rejected its input"),
+        }
         await scoped_actor.close();
     };
     // Multiple sends to same actor
     let counter = actor |x: i64| {
         println(f"Count: {x}");
     };
-    counter.send(1);
-    counter.send(2);
-    counter.send(3);
+    match counter.send(1) {
+        .Ok(_) => {},
+        .Err(_) => panic("counter actor rejected its first input"),
+    }
+    match counter.send(2) {
+        .Ok(_) => {},
+        .Err(_) => panic("counter actor rejected its second input"),
+    }
+    match counter.send(3) {
+        .Ok(_) => {},
+        .Err(_) => panic("counter actor rejected its third input"),
+    }
     await counter.close();
 
     // Lambda actor with complex body (if/else, function calls)
@@ -57,8 +84,14 @@ fn main() {
         let result = n * 2 + 1;
         println(f"Formula result: {result}");
     };
-    complex_actor.send(5);
-    complex_actor.send(15);
+    match complex_actor.send(5) {
+        .Ok(_) => {},
+        .Err(_) => panic("complex actor rejected its first input"),
+    }
+    match complex_actor.send(15) {
+        .Ok(_) => {},
+        .Err(_) => panic("complex actor rejected its second input"),
+    }
     await complex_actor.close();
 
     // Test actor factory pattern
@@ -71,7 +104,10 @@ fn run_multiplier_actor(factor: i64, value: i64) {
     let worker = actor |x: i64| {
         println(f"Multiplied by {factor}: {x * factor}");
     };
-    worker.send(value);
+    match worker.send(value) {
+        .Ok(_) => {},
+        .Err(_) => panic("multiplier actor rejected its input"),
+    }
     await worker.close();
     return;
 }

--- a/examples/multifile/03_text_stats/text_stats/text_stats.hew
+++ b/examples/multifile/03_text_stats/text_stats/text_stats.hew
@@ -10,7 +10,7 @@ pub fn char_count(text: string) -> i64 {
 }
 
 pub fn is_empty(text: string) -> bool {
-    text.len() == 0
+    text.is_empty()
 }
 
 pub fn truncate(text: string, max_len: i64) -> string {

--- a/examples/multifile/03_text_stats/text_stats/words/words.hew
+++ b/examples/multifile/03_text_stats/text_stats/words/words.hew
@@ -9,10 +9,11 @@
 // placed alongside words.hew (e.g. words/stopwords.hew) would also merge
 // into this sub-module automatically.
 //
-// Note: character-by-character scanning uses `text.slice(i, i+1)` rather
-// than `text.chars()` because `.chars()` is not yet supported by codegen.
+// Note: this scanner intentionally walks byte offsets with `slice`: `len()`
+// and `slice()` are byte-oriented. For Unicode codepoint iteration, use
+// `std.text.unicode.runes()` instead.
 pub fn word_count(text: string) -> i64 {
-    if text.len() == 0 {
+    if text.is_empty() {
         return 0;
     }
     var count = 1;

--- a/examples/network_file_reader.hew
+++ b/examples/network_file_reader.hew
@@ -1,8 +1,8 @@
 //! Status: runnable
-//! Description: File reader with actor message passing - Hew language example
+//! Description: File reader with a fallible std.fs read and actor message passing
 
-// File reader with actor message passing - Hew language example  
-// Demonstrates reading a file and printing via actor message passing
+// Demonstrates a fallible file read followed by direct calls to an actor's
+// receive functions. Pass a path after `--`, or use the bundled fixture.
 actor Printer {
     receive fn print_message(msg: i64) {
         println(f"Received value: {msg}");
@@ -19,12 +19,22 @@ fn fibonacci(n: i64) -> i64 {
 
 import std.fs;
 
+import std.os;
+
 fn main() {
     println("=== File Reader + Actor Pipeline ===");
-
-    // Read file contents directly
-    let contents = fs.read("examples/test_input.txt");
-    print(contents);
+    let path = if os.args_count() > 1 {
+        os.args(1)
+    } else {
+        "examples/test_input.txt"
+    };
+    // `try_read` keeps an input-path failure in the program's control flow.
+    // The successful contents are printed unchanged, preserving the simple
+    // stdout stream used by this example.
+    match fs.try_read(path) {
+        .Ok(contents) => print(contents),
+        .Err(error) => println(f"Could not read `{path}`: {fs.io_error_message(error)}"),
+    }
     println("---");
 
     // Send computed results through actor message passing

--- a/examples/observe_showcase.hew
+++ b/examples/observe_showcase.hew
@@ -1,4 +1,4 @@
-//! Status: aspirational (Hew roadmap: v0.7+ distributed Node API and transport stabilization)
+//! Status: runnable (native; requires the profiler for hew-observe)
 //! Description: observe_showcase.hew — Exemplar program for hew-observe
 
 // observe_showcase.hew — Exemplar program for hew-observe
@@ -13,18 +13,13 @@
 // Exercises the following hew-observe tabs:
 //   ① Overview    — scheduler counters, message rates, memory sparklines
 //   ② Actors      — multiple actor types with different profiles
-//   ⑤ Cluster     — node membership, connections, routing
+//   ⑤ Cluster     — empty for this single-node workload
 //   ⑥ Messages    — trace events: spawns and message sends
 //   ⑦ Timeline    — same events as a time-density view
 //
-// Note: this canonical showcase omits supervisors, so the Supervisors tab
-// stays empty when running it. The reason is a codegen gap: supervised
-// children with init() blocks are not yet started by the supervisor
-// bootstrap, so an init-style tree never boots and never reaches the
-// profiler. A supervisor whose children use default field values +
-// constructor args (no init()) DOES drive the tab. See
-// examples/observe_supervisor_showcase.hew for a live, restartable
-// supervision tree that populates the Supervisors tab.
+// Note: this showcase intentionally omits supervisors, so the Supervisors tab
+// stays empty. See examples/observe_supervisor_showcase.hew for a live,
+// restartable supervision tree.
 
 // ── Actor types ─────────────────────────────────────────────────────
 
@@ -40,8 +35,8 @@ actor Counter {
     }
 }
 
-// Slow worker that simulates processing delay. Messages queue up,
-// showing non-zero mailbox depth in the Actors tab.
+// Slow worker that simulates processing delay, making processing latency
+// visible in the Actors tab.
 actor SlowProcessor {
     let id: i32;
     var processed: i32;
@@ -81,10 +76,6 @@ fn main() {
     println("Run hew-observe in another terminal to inspect this program.");
     println("");
 
-    // Start a distributed node — populates the Cluster tab with
-    // membership, connection, and routing data.
-    Node.start("127.0.0.1:19000");
-
     // Spawn a variety of actors with different workload profiles.
     let c1 = spawn Counter(name: 1, value: 0);
     let c2 = spawn Counter(name: 2, value: 0);
@@ -94,14 +85,11 @@ fn main() {
     let logger = spawn Logger(entries: 0);
     let acc = spawn Accumulator(total: 0);
     sleep(100ms);
-
-    // Register a named actor in the cluster registry.
-    Node.register("main_counter", c1);
     println("7 actors spawned. Running workload for 60 seconds...");
     println("Watch hew-observe tabs: Overview, Actors, Messages, Timeline");
     println("");
 
-    // Run for 60 seconds — fills the 5-minute sparkline history and
+    // Run for 60 seconds — provides a minute of sparkline history and
     // generates a visible timeline of message events.
     var round: i32 = 0;
     while round < 60 {
@@ -158,6 +146,5 @@ fn main() {
     };
     println("");
     println(f"Counter total: {total}");
-    Node.shutdown();
     println("Showcase complete.");
 }

--- a/examples/progressive/06_structs.hew
+++ b/examples/progressive/06_structs.hew
@@ -1,5 +1,5 @@
-// Test 6: Structs
-// Defining and using structures
+// Lesson 6: Records
+// Defining and using record types with `type`
 type Person {
     age: i64;
     id: i64;

--- a/examples/regex_demo.hew
+++ b/examples/regex_demo.hew
@@ -1,5 +1,5 @@
-//! Status: aspirational (Hew roadmap: v0.6+ stdlib module stabilization plus codegen-rs parity)
-//! Description: Regex Demo — showcases Hew's stdlib regex support.
+//! Status: runnable
+//! Description: Regex Demo — showcases Hew's std.text.regex support.
 
 // Regex Demo — showcases Hew's stdlib regex support.
 //
@@ -10,6 +10,8 @@
 //   match x { s if pat.is_match(s) => ... } — regex-powered match guards
 //
 // Usage: hew build regex_demo.hew -o regex_demo && ./regex_demo
+import std.text.regex;
+
 fn main() {
     println("=== Regex Demo ===");
     let email_re = re"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$";

--- a/examples/services/distributed_counter.hew
+++ b/examples/services/distributed_counter.hew
@@ -1,11 +1,11 @@
-// Distributed Counter — replicated state across actor nodes
+// Distributed Counter — replicated state across local actors
 //
-// Models a counter replicated across multiple nodes. Each replica
-// maintains its own state and periodically syncs with a coordinator.
-// Reads are local (fast), writes go through the coordinator (consistent).
+// Models a counter replicated across three actors in one process. Each
+// replica maintains its own state and explicitly syncs with a coordinator.
+// Reads are local (fast); the coordinator's total updates when a sync arrives.
 //
-// This is a simplified CRDT-style pattern: each replica tracks local
-// increments, and the coordinator merges them into a global total.
+// This is a simplified replicated-state pattern: each replica tracks local
+// increments, and the coordinator records the latest report from each one.
 //
 // In Go you'd need channels between goroutines, a sync.Mutex for the
 // coordinator's map, and careful shutdown signalling. In Rust you'd
@@ -16,8 +16,9 @@
 // no locks, no data races — the actor model guarantees it.
 //
 // This example runs all replicas in one process to focus on the replication
-// pattern. A multi-node version would add a #[wire] message envelope and an
-// ActorMsg implementation before using Node.start/register/lookup.
+// pattern. It does not exercise the distributed runtime. A multi-node version
+// would define serializable request/reply types, implement ActorMsg, and use
+// Node.start/register/lookup to obtain RemotePid handles.
 
 // Coordinator — merges replica counts into a global total.
 actor Coordinator {
@@ -87,12 +88,13 @@ fn main() {
     let empty_names: Vec<string> = Vec.new();
     let empty_totals: Vec<i64> = Vec.new();
     let coord = spawn Coordinator(replica_names: empty_names, replica_totals: empty_totals, global_total: 0, sync_count: 0);
-    // Create replicas (in production these would be on separate nodes)
+    // Create process-local replicas (a production deployment could place them
+    // on separate nodes after adding the distributed message protocol).
     // Node.start("0.0.0.0:9000");
     let r1 = spawn Replica(name: "node-1", coordinator: coord, local_count: 0);
     let r2 = spawn Replica(name: "node-2", coordinator: coord, local_count: 0);
     let r3 = spawn Replica(name: "node-3", coordinator: coord, local_count: 0);
-    // Node.register("counter-1", r1);
+    // Node.register("counter-1", r1); // for a RemotePid-based deployment
 
     // Register replicas with coordinator
     coord.register_replica("node-1");

--- a/examples/services/health_monitor.hew
+++ b/examples/services/health_monitor.hew
@@ -10,8 +10,8 @@
 // with Arc<RwLock<HashMap>>.
 //
 // In Hew the monitor is an actor. Health state is actor state — no
-// locks needed. The check cycle uses `select` with a timeout to detect
-// unresponsive services without blocking forever.
+// locks needed. The check cycle uses `select` with a timeout to classify
+// unresponsive services defensively without blocking forever.
 
 // Service actor — responds to health checks. Can be made unhealthy.
 actor Service {
@@ -59,8 +59,8 @@ actor HealthMonitor {
                 .Some(value) => value,
                 .None => panic("service registry is inconsistent"),
             };
-            // Use select with timeout — if the service doesn't respond
-            // within 500ms, mark it unhealthy.
+            // Use select with a 500ms timeout — an explicit unhealthy
+            // response or a missing response both mark it unhealthy.
             let result = select {
                 r from svc.health_check() => r,
                 after 500ms => -1,
@@ -127,13 +127,25 @@ fn main() {
     println("--- All services healthy ---");
     monitor.check_all();
     sleep(30ms);
-    let _ = await monitor.report();
+    match await monitor.report() {
+        .Ok(_) => {},
+        .Err(_) => panic("[monitor] initial report ask failed"),
+    }
     // ── Normal traffic ──
     println("");
     println("--- Normal traffic ---");
-    let _ = await auth.handle(1);
-    let _ = await api.handle(2);
-    let _ = await cache.handle(3);
+    match await auth.handle(1) {
+        .Ok(_) => {},
+        .Err(_) => panic("[health] auth request 1 ask failed"),
+    }
+    match await api.handle(2) {
+        .Ok(_) => {},
+        .Err(_) => panic("[health] api request 2 ask failed"),
+    }
+    match await cache.handle(3) {
+        .Ok(_) => {},
+        .Err(_) => panic("[health] cache request 3 ask failed"),
+    }
     // ── Make cache unhealthy ──
     println("");
     println("--- Cache goes down ---");
@@ -141,13 +153,22 @@ fn main() {
     sleep(30ms);
     monitor.check_all();
     sleep(600ms);
-    let _ = await monitor.report();
+    match await monitor.report() {
+        .Ok(_) => {},
+        .Err(_) => panic("[monitor] degraded report ask failed"),
+    }
     // ── Remaining services still serve traffic ──
     println("");
     println("--- Healthy services still operational ---");
-    let _ = await auth.handle(4);
-    let _ = await api.handle(5);
+    match await auth.handle(4) {
+        .Ok(_) => {},
+        .Err(_) => panic("[health] auth request 4 ask failed"),
+    }
+    match await api.handle(5) {
+        .Ok(_) => {},
+        .Err(_) => panic("[health] api request 5 ask failed"),
+    }
     println("");
-    println("Health monitoring complete. The select timeout detects");
-    println("unresponsive services without blocking the monitor.");
+    println("Health monitoring complete. The select handles unhealthy");
+    println("responses and defensively times out unresponsive services.");
 }

--- a/examples/services/rate_limiter.hew
+++ b/examples/services/rate_limiter.hew
@@ -13,31 +13,11 @@
 // Pattern: Ask/Reply — the caller blocks until the limiter replies with
 // a boolean (allowed or rejected). This is back-pressure by design.
 actor RateLimiter {
-
-    // Try to acquire a token. Returns 1 if allowed, 0 if rejected.
-
-    // Refill tokens (called periodically by a refill timer).
-
-    // Simulated API worker that checks the limiter before processing.
-
-    // Periodic refill timer — adds tokens at a fixed interval.
-
-    // Create a limiter with 5 tokens, max 5, refilling 3 at a time
-
-    // Two API workers sharing the same limiter
-
-    // Start a refill timer: refill every 200ms, 3 cycles
-
-    // Burst: send 8 requests through 2 workers (only 5 tokens available)
-
-    // Check remaining tokens
-
-    // Wait for refill, then send more
-
-    // Final stats
     var tokens: i64;
     let max_tokens: i64;
     let refill_amount: i64;
+
+    // Try to acquire a token. Returns 1 if allowed, 0 if rejected.
     receive fn acquire() -> i64 {
         if tokens > 0 {
             tokens = tokens - 1;
@@ -46,6 +26,8 @@ actor RateLimiter {
             0
         }
     }
+
+    // Refill tokens (called periodically by a refill timer).
     receive fn refill() {
         let prev = tokens;
         tokens = tokens + refill_amount;
@@ -59,6 +41,7 @@ actor RateLimiter {
     }
 }
 
+// Simulated API worker that checks the limiter before processing.
 actor ApiWorker {
     let id: i64;
     let limiter: LocalPid<RateLimiter>;
@@ -67,16 +50,21 @@ actor ApiWorker {
     receive fn handle_request(request_id: i64) {
         scope {
             let allowed_r = await limiter.acquire();
-            let allowed = match allowed_r {
-                .Ok(v) => v,
-                .Err(_) => 0,
-            };
-            if allowed == 1 {
-                accepted = accepted + 1;
-                println(f"  [worker {id}] request {request_id}: ALLOWED ({accepted} served)");
-            } else {
-                rejected = rejected + 1;
-                println(f"  [worker {id}] request {request_id}: REJECTED ({rejected} dropped)");
+            match allowed_r {
+                .Ok(v) => {
+                    if v == 1 {
+                        accepted = accepted + 1;
+                        println(f"  [worker {id}] request {request_id}: ALLOWED ({accepted} served)");
+                    } else {
+                        rejected = rejected + 1;
+                        println(f"  [worker {id}] request {request_id}: REJECTED ({rejected} dropped)");
+                    }
+                },
+                .Err(_) => {
+                    // A failed ask means the limiter is unavailable, not that
+                    // this request consumed a legitimate rate-limit denial.
+                    println(f"  [worker {id}] request {request_id}: UNAVAILABLE (limiter ask failed)");
+                },
             }
         }
     }
@@ -86,6 +74,7 @@ actor ApiWorker {
     }
 }
 
+// Periodic refill timer that adds tokens at a fixed interval.
 actor RefillTimer {
     let limiter: LocalPid<RateLimiter>;
     let interval: duration;
@@ -102,11 +91,17 @@ actor RefillTimer {
 fn main() {
     println("=== Token Bucket Rate Limiter ===");
     println("");
+
+    // Create a limiter with 5 tokens, max 5, refilling 3 at a time
     let limiter = spawn RateLimiter(tokens: 5, max_tokens: 5, refill_amount: 3);
+    // Two API workers sharing the same limiter
     let w1 = spawn ApiWorker(id: 1, limiter: limiter, accepted: 0, rejected: 0);
     let w2 = spawn ApiWorker(id: 2, limiter: limiter, accepted: 0, rejected: 0);
+    // Start a refill timer: refill every 200ms, 3 cycles
     let timer = spawn RefillTimer(limiter: limiter, interval: 200ms, cycles: 3);
     timer.start();
+
+    // Burst: send 8 requests through 2 workers (only 5 tokens available)
     println("--- Burst: 8 requests, 5 tokens ---");
     w1.handle_request(0);
     w2.handle_request(1);
@@ -117,12 +112,16 @@ fn main() {
     w1.handle_request(6);
     w2.handle_request(7);
     sleep(100ms);
+
+    // Check remaining tokens
     let remaining_r = await limiter.available();
     match remaining_r {
         .Ok(n) => println(f"Tokens remaining after burst: {n}"),
         .Err(_) => println("Tokens remaining: err"),
     }
     println("");
+
+    // Wait for refill, then send more
     println("--- After refill ---");
     sleep(250ms);
     let after_refill_r = await limiter.available();
@@ -135,9 +134,17 @@ fn main() {
     w1.handle_request(102);
     sleep(100ms);
     println("");
+
+    // Final stats
     println("--- Worker stats ---");
-    let _ = await w1.stats();
-    let _ = await w2.stats();
+    match await w1.stats() {
+        .Ok(_) => {},
+        .Err(_) => panic("[rate-limiter] worker 1 stats ask failed"),
+    }
+    match await w2.stats() {
+        .Ok(_) => {},
+        .Err(_) => panic("[rate-limiter] worker 2 stats ask failed"),
+    }
     println("");
     println("Rate limiting complete. No mutexes, no channels — just actors.");
 }

--- a/examples/services/worker_pool.hew
+++ b/examples/services/worker_pool.hew
@@ -87,13 +87,12 @@ fn main() {
     w2.crash_test();
     sleep(200ms);
 
-    // Supervisor has already restarted worker 2 — get the fresh handle
-    let w2_new = sup.w2;
+    // ChildRef re-resolves worker 2's current incarnation after restart.
     println("--- Post-crash fan-out ---");
     let (p, q, r, s) = join {
         w0.compute(5),
         w1.compute(5),
-        w2_new.compute(5),
+        w2.compute(5),
         w3.compute(5),
     };
     println(f"Results: {p}, {q}, {r}, {s}  (all workers operational)");

--- a/examples/smtp_client.hew
+++ b/examples/smtp_client.hew
@@ -14,10 +14,6 @@
 //
 // Replace the string literals in main() with real values before running.
 //
-// NOTE: .Ok(()) as a match pattern is rejected by the checker when the .Ok
-// payload type is unit — the checker treats the inner () as a zero-element
-// tuple destructor rather than the unit type.  The workaround is .Ok(_).
-// Tracked: see hew-lang/hew#1598
 import std.net.smtp;
 
 fn send_plain(host: string, port: i64, username: string, password: string, from: string, to: string) -> Result<i64, string> {
@@ -26,7 +22,7 @@ fn send_plain(host: string, port: i64, username: string, password: string, from:
             let result = conn.try_send(from, to, "Hello from Hew", "This is a plain-text test email.");
             conn.close();
             match result {
-                .Ok(_) => Ok(0),
+                .Ok(()) => Ok(0),
                 .Err(msg) => Err(msg),
             }
         },
@@ -41,7 +37,7 @@ fn send_html(host: string, port: i64, username: string, password: string, from: 
             let result = conn.try_send_html(from, to, "HTML email from Hew", body);
             conn.close();
             match result {
-                .Ok(_) => Ok(0),
+                .Ok(()) => Ok(0),
                 .Err(msg) => Err(msg),
             }
         },
@@ -57,10 +53,10 @@ fn main() {
     let to = "recipient@example.com";
     match send_plain(host, 587, username, password, from, to) {
         .Ok(_) => println("Plain-text email sent."),
-        .Err(msg) => println("Error: " + msg),
+        .Err(msg) => println(f"Error: {msg}"),
     }
     match send_html(host, 465, username, password, from, to) {
         .Ok(_) => println("HTML email sent."),
-        .Err(msg) => println("Error: " + msg),
+        .Err(msg) => println(f"Error: {msg}"),
     }
 }

--- a/examples/supervisor_nested_tree.hew
+++ b/examples/supervisor_nested_tree.hew
@@ -1,4 +1,4 @@
-//! Status: aspirational (Hew roadmap: actor/supervisor codegen-rs runtime parity)
+//! Status: runnable
 //! Description: ─────────────────────────────────────────────────────────────────
 
 // ─────────────────────────────────────────────────────────────────

--- a/examples/supervisor_worker_pool.hew
+++ b/examples/supervisor_worker_pool.hew
@@ -57,7 +57,8 @@ fn main() {
     let sup = spawn WorkerPool;
     sleep(30ms);
 
-    // Get worker handles (typed — the compiler knows these are Worker actors)
+    // Get stable child references (typed as ChildRef<Worker> by the compiler).
+    // Each reference resolves the child's current incarnation on every send.
     let w1 = sup.w1;
     let w2 = sup.w2;
     let w3 = sup.w3;
@@ -75,11 +76,11 @@ fn main() {
     sleep(200ms);
 
     // Workers 1 and 3 are unaffected.
-    // Worker 2 has been restarted with fresh state (processed=0).
+    // Worker 2 has been restarted with fresh state (processed=0). The existing
+    // ChildRef remains valid and resolves the replacement incarnation.
     println("--- after restart, all workers operational ---");
-    let w2_new = sup.w2;
     w1.process(102);
-    w2_new.process(202);
+    w2.process(202);
     w3.process(301);
     sleep(50ms);
     println("");

--- a/examples/ux/03_fizzbuzz.hew
+++ b/examples/ux/03_fizzbuzz.hew
@@ -1,7 +1,6 @@
-// FizzBuzz - my version
+// FizzBuzz for the numbers 1 through 15.
 fn main() {
-    var i = 1;
-    while i <= 15 {
+    for i in 1 ..= 15 {
         if i % 15 == 0 {
             println("FizzBuzz");
         } else {
@@ -15,6 +14,5 @@ fn main() {
                 }
             }
         }
-        i = i + 1;
     }
 }

--- a/tests/hew/rate_limiter_outcome_test.hew
+++ b/tests/hew/rate_limiter_outcome_test.hew
@@ -1,0 +1,71 @@
+//! The limiter's business denial and an unavailable limiter are different
+//! outcomes: only a successful `0` reply increments `rejected`.
+//!
+//! The stopped supervisor is a bounded negative control for the `Err` arm. It
+//! produces `AskError.ActorStopped` without crashing the test process, so this
+//! executable test proves the unavailable path remains distinct from a normal
+//! rate-limit denial.
+
+import std.testing;
+
+actor ProbeLimiter {
+    receive fn acquire() -> i64 {
+        0
+    }
+}
+
+supervisor ProbeTree {
+    strategy: one_for_one;
+    intensity: 1 within 60s;
+
+    child limiter: ProbeLimiter;
+}
+
+actor ProbeWorker {
+    let tree: LocalPid<ProbeTree>;
+    var rejected: i64;
+    var unavailable: i64;
+    receive fn handle_request() -> i64 {
+        let result = await tree.limiter.acquire();
+        match result {
+            .Ok(value) => {
+                if value == 0 {
+                    rejected = rejected + 1;
+                    1
+                } else {
+                    0
+                }
+            },
+            .Err(_) => {
+                unavailable = unavailable + 1;
+                2
+            },
+        }
+    }
+    receive fn outcome_totals() -> i64 {
+        rejected * 10 + unavailable
+    }
+}
+
+#[test]
+fn _rate_limit_denial_does_not_hide_ask_failure() {
+    let tree = spawn ProbeTree;
+    sleep(30ms);
+    let worker = spawn ProbeWorker(tree: tree, rejected: 0, unavailable: 0);
+    match await worker.handle_request() {
+        .Ok(outcome) => testing.assert_eq(outcome, 1),
+        .Err(_) => testing.assert_true(false),
+    }
+    supervisor_stop(tree);
+    sleep(80ms);
+    match await worker.handle_request() {
+        .Ok(outcome) => testing.assert_eq(outcome, 2),
+        .Err(_) => testing.assert_true(false),
+    }
+    // 10 means one legitimate rejection; the ones digit means one separate
+    // unavailable result. If Err were mapped to rejection this would be 20.
+    match await worker.outcome_totals() {
+        .Ok(total) => testing.assert_eq(total, 11),
+        .Err(_) => testing.assert_true(false),
+    }
+}


### PR DESCRIPTION
## Why

Many examples predated current Hew language surfaces and no longer demonstrated the idioms users should copy. Refreshing them also gives the compiler a broad dogfood pass across actors, constants, for-in loops, f-strings, outcomes, and multi-module programs.

## What

- modernize 27 example source paths across algorithms, actors, services, networking, and tutorials
- replace manual counter loops and legacy formatting with current Hew constructs where they improve clarity
- update actor and service examples to exercise current request, reply, supervision, and outcome handling
- add a compiled rate-limiter outcome regression covering the refreshed service behavior

## Test

- cargo fmt --all -- --check
- make playground-manifest-check test-surface-examples test-ux-examples hew-check-all (1,542 corpus checks)
- execute all 25 runnable changed source paths via 24 invocations
- build HTTP JSON and SMTP examples
- bounded two-process chat server/client loopback proof