### PR TITLE
build(installers): install the newest release candidate by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,9 @@
 #     identity, e.g. `v0.6.0-rc2@sha256:<64 lowercase hex digits>`. The
 #     maintainer records it only after the pre-tag candidate publish succeeds.
 #
-# Homebrew tap updates use a separate optional credential and are skipped for
-# prereleases:
+# Homebrew tap updates use a separate optional credential and run for every
+# tag, prereleases included — hew.rb tracks the newest release (rc included),
+# hew@stable.rb tracks final releases only:
 #   HOMEBREW_TAP_TOKEN           — GitHub PAT with actions:write scope for hew-lang/homebrew-hew
 #
 # Required secrets for VS Code extension publishing (optional — skipped if absent):
@@ -1502,8 +1503,10 @@ jobs:
   homebrew:
     needs: release
     runs-on: ubuntu-24.04
-    # Formula updates are for final releases; -rc tags must not touch the tap.
-    if: ${{ !cancelled() && needs.release.result == 'success' && !contains(github.event.inputs.tag || github.ref_name, '-rc') }}
+    # Triggers every tag: Formula/hew.rb tracks the newest release including
+    # release candidates, Formula/hew@stable.rb tracks final releases only —
+    # update-formula.yml in homebrew-hew decides which formula(e) to touch.
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
     timeout-minutes: 5
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@
 #   make clean        — remove generated build and test artifacts
 # ============================================================================
 
-.PHONY: all build bootstrap install-hooks help shell-script-lint actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
+.PHONY: all build bootstrap install-hooks help shell-script-lint test-install-version-resolution actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
 .PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
 .PHONY: test-ownership-balance-corpus test-ownership-balance-runner-selftest
 .PHONY: stdlib-user-build-clean
@@ -94,6 +94,15 @@ help:
 LINT_GATES += shell-script-lint
 shell-script-lint:
 	@$(PYTHON) scripts/shell-script-lint.py
+
+# The installer's newest-tag semver picker (installers/install.sh's
+# pick_newest_tag()) has no coverage anywhere else in the build: it never
+# runs from a compiled binary, only from a shell function that curl | sh
+# executes directly. Wired into LINT_GATES so it runs on every PR the same
+# way shell-script-lint does, without a release download or network access.
+LINT_GATES += test-install-version-resolution
+test-install-version-resolution:
+	@sh installers/test-pick-newest-tag.sh
 
 
 # Local GitHub Actions syntax, expression, local-action input, and embedded-shell

