### PR TITLE
docs: name the programs and documents by their monikers

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,22 +1,7 @@
-# Hew v0.5 Compiler-Foundation Cutover — Freeze Notice
+# Hew — Breaking Changes
 
-## What is happening
-
-Hew is entering the v0.5 compiler-foundation cutover. The goal is a clean,
-typed intermediate-representation stack — Resolved HIR → SIR → Raw MIR —
-that replaces the legacy codegen walker and the wrapper-shape registry that
-grew up around it.
-
-v0.5 prioritises landing that new foundation correctly. It does **not**
-prioritise keeping the v0.4 internal surfaces stable. Any code that drives
-the legacy codegen walker, the wrapper-shape registry, or the `expr_types`-keyed
-ownership side tables should be treated as transitional until the cutover
-steps that replace those surfaces have landed.
-
-The compiler-foundation reference document is
-[`docs/internal/ir-ladder.md`](docs/internal/ir-ladder.md).
-
----
+A running log of breaking changes to Hew's compiler internals, runtime ABI,
+and standard library, by release.
 
 ## Distributed identity and remote PIDs in v0.6.0-rc1
 
@@ -99,50 +84,11 @@ user-declarable and the compiler emits the spec literal, whose codegen mirror
 
 ---
 
-## Main-branch freeze rules (effective immediately)
-
-The following categories of change are **frozen on `main`** until the
-corresponding cutover step lands:
-
-1. **No new structural patches to the legacy codegen walker** unless the change qualifies
-   as a bridge fix under the criteria below.
-
-2. **No new wrapper-shape registry expansions.** Adding entries to the
-   wrapper-shape registry extends a surface that the cutover deletes. Changes
-   in this category must wait for the relevant cutover step.
-
-3. **No new `expr_types`-keyed ownership side tables.** New side tables of
-   this form are rejected on `main` for the same reason.
-
----
-
-## Bridge-fix admission criteria
-
-An in-flight `main` change may proceed if and only if it satisfies **all
-three** of the following:
-
-1. It fixes a reproducible memory-safety or fail-closed defect (e.g.,
-   null-after-move, field-alias fail-closed, cleanup-all-exits) that
-   directly affects the ability to develop or test on `main`.
-
-2. It touches at most one walker call site and does **not** extend any
-   registry's wrapper-shape coverage.
-
-3. The same defect is captured as a reproduction fixture under
-   `tests/hew/` or `hew-cli/tests/` so the cutover branch can consume it
-   as both a target and a regression check.
-
-Changes that do not satisfy all three criteria **pause** until the relevant
-cutover step on the cutover branch picks them up.
-
----
-
 ## Public API and language surface
 
-The freeze rules above apply to **compiler internals only**. Public language
-semantics, standard-library APIs, and wire-protocol surfaces follow their
-normal deprecation and stability policy. See `CHANGELOG.md` for user-visible
-changes.
+Public language semantics, standard-library APIs, and wire-protocol surfaces
+follow their normal deprecation and stability policy. See `CHANGELOG.md` for
+user-visible changes.
 
 ---
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -3,7 +3,8 @@
 A running log of breaking changes to Hew's compiler internals, runtime ABI,
 and standard library, by release.
 
-v0.6.0 is the surface freeze and working front door on the current lowerer.
+v0.6.0 is the surface freeze and working front door on the current lowerer,
+with the ownership-generation ICEs documented as fail-closed limits.
 v0.7.0 is the final ladder release, with the legacy lowerer deleted.
 
 ## Distributed identity and remote PIDs in v0.6.0-rc1

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -3,6 +3,9 @@
 A running log of breaking changes to Hew's compiler internals, runtime ABI,
 and standard library, by release.
 
