### PR TITLE
fix(pkg): make every hew init template compile and run

### DIFF
--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -3,7 +3,7 @@ mod support;
 use std::fs;
 use std::process::Command;
 
-use support::hew_binary;
+use support::{hew_binary, require_codegen};
 
 /// Run `hew` in `dir` with an isolated HOME so a developer's real
 /// package-manager config cannot leak defaults into the scaffold.
@@ -300,6 +300,116 @@ fn init_lib_and_actor_conflict_is_rejected() {
         Some(2),
         "conflicting template flags should be a usage error:\nstderr: {}",
         String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn init_bin_scaffold_runs() {
+    require_codegen();
+    let tmp = support::tempdir();
+    let project_dir = tmp.path().join("bin_runs");
+    let init_out = run_hew(tmp.path(), &["init", "bin_runs"]);
+    assert!(
+        init_out.status.success(),
+        "hew init failed: {}",
+        String::from_utf8_lossy(&init_out.stderr)
+    );
+
+    let run_out = run_hew(&project_dir, &["run", "main.hew"]);
+    assert!(
+        run_out.status.success(),
+        "`hew run` failed on the freshly-generated bin scaffold:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&run_out.stdout),
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    assert!(
+        String::from_utf8_lossy(&run_out.stdout).contains("Hello from bin_runs!"),
+        "bin scaffold should print its greeting; got:\n{}",
+        String::from_utf8_lossy(&run_out.stdout)
+    );
+}
+
+#[test]
+fn init_lib_scaffold_checks() {
+    let tmp = support::tempdir();
+    let project_dir = tmp.path().join("lib_checks");
+    let init_out = run_hew(tmp.path(), &["init", "lib_checks", "--lib"]);
+    assert!(
+        init_out.status.success(),
+        "hew init --lib failed: {}",
+        String::from_utf8_lossy(&init_out.stderr)
+    );
+
+    // A library scaffold has no `main` fn, so `hew check` (not `hew run`) is
+    // the compile step the CLI's own follow-up hint recommends.
+    let check_out = run_hew(&project_dir, &["check", "lib_checks.hew"]);
+    assert!(
+        check_out.status.success(),
+        "`hew check` failed on the freshly-generated lib scaffold:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&check_out.stdout),
+        String::from_utf8_lossy(&check_out.stderr),
+    );
+}
+
+#[test]
+fn init_actor_scaffold_runs() {
+    require_codegen();
+    let tmp = support::tempdir();
+    let project_dir = tmp.path().join("actor_runs");
+    let init_out = run_hew(tmp.path(), &["init", "actor_runs", "--actor"]);
+    assert!(
+        init_out.status.success(),
+        "hew init --actor failed: {}",
+        String::from_utf8_lossy(&init_out.stderr)
+    );
+
+    let run_out = run_hew(&project_dir, &["run", "main.hew"]);
+    assert!(
+        run_out.status.success(),
+        "`hew run` failed on the freshly-generated actor scaffold:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&run_out.stdout),
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run_out.stdout).trim(),
+        "1\n2\n3",
+        "actor scaffold should print each incremented count; got:\n{}",
+        String::from_utf8_lossy(&run_out.stdout)
+    );
+}
+
+/// Negative control: the actor scaffold used to declare its mutable field
+/// with `let`, which the type checker rejects because `receive fn increment`
+/// reassigns it outside `init`. Prove that regression is caught, not just
+/// that the current scaffold happens to compile.
+#[test]
+fn init_actor_scaffold_with_let_field_fails_to_check() {
+    let tmp = support::tempdir();
+    let project_dir = tmp.path().join("actor_broken");
+    let init_out = run_hew(tmp.path(), &["init", "actor_broken", "--actor"]);
+    assert!(
+        init_out.status.success(),
+        "hew init --actor failed: {}",
+        String::from_utf8_lossy(&init_out.stderr)
+    );
+
+    let main_path = project_dir.join("main.hew");
+    let broken =
+        fs::read_to_string(&main_path)
+            .unwrap()
+            .replacen("var count: i32;", "let count: i32;", 1);
+    fs::write(&main_path, broken).unwrap();
+
+    let check_out = run_hew(&project_dir, &["check", "main.hew"]);
+    assert!(
+        !check_out.status.success(),
+        "an actor scaffold with an immutable `let count` field must fail to \
+         check once `receive fn increment` reassigns it"
+    );
+    let stderr = String::from_utf8_lossy(&check_out.stderr);
+    assert!(
+        stderr.contains("immutable"),
+        "checker should reject the reassignment as an immutable-field write; got:\n{stderr}"
     );
 }
 

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -489,7 +489,7 @@ fn write_template_source(dir: &Path, name: &str, template: manifest::ManifestTem
         ),
         manifest::ManifestTemplate::Actor => (
             "main.hew".to_string(),
-            "actor Counter {\n    let count: i32;\n\n    receive fn increment() {\n        \
+            "actor Counter {\n    var count: i32;\n\n    receive fn increment() {\n        \
              count = count + 1;\n        println(count);\n    }\n}\n\n\
              fn main() {\n    let c = spawn Counter(count: 0);\n    c.increment();\n    \
              c.increment();\n    c.increment();\n}\n"
@@ -3696,8 +3696,9 @@ mod tests {
             "should contain actor definition"
         );
         assert!(
-            src.contains("let count: i32"),
-            "actor state field must use `let` keyword"
+            src.contains("var count: i32"),
+            "actor state field must use `var` — `receive fn increment` reassigns it, \
+             and only a `var` field is mutable outside `init`"
         );
         assert!(
             !src.contains("self."),


### PR DESCRIPTION
## Why

`hew init --actor` scaffolds a project that fails `hew check`: the counter
field is declared `let count: i32;` and then reassigned in
`receive fn increment`, which the checker rejects because only a `var`
field is mutable outside `init`. Every user who ran `hew init --actor`
hit a compile error on the first template it wrote.

## What

- `hew-pkg/src/cli.rs`: scaffold the actor template's counter field as
  `var count: i32;` instead of `let count: i32;`.
- Update the existing unit test that pinned the old `let` field text to
  expect `var`.

## Test

- `hew-cli/tests/init_scaffold_e2e.rs`: added `init_bin_scaffold_runs` and
  `init_actor_scaffold_runs`, each running `hew init` into a temp dir then
  `hew run main.hew` and asserting success and expected output; added
  `init_lib_scaffold_checks`, which runs `hew check` since a library
  scaffold has no `main` to run.
- Added `init_actor_scaffold_with_let_field_fails_to_check` as a negative
  control: it reintroduces the old `let count: i32;` field and asserts
  `hew check` still rejects it, proving the scaffold really was broken.