--- a/installers/README.md
+++ b/installers/README.md
@@ -8,6 +8,18 @@ Installation options for [Hew](https://hew.sh).
 curl -fsSL https://hew.sh/install | sh
 ```
 
+Until v0.6.0 ships as a final release, this installs the newest published
+release _including release candidates_. Pass `--stable` to install the
+newest final release instead:
+
+```sh
+curl -fsSL https://hew.sh/install | sh -s -- --stable
+```
+
+Other `install.sh` flags: `--version <ver>` (pin an exact version),
+`--prefix <dir>` (installation directory), `--dry-run` (print what would be
+installed without installing it). `sh install.sh --help` lists all of them.
+
 ## Quick Install (FreeBSD)
 
 FreeBSD base includes `fetch(1)` — no extra packages needed:
@@ -46,16 +58,16 @@ installed without installing it). `.\install.ps1 -Help` lists all of them.
 
 ## Package Managers
 
-| Platform                 | Command                                                                          |
-| ------------------------ | -------------------------------------------------------------------------------- |
-| macOS / Linux (Homebrew) | `brew install hew-lang/tap/hew`                                                  |
-| FreeBSD (script)         | `fetch -o - https://hew.sh/install \| sh`                                        |
-| Arch Linux (AUR)         | `yay -S hew-bin`                                                                 |
-| Debian / Ubuntu          | `.deb` packages on the [releases page](https://github.com/hew-lang/hew/releases) |
-| Fedora / RHEL / openSUSE | See `rpm/hew.spec`                                                               |
-| Alpine Linux             | See `alpine/APKBUILD`                                                            |
-| Nix / NixOS              | See `nix/default.nix`                                                            |
-| Docker                   | `docker run --rm -v $(pwd):/work r.hew.sh/hew build /work/main.hew`              |
+| Platform                 | Command                                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| macOS / Linux (Homebrew) | `brew install hew-lang/tap/hew` (newest release, rc included) or `hew@stable` (final releases only) |
+| FreeBSD (script)         | `fetch -o - https://hew.sh/install \| sh`                                                           |
+| Arch Linux (AUR)         | `yay -S hew-bin`                                                                                    |
+| Debian / Ubuntu          | `.deb` packages on the [releases page](https://github.com/hew-lang/hew/releases)                    |
+| Fedora / RHEL / openSUSE | See `rpm/hew.spec`                                                                                  |
+| Alpine Linux             | See `alpine/APKBUILD`                                                                               |
+| Nix / NixOS              | See `nix/default.nix`                                                                               |
+| Docker                   | `docker run --rm -v $(pwd):/work r.hew.sh/hew build /work/main.hew`                                 |
 
 ## Docker Usage
 

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -4,7 +4,14 @@
 #        fetch -o - https://hew.sh/install | sh        (FreeBSD — no extra packages needed)
 #        wget -qO- https://hew.sh/install | sh         (wget fallback)
 #        irm https://hew.sh/install.ps1 | iex          (Windows PowerShell)
-#        sh install.sh [--version <ver>] [--prefix <dir>] [--help]
+#        sh install.sh [--version <ver>] [--stable] [--prefix <dir>] [--dry-run] [--help]
+#
+# Version policy: until v0.6.0 ships as a final release, the default install
+# picks the newest published release *including release candidates*, so
+# `curl | sh` tracks the pre-release ladder during the v0.6.0 stabilization
+# window. Pass --stable to install the newest tagged final release instead
+# (the policy the `hew@stable` Homebrew formula also uses). Once a final
+# v0.6.0 ships, the two policies agree until the next pre-release window.
 set -eu
 
 GITHUB_ORG="hew-lang"
@@ -57,8 +64,13 @@ USAGE:
 sh install.sh [OPTIONS]
 
 OPTIONS:
-    --version <ver>    Install a specific version (e.g. 0.1.3). Default: latest
+    --version <ver>    Install a specific version (e.g. 0.1.3). Default: newest
+                        release including release candidates
+    --stable           Install the newest final (non-rc) release instead of
+                        the newest release candidate
     --prefix  <dir>    Installation directory. Default: \$HEW_HOME or \$HOME/.hew
+    --dry-run          Resolve the version and print what would be installed,
+                        without downloading or installing anything
     --help             Print this help message
 EOF
     exit 0
@@ -69,6 +81,8 @@ EOF
 # ---------------------------------------------------------------------------
 REQUESTED_VERSION=""
 INSTALL_PREFIX=""
+STABLE_ONLY=""
+DRY_RUN=""
 
 parse_args() {
     while [ $# -gt 0 ]; do
@@ -78,10 +92,18 @@ parse_args() {
             REQUESTED_VERSION="$2"
             shift 2
             ;;
+        --stable)
+            STABLE_ONLY="1"
+            shift
+            ;;
         --prefix)
             [ -z "${2:-}" ] && err "--prefix requires a value"
             INSTALL_PREFIX="$2"
             shift 2
+            ;;
+        --dry-run)
+            DRY_RUN="1"
+            shift
             ;;
         --help | -h)
             usage
@@ -91,6 +113,9 @@ parse_args() {
             ;;
         esac
     done
+    if [ -n "$REQUESTED_VERSION" ] && [ -n "$STABLE_ONLY" ]; then
+        err "--version and --stable are mutually exclusive"
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -98,10 +123,10 @@ parse_args() {
 # ---------------------------------------------------------------------------
 detect_platform() {
     case "$(uname -s)" in
-    Linux*)   OS="linux" ;;
-    Darwin*)  OS="darwin" ;;
+    Linux*) OS="linux" ;;
+    Darwin*) OS="darwin" ;;
     FreeBSD*) OS="freebsd" ;;
-    *)        err "unsupported operating system: $(uname -s)" ;;
+    *) err "unsupported operating system: $(uname -s)" ;;
     esac
 
     case "$(uname -m)" in
