### PR TITLE
fix(mir): retain Bytes field-load shares

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -87,7 +87,7 @@ use hew_mir::{
 };
 pub(crate) use hew_types::short_name;
 use hew_types::{
-    runtime_call::{MathIntrinsic, RuntimeCapability},
+    runtime_call::{MathIntrinsic, RuntimeCapability, RuntimeDropOperandShape},
     wasm_capability_ids, BuiltinType, NumericWidth, ResolvedTy, WasmCapabilityId,
     WireCodecDirection, WireLayoutTable, WireTextFormat,
 };
@@ -7044,6 +7044,29 @@ fn emit_field_clone_step<'ctx>(
     Ok(())
 }
 
+/// Require the exact runtime ABI consumed by an inline `MonitorRef` drop.
+///
+/// `intern_runtime_decl` deliberately adopts declarations already present in
+/// the module, so every MonitorRef consumer must validate all three function
+/// type axes before emitting a call: result, fixed parameter list, and
+/// variadicness. LLVM permits calls through several near-miss declarations
+/// that are individually type-correct IR but disagree with the C ABI.
+fn verify_monitor_ref_close_abi(close_fn: FunctionValue<'_>, context: &str) -> CodegenResult<()> {
+    let fn_ty = close_fn.get_type();
+    let params = fn_ty.get_param_types();
+    let exact_i64_param = matches!(
+        params.as_slice(),
+        [BasicMetadataTypeEnum::IntType(i)] if i.get_bit_width() == 64
+    );
+    if fn_ty.get_return_type().is_some() || fn_ty.is_var_arg() || !exact_i64_param {
+        return Err(CodegenError::FailClosed(format!(
+            "{context}: `{}` must have exact non-vararg void(i64) ABI",
+            close_fn.get_name().to_string_lossy()
+        )));
+    }
+    Ok(())
+}
+
 /// Emit one field's drop step (used by both per-actor and per-record drop
 /// bodies, AND by per-actor clone's rollback chain). Reads
 /// `state.<field_idx>` and invokes the matching runtime drop helper or
@@ -7428,6 +7451,112 @@ pub(crate) fn emit_field_drop_step<'ctx>(
         // close ABI drifted from `void(self)` (e.g. a non-Unit return added an
         // sret param) — fail closed instead of calling with a mismatched ABI.
         StateFieldCloneKind::Resource { name, close } => {
+            // MonitorRef is the sole current inline resource: its close ABI
+            // consumes `ref_id: i64`, not a pointer to the record. Keep that
+            // distinction in RuntimeDropDescriptor::operand_shape rather than
+            // recovering it from a symbol spelling. The slot validation makes
+            // classifier/layout drift fail closed before an opaque-pointer GEP
+            // can address arbitrary bytes.
+            if let ResourceCloseAuthority::Runtime(descriptor) = close {
+                if matches!(
+                    descriptor.operand_shape(),
+                    RuntimeDropOperandShape::MonitorRefId
+                ) {
+                    let field_ty = st_ty.get_field_type_at_index(field_idx).ok_or_else(|| {
+                        CodegenError::FailClosed(format!(
+                            "MonitorRef resource drop: parent struct {st_ty:?} has no field at \
+                             index {field_idx}"
+                        ))
+                    })?;
+                    let monitor_ty = match field_ty {
+                        BasicTypeEnum::StructType(struct_ty) => struct_ty,
+                        other => {
+                            return Err(CodegenError::FailClosed(format!(
+                                "MonitorRef resource drop: parent field {field_idx} is {other:?}, \
+                             not the inline {{ i64 }} MonitorRef ABI"
+                            )))
+                        }
+                    };
+                    let fields = monitor_ty.get_field_types();
+                    if monitor_ty.is_packed()
+                        || fields.len() != 1
+                        || !matches!(fields[0], BasicTypeEnum::IntType(i) if i.get_bit_width() == 64)
+                    {
+                        return Err(CodegenError::FailClosed(format!(
+                            "MonitorRef resource drop: parent field {field_idx} has layout \
+                             {fields:?}, expected exactly inline {{ i64 }}"
+                        )));
+                    }
+                    let field_ptr = builder
+                        .build_struct_gep(
+                            st_ty,
+                            state,
+                            field_idx,
+                            &format!("drop_monitor_f{field_idx}_ptr"),
+                        )
+                        .llvm_ctx_with(|| format!("drop MonitorRef gep f{field_idx}"))?;
+                    let id_ptr = builder
+                        .build_struct_gep(
+                            monitor_ty,
+                            field_ptr,
+                            0,
+                            &format!("drop_monitor_f{field_idx}_id_ptr"),
+                        )
+                        .llvm_ctx_with(|| format!("drop MonitorRef id gep f{field_idx}"))?;
+                    let i64_ty = ctx.i64_type();
+                    let id = builder
+                        .build_load(i64_ty, id_ptr, &format!("drop_monitor_f{field_idx}_id"))
+                        .llvm_ctx_with(|| format!("drop MonitorRef id load f{field_idx}"))?
+                        .into_int_value();
+                    let parent = builder
+                        .get_insert_block()
+                        .and_then(|bb| bb.get_parent())
+                        .ok_or_else(|| {
+                            CodegenError::Llvm(
+                                "MonitorRef resource drop has no parent function".into(),
+                            )
+                        })?;
+                    let close_bb =
+                        ctx.append_basic_block(parent, &format!("monitor_f{field_idx}_close"));
+                    let cont_bb =
+                        ctx.append_basic_block(parent, &format!("monitor_f{field_idx}_cont"));
+                    let inactive = builder
+                        .build_int_compare(
+                            IntPredicate::EQ,
+                            id,
+                            i64_ty.const_zero(),
+                            &format!("monitor_f{field_idx}_inactive"),
+                        )
+                        .llvm_ctx_with(|| format!("drop MonitorRef inactive check f{field_idx}"))?;
+                    builder
+                        .build_conditional_branch(inactive, cont_bb, close_bb)
+                        .llvm_ctx_with(|| format!("drop MonitorRef branch f{field_idx}"))?;
+                    builder.position_at_end(close_bb);
+                    let mut declarations = RuntimeDeclMap::new();
+                    let close_fn = intern_runtime_decl(
+                        ctx,
+                        llvm_mod,
+                        &mut declarations,
+                        descriptor.c_symbol(),
+                    )?;
+                    verify_monitor_ref_close_abi(close_fn, "MonitorRef resource drop")?;
+                    builder
+                        .build_call(
+                            close_fn,
+                            &[id.into()],
+                            &format!("monitor_f{field_idx}_close_call"),
+                        )
+                        .llvm_ctx_with(|| format!("drop MonitorRef close f{field_idx}"))?;
+                    builder
+                        .build_store(id_ptr, i64_ty.const_zero())
+                        .llvm_ctx_with(|| format!("drop MonitorRef zero store f{field_idx}"))?;
+                    builder
+                        .build_unconditional_branch(cont_bb)
+                        .llvm_ctx_with(|| format!("drop MonitorRef continue f{field_idx}"))?;
+                    builder.position_at_end(cont_bb);
+                    return Ok(());
+                }
+            }
             let (close_fn, close_symbol) = match close {
                 ResourceCloseAuthority::Runtime(descriptor) => {
                     let symbol = descriptor.c_symbol();
@@ -7453,13 +7582,20 @@ pub(crate) fn emit_field_drop_step<'ctx>(
                     (close_fn, symbol)
                 }
             };
-            if close_fn.count_params() != 1 {
+            let expected_params = match close {
+                ResourceCloseAuthority::Runtime(descriptor) => match descriptor.operand_shape() {
+                    RuntimeDropOperandShape::HandlePtr => 1,
+                    RuntimeDropOperandShape::DuplexHalf { .. } => 2,
+                    RuntimeDropOperandShape::MonitorRefId => unreachable!("handled above"),
+                },
+                ResourceCloseAuthority::User(_) => 1,
+            };
+            if close_fn.count_params() != expected_params {
                 return Err(CodegenError::FailClosed(format!(
                     "resource `{name}` field drop: close symbol `{close_symbol}` has \
-                     {} params, expected exactly 1 (the consumed `self` handle). A \
+                     {} params, expected {expected_params} from its typed operand ABI. A \
                      non-Unit return (hidden sret param) or an extra parameter means \
-                     the close ABI drifted from `void(self)` (Q-β-C requires close to \
-                     consume self and return Unit). Refusing to call with a mismatched \
+                     the close ABI drifted. Refusing to call with a mismatched \
                      ABI (LESSONS: boundary-fail-closed, ffi-abi-width-mirror).",
                     close_fn.count_params()
                 )));
@@ -7495,10 +7631,23 @@ pub(crate) fn emit_field_drop_step<'ctx>(
                 .build_conditional_branch(is_null, cont_bb, close_bb)
                 .llvm_ctx_with(|| format!("drop resource branch f{field_idx}"))?;
             builder.position_at_end(close_bb);
+            let close_args: Vec<BasicMetadataValueEnum<'_>> = match close {
+                ResourceCloseAuthority::Runtime(descriptor) => match descriptor.operand_shape() {
+                    RuntimeDropOperandShape::HandlePtr => vec![handle.into()],
+                    RuntimeDropOperandShape::DuplexHalf { direction } => vec![
+                        handle.into(),
+                        ctx.i32_type()
+                            .const_int(direction.runtime_discriminant(), false)
+                            .into(),
+                    ],
+                    RuntimeDropOperandShape::MonitorRefId => unreachable!("handled above"),
+                },
+                ResourceCloseAuthority::User(_) => vec![handle.into()],
+            };
             builder
                 .build_call(
                     close_fn,
-                    &[handle.into()],
+                    &close_args,
                     &format!("resource_f{field_idx}_close_call"),
                 )
                 .llvm_ctx_with(|| format!("drop resource close call f{field_idx}"))?;
@@ -19525,6 +19674,87 @@ pub(crate) fn emit_prepared_carrier_drop<'ctx>(
         }
         StateFieldCloneKind::Resource { close, .. } => {
             let (slot, slot_ty) = place_pointer(fn_ctx, value)?;
+            if let ResourceCloseAuthority::Runtime(descriptor) = close {
+                if matches!(
+                    descriptor.operand_shape(),
+                    RuntimeDropOperandShape::MonitorRefId
+                ) {
+                    let monitor_ty = match slot_ty {
+                        BasicTypeEnum::StructType(struct_ty) => struct_ty,
+                        other => return Err(CodegenError::FailClosed(format!(
+                            "prepared MonitorRef resource has slot type {other:?}, expected inline {{ i64 }}"
+                        ))),
+                    };
+                    let fields = monitor_ty.get_field_types();
+                    if monitor_ty.is_packed()
+                        || fields.len() != 1
+                        || !matches!(fields[0], BasicTypeEnum::IntType(i) if i.get_bit_width() == 64)
+                    {
+                        return Err(CodegenError::FailClosed(format!(
+                            "prepared MonitorRef resource has layout {fields:?}, expected inline {{ i64 }}"
+                        )));
+                    }
+                    let id_ptr = fn_ctx
+                        .builder
+                        .build_struct_gep(monitor_ty, slot, 0, "prepared_monitor_ref_id_ptr")
+                        .llvm_ctx("prepared MonitorRef id gep")?;
+                    let i64_ty = fn_ctx.ctx.i64_type();
+                    let id = fn_ctx
+                        .builder
+                        .build_load(i64_ty, id_ptr, "prepared_monitor_ref_id")
+                        .llvm_ctx("prepared MonitorRef id load")?;
+                    let parent = fn_ctx
+                        .builder
+                        .get_insert_block()
+                        .and_then(|bb| bb.get_parent())
+                        .ok_or_else(|| {
+                            CodegenError::Llvm(
+                                "prepared MonitorRef resource has no parent function".into(),
+                            )
+                        })?;
+                    let close_bb = fn_ctx
+                        .ctx
+                        .append_basic_block(parent, "prepared_monitor_ref_close");
+                    let cont_bb = fn_ctx
+                        .ctx
+                        .append_basic_block(parent, "prepared_monitor_ref_cont");
+                    let inactive = fn_ctx
+                        .builder
+                        .build_int_compare(
+                            IntPredicate::EQ,
+                            id.into_int_value(),
+                            i64_ty.const_zero(),
+                            "prepared_monitor_ref_inactive",
+                        )
+                        .llvm_ctx("prepared MonitorRef inactive check")?;
+                    fn_ctx
+                        .builder
+                        .build_conditional_branch(inactive, cont_bb, close_bb)
+                        .llvm_ctx("prepared MonitorRef branch")?;
+                    fn_ctx.builder.position_at_end(close_bb);
+                    let helper = intern_runtime_decl(
+                        fn_ctx.ctx,
+                        fn_ctx.llvm_mod,
+                        &mut fn_ctx.runtime_decls.borrow_mut(),
+                        descriptor.c_symbol(),
+                    )?;
+                    verify_monitor_ref_close_abi(helper, "prepared MonitorRef resource")?;
+                    fn_ctx
+                        .builder
+                        .build_call(helper, &[id.into()], "prepared_monitor_ref_close")
+                        .llvm_ctx("prepared MonitorRef close")?;
+                    fn_ctx
+                        .builder
+                        .build_store(id_ptr, i64_ty.const_zero())
+                        .llvm_ctx("prepared MonitorRef zero store")?;
+                    fn_ctx
+                        .builder
+                        .build_unconditional_branch(cont_bb)
+                        .llvm_ctx("prepared MonitorRef continue")?;
+                    fn_ctx.builder.position_at_end(cont_bb);
+                    return Ok(());
+                }
+            }
             let handle = fn_ctx
                 .builder
                 .build_load(slot_ty, slot, "prepared_resource_handle")
@@ -19545,9 +19775,31 @@ pub(crate) fn emit_prepared_carrier_drop<'ctx>(
                     })?
                 }
             };
+            let args: Vec<BasicMetadataValueEnum<'_>> = match close {
+                ResourceCloseAuthority::Runtime(descriptor) => match descriptor.operand_shape() {
+                    RuntimeDropOperandShape::HandlePtr => vec![handle.into()],
+                    RuntimeDropOperandShape::DuplexHalf { direction } => vec![
+                        handle.into(),
+                        fn_ctx
+                            .ctx
+                            .i32_type()
+                            .const_int(direction.runtime_discriminant(), false)
+                            .into(),
+                    ],
+                    RuntimeDropOperandShape::MonitorRefId => unreachable!("handled above"),
+                },
+                ResourceCloseAuthority::User(_) => vec![handle.into()],
+            };
+            if helper.count_params() != args.len() as u32 {
+                return Err(CodegenError::FailClosed(format!(
+                    "prepared resource close has {} params, expected {} from its typed operand ABI",
+                    helper.count_params(),
+                    args.len(),
+                )));
+            }
             fn_ctx
                 .builder
-                .build_call(helper, &[handle.into()], "prepared_resource_close")
+                .build_call(helper, &args, "prepared_resource_close")
                 .llvm_ctx("prepared resource close")?;
             fn_ctx
                 .builder

--- a/hew-codegen-rs/src/llvm_tests.rs
+++ b/hew-codegen-rs/src/llvm_tests.rs
@@ -6877,6 +6877,237 @@ fn failed_actor_sender_transfer_closes_the_prepared_owner() {
 }
 
 #[test]
