### PR TITLE
refactor(mir): key every MIR stage join by callable identity

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -79,11 +79,11 @@ use hew_mir::{
     CallAuthority, CheckedMirFunction, CmpPred, CooperateKind, CooperateSite, DropFnSpec, DropKind,
     DynVtableInstance, ElabDrop, ElaboratedMirFunction, EnumLayout, ExitPath, FieldOffset,
     FloatWidth, FunctionCallConv, Instr, IntArithOp, IntSignedness, IoHandleKind, IrPipeline,
-    LambdaEnvFieldDrop, MachineVariantLayout, MirConst, MirConstValue, MirScope, ParamBoundaryMode,
-    ParamLoanStorage, Place, RawMirFunction, RawValueDef, RawValueId, RawValueOp,
-    RawVirtualValueFacts, RecordLayout, RegexLiteral, ResourceCloseAuthority, RuntimeCall,
-    SourceOrigin, StateFieldCloneKind, Strategy, StringRetainCondition, SupervisorChildLayout,
-    SuspendKind, Terminator, TrapKind,
+    LambdaEnvFieldDrop, MachineVariantLayout, MirCallableKey, MirConst, MirConstValue, MirScope,
+    ParamBoundaryMode, ParamLoanStorage, Place, RawMirFunction, RawValueDef, RawValueId,
+    RawValueOp, RawVirtualValueFacts, RecordLayout, RegexLiteral, ResourceCloseAuthority,
+    RuntimeCall, SourceOrigin, StateFieldCloneKind, Strategy, StringRetainCondition,
+    SupervisorChildLayout, SuspendKind, Terminator, TrapKind,
 };
 pub(crate) use hew_types::short_name;
 use hew_types::{
@@ -22320,7 +22320,7 @@ fn compute_borrow_taint(func: &RawMirFunction) -> HashSet<u32> {
 /// [`has_unhandled_non_string_borrow_use`] on the live path.
 fn compute_borrow_drop_taint(
     func: &RawMirFunction,
-    elab: Option<&hew_mir::ElaboratedMirFunction>,
+    elab: &hew_mir::ElaboratedMirFunction,
     record_field_resolved_tys: &HashMap<String, Vec<ResolvedTy>>,
     enum_layouts: &[EnumLayout],
     machine_layouts: &MachineLayoutMap<'_>,
@@ -22339,16 +22339,14 @@ fn compute_borrow_drop_taint(
             tainted.insert(idx as u32);
         }
     }
-    if let Some(elab) = elab {
-        for base in elab
-            .drop_plans
-            .iter()
-            .flat_map(|(_, plan)| &plan.drops)
-            .filter_map(|drop| place_base_local(&drop.place))
-        {
-            if (base as usize) < func.params.len() {
-                tainted.insert(base);
-            }
+    for base in elab
+        .drop_plans
+        .iter()
+        .flat_map(|(_, plan)| &plan.drops)
+        .filter_map(|drop| place_base_local(&drop.place))
+    {
+        if (base as usize) < func.params.len() {
+            tainted.insert(base);
         }
     }
     if tainted.is_empty() {
@@ -23668,7 +23666,7 @@ fn call_destination_has_specialized_crash_cleanup_lifecycle(
 )]
 fn collect_helper_crash_cleanup_descriptors(
     func: &RawMirFunction,
-    elab: Option<&ElaboratedMirFunction>,
+    elab: &ElaboratedMirFunction,
     has_suspend: bool,
     include_unwind_plans: bool,
     record_field_tys: &HashMap<String, Vec<ResolvedTy>>,
@@ -23708,21 +23706,19 @@ fn collect_helper_crash_cleanup_descriptors(
     // mis-marked retire-only and leaked.
     let mut on_back_edge: HashSet<Place> = HashSet::new();
     let mut off_back_edge: HashSet<Place> = HashSet::new();
-    if let Some(elab) = elab {
-        for (exit, plan) in &elab.drop_plans {
-            if !include_unwind_plans && matches!(exit, ExitPath::Unwind { .. }) {
-                continue;
-            }
-            let is_back_edge = matches!(
-                exit,
-                ExitPath::Goto { block, .. } if back_edge_blocks.contains(block)
-            );
-            for drop in &plan.drops {
-                if is_back_edge {
-                    on_back_edge.insert(drop.place);
-                } else {
-                    off_back_edge.insert(drop.place);
-                }
+    for (exit, plan) in &elab.drop_plans {
+        if !include_unwind_plans && matches!(exit, ExitPath::Unwind { .. }) {
+            continue;
+        }
+        let is_back_edge = matches!(
+            exit,
+            ExitPath::Goto { block, .. } if back_edge_blocks.contains(block)
+        );
+        for drop in &plan.drops {
+            if is_back_edge {
+                on_back_edge.insert(drop.place);
+            } else {
+                off_back_edge.insert(drop.place);
             }
         }
     }
@@ -23810,7 +23806,7 @@ fn collect_helper_crash_cleanup_descriptors(
     let mut by_place = HashMap::<Place, usize>::new();
     let mut entry_cancel_unguarded = HashSet::<Place>::new();
     let entry_block_id = func.blocks.first().map(|block| block.id);
-    for (exit, plan) in elab.into_iter().flat_map(|elab| elab.drop_plans.iter()) {
+    for (exit, plan) in &elab.drop_plans {
         if !include_unwind_plans && matches!(exit, ExitPath::Unwind { .. }) {
             continue;
         }
@@ -34477,17 +34473,11 @@ fn validate_context_markers_for_codegen(func: &RawMirFunction) -> Vec<hew_mir::M
 /// Lower one function from `raw_mir`, consuming `elaborated_mir.drop_plans`
 /// to emit LIFO close calls before every exit terminator.
 ///
-/// `elab` is the `ElaboratedMirFunction` whose `name` matches `func.name`.
-/// When `pipeline.elaborated_mir` has no matching entry (e.g. in hand-built
-/// test pipelines that predate elaboration), `elab` may be `None`; in that
-/// case `emit_elab_drops` receives an empty slice and emits nothing — the
-/// inline `Instr::Drop` path in `lower_instruction` still fires for any
-/// `Instr::Drop` entries baked into `raw_mir.blocks`.
-///
-/// `checked` carries the cooperate-site side table computed by the MIR
-/// dataflow pass. Empty/missing checked MIR means no cooperate injection
-/// for legacy hand-built codegen tests; full lowered pipelines always carry
-/// a matching checked function.
+/// `elab` and `checked` are the mandatory artifacts with the same
+/// [`MirCallableKey`] as `func`. Module orchestration validates and indexes all
+/// three stage sets before creating any LLVM definitions, so this function
+/// never guesses identity from linkage/display names and never substitutes an
+/// empty stage.
 ///
 /// `module_uses_runtime` is true when the module declares an actor, declares a
 /// supervisor, or reaches a runtime-owned authority (Node, metrics). When true,
@@ -35814,8 +35804,8 @@ fn apply_optnone_for_debug<'ctx>(ctx: &'ctx Context, func: inkwell::values::Func
 /// independently validate.
 fn virtual_raw_value_facts(
     func: &RawMirFunction,
-    checked: Option<&CheckedMirFunction>,
-    elaborated: Option<&ElaboratedMirFunction>,
+    checked: &CheckedMirFunction,
+    elaborated: &ElaboratedMirFunction,
 ) -> CodegenResult<Option<RawVirtualValueFacts>> {
     verify_raw_virtual_value_ladder(func, checked, elaborated).map_err(|error| {
         CodegenError::FailClosed(format!(
@@ -35838,8 +35828,8 @@ fn lower_function<'ctx>(
     representation_loan_params_by_function: &HashMap<String, Vec<u32>>,
     param_boundary_modes_by_function: &HashMap<String, Vec<Option<ParamBoundaryMode>>>,
     machine_step_symbols: &HashSet<String>,
-    elab: Option<&ElaboratedMirFunction>,
-    checked: Option<&CheckedMirFunction>,
+    elab: &ElaboratedMirFunction,
+    checked: &CheckedMirFunction,
     record_layouts: &RecordLayoutMap<'ctx>,
     actor_layouts: &[ActorLayout],
     machine_layouts: &MachineLayoutMap<'ctx>,
@@ -36722,41 +36712,32 @@ fn lower_function<'ctx>(
     // the PRIOR node on reassignment (`var t = ...; loop { t = ... }`); gating on
     // this set keeps the release fail-closed — it can never fire for a consumed,
     // aliased, or non-owning local, so it cannot introduce a double-free.
-    let indirect_enum_owned_locals: HashSet<u32> = elab
-        .map(|e| {
-            let mut owners = HashSet::new();
-            for (_, plan) in &e.drop_plans {
-                for drop in &plan.drops {
-                    if drop.kind == hew_mir::DropKind::IndirectEnum {
-                        if let Place::Local(l) = drop.place {
-                            owners.insert(l);
-                        }
+    let indirect_enum_owned_locals: HashSet<u32> = {
+        let mut owners = HashSet::new();
+        for (_, plan) in &elab.drop_plans {
+            for drop in &plan.drops {
+                if drop.kind == hew_mir::DropKind::IndirectEnum {
+                    if let Place::Local(l) = drop.place {
+                        owners.insert(l);
                     }
                 }
             }
-            owners
-        })
-        .unwrap_or_default();
+        }
+        owners
+    };
 
-    // Extract drop_plans from the matched elaborated function, or an empty
-    // ('static) slice when no elaborated function is available (hand-built test
-    // pipelines that inline Instr::Drop instead of using drop_plans). Threaded
-    // onto `FnCtx` so the block loop AND `emit_suspend_point` (the shared
-    // suspend-ramp helper) read the same per-function plan set.
-    let drop_plans: &[(ExitPath, hew_mir::DropPlan)] =
-        elab.map(|e| e.drop_plans.as_slice()).unwrap_or(&[]);
+    // Thread the matched stage's mandatory plans onto `FnCtx` so the block
+    // loop and `emit_suspend_point` read the same per-function plan set.
+    let drop_plans: &[(ExitPath, hew_mir::DropPlan)] = &elab.drop_plans;
     // Loop back-edge block ids, so the crash-cleanup collector can recognise a
     // reassigned-`while let` scrutinee snapshot (dropped only on the back-edge
     // Goto) and retire — never drop — it on the return sweep.
     let back_edge_blocks: HashSet<u32> = checked
-        .map(|c| {
-            c.cooperate_sites
-                .iter()
-                .filter(|site| site.kind == CooperateKind::LoopBackEdge)
-                .map(|site| site.bb_id)
-                .collect()
-        })
-        .unwrap_or_default();
+        .cooperate_sites
+        .iter()
+        .filter(|site| site.kind == CooperateKind::LoopBackEdge)
+        .map(|site| site.bb_id)
+        .collect();
     let module_triple = llvm_mod
         .get_triple()
         .as_str()
@@ -36786,13 +36767,10 @@ fn lower_function<'ctx>(
             _ => None,
         })
         .collect::<HashSet<_>>();
-    // Production Checked MIR reaches this point only after the ownership-event
-    // validator has accepted every Join/Rearm. Re-derive physical equivalence
-    // from that immutable event stream, and keep hand-built Raw-only pipelines
-    // fail-closed with no lineage admission.
-    let helper_crash_cleanup_lineages = checked
-        .map(helper_crash_cleanup_owner_lineages)
-        .unwrap_or_default();
+    // Checked MIR reaches this point only after the ownership-event validator
+    // has accepted every Join/Rearm. Re-derive physical equivalence from that
+    // immutable event stream.
+    let helper_crash_cleanup_lineages = helper_crash_cleanup_owner_lineages(checked);
     let mut helper_crash_cleanup_descriptors = collect_helper_crash_cleanup_descriptors(
         func,
         elab,
@@ -36948,8 +36926,7 @@ fn lower_function<'ctx>(
         )));
     }
 
-    let cooperate_sites: &[CooperateSite] =
-        checked.map(|c| c.cooperate_sites.as_slice()).unwrap_or(&[]);
+    let cooperate_sites: &[CooperateSite] = &checked.cooperate_sites;
     let owned_carrier_cancel_drops = collect_owned_carrier_cancel_drops(func)?;
     initialize_owned_carrier_drop_guards(&fn_ctx, &owned_carrier_cancel_drops)?;
     initialize_helper_crash_cleanup_guards(&fn_ctx, func.params.len())?;
@@ -37459,10 +37436,126 @@ fn lower_function<'ctx>(
 // Module-level orchestration
 // ---------------------------------------------------------------------------
 
+/// Exact Raw -> Checked -> Elaborated association for one emission.
+///
+/// The maps own their keys so lookups cannot accidentally fall back to vector
+/// position or presentation/linkage names. Construction is the fail-closed
+/// emission boundary: every stage must contain exactly one artifact for every
+/// callable key, and the matched artifacts must agree on their output name and
+/// return type.
+struct MirStageIndex<'a> {
+    checked: HashMap<MirCallableKey, &'a CheckedMirFunction>,
+    elaborated: HashMap<MirCallableKey, &'a ElaboratedMirFunction>,
+}
+
+fn mir_callable_key_label(key: &MirCallableKey) -> String {
+    format!("{} ({:?})", key.declaration.full_path(), key.instance)
+}
+
+fn validate_and_index_mir_stages(pipeline: &IrPipeline) -> CodegenResult<MirStageIndex<'_>> {
+    if let Some(diagnostic) =
+        hew_mir::identity::validate_unique_callable_keys(&pipeline.raw_mir).first()
+    {
+        let hew_mir::MirDiagnosticKind::CallableKeyCollision {
+            declaration,
+            first_symbol,
+            second_symbol,
+        } = &diagnostic.kind
+        else {
+            unreachable!("callable-key validation emits only collision diagnostics");
+        };
+        return Err(CodegenError::FailClosed(format!(
+            "duplicate Raw MIR callable key {declaration}: symbols `{first_symbol}` and `{second_symbol}` claim one identity"
+        )));
+    }
+    let raw_by_key = pipeline
+        .raw_mir
+        .iter()
+        .map(|raw| (raw.key.clone(), raw))
+        .collect::<HashMap<_, _>>();
+
+    let mut checked_by_key = HashMap::with_capacity(pipeline.checked_mir.len());
+    for checked in &pipeline.checked_mir {
+        if let Some(first) = checked_by_key.insert(checked.key.clone(), checked) {
+            return Err(CodegenError::FailClosed(format!(
+                "duplicate Checked MIR callable key {}: symbols `{}` and `{}` claim one identity",
+                mir_callable_key_label(&checked.key),
+                first.name,
+                checked.name
+            )));
+        }
+    }
+
+    let mut elaborated_by_key = HashMap::with_capacity(pipeline.elaborated_mir.len());
+    for elaborated in &pipeline.elaborated_mir {
+        if let Some(first) = elaborated_by_key.insert(elaborated.key.clone(), elaborated) {
+            return Err(CodegenError::FailClosed(format!(
+                "duplicate Elaborated MIR callable key {}: symbols `{}` and `{}` claim one identity",
+                mir_callable_key_label(&elaborated.key),
+                first.name,
+                elaborated.name
+            )));
+        }
+    }
+
+    for raw in &pipeline.raw_mir {
+        let key_label = mir_callable_key_label(&raw.key);
+        let checked = checked_by_key.get(&raw.key).ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "Raw MIR function `{}` with callable key {key_label} has no matching Checked MIR artifact",
+                raw.name
+            ))
+        })?;
+        let elaborated = elaborated_by_key.get(&raw.key).ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "Raw MIR function `{}` with callable key {key_label} has no matching Elaborated MIR artifact",
+                raw.name
+            ))
+        })?;
+        if checked.name != raw.name || elaborated.name != raw.name {
+            return Err(CodegenError::FailClosed(format!(
+                "MIR artifacts for callable key {key_label} disagree on linkage/display name: Raw=`{}`, Checked=`{}`, Elaborated=`{}`",
+                raw.name, checked.name, elaborated.name
+            )));
+        }
+        if checked.return_ty != raw.return_ty || elaborated.return_ty != raw.return_ty {
+            return Err(CodegenError::FailClosed(format!(
+                "MIR artifacts for callable key {key_label} disagree on return type for symbol `{}`: Raw=`{}`, Checked=`{}`, Elaborated=`{}`",
+                raw.name, raw.return_ty, checked.return_ty, elaborated.return_ty
+            )));
+        }
+    }
+
+    for checked in &pipeline.checked_mir {
+        if !raw_by_key.contains_key(&checked.key) {
+            return Err(CodegenError::FailClosed(format!(
+                "Checked MIR function `{}` with callable key {} has no matching Raw MIR artifact",
+                checked.name,
+                mir_callable_key_label(&checked.key)
+            )));
+        }
+    }
+    for elaborated in &pipeline.elaborated_mir {
+        if !raw_by_key.contains_key(&elaborated.key) {
+            return Err(CodegenError::FailClosed(format!(
+                "Elaborated MIR function `{}` with callable key {} has no matching Raw MIR artifact",
+                elaborated.name,
+                mir_callable_key_label(&elaborated.key)
+            )));
+        }
+    }
+
+    Ok(MirStageIndex {
+        checked: checked_by_key,
+        elaborated: elaborated_by_key,
+    })
+}
+
 /// Build the LLVM module for a lowered pipeline.
 ///
-/// `checked_mir` is all-or-nothing — if non-empty, every `raw_mir` function
-/// MUST have a matching entry. Fails closed at codegen time if violated.
+/// Every Raw function must have exactly one Checked and one Elaborated artifact
+/// with the same [`MirCallableKey`]. Missing, duplicate, extra, or mismatched
+/// stage artifacts fail before the module creates any LLVM definitions.
 ///
 /// Test-only thin wrapper over [`build_module_for_target`] with no target
 /// machine and no debug info; production emits through
@@ -37560,6 +37653,7 @@ fn build_module_for_target<'ctx>(
     debug: Option<DebugInput<'_>>,
 ) -> CodegenResult<LlvmModule<'ctx>> {
     pipeline.debug_assert_capabilities_current();
+    let mir_stages = validate_and_index_mir_stages(pipeline)?;
     let llvm_mod = ctx.create_module(name);
     let emit_wasm_entry_alias = target_machine.is_some_and(|machine| {
         machine
@@ -38136,27 +38230,20 @@ fn build_module_for_target<'ctx>(
             // through `declare_function`.
             continue;
         }
-        // Match by name: elaborated_mir is parallel to raw_mir when the
-        // full pipeline runs. Hand-built test pipelines may leave
-        // elaborated_mir empty; `find` returns `None` in that case and
-        // `lower_function` falls back to the inline Instr::Drop path.
-        let elab = pipeline.elaborated_mir.iter().find(|e| e.name == func.name);
-        let checked = if pipeline.checked_mir.is_empty() {
-            None
-        } else {
-            Some(
-                pipeline
-                    .checked_mir
-                    .iter()
-                    .find(|c| c.name == func.name)
-                    .ok_or_else(|| {
-                        CodegenError::FailClosed(format!(
-                            "function `{}` has no matching checked MIR for cooperate-site lowering",
-                            func.name
-                        ))
-                    })?,
-            )
-        };
+        let elab = *mir_stages.elaborated.get(&func.key).ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "validated Elaborated MIR index lost callable key {} for `{}`",
+                mir_callable_key_label(&func.key),
+                func.name
+            ))
+        })?;
+        let checked = *mir_stages.checked.get(&func.key).ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "validated Checked MIR index lost callable key {} for `{}`",
+                mir_callable_key_label(&func.key),
+                func.name
+            ))
+        })?;
         lower_function(
             ctx,
             &llvm_mod,

--- a/hew-codegen-rs/src/llvm_tests.rs
+++ b/hew-codegen-rs/src/llvm_tests.rs
@@ -816,6 +816,46 @@ fn mir_stage_boundary_rejects_duplicate_key_in_every_stage() {
 }
 
 #[test]
+fn mir_stage_boundary_rejects_unmatched_extra_checked_artifact() {
+    let mut pipeline = empty_pipeline_with_const_42();
+    let mut extra = pipeline.checked_mir[0].clone();
+    extra.name = "orphan_checked_symbol".to_string();
+    extra.key = MirCallableKey::for_test("fixture.stage.orphan.checked");
+    pipeline.checked_mir.push(extra);
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &pipeline, "orphan_checked_stage")
+        .expect_err("an unmatched Checked artifact must fail before emission");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("an unmatched Checked artifact must fail closed");
+    };
+    assert_eq!(
+        message,
+        "Checked MIR function `orphan_checked_symbol` with callable key fixture.stage.orphan.checked (Monomorphic) has no matching Raw MIR artifact"
+    );
+}
+
+#[test]
+fn mir_stage_boundary_rejects_unmatched_extra_elaborated_artifact() {
+    let mut pipeline = empty_pipeline_with_const_42();
+    let mut extra = pipeline.elaborated_mir[0].clone();
+    extra.name = "orphan_elaborated_symbol".to_string();
+    extra.key = MirCallableKey::for_test("fixture.stage.orphan.elaborated");
+    pipeline.elaborated_mir.push(extra);
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &pipeline, "orphan_elaborated_stage")
+        .expect_err("an unmatched Elaborated artifact must fail before emission");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("an unmatched Elaborated artifact must fail closed");
+    };
+    assert_eq!(
+        message,
+        "Elaborated MIR function `orphan_elaborated_symbol` with callable key fixture.stage.orphan.elaborated (Monomorphic) has no matching Raw MIR artifact"
+    );
+}
+
+#[test]
 fn mir_stage_boundary_rejects_crossed_callable_keys() {
     let mut first = empty_pipeline_with_const_42();
     first.raw_mir[0].name = "first_symbol".to_string();

--- a/hew-codegen-rs/src/llvm_tests.rs
+++ b/hew-codegen-rs/src/llvm_tests.rs
@@ -424,6 +424,72 @@ fn catalog_ffi_symbols_agree_across_all_shared_symbol_entries() {
     );
 }
 
