### PR TITLE
docs(syntax): make syntax-data.json and the spec match the compiler

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -46,3 +46,12 @@ JOURNEY.md
 # WHY: the generator and prettier disagree about array formatting.
 # WHEN: remove once the generator emits prettier-shaped output itself.
 scripts/cabi-surface.json
+
+# Hand-maintained syntax authority; prettier collapsing its arrays turns a
+# one-keyword edit into a whole-file reflow that buries the real change.
+#
+# WHY: nothing generates this file's shape and prettier disagrees with the
+# hand-maintained array formatting.
+# WHEN: remove once a real generator writes this file and emits
+# prettier-shaped output.
+docs/syntax-data.json

--- a/docs/internal/versioning.md
+++ b/docs/internal/versioning.md
@@ -149,6 +149,9 @@ the Hew language edition; it governs how the compiler's own source compiles.
 
 - **Workspace `Cargo.toml`** (`[workspace.package] version = "..."`) — the
   source of truth. All crates inherit via `version.workspace = true`.
+- **`docs/syntax-data.json`** — its `version` field is hand-maintained and
+  checked against `CARGO_PKG_VERSION` by a `hew-lexer` test; a release bump
+  that skips it fails `cargo test -p hew-lexer`.
 - **`CHANGELOG.md`** — `[Unreleased]` becomes `[X.Y.Z]` at tag time.
 - **`docs/releases/vX.Y.Z.md`** — curated narrative release notes
   (when the release warrants them; PATCH releases may skip this).

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -13,9 +13,9 @@ This is the concrete expansion of the `ci-full-run-pre-tag` todo.
 - [ ] CHANGELOG.md has either a populated `[Unreleased]` section or the dated
       `[X.Y.Z]` section for the intended release
 - [ ] Curated GitHub release notes are drafted at `docs/releases/vX.Y.Z.md`
-- [ ] `workspace.package.version` in `Cargo.toml`, `Cargo.lock`, the intended
-      changelog record, and `docs/releases/vX.Y.Z.md` all name the candidate
-      that will be tagged
+- [ ] `workspace.package.version` in `Cargo.toml`, `Cargo.lock`,
+      `docs/syntax-data.json`, the intended changelog record, and
+      `docs/releases/vX.Y.Z.md` all name the candidate that will be tagged
 
 ## Phase 1 — Assemble the candidate
 
@@ -57,9 +57,10 @@ git log --oneline -5  # confirm expected HEAD
 ## Phase 2 — Establish the release identity
 
 > **Prerequisite:** Any required version bump must update `Cargo.toml`'s