+fn prepared_half_carrier_drop_keeps_the_typed_direction_operand() {
+    for (name, builtin, direction) in [
+        ("SendHalf", hew_types::BuiltinType::SendHalf, 0_u64),
+        ("RecvHalf", hew_types::BuiltinType::RecvHalf, 1_u64),
+    ] {
+        let ctx = Context::create();
+        let module = ctx.create_module("prepared_half_carrier_cleanup");
+        let harness = build_harness(&ctx, &[], &[]);
+        let mut fn_ctx = make_test_fn_ctx(&ctx, &module, &harness, "half_cleanup");
+        let half_ty = ResolvedTy::named_builtin(name, builtin, vec![]);
+        let ptr_ty = ctx.ptr_type(AddressSpace::default());
+        let slot = fn_ctx
+            .builder
+            .build_alloca(ptr_ty, "local_0")
+            .expect("half carrier slot");
+        fn_ctx.locals.insert(0, (slot, ptr_ty.into()));
+        fn_ctx.local_tys.insert(0, half_ty.clone());
+        let plan = hew_mir::state_clone::classify_value_snapshot_plan_with_lifecycle_registry(
+            &half_ty,
+            &[],
+            &[],
+            &[],
+            fn_ctx.lifecycle_registry,
+        )
+        .unwrap_or_else(|error| panic!("{name} must have a typed plan: {error:?}"));
+
+        emit_prepared_carrier_drop(
+            &fn_ctx,
+            Place::Local(0),
+            &plan,
+            hew_mir::PreparedCarrierBoundary::Actor,
+        )
+        .unwrap_or_else(|error| panic!("{name} prepared cleanup failed: {error}"));
+        finish_test_fn(&fn_ctx);
+
+        assert!(module.verify().is_ok(), "{name} prepared IR must verify");
+        let ir = module.print_to_string().to_string();
+        assert!(
+            ir.contains("call i32 @hew_duplex_close_half")
+                && ir.contains(&format!("i32 {direction}")),
+            "{name} prepared close must materialise its descriptor direction; IR:\n{ir}",
+        );
+    }
+}
+
+fn assert_monitor_ref_guarded_drop_cfg(
+    ir: &str,
+    inactive_value: &str,
+    close_block: &str,
+    cont_block: &str,
+) {
+    let predicate = format!("%{inactive_value} = icmp eq i64");
+    let branch = format!("br i1 %{inactive_value}, label %{cont_block}, label %{close_block}");
+    assert!(
+        ir.contains(&predicate),
+        "MonitorRef guard must compare its id with zero; IR:\n{ir}"
+    );
+    assert!(
+        ir.contains(&format!("{predicate} %")) && ir.contains(&format!(", 0\n  {branch}")),
+        "zero/inactive must branch directly to continuation and nonzero/active to close; IR:\n{ir}"
+    );
+
+    let close_marker = format!("\n{close_block}:");
+    let cont_marker = format!("\n{cont_block}:");
+    let close_start = ir
+        .find(&close_marker)
+        .unwrap_or_else(|| panic!("missing MonitorRef close block `{close_block}`; IR:\n{ir}"));
+    let cont_start = ir
+        .find(&cont_marker)
+        .unwrap_or_else(|| panic!("missing MonitorRef continuation `{cont_block}`; IR:\n{ir}"));
+    assert!(
+        close_start < cont_start,
+        "unexpected MonitorRef block order; IR:\n{ir}"
+    );
+    let close_body = &ir[close_start..cont_start];
+    let call_at = close_body
+        .find("call void @hew_actor_demonitor(i64")
+        .unwrap_or_else(|| panic!("active close block must call demonitor; IR:\n{ir}"));
+    let disarm_at = close_body
+        .find("store i64 0")
+        .unwrap_or_else(|| panic!("active close block must disarm the id; IR:\n{ir}"));
+    assert!(
+        call_at < disarm_at && close_body.contains(&format!("br label %{cont_block}")),
+        "active close must call, then disarm, then continue; IR:\n{ir}"
+    );
+
+    let cont_end = ir[cont_start..]
+        .find("\n}")
+        .map_or(ir.len(), |offset| cont_start + offset);
+    let cont_body = &ir[cont_start..cont_end];
+    assert!(
+        !cont_body.contains("call void @hew_actor_demonitor"),
+        "inactive continuation must contain no demonitor call; IR:\n{ir}"
+    );
+}
+
+#[test]
+fn prepared_monitor_ref_drop_guards_inactive_id_and_zeros_active_id() {
+    let ctx = Context::create();
+    let module = ctx.create_module("prepared_monitor_ref_cleanup");
+    let harness = build_harness(&ctx, &[], &[]);
+    let mut fn_ctx = make_test_fn_ctx(&ctx, &module, &harness, "monitor_cleanup");
+    let ty = ResolvedTy::named_builtin("MonitorRef", hew_types::BuiltinType::MonitorRef, vec![]);
+    let i64_ty = ctx.i64_type();
+    let monitor_ty = ctx.struct_type(&[i64_ty.into()], false);
+    let slot = fn_ctx
+        .builder
+        .build_alloca(monitor_ty, "local_0")
+        .expect("monitor slot");
+    fn_ctx.locals.insert(0, (slot, monitor_ty.into()));
+    fn_ctx.local_tys.insert(0, ty.clone());
+    let plan = hew_mir::state_clone::classify_value_snapshot_plan_with_lifecycle_registry(
+        &ty,
+        &[],
+        &[],
+        &[],
+        fn_ctx.lifecycle_registry,
+    )
+    .expect("MonitorRef plan");
+    emit_prepared_carrier_drop(
+        &fn_ctx,
+        Place::Local(0),
+        &plan,
+        hew_mir::PreparedCarrierBoundary::Actor,
+    )
+    .expect("prepared MonitorRef cleanup");
+    finish_test_fn(&fn_ctx);
+    assert!(module.verify().is_ok());
+    let ir = module.print_to_string().to_string();
+    assert_monitor_ref_guarded_drop_cfg(
+        &ir,
+        "prepared_monitor_ref_inactive",
+        "prepared_monitor_ref_close",
+        "prepared_monitor_ref_cont",
+    );
+}
+
+#[test]
+fn prepared_monitor_ref_drop_rejects_every_near_miss_predeclared_abi() {
+    for abi in ["nonvoid", "pointer", "varargs"] {
+        let ctx = Context::create();
+        let module = ctx.create_module("prepared_monitor_ref_wrong_abi");
+        let harness = build_harness(&ctx, &[], &[]);
+        let mut fn_ctx = make_test_fn_ctx(&ctx, &module, &harness, "monitor_cleanup");
+        let ty =
+            ResolvedTy::named_builtin("MonitorRef", hew_types::BuiltinType::MonitorRef, vec![]);
+        let i64_ty = ctx.i64_type();
+        let monitor_ty = ctx.struct_type(&[i64_ty.into()], false);
+        let slot = fn_ctx
+            .builder
+            .build_alloca(monitor_ty, "local_0")
+            .expect("monitor slot");
+        fn_ctx.locals.insert(0, (slot, monitor_ty.into()));
+        fn_ctx.local_tys.insert(0, ty.clone());
+        let fn_ty = match abi {
+            "nonvoid" => ctx.i32_type().fn_type(&[i64_ty.into()], false),
+            "pointer" => ctx
+                .void_type()
+                .fn_type(&[ctx.ptr_type(AddressSpace::default()).into()], false),
+            "varargs" => ctx.void_type().fn_type(&[i64_ty.into()], true),
+            _ => unreachable!(),
+        };
+        module.add_function("hew_actor_demonitor", fn_ty, None);
+        let plan = hew_mir::state_clone::classify_value_snapshot_plan_with_lifecycle_registry(
+            &ty,
+            &[],
+            &[],
+            &[],
+            fn_ctx.lifecycle_registry,
+        )
+        .expect("MonitorRef plan");
+        let err = emit_prepared_carrier_drop(
+            &fn_ctx,
+            Place::Local(0),
+            &plan,
+            hew_mir::PreparedCarrierBoundary::Actor,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, CodegenError::FailClosed(ref msg)
+                if msg.contains("exact non-vararg void(i64) ABI")),
+            "prepared MonitorRef must reject {abi}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn prepared_monitor_ref_drop_rejects_invalid_carrier_layouts() {
+    for layout in ["packed", "wrong-width", "scalar"] {
+        let ctx = Context::create();
+        let module = ctx.create_module("prepared_monitor_ref_wrong_carrier");
+        let harness = build_harness(&ctx, &[], &[]);
+        let mut fn_ctx = make_test_fn_ctx(&ctx, &module, &harness, "monitor_cleanup");
+        let ty =
+            ResolvedTy::named_builtin("MonitorRef", hew_types::BuiltinType::MonitorRef, vec![]);
+        let slot_ty: BasicTypeEnum<'_> = match layout {
+            "packed" => ctx.struct_type(&[ctx.i64_type().into()], true).into(),
+            "wrong-width" => ctx.struct_type(&[ctx.i32_type().into()], false).into(),
+            "scalar" => ctx.i64_type().into(),
+            _ => unreachable!(),
+        };
+        let slot = fn_ctx
+            .builder
+            .build_alloca(slot_ty, "local_0")
+            .expect("forged MonitorRef carrier slot");
+        fn_ctx.locals.insert(0, (slot, slot_ty));
+        fn_ctx.local_tys.insert(0, ty.clone());
+        let plan = hew_mir::state_clone::classify_value_snapshot_plan_with_lifecycle_registry(
+            &ty,
+            &[],
+            &[],
+            &[],
+            fn_ctx.lifecycle_registry,
+        )
+        .expect("MonitorRef plan");
+        let err = emit_prepared_carrier_drop(
+            &fn_ctx,
+            Place::Local(0),
+            &plan,
+            hew_mir::PreparedCarrierBoundary::Actor,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, CodegenError::FailClosed(ref msg)
+                if msg.contains("prepared MonitorRef resource")),
+            "prepared MonitorRef must reject {layout} carrier, got {err:?}"
+        );
+    }
+}
+
+#[test]
 fn aggregate_borrowed_ingress_array_retains_each_string_occurrence() {
     let ctx = Context::create();
     let m = ctx.create_module("aggregate_borrowed_ingress_array");
@@ -17177,6 +17408,174 @@ fn builtin_resource_field_drop_interns_typed_runtime_release() {
             "{name} drop must call its typed runtime release; IR:\n{ir}",
         );
     }
+}
+
+#[test]
+fn aggregate_half_resource_drops_keep_the_typed_direction_operand() {
+    use hew_types::runtime_call::RuntimeDropDescriptor;
+
+    for (name, descriptor, direction) in [
+        ("SendHalf", RuntimeDropDescriptor::SendHalfClose, 0_u64),
+        ("RecvHalf", RuntimeDropDescriptor::RecvHalfClose, 1_u64),
+    ] {
+        let ctx = Context::create();
+        let ptr_ty = ctx.ptr_type(AddressSpace::default());
+        let parent_st = ctx.struct_type(&[ptr_ty.into()], false);
+        let (llvm_mod, builder, slot, _) =
+            bytes_field_drop_test_harness(&ctx, parent_st, "aggregate_half_resource_drop");
+        let td = host_target_data();
+        let ml = MachineLayoutMap::new();
+        let rs = RecordLayoutMap::new();
+        let w = empty_drop_witnesses(&td, &ml, &rs);
+
+        emit_field_drop_step(
+            &ctx,
+            &llvm_mod,
+            &builder,
+            Some(parent_st),
+            slot,
+            0,
+            &StateFieldCloneKind::Resource {
+                name: name.to_string(),
+                close: ResourceCloseAuthority::Runtime(descriptor),
+            },
+            &w,
+        )
+        .unwrap_or_else(|error| panic!("{name} aggregate drop failed: {error}"));
+        builder
+            .build_return(Some(&ctx.i32_type().const_zero()))
+            .expect("host return");
+
+        assert!(llvm_mod.verify().is_ok(), "{name} aggregate IR must verify");
+        let ir = llvm_mod.print_to_string().to_string();
+        assert!(
+            ir.contains("call i32 @hew_duplex_close_half")
+                && ir.contains(&format!("i32 {direction}")),
+            "{name} aggregate close must materialise its descriptor direction; IR:\n{ir}",
+        );
+    }
+}
+
+#[test]
+fn aggregate_monitor_ref_drop_rejects_every_near_miss_predeclared_abi() {
+    for abi in ["nonvoid", "pointer", "varargs"] {
+        let ctx = Context::create();
+        let i64_ty = ctx.i64_type();
+        let monitor_ty = ctx.struct_type(&[i64_ty.into()], false);
+        let parent_ty = ctx.struct_type(&[monitor_ty.into()], false);
+        let (module, builder, slot, _) =
+            bytes_field_drop_test_harness(&ctx, parent_ty, "monitor_ref_wrong_abi");
+        let fn_ty = match abi {
+            "nonvoid" => ctx.i32_type().fn_type(&[i64_ty.into()], false),
+            "pointer" => ctx
+                .void_type()
+                .fn_type(&[ctx.ptr_type(AddressSpace::default()).into()], false),
+            "varargs" => ctx.void_type().fn_type(&[i64_ty.into()], true),
+            _ => unreachable!(),
+        };
+        module.add_function("hew_actor_demonitor", fn_ty, None);
+        let td = host_target_data();
+        let ml = MachineLayoutMap::new();
+        let rs = RecordLayoutMap::new();
+        let w = empty_drop_witnesses(&td, &ml, &rs);
+
+        let err = emit_field_drop_step(
+            &ctx,
+            &module,
+            &builder,
+            Some(parent_ty),
+            slot,
+            0,
+            &StateFieldCloneKind::Resource {
+                name: "MonitorRef".to_string(),
+                close: ResourceCloseAuthority::Runtime(
+                    hew_types::runtime_call::RuntimeDropDescriptor::MonitorRefClose,
+                ),
+            },
+            &w,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, CodegenError::FailClosed(ref msg)
+                if msg.contains("exact non-vararg void(i64) ABI")),
+            "aggregate MonitorRef must reject {abi}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn aggregate_monitor_ref_drop_rejects_packed_inline_layout() {
+    let ctx = Context::create();
+    let packed_monitor_ty = ctx.struct_type(&[ctx.i64_type().into()], true);
+    let parent_ty = ctx.struct_type(&[packed_monitor_ty.into()], false);
+    let (module, builder, slot, _) =
+        bytes_field_drop_test_harness(&ctx, parent_ty, "monitor_ref_packed_layout");
+    let td = host_target_data();
+    let ml = MachineLayoutMap::new();
+    let rs = RecordLayoutMap::new();
+    let w = empty_drop_witnesses(&td, &ml, &rs);
+    let err = emit_field_drop_step(
+        &ctx,
+        &module,
+        &builder,
+        Some(parent_ty),
+        slot,
+        0,
+        &StateFieldCloneKind::Resource {
+            name: "MonitorRef".to_string(),
+            close: ResourceCloseAuthority::Runtime(
+                hew_types::runtime_call::RuntimeDropDescriptor::MonitorRefClose,
+            ),
+        },
+        &w,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, CodegenError::FailClosed(ref msg)
+            if msg.contains("MonitorRef resource drop") && msg.contains("expected exactly inline")),
+        "packed MonitorRef aggregate must fail closed, got {err:?}"
+    );
+}
+
+#[test]
+fn aggregate_monitor_ref_drop_guards_inactive_id_and_zeros_active_id() {
+    let ctx = Context::create();
+    let i64_ty = ctx.i64_type();
+    let monitor_ty = ctx.struct_type(&[i64_ty.into()], false);
+    let parent_ty = ctx.struct_type(&[monitor_ty.into()], false);
+    let (module, builder, slot, _) =
+        bytes_field_drop_test_harness(&ctx, parent_ty, "monitor_ref_active_inactive");
+    let td = host_target_data();
+    let ml = MachineLayoutMap::new();
+    let rs = RecordLayoutMap::new();
+    let w = empty_drop_witnesses(&td, &ml, &rs);
+    emit_field_drop_step(
+        &ctx,
+        &module,
+        &builder,
+        Some(parent_ty),
+        slot,
+        0,
+        &StateFieldCloneKind::Resource {
+            name: "MonitorRef".to_string(),
+            close: ResourceCloseAuthority::Runtime(
+                hew_types::runtime_call::RuntimeDropDescriptor::MonitorRefClose,
+            ),
+        },
+        &w,
+    )
+    .expect("MonitorRef aggregate drop");
+    builder
+        .build_return(Some(&ctx.i32_type().const_zero()))
+        .expect("host return");
+    assert!(module.verify().is_ok());
+    let ir = module.print_to_string().to_string();
+    assert_monitor_ref_guarded_drop_cfg(
+        &ir,
+        "monitor_f0_inactive",
+        "monitor_f0_close",
+        "monitor_f0_cont",
+    );
 }
 
 #[test]