@@ -142,19 +167,70 @@ http_download() {
 
 # ---------------------------------------------------------------------------
 # Resolve version
+#
+# Picks the newest tag by semver (major.minor.patch[-rcN]), not by GitHub's
+# release-creation order, since a hotfix tagged later could otherwise shadow
+# a newer version. Both the default (rc-inclusive) and --stable pick from the
+# same /releases listing so there is one authority for "what tags exist";
+# --stable just drops any tag containing '-', mirroring how the release
+# workflow itself decides final vs. pre-release (release.yml, RELEASE_TAG
+# check before attaching Linux packages).
+#
+# SHORTCUT: the semver comparison below only understands this repo's actual
+# tag scheme, `vX.Y.Z` or `vX.Y.Z-rcN` — WHY: that is the only scheme the
+# release workflow emits (release.yml sets `prerelease` from `contains(tag,
+# '-rc')`); WHEN this breaks: a tag with any other prerelease label (e.g.
+# `-beta1`) would sort as an unrelated string; WHAT the real fix looks like:
+# a full SemVer 2.0.0 §11 precedence comparison if the tag scheme ever grows
+# more prerelease kinds.
 # ---------------------------------------------------------------------------
+pick_newest_tag() {
+    # stdin: one 'vX.Y.Z' or 'vX.Y.Z-rcN' tag per line (with leading 'v').
+    # stdout: the highest tag by the scheme above.
+    awk -F'[.-]' '
+        {
+            major = $1 + 0; minor = $2 + 0; patch = $3 + 0
+            # $4 holds "rcN" for a candidate, empty for a final release.
+            # A final release outranks any rc of the same major.minor.patch.
+            rc = ($4 == "") ? 999999 : (substr($4, 3) + 0)
+            key = sprintf("%06d.%06d.%06d.%06d", major, minor, patch, rc)
+            if (key > best) { best = key; bestline = $0 }
+        }
+        END { print bestline }
+    '
+}
+
 resolve_version() {
     if [ -n "$REQUESTED_VERSION" ]; then
         # Strip leading 'v' if provided
         VERSION="${REQUESTED_VERSION#v}"
-    else
-        _rv_response="$(http_get "${GITHUB_API}/releases/latest")" ||
-            err "failed to fetch latest release from GitHub API"
-        _rv_raw="$(printf '%s' "$_rv_response" | grep '"tag_name"' | sed 's/.*"tag_name":[[:space:]]*"//;s/".*//')"
-        VERSION="${_rv_raw#v}"
-        if [ -z "$VERSION" ]; then
-            err "could not determine latest version"
+        return
+    fi
+
+    # per_page=100 is a SHORTCUT: WHY — the repo has well under 100 release
+    # tags today, so one unpaginated page covers every candidate; WHEN this
+    # breaks — release count crosses 100; WHAT the real fix looks like —
+    # follow the API's Link: rel="next" header across pages.
+    _rv_response="$(http_get "${GITHUB_API}/releases?per_page=100")" ||
+        err "failed to fetch releases from GitHub API"
+    _rv_tags="$(printf '%s' "$_rv_response" | grep '"tag_name"' |
+        sed 's/.*"tag_name":[[:space:]]*"//;s/".*//' | grep '^v[0-9]')"
+    if [ -z "$_rv_tags" ]; then
+        err "could not determine available versions"
+    fi
+
+    if [ -n "$STABLE_ONLY" ]; then
+        # Final releases only, matching the workflow's own final-vs-rc test.
+        _rv_tags="$(printf '%s\n' "$_rv_tags" | grep -v -- '-')"
+        if [ -z "$_rv_tags" ]; then
+            err "could not determine a stable version"
         fi
+    fi
+
+    _rv_best="$(printf '%s\n' "$_rv_tags" | sed 's/^v//' | pick_newest_tag)"
+    VERSION="${_rv_best}"
+    if [ -z "$VERSION" ]; then
+        err "could not determine newest version"
     fi
 }
 