-> workspace version, every lockfile, the dated changelog record, and the exact
-> `docs/releases/vX.Y.Z.md` file together. Tagging a commit where any one of
-> those identities differs produces a split release record.
+> workspace version, every lockfile, `docs/syntax-data.json`, the dated
+> changelog record, and the exact `docs/releases/vX.Y.Z.md` file together.
+> Tagging a commit where any one of those identities differs produces a split
+> release record.
 
 ```bash
 # Set the intended version in the root [workspace.package], if needed.
@@ -81,8 +82,8 @@ release_version="$(scripts/workspace-version.py)"
 release_tag="v${release_version}"
 test -f "docs/releases/${release_tag}.md"
 
-git add Cargo.toml Cargo.lock hew-parser/fuzz/Cargo.lock CHANGELOG.md \
-  "docs/releases/${release_tag}.md"
+git add Cargo.toml Cargo.lock hew-parser/fuzz/Cargo.lock docs/syntax-data.json \
+  CHANGELOG.md "docs/releases/${release_tag}.md"
 git commit -m "chore(release): prepare ${release_tag}"
 ```
 

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -2672,7 +2672,7 @@ machine Name {
     state StateB { field: Type; }         // state with data
 
     // Transitions: on Event: Source => Target { body }
-    on EventX: StateA => StateB { StateB } // explicit body returns target value
+    on EventX: StateA => StateB { .StateB } // explicit body returns target value
     on EventY: StateA => StateB { StateB { field: event.payload } }
 
     // Head binding: name payload fields at the rule site
@@ -3744,9 +3744,9 @@ pairs are not cloneable generator captures. A whole owned value loaded from a
 generator environment is an alias; it must be cloned explicitly before being
 yielded or otherwise moved into another owner.
 
-> See HEW-FUTURE.md §1.6 for the remaining deferred generator forms (`async gen
-> fn`, `Lazy<T>`, `#[prefetch(N)]`). `gen fn`, `gen {}`, and `receive gen fn`
-> use the snapshot semantics above.
+> See HEW-FUTURE.md §1.6 for the remaining deferred generator forms
+> (`Lazy<T>`, `#[prefetch(N)]`). `gen fn`, `gen {}`, `async gen fn`, and
+> `receive gen fn` use the snapshot semantics above.
 
 ---
 
@@ -5356,8 +5356,8 @@ If you want this to be directly executable as an engineering project, the next m
   ladder: AST → Resolved HIR → SIR → Raw MIR → Checked MIR → Elaborated
   MIR → LLVM IR via inkwell. The v0.4 Rust-frontend / C++ backend /
   MessagePack-AST pipeline is no longer the design.
-- **Deferred to next edition.** Generators (`async gen fn` /
-  `receive gen fn` / `Lazy<T>` / `#[prefetch(N)]`), closures with captured
+- **Deferred to next edition.** Generators (`Lazy<T>` / `#[prefetch(N)]`),
+  closures with captured
   environment, user-facing `Arc<T>`, `dyn Trait`, `DoubleEndedIterator`,
   generic `HashMap<K, V>` over owned-aggregate/float keys, cancellation
   tokens, actor await + read-after-send barrier, and the self-hosting

--- a/docs/syntax-data.json
+++ b/docs/syntax-data.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0-pre",
+  "version": "0.6.0-rc3",
   "description": "Canonical syntax data exported from the Hew compiler. Used by tree-sitter-hew, vscode-hew, hew.sh, and hew.run to generate syntax highlighting grammars.",
   "keywords": {
     "control_flow": [
@@ -27,7 +27,6 @@
       "pub",
       "import",
       "package",
-      "super",
       "extern",
       "where",
       "type",
@@ -54,16 +53,10 @@
       "await_restart",
       "this"
     ],
-    "wire": [
-      "reserved",
-      "optional",
-      "deprecated",
-      "default"
-    ],
+    "wire": ["reserved", "optional", "deprecated", "default"],
     "supervisor_config": [
       "child",
       "restart",
-      "budget",
       "strategy",
       "permanent",
       "transient",
@@ -75,10 +68,7 @@
       "simple_one_for_one",
       "pool"
     ],
-    "logical": [
-      "true",
-      "false"
-    ],
+    "logical": ["true", "false"],
     "machine": [
       "machine",
       "state",
@@ -89,17 +79,15 @@
       "exit",
       "emit"
     ],
-    "other": [
-      "dyn",
-      "unsafe",
-      "is"
-    ],
+    "other": ["dyn", "unsafe", "is"],
     "reserved_unused": [
       "try",
       "catch",
       "race",
       "foreign",
-      "cooperate"
+      "cooperate",
+      "super",
+      "budget"
     ]
   },
   "all_keywords": [
@@ -188,6 +176,8 @@
   "contextual_identifiers": {
     "description": "Identifiers that have special meaning in specific parser contexts but are NOT reserved keywords (they can be used as regular identifiers elsewhere).",
     "self": "Selects the imported module itself inside a dotted import selection (import path.{self as alias}).",
+    "clone": "Prefix clone operator (clone <operand>) when immediately followed by an operand; an ordinary identifier otherwise (x.clone(), fn clone(...)).",
+    "consume": "By-move parameter modifier (fn f(consume x: T)) when leading a parameter declaration; an ordinary identifier otherwise (fn f(consume: T), x.consume()).",
     "events": "Machine input-event vocabulary block header (contextual inside machine body)",
     "emits": "Machine Mealy-output manifest block header (contextual inside machine body)",
     "reenter": "Machine transition self-re-entry modifier (contextual after target state name)",
@@ -215,34 +205,10 @@
     "fail": "Overflow policy: reject the send with Full"
   },
   "operators": {
-    "arithmetic": [
-      "+",
-      "-",
-      "*",
-      "/",
-      "%"
-    ],
-    "comparison": [
-      "==",
-      "!=",
-      "<",
-      "<=",
-      ">",
-      ">="
-    ],
-    "logical": [
-      "&&",
-      "||",
-      "!"
-    ],
-    "bitwise": [
-      "&",
-      "|",
-      "^",
-      "~",
-      "<<",
-      ">>"
-    ],
+    "arithmetic": ["+", "-", "*", "/", "%"],
+    "comparison": ["==", "!=", "<", "<=", ">", ">="],
+    "logical": ["&&", "||", "!"],
+    "bitwise": ["&", "|", "^", "~", "<<", ">>"],
     "assignment": [
       "=",
       "+=",
@@ -256,24 +222,12 @@
       "<<=",
       ">>="
     ],
-    "arrow": [
-      "->",
-      "=>"
-    ],
-    "range": [
-      "..",
-      "..="
-    ],
-    "other": [
-      "?",
-      "@",
-      ".",
-      "::",
-      "#["
-    ],
+    "arrow": ["->", "=>"],
+    "range": ["..", "..="],
+    "other": ["?", "@", ".", "::", "#["],
     "path_separators": {
       "primary": ".",
-      "deprecated": ["::"]
+      "removed": ["::"]
     }
   },
   "types": {
@@ -289,33 +243,18 @@
       "isize",
       "usize"
     ],
-    "float": [
-      "f32",
-      "f64"
-    ],
+    "float": ["f32", "f64"],
     "primitive": [
       "bool",
       "char",
       "string",
       "bytes",
       "void",
-      "never",
       "duration",
       "instant"
     ],
-    "collections": [
-      "HashMap",
-      "HashSet",
-      "Vec"
-    ],
-    "option_result": [
-      "Option",
-      "Result",
-      "Ok",
-      "Err",
-      "Some",
-      "None"
-    ],
+    "collections": ["HashMap", "HashSet", "Vec"],
+    "option_result": ["Option", "Result", "Ok", "Err", "Some", "None"],
     "concurrency": [
       "LocalPid",
       "RemotePid",
@@ -327,24 +266,10 @@
       "Generator",
       "AsyncGenerator"
     ],
-    "marker_traits": [
-      "Send",
-      "Frozen",
-      "Copy",
-      "Arc",
-      "Rc",
-      "Weak"
-    ],
-    "other": [
-      "Range"
-    ]
+    "marker_traits": ["Send", "Frozen", "Copy", "Arc", "Rc", "Weak"],
+    "other": ["Range"]
   },
-  "string_prefixes": [
-    "f",
-    "r",
-    "re",
-    "b"
-  ],
+  "string_prefixes": ["f", "r", "re", "b"],
   "comment_styles": {
     "line": "//",
     "doc": "///",
@@ -353,13 +278,6 @@
     "block_end": "*/"
   },
   "literal_suffixes": {
-    "duration": [
-      "ns",
-      "us",
-      "ms",
-      "s",
-      "m",
-      "h"
-    ]
+    "duration": ["ns", "us", "ms", "s", "m", "h"]
   }
 }