+v0.6.0 is the surface freeze and working front door on the current lowerer.
+v0.7.0 is the final ladder release, with the legacy lowerer deleted.
+
 ## Distributed identity and remote PIDs in v0.6.0-rc1
 
 - Node identity is derived from the stable authenticated Noise key or TLS SPKI.

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -3,8 +3,8 @@
 Visual documentation of the Hew compilation pipeline, runtime architecture, and
 protocol formats using Mermaid diagrams. Every diagram reflects the current
 compiler pipeline; the `LADDER` program (final IR ladder, legacy lowerer
-deleted, `v0.7.0`) replaces the `--sir-lower` strict lane below with the sole
-route — see `~/projects/hew-lang/hew-orchestration/plans/MONIKERS.md`.
+deleted, `v0.7.0`) replaces the strict lane below with the sole route — see
+the orchestration registry's `MONIKERS.md`.
 
 > **Rendering:** These diagrams use [Mermaid](https://mermaid.js.org/) syntax. GitHub renders them natively in Markdown. For local viewing, use a Mermaid-compatible Markdown previewer or the [Mermaid Live Editor](https://mermaid.live/).
 
@@ -40,7 +40,9 @@ flowchart TD
 - `hew machine diagram [--format mermaid|graphviz|json] <file.hew>` — render machine declarations
 - `hew machine list <file.hew>` — list machines, states, and events
 
-The C++/MLIR flags (`--emit-mlir`, `--emit-llvm`, `--emit-obj`) never existed in the current pipeline and are not available.
+`hew tool compile` does not accept `--emit-mlir` or `--emit-obj`; it accepts
+`--emit-dir` (directory for emitted `.ll`/`.o`/`.wasm` artefacts) and
+`--emit-llvm` (retain the pre-optimization textual LLVM IR).
 
 ---
 

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -1,8 +1,10 @@
 # Hew Compiler & Runtime Diagrams
 
 Visual documentation of the Hew compilation pipeline, runtime architecture, and
-protocol formats using Mermaid diagrams. Every diagram reflects the current v0.5
-codebase.
+protocol formats using Mermaid diagrams. Every diagram reflects the current
+compiler pipeline; the `LADDER` program (final IR ladder, legacy lowerer
+deleted, `v0.7.0`) replaces the `--sir-lower` strict lane below with the sole
+route — see `~/projects/hew-lang/hew-orchestration/plans/MONIKERS.md`.
 
 > **Rendering:** These diagrams use [Mermaid](https://mermaid.js.org/) syntax. GitHub renders them natively in Markdown. For local viewing, use a Mermaid-compatible Markdown previewer or the [Mermaid Live Editor](https://mermaid.live/).
 
@@ -31,14 +33,14 @@ flowchart TD
     OBJ --> LINK["link"]
 ```
 
-**Current v0.5 inspection commands:**
+**Inspection commands:**
 
 - `hew tool compile --dump-mir raw|checked|elab <file.hew>` — inspect the MIR ladder without LLVM emission
 - `hew tool compile --emit-dir <dir> <file.hew>` — write LLVM/object/WASM artefacts for the Rust codegen path
 - `hew machine diagram [--format mermaid|graphviz|json] <file.hew>` — render machine declarations
 - `hew machine list <file.hew>` — list machines, states, and events
 
-The retired C++/MLIR flags (`--emit-mlir`, `--emit-llvm`, `--emit-obj`) are not available in v0.5.
+The C++/MLIR flags (`--emit-mlir`, `--emit-llvm`, `--emit-obj`) never existed in the current pipeline and are not available.
 
 ---
 

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -2,9 +2,10 @@
 
 Visual documentation of the Hew compilation pipeline, runtime architecture, and
 protocol formats using Mermaid diagrams. Every diagram reflects the current
-compiler pipeline; the `LADDER` program (final IR ladder, legacy lowerer
-deleted, `v0.7.0`) replaces the strict lane below with the sole route — see
-the orchestration registry's `MONIKERS.md`.
+compiler pipeline. The `LADDER` program (final IR ladder, legacy lowerer
+deleted, `v0.7.0`) tracks this pipeline's evolution; its `P5-CUTOVER` phase
+deletes the `--sir-lower` flag shown below — see the orchestration registry's
+`MONIKERS.md`.
 
 > **Rendering:** These diagrams use [Mermaid](https://mermaid.js.org/) syntax. GitHub renders them natively in Markdown. For local viewing, use a Mermaid-compatible Markdown previewer or the [Mermaid Live Editor](https://mermaid.live/).
 


### PR DESCRIPTION
## Why

BREAKING.md still opened with the v0.5 compiler-foundation cutover's freeze
notice as though it were in effect (six v0.5.x releases after it shipped),
and docs/diagrams.md dated itself to the v0.5 codebase and framed
`--sir-lower` as a temporary strict lane, then claimed C++/MLIR compile flags
never existed when `hew tool compile` actually accepts `--emit-llvm`. Both
described a superseded state as current instead of pointing at the
orchestration registry's monikers (`LADDER`, `FREEZE`) for the program that
replaced it.

## What

- **BREAKING.md**: drops the shipped v0.5 cutover notice, main-branch freeze
  rules, and bridge-fix admission criteria; keeps the doc as a running
  breaking-changes log (the distributed-identity, `HewChildSpec`, and
  removed-in-v0.5 sections were already accurate and are unchanged). Adds an
  identity statement for the D332 release mapping: v0.6.0 is the surface
  freeze and working front door on the current lowerer, v0.7.0 is the final
  ladder with the legacy lowerer deleted.
- **docs/diagrams.md**: drops the stale "current v0.5" version claim, points
  readers at the orchestration registry's `MONIKERS.md` (no home-directory
  path) for the `LADDER` program instead of naming the retired `--sir-lower`
  strict-lane framing in prose (the diagram edge that names the real
  `--sir-lower` flag is unchanged), and replaces the false "C++/MLIR flags
  never existed" sentence with what `hew tool compile` actually accepts per
  `hew-cli/src/args.rs` (`--emit-dir`, `--emit-llvm`; not `--emit-mlir` or
  `--emit-obj`).

Grepped both touched files for every name in the registry's retired-names
table:

```
$ grep -noE 'Tracks A[-–]D|compiler-core program|D274 sequencing|SIR modernization S0[-–]S15|OWN-S\b|OWN-MIR|OWN-HIR-FACTS|IR-IDENTITY|VALUE-IDENTITY|SIR-CORE|SIR-VALUES|SIR-CONCURRENCY|SIR-CUTOVER|NYI-ZERO|ACTOR-MESSAGE|MACHINE-RESOURCE|WIRE-LIFECYCLE|ASYNC-LIFECYCLE|STDLIB-COHERENCE|TOOLCHAIN-COHERENCE|ECOSYSTEM-SHIP|RC3-CANDIDATE|rc3 ships the ladder|13-state lifecycle|schema-3 contracts|hash chains|\bF6\b|\bF14\b|\bF19\b|\bF20\b|\bA6\b|ownership seams|thin producer conversion|SirMode\b|shadow mode|PLANNING\.md|active\.md|\badze\b|C\+\+/MLIR|hew-codegen \(C\+\+\)|MessagePack boundary' BREAKING.md docs/diagrams.md
(no output; exit 1)
```

`.claude/CLAUDE.md` and `.claude/references/*.md` are gitignored and live
only in the shared checkout, outside a worktree's reach — their moniker
updates (a Monikers paragraph naming `LADDER`/`FREEZE`/`PLATFORM`/`CORO`/
`DOC-LADDER`/`DOC-MATRIX`/`DOC-FFI`, and a lifecycle table matched to D332)
are left as an open problem for direct application in the main checkout.

`docs/internal/ir-ladder.md`, `sir-domain-matrix.md`, and
`runtime-ownership-table.md` are left untouched (they live on #3211).

## Test

Docs-only change; no build or test surface affected.