@@ -212,6 +288,17 @@ main() {
 
     resolve_version
 
+    archive_name="hew-v${VERSION}-${OS}-${ARCH}.tar.gz"
+    base_url="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/v${VERSION}"
+
+    if [ -n "$DRY_RUN" ]; then
+        printf "  tag:      v%s\n" "$VERSION"
+        printf "  platform: %s-%s\n" "$OS" "$ARCH"
+        printf "  archive:  %s/%s\n" "$base_url" "$archive_name"
+        printf "  prefix:   %s\n" "$INSTALL_PREFIX"
+        exit 0
+    fi
+
     print_banner
     printf "  %bInstalling Hew v%s (%s-%s)%b\n\n" "${BOLD}" "$VERSION" "$OS" "$ARCH" "${RESET}"
 
@@ -229,9 +316,7 @@ main() {
     # Set up temp directory
     TMPDIR_INSTALL="$(mktemp -d)"
 
-    archive_name="hew-v${VERSION}-${OS}-${ARCH}.tar.gz"
     checksums_name="hew-v${VERSION}-checksums.txt"
-    base_url="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/v${VERSION}"
 
     # Download archive
     step_start "Downloading"
@@ -281,7 +366,7 @@ main() {
     # Generate shell completions from the installed binaries
     for shell in bash zsh fish; do
         "${INSTALL_PREFIX}/bin/hew" completions "${shell}" \
-            > "${INSTALL_PREFIX}/completions/hew.${shell}" 2>/dev/null || true
+            >"${INSTALL_PREFIX}/completions/hew.${shell}" 2>/dev/null || true
     done
 
     for f in LICENSE-MIT LICENSE-APACHE NOTICE README.md; do

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -180,8 +180,12 @@ http_download() {
 # tag scheme, `vX.Y.Z` or `vX.Y.Z-rcN` — WHY: that is the only scheme the
 # release workflow emits (release.yml sets `prerelease` from `contains(tag,
 # '-rc')`); WHEN this breaks: a tag with any other prerelease label (e.g.
-# `-beta1`) would sort as an unrelated string; WHAT the real fix looks like:
-# a full SemVer 2.0.0 §11 precedence comparison if the tag scheme ever grows
+# `-beta1`) silently lands in the rc0 slot (`substr("beta1", 3) + 0` is `0`),
+# below every rcN of the same core version and above any older final — that
+# happens to match SemVer precedence for a single prerelease label, but two
+# different labels on the same core version (`-beta1` and `-rc1`) would both
+# collapse to rc0 and tie-break arbitrarily; WHAT the real fix looks like: a
+# full SemVer 2.0.0 §11 precedence comparison if the tag scheme ever grows
 # more prerelease kinds.
 # ---------------------------------------------------------------------------
 pick_newest_tag() {

--- a/installers/test-pick-newest-tag.sh
+++ b/installers/test-pick-newest-tag.sh
@@ -70,8 +70,8 @@ check "final release beats an rc of the same version" \
 0.6.0" \
     "0.6.0"
 
-# 0.6.0-rc10 beats 0.6.0-rc9 — catches substr(\$4, 3) losing its + 0 numeric
-# coercion and comparing "10" < "9" lexically.
+# 0.6.0-rc10 beats 0.6.0-rc9 — catches the sprintf("%06d", ...) padding being
+# dropped and comparing "10" < "9" lexically.
 check "rc10 beats rc9" \
     "0.6.0-rc9
 0.6.0-rc10" \

--- a/installers/test-pick-newest-tag.sh
+++ b/installers/test-pick-newest-tag.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Fixture for install.sh's pick_newest_tag() semver picker and the --stable
+# pre-release filter that feeds it.
+#
+# installers/docker/test-install.sh is the precedent for a standalone shell
+# test living in this directory; this one exercises the tag-comparison logic
+# in isolation instead of a full install, so a regression is caught without
+# downloading a release or hitting the GitHub API.
+set -eu
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+INSTALL_SH="${SCRIPT_DIR}/install.sh"
+
+# install.sh unconditionally runs `main "$@"` at end of file, so it cannot be
+# sourced directly — extract just the pick_newest_tag() function body.
+pick_newest_tag_def="$(awk '/^pick_newest_tag\(\) \{/,/^}/' "$INSTALL_SH")"
+if [ -z "$pick_newest_tag_def" ]; then
+    echo "FAIL: could not extract pick_newest_tag() from ${INSTALL_SH}" >&2
+    exit 1
+fi
+eval "$pick_newest_tag_def"
+
+fail=0
+
+# Default (rc-inclusive) path: pick_newest_tag() over the raw tag list.
+check() {
+    description="$1"
+    input="$2"
+    expected="$3"
+    actual="$(printf '%s\n' "$input" | pick_newest_tag)"
+    if [ "$actual" != "$expected" ]; then
+        echo "FAIL: ${description}"
+        echo "  expected: ${expected}"
+        echo "  got:      ${actual}"
+        fail=1
+    else
+        echo "ok: ${description}"
+    fi
+}
+
+# --stable path: resolve_version()'s own filter (grep -v -- '-') ahead of
+# pick_newest_tag(), so this is a faithful negative control rather than a
+# reimplementation of the filter.
+check_stable() {
+    description="$1"
+    input="$2"
+    expected="$3"
+    actual="$(printf '%s\n' "$input" | grep -v -- '-' | pick_newest_tag)"
+    if [ "$actual" != "$expected" ]; then
+        echo "FAIL: ${description}"
+        echo "  expected: ${expected}"
+        echo "  got:      ${actual}"
+        fail=1
+    else
+        echo "ok: ${description}"
+    fi
+}
+
+# 0.10.0 beats 0.9.9 — catches lexical rather than numeric comparison, the
+# reason the %06d padding exists.
+check "numeric minor beats a lexically-larger patch" \
+    "0.9.9
+0.10.0" \
+    "0.10.0"
+
+# 0.6.0 beats 0.6.0-rc3 — catches the final-release rc=999999 sentinel being
+# dropped or inverted.
+check "final release beats an rc of the same version" \
+    "0.6.0-rc3
+0.6.0" \
+    "0.6.0"
+
+# 0.6.0-rc10 beats 0.6.0-rc9 — catches substr(\$4, 3) losing its + 0 numeric
+# coercion and comparing "10" < "9" lexically.
+check "rc10 beats rc9" \
+    "0.6.0-rc9
+0.6.0-rc10" \
+    "0.6.0-rc10"
+
+# 0.6.0-rc2 beats 0.5.6 — catches an over-eager stable filter leaking onto
+# the default (rc-inclusive) path.
+check "rc beats an older final release on the default path" \
+    "0.5.6
+0.6.0-rc2" \
+    "0.6.0-rc2"
+
+# --stable drops every rc and keeps the newest final — the negative control
+# for the grep -v -- '-' filter.
+check_stable "--stable returns the newest final, not the newer rc" \
+    "0.5.6
+0.6.0-rc2" \
+    "0.5.6"
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "All pick_newest_tag() cases passed."
+else
+    echo "pick_newest_tag() regression detected." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Why

Until v0.6.0 ships, `curl | sh` installs whatever GitHub's `/releases/latest`
endpoint returns — the newest *final* release only, so the installer never
picks up a release candidate even when the rc is the newest thing published.

## What

- **install.sh**: default version resolution now walks the GitHub `/releases`
  list (rc tags included) and picks the newest tag by semver, instead of
  hitting the non-prerelease-only `/releases/latest` endpoint. Adds `--stable`
  (newest final release only) and `--dry-run` (print the resolved tag, archive
  URL, and prefix without downloading or installing).
- **installers/README.md**: documents `--stable`, `--dry-run`, and the two
  Homebrew channels.
- **release.yml**: the Homebrew tap trigger now fires for every tag, not just
  final releases — `Formula/hew.rb` in homebrew-hew tracks the newest release
  (rc included), `Formula/hew@stable.rb` tracks final releases only.

Companion changes in `hew-lang/homebrew-hew` (pushed to main): add
`Formula/hew@stable.rb` and repoint `Formula/hew.rb` at v0.6.0-rc2, then
update `update-formula.yml` to drop its rc skip and update both formulae —
`hew.rb` for every tag, `hew@stable.rb` only when the version has no `-`.

## Test

- `sh -n installers/install.sh`.
- `make test-install-version-resolution`: a committed offline fixture
  (`installers/test-pick-newest-tag.sh`) for the semver picker
  (`pick_newest_tag`) and the `--stable` filter, wired into the `make lint`
  gate CI already runs. Cases: 0.10.0 beats 0.9.9 (numeric, not lexical);
  0.6.0 beats 0.6.0-rc3 (the final-release sentinel); rc10 beats rc9
  (numeric coercion on the rc suffix); 0.6.0-rc2 beats 0.5.6 on the default
  path; `--stable` returns 0.5.6 over the same input as a negative control.
- Live against the GitHub API: `--dry-run`, `--dry-run --stable`,
  `--dry-run --version 0.5.6`, an unknown flag, and `--version` + `--stable`
  together (rejected as mutually exclusive).
- Full install run (`--stable --prefix <scratch>`) followed by `hew version`
  against the installed binary.
- Downloaded the real v0.6.0-rc2 linux-x86_64 tarball, verified its checksum
  and layout against the `hew@stable`/`hew` Homebrew formula's `install`
  block, and ran the formula's `test do` program (`import std.math;
  math.clamp`) against the extracted build.

by CI.