--- a/docs/syntax-data.json
+++ b/docs/syntax-data.json
@@ -53,7 +53,12 @@
       "await_restart",
       "this"
     ],
-    "wire": ["reserved", "optional", "deprecated", "default"],
+    "wire": [
+      "reserved",
+      "optional",
+      "deprecated",
+      "default"
+    ],
     "supervisor_config": [
       "child",
       "restart",
@@ -68,7 +73,10 @@
       "simple_one_for_one",
       "pool"
     ],
-    "logical": ["true", "false"],
+    "logical": [
+      "true",
+      "false"
+    ],
     "machine": [
       "machine",
       "state",
@@ -79,7 +87,11 @@
       "exit",
       "emit"
     ],
-    "other": ["dyn", "unsafe", "is"],
+    "other": [
+      "dyn",
+      "unsafe",
+      "is"
+    ],
     "reserved_unused": [
       "try",
       "catch",
@@ -205,10 +217,34 @@
     "fail": "Overflow policy: reject the send with Full"
   },
   "operators": {
-    "arithmetic": ["+", "-", "*", "/", "%"],
-    "comparison": ["==", "!=", "<", "<=", ">", ">="],
-    "logical": ["&&", "||", "!"],
-    "bitwise": ["&", "|", "^", "~", "<<", ">>"],
+    "arithmetic": [
+      "+",
+      "-",
+      "*",
+      "/",
+      "%"
+    ],
+    "comparison": [
+      "==",
+      "!=",
+      "<",
+      "<=",
+      ">",
+      ">="
+    ],
+    "logical": [
+      "&&",
+      "||",
+      "!"
+    ],
+    "bitwise": [
+      "&",
+      "|",
+      "^",
+      "~",
+      "<<",
+      ">>"
+    ],
     "assignment": [
       "=",
       "+=",
@@ -222,9 +258,21 @@
       "<<=",
       ">>="
     ],
-    "arrow": ["->", "=>"],
-    "range": ["..", "..="],
-    "other": ["?", "@", ".", "::", "#["],
+    "arrow": [
+      "->",
+      "=>"
+    ],
+    "range": [
+      "..",
+      "..="
+    ],
+    "other": [
+      "?",
+      "@",
+      ".",
+      "::",
+      "#["
+    ],
     "path_separators": {
       "primary": ".",
       "removed": ["::"]
@@ -243,18 +291,31 @@
       "isize",
       "usize"
     ],
-    "float": ["f32", "f64"],
+    "float": [
+      "f32",
+      "f64"
+    ],
     "primitive": [
       "bool",
       "char",
       "string",
       "bytes",
-      "void",
       "duration",
       "instant"
     ],
-    "collections": ["HashMap", "HashSet", "Vec"],
-    "option_result": ["Option", "Result", "Ok", "Err", "Some", "None"],
+    "collections": [
+      "HashMap",
+      "HashSet",
+      "Vec"
+    ],
+    "option_result": [
+      "Option",
+      "Result",
+      "Ok",
+      "Err",
+      "Some",
+      "None"
+    ],
     "concurrency": [
       "LocalPid",
       "RemotePid",
@@ -266,10 +327,24 @@
       "Generator",
       "AsyncGenerator"
     ],
-    "marker_traits": ["Send", "Frozen", "Copy", "Arc", "Rc", "Weak"],
-    "other": ["Range"]
+    "marker_traits": [
+      "Send",
+      "Frozen",
+      "Copy",
+      "Arc",
+      "Rc",
+      "Weak"
+    ],
+    "other": [
+      "Range"
+    ]
   },