+fn fixture_stages(raw: &RawMirFunction) -> (CheckedMirFunction, ElaboratedMirFunction) {
+    let elaborated = ElaboratedMirFunction {
+        name: raw.name.clone(),
+        key: raw.key.clone(),
+        return_ty: raw.return_ty.clone(),
+        statements: raw
+            .blocks
+            .iter()
+            .flat_map(|block| block.statements.iter().cloned())
+            .collect(),
+        decisions: raw.decisions.clone(),
+        blocks: raw
+            .blocks
+            .iter()
+            .map(|block| ElabBlock {
+                id: block.id,
+                kind: BlockKind::Normal,
+                drops: Vec::new(),
+                successor: None,
+            })
+            .collect(),
+        drop_plans: Vec::new(),
+        coroutine: None,
+        lambda_captures: Vec::new(),
+    };
+    let checked = CheckedMirFunction {
+        name: raw.name.clone(),
+        key: raw.key.clone(),
+        return_ty: raw.return_ty.clone(),
+        blocks: raw.blocks.clone(),
+        decisions: raw.decisions.clone(),
+        checks: Vec::new(),
+        cooperate_sites: Vec::new(),
+        ownership_elaboration: Some(Box::new(elaborated.clone())),
+    };
+    (checked, elaborated)
+}
+
+fn complete_fixture_stages(mut pipeline: IrPipeline) -> IrPipeline {
+    for raw in &pipeline.raw_mir {
+        let (mut checked, derived_elaborated) = fixture_stages(raw);
+        let elaborated = pipeline
+            .elaborated_mir
+            .iter()
+            .find(|elaborated| elaborated.key == raw.key)
+            .cloned()
+            .unwrap_or(derived_elaborated);
+        if !pipeline
+            .elaborated_mir
+            .iter()
+            .any(|candidate| candidate.key == raw.key)
+        {
+            pipeline.elaborated_mir.push(elaborated.clone());
+        }
+        if !pipeline
+            .checked_mir
+            .iter()
+            .any(|candidate| candidate.key == raw.key)
+        {
+            checked.ownership_elaboration = Some(Box::new(elaborated));
+            pipeline.checked_mir.push(checked);
+        }
+    }
+    pipeline
+}
+
 fn empty_pipeline_with_const_42() -> IrPipeline {
     let return_ty = ResolvedTy::I64;
     let main = RawMirFunction {
@@ -462,7 +528,7 @@ fn empty_pipeline_with_const_42() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![main],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -485,7 +551,7 @@ fn empty_pipeline_with_const_42() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// Raw-MIR fixture for the first value-only ABI proof. The two scalar
@@ -681,8 +747,8 @@ fn virtual_raw_values_require_checked_and_elaborated_mir_at_codegen() {
         panic!("missing virtual Checked MIR must fail closed");
     };
     assert!(
-        message.contains("requires matching Checked MIR"),
-        "missing Checked MIR must be diagnosed at virtual admission: {message}"
+        message.contains("no matching Checked MIR artifact"),
+        "missing Checked MIR must be diagnosed at the stage boundary: {message}"
     );
 
     let ctx = Context::create();
@@ -694,9 +760,127 @@ fn virtual_raw_values_require_checked_and_elaborated_mir_at_codegen() {
         panic!("missing virtual Elaborated MIR must fail closed");
     };
     assert!(
-        message.contains("requires matching Elaborated MIR"),
-        "missing Elaborated MIR must be diagnosed at virtual admission: {message}"
+        message.contains("no matching Elaborated MIR artifact"),
+        "missing Elaborated MIR must be diagnosed at the stage boundary: {message}"
     );
+}
+
+#[test]
+fn mir_stage_join_rejects_same_name_with_different_key() {
+    let mut pipeline = empty_pipeline_with_const_42();
+    pipeline.checked_mir[0].key =
+        MirCallableKey::for_test("fixture.stage.checked.same-name-wrong-key");
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &pipeline, "same_name_wrong_key")
+        .expect_err("a matching presentation name must not substitute for callable identity");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("same-name/different-key stage join must fail closed");
+    };
+    assert!(
+        message.contains("no matching Checked MIR artifact"),
+        "the stage join must use only MirCallableKey: {message}"
+    );
+}
+
+#[test]
+fn mir_stage_boundary_rejects_duplicate_key_in_every_stage() {
+    let base = empty_pipeline_with_const_42();
+    let mut duplicate_raw = base.clone();
+    duplicate_raw.raw_mir.push(base.raw_mir[0].clone());
+    let mut duplicate_checked = base.clone();
+    duplicate_checked
+        .checked_mir
+        .push(base.checked_mir[0].clone());
+    let mut duplicate_elaborated = base;
+    duplicate_elaborated
+        .elaborated_mir
+        .push(duplicate_elaborated.elaborated_mir[0].clone());
+
+    for (stage, pipeline) in [
+        ("Raw", duplicate_raw),
+        ("Checked", duplicate_checked),
+        ("Elaborated", duplicate_elaborated),
+    ] {
+        let ctx = Context::create();
+        let error = build_module(&ctx, &pipeline, "duplicate_stage_key")
+            .expect_err("duplicate stage artifacts must fail before emission");
+        let CodegenError::FailClosed(message) = error else {
+            panic!("duplicate {stage} key must fail closed");
+        };
+        assert!(
+            message.contains(&format!("duplicate {stage} MIR callable key")),
+            "the duplicate-key diagnostic must name the rejected stage: {message}"
+        );
+    }
+}
+
+#[test]
+fn mir_stage_boundary_rejects_crossed_callable_keys() {
+    let mut first = empty_pipeline_with_const_42();
+    first.raw_mir[0].name = "first_symbol".to_string();
+    first.checked_mir[0].name = "first_symbol".to_string();
+    first.elaborated_mir[0].name = "first_symbol".to_string();
+    let first_key = MirCallableKey::for_test("fixture.stage.first");
+    first.raw_mir[0].key = first_key.clone();
+    first.checked_mir[0].key = first_key.clone();
+    first.elaborated_mir[0].key = first_key;
+
+    let mut second_raw = first.raw_mir[0].clone();
+    second_raw.name = "second_symbol".to_string();
+    second_raw.key = MirCallableKey::for_test("fixture.stage.second");
+    let (second_checked, second_elaborated) = fixture_stages(&second_raw);
+    first.raw_mir.push(second_raw);
+    first.checked_mir.push(second_checked);
+    first.elaborated_mir.push(second_elaborated);
+
+    let checked_first_key = first.checked_mir[0].key.clone();
+    first.checked_mir[0].key = first.checked_mir[1].key.clone();
+    first.checked_mir[1].key = checked_first_key;
+
+    let ctx = Context::create();
+    let error = build_module(&ctx, &first, "crossed_stage_keys")
+        .expect_err("crossed stage identities must not associate by vector position or name");
+    let CodegenError::FailClosed(message) = error else {
+        panic!("crossed callable keys must fail closed");
+    };
+    assert!(
+        message.contains("disagree on linkage/display name"),
+        "wrong stage keys must expose the crossed artifact rather than silently join: {message}"
+    );
+}
+
+#[test]
+fn mir_stage_boundary_rejects_same_key_metadata_drift() {
+    let base = empty_pipeline_with_const_42();
+    let mut wrong_name = base.clone();
+    wrong_name.checked_mir[0].name = "wrong_checked_symbol".to_string();
+    let mut wrong_return = base;
+    wrong_return.elaborated_mir[0].return_ty = ResolvedTy::Unit;
+
+    for (slug, pipeline, expected) in [
+        (
+            "wrong_stage_name",
+            wrong_name,
+            "disagree on linkage/display name",
+        ),
+        (
+            "wrong_stage_return",
+            wrong_return,
+            "disagree on return type",
+        ),
+    ] {
+        let ctx = Context::create();
+        let error = build_module(&ctx, &pipeline, slug)
+            .expect_err("same-key stage metadata drift must fail before emission");
+        let CodegenError::FailClosed(message) = error else {
+            panic!("same-key stage metadata drift must fail closed");
+        };
+        assert!(
+            message.contains(expected),
+            "the mismatch diagnostic must identify the drift: {message}"
+        );
+    }
 }
 
 #[test]