--- a/hew-mir/src/lower/drop_plan.rs
+++ b/hew-mir/src/lower/drop_plan.rs
@@ -7453,27 +7453,6 @@ pub(super) fn resource_opaque_close_registry(
         .collect()
 }
 
-fn builtin_resource_drop_descriptor(
-    builtin: BuiltinType,
-) -> Option<hew_types::runtime_call::RuntimeDropDescriptor> {
-    use hew_types::runtime_call::RuntimeDropDescriptor;
-    match builtin {
-        BuiltinType::Duplex => Some(RuntimeDropDescriptor::DuplexClose),
-        BuiltinType::Stream => Some(RuntimeDropDescriptor::StreamClose),
-        BuiltinType::Sink => Some(RuntimeDropDescriptor::SinkClose),
-        BuiltinType::Sender => Some(RuntimeDropDescriptor::SenderClose),
-        BuiltinType::Receiver => Some(RuntimeDropDescriptor::ReceiverClose),
-        BuiltinType::LambdaActorHandle | BuiltinType::LambdaPid => {
-            Some(RuntimeDropDescriptor::LambdaActorHandleClose)
-        }
-        BuiltinType::SendHalf => Some(RuntimeDropDescriptor::SendHalfClose),
-        BuiltinType::RecvHalf => Some(RuntimeDropDescriptor::RecvHalfClose),
-        BuiltinType::CancellationToken => Some(RuntimeDropDescriptor::CancellationTokenRelease),
-        BuiltinType::MonitorRef => Some(RuntimeDropDescriptor::MonitorRefClose),
-        _ => None,
-    }
-}
-
 pub(super) fn resource_drop_fn(
     ty: &ResolvedTy,
     type_classes: &hew_hir::TypeClassTable,
@@ -7486,7 +7465,7 @@ pub(super) fn resource_drop_fn(
         ResolvedTy::Named {
             builtin: Some(builtin),
             ..
-        } => builtin_resource_drop_descriptor(*builtin).map(crate::model::DropFnSpec::Runtime),
+        } => RuntimeDropDescriptor::for_builtin(*builtin).map(crate::model::DropFnSpec::Runtime),
         ResolvedTy::Named {
             name,
             builtin: None,
@@ -7941,7 +7920,6 @@ pub(super) fn ty_is_generator_handle(ty: &ResolvedTy) -> bool {
 pub(super) fn stream_handle_drop_descriptor(
     ty: &ResolvedTy,
 ) -> Option<hew_types::runtime_call::RuntimeDropDescriptor> {
-    use hew_types::runtime_call::RuntimeDropDescriptor;
     let ResolvedTy::Named {
         builtin: Some(builtin),
         ..
@@ -7949,11 +7927,12 @@ pub(super) fn stream_handle_drop_descriptor(
     else {
         return None;
     };
-    match builtin {
-        hew_types::BuiltinType::Stream => Some(RuntimeDropDescriptor::StreamClose),
-        hew_types::BuiltinType::Receiver => Some(RuntimeDropDescriptor::ReceiverClose),
-        _ => None,
-    }
+    matches!(
+        builtin,
+        hew_types::BuiltinType::Stream | hew_types::BuiltinType::Receiver
+    )
+    .then(|| hew_types::runtime_call::RuntimeDropDescriptor::for_builtin(*builtin))
+    .flatten()
 }
 /// Whether `ty` is a `Stream<T>` / `Receiver<T>` for-await cursor handle — the
 /// registration gate for `scope_stream_bindings`, mirroring

--- a/hew-mir/src/lower/expr.rs
+++ b/hew-mir/src/lower/expr.rs
@@ -1506,6 +1506,9 @@ impl Builder {
                   scatter the panic discipline across helper boundaries"
     )]
     pub(crate) fn stmt(&mut self, stmt: &hew_hir::HirStmt) {
+        if self.field_load_classification_poisoned {
+            return;
+        }
         // Stage 2 (gdb `-g`): every `Instr` this statement lowers is attributed
         // to the statement's source span so gdb steps line-by-line. The cursor
         // stays set across the whole statement, so synthesised instructions
@@ -1517,6 +1520,10 @@ impl Builder {
         match &stmt.kind {
             HirStmtKind::Let(binding, Some(value)) => {
                 let binding_ty = self.subst_ty(&binding.ty);
+                if !self.field_load_classification_is_valid(value) {
+                    self.poisoned_let_bindings.insert(binding.id);
+                    return;
+                }
                 let owned_string_record_key =
                     self.owned_string_record_init_key_for_let(&binding_ty, value);
                 if owned_string_record_key.is_some() {
@@ -1582,6 +1589,14 @@ impl Builder {
                 let diag_len_before_value = self.diagnostics.len();
                 let value_place = self.lower_let_value(binding.id, value);
                 self.suppress_typed_produced_owner_sites.remove(&value.site);
+                // A nested field load may discover the classification error
+                // only while lowering this initializer. Stop before *any*
+                // binding publication or `decide` call; finalization will seal
+                // the whole partial body as Unreachable.
+                if self.field_load_classification_poisoned {
+                    self.poisoned_let_bindings.insert(binding.id);
+                    return;
+                }
                 // Cascade suppression: a `let` whose initializer failed to lower
                 // (`None`) AFTER emitting its own diagnostic poisons the binding,
                 // so a later `BindingRef` to it stays silent instead of stacking
@@ -1861,23 +1876,32 @@ impl Builder {
                         }
                     };
                     if !alias_inheritance_ambiguous {
-                        match self
-                            .field_projection_alias_provenance(value, &binding_ty)
-                            .or(inherited_alias_provenance)
-                        {
-                            Some(provenance) => self.register_owned_local_alias(
-                                binding.id,
-                                binding.name.clone(),
-                                binding_ty.clone(),
-                                provenance,
-                                warrant,
-                            ),
-                            None => self.register_owned_local(
-                                binding.id,
-                                binding.name.clone(),
-                                binding_ty.clone(),
-                                warrant,
-                            ),
+                        match self.field_projection_alias_provenance(value, &binding_ty) {
+                            Ok(projection_alias) => {
+                                match projection_alias.or(inherited_alias_provenance) {
+                                    Some(provenance) => self.register_owned_local_alias(
+                                        binding.id,
+                                        binding.name.clone(),
+                                        binding_ty.clone(),
+                                        provenance,
+                                        warrant,
+                                    ),
+                                    None => self.register_owned_local(
+                                        binding.id,
+                                        binding.name.clone(),
+                                        binding_ty.clone(),
+                                        warrant,
+                                    ),
+                                }
+                            }
+                            Err(error) => {
+                                self.report_field_load_classification_failure(
+                                    value.site,
+                                    &binding_ty,
+                                    &error,
+                                );
+                                return;
+                            }
                         }
                     }
                     // Tag generator/`AsyncGenerator` handle bindings with their
@@ -2070,7 +2094,13 @@ impl Builder {
             }
             HirStmtKind::Let(_, None) => {}
             HirStmtKind::Expr(expr) => {
+                if !self.field_load_classification_is_valid(expr) {
+                    return;
+                }
                 self.lower_expr_statement(expr);
+                if self.field_load_classification_poisoned {
+                    return;
+                }
                 self.statements.push(MirStatement::Evaluate {
                     site: expr.site,
                     ty: self.subst_ty(&expr.ty),
@@ -2078,12 +2108,18 @@ impl Builder {
             }
             HirStmtKind::Assign { target, value } => {
                 self.assign(target, value);
+                if self.field_load_classification_poisoned {
+                    return;
+                }
                 self.statements.push(MirStatement::Evaluate {
                     site: value.site,
                     ty: ResolvedTy::Unit,
                 });
             }
             HirStmtKind::Return(Some(expr)) => {
+                if !self.field_load_classification_is_valid(expr) {
+                    return;
+                }
                 let returned_binding = match &expr.kind {
                     HirExprKind::BindingRef {
                         resolved: ResolvedRef::Binding(binding),
@@ -2092,6 +2128,9 @@ impl Builder {
                     _ => None,
                 };
                 let value_place = self.lower_value_for_move(expr);
+                if self.field_load_classification_poisoned {
+                    return;
+                }
                 self.decide(expr);
                 self.mark_returned_binding_moved(expr);
                 self.statements.push(MirStatement::Return {
@@ -2279,11 +2318,17 @@ impl Builder {
     /// The one publication boundary for expression results. Recursive lowering
     /// returns here before a parent advances to its next argument or field.
     pub(crate) fn lower_value(&mut self, expr: &HirExpr) -> Option<Place> {
+        if self.field_load_classification_poisoned {
+            return None;
+        }
         let expr_ty = self.subst_ty(&expr.ty);
         if self.reject_unsupported_vec_iter_boundary(&expr_ty, expr.site, "an expression value") {
             return None;
         }
         let value = self.lower_value_inner(expr);
+        if self.field_load_classification_poisoned {
+            return None;
+        }
         if let Some(place) = value {
             // Specialised HIR rewrites retain consumed checker children as
             // non-evaluated source anchors. Publish those source occurrences to
@@ -4718,6 +4763,11 @@ impl Builder {
                     });
                     return None;
                 };
+                let field_ty = self.subst_ty(&expr.ty);
+                if let Err(error) = self.classify_field_load(&field_ty) {
+                    self.report_field_load_classification_failure(expr.site, &field_ty, &error);
+                    return None;
+                }
                 self.mark_owned_string_record_field_site(object);
                 let record_place = self.lower_value(object)?;
                 self.finalize_vec_clone_projection_base_owner(object, record_place);
@@ -4727,15 +4777,20 @@ impl Builder {
                     field_offset,
                     dest,
                 });
-                let field_ty = self.subst_ty(&expr.ty);
-                self.note_carrier_projection(
+                if let Err(error) = self.note_carrier_projection(
                     record_place,
                     field_offset.0,
                     dest,
                     &field_ty,
                     expr.site,
-                );
-                self.publish_handle_transfer_projection(expr, &field_ty);
+                ) {
+                    self.report_field_load_classification_failure(expr.site, &field_ty, &error);
+                    return None;
+                }
+                if let Err(error) = self.publish_handle_transfer_projection(expr, &field_ty) {
+                    self.report_field_load_classification_failure(expr.site, &field_ty, &error);
+                    return None;
+                }
                 Some(dest)
             }
             HirExprKind::Scope { body } => Some(self.lower_task_scope(body)),
@@ -4851,6 +4906,11 @@ impl Builder {
                 // additional instructions.  This is the complement of the
                 // `lower_runtime_call` path that stores the output Places into
                 // `tuple_decomp`.
+                let field_ty = self.subst_ty(&expr.ty);
+                if let Err(error) = self.classify_field_load(&field_ty) {
+                    self.report_field_load_classification_failure(expr.site, &field_ty, &error);
+                    return None;
+                }
                 let inner_place = self.lower_value(tuple)?;
                 if let Place::Local(local_idx) = inner_place {
                     if let Some(parts) = self.tuple_decomp.get(&local_idx) {
@@ -4870,8 +4930,16 @@ impl Builder {
                     field_index,
                     dest,
                 });
-                let field_ty = self.subst_ty(&expr.ty);
-                self.note_carrier_projection(inner_place, field_index, dest, &field_ty, expr.site);
+                if let Err(error) = self.note_carrier_projection(
+                    inner_place,
+                    field_index,
+                    dest,
+                    &field_ty,
+                    expr.site,
+                ) {
+                    self.report_field_load_classification_failure(expr.site, &field_ty, &error);
+                    return None;
+                }
                 Some(dest)
             }
             HirExprKind::Index { container, index } => {
@@ -6583,7 +6651,13 @@ impl Builder {
                 // dead cursor block for any lexically-following code. A `return`
                 // diverges, so this expression yields no value (`None`).
                 if let Some(expr_value) = value {
+                    if !self.field_load_classification_is_valid(expr_value) {
+                        return None;
+                    }
                     let value_place = self.lower_value_for_move(expr_value);
+                    if self.field_load_classification_poisoned {
+                        return None;
+                    }
                     self.decide(expr_value);
                     self.mark_returned_binding_moved(expr_value);
                     self.statements.push(MirStatement::Return {

--- a/hew-mir/src/lower/expr/binding_ty_is_plain_vec_tuple.rs
+++ b/hew-mir/src/lower/expr/binding_ty_is_plain_vec_tuple.rs
@@ -953,23 +953,13 @@ fn classify_field_load_freezes_the_three_way_verdict_table() {
 
 /// A classification failure is an internal lowering invariant at the exact
 /// source site, and it leaves no carrier-projection ownership record behind.
-#[test]
-fn field_load_classification_failure_is_diagnostic_and_emits_no_carrier_artifact() {
-    let mut builder = Builder {
-        current_function_symbol: "field_load_failure".to_string(),
-        ..Builder::default()
-    };
+fn classification_poison_field_load() -> HirExpr {
     let unknown = unregistered_named("Unknown");
     let holder = unregistered_named("Holder");
-    builder.record_field_orders.insert(
-        "Holder".to_string(),
-        vec![("payload".to_string(), unknown.clone())],
-    );
-    builder.binding_locals.insert(BindingId(1), Place::Local(0));
     let root = HirExpr {
         node: hew_hir::HirNodeId(1),
         site: SiteId(76),
-        ty: holder,
+        ty: holder.clone(),
         value_class: ValueClass::CowValue,
         intent: IntentKind::Read,
         kind: HirExprKind::BindingRef {
@@ -978,7 +968,7 @@ fn field_load_classification_failure_is_diagnostic_and_emits_no_carrier_artifact
         },
         span: 0..0,
     };
-    let field_load = HirExpr {
+    HirExpr {
         node: hew_hir::HirNodeId(2),
         site: SiteId(77),
         ty: unknown,
@@ -989,46 +979,139 @@ fn field_load_classification_failure_is_diagnostic_and_emits_no_carrier_artifact
             field: "payload".to_string(),
         },
         span: 0..0,
-    };
+    }
+}
 
-    assert_eq!(builder.lower_value(&field_load), None);
-    let second_field_load = HirExpr {
-        site: SiteId(78),
-        ..field_load.clone()
-    };
-    assert_eq!(builder.lower_value(&second_field_load), None);
-
-    assert!(builder.instructions.is_empty());
-    assert!(builder.owned_carrier_neutralize.is_empty());
-    assert!(matches!(
-        builder.diagnostics.as_slice(),
-        [MirDiagnostic {
-            kind: MirDiagnosticKind::LoweringInvariant {
-                function,
-                rule,
-                block: Some(0),
-                detail,
-            },
-            ..
-        }] if function == "field_load_failure"
-            && rule == "field-load-classification"
-            && detail.starts_with("site SiteId(77):")
-            && detail.contains("Unknown")
-    ));
-
-    let finalized = super::super::finalize_body(
-        &mut builder,
-        super::super::BodySeal::Cursor(Terminator::Return),
-        super::super::BodyFinalizeSpec::nested_body(),
+fn classification_poison_module() -> hew_hir::HirModule {
+    // Exercise the poison through the ordinary free-function body ramp. This
+    // is deliberately a forged post-checker HIR module: a source program
+    // cannot name the missing `Unknown` layout, while MIR still needs to fail
+    // closed if checker/layout authority ever drifts at this boundary.
+    let unknown = unregistered_named("Unknown");
+    let holder = unregistered_named("Holder");
+    let mut type_classes = hew_hir::TypeClassTable::default();
+    type_classes.insert(
+        "Unknown".to_string(),
+        (hew_hir::ResourceMarker::Resource, Some("close".to_string())),
     );
+    let function_id = hew_hir::ItemId(2);
+    hew_hir::HirModule {
+        items: vec![
+            hew_hir::HirItem::Record(hew_hir::HirRecordDecl {
+                id: hew_hir::ItemId(1),
+                node: hew_hir::HirNodeId(3),
+                name: "Holder".to_string(),
+                defining_module: None,
+                type_params: Vec::new(),
+                positional_field_tys: Vec::new(),
+                fields: vec![hew_hir::HirField {
+                    name: "payload".to_string(),
+                    ty: unknown.clone(),
+                    default: None,
+                    is_mutable: false,
+                    span: 0..0,
+                }],
+                span: 0..0,
+            }),
+            hew_hir::HirItem::Function(hew_hir::HirFn {
+                id: function_id,
+                node: hew_hir::HirNodeId(4),
+                declaration: hew_types::DefId::for_test("field_load_failure"),
+                name: "field_load_failure".to_string(),
+                type_params: Vec::new(),
+                params: vec![hew_hir::HirBinding {
+                    id: BindingId(1),
+                    name: "holder".to_string(),
+                    ty: holder,
+                    mutable: false,
+                    span: 0..0,
+                    is_consume: false,
+                }],
+                return_ty: ResolvedTy::Unit,
+                body: hew_hir::HirBlock {
+                    node: hew_hir::HirNodeId(5),
+                    scope: hew_hir::ScopeId(1),
+                    statements: vec![hew_hir::HirStmt {
+                        node: hew_hir::HirNodeId(6),
+                        kind: hew_hir::HirStmtKind::Expr(classification_poison_field_load()),
+                        span: 0..0,
+                    }],
+                    tail: None,
+                    ty: ResolvedTy::Unit,
+                    span: 0..0,
+                },
+                span: 0..0,
+                is_generator: false,
+                intrinsic_id: None,
+            }),
+        ],
+        produced_value_facts: std::collections::HashMap::new(),
+        diagnostic_source_modules: std::collections::HashMap::new(),
+        root_item_ids: [function_id].into_iter().collect(),
+        entry_declaration: None,
+        caller_visible_param_projections: std::collections::HashSet::new(),
+        wire_layouts: std::sync::Arc::new(std::collections::HashMap::new()),
+        type_classes,
+        monomorphisations: Vec::new(),
+        call_site_type_args: std::collections::HashMap::new(),
+        vec_generic_element_abi: std::collections::HashMap::new(),
+        record_layouts: Vec::new(),
+        enum_layouts: Vec::new(),
+        machine_instantiations: Vec::new(),
+        supervisor_child_slots: std::collections::HashMap::new(),
+        pool_accessor_sites: std::collections::HashMap::new(),
+        regex_literals: Vec::new(),
+    }
+}
+
+#[test]
+fn field_load_classification_failure_is_diagnostic_and_emits_no_carrier_artifact() {
+    let module = classification_poison_module();
+    let pipeline = super::super::lower_hir_module(&module);
+    assert!(
+        matches!(
+            pipeline.diagnostics.as_slice(),
+            [MirDiagnostic {
+                kind: MirDiagnosticKind::LoweringInvariant {
+                    function,
+                    rule,
+                    block: Some(0),
+                    detail,
+                },
+                ..
+            }] if function == "field_load_failure"
+                && rule == "field-load-classification"
+                && detail.starts_with("site SiteId(77):")
+                && detail.contains("Unknown")
+        ),
+        "unexpected poison diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+
+    let raw = pipeline
+        .raw_mir
+        .iter()
+        .find(|function| function.name == "field_load_failure")
+        .expect("the ordinary function ramp must retain the poisoned body");
     assert!(matches!(
-        finalized.blocks.as_slice(),
+        raw.blocks.as_slice(),
         [block]
             if block.statements.is_empty()
                 && block.instructions.is_empty()
                 && matches!(block.terminator, Terminator::Unreachable)
     ));
-    assert!(finalized.body_statements.is_empty());
+    let checked = pipeline
+        .checked_mir
+        .iter()
+        .find(|function| function.name == "field_load_failure")
+        .expect("checked MIR must retain the same poisoned body");
+    assert!(matches!(
+        checked.blocks.as_slice(),
+        [block]
+            if block.statements.is_empty()
+                && block.instructions.is_empty()
+                && matches!(block.terminator, Terminator::Unreachable)
+    ));
 }
 
 /// Fresh producers and whole-value rebinds do not enter the field-load seam,

--- a/hew-mir/src/lower/expr/binding_ty_is_plain_vec_tuple.rs
+++ b/hew-mir/src/lower/expr/binding_ty_is_plain_vec_tuple.rs
@@ -871,9 +871,9 @@ fn register_owned_local_records_classified_ownership_and_scope_exit() {
 }
 
 /// Frozen three-way verdict table for the `let`-bound field-load
-/// classification — the load-bearing double-free boundary. A `string` field retains
-/// (codegen clones), an inline aggregate (record / tuple) byte-copies to an
-/// interior alias, and every single-pointer heap leaf (`Vec` / `bytes` /
+/// classification — the load-bearing double-free boundary. A `string` or
+/// `bytes` field retains, an inline aggregate (record / tuple) byte-copies to
+/// an interior alias, and every remaining single-pointer heap leaf (`Vec` /
 /// `Generator` / indirect-enum node) transfers its one handle. Only
 /// `ByteCopyAlias` dispositions its binder `AliasOf`; the table freezes the
 /// class each shape maps to so a mis-tag (which would admit an owner the
@@ -887,16 +887,19 @@ fn classify_field_load_freezes_the_three_way_verdict_table() {
         vec![("a".to_string(), ResolvedTy::String)],
     );
 
-    // Retained: `string` — codegen `hew_string_clone`s the load.
-    assert_eq!(
-        builder.classify_field_load(&ResolvedTy::String),
-        Some(FieldLoadClass::Retained),
-    );
+    // Retained: `string` and `bytes` each receive a balanced +1 for the load.
+    for (label, ty) in [("string", ResolvedTy::String), ("bytes", ResolvedTy::Bytes)] {
+        assert_eq!(
+            builder.classify_field_load(&ty),
+            Ok(Some(FieldLoadClass::Retained)),
+            "{label} keeps the aggregate root live and owns a retained share",
+        );
+    }
 
     // ByteCopyAlias: inline aggregates — record and tuple.
     assert_eq!(
         builder.classify_field_load(&unregistered_named("Rec")),
-        Some(FieldLoadClass::ByteCopyAlias),
+        Ok(Some(FieldLoadClass::ByteCopyAlias)),
         "a heap-owning record field is byte-copied to an interior alias",
     );
     assert_eq!(
@@ -904,14 +907,13 @@ fn classify_field_load_freezes_the_three_way_verdict_table() {
             ResolvedTy::String,
             ResolvedTy::String,
         ])),
-        Some(FieldLoadClass::ByteCopyAlias),
+        Ok(Some(FieldLoadClass::ByteCopyAlias)),
         "a heap-owning tuple field is byte-copied to an interior alias",
     );
 
     // HandleTransfer: every single-pointer heap leaf.
     for (label, ty) in [
         ("Vec", vec_of_ty(ResolvedTy::String)),
-        ("bytes", ResolvedTy::Bytes),
         (
             "Generator",
             ResolvedTy::named_builtin(
@@ -924,13 +926,133 @@ fn classify_field_load_freezes_the_three_way_verdict_table() {
     ] {
         assert_eq!(
             builder.classify_field_load(&ty),
-            Some(FieldLoadClass::HandleTransfer),
+            Ok(Some(FieldLoadClass::HandleTransfer)),
             "{label} transfers its one owned handle to the binder",
         );
     }
 
     // Heap-free field: no scope-exit drop obligation to classify.
-    assert_eq!(builder.classify_field_load(&ResolvedTy::I64), None);
+    assert_eq!(builder.classify_field_load(&ResolvedTy::I64), Ok(None));
+
+    // A bare unknown has no ownership decision and therefore fails before the
+    // snapshot classifier; it is still an error, never the heap-free answer.
+    assert!(matches!(
+        builder.classify_field_load(&unregistered_named("Unknown")),
+        Err(crate::state_clone::ClassificationError::Unsupported { .. })
+    ));
+
+    // Missing layout is a non-vacuous error, never the heap-free `Ok(None)`
+    // verdict. The owning Vec reaches snapshot planning and exposes the
+    // missing child layout at the field-load source site.
+    assert!(matches!(
+        builder.classify_field_load(&vec_of_ty(unregistered_named("Unknown"))),
+        Err(crate::state_clone::ClassificationError::MissingRecordLayout { ref name })
+            if name == "Unknown"
+    ));
+}
+
+/// A classification failure is an internal lowering invariant at the exact
+/// source site, and it leaves no carrier-projection ownership record behind.
+#[test]
+fn field_load_classification_failure_is_diagnostic_and_emits_no_carrier_artifact() {
+    let mut builder = Builder {
+        current_function_symbol: "field_load_failure".to_string(),
+        ..Builder::default()
+    };
+    let unknown = unregistered_named("Unknown");
+    let holder = unregistered_named("Holder");
+    builder.record_field_orders.insert(
+        "Holder".to_string(),
+        vec![("payload".to_string(), unknown.clone())],
+    );
+    builder.binding_locals.insert(BindingId(1), Place::Local(0));
+    let root = HirExpr {
+        node: hew_hir::HirNodeId(1),
+        site: SiteId(76),
+        ty: holder,
+        value_class: ValueClass::CowValue,
+        intent: IntentKind::Read,
+        kind: HirExprKind::BindingRef {
+            name: "holder".to_string(),
+            resolved: ResolvedRef::Binding(BindingId(1)),
+        },
+        span: 0..0,
+    };
+    let field_load = HirExpr {
+        node: hew_hir::HirNodeId(2),
+        site: SiteId(77),
+        ty: unknown,
+        value_class: ValueClass::CowValue,
+        intent: IntentKind::Read,
+        kind: HirExprKind::FieldAccess {
+            object: Box::new(root),
+            field: "payload".to_string(),
+        },
+        span: 0..0,
+    };
+
+    assert_eq!(builder.lower_value(&field_load), None);
+    let second_field_load = HirExpr {
+        site: SiteId(78),
+        ..field_load.clone()
+    };
+    assert_eq!(builder.lower_value(&second_field_load), None);
+
+    assert!(builder.instructions.is_empty());
+    assert!(builder.owned_carrier_neutralize.is_empty());
+    assert!(matches!(
+        builder.diagnostics.as_slice(),
+        [MirDiagnostic {
+            kind: MirDiagnosticKind::LoweringInvariant {
+                function,
+                rule,
+                block: Some(0),
+                detail,
+            },
+            ..
+        }] if function == "field_load_failure"
+            && rule == "field-load-classification"
+            && detail.starts_with("site SiteId(77):")
+            && detail.contains("Unknown")
+    ));
+
+    let finalized = super::super::finalize_body(
+        &mut builder,
+        super::super::BodySeal::Cursor(Terminator::Return),
+        super::super::BodyFinalizeSpec::nested_body(),
+    );
+    assert!(matches!(
+        finalized.blocks.as_slice(),
+        [block]
+            if block.statements.is_empty()
+                && block.instructions.is_empty()
+                && matches!(block.terminator, Terminator::Unreachable)
+    ));
+    assert!(finalized.body_statements.is_empty());
+}
+
+/// Fresh producers and whole-value rebinds do not enter the field-load seam,
+/// so absent layout facts on their type cannot manufacture an unrelated ICE.
+#[test]
+fn non_projection_initializer_skips_field_load_classification() {
+    let builder = Builder::default();
+    let value = HirExpr {
+        node: hew_hir::HirNodeId(1),
+        site: SiteId(88),
+        ty: unregistered_named("Unknown"),
+        value_class: ValueClass::CowValue,
+        intent: IntentKind::Read,
+        kind: HirExprKind::BindingRef {
+            name: "whole".to_string(),
+            resolved: ResolvedRef::Binding(BindingId(1)),
+        },
+        span: 0..0,
+    };
+
+    assert_eq!(
+        builder.field_projection_alias_provenance(&value, &value.ty),
+        Ok(None),
+    );
 }
 
 /// A byte-copy aggregate field projection registers its binder `AliasOf`

--- a/hew-mir/src/lower/field_load_poison.rs
+++ b/hew-mir/src/lower/field_load_poison.rs
@@ -1,0 +1,30 @@
+//! Transaction rollback for a failed field-load lifecycle classification.
+
+use super::{BasicBlock, Builder, FinalizedBody, Terminator};
+
+impl Builder {
+    /// Discard an ownership transaction after a field-load classifier failure.
+    ///
+    /// The callable body may have accumulated arbitrary partial ownership
+    /// facts before the failure. Keeping any of them would make later drop or
+    /// transfer elaboration observe a half-built authority graph, so the only
+    /// valid body is an empty `Unreachable` block carrying the diagnostic.
+    pub(super) fn take_field_load_classification_poisoned_body(&mut self) -> FinalizedBody {
+        self.pending_blocks.clear();
+        self.statements.clear();
+        self.instructions.clear();
+        self.pending_outbound_actor_args.clear();
+        self.pending_owned_call_args.clear();
+        self.pending_affine_call_consumes.clear();
+        self.deferred_affine_call_consume_sites.clear();
+        FinalizedBody {
+            blocks: vec![BasicBlock {
+                id: 0,
+                statements: Vec::new(),
+                instructions: Vec::new(),
+                terminator: Terminator::Unreachable,
+            }],
+            body_statements: Vec::new(),
+        }
+    }
+}

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -81,6 +81,9 @@ mod task;
 mod temp_drop;
 mod vec_index;
 
+#[cfg(test)]
+mod synthesized_identity_tests;
+
 use self::edge_owner_replay::{
     lexical_scope_is_closed, materialize_edge_lifecycle_owner_transitions,
     materialize_exact_owner_join_transfers, ownership_join_states,
@@ -1172,6 +1175,12 @@ struct Builder {
     pub(crate) synthetic_borrowed_temp_drop_bindings: HashSet<BindingId>,
     /// Diagnostics collected during MIR building (e.g., Unsupported HIR nodes).
     pub(crate) diagnostics: Vec<MirDiagnostic>,
+    /// A failed field-load classification invalidates every ownership fact that
+    /// might follow it. This is a per-body transaction flag, not a diagnostic
+    /// dedup key: it is set before the one-ICE-per-function reporting policy so
+    /// a second failed source site cannot resume lowering merely because it
+    /// produces no second diagnostic.
+    pub(crate) field_load_classification_poisoned: bool,
     /// Per-function de-duplication for W3.029 user-aggregate value-class
     /// diagnostics. Keyed by the same bare/mangled record-layout key used by
     /// `record_field_orders`.
@@ -11815,48 +11824,6 @@ fn canonicalize_release_owner_ids(blocks: &mut [BasicBlock]) {
 }
 
 #[cfg(test)]
-mod synthesized_identity_tests {
-    use super::*;
-
-    #[test]
-    fn a_builder_carrying_a_callable_identity_mints_ordinal_children_of_it() {
-        let parent = crate::model::MirCallableKey::for_test("app.owner");
-        let mut builder = Builder {
-            current_callable_key: Some(parent.clone()),
-            ..Builder::default()
-        };
-
-        let first =
-            builder.mint_synthesized_child_key(crate::model::SynthesizedCallable::GeneratorBody);
-        let second = builder
-            .mint_synthesized_child_key(crate::model::SynthesizedCallable::ClosureInvokeShim);
-
-        assert_eq!(
-            first,
-            parent.child(crate::model::SynthesizedCallable::GeneratorBody(0))
-        );
-        assert_eq!(
-            second,
-            parent.child(crate::model::SynthesizedCallable::ClosureInvokeShim(1)),
-            "one shared per-parent sequence: the second child is ordinal 1 even though it \
-             is the first of its variant"
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "carries no callable identity")]
-    fn a_builder_with_no_callable_identity_refuses_to_mint_a_child_key() {
-        // The negative control for the `current_callable_key: Option<..>`
-        // fail-closed claim. Without it the producer would have to invent an
-        // identity from the emitted symbol — the exact reconstruction this
-        // slice removes — and two synthesized callables could then collide.
-        let mut builder = Builder::default();
-        let _ =
-            builder.mint_synthesized_child_key(crate::model::SynthesizedCallable::GeneratorBody);
-    }
-}
-
-#[cfg(test)]
 mod lexical_scope_join_tests {
     use super::*;
     use crate::model::{OwnerDropRecipe, OwnerId, OwnershipEvent};
@@ -12780,6 +12747,30 @@ pub(in crate::lower) fn finalize_body(
     spec: BodyFinalizeSpec,
 ) -> FinalizedBody {
     let _timing = crate::timing::stage("finalize_body");
+    if builder.field_load_classification_poisoned {
+        // A classifier error means the partially accumulated ownership stream
+        // has no sound continuation. Do not splice drops, transfers, or edge
+        // carries over it: discard the partial transaction and retain one
+        // validator-safe body whose only terminator is Unreachable. The
+        // diagnostic itself remains on the Builder for the normal projection
+        // path in `lower_function`.
+        builder.pending_blocks.clear();
+        builder.statements.clear();
+        builder.instructions.clear();
+        builder.pending_outbound_actor_args.clear();
+        builder.pending_owned_call_args.clear();
+        builder.pending_affine_call_consumes.clear();
+        builder.deferred_affine_call_consume_sites.clear();
+        return FinalizedBody {
+            blocks: vec![BasicBlock {
+                id: 0,
+                statements: Vec::new(),
+                instructions: Vec::new(),
+                terminator: Terminator::Unreachable,
+            }],
+            body_statements: Vec::new(),
+        };
+    }
     let mut blocks = match seal {
         BodySeal::Cursor(terminator) => builder.seal_body_blocks(terminator),
         BodySeal::AlreadyTerminated => {
@@ -13433,17 +13424,18 @@ enum Disposition {
 /// risk, so it keys on the same facts codegen implements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FieldLoadClass {
-    /// A `string` field: codegen `hew_string_clone`s the load, so the binder
-    /// owns a fresh `+1` released by its own drop; the root keeps the original.
+    /// A `string` or `bytes` field follows its type-specific lowering path to
+    /// materialize a balanced retained share: the binder owns a fresh `+1`
+    /// released by its own drop while the root keeps the original.
     Retained,
     /// An inline aggregate field (record / tuple / array / inline-enum): the load
     /// byte-copies the member with no retain, so the binder is an interior ALIAS
     /// — the projected root's composite drop frees every original exactly once.
     ByteCopyAlias,
-    /// A single-pointer heap leaf (`Vec` / `bytes` / `HashMap` / `HashSet` /
-    /// `Generator` / indirect-enum node): the load transfers the one owned
-    /// handle, so the binder becomes the owner and the root's whole-root
-    /// exclusion posture is correct.
+    /// A single-pointer heap leaf (`Vec` / `HashMap` / `HashSet` / `Generator`
+    /// / indirect-enum node): the load transfers the one owned handle, so the
+    /// binder becomes the owner and the root's whole-root exclusion posture is
+    /// correct.
     HandleTransfer,
 }
 
@@ -14626,6 +14618,10 @@ impl Builder {
         for stmt in &func.body.statements {
             self.stmt(stmt);
         }
+        if self.field_load_classification_poisoned {
+            self.active_scopes.pop();
+            return;
+        }
         if let Some(tail) = &func.body.tail {
             let returned_binding = match &tail.kind {
                 HirExprKind::BindingRef {
@@ -14642,6 +14638,10 @@ impl Builder {
                 u32::try_from(tail.span.end).unwrap_or(u32::MAX),
             ));
             let value_place = self.lower_value_for_move(tail);
+            if self.field_load_classification_poisoned {
+                self.active_scopes.pop();
+                return;
+            }
             self.decide(tail);
             self.mark_returned_binding_moved(tail);
             // A divergent tail leaves the cursor at an unreachable join block.

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -67,6 +67,7 @@ mod drop_plan;
 mod edge_owner_replay;
 mod expr;
 mod facts;
+mod field_load_poison;
 mod machine_synth;
 mod move_value;
 mod owned_cursor_call;
@@ -12748,28 +12749,7 @@ pub(in crate::lower) fn finalize_body(
 ) -> FinalizedBody {
     let _timing = crate::timing::stage("finalize_body");
     if builder.field_load_classification_poisoned {
-        // A classifier error means the partially accumulated ownership stream
-        // has no sound continuation. Do not splice drops, transfers, or edge
-        // carries over it: discard the partial transaction and retain one
-        // validator-safe body whose only terminator is Unreachable. The
-        // diagnostic itself remains on the Builder for the normal projection
-        // path in `lower_function`.
-        builder.pending_blocks.clear();
-        builder.statements.clear();
-        builder.instructions.clear();
-        builder.pending_outbound_actor_args.clear();
-        builder.pending_owned_call_args.clear();
-        builder.pending_affine_call_consumes.clear();
-        builder.deferred_affine_call_consume_sites.clear();
-        return FinalizedBody {
-            blocks: vec![BasicBlock {
-                id: 0,
-                statements: Vec::new(),
-                instructions: Vec::new(),
-                terminator: Terminator::Unreachable,
-            }],
-            body_statements: Vec::new(),
-        };
+        return builder.take_field_load_classification_poisoned_body();
     }
     let mut blocks = match seal {
         BodySeal::Cursor(terminator) => builder.seal_body_blocks(terminator),

--- a/hew-mir/src/lower/move_value.rs
+++ b/hew-mir/src/lower/move_value.rs
@@ -95,45 +95,52 @@ impl Builder {
         dest: Place,
         field_ty: &hew_types::ResolvedTy,
         site: SiteId,
-    ) {
-        let authority = self.owned_carrier_authority(aggregate).or_else(|| {
-            let field_ty = self.subst_ty(field_ty);
-            if !scope_exit_tuple_projection_has_null_safe_drop(&field_ty)
-                || self.classify_field_load(&field_ty) != Some(FieldLoadClass::HandleTransfer)
+    ) -> Result<(), crate::state_clone::ClassificationError> {
+        let field_load = self.classify_field_load(field_ty)?;
+        // A registered carrier already owns the aggregate's terminal snapshot
+        // drop. Every field whose snapshot root stays inside that protocol must
+        // therefore carry the root-relative neutralize path: both inline
+        // Product/TaggedUnion loads (ByteCopyAlias) and one-handle transfers.
+        // Retained String/Bytes and heap-free fields stay outside this route.
+        let authority = match self.owned_carrier_authority(aggregate) {
+            Some(authority)
+                if matches!(
+                    field_load,
+                    Some(FieldLoadClass::ByteCopyAlias | FieldLoadClass::HandleTransfer)
+                ) =>
             {
-                return None;
+                Some(authority)
             }
-            self.owned_locals
-                .iter()
-                .find(|entry| {
-                    entry.disposition == Disposition::ScopeExit
-                        && matches!(entry.ty, ResolvedTy::Tuple(_))
-                        && self.binding_locals.get(&entry.binding).copied() == Some(aggregate)
-                })
-                .map(|entry| OwnedCarrierNeutralizeTarget::ScopeExitTuple {
-                    root: aggregate,
-                    owner: (entry.binding, entry.name.clone(), site),
-                })
-        });
+            Some(_) => None,
+            None => {
+                // Seeding a carrier from an ordinary scope-exit tuple is
+                // narrower: only a null-safe, one-handle transfer may clear a
+                // tuple slot. Inline aggregates still use their own composite
+                // drop protocol and must not acquire this fallback authority.
+                let field_ty = self.subst_ty(field_ty);
+                if !scope_exit_tuple_projection_has_null_safe_drop(&field_ty)
+                    || field_load != Some(FieldLoadClass::HandleTransfer)
+                {
+                    None
+                } else {
+                    self.owned_locals
+                        .iter()
+                        .find(|entry| {
+                            entry.disposition == Disposition::ScopeExit
+                                && matches!(entry.ty, ResolvedTy::Tuple(_))
+                                && self.binding_locals.get(&entry.binding).copied()
+                                    == Some(aggregate)
+                        })
+                        .map(|entry| OwnedCarrierNeutralizeTarget::ScopeExitTuple {
+                            root: aggregate,
+                            owner: (entry.binding, entry.name.clone(), site),
+                        })
+                }
+            }
+        };
         let Some(authority) = authority else {
-            return;
+            return Ok(());
         };
-        let record_layouts = outbound_record_layouts(self);
-        let Ok(plan) = crate::state_clone::classify_value_snapshot_plan_with_lifecycle_registry(
-            field_ty,
-            &record_layouts,
-            &self.enum_layouts,
-            &self.opaque_handle_names,
-            &self.lifecycle_registry,
-        ) else {
-            return;
-        };
-        if matches!(
-            plan.root(),
-            SnapshotFieldKind::BitCopy { .. } | SnapshotFieldKind::String
-        ) {
-            return;
-        }
         let (root, mut fields, scope_exit_owner) = match authority {
             OwnedCarrierNeutralizeTarget::Whole(root) => (root, Vec::new(), None),
             OwnedCarrierNeutralizeTarget::ScopeExitTuple { root, owner } => {
@@ -154,6 +161,7 @@ impl Builder {
                 scope_exit_owner,
             },
         );
+        Ok(())
     }
 
     /// Register a top-level enum payload binder moved out of `scrutinee_local`.
@@ -561,6 +569,9 @@ impl Builder {
     /// create a second drop authority. Borrow and projection roots bypass this
     /// funnel and continue through `lower_value`.
     pub(crate) fn lower_value_for_move(&mut self, expr: &HirExpr) -> Option<Place> {
+        if self.field_load_classification_poisoned {
+            return None;
+        }
         self.lower_value_with_vec_iter_transfer(expr, true, false)
     }
 
@@ -1243,8 +1254,8 @@ fn projection_root_use_is_invalid(instr: &Instr, root: Place, fields: &[u32]) ->
 
 #[cfg(test)]
 mod scope_exit_tuple_projection_tests {
-    use super::scope_exit_tuple_projection_has_null_safe_drop;
-    use hew_types::{BuiltinType, ResolvedTy};
+    use super::*;
+    use hew_types::BuiltinType;
 
     fn builtin_ty(builtin: BuiltinType) -> ResolvedTy {
         ResolvedTy::named_builtin(builtin.canonical_name(), builtin, vec![ResolvedTy::String])
@@ -1283,5 +1294,117 @@ mod scope_exit_tuple_projection_tests {
                 "{builtin:?} must retain its dedicated ownership protocol"
             );
         }
+    }
+
+    fn registered_carrier() -> Builder {
+        let mut builder = Builder::default();
+        builder.owned_carrier_neutralize.insert(
+            Place::Local(0),
+            OwnedCarrierNeutralizeTarget::Whole(Place::Local(0)),
+        );
+        builder
+    }
+
+    fn projection_of(builder: &Builder, dest: Place) -> Option<(Place, Vec<u32>)> {
+        match builder.owned_carrier_neutralize.get(&dest) {
+            Some(OwnedCarrierNeutralizeTarget::Projection { root, fields, .. }) => {
+                Some((*root, fields.clone()))
+            }
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn registered_carrier_propagates_inline_product_and_tagged_union_fields() {
+        let mut product = registered_carrier();
+        product
+            .note_carrier_projection(
+                Place::Local(0),
+                3,
+                Place::Local(1),
+                &ResolvedTy::Tuple(vec![ResolvedTy::String]),
+                SiteId(1),
+            )
+            .expect("inline product field has a total ownership class");
+        assert_eq!(
+            projection_of(&product, Place::Local(1)),
+            Some((Place::Local(0), vec![3]))
+        );
+
+        let mut tagged = registered_carrier();
+        tagged.enum_layouts.push(crate::model::EnumLayout {
+            name: "Payload".to_string(),
+            tag_width: 1,
+            variants: vec![crate::model::MachineVariantLayout {
+                name: "Value".to_string(),
+                field_tys: vec![ResolvedTy::String],
+                field_names: vec!["value".to_string()],
+            }],
+            is_indirect: false,
+        });
+        tagged
+            .note_carrier_projection(
+                Place::Local(0),
+                4,
+                Place::Local(2),
+                &ResolvedTy::named_user("Payload", vec![]),
+                SiteId(2),
+            )
+            .expect("inline tagged-union field has a total ownership class");
+        assert_eq!(
+            projection_of(&tagged, Place::Local(2)),
+            Some((Place::Local(0), vec![4]))
+        );
+    }
+
+    #[test]
+    fn registered_carrier_excludes_retained_and_heap_free_fields() {
+        let mut builder = registered_carrier();
+        for (field, dest, ty) in [
+            (0, Place::Local(1), ResolvedTy::String),
+            (1, Place::Local(2), ResolvedTy::Bytes),
+            (2, Place::Local(3), ResolvedTy::I64),
+        ] {
+            builder
+                .note_carrier_projection(Place::Local(0), field, dest, &ty, SiteId(field))
+                .expect("retained and heap-free field classes are total");
+            assert!(projection_of(&builder, dest).is_none());
+        }
+    }
+
+    #[test]
+    fn scope_exit_tuple_fallback_stays_handle_transfer_and_null_safe_only() {
+        let mut builder = Builder::default();
+        let tuple = ResolvedTy::Tuple(vec![builtin_ty(BuiltinType::Vec)]);
+        builder.binding_locals.insert(BindingId(1), Place::Local(0));
+        builder.register_owned_local(
+            BindingId(1),
+            "tuple".to_string(),
+            tuple,
+            crate::lower::OwnerMintWarrant::granting_for_tests(),
+        );
+
+        let vec_ty = builtin_ty(BuiltinType::Vec);
+        builder
+            .note_carrier_projection(Place::Local(0), 0, Place::Local(1), &vec_ty, SiteId(3))
+            .expect("null-safe Vec fallback is a handle transfer");
+        assert!(matches!(
+            builder.owned_carrier_neutralize.get(&Place::Local(1)),
+            Some(OwnedCarrierNeutralizeTarget::Projection {
+                scope_exit_owner: Some(_),
+                ..
+            })
+        ));
+
+        builder
+            .note_carrier_projection(
+                Place::Local(0),
+                0,
+                Place::Local(2),
+                &ResolvedTy::Tuple(vec![ResolvedTy::String]),
+                SiteId(4),
+            )
+            .expect("inline aggregate does not seed a tuple fallback");
+        assert!(projection_of(&builder, Place::Local(2)).is_none());
     }
 }

--- a/hew-mir/src/lower/ownership.rs
+++ b/hew-mir/src/lower/ownership.rs
@@ -4,18 +4,19 @@ use super::{
     actor_name_from_handle_ty, affine_release_needs_drop_flag, base_local, binding_ref_target,
     callee_returns_fresh_owner, callee_returns_retained_string_owner,
     hir_expr_contains_synthetic_vec_get_clone, local_is_rewritten_after_current_iteration,
-    machine_layout_ty_matches, monomorphic_user_record_key, named_type_marker, ty_is_closure_pair,
-    ty_is_heap_owning_enum_composite, ty_is_local_collection_handle, user_record_layout_key,
-    vec_iter_record_layout_key, ActiveIterationOwner, AffineCallConsumeCandidate, BasicBlock,
-    BindingId, Builder, BuiltinType, ClosurePairIngress, CmpPred, DecisionFact, DischargeSite,
-    Disposition, FieldLoadClass, HashMap, HashSet, HirBinding, HirBlock, HirExpr, HirExprKind,
-    HirProducedValueRelation, HirStmtKind, Instr, IntentKind, LayoutClass, MirDiagnostic,
-    MirDiagnosticKind, MirStatement, OwnedCarrierNeutralizeTarget, OwnedLocalEntry,
-    OwnerMintOrigin, OwnerMintWarrant, OwnershipCtx, OwnershipDecision, Place, PlaceProvenance,
-    ProducedValueOwnership, Projection, ResolvedRef, ResolvedTy, ResourceMarker, SiteId, Strategy,
-    Terminator, ValueClass, ValueOwnership, ValueProvenance, SYNTHETIC_CALL_SCRUTINEE_NAME,
-    SYNTHETIC_COPY_IN_PARAM_TEMP_NAME, SYNTHETIC_DISCARDED_CALL_RESULT_NAME,
-    SYNTHETIC_OWNED_TEMP_BINDING_BASE, SYNTHETIC_WHILE_LET_ITERATION_NAME,
+    machine_layout_ty_matches, monomorphic_user_record_key, named_type_marker,
+    outbound_record_layouts, ty_is_closure_pair, ty_is_heap_owning_enum_composite,
+    ty_is_local_collection_handle, user_record_layout_key, vec_iter_record_layout_key,
+    ActiveIterationOwner, AffineCallConsumeCandidate, BasicBlock, BindingId, Builder, BuiltinType,
+    ClosurePairIngress, CmpPred, DecisionFact, DischargeSite, Disposition, FieldLoadClass, HashMap,
+    HashSet, HirBinding, HirBlock, HirExpr, HirExprKind, HirProducedValueRelation, HirStmtKind,
+    Instr, IntentKind, LayoutClass, MirDiagnostic, MirDiagnosticKind, MirStatement,
+    OwnedCarrierNeutralizeTarget, OwnedLocalEntry, OwnerMintOrigin, OwnerMintWarrant, OwnershipCtx,
+    OwnershipDecision, Place, PlaceProvenance, ProducedValueOwnership, Projection, ResolvedRef,
+    ResolvedTy, ResourceMarker, SiteId, Strategy, Terminator, ValueClass, ValueOwnership,
+    ValueProvenance, SYNTHETIC_CALL_SCRUTINEE_NAME, SYNTHETIC_COPY_IN_PARAM_TEMP_NAME,
+    SYNTHETIC_DISCARDED_CALL_RESULT_NAME, SYNTHETIC_OWNED_TEMP_BINDING_BASE,
+    SYNTHETIC_WHILE_LET_ITERATION_NAME,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3468,12 +3469,13 @@ impl Builder {
     ///
     /// Returns `None` — keeping today's `ScopeExit` ownership — for the other two
     /// load classes the split names, so their behaviour is unchanged:
-    /// [`Retained`](FieldLoadClass::Retained) (a `string` field: codegen
-    /// `hew_string_clone`s the load, so the binder owns a fresh `+1` released by
-    /// its own drop) and [`HandleTransfer`](FieldLoadClass::HandleTransfer) (a
-    /// single-pointer heap leaf — `Vec` / `bytes` / `HashMap` / `HashSet` /
-    /// `Generator` / indirect-enum node: the load transfers the one handle, the
-    /// binder becomes the owner, and the root's whole-root exclusion posture is
+    /// [`Retained`](FieldLoadClass::Retained) (a `string` or `bytes` field: its
+    /// type-specific lowering path materializes a balanced retained share, so
+    /// the binder owns a fresh `+1` released by its own drop while the root keeps
+    /// the original) and [`HandleTransfer`](FieldLoadClass::HandleTransfer)
+    /// (a single-pointer heap leaf — `Vec` / `HashMap` / `HashSet` / `Generator`
+    /// / indirect-enum node: the load transfers the one handle, the binder
+    /// becomes the owner, and the root's whole-root exclusion posture is
     /// correct).
     ///
     /// It also returns `None` for any non-projection RHS (a fresh call result /
@@ -3489,46 +3491,87 @@ impl Builder {
         &self,
         value: &HirExpr,
         binding_ty: &ResolvedTy,
-    ) -> Option<ValueProvenance> {
-        // Only an inline aggregate field is a ByteCopyAlias. `string` (Retained)
-        // and single-pointer handles (HandleTransfer) keep `ScopeExit`
-        // ownership — the exact facts codegen implements (retain vs copy vs
-        // transfer), so the classification cannot admit an owner the binder
-        // also releases (the load-bearing double-free risk).
-        if self.classify_field_load(binding_ty) != Some(FieldLoadClass::ByteCopyAlias) {
-            return None;
-        }
-        // The RHS must be a field projection of a live owner: `root.field` /
-        // `root.N`. A fresh producer (call result / constructor) owns itself.
+    ) -> Result<Option<ValueProvenance>, crate::state_clone::ClassificationError> {
+        // A fresh producer or whole-value rebind is not a field-load seam at
+        // all. Extract that shape first so this authority never asks the
+        // snapshot classifier for layout facts the non-projection path does
+        // not require.
         let (root_binding, projection) = match &value.kind {
             HirExprKind::FieldAccess { object, field } => {
-                let root = binding_ref_target(object)?;
-                let ordinal = self.record_field_ordinal(object, field)?;
+                let (Some(root), Some(ordinal)) = (
+                    binding_ref_target(object),
+                    self.record_field_ordinal(object, field),
+                ) else {
+                    return Ok(None);
+                };
                 (root, Projection::Field(ordinal))
             }
             HirExprKind::TupleIndex { tuple, index } => {
-                let root = binding_ref_target(tuple)?;
+                let Some(root) = binding_ref_target(tuple) else {
+                    return Ok(None);
+                };
                 let ordinal = u32::try_from(*index)
                     .expect("checked tuple projection index must fit the MIR u32 carrier");
                 (root, Projection::Field(ordinal))
             }
-            _ => return None,
+            _ => return Ok(None),
         };
-        let root_place = self.binding_locals.get(&root_binding).copied()?;
-        Some(ValueProvenance::projection(
+        // Only an inline aggregate field is a ByteCopyAlias. `string` / `bytes`
+        // (Retained) and single-pointer handles (HandleTransfer) keep
+        // `ScopeExit` ownership — the exact facts codegen implements (retain vs
+        // copy vs transfer), so the classification cannot admit an owner the
+        // binder also releases (the load-bearing double-free risk).
+        if self.classify_field_load(binding_ty)? != Some(FieldLoadClass::ByteCopyAlias) {
+            return Ok(None);
+        }
+        let Some(root_place) = self.binding_locals.get(&root_binding).copied() else {
+            return Ok(None);
+        };
+        Ok(Some(ValueProvenance::projection(
             PlaceProvenance::from(root_place),
             vec![projection],
-        ))
+        )))
     }
     /// The three-way ownership class of a `let`-bound field LOAD, keyed on the
     /// field type and frozen to mirror exactly what codegen emits for the load.
-    /// Returns `None` for a heap-free field (no drop obligation to classify).
+    /// Returns `Ok(None)` only for a heap-free field (no drop obligation to
+    /// classify). A missing layout or unsupported ownership decision is an
+    /// error, never a conservative-looking no-op: callers must surface it at
+    /// the source site and stop the affected lowering path.
     /// This is the authority the field-projection alias seam and its verdict-
     /// table pin read; misassigning a class here is the load-bearing double-free
     /// risk, so it keys on the same facts codegen implements.
-    pub(crate) fn classify_field_load(&self, ty: &ResolvedTy) -> Option<FieldLoadClass> {
+    pub(crate) fn classify_field_load(
+        &self,
+        ty: &ResolvedTy,
+    ) -> Result<Option<FieldLoadClass>, crate::state_clone::ClassificationError> {
         let ty = self.subst_ty(ty);
         let owned = ValueOwnership::classify(&ty, Place::Local(0), &self.ownership_ctx());
+        match owned.decision() {
+            // Raw scalar/pointer and borrowed values have no field-load
+            // cleanup authority. Do this before snapshot planning: they do not
+            // require record/enum layout facts, so an absent layout cannot
+            // manufacture a false invariant failure.
+            OwnershipDecision::NoHeap | OwnershipDecision::Borrowed { .. } => return Ok(None),
+            OwnershipDecision::InteriorAlias { .. } | OwnershipDecision::Unsupported { .. } => {
+                return Err(crate::state_clone::ClassificationError::Unsupported {
+                    rendered: format!(
+                        "field-load ownership decision for `{}` is {:?}",
+                        ty.user_facing(),
+                        owned.decision()
+                    ),
+                });
+            }
+            OwnershipDecision::OwnsHeap { .. } => {}
+        }
+        let record_layouts = outbound_record_layouts(self);
+        let plan = crate::state_clone::classify_value_snapshot_plan_with_lifecycle_registry(
+            &ty,
+            &record_layouts,
+            &self.enum_layouts,
+            &self.opaque_handle_names,
+            &self.lifecycle_registry,
+        )?;
         match owned.decision() {
             // Inline aggregate (record / tuple / array / inline-enum): the load
             // byte-copies the member with no retain, so the binder is an
@@ -3536,22 +3579,93 @@ impl Builder {
             OwnershipDecision::OwnsHeap {
                 layout: LayoutClass::Product | LayoutClass::TaggedUnion,
                 ..
-            } => Some(FieldLoadClass::ByteCopyAlias),
-            // Every other heap-owning field is a single release handle. `string`
-            // is the ONE retaining leaf (codegen `hew_string_clone`s the load →
-            // the binder owns a fresh `+1`); every other leaf (`Vec` / `bytes` /
-            // `HashMap` / `HashSet` / `Generator` / indirect-enum node) transfers
-            // its one handle to the binder.
-            OwnershipDecision::OwnsHeap { .. } => {
-                if matches!(ty, ResolvedTy::String) {
-                    Some(FieldLoadClass::Retained)
-                } else {
-                    Some(FieldLoadClass::HandleTransfer)
-                }
+            } => Ok(Some(FieldLoadClass::ByteCopyAlias)),
+            // The shared snapshot authority identifies every field load whose
+            // value is independent of the carrier protocol. String and Bytes
+            // each receive a balanced retain; all remaining heap-owning leaves
+            // (`Vec` / `HashMap` / `HashSet` / `Generator` / indirect-enum
+            // node) transfer their one handle to the binder.
+            OwnershipDecision::OwnsHeap { .. }
+                if super::snapshot_root_outside_carrier_protocol(plan.root()) =>
+            {
+                Ok(Some(FieldLoadClass::Retained))
             }
-            // Heap-free / borrowed / already-an-alias / unsupported: no
-            // scope-exit drop obligation for the field-projection seam to record.
-            _ => None,
+            OwnershipDecision::OwnsHeap { .. } => Ok(Some(FieldLoadClass::HandleTransfer)),
+            OwnershipDecision::NoHeap | OwnershipDecision::Borrowed { .. } => Ok(None),
+            OwnershipDecision::InteriorAlias { .. } | OwnershipDecision::Unsupported { .. } => {
+                unreachable!(
+                    "field-load non-owning classifications return before snapshot planning"
+                )
+            }
+        }
+    }
+
+    /// Surface a failed field-load classification exactly once at its HIR site.
+    /// The classifier is a shared ownership authority; a missing layout here is
+    /// a lowering invariant, so downstream MIR and codegen must not continue.
+    pub(crate) fn report_field_load_classification_failure(
+        &mut self,
+        site: SiteId,
+        ty: &ResolvedTy,
+        error: &crate::state_clone::ClassificationError,
+    ) {
+        // Poisoning is deliberately independent of diagnostic multiplicity.
+        // The first site wins the single LoweringInvariant, but every later
+        // endpoint must still stop instead of treating dedup as success.
+        self.field_load_classification_poisoned = true;
+        let rule = "field-load-classification";
+        if self.diagnostics.iter().any(|diagnostic| {
+            matches!(
+                &diagnostic.kind,
+                MirDiagnosticKind::LoweringInvariant {
+                    function,
+                    rule: existing_rule,
+                    ..
+                } if function == &self.current_function_symbol
+                    && existing_rule == rule
+            )
+        }) {
+            return;
+        }
+        self.diagnostics.push(MirDiagnostic {
+            kind: MirDiagnosticKind::LoweringInvariant {
+                function: self.current_function_symbol.clone(),
+                rule: rule.to_string(),
+                block: Some(self.current_block_id),
+                detail: format!(
+                    "site {site:?}: field load `{}` has no total ownership classification: {error}",
+                    ty.user_facing()
+                ),
+            },
+            note: "MIR stops this field-load path rather than guessing whether the \
+                   parent or extracted value owns cleanup; no compilation artifact is \
+                   emitted while the lowering invariant is present."
+                .to_string(),
+        });
+    }
+
+    /// Check the actual field/tuple-load boundary before its enclosing
+    /// statement publishes a `Bind` or `Evaluate`. The classifier's `Err`
+    /// becomes the one per-function invariant diagnostic; the boolean is the
+    /// caller's stop signal and therefore does not depend on whether that
+    /// diagnostic was already emitted for an earlier source site.
+    pub(crate) fn field_load_classification_is_valid(&mut self, value: &HirExpr) -> bool {
+        if self.field_load_classification_poisoned {
+            return false;
+        }
+        if !matches!(
+            value.kind,
+            HirExprKind::FieldAccess { .. } | HirExprKind::TupleIndex { .. }
+        ) {
+            return true;
+        }
+        let ty = self.subst_ty(&value.ty);
+        match self.classify_field_load(&ty) {
+            Ok(_) => true,
+            Err(error) => {
+                self.report_field_load_classification_failure(value.site, &ty, &error);
+                false
+            }
         }
     }
 
@@ -3566,14 +3680,14 @@ impl Builder {
         &mut self,
         value: &HirExpr,
         binding_ty: &ResolvedTy,
-    ) {
-        if self.owned_field_projection_move_sites.last() != Some(&value.site)
-            || value.intent != hew_hir::IntentKind::Consume
-            || self.classify_field_load(binding_ty) != Some(FieldLoadClass::HandleTransfer)
+    ) -> Result<(), crate::state_clone::ClassificationError> {
+        if self.owned_field_projection_move_sites.last() == Some(&value.site)
+            && value.intent == hew_hir::IntentKind::Consume
+            && self.classify_field_load(binding_ty)? == Some(FieldLoadClass::HandleTransfer)
         {
-            return;
+            self.publish_projection_source_transfer(value);
         }
-        self.publish_projection_source_transfer(value);
+        Ok(())
     }
 
     /// Publish the aggregate source handoff when an unguarded consuming match
@@ -3589,7 +3703,10 @@ impl Builder {
     /// double free. Ending the root generation here leaves the binder the sole
     /// owner; the root's remaining owned fields are discharged by the escaped-
     /// sibling field splice, so the handoff does not leak them.
-    pub(crate) fn publish_consuming_match_projection(&mut self, value: &HirExpr) {
+    pub(crate) fn publish_consuming_match_projection(
+        &mut self,
+        value: &HirExpr,
+    ) -> Result<(), crate::state_clone::ClassificationError> {
         // A PROJECTION only. `projection_root_binding` also resolves a bare
         // `BindingRef`, so without this the transfer would fire for
         // `match r { .. }` over a whole local and end the generation of a
@@ -3599,15 +3716,16 @@ impl Builder {
             value.kind,
             HirExprKind::FieldAccess { .. } | HirExprKind::TupleIndex { .. }
         ) {
-            return;
+            return Ok(());
         }
-        if self.classify_field_load(&value.ty) != Some(FieldLoadClass::ByteCopyAlias) {
-            return;
+        if self.classify_field_load(&value.ty)? != Some(FieldLoadClass::ByteCopyAlias) {
+            return Ok(());
         }
-        if !self.projected_enum_payload_is_handle_transfer(&value.ty) {
-            return;
+        if !self.projected_enum_payload_is_handle_transfer(&value.ty)? {
+            return Ok(());
         }
         self.publish_projection_source_transfer(value);
+        Ok(())
     }
 
     /// True when the inline enum type `ty` carries a payload the destructure
@@ -3630,21 +3748,27 @@ impl Builder {
     /// aggregate payload carries its own handoff authority. WHAT: recurse this
     /// classification through `ByteCopyAlias` payloads and publish the
     /// transfer for the exact nested leaf rather than the root generation.
-    fn projected_enum_payload_is_handle_transfer(&self, ty: &ResolvedTy) -> bool {
+    fn projected_enum_payload_is_handle_transfer(
+        &self,
+        ty: &ResolvedTy,
+    ) -> Result<bool, crate::state_clone::ClassificationError> {
         let subst = self.subst_ty(ty);
         let ResolvedTy::Named { name, args, .. } = &subst else {
-            return false;
+            return Ok(false);
         };
         let Some(layout) = crate::model::find_enum_layout(name, args, &self.enum_layouts) else {
-            return false;
+            return Ok(false);
         };
-        layout
+        for field_ty in layout
             .variants
             .iter()
             .flat_map(|variant| variant.field_tys.iter())
-            .any(|field_ty| {
-                self.classify_field_load(field_ty) == Some(FieldLoadClass::HandleTransfer)
-            })
+        {
+            if self.classify_field_load(field_ty)? == Some(FieldLoadClass::HandleTransfer) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     fn publish_projection_source_transfer(&mut self, value: &HirExpr) {

--- a/hew-mir/src/lower/pattern.rs
+++ b/hew-mir/src/lower/pattern.rs
@@ -4785,7 +4785,14 @@ impl Builder {
         if arms.iter().all(|arm| arm.guard.is_none())
             && arms.iter().any(|arm| !arm.bindings.is_empty())
         {
-            self.publish_consuming_match_projection(scrutinee);
+            if let Err(error) = self.publish_consuming_match_projection(scrutinee) {
+                self.report_field_load_classification_failure(
+                    scrutinee.site,
+                    &scrutinee.ty,
+                    &error,
+                );
+                return None;
+            }
         }
         let scrutinee_local = match scrutinee_place {
             Place::Local(n) => n,

--- a/hew-mir/src/lower/synthesized_identity_tests.rs
+++ b/hew-mir/src/lower/synthesized_identity_tests.rs
@@ -1,0 +1,40 @@
+//! Callable-key child synthesis tests, kept beside the lowering module so the
+//! production coordinator remains below the structural line ceiling.
+
+use super::*;
+
+#[test]
+fn a_builder_carrying_a_callable_identity_mints_ordinal_children_of_it() {
+    let parent = crate::model::MirCallableKey::for_test("app.owner");
+    let mut builder = Builder {
+        current_callable_key: Some(parent.clone()),
+        ..Builder::default()
+    };
+
+    let first =
+        builder.mint_synthesized_child_key(crate::model::SynthesizedCallable::GeneratorBody);
+    let second =
+        builder.mint_synthesized_child_key(crate::model::SynthesizedCallable::ClosureInvokeShim);
+
+    assert_eq!(
+        first,
+        parent.child(crate::model::SynthesizedCallable::GeneratorBody(0))
+    );
+    assert_eq!(
+        second,
+        parent.child(crate::model::SynthesizedCallable::ClosureInvokeShim(1)),
+        "one shared per-parent sequence: the second child is ordinal 1 even though it \
+         is the first of its variant"
+    );
+}
+
+#[test]
+#[should_panic(expected = "carries no callable identity")]
+fn a_builder_with_no_callable_identity_refuses_to_mint_a_child_key() {
+    // The negative control for the `current_callable_key: Option<..>`
+    // fail-closed claim. Without it the producer would have to invent an
+    // identity from the emitted symbol — the exact reconstruction this slice
+    // removes — and two synthesized callables could then collide.
+    let mut builder = Builder::default();
+    let _ = builder.mint_synthesized_child_key(crate::model::SynthesizedCallable::GeneratorBody);
+}

--- a/hew-mir/src/lower/temp_drop.rs
+++ b/hew-mir/src/lower/temp_drop.rs
@@ -4872,11 +4872,12 @@ fn fresh_string_producer_term_admissible(
 /// The two sides are coupled and MUST move together: codegen retains ONLY
 /// string-typed `*FieldLoad` dests (detected by the dest's `ResolvedTy`), so this
 /// classifier admits ONLY string-typed `*FieldLoad` dests (same type gate). A
-/// non-string field load (`bytes` / `Vec<T>` / nested record) is NOT retained by
-/// codegen and stays a projection alias here — it leaks rather than double-frees,
-/// the safe default, until the retain-on-share spine lands. The type gate uses
-/// the function's `locals` table (the dest local's declared `ResolvedTy`), the
-/// same precise string distinguisher codegen uses.
+/// non-string `Vec<T>` / nested-record field load is NOT retained by codegen and
+/// stays a projection alias here. `bytes` is intentionally different: its
+/// retain-on-share is inserted by MIR's `finalize_bytes_ownership`, not by the
+/// codegen string-retain path this classifier describes. The type gate uses the
+/// function's `locals` table (the dest local's declared `ResolvedTy`), the same
+/// precise string distinguisher codegen uses.
 pub(super) fn string_field_load_producer_dest(
     instr: &Instr,
     locals: &[ResolvedTy],

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -1829,22 +1829,6 @@ fn classify_named(
     if matches!(builtin, Some(hew_types::BuiltinType::Sender)) {
         return Ok(StateFieldCloneKind::ChannelSender);
     }
-    if matches!(builtin, Some(hew_types::BuiltinType::Receiver)) {
-        return Ok(StateFieldCloneKind::Resource {
-            name: "Receiver".to_string(),
-            close: ResourceCloseAuthority::Runtime(
-                hew_types::runtime_call::RuntimeDropDescriptor::ReceiverClose,
-            ),
-        });
-    }
-    if matches!(builtin, Some(hew_types::BuiltinType::LambdaPid)) {
-        return Ok(StateFieldCloneKind::Resource {
-            name: "LambdaPid".to_string(),
-            close: ResourceCloseAuthority::Runtime(
-                hew_types::runtime_call::RuntimeDropDescriptor::LambdaActorHandleClose,
-            ),
-        });
-    }
     if matches!(
         builtin,
         Some(
@@ -1855,6 +1839,45 @@ fn classify_named(
         )
     ) {
         return Ok(StateFieldCloneKind::BitCopy { size_bytes: 0 });
+    }
+
+    // Stream/Sink remain `IoHandle` rather than `Resource`: their close
+    // descriptor is shared with ordinary lexical drops, while actor-state
+    // clone is deliberately refused by the IO-handle protocol.
+    if matches!(builtin, Some(hew_types::BuiltinType::Stream)) {
+        return Ok(StateFieldCloneKind::IoHandle {
+            kind: IoHandleKind::Stream,
+        });
+    }
+    if matches!(builtin, Some(hew_types::BuiltinType::Sink)) {
+        return Ok(StateFieldCloneKind::IoHandle {
+            kind: IoHandleKind::Sink,
+        });
+    }
+
+    // Runtime-close identity is a closed typed table shared with ordinary
+    // scope-exit drop planning. Do not recover it from `name`: user nominals
+    // with the same leaf arrive with `builtin: None` and retain their own
+    // layout/lifecycle authority below.
+    if let Some((builtin, descriptor)) = builtin.and_then(|builtin| {
+        hew_types::runtime_call::RuntimeDropDescriptor::for_builtin(builtin)
+            .map(|descriptor| (builtin, descriptor))
+    }) {
+        return Ok(StateFieldCloneKind::Resource {
+            name: builtin.canonical_name().to_string(),
+            close: ResourceCloseAuthority::Runtime(descriptor),
+        });
+    }
+
+    // This opaque compiler-internal carrier bears the Resource marker so
+    // untyped paths never copy it, but it has no runtime close descriptor or
+    // source-level constructor. Keep a forged snapshot fail-closed and
+    // distinct from a missing user-record layout; inventing `hew_actor_close`
+    // here would change its unratified ownership contract.
+    if matches!(builtin, Some(hew_types::BuiltinType::BoxedActor)) {
+        return Err(ClassificationError::Unsupported {
+            rendered: "builtin BoxedActor has no runtime lifecycle descriptor".to_string(),
+        });
     }
 
     // Non-opaque user records/enums still shadow builtin *spellings*. A typed
@@ -2001,17 +2024,6 @@ fn classify_named(
     // `.close()` and standalone-binding drop paths use). No dup helper exists,
     // so the clone/restart direction fails closed (handled in the codegen clone
     // step), matching the affine-resource posture.
-    if matches!(builtin, Some(hew_types::BuiltinType::Stream)) {
-        return Ok(StateFieldCloneKind::IoHandle {
-            kind: IoHandleKind::Stream,
-        });
-    }
-    if matches!(builtin, Some(hew_types::BuiltinType::Sink)) {
-        return Ok(StateFieldCloneKind::IoHandle {
-            kind: IoHandleKind::Sink,
-        });
-    }
-
     // `Generator<Y, R>` / `AsyncGenerator<Y>` pointer-backed runtime handle.
     // Same posture as Stream/Sink: drop routes to `hew_gen_coro_destroy` (the
     // standalone generator-binding release symbol), no dup helper, clone/restart
@@ -2694,6 +2706,111 @@ mod tests {
     }
 
     #[test]
+    fn runtime_close_builtin_snapshot_inventory_is_typed_and_clone_refusing() {
+        use hew_types::runtime_call::RuntimeDropDescriptor as Drop;
+        use hew_types::BuiltinType;
+
+        let inventory = [
+            (BuiltinType::Duplex, Drop::DuplexClose),
+            (BuiltinType::HewDuplex, Drop::DuplexClose),
+            (BuiltinType::Receiver, Drop::ReceiverClose),
+            (BuiltinType::SendHalf, Drop::SendHalfClose),
+            (BuiltinType::HewSendHalf, Drop::SendHalfClose),
+            (BuiltinType::RecvHalf, Drop::RecvHalfClose),
+            (BuiltinType::HewRecvHalf, Drop::RecvHalfClose),
+            (BuiltinType::LambdaActorHandle, Drop::LambdaActorHandleClose),
+            (BuiltinType::LambdaPid, Drop::LambdaActorHandleClose),
+            (BuiltinType::MonitorRef, Drop::MonitorRefClose),
+        ];
+
+        for (builtin_kind, descriptor) in inventory {
+            let mut visited = HashSet::new();
+            let root =
+                classify_state_field(&builtin(builtin_kind, vec![]), &no_records(), &mut visited)
+                    .unwrap_or_else(|err| panic!("{builtin_kind:?} must classify: {err:?}"));
+            assert_eq!(
+                root,
+                StateFieldCloneKind::Resource {
+                    name: builtin_kind.canonical_name().to_string(),
+                    close: ResourceCloseAuthority::Runtime(descriptor),
+                },
+            );
+            assert!(
+                !ValueSnapshotPlan { root }
+                    .is_clone_total(&[], &[], &[], &registry(&[]))
+                    .unwrap(),
+                "{builtin_kind:?} must retain the actor-state clone refusal",
+            );
+        }
+    }
+
+    #[test]
+    fn every_resource_marker_has_a_closed_lifecycle_disposition() {
+        use hew_types::{builtin_type::BuiltinTypeMarker, BuiltinType};
+
+        for info in hew_types::builtin_types() {
+            if info.kind.marker() != BuiltinTypeMarker::Resource {
+                continue;
+            }
+            let admitted =
+                matches!(
+                    info.kind,
+                    BuiltinType::LocalPid | BuiltinType::HewActor | BuiltinType::BoxedActor
+                ) || hew_types::runtime_call::RuntimeDropDescriptor::for_builtin(info.kind)
+                    .is_some();
+            assert!(
+                admitted,
+                "resource builtin {:?} lacks an explicit lifecycle disposition",
+                info.kind
+            );
+        }
+    }
+
+    #[test]
+    fn stream_sink_and_sender_keep_their_distinct_typed_snapshot_protocols() {
+        let cases = [
+            (
+                hew_types::BuiltinType::Stream,
+                StateFieldCloneKind::IoHandle {
+                    kind: IoHandleKind::Stream,
+                },
+            ),
+            (
+                hew_types::BuiltinType::Sink,
+                StateFieldCloneKind::IoHandle {
+                    kind: IoHandleKind::Sink,
+                },
+            ),
+            (
+                hew_types::BuiltinType::Sender,
+                StateFieldCloneKind::ChannelSender,
+            ),
+        ];
+        for (builtin_kind, expected) in cases {
+            let mut visited = HashSet::new();
+            assert_eq!(
+                classify_state_field(&builtin(builtin_kind, vec![]), &no_records(), &mut visited,),
+                Ok(expected),
+                "{builtin_kind:?} must not be flattened into a generic resource",
+            );
+        }
+    }
+
+    #[test]
+    fn boxed_actor_has_no_forged_snapshot_close_authority() {
+        let mut visited = HashSet::new();
+        assert!(matches!(
+            classify_state_field(
+                &builtin(hew_types::BuiltinType::BoxedActor, vec![]),
+                &no_records(),
+                &mut visited,
+            ),
+            Err(ClassificationError::Unsupported { ref rendered })
+                if rendered.contains("BoxedActor") && rendered.contains("lifecycle descriptor")
+        ));
+    }
+
+    #[test]
     fn net_connection_without_lifecycle_registry_fails_closed_as_opaque() {
         let mut v = HashSet::new();
         let ty = ResolvedTy::Named {
@@ -2744,6 +2861,14 @@ mod tests {
             ("Sink", vec![ResolvedTy::I64]),
             ("Generator", vec![ResolvedTy::I64, ResolvedTy::Unit]),
             ("AsyncGenerator", vec![ResolvedTy::I64]),
+            ("Duplex", vec![]),
+            ("Receiver", vec![]),
+            ("SendHalf", vec![]),
+            ("RecvHalf", vec![]),
+            ("LambdaPid", vec![]),
+            ("LambdaActorHandle", vec![]),
+            ("MonitorRef", vec![]),
+            ("HewDuplex", vec![]),
         ];
 
         for (name, args) in collisions {

--- a/hew-mir/tests/lowering_expr/bytes_retained_local_share.rs
+++ b/hew-mir/tests/lowering_expr/bytes_retained_local_share.rs
@@ -1,6 +1,9 @@
-use hew_hir::{lower_program, ResolutionCtx};
-use hew_mir::{Instr, IrPipeline, OwnershipEvent, Place};
-use hew_types::{module_registry::ModuleRegistry, Checker};
+use hew_hir::{lower_program, BindingId, ResolutionCtx};
+use hew_mir::{
+    CheckedMirFunction, CowHeapRelease, DropKind, ExitPath, Instr, IrPipeline, MirStatement,
+    OwnerId, OwnershipEvent, Place,
+};
+use hew_types::{module_registry::ModuleRegistry, Checker, ResolvedTy};
 
 fn pipeline(source: &str) -> IrPipeline {
     let parsed = hew_parser::parse(source);
@@ -28,6 +31,97 @@ fn pipeline(source: &str) -> IrPipeline {
         hir.diagnostics
     );
     hew_mir::lower_hir_module(&hir.module)
+}
+
+fn named_binding(function: &CheckedMirFunction, name: &str) -> BindingId {
+    function
+        .blocks
+        .iter()
+        .flat_map(|block| block.statements.iter())
+        .find_map(|statement| match statement {
+            MirStatement::Bind {
+                binding,
+                name: candidate,
+                ..
+            } if candidate == name => Some(*binding),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("{name} binding"))
+}
+
+fn owner_publication(
+    function: &CheckedMirFunction,
+    binding: BindingId,
+) -> (OwnerId, Place, ResolvedTy) {
+    function
+        .blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .find_map(|instruction| match instruction {
+            Instr::OwnershipEvent(OwnershipEvent::Mint { owner, place, ty })
+                if owner.binding == binding =>
+            {
+                Some((*owner, *place, ty.clone()))
+            }
+            Instr::OwnershipEvent(OwnershipEvent::Transfer {
+                to: Some(place),
+                to_owner: Some(owner),
+                to_ty: Some(ty),
+                ..
+            }) if owner.binding == binding => Some((*owner, *place, ty.clone())),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("owner publication for {binding:?}"))
+}
+
+fn assert_exact_return_drops(
+    pipeline: &IrPipeline,
+    holder: (Place, &ResolvedTy),
+    extracted: (Place, &ResolvedTy),
+) {
+    let elaborated = pipeline
+        .elaborated_mir
+        .iter()
+        .find(|function| function.name == "field_load_share")
+        .expect("field_load_share Elaborated MIR");
+    let return_plan = elaborated
+        .drop_plans
+        .iter()
+        .find_map(|(exit, plan)| matches!(exit, ExitPath::Return { .. }).then_some(plan))
+        .expect("field_load_share return drop plan");
+    let holder_drops = return_plan
+        .drops
+        .iter()
+        .filter(|drop| {
+            drop.place == holder.0
+                && &drop.ty == holder.1
+                && matches!(drop.kind, DropKind::RecordInPlace)
+        })
+        .count();
+    let extracted_drops = return_plan
+        .drops
+        .iter()
+        .filter(|drop| {
+            drop.place == extracted.0
+                && &drop.ty == extracted.1
+                && matches!(
+                    drop.kind,
+                    DropKind::CowHeap {
+                        release: CowHeapRelease::Bytes
+                    }
+                )
+        })
+        .count();
+    assert_eq!(holder_drops, 1, "the holder root drops exactly once");
+    assert_eq!(
+        extracted_drops, 1,
+        "the retained extracted bytes owner drops exactly once"
+    );
+    assert_eq!(
+        return_plan.drops.len(),
+        2,
+        "the return plan contains no stale or duplicate cleanup"
+    );
 }
 
 #[test]
@@ -107,4 +201,77 @@ fn owned_partner_escape() -> bytes {
                 }) if *from == source
             ))
         ));
+}
+
+#[test]
+fn retained_bytes_field_keeps_the_record_root_and_drops_both_owners_once() {
+    let pipeline = pipeline(
+        r#"
+type Holder { payload: bytes }
+
+fn field_load_share() -> i64 {
+    let holder = Holder { payload: "field-load".to_bytes() };
+    let extracted = holder.payload;
+    extracted.len() + holder.payload.len()
+}
+"#,
+    );
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "{:#?}",
+        pipeline.diagnostics
+    );
+    let checked = pipeline
+        .checked_mir
+        .iter()
+        .find(|function| function.name == "field_load_share")
+        .expect("field_load_share Checked MIR");
+
+    let holder_binding = named_binding(checked, "holder");
+    let extracted_binding = named_binding(checked, "extracted");
+    let (holder_owner, holder_place, holder_ty) = owner_publication(checked, holder_binding);
+    let (extracted_owner, extracted_place, extracted_ty) =
+        owner_publication(checked, extracted_binding);
+    assert_eq!(extracted_ty, ResolvedTy::Bytes);
+
+    let projected = checked.blocks.iter().find_map(|block| {
+        block
+            .instructions
+            .iter()
+            .find_map(|instruction| match instruction {
+                Instr::RecordFieldLoad { record, dest, .. } if *record == holder_place => {
+                    Some(*dest)
+                }
+                _ => None,
+            })
+    });
+    let projected = projected.expect("bytes field load from the holder owner");
+    assert!(checked.blocks.iter().any(|block| {
+        block.instructions.iter().any(
+            |instruction| matches!(instruction, Instr::BytesRetain { value } if *value == projected),
+        )
+    }));
+    assert!(
+        checked.blocks.iter().all(|block| {
+            block.instructions.iter().all(|instruction| {
+                !matches!(
+                    instruction,
+                    Instr::OwnershipEvent(OwnershipEvent::Transfer {
+                        owner,
+                        from,
+                        to: None,
+                        ..
+                    }) if *owner == holder_owner && *from == holder_place
+                )
+            })
+        }),
+        "a retained bytes projection must not discharge the live record root",
+    );
+    assert_ne!(holder_owner, extracted_owner);
+
+    assert_exact_return_drops(
+        &pipeline,
+        (holder_place, &holder_ty),
+        (extracted_place, &extracted_ty),
+    );
 }

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -47,7 +47,7 @@
 //! covered by this substrate by design — it is structurally open-set
 //! and clippy-gated.
 
-use crate::ResolvedTy;
+use crate::{BuiltinType, ResolvedTy};
 use serde::{Deserialize, Serialize};
 use strum::{EnumIter, IntoEnumIterator};
 
@@ -2746,7 +2746,85 @@ pub enum RuntimeDropDescriptor {
     MonitorRefClose,
 }
 
+/// The exact operand shape consumed by a runtime resource-close descriptor.
+///
+/// This stays coupled to [`RuntimeDropDescriptor`], rather than inferred from
+/// its C symbol: two descriptors may share a symbol while carrying different
+/// typed operands (`SendHalf` versus `RecvHalf`), and `MonitorRef` owns an
+/// inline record slot rather than a pointer handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeDropOperandShape {
+    /// One opaque heap-handle pointer.
+    HandlePtr,
+    /// One opaque half-handle pointer plus the typed duplex direction.
+    DuplexHalf { direction: DuplexHalfDropDirection },
+    /// The `ref_id: i64` field in an inline `MonitorRef` record.
+    MonitorRefId,
+}
+
+/// Direction materialised for the shared `hew_duplex_close_half` ABI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DuplexHalfDropDirection {
+    Send,
+    Recv,
+}
+
+impl DuplexHalfDropDirection {
+    /// Runtime ABI discriminant for `hew_duplex_close_half`.
+    #[must_use]
+    pub const fn runtime_discriminant(self) -> u64 {
+        match self {
+            Self::Send => 0,
+            Self::Recv => 1,
+        }
+    }
+}
+
 impl RuntimeDropDescriptor {
+    /// The typed builtin identity whose scope-exit close this descriptor
+    /// represents. Internal ABI aliases share their public handle family's
+    /// descriptor, so snapshot/drop planning never has to recover lifecycle
+    /// from a presentation name.
+    #[must_use]
+    pub const fn for_builtin(builtin: BuiltinType) -> Option<Self> {
+        match builtin {
+            BuiltinType::Duplex | BuiltinType::HewDuplex => Some(Self::DuplexClose),
+            BuiltinType::Stream => Some(Self::StreamClose),
+            BuiltinType::Sink => Some(Self::SinkClose),
+            BuiltinType::Sender => Some(Self::SenderClose),
+            BuiltinType::Receiver => Some(Self::ReceiverClose),
+            BuiltinType::LambdaActorHandle | BuiltinType::LambdaPid => {
+                Some(Self::LambdaActorHandleClose)
+            }
+            BuiltinType::SendHalf | BuiltinType::HewSendHalf => Some(Self::SendHalfClose),
+            BuiltinType::RecvHalf | BuiltinType::HewRecvHalf => Some(Self::RecvHalfClose),
+            BuiltinType::CancellationToken => Some(Self::CancellationTokenRelease),
+            BuiltinType::MonitorRef => Some(Self::MonitorRefClose),
+            _ => None,
+        }
+    }
+
+    /// The slot/operand ABI required by this close ritual.
+    #[must_use]
+    pub const fn operand_shape(self) -> RuntimeDropOperandShape {
+        match self {
+            Self::SendHalfClose => RuntimeDropOperandShape::DuplexHalf {
+                direction: DuplexHalfDropDirection::Send,
+            },
+            Self::RecvHalfClose => RuntimeDropOperandShape::DuplexHalf {
+                direction: DuplexHalfDropDirection::Recv,
+            },
+            Self::MonitorRefClose => RuntimeDropOperandShape::MonitorRefId,
+            Self::DuplexClose
+            | Self::StreamClose
+            | Self::SinkClose
+            | Self::SenderClose
+            | Self::ReceiverClose
+            | Self::LambdaActorHandleClose
+            | Self::CancellationTokenRelease => RuntimeDropOperandShape::HandlePtr,
+        }
+    }
+
     /// The C-ABI runtime symbol the drop lowers to. NB
     /// [`RuntimeDropDescriptor::SendHalfClose`] and
     /// [`RuntimeDropDescriptor::RecvHalfClose`] share
@@ -3620,6 +3698,80 @@ mod tests {
                 "RuntimeDropDescriptor {d:?} has no entry in the \
                  codegen `runtime_drop_symbol` parity table; add it to \
                  both or remove the variant"
+            );
+        }
+    }
+
+    #[test]
+    fn builtin_resource_close_inventory_has_one_typed_descriptor_authority() {
+        use BuiltinType::*;
+
+        let inventory = [
+            (Duplex, Some(RuntimeDropDescriptor::DuplexClose)),
+            (HewDuplex, Some(RuntimeDropDescriptor::DuplexClose)),
+            (Stream, Some(RuntimeDropDescriptor::StreamClose)),
+            (Sink, Some(RuntimeDropDescriptor::SinkClose)),
+            (Sender, Some(RuntimeDropDescriptor::SenderClose)),
+            (Receiver, Some(RuntimeDropDescriptor::ReceiverClose)),
+            (SendHalf, Some(RuntimeDropDescriptor::SendHalfClose)),
+            (HewSendHalf, Some(RuntimeDropDescriptor::SendHalfClose)),
+            (RecvHalf, Some(RuntimeDropDescriptor::RecvHalfClose)),
+            (HewRecvHalf, Some(RuntimeDropDescriptor::RecvHalfClose)),
+            (
+                LambdaActorHandle,
+                Some(RuntimeDropDescriptor::LambdaActorHandleClose),
+            ),
+            (
+                LambdaPid,
+                Some(RuntimeDropDescriptor::LambdaActorHandleClose),
+            ),
+            (
+                CancellationToken,
+                Some(RuntimeDropDescriptor::CancellationTokenRelease),
+            ),
+            (MonitorRef, Some(RuntimeDropDescriptor::MonitorRefClose)),
+            // These marker-bearing internal carriers have no executable
+            // runtime close contract. They must remain unsupported rather
+            // than acquiring one by spelling or marker alone.
+            (LocalPid, None),
+            (HewActor, None),
+            (BoxedActor, None),
+        ];
+
+        for (builtin, expected) in inventory {
+            assert_eq!(
+                RuntimeDropDescriptor::for_builtin(builtin),
+                expected,
+                "typed lifecycle inventory drifted for {builtin:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_resource_drop_operands_are_exhaustively_typed() {
+        use DuplexHalfDropDirection::{Recv, Send};
+        use RuntimeDropDescriptor::*;
+        use RuntimeDropOperandShape::{DuplexHalf, HandlePtr, MonitorRefId};
+
+        let expected = [
+            (DuplexClose, HandlePtr),
+            (StreamClose, HandlePtr),
+            (SinkClose, HandlePtr),
+            (SenderClose, HandlePtr),
+            (ReceiverClose, HandlePtr),
+            (LambdaActorHandleClose, HandlePtr),
+            (SendHalfClose, DuplexHalf { direction: Send }),
+            (RecvHalfClose, DuplexHalf { direction: Recv }),
+            (CancellationTokenRelease, HandlePtr),
+            (MonitorRefClose, MonitorRefId),
+        ];
+
+        assert_eq!(all_runtime_drop_descriptors().len(), expected.len());
+        for (descriptor, shape) in expected {
+            assert_eq!(
+                descriptor.operand_shape(),
+                shape,
+                "operand ABI drifted for {descriptor:?}"
             );
         }
     }


### PR DESCRIPTION
## Why

Bytes field shares were misclassified as transfers, which dropped live ownership from the replay spine. The first signed repair then exposed a broader typed-builtin lifecycle gap in hosted CI: `Duplex` halves and inline `MonitorRef` carriers could reach cleanup without one exact runtime drop descriptor and operand ABI. Classification or ABI disagreement must stop artifact construction, never collapse into an ordinary no-transfer/default cleanup path.

## What

- classify canonical Bytes field-load snapshots as retained shares
- propagate field-load classification failures through every projection endpoint and finalize poisoned partial bodies as one validator-safe `Unreachable`
- centralize builtin lifecycle identity in one typed `RuntimeDropDescriptor` authority
- carry pointer, directional Duplex-half, and inline MonitorRef operands explicitly into aggregate and prepared-carrier cleanup
- require adopted MonitorRef runtime declarations to match exact non-vararg `void(i64)` and reject malformed/packed carriers
- keep Stream, Sink, Sender, and unsupported internal `BoxedActor` dispositions explicit rather than inferring a generic pointer-close ABI

## Test

- `make test-vertical-slice`
- `make fuzz-oracle` — 777 candidates passed
- `make test` — 14,015 passed; all 37 non-pass outcomes were baseline-known
- canonical O0 ASan fixture gate — 17 passed; only the two separately tracked F6 failures remain
- focused MonitorRef ABI/CFG, directional-half, typed lifecycle inventory, and production poison-finalizer tests
- `make lint`
- two independent exact-delta reviews, final verdict GO

Fixes #3200