-  "string_prefixes": ["f", "r", "re", "b"],
+  "string_prefixes": [
+    "f",
+    "r",
+    "re",
+    "b"
+  ],
   "comment_styles": {
     "line": "//",
     "doc": "///",
@@ -278,6 +353,13 @@
     "block_end": "*/"
   },
   "literal_suffixes": {
-    "duration": ["ns", "us", "ms", "s", "m", "h"]
+    "duration": [
+      "ns",
+      "us",
+      "ms",
+      "s",
+      "m",
+      "h"
+    ]
   }
 }

--- a/editors/emacs/hew-mode.el
+++ b/editors/emacs/hew-mode.el
@@ -83,7 +83,7 @@
 (defconst hew-builtin-types
   '("i8" "i16" "i32" "i64" "u8" "u16" "u32" "u64"
     "f32" "f64" "isize" "usize"
-    "bool" "char" "string" "bytes" "void" "never" "duration" "instant"
+    "bool" "char" "string" "bytes" "void" "duration" "instant"
     "Result" "Option" "Ok" "Err" "Some" "Vec" "HashMap" "HashSet" "Range"
     "Box" "Arc" "Rc" "Weak"
     "LocalPid" "RemotePid" "LambdaPid" "Task" "Scope"

--- a/editors/emacs/hew-mode.el
+++ b/editors/emacs/hew-mode.el
@@ -68,7 +68,7 @@
 (defconst hew-keywords
   '("if" "else" "is" "match" "loop" "for" "in" "while"
     "break" "continue" "return"
-    "let" "var" "const" "mut" "fn" "gen" "type" "record" "indirect" "enum"
+    "let" "var" "const" "mut" "fn" "gen" "type" "indirect" "enum"
     "trait" "impl" "import" "pub" "super" "where"
     "actor" "fork" "receive" "init" "spawn" "async" "move" "await" "await_restart" "this"
     "supervisor" "child" "restart" "budget" "strategy"
@@ -83,7 +83,7 @@
 (defconst hew-builtin-types
   '("i8" "i16" "i32" "i64" "u8" "u16" "u32" "u64"
     "f32" "f64" "isize" "usize"
-    "bool" "char" "string" "bytes" "void" "duration" "instant"
+    "bool" "char" "string" "bytes" "duration" "instant"
     "Result" "Option" "Ok" "Err" "Some" "Vec" "HashMap" "HashSet" "Range"
     "Box" "Arc" "Rc" "Weak"
     "LocalPid" "RemotePid" "LambdaPid" "Task" "Scope"

--- a/editors/nano/hew.nanorc
+++ b/editors/nano/hew.nanorc
@@ -65,7 +65,7 @@ color green "\<(try|catch|race|foreign|cooperate|super|budget)\>"
 
 # Types — primitives
 color brightblue "\<(i8|i16|i32|i64|u8|u16|u32|u64|isize|usize|f32|f64)\>"
-color brightblue "\<(bool|char|string|bytes|void|duration|instant)\>"
+color brightblue "\<(bool|char|string|bytes|duration|instant)\>"
 
 # Types — generic / collection / concurrency
 color brightblue "\<(HashMap|HashSet|Vec|Option|Result|Ok|Err|Some|Box|Arc|Rc|Weak|Range)\>"

--- a/editors/nano/hew.nanorc
+++ b/editors/nano/hew.nanorc
@@ -1,6 +1,6 @@
 ## Hew syntax highlighting for GNU nano
 ## Generated from syntax-data.json — do not edit by hand.
-## syntax-data.json version: 0.10.0-pre
+## syntax-data.json version: 0.6.0-rc3
 
 syntax "hew" "\.hew$"
 
@@ -41,15 +41,15 @@ color brightwhite "\<(yield|defer|select|join|after|from|await|scope)\>"
 
 # Declaration keywords
 color green "\<(let|var|const|mut|fn|gen|async|pub|import|package)\>"
-color green "\<(super|extern|where|record|type|indirect|enum|trait|impl|as)\>"
+color green "\<(extern|where|type|indirect|enum|trait|impl|as)\>"
 
 # Actor & concurrency
 color brightgreen "\<(actor|supervisor|spawn|receive|init|scope|fork|move|select|join)\>"
 color brightgreen "\<(after|from|await|await_restart|this)\>"
 
 # Supervisor configuration
-color brightgreen "\<(child|restart|budget|strategy|permanent|transient|temporary|brutal_kill|one_for_one|one_for_all)\>"
-color brightgreen "\<(rest_for_one|simple_one_for_one|pool)\>"
+color brightgreen "\<(child|restart|strategy|permanent|transient|temporary|brutal_kill|one_for_one|one_for_all|rest_for_one)\>"
+color brightgreen "\<(simple_one_for_one|pool)\>"
 
 # Wire protocol
 color green "\<(reserved|optional|deprecated|default)\>"
@@ -61,11 +61,11 @@ color green "\<(machine|state|event|on|when|entry|exit|emit)\>"
 color green "\<(dyn|unsafe|is)\>"
 
 # Reserved keywords
-color green "\<(try|catch|race|foreign|cooperate)\>"
+color green "\<(try|catch|race|foreign|cooperate|super|budget)\>"
 
 # Types — primitives
 color brightblue "\<(i8|i16|i32|i64|u8|u16|u32|u64|isize|usize|f32|f64)\>"
-color brightblue "\<(bool|char|string|bytes|void|never|duration|instant)\>"
+color brightblue "\<(bool|char|string|bytes|void|duration|instant)\>"
 
 # Types — generic / collection / concurrency
 color brightblue "\<(HashMap|HashSet|Vec|Option|Result|Ok|Err|Some|Box|Arc|Rc|Weak|Range)\>"

--- a/editors/sublime/Hew.tmLanguage.json
+++ b/editors/sublime/Hew.tmLanguage.json
@@ -2,9 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Hew",
   "scopeName": "source.hew",
-  "fileTypes": [
-    "hew"
-  ],
+  "fileTypes": ["hew"],
   "patterns": [
     {
       "include": "#comments"
@@ -254,7 +252,7 @@
         {
           "comment": "Declarations",
           "name": "keyword.declaration.hew",
-          "match": "\\b(as|async|const|enum|extern|fn|gen|impl|import|indirect|let|mut|package|pub|record|super|trait|type|var|where)\\b"
+          "match": "\\b(as|async|const|enum|extern|fn|gen|impl|import|indirect|let|mut|package|pub|record|trait|type|var|where)\\b"
         },
         {
           "comment": "Actor and concurrency",
@@ -264,7 +262,7 @@
         {
           "comment": "Supervisor",
           "name": "keyword.supervisor.hew",
-          "match": "\\b(budget|child|restart|strategy|supervisor)\\b"
+          "match": "\\b(child|restart|strategy|supervisor)\\b"
         },
         {
           "comment": "Supervisor strategy and overflow policy values",
@@ -326,7 +324,7 @@
         {
           "comment": "Primitive types",
           "name": "storage.type.primitive.hew",
-          "match": "\\b(bool|bytes|char|duration|instant|never|string|void)\\b"
+          "match": "\\b(bool|bytes|char|duration|instant|string|void)\\b"
         },
         {
           "comment": "Generic / collection types",
@@ -767,7 +765,7 @@
         {
           "comment": "Contextual identifiers (special meaning in specific contexts)",
           "name": "variable.language.contextual.hew",
-          "match": "\\b(block|coalesce|drop_new|drop_old|emits|events|export|fail|fallback|infinity|initial|intensity|json|mailbox|overflow|reenter|repeated|shutdown|wired_to|within|yaml)\\b"
+          "match": "\\b(block|clone|coalesce|consume|drop_new|drop_old|emits|events|export|fail|fallback|infinity|initial|intensity|json|mailbox|overflow|reenter|repeated|shutdown|wired_to|within|yaml)\\b"
         },
         {
           "comment": "Identifier (catch-all for variables, parameters, fields)",

--- a/editors/sublime/Hew.tmLanguage.json
+++ b/editors/sublime/Hew.tmLanguage.json
@@ -252,7 +252,7 @@
         {
           "comment": "Declarations",
           "name": "keyword.declaration.hew",
-          "match": "\\b(as|async|const|enum|extern|fn|gen|impl|import|indirect|let|mut|package|pub|record|trait|type|var|where)\\b"
+          "match": "\\b(as|async|const|enum|extern|fn|gen|impl|import|indirect|let|mut|package|pub|trait|type|var|where)\\b"
         },
         {
           "comment": "Actor and concurrency",
@@ -324,7 +324,7 @@
         {
           "comment": "Primitive types",
           "name": "storage.type.primitive.hew",
-          "match": "\\b(bool|bytes|char|duration|instant|string|void)\\b"
+          "match": "\\b(bool|bytes|char|duration|instant|string)\\b"
         },
         {
           "comment": "Generic / collection types",

--- a/hew-lexer/src/lib.rs
+++ b/hew-lexer/src/lib.rs
@@ -1340,6 +1340,22 @@ mod tests {
             "all_keywords in syntax-data.json must exactly match the lexer's ALL_KEYWORDS, in order"
         );
 
+        // WHY: nothing generates docs/syntax-data.json's `version` field — it
+        // is hand-maintained and had drifted to a value no release ever
+        // shipped (0.10.0-pre) while the workspace was on 0.6.0-rc3. This
+        // assertion is the authority that keeps it honest; a mismatch means
+        // the JSON's version was hand-edited without checking Cargo.toml.
+        // WHEN: obsolete once a real generator writes this file from the
+        // workspace version at build/sync time.
+        // WHAT: `scripts/sync-downstream.sh` would emit the file instead of
+        // validating a hand-maintained copy.
+        assert_eq!(
+            data["version"].as_str(),
+            Some(env!("CARGO_PKG_VERSION")),
+            "syntax-data.json's version field must match the workspace version \
+             (hew-lexer/Cargo.toml uses version.workspace = true)"
+        );
+
         // Verify the union of categorized keywords equals all_keywords.
         let categories = data["keywords"]
             .as_object()

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -121,7 +121,7 @@ spec-0077   3711765580   # SNIPPET: bare `let`/`var` — machine state illustrat
 spec-0078   1861586926   # SNIPPET: bare `let` after machine transitions — illustration
 spec-0079   3943447574   # SNIPPET: bare `let m = ...` — machine instantiation illustration
 spec-0080   249349858   # SNIPPET: bare `Option` identifier — option-type illustration
-spec-0081   1181031507   # IMPL-GAP: undefined `StateB` — machine-state enum reference illustration
+spec-0081   3231394512   # SNIPPET: placeholder `field: Type` on `StateB` — target has a required field so `.StateB` (fine for a unit state) hits E_PATH_KIND_MISMATCH; the fence never supplies a real field value
 spec-0082   3707425012   # SPEC-BUG: interleaved `event` declarations — old machine syntax pre-`events {}`
 spec-0083   813722226   # SNIPPET: bare `on event { ... }` — machine transition illustration
 spec-0084   2915754722   # SNIPPET: bare `on event ...` — machine state illustration


### PR DESCRIPTION
## Why

docs/syntax-data.json and docs/specs/HEW-SPEC-2026.md had drifted from what the compiler actually accepts - a type it rejects, a separator it hard-errors on, keywords with no parser consumer, contextual identifiers missing from the data, a stale version, and spec text describing generator forms as deferred when they compile and typecheck today.

## What

- **syntax-data.json**: removed `never` from `types.primitive` (`hew check` rejects it - `Ty::Never` has no lexer token or user-facing spelling, only the internal `!` marker exists). Renamed `path_separators.deprecated` to `removed` - `::` is `E_PATH_LEGACY_SEPARATOR`, a hard error, not a warning. Moved `super`/`budget` from `declarations`/`supervisor_config` into `reserved_unused`; neither has a parser consumer beyond the generic contextual-identifier-fallback path. Added `consume`/`clone` to `contextual_identifiers`, both special-cased in `hew-parser/src/parser/core.rs`. Bumped the stale `version` field to the workspace version and added a `hew-lexer` test asserting they stay in sync going forward, since nothing in-tree generates this file today.
- **HEW-SPEC-2026.md**: `async gen fn` and `receive gen fn` were listed as deferred in two places (§4.12 and the edition changelog) while both compile and typecheck; only `Lazy<T>` and `#[prefetch(N)]` remain deferred, per HEW-FUTURE.md §1.6. The §3.11.1 machine transition example used a bare `StateB` variant body, which the checker rejects as `E_BARE_VARIANT_EXPR`; dot-qualified it.
- **editors/**: regenerated `editors/nano/hew.nanorc` from the corrected syntax-data.json via `tools/downstream/generate-nano.mjs` (this also drops `record`, which isn't in `ALL_KEYWORDS`/syntax-data.json either - stale in sublime/emacs too, left as a follow-up). Hand-synced `editors/sublime/Hew.tmLanguage.json`'s `super`/`budget`/`never` categories and its `clone`/`consume` contextual entries; dropped `never` from `editors/emacs/hew-mode.el`'s builtin-type list (emacs highlights reserved words like `try`/`catch` uniformly, so `super`/`budget` staying there is consistent with its existing pattern, not drift).
- **scripts/doc-test-expected-failures.txt**: the machine-example fence's content hash changed with the dot-qualify fix; re-verified its failure (a required `field: Type` on `StateB` makes the unit-state `.StateB` shorthand a constructor-kind mismatch, not the old bare-variant error) and updated the label.
- **workspace CLAUDE.md**: fixed the sync-order step that still pointed at hew.sh's `tools/generate-monarch.mjs`, retired when hew.sh moved to TextMate grammars, and noted that a version bump needs `docs/syntax-data.json` alongside `Cargo.toml`.
- vscode-hew and vim-hew now drift from the same reclassification; filed hew-lang/hew#3219 to sync them, since they are separate repos with their own push convention.

hew.sh: deleted the dead `tools/generate-monarch.mjs` script and its `.env.example` reference in a separate commit pushed directly to hew.sh main (`chore: remove the retired monarch generator`).

## Test

- `cargo test -p hew-lexer --lib`, including `syntax_data_json_covers_all_keywords` (extended with the version assertion) and `sublime_grammar_keywords_match_lexer_surface`.
- `HEW_BIN=<release hew> scripts/corpus-ratchet.sh doc-fences` - passes with the updated expected-failure label.
- `scripts/sync-downstream.sh --check` - confirms tree-sitter-hew needed no change (super/budget/never were never in its grammar rules) and editors/nano now matches the generator's output.
- Verified against a built `hew` binary that `never` and `::` are rejected, and that plain `gen fn`/`async gen fn` and the bare-vs-dot-qualified machine transition body behave as described above.