@@ -765,6 +949,8 @@ fn virtual_raw_tuple_return_abi_is_rejected_before_layout_lowering() {
         panic!("fixture instruction 4 must be ReturnAbi materialization");
     };
     *value = RawValueId(2);
+    pipeline.checked_mir[0].return_ty = pipeline.raw_mir[0].return_ty.clone();
+    pipeline.elaborated_mir[0].return_ty = pipeline.raw_mir[0].return_ty.clone();
 
     let ctx = Context::create();
     let error = build_module(&ctx, &pipeline, "virtual_raw_tuple_return")
@@ -1068,6 +1254,8 @@ fn debug_subroutine_keeps_unresolved_parameter_slot_order() {
         dest: Place::ReturnSlot,
         src: Place::Local(1),
     }];
+    pipeline.checked_mir[0].name = handler.name.clone();
+    pipeline.elaborated_mir[0].name = handler.name.clone();
 
     let ctx = Context::create();
     let debug = DebugInput {
@@ -1477,7 +1665,9 @@ fn platform_int_width_probe_pipeline() -> IrPipeline {
         field_tys: vec![ResolvedTy::Usize, ResolvedTy::Isize],
         field_names: vec!["unsigned".to_string(), "signed".to_string()],
     }];
-    pipeline
+    pipeline.checked_mir.clear();
+    pipeline.elaborated_mir.clear();
+    complete_fixture_stages(pipeline)
 }
 
 fn platform_int_width_probe_ir(triple: &str) -> String {
@@ -1878,6 +2068,7 @@ fn non_context_function_callclosure_uses_zeroed_fallback_context() {
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
 
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m = build_module(&ctx, &pipeline, "call_closure_default_context")
         .expect("default-callconv CallClosure must build with a fallback context");
@@ -1916,7 +2107,7 @@ fn hashmap_descriptor_width_probe_pipeline() -> IrPipeline {
         terminator: Terminator::Return,
     };
     let blocks = vec![entry, ret];
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![RawMirFunction {
             source_origin: hew_mir::SourceOrigin::Unknown,
             key: hew_mir::MirCallableKey::for_test("main"),
@@ -1971,7 +2162,7 @@ fn hashmap_descriptor_width_probe_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn hashmap_descriptor_probe_ir(module_name: &str, triple: Option<&str>) -> String {
@@ -2056,7 +2247,7 @@ fn vec_descriptor_width_probe_pipeline() -> IrPipeline {
         instructions: Vec::new(),
         terminator: Terminator::Return,
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![RawMirFunction {
             source_origin: hew_mir::SourceOrigin::Unknown,
             key: hew_mir::MirCallableKey::for_test("main"),
@@ -2104,7 +2295,7 @@ fn vec_descriptor_width_probe_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn vec_descriptor_probe_ir(module_name: &str, triple: Option<&str>) -> String {
@@ -2189,7 +2380,7 @@ fn pipeline_with_user_const_load(
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![main],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -2218,7 +2409,7 @@ fn pipeline_with_user_const_load(
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 #[test]
@@ -2326,7 +2517,7 @@ fn pipeline_with_float_return() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![main],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -2349,7 +2540,7 @@ fn pipeline_with_float_return() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn unique_codegen_front_artifact_stem(test_name: &str) -> std::path::PathBuf {
@@ -2486,6 +2677,7 @@ fn actor_handler_signature_leads_with_execution_context_pointer() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m =
         build_module(&ctx, &pipeline, "handler_ctx_test").expect("actor-handler module must build");
@@ -2574,6 +2766,7 @@ fn context_field_actor_offset_emits_gep_and_load() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m = build_module(&ctx, &pipeline, "ctx_field_test")
         .expect("ContextField actor load must build");
@@ -2656,6 +2849,7 @@ fn string_literal_return_builds_and_verifies() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m = build_module(&ctx, &pipeline, "string_lit_test").expect("StringLit module must build");
     assert!(m.verify().is_ok(), "StringLit module must pass LLVM verify");
@@ -2916,7 +3110,7 @@ fn pipeline_with_select_terminator(arm_kind: hew_mir::SelectArmKind) -> IrPipeli
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![main],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -2939,7 +3133,7 @@ fn pipeline_with_select_terminator(arm_kind: hew_mir::SelectArmKind) -> IrPipeli
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// Stream-next arms allocate their own readiness channel, register
@@ -3133,7 +3327,7 @@ fn pipeline_with_select_arms(
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![main],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -3156,7 +3350,7 @@ fn pipeline_with_select_arms(
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn pipeline_with_select_actor_handler_arms(
@@ -4271,6 +4465,7 @@ fn generic_enum_local_resolves_by_mangled_key() {
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
 
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m = build_module(&ctx, &pipeline, "generic_enum_mangle_test")
         .expect("Option<i64> local must resolve via mangled key; bare-name lookup is wrong");
@@ -4360,6 +4555,7 @@ fn yield_terminator_lowers_to_coro_suspend_and_publishes_out_pointer() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m = build_module(&ctx, &pipeline, "gen_yield_codegen_test")
         .expect("Terminator::Yield must lower without error");
@@ -4525,6 +4721,7 @@ fn make_generator_terminator_constructs_coro_companion_and_module_verifies() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m = build_module(&ctx, &pipeline, "make_generator_codegen_test")
         .expect("Terminator::MakeGenerator must lower without error");
@@ -5009,6 +5206,7 @@ fn cancellation_token_is_cancelled_emits_runtime_observation_call() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m = build_module(&ctx, &pipeline, "cancel_token_is_cancelled_codegen_test")
         .expect("CancellationToken.is_cancelled must lower to runtime observation call");
@@ -5432,7 +5630,7 @@ fn wasm_exclusion_scan_flags_runtime_duplex_close_in_elab_drop() {
 /// Wrap a single raw-MIR function into an otherwise-empty `IrPipeline` for
 /// the wasm-exclusion-scan regressions.
 fn raw_mir_only_pipeline(body: RawMirFunction) -> IrPipeline {
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![body],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -5455,7 +5653,7 @@ fn raw_mir_only_pipeline(body: RawMirFunction) -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 #[test]
@@ -5579,7 +5777,11 @@ fn native_direct_call_uses_llvm_cleanup_unwind_edge() {
     };
     let mut pipeline = raw_mir_only_pipeline(caller);
     pipeline.raw_mir.insert(0, callee);
+    pipeline
+        .elaborated_mir
+        .retain(|candidate| candidate.key != elab.key);
     pipeline.elaborated_mir.push(elab);
+    let pipeline = complete_fixture_stages(pipeline);
 
     for triple in cleanup_strategy_test_triples() {
         let ctx = Context::create();
@@ -10440,6 +10642,7 @@ fn coerce_to_dyn_trait_arm_emits_fat_ptr_when_vtable_registry_populated() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let tmp = tempfile::Builder::new()
         .prefix("hew-dyn-coerce-ok-")
         .tempdir()
@@ -10809,6 +11012,7 @@ fn coerce_to_dyn_trait_fails_closed_when_source_slot_disagrees_with_concrete_typ
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let tmp = tempfile::Builder::new()
         .prefix("hew-dyn-coerce-slot-mismatch-")
         .tempdir()
@@ -10923,6 +11127,7 @@ fn coerce_to_dyn_trait_arm_fails_closed_when_vtable_registry_missing_entry() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let tmp = tempfile::Builder::new()
         .prefix("hew-dyn-coerce-miss-")
         .tempdir()
@@ -11106,7 +11311,7 @@ fn helper_crash_cleanup_write_set_admits_grounded_string_literal_owner() {
     };
     let descriptors = collect_helper_crash_cleanup_descriptors(
         &raw,
-        Some(&elab),
+        &elab,
         false,
         true,
         &HashMap::new(),
@@ -11277,7 +11482,7 @@ fn helper_crash_cleanup_uses_guarded_owner_across_entry_cancel_plan() {
         };
         let descriptors = collect_helper_crash_cleanup_descriptors(
             &raw,
-            Some(&elab),
+            &elab,
             false,
             true,
             &HashMap::new(),
@@ -11771,7 +11976,7 @@ fn helper_crash_cleanup_terminator_admission_matches_hooked_lowering_tails() {
         };
         let result = collect_helper_crash_cleanup_descriptors(
             &raw,
-            Some(&elab),
+            &elab,
             false,
             true,
             &HashMap::new(),
@@ -12181,6 +12386,7 @@ fn frame_owned_trait_object_drop_with_drop_fn_fails_closed() {
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
+    let pipeline = complete_fixture_stages(pipeline);
     let tmp = tempfile::Builder::new()
         .prefix("hew-frame-owned-drop-fail-")
         .tempdir()
@@ -12295,7 +12501,7 @@ fn single_resource_drop_pipeline(name: &str, resource_ty: ResolvedTy) -> IrPipel
         coroutine: None,
         lambda_captures: vec![],
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![raw],
         checked_mir: vec![],
         elaborated_mir: vec![elab],
@@ -12318,7 +12524,7 @@ fn single_resource_drop_pipeline(name: &str, resource_ty: ResolvedTy) -> IrPipel
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A `CancellationToken` owns a `release` close. Reaching codegen as a
@@ -12679,7 +12885,7 @@ fn minimal_pipeline_with_unit_main(with_actor: bool) -> IrPipeline {
     } else {
         vec![]
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![main],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -12702,7 +12908,7 @@ fn minimal_pipeline_with_unit_main(with_actor: bool) -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// For a native actor-using program, the `main` function's IR must contain
@@ -12909,6 +13115,7 @@ fn on_crash_definition_consumes_trailing_actor_state_pointer() {
         state_drop_fn_symbol: None,
         state_field_clone_kinds: None,
     }];
+    let pipeline = complete_fixture_stages(pipeline);
 
     let ctx = Context::create();
     let module = build_module(&ctx, &pipeline, "crash_state_pointer")
@@ -13057,7 +13264,7 @@ fn pipeline_with_coro_probe() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![probe],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -13080,7 +13287,7 @@ fn pipeline_with_coro_probe() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A function carrying `Terminator::Suspend` lowers to a `presplitcoroutine`
@@ -13269,7 +13476,7 @@ fn pipeline_with_string_stream_send_pump() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![probe],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -13292,7 +13499,7 @@ fn pipeline_with_string_stream_send_pump() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A `string`-typed `SuspendKind::StreamSend` (the receive-gen-fn pump's
@@ -14043,7 +14250,9 @@ fn wasm_string_concat_rearms_cleanup_at_runtime_abi_producer_boundary() {
     };
     let mut pipeline = empty_pipeline_with_const_42();
     pipeline.raw_mir = vec![raw];
+    pipeline.checked_mir.clear();
     pipeline.elaborated_mir = vec![elab];
+    let pipeline = complete_fixture_stages(pipeline);
 
     let ctx = Context::create();
     let machine = target_machine_for_triple("wasm32-wasi")
@@ -14163,7 +14372,9 @@ fn wasm_vec_new_rearms_cleanup_after_complete_handle_publication() {
     };
     let mut pipeline = empty_pipeline_with_const_42();
     pipeline.raw_mir = vec![raw];
+    pipeline.checked_mir.clear();
     pipeline.elaborated_mir = vec![elab];
+    let pipeline = complete_fixture_stages(pipeline);
 
     let ctx = Context::create();
     let machine = target_machine_for_triple("wasm32-wasi")
@@ -14968,7 +15179,7 @@ fn pipeline_with_two_suspends() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir: vec![probe],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -14991,7 +15202,7 @@ fn pipeline_with_two_suspends() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A coroutine with TWO non-final suspends emits exactly ONE fallthrough
@@ -15188,6 +15399,7 @@ fn non_ptr_logical_return_coro_fn_compiles_as_ptr_ramp() {
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
 
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let module = build_module(&ctx, &pipeline, "non_ptr_coro_test").expect(
         "W6.010: a suspend-carrying fn with a non-ptr logical return must \
@@ -15498,7 +15710,7 @@ fn pipeline_with_actor_handlers(
         state_drop_fn_symbol: None,
         state_field_clone_kinds: None,
     };
-    IrPipeline {
+    complete_fixture_stages(IrPipeline {
         raw_mir,
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -15521,7 +15733,7 @@ fn pipeline_with_actor_handlers(
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A unit-reply suspendable handler layout (the simplest driver shape: no
@@ -15693,6 +15905,9 @@ fn owned_state_source_transfer_rejection_is_process_fatal_before_live_store() {
         field_tys: vec![ResolvedTy::String],
         field_names: vec!["value".to_string()],
     });
+    pipeline
+        .elaborated_mir
+        .retain(|candidate| candidate.key != hew_mir::MirCallableKey::for_test(symbol));
     pipeline
         .elaborated_mir
         .push(hew_mir::ElaboratedMirFunction {
@@ -19408,6 +19623,7 @@ fn closure_env_free_thunk_ir(ownership: hew_mir::ClosureEnvFieldOwnership, modul
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
     };
 
+    let pipeline = complete_fixture_stages(pipeline);
     let ctx = Context::create();
     let m = build_module(&ctx, &pipeline, module).expect("heap-box closure env module must build");
     m.verify().expect("heap-box closure env module must verify");

--- a/hew-codegen-rs/tests/abi.rs
+++ b/hew-codegen-rs/tests/abi.rs
@@ -2,6 +2,9 @@
 // Add new abi-behaviour tests under `tests/abi/`, wire them into this
 // file via #[path] — do not create a new top-level tests/*.rs file.
 
+#[path = "support/mir_fixture.rs"]
+mod mir_fixture;
+
 #[path = "abi/abi_offset_parity.rs"]
 mod abi_offset_parity;
 #[path = "abi/actor_dispatch_borrow_abi.rs"]

--- a/hew-codegen-rs/tests/abi/actor_dispatch_borrow_abi.rs
+++ b/hew-codegen-rs/tests/abi/actor_dispatch_borrow_abi.rs
@@ -1094,7 +1094,7 @@ fn boxed_enum_recv_pipeline() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![handler],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -1117,7 +1117,7 @@ fn boxed_enum_recv_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 #[test]

--- a/hew-codegen-rs/tests/abi/cycle_capable_spawn_abi.rs
+++ b/hew-codegen-rs/tests/abi/cycle_capable_spawn_abi.rs
@@ -93,7 +93,7 @@ fn spawn_pipeline(
         state_field_clone_kinds: None,
     };
 
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![spawn_fn],
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -116,7 +116,7 @@ fn spawn_pipeline(
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {

--- a/hew-codegen-rs/tests/abi/dyn_trait_method_dispatch.rs
+++ b/hew-codegen-rs/tests/abi/dyn_trait_method_dispatch.rs
@@ -60,7 +60,7 @@ fn dyn_trait_ty(trait_name: &str) -> ResolvedTy {
 }
 
 fn empty_pipeline(raw_mir: Vec<RawMirFunction>) -> IrPipeline {
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir,
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -83,7 +83,7 @@ fn empty_pipeline(raw_mir: Vec<RawMirFunction>) -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {

--- a/hew-codegen-rs/tests/emission.rs
+++ b/hew-codegen-rs/tests/emission.rs
@@ -2,6 +2,9 @@
 // Add new emission-behaviour tests under `tests/emission/`, wire them into this
 // file via #[path] — do not create a new top-level tests/*.rs file.
 
+#[path = "support/mir_fixture.rs"]
+mod mir_fixture;
+
 #[path = "ir_assertions.rs"]
 mod ir_assertions;
 

--- a/hew-codegen-rs/tests/emission/cooperate_emission.rs
+++ b/hew-codegen-rs/tests/emission/cooperate_emission.rs
@@ -57,7 +57,7 @@ fn loop_pipeline_with_sites(cooperate_sites: Vec<CooperateSite>) -> IrPipeline {
             terminator: Terminator::Goto { target: 0 },
         },
     ];
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![RawMirFunction {
             source_origin: hew_mir::SourceOrigin::Unknown,
             key: hew_mir::MirCallableKey::for_test("main"),
@@ -110,7 +110,7 @@ fn loop_pipeline_with_sites(cooperate_sites: Vec<CooperateSite>) -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn loop_pipeline() -> IrPipeline {
@@ -255,12 +255,12 @@ fn loop_back_edge_on_missing_bb_fails_closed() {
 #[test]
 fn missing_checked_mir_function_fails_closed() {
     let mut pipeline = loop_pipeline();
-    pipeline.checked_mir[0].name = "other".to_string();
+    pipeline.checked_mir.clear();
 
     let msg = expect_fail_closed(&pipeline, "missing_checked_mir_function");
 
     assert!(
-        msg.contains("main") && msg.contains("no matching checked MIR"),
+        msg.contains("main") && msg.contains("no matching Checked MIR"),
         "FailClosed must identify the raw_mir function missing checked MIR; got: {msg}"
     );
 }

--- a/hew-codegen-rs/tests/emission/dyn_trait_drop_in_place_emission.rs
+++ b/hew-codegen-rs/tests/emission/dyn_trait_drop_in_place_emission.rs
@@ -106,7 +106,7 @@ fn pipeline_with(
     registry: Vec<DynVtableInstance>,
     record_layouts: Vec<RecordLayout>,
 ) -> IrPipeline {
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir,
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -129,7 +129,7 @@ fn pipeline_with(
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {

--- a/hew-codegen-rs/tests/emission/dyn_trait_thunk_emission.rs
+++ b/hew-codegen-rs/tests/emission/dyn_trait_thunk_emission.rs
@@ -128,7 +128,7 @@ fn vtable_instance(
 }
 
 fn pipeline_with(raw_mir: Vec<RawMirFunction>, registry: Vec<DynVtableInstance>) -> IrPipeline {
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir,
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -151,7 +151,7 @@ fn pipeline_with(raw_mir: Vec<RawMirFunction>, registry: Vec<DynVtableInstance>)
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {

--- a/hew-codegen-rs/tests/emission/dyn_trait_vtable_emission.rs
+++ b/hew-codegen-rs/tests/emission/dyn_trait_vtable_emission.rs
@@ -144,7 +144,7 @@ fn vtable_instance(
 }
 
 fn pipeline_with(raw_mir: Vec<RawMirFunction>, registry: Vec<DynVtableInstance>) -> IrPipeline {
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir,
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -167,7 +167,7 @@ fn pipeline_with(raw_mir: Vec<RawMirFunction>, registry: Vec<DynVtableInstance>)
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {

--- a/hew-codegen-rs/tests/emission/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/emission/supervisor_emission.rs
@@ -180,12 +180,8 @@ fn supervisor_pipeline() -> IrPipeline {
         }],
     };
 
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![bootstrap_fn.clone(), main_fn.clone()],
-        // Keep `checked_mir` empty — the build_module skip-set bypasses
-        // lower_function for the bootstrap symbol, and `main`'s body has no
-        // cooperate sites. An empty `checked_mir` triggers the
-        // hand-built-test fallback path (see `build_module`).
         checked_mir: vec![],
         elaborated_mir: vec![],
         capabilities: hew_mir::ModuleCapabilities::EMPTY,
@@ -211,7 +207,7 @@ fn supervisor_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn emit_to_string(pipeline: &IrPipeline, slug: &str) -> String {
@@ -503,7 +499,7 @@ fn on_crash_pipeline() -> IrPipeline {
         }],
     };
 
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![on_crash_fn, bootstrap_fn, main_fn],
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -526,7 +522,7 @@ fn on_crash_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// When a child's actor has `#[on(crash)]`, the emitted child spec must carry
@@ -845,7 +841,7 @@ fn nested_supervisor_pipeline() -> IrPipeline {
         ],
     };
 
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![root_fn, inner_fn, main_fn],
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -868,7 +864,7 @@ fn nested_supervisor_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A nested-supervisor child registers through
@@ -1053,7 +1049,7 @@ fn pool_then_static_pipeline() -> IrPipeline {
         ],
     };
 
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![bootstrap_fn, main_fn],
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -1076,7 +1072,7 @@ fn pool_then_static_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A static pool (`pool name: Type(count: N)`) now spawns its N members as

--- a/hew-codegen-rs/tests/emission/task_abi_emission.rs
+++ b/hew-codegen-rs/tests/emission/task_abi_emission.rs
@@ -171,7 +171,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
         ],
         terminator: Terminator::Return,
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![
             RawMirFunction {
                 source_origin: hew_mir::SourceOrigin::Unknown,
@@ -260,7 +260,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
@@ -285,7 +285,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
         }],
         terminator: Terminator::Return,
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![
             RawMirFunction {
                 source_origin: hew_mir::SourceOrigin::Unknown,
@@ -374,7 +374,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn pipeline_with_spawn_task_closure() -> IrPipeline {
@@ -420,7 +420,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
         }],
         terminator: Terminator::Return,
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![
             RawMirFunction {
                 source_origin: hew_mir::SourceOrigin::Unknown,
@@ -517,7 +517,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// `hew_task_new` must produce a `declare ptr @hew_task_new()` in the IR

--- a/hew-codegen-rs/tests/emission/wasm_actor_metadata_emission.rs
+++ b/hew-codegen-rs/tests/emission/wasm_actor_metadata_emission.rs
@@ -140,7 +140,7 @@ fn spawn_pipeline() -> IrPipeline {
         state_field_clone_kinds: None,
     };
 
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![spawn_fn, handler_fn],
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -163,7 +163,7 @@ fn spawn_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {

--- a/hew-codegen-rs/tests/exec.rs
+++ b/hew-codegen-rs/tests/exec.rs
@@ -2,6 +2,9 @@
 // Add new exec-behaviour tests under `tests/exec/`, wire them into this
 // file via #[path] — do not create a new top-level tests/*.rs file.
 
+#[path = "support/mir_fixture.rs"]
+mod mir_fixture;
+
 use std::process::{Command, Output};
 
 fn run_hew_command(command: &mut Command, label: impl Into<String>) -> Output {

--- a/hew-codegen-rs/tests/exec/machine_emit_exec.rs
+++ b/hew-codegen-rs/tests/exec/machine_emit_exec.rs
@@ -184,7 +184,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
         instr_spans: ::std::collections::BTreeMap::new(),
     };
 
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![step_fn, caller],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -207,7 +207,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// Emit the pipeline to a `.ll` file and return the IR text.

--- a/hew-codegen-rs/tests/exec/mem_floor_intrinsic_exec.rs
+++ b/hew-codegen-rs/tests/exec/mem_floor_intrinsic_exec.rs
@@ -27,10 +27,7 @@
 #![cfg(unix)]
 
 use hew_codegen_rs::{emit_module, CodegenError, EmitOptions};
-use hew_mir::{
-    BasicBlock, CheckedMirFunction, ElaboratedMirFunction, FunctionCallConv, Instr, IrPipeline,
-    Place, RawMirFunction, Terminator,
-};
+use hew_mir::{BasicBlock, FunctionCallConv, Instr, IrPipeline, Place, RawMirFunction, Terminator};
 use hew_types::ResolvedTy;
 
 // ── pipeline builders ──
@@ -240,7 +237,7 @@ fn floor_exec_pipeline() -> IrPipeline {
 }
 
 fn floor_pipeline_with_driver(driver: RawMirFunction) -> IrPipeline {
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![
             floor_fn(
                 "mem$alloc",
@@ -279,11 +276,8 @@ fn floor_pipeline_with_driver(driver: RawMirFunction) -> IrPipeline {
             ),
             driver,
         ],
-        // Empty checked/elaborated MIR: these functions carry no cooperate
-        // sites and no drop plans, so the codegen loop's per-function lookup
-        // resolves to `None` (the hand-built-pipeline fallback path).
-        checked_mir: vec![] as Vec<CheckedMirFunction>,
-        elaborated_mir: vec![] as Vec<ElaboratedMirFunction>,
+        checked_mir: vec![],
+        elaborated_mir: vec![],
         capabilities: hew_mir::ModuleCapabilities::EMPTY,
         diagnostics: vec![],
         wire_layouts: std::sync::Arc::default(),
@@ -303,7 +297,7 @@ fn floor_pipeline_with_driver(driver: RawMirFunction) -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 // ── WASM parity ────────────────────────────────────────────────────────────

--- a/hew-codegen-rs/tests/exec/user_enum_exec.rs
+++ b/hew-codegen-rs/tests/exec/user_enum_exec.rs
@@ -180,7 +180,7 @@ fn colour_red_pipeline() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![main_fn],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -203,7 +203,7 @@ fn colour_red_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// The tagged-union outer struct must be emitted under the enum type name

--- a/hew-codegen-rs/tests/pipeline.rs
+++ b/hew-codegen-rs/tests/pipeline.rs
@@ -2,6 +2,9 @@
 // Add new pipeline-behaviour tests under `tests/pipeline/`, wire them into this
 // file via #[path] — do not create a new top-level tests/*.rs file.
 
+#[path = "support/mir_fixture.rs"]
+mod mir_fixture;
+
 #[path = "pipeline/dwarf_emitted_object.rs"]
 mod dwarf_emitted_object;
 #[path = "pipeline/dwarf_variable_dies.rs"]

--- a/hew-codegen-rs/tests/pipeline/verify_pipeline.rs
+++ b/hew-codegen-rs/tests/pipeline/verify_pipeline.rs
@@ -58,7 +58,7 @@ fn pipeline_const_42() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![main],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -81,7 +81,7 @@ fn pipeline_const_42() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A pipeline whose function declares an array return type. Array returns are
@@ -116,7 +116,7 @@ fn pipeline_unsupported_array_return() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![main],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -139,7 +139,7 @@ fn pipeline_unsupported_array_return() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-codegen-rs/tests/structural.rs
+++ b/hew-codegen-rs/tests/structural.rs
@@ -2,6 +2,9 @@
 // Add new structural-behaviour tests under `tests/structural/`, wire them into this
 // file via #[path] — do not create a new top-level tests/*.rs file.
 
+#[path = "support/mir_fixture.rs"]
+mod mir_fixture;
+
 #[path = "ir_assertions.rs"]
 mod ir_assertions;
 

--- a/hew-codegen-rs/tests/structural/composite_return.rs
+++ b/hew-codegen-rs/tests/structural/composite_return.rs
@@ -119,7 +119,7 @@ fn option_some_pipeline() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![maybe_fn],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -142,7 +142,7 @@ fn option_some_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// Build a pipeline with `fn greet() -> Option<string> { Some("hello") }`.
@@ -222,7 +222,7 @@ fn option_string_pipeline() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![greet_fn],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -245,7 +245,7 @@ fn option_string_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// Option<i64> composite return produces valid LLVM IR with aggregate ret.
@@ -361,7 +361,7 @@ fn envelope_i64_pipeline() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![send_fn],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -384,7 +384,7 @@ fn envelope_i64_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// W5.020 — `Envelope<i64>` with a non-param `Message(string)` variant is a
@@ -445,7 +445,7 @@ fn bytes_return_pipeline() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![make_fn],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -468,7 +468,7 @@ fn bytes_return_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A plain top-level `bytes` return is a single heap-owning leaf and must lower
@@ -522,7 +522,7 @@ fn tuple_of_bytes_return_pipeline() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![make_fn],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -545,7 +545,7 @@ fn tuple_of_bytes_return_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A `(bytes,)` tuple return is admitted via the W5.021 tuple drop spine: the
@@ -613,7 +613,7 @@ fn generic_record_of_string_return_pipeline() -> IrPipeline {
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
     };
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![make_fn],
         checked_mir: Vec::new(),
         elaborated_mir: Vec::new(),
@@ -636,7 +636,7 @@ fn generic_record_of_string_return_pipeline() -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 /// A generic record instantiation (`Pair<string>`) carrying owned heap reaches

--- a/hew-codegen-rs/tests/structural/lifecycle_state_transaction.rs
+++ b/hew-codegen-rs/tests/structural/lifecycle_state_transaction.rs
@@ -72,13 +72,13 @@ fn with_required_system_store_counterfactuals(mut pipeline: IrPipeline) -> IrPip
     let checked = pipeline
         .checked_mir
         .iter()
-        .find(|function| function.name == receive.name)
+        .find(|function| function.key == receive.key)
         .expect("checked receive state-store MIR")
         .clone();
     let elaborated = pipeline
         .elaborated_mir
         .iter()
-        .find(|function| function.name == receive.name)
+        .find(|function| function.key == receive.key)
         .expect("elaborated receive state-store MIR")
         .clone();
     let actor_layout_key = match &receive.source_origin {
@@ -98,8 +98,10 @@ fn with_required_system_store_counterfactuals(mut pipeline: IrPipeline) -> IrPip
             "LifecycleWriter__counterfactual_on_down",
         ),
     ] {
+        let key = hew_mir::MirCallableKey::for_test(name);
         let mut system = receive.clone();
         system.name = name.to_string();
+        system.key = key.clone();
         system.source_origin = SourceOrigin::SynthesizedActorHandler {
             kind,
             actor_layout_key: actor_layout_key.clone(),
@@ -108,10 +110,16 @@ fn with_required_system_store_counterfactuals(mut pipeline: IrPipeline) -> IrPip
 
         let mut system_checked = checked.clone();
         system_checked.name = name.to_string();
+        system_checked.key = key.clone();
+        if let Some(ownership_elaboration) = &mut system_checked.ownership_elaboration {
+            ownership_elaboration.name = name.to_string();
+            ownership_elaboration.key = key.clone();
+        }
         pipeline.checked_mir.push(system_checked);
 
         let mut system_elaborated = elaborated.clone();
         system_elaborated.name = name.to_string();
+        system_elaborated.key = key;
         pipeline.elaborated_mir.push(system_elaborated);
     }
     pipeline

--- a/hew-codegen-rs/tests/structural/machine_layout.rs
+++ b/hew-codegen-rs/tests/structural/machine_layout.rs
@@ -33,6 +33,7 @@ fn empty_pipeline(machine_layouts: Vec<MachineLayout>) -> IrPipeline {
 }
 
 fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> Result<String, CodegenError> {
+    let pipeline = crate::mir_fixture::complete_stages(pipeline.clone());
     let tmp = std::env::temp_dir().join(format!("hew-machine-layout-{module_name}"));
     std::fs::create_dir_all(&tmp).expect("create scratch dir");
     let options = EmitOptions {
@@ -45,7 +46,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> Result<String, CodegenEr
         opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
-    let artefacts = emit_module(pipeline, &options)?;
+    let artefacts = emit_module(&pipeline, &options)?;
     let ll_path = artefacts
         .ll_path
         .expect("emit_module must produce textual LLVM IR");

--- a/hew-codegen-rs/tests/structural/periodic_spawn_arming.rs
+++ b/hew-codegen-rs/tests/structural/periodic_spawn_arming.rs
@@ -141,7 +141,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
         state_field_clone_kinds: None,
     };
 
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![spawn_fn, handler_fn],
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -164,7 +164,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {

--- a/hew-codegen-rs/tests/structural/state_clone_synthesis.rs
+++ b/hew-codegen-rs/tests/structural/state_clone_synthesis.rs
@@ -110,7 +110,7 @@ fn classified_actor(
 }
 
 fn pipeline_with(actors: Vec<ActorLayout>, records: Vec<RecordLayout>) -> IrPipeline {
-    IrPipeline {
+    crate::mir_fixture::complete_stages(IrPipeline {
         raw_mir: vec![trivial_main()],
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -133,7 +133,7 @@ fn pipeline_with(actors: Vec<ActorLayout>, records: Vec<RecordLayout>) -> IrPipe
         user_clone_record_seeds: vec![],
         lint_warnings: vec![],
         lifecycle_registry: hew_hir::LifecycleRegistry::default(),
-    }
+    })
 }
 
 fn try_emit_to_string(pipeline: &IrPipeline, slug: &str) -> Result<String, CodegenError> {

--- a/hew-codegen-rs/tests/support/mir_fixture.rs
+++ b/hew-codegen-rs/tests/support/mir_fixture.rs
@@ -1,0 +1,71 @@
+use hew_mir::{
+    BlockKind, CheckedMirFunction, ElabBlock, ElaboratedMirFunction, IrPipeline, RawMirFunction,
+};
+
+fn stages_for(raw: &RawMirFunction) -> (CheckedMirFunction, ElaboratedMirFunction) {
+    let elaborated = ElaboratedMirFunction {
+        name: raw.name.clone(),
+        key: raw.key.clone(),
+        return_ty: raw.return_ty.clone(),
+        statements: raw
+            .blocks
+            .iter()
+            .flat_map(|block| block.statements.iter().cloned())
+            .collect(),
+        decisions: raw.decisions.clone(),
+        blocks: raw
+            .blocks
+            .iter()
+            .map(|block| ElabBlock {
+                id: block.id,
+                kind: BlockKind::Normal,
+                drops: Vec::new(),
+                successor: None,
+            })
+            .collect(),
+        drop_plans: Vec::new(),
+        coroutine: None,
+        lambda_captures: Vec::new(),
+    };
+    let checked = CheckedMirFunction {
+        name: raw.name.clone(),
+        key: raw.key.clone(),
+        return_ty: raw.return_ty.clone(),
+        blocks: raw.blocks.clone(),
+        decisions: raw.decisions.clone(),
+        checks: Vec::new(),
+        cooperate_sites: Vec::new(),
+        ownership_elaboration: Some(Box::new(elaborated.clone())),
+    };
+    (checked, elaborated)
+}
+
+/// Complete a hand-built test pipeline with exact-key Checked and Elaborated
+/// artifacts. Existing explicit stage fixtures retain authority.
+pub(crate) fn complete_stages(mut pipeline: IrPipeline) -> IrPipeline {
+    for raw in &pipeline.raw_mir {
+        let (mut checked, derived_elaborated) = stages_for(raw);
+        let elaborated = pipeline
+            .elaborated_mir
+            .iter()
+            .find(|candidate| candidate.key == raw.key)
+            .cloned()
+            .unwrap_or(derived_elaborated);
+        if !pipeline
+            .elaborated_mir
+            .iter()
+            .any(|candidate| candidate.key == raw.key)
+        {
+            pipeline.elaborated_mir.push(elaborated.clone());
+        }
+        if !pipeline
+            .checked_mir
+            .iter()
+            .any(|candidate| candidate.key == raw.key)
+        {
+            checked.ownership_elaboration = Some(Box::new(elaborated));
+            pipeline.checked_mir.push(checked);
+        }
+    }
+    pipeline
+}

--- a/hew-mir/src/identity.rs
+++ b/hew-mir/src/identity.rs
@@ -10,8 +10,8 @@
 //! compared presentation strings. Two callables with equal names — an imported
 //! module's function and a local one, two generic instances whose mangling
 //! collides, a synthesized closure of a same-named parent — are
-//! indistinguishable to such a join, which is why the retain-by-name and
-//! fail-open joins downstream exist at all.
+//! indistinguishable to such a join. Downstream stage association therefore
+//! uses this key exclusively; presentation names remain output metadata.
 //!
 //! The key is deliberately NOT constructible from a symbol string: identity is
 //! minted once and projected here. There is no `From<String>` and no
@@ -176,7 +176,7 @@ impl MirCallableKey {
 
 /// Reject a module whose raw MIR realizes one callable identity twice.
 ///
-/// The key is what every downstream join is being moved onto, so two
+/// The key is the authority for every downstream stage join, so two
 /// functions sharing one key would make that join ambiguous exactly the way
 /// two functions sharing one `name` do today. This is the fail-closed
 /// boundary: a collision is a lowering bug (a producer that minted the same

--- a/hew-mir/src/identity.rs
+++ b/hew-mir/src/identity.rs
@@ -34,9 +34,9 @@
 //! whose `declaration` is reconstructed from the owner's qualified path with
 //! the same `legacy_reconstruct_from_full_path` call. In every case the key
 //! is anchored on the declaration identity hew-hir currently reconstructs,
-//! not on a resolver-native mint; resolver-native minting for all three
-//! (ordinary functions, machines, and the actor/supervisor synthetics) is the
-//! tracked upstream fix — see `.tmp/TODO.md`.
+//! not on a resolver-native mint. Resolver-native provenance for ordinary
+//! functions, machines, and actor/supervisor synthetics remains outside this
+//! stage-association cutover.
 //!
 //! `RawMirFunction::name` (and its Checked/Elaborated twins) stays as the
 //! presentation/linkage alias beside the key.

--- a/hew-mir/src/lower/facts.rs
+++ b/hew-mir/src/lower/facts.rs
@@ -1493,32 +1493,44 @@ fn sync_param_boundary_modes(
     checked_mir: &mut [CheckedMirFunction],
     elaborated_mir: &mut [ElaboratedMirFunction],
 ) {
-    let boundary_decisions_for = |name: &str| {
-        raw_mir
-            .iter()
-            .find(|raw| raw.name == name)
-            .expect("MIR function has no raw parameter-boundary authority")
+    let mut boundary_decisions_by_key = HashMap::with_capacity(raw_mir.len());
+    for raw in raw_mir {
+        let decisions = raw
             .decisions
             .iter()
             .filter(|decision| matches!(decision.strategy, Strategy::ParamBoundary(_)))
             .cloned()
-            .collect::<Vec<_>>()
-    };
+            .collect::<Vec<_>>();
+        assert!(
+            boundary_decisions_by_key
+                .insert(raw.key.clone(), decisions)
+                .is_none(),
+            "duplicate Raw MIR callable key reached parameter-boundary synchronization"
+        );
+    }
     for checked in checked_mir {
         checked
             .decisions
             .retain(|decision| !matches!(decision.strategy, Strategy::ParamBoundary(_)));
-        checked
-            .decisions
-            .extend(boundary_decisions_for(&checked.name));
+        checked.decisions.extend(
+            boundary_decisions_by_key
+                .get(&checked.key)
+                .expect("Checked MIR has no Raw parameter-boundary authority")
+                .iter()
+                .cloned(),
+        );
     }
     for elaborated in elaborated_mir {
         elaborated
             .decisions
             .retain(|decision| !matches!(decision.strategy, Strategy::ParamBoundary(_)));
-        elaborated
-            .decisions
-            .extend(boundary_decisions_for(&elaborated.name));
+        elaborated.decisions.extend(
+            boundary_decisions_by_key
+                .get(&elaborated.key)
+                .expect("Elaborated MIR has no Raw parameter-boundary authority")
+                .iter()
+                .cloned(),
+        );
     }
 }
 
@@ -1616,7 +1628,7 @@ mod param_boundary_effect_tests {
 
     fn checked(raw: &RawMirFunction) -> CheckedMirFunction {
         CheckedMirFunction {
-            key: crate::model::MirCallableKey::for_test(&raw.name),
+            key: raw.key.clone(),
             name: raw.name.clone(),
             return_ty: raw.return_ty.clone(),
             blocks: raw.blocks.clone(),
@@ -1629,7 +1641,7 @@ mod param_boundary_effect_tests {
 
     fn elaborated(raw: &RawMirFunction) -> ElaboratedMirFunction {
         ElaboratedMirFunction {
-            key: crate::model::MirCallableKey::for_test(&raw.name),
+            key: raw.key.clone(),
             name: raw.name.clone(),
             return_ty: raw.return_ty.clone(),
             statements: vec![],
@@ -1649,7 +1661,15 @@ mod param_boundary_effect_tests {
         let mut checked = raw.iter().map(checked).collect::<Vec<_>>();
         let mut elaborated = raw.iter().map(elaborated).collect::<Vec<_>>();
         finalize_param_boundary_modes(raw, &mut checked, &mut elaborated);
-        for ((raw, checked), elaborated) in raw.iter().zip(&checked).zip(&elaborated) {
+        for raw in raw.iter() {
+            let checked = checked
+                .iter()
+                .find(|checked| checked.key == raw.key)
+                .expect("fixture must retain key-matched Checked MIR");
+            let elaborated = elaborated
+                .iter()
+                .find(|elaborated| elaborated.key == raw.key)
+                .expect("fixture must retain key-matched Elaborated MIR");
             assert_eq!(
                 boundary_decisions(&raw.decisions),
                 boundary_decisions(&checked.decisions)
@@ -1890,7 +1910,8 @@ mod param_boundary_effect_tests {
         // mutation.
         let mut raw = [ResolvedTy::I64, ResolvedTy::String]
             .into_iter()
-            .map(|element_ty| {
+            .enumerate()
+            .map(|(index, element_ty)| {
                 let vec_ty = ResolvedTy::Named {
                     name: "Vec".to_string(),
                     args: vec![element_ty],
@@ -1903,6 +1924,8 @@ mod param_boundary_effect_tests {
                     vec![],
                     call("hew_vec_len"),
                 );
+                let key = format!("fixture.vec_len_reader.{index}");
+                function.key = crate::model::MirCallableKey::for_test(&key);
                 function.params = vec![vec_ty.clone()];
                 function.locals = vec![vec_ty.clone()];
                 function.decisions[0].ty = vec_ty;

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -3978,11 +3978,22 @@ pub fn lower_hir_module_with_facts(module: &HirModule, pointer_width: PointerWid
         });
     }
 
+    // Fail closed before any module-wide stage association. A duplicated Raw
+    // key is already a complete lowering diagnostic; letting the parameter-
+    // boundary synchronizer index that invalid set would panic before the
+    // caller can observe the diagnostic.
+    let callable_key_diagnostics = crate::identity::validate_unique_callable_keys(&raw_mir);
+    let callable_keys_are_unique = callable_key_diagnostics.is_empty();
+    diagnostics.extend(callable_key_diagnostics);
+
     // OPM-1: all ordinary, generated, and monomorphised functions are now
     // present. Refine the initial typed parameter modes through the complete
     // module call graph before any checked-MIR consumer or backend capability
-    // snapshot observes them.
-    facts::finalize_param_boundary_modes(&mut raw_mir, &mut checked_mir, &mut elaborated_mir);
+    // snapshot observes them. Association is meaningful only for the unique
+    // key set admitted above.
+    if callable_keys_are_unique {
+        facts::finalize_param_boundary_modes(&mut raw_mir, &mut checked_mir, &mut elaborated_mir);
+    }
 
     // W3.031 Stage 2 — build the deduplicated `dyn Trait` vtable
     // registry from every `Instr::CoerceToDynTrait` reached by any
@@ -4022,12 +4033,6 @@ pub fn lower_hir_module_with_facts(module: &HirModule, pointer_width: PointerWid
     // flattened `<Self>::<method>` mangling, so MIR and codegen agree without
     // translation glue.
     let capabilities = crate::model::ModuleCapabilities::from_raw_mir(&raw_mir, &extern_decls);
-
-    // Fail-closed identity boundary. Every producer above minted a
-    // `MirCallableKey`; if two bodies claim one, the joins that are being moved
-    // onto the key would be as ambiguous as the name comparisons they replace.
-    // Reject here rather than emitting a module with a duplicated identity.
-    diagnostics.extend(crate::identity::validate_unique_callable_keys(&raw_mir));
 
     let pipeline = IrPipeline {
         raw_mir,

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -8100,8 +8100,8 @@ pub enum MirDiagnosticKind {
     },
     /// Two lowered bodies in one module carry the same [`MirCallableKey`].
     ///
-    /// Callable identity is the key every cross-stage join is being moved
-    /// onto, so a duplicate makes that join ambiguous. Reported with both
+    /// Callable identity is the key every cross-stage join uses, so a
+    /// duplicate makes that join ambiguous. Reported with both
     /// emitted symbols so the author can see which two bodies collided; the
     /// symbols are presentation only — the collision is decided on the key.
     CallableKeyCollision {

--- a/hew-mir/src/raw_values.rs
+++ b/hew-mir/src/raw_values.rs
@@ -366,7 +366,7 @@ pub fn verify_raw_virtual_value_checked(
     facts: &RawVirtualValueFacts,
 ) -> Result<(), RawVirtualValueError> {
     verify_facts_match_raw(raw, facts)?;
-    if checked.name != raw.name || checked.return_ty != raw.return_ty {
+    if checked.key != raw.key || checked.name != raw.name || checked.return_ty != raw.return_ty {
         return Err(raw_virtual_error(format!(
             "raw virtual-value checked MIR does not match Raw identity for `{}`",
             raw.name
@@ -422,7 +422,8 @@ pub fn verify_raw_virtual_value_elaborated(
     facts: &RawVirtualValueFacts,
 ) -> Result<(), RawVirtualValueError> {
     verify_raw_virtual_value_checked(raw, checked, facts)?;
-    if elaborated.name != raw.name
+    if elaborated.key != raw.key
+        || elaborated.name != raw.name
         || elaborated.return_ty != raw.return_ty
         || elaborated.decisions != checked.decisions
         || !elaborated.statements.is_empty()
@@ -468,35 +469,18 @@ pub fn verify_raw_virtual_value_elaborated(
 /// Verify the mandatory Raw -> Checked -> Elaborated ladder for a virtual Raw
 /// body, returning the canonical facts codegen may use for LLVM realization.
 ///
-/// Legacy storage-oriented Raw MIR deliberately retains its existing optional
-/// stage behavior.  Once a body contains any virtual value, however, both
-/// mirrors are mandatory so a hand-built pipeline cannot bypass ownership or
-/// scheduler admission at codegen.
-///
 /// # Errors
 ///
-/// Returns [`RawVirtualValueError`] when a virtual Raw body is malformed or
-/// either mandatory ladder mirror is missing or not the zero-effect mirror.
+/// Returns [`RawVirtualValueError`] when a virtual Raw body is malformed or a
+/// mandatory ladder mirror is not the zero-effect mirror.
 pub fn verify_raw_virtual_value_ladder(
     raw: &RawMirFunction,
-    checked: Option<&CheckedMirFunction>,
-    elaborated: Option<&ElaboratedMirFunction>,
+    checked: &CheckedMirFunction,
+    elaborated: &ElaboratedMirFunction,
 ) -> Result<Option<RawVirtualValueFacts>, RawVirtualValueError> {
     let Some(facts) = verify_raw_virtual_value_function(raw)? else {
         return Ok(None);
     };
-    let checked = checked.ok_or_else(|| {
-        raw_virtual_error(format!(
-            "raw virtual-value function `{}` requires matching Checked MIR before codegen",
-            raw.name
-        ))
-    })?;
-    let elaborated = elaborated.ok_or_else(|| {
-        raw_virtual_error(format!(
-            "raw virtual-value function `{}` requires matching Elaborated MIR before codegen",
-            raw.name
-        ))
-    })?;
     verify_raw_virtual_value_elaborated(raw, checked, elaborated, &facts)?;
     Ok(Some(facts))
 }

--- a/hew-mir/src/sir.rs
+++ b/hew-mir/src/sir.rs
@@ -379,7 +379,7 @@ fn verify_strict_sir_raw_checked(
             callable.symbol
         )));
     }
-    if checked.name != raw.name || checked.return_ty != raw.return_ty {
+    if checked.key != raw.key || checked.name != raw.name || checked.return_ty != raw.return_ty {
         return Err(SirMirLoweringError::unsupported(format!(
             "strict SIR raw/checked verifier: checked function identity does not match raw `{}`",
             raw.name
@@ -1090,6 +1090,7 @@ fn zero_drop_elaboration(
     checked: &CheckedMirFunction,
 ) -> Result<ElaboratedMirFunction, SirMirLoweringError> {
     debug_assert_eq!(raw.name, checked.name);
+    debug_assert_eq!(raw.key, checked.key);
     debug_assert_eq!(raw.return_ty, checked.return_ty);
     debug_assert_eq!(raw.blocks, checked.blocks);
     let mut blocks = raw
@@ -3388,12 +3389,17 @@ mod tests {
                     && plan.drops.is_empty()
             }));
         }
-        for ((raw, checked), elaborated) in pipeline
-            .raw_mir
-            .iter()
-            .zip(&pipeline.checked_mir)
-            .zip(&pipeline.elaborated_mir)
-        {
+        for raw in &pipeline.raw_mir {
+            let checked = pipeline
+                .checked_mir
+                .iter()
+                .find(|checked| checked.key == raw.key)
+                .expect("strict SIR pipeline must retain key-matched Checked MIR");
+            let elaborated = pipeline
+                .elaborated_mir
+                .iter()
+                .find(|elaborated| elaborated.key == raw.key)
+                .expect("strict SIR pipeline must retain key-matched Elaborated MIR");
             let cancellation_blocks = checked
                 .cooperate_sites
                 .iter()


### PR DESCRIPTION
## Why

Raw, Checked, and Elaborated MIR already carried MirCallableKey, but code generation still associated stages by display name and allowed missing later-stage artifacts. Same-named callables could therefore receive the wrong facts, while hand-built pipelines could bypass the verified ladder.

## What

- validate duplicate-free, exact Raw/Checked/Elaborated callable-key sets before creating an LLVM module
- join function lowering and parameter-boundary facts only by MirCallableKey
- require Checked and Elaborated artifacts throughout codegen; remove empty-stage and optional-stage compatibility paths
- migrate hand-built MIR fixtures to explicit unique test identities
- add missing, extra, duplicate, crossed-key, and metadata-drift falsifiers

Resolver-native HIR provenance is deliberately separate follow-up work; this PR hard-cuts stage association to the identity already carried by all three MIR forms.

## Test

- cargo test -p hew-codegen-rs --lib
- cargo test -p hew-mir --lib
- cargo test -p hew-compile --lib
- ABI, emission, pipeline, structural, and affected exec integration suites
- make checked-mir-verify
- make test-hew-ratchet
- cargo clippy for touched compiler crates with warnings denied
- candidate/base full-exec differential: identical 15 failing test IDs, with no stage-key diagnostic