### PR TITLE
test(std): compile the standard library doc fences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1379,6 +1379,7 @@ test-doc-examples: hew-native
 # Drive matching and mutated doc-failure sets through the production harness.
 doc-ratchet-selftest:
 	@scripts/tests/test_doc_ratchet_membership.sh
+	@scripts/tests/test_std_doc_fence_extraction.sh
 
 # Shell/python only; no artifacts.
 

--- a/Makefile
+++ b/Makefile
@@ -1360,18 +1360,19 @@ test-example-expectations-selftest:
 
 # Python only; no artifacts.
 
-# Check ```hew fenced blocks in docs/ against hew check.
-# Extracts each fence from the Markdown guides and docs/language/*.hew module
-# doc blocks into .tmp/doc-fences/, runs `hew check` on each, and applies the
-# ratchet from scripts/doc-test-expected-failures.txt so known-failing fences
-# do not block the gate while new failures always do.
+# Check ```hew fenced blocks in docs/ and std/ against hew check.
+# Extracts each fence from the Markdown guides, docs/language/*.hew module
+# doc blocks, and every std/**/*.hew doc comment into .tmp/doc-fences/, runs
+# `hew check` on each, and applies the ratchet from
+# scripts/doc-test-expected-failures.txt so known-failing fences do not block
+# the gate while new failures always do.
 #
 # Skip-annotated fences (<!-- doctest: skip --> or preceding NYI callout) are
 # never compiled — they describe aspirational or not-yet-implemented surfaces.
 # Fail-closed default: a fence is compiled unless explicitly skipped.
 #
-# Run `make test-doc-examples` after any docs/ change to confirm no fence
-# regressions were introduced.
+# Run `make test-doc-examples` after any docs/ or std/ change to confirm no
+# fence regressions were introduced.
 test-doc-examples: hew-native
 	@HEW_BIN="$(DEBUG_HEW)" scripts/corpus-ratchet.sh doc-fences
 

--- a/scripts/corpus-ratchet.sh
+++ b/scripts/corpus-ratchet.sh
@@ -938,7 +938,8 @@ hew_corpus_diagnostic() {
 
 # ── Corpus: doc-fences ────────────────────────────────────────────────────────
 #
-# Extracts every ```hew fence from the language guide and the spec into
+# Extracts every ```hew fence from the language guide, the spec, the
+# docs/language/*.hew modules, and every std/**/*.hew doc comment into
 # individual files, then type-checks each one. A fence whose preceding five
 # lines carry a "Not yet implemented" callout or a `<!-- doctest: skip -->`
 # comment is SKIPPED — spec-ahead-of-implementation is not drift when a plan
@@ -962,6 +963,10 @@ DOC_FENCE_SOURCES=(
     "docs/specs/HEW-SPEC-2026.md:spec"
 )
 DOC_FENCE_LANGUAGE_DIR="$REPO_ROOT/docs/language"
+# Overridable so a test can point extraction at a small fixture tree instead
+# of the real std/ (hundreds of fences) to exercise the tri-state extractor.
+DOC_FENCE_STD_DIR="${DOC_FENCE_STD_DIR:-$REPO_ROOT/std}"
+STD_FENCE_SOURCES=()
 
 # Substrings that, in the five lines before a ```hew fence, mark it skippable.
 DOC_FENCE_NYI_PATTERNS=("Not yet implemented" "doctest: skip" "doctest:skip")
@@ -988,6 +993,42 @@ doc_fence_add_language_sources() {
 
     if ((found == 0)); then
         echo "error: no language documentation modules found in $DOC_FENCE_LANGUAGE_DIR" >&2
+        exit 1
+    fi
+}
+
+# std/**/*.hew doc comments use a different fencing convention than the guide
+# and spec: item-level `///` comments (not only module-level `//!`), and a
+# BARE ``` open (implicit hew — the only language std fences are written in)
+# rather than an explicit ```hew tag. A handful of fences carry an explicit
+# non-hew tag (e.g. ```text) that must stay excluded. doc_fence_extract's
+# open condition (`stripped == '```hew'` only) and prefix strip (`//!` only)
+# don't cover either case, so std gets its own enumerator and extractor
+# instead of overloading the guide/spec one and risking a change in behaviour
+# there.
+# STD_FENCE_SOURCES pairs carry the ABSOLUTE file path (unlike
+# DOC_FENCE_SOURCES's REPO_ROOT-relative paths) because DOC_FENCE_STD_DIR is
+# overridable to a fixture tree outside REPO_ROOT for testing; run_doc_fences
+# uses the std entries as-is instead of rejoining them under REPO_ROOT.
+doc_fence_add_std_sources() {
+    local std_file relative_path slug
+    local found=0
+
+    if [[ ! -d "$DOC_FENCE_STD_DIR" ]]; then
+        echo "error: standard library directory not found: $DOC_FENCE_STD_DIR" >&2
+        exit 1
+    fi
+
+    while IFS= read -r std_file; do
+        found=1
+        relative_path="${std_file#"$DOC_FENCE_STD_DIR"/}"
+        slug="${relative_path%.hew}"
+        slug="${slug//\//-}"
+        STD_FENCE_SOURCES+=("$std_file:std-$slug")
+    done < <(find "$DOC_FENCE_STD_DIR" -type f -name '*.hew' -not -path '*/target/*' -print | LC_ALL=C sort)
+
+    if ((found == 0)); then
+        echo "error: no standard library modules found in $DOC_FENCE_STD_DIR" >&2
         exit 1
     fi
 }
@@ -1023,6 +1064,90 @@ doc_fence_extract() {
         line="${lines[$i]}"
         stripped="${line%%$'\r'}"
         if [[ "$stripped" != '```hew' ]]; then
+            ((i += 1))
+            continue
+        fi
+
+        fence_num=$((fence_num + 1))
+        printf -v fence_id "%s-%04d" "$prefix" "$fence_num"
+
+        skip=0
+        for ((j = i > 5 ? i - 5 : 0; j < i; j++)); do
+            ctx_line="${lines[$j]}"
+            for marker in "${DOC_FENCE_NYI_PATTERNS[@]}"; do
+                if [[ "$ctx_line" == *"$marker"* ]]; then
+                    skip=1
+                    break 2
+                fi
+            done
+        done
+
+        ((i += 1))
+        content=""
+        while ((i < total)); do
+            fline="${lines[$i]}"
+            fstripped="${fline%%$'\r'}"
+            if [[ "$fstripped" == '```' ]]; then
+                ((i += 1))
+                break
+            fi
+            content="${content}${fline}"$'\n'
+            ((i += 1))
+        done
+
+        outfile="$DOC_FENCE_OUTDIR/${fence_id}.hew"
+        printf '%s' "$content" >"$outfile"
+
+        DOC_FENCE_IDS+=("$fence_id")
+        DOC_FENCE_SKIPPED+=("$skip")
+    done
+}
+
+# std's counterpart to doc_fence_extract: strips both `//!` and `///` doc
+# prefixes, and tracks a third "inside a non-hew fence" state so a bare ```
+# that closes e.g. a ```text block is never mistaken for the open of the next
+# implicit-hew fence (which is itself opened by a bare ```, since std never
+# tags its own fences ```hew). Content lines outside any comment prefix have
+# already been blanked by the strip pass, so a fence body line is never
+# confused with a fence delimiter.
+doc_fence_extract_std() {
+    local filepath="$1"
+    local prefix="$2"
+    local lines=()
+    local line total fence_num i stripped fence_id skip j ctx_line marker
+    local content fline fstripped outfile in_other=0
+
+    while IFS= read -r line; do
+        case "$line" in
+        '//!'*)
+            line="${line#//!}"
+            line="${line# }"
+            ;;
+        '///'*)
+            line="${line#///}"
+            line="${line# }"
+            ;;
+        *) line="" ;;
+        esac
+        lines+=("$line")
+    done <"$filepath"
+
+    total="${#lines[@]}"
+    fence_num=0
+    i=0
+
+    while ((i < total)); do
+        line="${lines[$i]}"
+        stripped="${line%%$'\r'}"
+
+        if ((in_other)); then
+            [[ "$stripped" == '```' ]] && in_other=0
+            ((i += 1))
+            continue
+        fi
+
+        if [[ "$stripped" != '```' && "$stripped" != '```hew' ]]; then
+            [[ "$stripped" == '```'* ]] && in_other=1
             ((i += 1))
             continue
         fi
@@ -1105,7 +1230,7 @@ run_doc_fences() {
     mkdir -p "$DOC_FENCE_OUTDIR"
     doc_fence_add_language_sources
 
-    echo "==> Doc-test harness: extracting hew fences from docs/"
+    echo "==> Doc-test harness: extracting hew fences from docs/ and std/"
     for entry in "${DOC_FENCE_SOURCES[@]}"; do
         doc_path="${entry%%:*}"
         prefix="${entry##*:}"
@@ -1116,6 +1241,15 @@ run_doc_fences() {
         fi
         echo "  Scanning: $doc_path"
         doc_fence_extract "$full_path" "$prefix"
+    done
+
+    echo "  Scanning: std/ (standard library doc fences)"
+    doc_fence_add_std_sources
+    for entry in "${STD_FENCE_SOURCES[@]}"; do
+        # Unlike DOC_FENCE_SOURCES, entries here already carry an absolute
+        # path (see doc_fence_add_std_sources) — do not rejoin with REPO_ROOT.
+        full_path="${entry%%:*}"
+        doc_fence_extract_std "$full_path" "${entry##*:}"
     done
 
     total_fences="${#DOC_FENCE_IDS[@]}"

--- a/scripts/corpus-ratchet.sh
+++ b/scripts/corpus-ratchet.sh
@@ -1118,13 +1118,18 @@ doc_fence_extract_std() {
     local content fline fstripped outfile in_other=0
 
     while IFS= read -r line; do
-        case "$line" in
+        # doc comments on trait/impl members are indented (unlike the
+        # module-level `//!` sources doc_fence_extract handles), so the
+        # comment marker is matched after trimming leading whitespace rather
+        # than only at column 0.
+        local trimmed="${line#"${line%%[![:space:]]*}"}"
+        case "$trimmed" in
         '//!'*)
-            line="${line#//!}"
+            line="${trimmed#//!}"
             line="${line# }"
             ;;
         '///'*)
-            line="${line#///}"
+            line="${trimmed#///}"
             line="${line# }"
             ;;
         *) line="" ;;

--- a/scripts/tests/test_std_doc_fence_extraction.sh
+++ b/scripts/tests/test_std_doc_fence_extraction.sh
@@ -42,8 +42,11 @@ FIXTURE_STD_DIR="$TMP_ROOT/std-fixture"
 mkdir -p "$FIXTURE_STD_DIR"
 
 # One module-level (`//!`) fence, one item-level (`///`) fence, a `text`
-# -tagged fence that must be excluded, and a further `///` fence directly
-# after it — the tooth that catches an in_other regression.
+# -tagged fence that must be excluded, a further `///` fence directly after
+# it — the tooth that catches an in_other regression — and an indented `///`
+# fence on a trait member — the tooth that catches an indented-marker
+# regression (doc comments on trait/impl members are indented, unlike the
+# column-0 module-level `//!` sources).
 cat >"$FIXTURE_STD_DIR/example.hew" <<'FIXTURE_EOF'
 //! Module doc.
 //!
@@ -70,6 +73,15 @@ pub fn noop() {}
 /// let c = 3;
 /// ```
 pub fn another() {}
+
+pub trait Greeter {
+    /// A trait member doc with an indented example.
+    ///
+    /// ```
+    /// let d = 4;
+    /// ```
+    fn greet();
+}
 FIXTURE_EOF
 
 FAKE_HEW="$TMP_ROOT/hew"
@@ -92,10 +104,10 @@ DOC_FENCE_STD_DIR="$FIXTURE_STD_DIR" \
 
 mapfile -t FIXTURE_OUTFILES < <(find "$OUTDIR" -name '*example*.hew' | LC_ALL=C sort)
 
-if ((${#FIXTURE_OUTFILES[@]} == 3)); then
-    pass "fixture yields exactly 3 hew fences (the text-tagged fence is excluded)"
+if ((${#FIXTURE_OUTFILES[@]} == 4)); then
+    pass "fixture yields exactly 4 hew fences (the text-tagged fence is excluded)"
 else
-    fail "fixture yielded ${#FIXTURE_OUTFILES[@]} fences, expected 3 (got: ${FIXTURE_OUTFILES[*]:-none})"
+    fail "fixture yielded ${#FIXTURE_OUTFILES[@]} fences, expected 4 (got: ${FIXTURE_OUTFILES[*]:-none})"
 fi
 
 if ((${#FIXTURE_OUTFILES[@]} >= 1)) &&
@@ -127,6 +139,17 @@ if ! grep -rq 'hew wire check' "$OUTDIR"/*example*.hew 2>/dev/null; then
     pass "the text-tagged fence itself is never extracted as a hew fence"
 else
     fail "the text-tagged fence's content leaked into an extracted hew fence"
+fi
+
+# The pinned bug this fixture tooth catches: without trimming leading
+# whitespace before matching the `///` marker, an indented trait-member doc
+# comment is never recognized as a doc comment at all, so its fence is
+# silently dropped instead of extracted.
+if ((${#FIXTURE_OUTFILES[@]} >= 4)) &&
+    grep -qxF 'let d = 4;' "${FIXTURE_OUTFILES[3]}" 2>/dev/null; then
+    pass "fourth fence (indented trait-member /// doc) extracts its own content"
+else
+    fail "fourth fence content mismatch: $(cat "${FIXTURE_OUTFILES[3]:-/dev/null}" 2>/dev/null || echo MISSING)"
 fi
 
 echo ""

--- a/scripts/tests/test_std_doc_fence_extraction.sh
+++ b/scripts/tests/test_std_doc_fence_extraction.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Negative-control regression test for doc_fence_extract_std's tri-state
+# fence scanner (scripts/corpus-ratchet.sh).
+#
+# std/**/*.hew doc comments fence hew examples with a BARE ``` (no ```hew
+# tag) and mix module-level `//!` with item-level `///` comments. A fence
+# tagged with another language (```text) must never contribute a hew fence,
+# and — the bug this test pins — its closing bare ``` must never be mistaken
+# for the OPEN of the next real hew fence. Getting that wrong doesn't shrink
+# the fence count (a stray fence still gets captured), it corrupts fence
+# CONTENT: the fence after a ```text block ends up holding the prose between
+# the two fences instead of its own code.
+#
+# WHEN OBSOLETE: superseded if doc_fence_extract_std is deleted or std moves
+# off the bare-fence convention entirely.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HARNESS="$REPO_ROOT/scripts/corpus-ratchet.sh"
+
+PASSES=0
+FAILURES=0
+
+pass() {
+    echo "PASS: $*"
+    PASSES=$((PASSES + 1))
+}
+
+fail() {
+    echo "FAIL: $*" >&2
+    FAILURES=$((FAILURES + 1))
+}
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hew-std-fence-test.XXXXXX")"
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FIXTURE_STD_DIR="$TMP_ROOT/std-fixture"
+mkdir -p "$FIXTURE_STD_DIR"
+
+# One module-level (`//!`) fence, one item-level (`///`) fence, a `text`
+# -tagged fence that must be excluded, and a further `///` fence directly
+# after it — the tooth that catches an in_other regression.
+cat >"$FIXTURE_STD_DIR/example.hew" <<'FIXTURE_EOF'
+//! Module doc.
+//!
+//! ```
+//! let a = 1;
+//! ```
+
+/// Item doc with an example.
+///
+/// ```
+/// let b = 2;
+/// ```
+pub fn noop() {}
+
+/// A schema check example (not hew).
+///
+/// ```text
+/// hew wire check <file.hew> --against <baseline.hew>
+/// ```
+///
+/// Another example right after the text fence.
+///
+/// ```
+/// let c = 3;
+/// ```
+pub fn another() {}
+FIXTURE_EOF
+
+FAKE_HEW="$TMP_ROOT/hew"
+cat >"$FAKE_HEW" <<'FAKE_HEW_EOF'
+#!/usr/bin/env bash
+[[ $# -eq 2 && "$1" == "check" ]] || exit 64
+exit 0
+FAKE_HEW_EOF
+chmod +x "$FAKE_HEW"
+
+OUTDIR="$TMP_ROOT/fences"
+EXPECTED_EMPTY="$TMP_ROOT/expected-empty.txt"
+touch "$EXPECTED_EMPTY"
+
+DOC_FENCE_STD_DIR="$FIXTURE_STD_DIR" \
+    "$HARNESS" doc-fences \
+    --expected-failures "$EXPECTED_EMPTY" \
+    --outdir "$OUTDIR" \
+    --hew-bin "$FAKE_HEW" >"$TMP_ROOT/harness-output.txt" 2>&1 || true
+
+mapfile -t FIXTURE_OUTFILES < <(find "$OUTDIR" -name '*example*.hew' | LC_ALL=C sort)
+
+if ((${#FIXTURE_OUTFILES[@]} == 3)); then
+    pass "fixture yields exactly 3 hew fences (the text-tagged fence is excluded)"
+else
+    fail "fixture yielded ${#FIXTURE_OUTFILES[@]} fences, expected 3 (got: ${FIXTURE_OUTFILES[*]:-none})"
+fi
+
+if ((${#FIXTURE_OUTFILES[@]} >= 1)) &&
+    grep -qxF 'let a = 1;' "${FIXTURE_OUTFILES[0]}" 2>/dev/null; then
+    pass "first fence (module //! doc) extracts its own content"
+else
+    fail "first fence content mismatch: $(cat "${FIXTURE_OUTFILES[0]:-/dev/null}" 2>/dev/null || echo MISSING)"
+fi
+
+if ((${#FIXTURE_OUTFILES[@]} >= 2)) &&
+    grep -qxF 'let b = 2;' "${FIXTURE_OUTFILES[1]}" 2>/dev/null; then
+    pass "second fence (item /// doc) extracts its own content"
+else
+    fail "second fence content mismatch: $(cat "${FIXTURE_OUTFILES[1]:-/dev/null}" 2>/dev/null || echo MISSING)"
+fi
+
+# The pinned bug: without the in_other tri-state, this third extracted fence
+# holds the prose ("Another example...") swallowed between the ```text
+# close and the real fence open, instead of `let c = 3;`.
+if ((${#FIXTURE_OUTFILES[@]} >= 3)) &&
+    grep -qxF 'let c = 3;' "${FIXTURE_OUTFILES[2]}" 2>/dev/null &&
+    ! grep -q 'Another example' "${FIXTURE_OUTFILES[2]}" 2>/dev/null; then
+    pass "fence after a text-tagged block extracts its own content, not the intervening prose"
+else
+    fail "fence after text-tagged block corrupted: $(cat "${FIXTURE_OUTFILES[2]:-/dev/null}" 2>/dev/null || echo MISSING)"
+fi
+
+if ! grep -rq 'hew wire check' "$OUTDIR"/*example*.hew 2>/dev/null; then
+    pass "the text-tagged fence itself is never extracted as a hew fence"
+else
+    fail "the text-tagged fence's content leaked into an extracted hew fence"
+fi
+
+echo ""
+echo "std doc-fence extraction self-test: $PASSES passed, $FAILURES failed"
+((FAILURES == 0))

--- a/std/bench/bench.hew
+++ b/std/bench/bench.hew
@@ -8,6 +8,11 @@
 //! ```
 //! import std.bench;
 //!
+//! fn fibonacci(n: i64) -> i64 {
+//!     if n < 2 { return n; }
+//!     return fibonacci(n - 1) + fibonacci(n - 2);
+//! }
+//!
 //! fn main() {
 //!     let s = bench.suite("My Benchmarks");
 //!     s.add("fib_20", 1000, || { fibonacci(20); });

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -156,6 +156,10 @@ pub enum AskError {
 /// Returned as `Err(TimeoutError.Timeout)` when the deadline fires before an
 /// item arrives.  Distinguishes a timeout from a closed channel (`Ok(None)`).
 ///
+/// Not yet implemented: `await ... | after d` requires a suspendable
+/// actor/closure/task context, so this snippet is illustrative only and does
+/// not compile standalone.
+///
 /// ```hew
 /// match await rx.recv() | after 50ms {
 ///     Ok(Some(v)) => v,       // item received before deadline
@@ -209,6 +213,9 @@ pub trait ActorMsg {
 /// generic `P: Pid` sends are fail-closed unless `P.Msg` is concretely proven
 /// Serializable; local-only dispatch through `LocalPid<T>` keeps the value
 /// model below.
+///
+/// Not yet implemented: the checker cannot express the `P.Msg: Serializable`
+/// projection bound yet (A640), so this snippet does not compile today.
 ///
 /// ```
 /// fn ping<P: Pid>(p: P, msg: P.Msg) -> Result<(), SendError> {
@@ -855,7 +862,10 @@ pub fn print(value: dyn Display) {}
 /// # Examples
 ///
 /// ```
-/// assert(x > 0);
+/// fn main() {
+///     let x = 5;
+///     assert(x > 0);
+/// }
 /// ```
 pub fn assert(condition: bool) {}
 
@@ -866,7 +876,13 @@ pub fn assert(condition: bool) {}
 /// # Examples
 ///
 /// ```
-/// assert_eq(add(1, 2), 3);
+/// fn add(a: i64, b: i64) -> i64 {
+///     a + b
+/// }
+///
+/// fn main() {
+///     assert_eq(add(1, 2), 3);
+/// }
 /// ```
 pub fn assert_eq(left: dyn Display, right: dyn Display) {}
 
@@ -877,7 +893,11 @@ pub fn assert_eq(left: dyn Display, right: dyn Display) {}
 /// # Examples
 ///
 /// ```
-/// assert_ne(a, b);
+/// fn main() {
+///     let a = 1;
+///     let b = 2;
+///     assert_ne(a, b);
+/// }
 /// ```
 pub fn assert_ne(left: dyn Display, right: dyn Display) {}
 
@@ -921,6 +941,9 @@ pub fn max(a: i32, b: i32) -> i32 {
 }
 
 /// Convert an integer to a floating-point number.
+///
+/// Not yet implemented: the checker admits the call but cannot lower it to
+/// an executable target yet, so this snippet does not compile today.
 ///
 /// # Examples
 ///
@@ -987,7 +1010,8 @@ pub fn string_equals(a: string, b: string) -> bool {
 
 /// Convert an integer to a string.
 ///
-/// # Examples
+/// Not yet implemented: the checker admits the call but cannot lower it to
+/// an executable target yet, so this snippet does not compile today.
 ///
 /// ```
 /// let s = string_from_int(42);  // "42"
@@ -1008,7 +1032,8 @@ pub fn string_starts_with(s: string, prefix: string) -> bool {
 
 /// Extract a substring by byte indices `[start, end)`.
 ///
-/// # Examples
+/// Not yet implemented: the checker admits the call but cannot lower it to
+/// an executable target yet, so this snippet does not compile today.
 ///
 /// ```
 /// let s = substring("hello", 0, 3);  // "hel"

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -828,9 +828,11 @@ impl Display for duration {
 /// # Examples
 ///
 /// ```
-/// println(42);
-/// println("hello");
-/// println(true);
+/// fn main() {
+///     println(42);
+///     println("hello");
+///     println(true);
+/// }
 /// ```
 pub fn println(value: dyn Display) {}
 
@@ -839,7 +841,9 @@ pub fn println(value: dyn Display) {}
 /// # Examples
 ///
 /// ```
-/// print("Enter name: ");
+/// fn main() {
+///     print("Enter name: ");
+/// }
 /// ```
 pub fn print(value: dyn Display) {}
 
@@ -885,7 +889,9 @@ pub fn assert_ne(left: dyn Display, right: dyn Display) {}
 /// # Examples
 ///
 /// ```
-/// let x = abs(-5);  // 5
+/// fn main() {
+///     let x = abs(-5);  // 5
+/// }
 /// ```
 pub fn abs(x: i32) -> i32 {
     0 as i32
@@ -896,7 +902,9 @@ pub fn abs(x: i32) -> i32 {
 /// # Examples
 ///
 /// ```
-/// let r = sqrt(9.0);  // 3.0
+/// fn main() {
+///     let r = sqrt(9.0);  // 3.0
+/// }
 /// ```
 pub fn sqrt(x: f64) -> f64 {
     0.0
@@ -931,7 +939,9 @@ pub fn to_float(x: i32) -> f64 {
 /// # Examples
 ///
 /// ```
-/// let full = string_concat("hello ", "world");
+/// fn main() {
+///     let full = string_concat("hello ", "world");
+/// }
 /// ```
 pub fn string_concat(a: string, b: string) -> string {
     ""
@@ -950,9 +960,11 @@ pub fn string_length(s: string) -> i32 {
 /// # Examples
 ///
 /// ```
-/// let s = to_string(42);     // "42"
-/// let t = to_string(true);   // "true"
-/// let u = to_string('x');    // "x"
+/// fn main() {
+///     let s = to_string(42);     // "42"
+///     let t = to_string(true);   // "true"
+///     let u = to_string('x');    // "x"
+/// }
 /// ```
 pub fn to_string(value: dyn Display) -> string {
     ""
@@ -1036,9 +1048,11 @@ pub fn string_trim(s: string) -> string {
 /// # Examples
 ///
 /// ```
-/// sleep(10ms);   // sleep for 10 milliseconds
-/// sleep(2s);     // sleep for 2 seconds
-/// sleep(500ms);  // sleep for 500 milliseconds
+/// fn main() {
+///     sleep(10ms);   // sleep for 10 milliseconds
+///     sleep(2s);     // sleep for 2 seconds
+///     sleep(500ms);  // sleep for 500 milliseconds
+/// }
 /// ```
 pub fn sleep(d: duration) {}
 
@@ -1048,8 +1062,10 @@ pub fn sleep(d: duration) {}
 /// `instant + duration` to construct a future `instant`:
 ///
 /// ```
-/// let deadline = instant.now() + 10ms;
-/// sleep_until(deadline);   // wait until 10 ms from now
+/// fn main() {
+///     let deadline = instant.now() + 10ms;
+///     sleep_until(deadline);   // wait until 10 ms from now
+/// }
 /// ```
 ///
 /// The `instant + duration` operation adds a duration offset to a monotonic
@@ -1059,14 +1075,16 @@ pub fn sleep(d: duration) {}
 /// # Examples
 ///
 /// ```
-/// let deadline = instant.now();
-/// // ... do work ...
-/// sleep_until(deadline);   // wait until the deadline if not yet reached
+/// fn main() {
+///     let deadline = instant.now();
+///     // ... do work ...
+///     sleep_until(deadline);   // wait until the deadline if not yet reached
 ///
-/// // Sleep for exactly 50 ms from a fixed reference point:
-/// let t0 = instant.now();
-/// // ... do work ...
-/// sleep_until(t0 + 50ms);  // accounts for time already spent
+///     // Sleep for exactly 50 ms from a fixed reference point:
+///     let t0 = instant.now();
+///     // ... do work ...
+///     sleep_until(t0 + 50ms);  // accounts for time already spent
+/// }
 /// ```
 pub fn sleep_until(target: instant) {}
 
@@ -1085,6 +1103,8 @@ pub fn exit(code: i32) {}
 /// # Examples
 ///
 /// ```
-/// panic("something went wrong");
+/// fn main() {
+///     panic("something went wrong");
+/// }
 /// ```
 pub fn panic(message: string) {}

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -1013,6 +1013,8 @@ pub fn string_equals(a: string, b: string) -> bool {
 /// Not yet implemented: the checker admits the call but cannot lower it to
 /// an executable target yet, so this snippet does not compile today.
 ///
+/// # Examples
+///
 /// ```
 /// let s = string_from_int(42);  // "42"
 /// ```
@@ -1034,6 +1036,8 @@ pub fn string_starts_with(s: string, prefix: string) -> bool {
 ///
 /// Not yet implemented: the checker admits the call but cannot lower it to
 /// an executable target yet, so this snippet does not compile today.
+///
+/// # Examples
 ///
 /// ```
 /// let s = substring("hello", 0, 3);  // "hel"

--- a/std/channel/channel.hew
+++ b/std/channel/channel.hew
@@ -37,8 +37,8 @@
 //!     tx.close();
 //!
 //!     match rx.recv() {
-//!         Some(msg) => println(msg),  // hello
-//!         None => println("closed"),
+//!         .Some(msg) => println(msg),  // hello
+//!         .None => println("closed"),
 //!     }
 //!     rx.close();
 //! }

--- a/std/channel/channel.hew
+++ b/std/channel/channel.hew
@@ -160,9 +160,16 @@ impl ReceiverMethods for Receiver {
 /// # Examples
 ///
 /// ```
-/// let (tx, rx) = channel.new(16);
-/// tx.send("hello");       // infers Sender<string>
-/// println(rx.recv());     // infers Receiver<string>
+/// import std.channel.channel;
+///
+/// fn main() {
+///     let (tx, rx) = channel.new(16);
+///     tx.send("hello");       // infers Sender<string>
+///     match rx.recv() {       // infers Receiver<string>
+///         .Some(v) => println(v),  // hello
+///         .None => println("closed"),
+///     }
+/// }
 /// ```
 pub fn new(capacity: i64) -> (Sender, Receiver) {
     match try_new(capacity) {

--- a/std/crypto/encrypt/encrypt.hew
+++ b/std/crypto/encrypt/encrypt.hew
@@ -5,6 +5,7 @@
 //! # Examples
 //!
 //! ```
+//! import std.crypto.crypto;
 //! import std.crypto.encrypt;
 //!
 //! fn main() {

--- a/std/crypto/encrypt/encrypt.hew
+++ b/std/crypto/encrypt/encrypt.hew
@@ -11,8 +11,8 @@
 //!     let key = crypto.random_bytes(32);
 //!     let ciphertext = encrypt.seal(key, "hello world");
 //!     match encrypt.try_open(key, ciphertext) {
-//!         Ok(plaintext) => println(plaintext),
-//!         Err(err) => println(encrypt.error_message(err)),
+//!         .Ok(plaintext) => println(plaintext),
+//!         .Err(err) => println(encrypt.error_message(err)),
 //!     }
 //! }
 //! ```

--- a/std/crypto/jwt/jwt.hew
+++ b/std/crypto/jwt/jwt.hew
@@ -135,7 +135,13 @@ pub fn decode(token: string, secret: string, algorithm: string) -> string {
 /// # Examples
 ///
 /// ```
-/// let payload = jwt.decode_insecure(token);
+/// import std.crypto.jwt;
+///
+/// fn main() {
+///     let token = jwt.encode("{\"sub\":\"1234\"}", "secret", "HS256");
+///     let payload = jwt.decode_insecure(token);
+///     println(payload);
+/// }
 /// ```
 pub fn decode_insecure(token: string) -> string {
     unsafe {
@@ -150,8 +156,13 @@ pub fn decode_insecure(token: string) -> string {
 /// # Examples
 ///
 /// ```
-/// if jwt.validate(token, "my_secret", "HS256") {
-///     println("valid");
+/// import std.crypto.jwt;
+///
+/// fn main() {
+///     let token = jwt.encode("{\"sub\":\"1234\"}", "my_secret", "HS256");
+///     if jwt.validate(token, "my_secret", "HS256") {
+///         println("valid");
+///     }
 /// }
 /// ```
 pub fn validate(token: string, secret: string, algorithm: string) -> bool {

--- a/std/crypto/jwt/jwt.hew
+++ b/std/crypto/jwt/jwt.hew
@@ -9,8 +9,8 @@
 //!
 //! fn main() {
 //!     match jwt.try_encode("{\"sub\":\"1234\"}", "secret", "HS256") {
-//!         Ok(token) => println(token),
-//!         Err(err) => println(jwt.error_message(err)),
+//!         .Ok(token) => println(token),
+//!         .Err(err) => println(jwt.error_message(err)),
 //!     }
 //! }
 //! ```

--- a/std/crypto/password/password.hew
+++ b/std/crypto/password/password.hew
@@ -23,7 +23,11 @@
 /// # Examples
 ///
 /// ```
-/// let hash = password.hash("hunter2");
+/// import std.crypto.password;
+///
+/// fn main() {
+///     let hash = password.hash("hunter2");
+/// }
 /// ```
 pub fn hash(password: string) -> string {
     unsafe {
@@ -70,7 +74,11 @@ pub fn try_verify(password: string, hash: string) -> Result<bool, string> {
 /// # Examples
 ///
 /// ```
-/// let hash = password.hash_custom("hunter2", 6);
+/// import std.crypto.password;
+///
+/// fn main() {
+///     let hash = password.hash_custom("hunter2", 6);
+/// }
 /// ```
 pub fn hash_custom(password: string, cost: i64) -> string {
     match try_hash_custom(password, cost) {

--- a/std/crypto/password/password.hew
+++ b/std/crypto/password/password.hew
@@ -42,8 +42,13 @@ pub fn hash(password: string) -> string {
 /// # Examples
 ///
 /// ```
-/// if password.verify("hunter2", stored_hash) {
-///     println("access granted");
+/// import std.crypto.password;
+///
+/// fn main() {
+///     let stored_hash = password.hash("hunter2");
+///     if password.verify("hunter2", stored_hash) {
+///         println("access granted");
+///     }
 /// }
 /// ```
 pub fn verify(password: string, hash: string) -> bool {

--- a/std/encoding/markdown/markdown.hew
+++ b/std/encoding/markdown/markdown.hew
@@ -20,7 +20,11 @@
 /// # Examples
 ///
 /// ```
-/// let html = markdown.to_html("**bold** text");
+/// import std.encoding.markdown;
+///
+/// fn main() {
+///     let html = markdown.to_html("**bold** text");
+/// }
 /// ```
 pub fn to_html(md: string) -> string {
     unsafe {
@@ -36,7 +40,11 @@ pub fn to_html(md: string) -> string {
 /// # Examples
 ///
 /// ```
-/// let safe = markdown.to_html_safe("Click <script>alert(1)</script>");
+/// import std.encoding.markdown;
+///
+/// fn main() {
+///     let safe = markdown.to_html_safe("Click <script>alert(1)</script>");
+/// }
 /// ```
 pub fn to_html_safe(md: string) -> string {
     unsafe {

--- a/std/encoding/protobuf/protobuf.hew
+++ b/std/encoding/protobuf/protobuf.hew
@@ -117,9 +117,13 @@ impl Message {
 /// # Examples
 ///
 /// ```
-/// let msg = protobuf.new();
-/// msg.set_varint(1, 100);
-/// msg.close();
+/// import std.encoding.protobuf;
+///
+/// fn main() {
+///     let msg = protobuf.new();
+///     msg.set_varint(1, 100);
+///     msg.close();
+/// }
 /// ```
 pub fn new() -> Message {
     unsafe {

--- a/std/encoding/wire/wire.hew
+++ b/std/encoding/wire/wire.hew
@@ -14,8 +14,8 @@
 //!     let e = UserCreated { id: 42, name: "ada" };
 //!     let j = e.to_json();          // {"id":42,"name":"ada"}
 //!     match UserCreated.from_json(j) {
-//!         Ok(back) => println(back.name),   // ada
-//!         Err(_) => println("parse failed"),
+//!         .Ok(back) => println(back.name),   // ada
+//!         .Err(_) => println("parse failed"),
 //!     }
 //! }
 //! ```

--- a/std/fmt/fmt.hew
+++ b/std/fmt/fmt.hew
@@ -26,9 +26,13 @@ import std.string;
 /// # Examples
 ///
 /// ```
-/// fmt.to_hex(255)   // "ff"
-/// fmt.to_hex(0)     // "0"
-/// fmt.to_hex(-16)   // "-10"
+/// import std.fmt;
+///
+/// fn main() {
+///     println(fmt.to_hex(255));   // "ff"
+///     println(fmt.to_hex(0));   // "0"
+///     println(fmt.to_hex(-16));   // "-10"
+/// }
 /// ```
 pub fn to_hex(n: i64) -> string {
     if n == 0 {
@@ -63,9 +67,13 @@ pub fn to_hex(n: i64) -> string {
 /// # Examples
 ///
 /// ```
-/// fmt.to_binary(10)   // "1010"
-/// fmt.to_binary(0)    // "0"
-/// fmt.to_binary(-5)   // "-101"
+/// import std.fmt;
+///
+/// fn main() {
+///     println(fmt.to_binary(10));   // "1010"
+///     println(fmt.to_binary(0));   // "0"
+///     println(fmt.to_binary(-5));   // "-101"
+/// }
 /// ```
 pub fn to_binary(n: i64) -> string {
     if n == 0 {
@@ -100,9 +108,13 @@ pub fn to_binary(n: i64) -> string {
 /// # Examples
 ///
 /// ```
-/// fmt.to_octal(8)    // "10"
-/// fmt.to_octal(0)    // "0"
-/// fmt.to_octal(-9)   // "-11"
+/// import std.fmt;
+///
+/// fn main() {
+///     println(fmt.to_octal(8));   // "10"
+///     println(fmt.to_octal(0));   // "0"
+///     println(fmt.to_octal(-9));   // "-11"
+/// }
 /// ```
 pub fn to_octal(n: i64) -> string {
     if n == 0 {
@@ -163,8 +175,12 @@ fn hex_digit(d: i64) -> string {
 /// # Examples
 ///
 /// ```
-/// fmt.pad_left("42", 5, " ")   // "   42"
-/// fmt.pad_left("42", 5, "0")   // "00042"
+/// import std.fmt;
+///
+/// fn main() {
+///     println(fmt.pad_left("42", 5, " "));   // "   42"
+///     println(fmt.pad_left("42", 5, "0"));   // "00042"
+/// }
 /// ```
 pub fn pad_left(s: string, width: i64, fill: string) -> string {
     string.pad_left(s, width, fill)
@@ -179,7 +195,11 @@ pub fn pad_left(s: string, width: i64, fill: string) -> string {
 /// # Examples
 ///
 /// ```
-/// fmt.pad_right("hi", 5, ".")   // "hi..."
+/// import std.fmt;
+///
+/// fn main() {
+///     println(fmt.pad_right("hi", 5, "."));   // "hi..."
+/// }
 /// ```
 pub fn pad_right(s: string, width: i64, fill: string) -> string {
     string.pad_right(s, width, fill)
@@ -190,8 +210,12 @@ pub fn pad_right(s: string, width: i64, fill: string) -> string {
 /// # Examples
 ///
 /// ```
-/// fmt.repeat("ab", 3)   // "ababab"
-/// fmt.repeat("*", 5)    // "*****"
+/// import std.fmt;
+///
+/// fn main() {
+///     println(fmt.repeat("ab", 3));   // "ababab"
+///     println(fmt.repeat("*", 5));   // "*****"
+/// }
 /// ```
 pub fn repeat(s: string, count: i64) -> string {
     s.repeat(count)

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -20,8 +20,8 @@
 //!
 //! fn main() {
 //!     match load_config("config.toml") {
-//!         Ok(data) => println(data),
-//!         Err(e) => {
+//!         .Ok(data) => println(data),
+//!         .Err(e) => {
 //!             match e {
 //!                 IoError.NotFound(_) => println("missing"),
 //!                 _ => println("i/o error"),
@@ -185,7 +185,11 @@ fn last_io_error() -> IoError {
 /// # Examples
 ///
 /// ```
-/// let src = fs.read("main.hew");
+/// import std.fs;
+///
+/// fn main() {
+///     let src = fs.read("main.hew");
+/// }
 /// ```
 pub fn read(path: string) -> string {
     unsafe {
@@ -273,8 +277,12 @@ pub fn try_append(file_path: string, content: string) -> Result<i64, IoError> {
 /// # Examples
 ///
 /// ```
-/// if fs.exists("config.toml") {
-///     println("found config");
+/// import std.fs;
+///
+/// fn main() {
+///     if fs.exists("config.toml") {
+///         println("found config");
+///     }
 /// }
 /// ```
 pub fn exists(path: string) -> bool {
@@ -317,8 +325,12 @@ pub fn size(path: string) -> i64 {
 /// # Examples
 ///
 /// ```
-/// let data = fs.read_bytes("image.png");
-/// println(data.len());
+/// import std.fs;
+///
+/// fn main() {
+///     let data = fs.read_bytes("image.png");
+///     println(data.len());
+/// }
 /// ```
 pub fn read_bytes(path: string) -> bytes {
     unsafe {
@@ -422,9 +434,13 @@ pub fn try_mkdir_all(dir_path: string) -> Result<i64, IoError> {
 /// # Examples
 ///
 /// ```
-/// let entries = fs.list_dir("/tmp");
-/// for entry in entries {
-///     println(entry);
+/// import std.fs;
+///
+/// fn main() {
+///     let entries = fs.list_dir("/tmp");
+///     for entry in entries {
+///         println(entry);
+///     }
 /// }
 /// ```
 pub fn list_dir(path: string) -> Vec<string> {

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -14,7 +14,9 @@
 //! and the `?` operator for clean error propagation:
 //!
 //! ```
-//! fn load_config(path: string) -> Result<string, IoError> {
+//! import std.fs;
+//!
+//! fn load_config(path: string) -> Result<string, fs.IoError> {
 //!     fs.try_read(path)
 //! }
 //!
@@ -23,7 +25,7 @@
 //!         .Ok(data) => println(data),
 //!         .Err(e) => {
 //!             match e {
-//!                 IoError.NotFound(_) => println("missing"),
+//!                 fs.IoError.NotFound(_) => println("missing"),
 //!                 _ => println("i/o error"),
 //!             }
 //!         },
@@ -131,9 +133,14 @@ pub fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
 /// For network errors use `net.net_error_message` in `std.net`.
 ///
 /// ```
-/// match result {
-///     Err(e) => panic("operation failed: " + fs.io_error_message(e)),
-///     Ok(_) => {},
+/// import std.fs;
+///
+/// fn main() {
+///     let result: Result<i64, fs.IoError> = fs.try_delete("/tmp/scratch-file");
+///     match result {
+///         .Err(e) => panic("operation failed: " + fs.io_error_message(e)),
+///         .Ok(_) => {},
+///     }
 /// }
 /// ```
 pub fn io_error_message(e: IoError) -> string {

--- a/std/io/closable.hew
+++ b/std/io/closable.hew
@@ -13,7 +13,7 @@
 //! fn serve_one(addr: string) -> Result<(), closable.CloseError> {
 //!     let listener = net.listen(addr);
 //!     let conn = listener.accept();
-//!     conn.write("hello\n");
+//!     let _ = conn.write_string("hello\n");
 //!     listener.close()
 //! }
 //! ```
@@ -58,10 +58,31 @@ pub trait Closable {
 /// # Pattern matching
 ///
 /// ```
-/// match handle.close() {
-///     Ok(()) => {},
-///     Err(CloseError.Io(e)) => println(fs.io_error_message(e)),
-///     Err(CloseError.AlreadyClosed) => {},
+/// import std.fs;
+/// import std.io.closable;
+///
+/// type Handle {
+///     already_closed: bool;
+/// }
+///
+/// impl closable.Closable for Handle {
+///     fn close(val: Self) -> Result<(), closable.CloseError> {
+///         if val.already_closed {
+///             return Err(closable.CloseError.AlreadyClosed);
+///         }
+///         Ok(())
+///     }
+/// }
+///
+/// fn main() {
+///     let handle = Handle { already_closed: false };
+///     match handle.close() {
+///         .Ok(_) => {},
+///         .Err(err) => match err {
+///             closable.CloseError.Io(e) => println(fs.io_error_message(e)),
+///             closable.CloseError.AlreadyClosed => {},
+///         },
+///     }
 /// }
 /// ```
 pub enum CloseError {

--- a/std/io/scanner.hew
+++ b/std/io/scanner.hew
@@ -30,8 +30,8 @@
 //!
 //! fn main() {
 //!     let ls = scanner.lines("foo\nbar\nbaz");
-//!     for i in 0 .. ls.len() {
-//!         println(ls.get(i));
+//!     for l in ls {
+//!         println(l);
 //!     }
 //! }
 //! ```
@@ -156,7 +156,7 @@ pub fn from_file(path: string) -> Result<Scanner, fs.IoError> {
 ///
 /// fn main() {
 ///     var sc = scanner.from_string("one two  three");
-///     sc = scanner.with_split(sc, scanner.SplitWords);
+///     sc = scanner.with_split(sc, scanner.SplitMode.SplitWords);
 ///     sc = scanner.scan(sc);
 ///     while scanner.has_next(sc) {
 ///         println(scanner.text(sc));

--- a/std/io/scanner.hew
+++ b/std/io/scanner.hew
@@ -48,7 +48,7 @@
 //!
 //! fn main() {
 //!     match scanner.from_file("input.txt") {
-//!         Ok(sc0) => {
+//!         .Ok(sc0) => {
 //!             var sc = sc0;
 //!             sc = scanner.scan(sc);
 //!             while scanner.has_next(sc) {
@@ -56,7 +56,7 @@
 //!                 sc = scanner.scan(sc);
 //!             }
 //!         },
-//!         Err(e) => panic(fs.io_error_message(e)),
+//!         .Err(e) => panic(fs.io_error_message(e)),
 //!     }
 //! }
 //! ```

--- a/std/iter.hew
+++ b/std/iter.hew
@@ -7,7 +7,17 @@
 //! through chained constructor calls:
 //!
 //! ```
-//! let doubled_first_two = iter.take(iter.map(it, |x: i64| x * 2), 2);
+//! import std.iter;
+//!
+//! fn main() {
+//!     let v: Vec<i64> = Vec.new();
+//!     v.push(1);
+//!     v.push(2);
+//!     v.push(3);
+//!     let it = v.iter();
+//!     let doubled_first_two = iter.take(iter.map(it, |x: i64| x * 2), 2);
+//!     println(iter.collect(doubled_first_two).len());  // 2
+//! }
 //! ```
 //!
 //! `Iterator.next` takes a mutable receiver (`fn next(var self) -> Option<Self.Item>`).

--- a/std/metrics/metrics.hew
+++ b/std/metrics/metrics.hew
@@ -176,8 +176,12 @@ impl HistogramMethods for Histogram {
 /// # Examples
 ///
 /// ```
-/// let hits = metrics.counter("app.cache_hits");
-/// hits.inc();
+/// import std.metrics;
+///
+/// fn main() {
+///     let hits = metrics.counter("app.cache_hits");
+///     hits.inc();
+/// }
 /// ```
 pub fn counter(name: string) -> Counter {
     let id = unsafe {

--- a/std/misc/log/log.hew
+++ b/std/misc/log/log.hew
@@ -14,6 +14,8 @@
 //! # Usage — module-level
 //!
 //! ```
+//! import std.misc.log;
+//!
 //! fn main() {
 //!     log.setup();   // set global level to INFO
 //!     log.info("server starting");
@@ -25,6 +27,8 @@
 //! # Usage — Logger value
 //!
 //! ```
+//! import std.misc.log;
+//!
 //! fn main() {
 //!     let lg = log.new_logger(log.DEBUG, log.JSON);
 //!     log.logger_info(lg, "startup", [log.field("svc", "auth")]);
@@ -51,12 +55,12 @@
 //! # Output formats
 //!
 //! TEXT (0) — coloured timestamp + level + message + fields to stderr:
-//! ```
+//! ```text
 //! 12:34:56.789 INFO  server starting  port=8080
 //! ```
 //!
 //! JSON (1) — single-line NDJSON to stderr:
-//! ```
+//! ```text
 //! {"ts":1234567890.123,"level":"INFO","msg":"server starting","port":"8080"}
 //! ```
 

--- a/std/misc/log/log.hew
+++ b/std/misc/log/log.hew
@@ -95,8 +95,12 @@ pub const JSON: i64 = 1;
 /// # Example
 ///
 /// ```
-/// let lg = log.new_logger(log.DEBUG, log.JSON);
-/// log.logger_info(lg, "ready", [log.field_int("port", 8080)]);
+/// import std.misc.log;
+///
+/// fn main() {
+///     let lg = log.new_logger(log.DEBUG, log.JSON);
+///     log.logger_info(lg, "ready", [log.field_int("port", 8080)]);
+/// }
 /// ```
 pub type Logger {
     level: i64;
@@ -139,8 +143,12 @@ pub fn logger_format(lg: Logger) -> i64 {
 /// # Example
 ///
 /// ```
-/// let f = log.field("env", "production");    // "env=production"
-/// let g = log.field("user", "John Doe");     // user="John Doe"  (quoted)
+/// import std.misc.log;
+///
+/// fn main() {
+///     let f = log.field("env", "production");    // "env=production"
+///     let g = log.field("user", "John Doe");     // user="John Doe"  (quoted)
+/// }
 /// ```
 pub fn field(key: string, val: string) -> string {
     let encoded = unsafe {
@@ -154,7 +162,11 @@ pub fn field(key: string, val: string) -> string {
 /// # Example
 ///
 /// ```
-/// let f = log.field_int("port", 8080);  // "port=8080"
+/// import std.misc.log;
+///
+/// fn main() {
+///     let f = log.field_int("port", 8080);  // "port=8080"
+/// }
 /// ```
 pub fn field_int(key: string, val: i64) -> string {
     key + "=" + string.from_int(val)
@@ -165,7 +177,11 @@ pub fn field_int(key: string, val: i64) -> string {
 /// # Example
 ///
 /// ```
-/// let f = log.field_float("ratio", 0.75);  // "ratio=0.75"
+/// import std.misc.log;
+///
+/// fn main() {
+///     let f = log.field_float("ratio", 0.75);  // "ratio=0.75"
+/// }
 /// ```
 pub fn field_float(key: string, val: f64) -> string {
     key + "=" + string.from_float(val)
@@ -176,7 +192,11 @@ pub fn field_float(key: string, val: f64) -> string {
 /// # Example
 ///
 /// ```
-/// let f = log.field_bool("debug", true);  // "debug=true"
+/// import std.misc.log;
+///
+/// fn main() {
+///     let f = log.field_bool("debug", true);  // "debug=true"
+/// }
 /// ```
 pub fn field_bool(key: string, val: bool) -> string {
     key + "=" + string.from_bool(val)
@@ -221,7 +241,11 @@ pub fn setup() {
 /// # Examples
 ///
 /// ```
-/// log.set_level(log.DEBUG);
+/// import std.misc.log;
+///
+/// fn main() {
+///     log.set_level(log.DEBUG);
+/// }
 /// ```
 pub fn set_level(level: i64) {
     unsafe {
@@ -243,8 +267,12 @@ pub fn get_level() -> i64 {
 /// # Examples
 ///
 /// ```
-/// log.set_format(log.JSON);
-/// log.info_with("structured", [log.field("service", "api")]);
+/// import std.misc.log;
+///
+/// fn main() {
+///     log.set_format(log.JSON);
+///     log.info_with("structured", [log.field("service", "api")]);
+/// }
 /// ```
 pub fn set_format(format: i64) {
     unsafe {
@@ -271,7 +299,11 @@ pub fn error(msg: string) {
 /// # Example
 ///
 /// ```
-/// log.error_with("request failed", [log.field_int("status", 500), log.field("path", "/api")]);
+/// import std.misc.log;
+///
+/// fn main() {
+///     log.error_with("request failed", [log.field_int("status", 500), log.field("path", "/api")]);
+/// }
 /// ```
 pub fn error_with(msg: string, fields: Vec<string>) {
     let full = compose(msg, fields);
@@ -307,7 +339,11 @@ pub fn info(msg: string) {
 /// # Example
 ///
 /// ```
-/// log.info_with("server started", [log.field_int("port", 8080)]);
+/// import std.misc.log;
+///
+/// fn main() {
+///     log.info_with("server started", [log.field_int("port", 8080)]);
+/// }
 /// ```
 pub fn info_with(msg: string, fields: Vec<string>) {
     let full = compose(msg, fields);
@@ -372,8 +408,12 @@ pub fn logger_warn(lg: Logger, msg: string, fields: Vec<string>) {
 /// # Example
 ///
 /// ```
-/// let lg = log.new_logger(log.INFO, log.JSON);
-/// log.logger_info(lg, "ready", [log.field("svc", "auth")]);
+/// import std.misc.log;
+///
+/// fn main() {
+///     let lg = log.new_logger(log.INFO, log.JSON);
+///     log.logger_info(lg, "ready", [log.field("svc", "auth")]);
+/// }
 /// ```
 pub fn logger_info(lg: Logger, msg: string, fields: Vec<string>) {
     let full = compose(msg, fields);

--- a/std/misc/uuid/uuid.hew
+++ b/std/misc/uuid/uuid.hew
@@ -23,8 +23,12 @@
 /// # Examples
 ///
 /// ```
-/// let id = uuid.v4();
-/// // e.g. "550e8400-e29b-41d4-a716-446655440000"
+/// import std.misc.uuid;
+///
+/// fn main() {
+///     let id = uuid.v4();
+///     // e.g. "550e8400-e29b-41d4-a716-446655440000"
+/// }
 /// ```
 pub fn v4() -> string {
     unsafe {
@@ -39,7 +43,11 @@ pub fn v4() -> string {
 /// # Examples
 ///
 /// ```
-/// let id = uuid.v7();
+/// import std.misc.uuid;
+///
+/// fn main() {
+///     let id = uuid.v7();
+/// }
 /// ```
 pub fn v7() -> string {
     unsafe {
@@ -52,8 +60,12 @@ pub fn v7() -> string {
 /// # Examples
 ///
 /// ```
-/// uuid.is_valid("550e8400-e29b-41d4-a716-446655440000")  // true
-/// uuid.is_valid("not-a-uuid")                             // false
+/// import std.misc.uuid;
+///
+/// fn main() {
+///     println(uuid.is_valid("550e8400-e29b-41d4-a716-446655440000"));   // true
+///     println(uuid.is_valid("not-a-uuid"));   // false
+/// }
 /// ```
 pub fn is_valid(s: string) -> bool {
     unsafe {

--- a/std/net/dns/dns.hew
+++ b/std/net/dns/dns.hew
@@ -28,7 +28,11 @@ import std.net;
 /// # Examples
 ///
 /// ```
-/// let addrs = dns.resolve("localhost");  // ["127.0.0.1", "::1"]
+/// import std.net.dns;
+///
+/// fn main() {
+///     let addrs = dns.resolve("localhost");  // ["127.0.0.1", "::1"]
+/// }
 /// ```
 pub fn resolve(hostname: string) -> Vec<string> {
     unsafe {
@@ -61,7 +65,11 @@ pub fn try_resolve(hostname: string) -> Result<Vec<string>, net.NetError> {
 /// # Examples
 ///
 /// ```
-/// let ip = dns.lookup_host("localhost");  // "127.0.0.1"
+/// import std.net.dns;
+///
+/// fn main() {
+///     let ip = dns.lookup_host("localhost");  // "127.0.0.1"
+/// }
 /// ```
 pub fn lookup_host(hostname: string) -> string {
     unsafe {
@@ -96,7 +104,11 @@ pub fn try_lookup_host(hostname: string) -> Result<string, net.NetError> {
 /// # Examples
 ///
 /// ```
-/// let addrs = dns.resolve_timed("slow.example.com", 500);
+/// import std.net.dns;
+///
+/// fn main() {
+///     let addrs = dns.resolve_timed("slow.example.com", 500);
+/// }
 /// ```
 pub fn resolve_timed(hostname: string, deadline_ms: i64) -> Vec<string> {
     unsafe {

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -12,13 +12,13 @@
 //!
 //! fn main() {
 //!     match http.listen(":8080") {
-//!         Ok(server) => {
+//!         .Ok(server) => {
 //!             let req = server.accept();
 //!             req.respond_text(200, "Hello from Hew!");
 //!             req.close();
 //!             server.close();
 //!         },
-//!         Err(_err) => {
+//!         .Err(_err) => {
 //!             println(http.listen_error());
 //!         },
 //!     }

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -131,8 +131,19 @@ trait RequestMethods {
     /// # Examples
     ///
     /// ```
-    /// req.respond_text(200, "OK");
-    /// req.respond_text(404, "Not Found");
+    /// import std.net.http;
+    ///
+    /// fn main() {
+    ///     match http.listen(":8080") {
+    ///         .Ok(server) => {
+    ///             let req = server.accept();
+    ///             req.respond_text(200, "OK");
+    ///             req.close();
+    ///             server.close();
+    ///         },
+    ///         .Err(_err) => println(http.listen_error()),
+    ///     }
+    /// }
     /// ```
     fn respond_text(self, status: i64, body: string) -> i64;
 
@@ -147,10 +158,21 @@ trait RequestMethods {
     /// # Examples
     ///
     /// ```
-    /// let body = req.respond_stream(200, "text/plain");
-    /// body.write("chunk 1");
-    /// body.write("chunk 2");
-    /// body.close();
+    /// import std.net.http;
+    ///
+    /// fn main() {
+    ///     match http.listen(":8080") {
+    ///         .Ok(server) => {
+    ///             let req = server.accept();
+    ///             let body = req.respond_stream(200, "text/plain");
+    ///             body.write("chunk 1");
+    ///             body.write("chunk 2");
+    ///             body.close();
+    ///             server.close();
+    ///         },
+    ///         .Err(_err) => println(http.listen_error()),
+    ///     }
+    /// }
     /// ```
     fn respond_stream(self, status: i64, content_type: string) -> Sink<string>;
 
@@ -355,9 +377,14 @@ pub fn listen_error() -> string {
 /// # Examples
 ///
 /// ```
-/// match http.listen("127.0.0.1:0") {
-///     Ok(server) => server.close(),
-///     Err(err) => println(f"listen failed: {net.net_error_message(err)}"),
+/// import std.net;
+/// import std.net.http;
+///
+/// fn main() {
+///     match http.listen("127.0.0.1:0") {
+///         .Ok(server) => server.close(),
+///         .Err(err) => println(f"listen failed: {net.net_error_message(err)}"),
+///     }
 /// }
 /// ```
 pub fn listen(addr: string) -> Result<Server, net.NetError> {

--- a/std/net/http/http_client.hew
+++ b/std/net/http/http_client.hew
@@ -139,11 +139,15 @@ fn content_type_headers(content_type: string) -> Vec<(string, string)> {
 /// # Examples
 ///
 /// ```
-/// let headers: Vec<(string, string)> = Vec.new();
-/// headers.push(("Accept", "application/json"));
-/// let resp = http_client.request("GET", "https://example.com", "", headers);
-/// println(resp.status());
-/// resp.close();
+/// import std.net.http.http_client;
+///
+/// fn main() {
+///     let headers: Vec<(string, string)> = Vec.new();
+///     headers.push(("Accept", "application/json"));
+///     let resp = http_client.request("GET", "https://example.com", "", headers);
+///     println(resp.status());
+///     resp.close();
+/// }
 /// ```
 pub fn request(method: string, url: string, body: string, headers: Vec<(string, string)>) -> Response {
     unsafe {
@@ -161,10 +165,14 @@ pub fn request(method: string, url: string, body: string, headers: Vec<(string, 
 /// # Examples
 ///
 /// ```
-/// let headers: Vec<(string, string)> = Vec.new();
-/// match http_client.request_string("GET", "https://example.com", "", headers) {
-///     Some(body) => println(body),
-///     None => println("request failed"),
+/// import std.net.http.http_client;
+///
+/// fn main() {
+///     let headers: Vec<(string, string)> = Vec.new();
+///     match http_client.request_string("GET", "https://example.com", "", headers) {
+///         .Some(body) => println(body),
+///         .None => println("request failed"),
+///     }
 /// }
 /// ```
 pub fn request_string(method: string, url: string, body: string, headers: Vec<(string, string)>) -> Option<string> {
@@ -227,9 +235,13 @@ pub fn last_error() -> string {
 /// # Examples
 ///
 /// ```
-/// let resp = http_client.get("https://example.com");
-/// println(resp.status());
-/// resp.close();
+/// import std.net.http.http_client;
+///
+/// fn main() {
+///     let resp = http_client.get("https://example.com");
+///     println(resp.status());
+///     resp.close();
+/// }
 /// ```
 pub fn get(url: string) -> Response {
     request("GET", url, "", empty_headers())
@@ -240,8 +252,12 @@ pub fn get(url: string) -> Response {
 /// # Examples
 ///
 /// ```
-/// let resp = http_client.post("https://api.example.com/data", "application/json", "{}");
-/// resp.close();
+/// import std.net.http.http_client;
+///
+/// fn main() {
+///     let resp = http_client.post("https://api.example.com/data", "application/json", "{}");
+///     resp.close();
+/// }
 /// ```
 pub fn post(url: string, content_type: string, body: string) -> Response {
     request("POST", url, body, content_type_headers(content_type))
@@ -259,9 +275,13 @@ pub fn post(url: string, content_type: string, body: string) -> Response {
 /// # Examples
 ///
 /// ```
-/// match http_client.get_string("https://example.com") {
-///     Some(body) => println(body),
-///     None => println("request failed"),
+/// import std.net.http.http_client;
+///
+/// fn main() {
+///     match http_client.get_string("https://example.com") {
+///         .Some(body) => println(body),
+///         .None => println("request failed"),
+///     }
 /// }
 /// ```
 pub fn get_string(url: string) -> Option<string> {
@@ -277,13 +297,17 @@ pub fn get_string(url: string) -> Option<string> {
 /// # Examples
 ///
 /// ```
-/// match http_client.post_string(
-///     "https://api.example.com/submit",
-///     "application/json",
-///     "{\"key\": \"value\"}",
-/// ) {
-///     Some(body) => println(body),
-///     None => println("request failed"),
+/// import std.net.http.http_client;
+///
+/// fn main() {
+///     match http_client.post_string(
+///         "https://api.example.com/submit",
+///         "application/json",
+///         "{\"key\": \"value\"}",
+///     ) {
+///         .Some(body) => println(body),
+///         .None => println("request failed"),
+///     }
 /// }
 /// ```
 pub fn post_string(url: string, content_type: string, body: string) -> Option<string> {

--- a/std/net/http/http_client.hew
+++ b/std/net/http/http_client.hew
@@ -19,8 +19,8 @@
 //!
 //! fn main() {
 //!     match http_client.get_string("https://example.com") {
-//!         Some(body) => println(body),
-//!         None => println("request failed"),
+//!         .Some(body) => println(body),
+//!         .None => println("request failed"),
 //!     }
 //!
 //!     let headers: Vec<(string, string)> = Vec.new();

--- a/std/net/ipnet/ipnet.hew
+++ b/std/net/ipnet/ipnet.hew
@@ -59,8 +59,12 @@ pub fn is_private(addr: string) -> bool {
 /// # Examples
 ///
 /// ```
-/// ipnet.cidr_contains("10.0.0.0/8", "10.1.2.3")  // true
-/// ipnet.cidr_contains("10.0.0.0/8", "172.16.0.1") // false
+/// import std.net.ipnet;
+///
+/// fn main() {
+///     println(ipnet.cidr_contains("10.0.0.0/8", "10.1.2.3"));   // true
+///     println(ipnet.cidr_contains("10.0.0.0/8", "172.16.0.1"));   // false
+/// }
 /// ```
 pub fn cidr_contains(cidr: string, ip: string) -> bool {
     let contains = unsafe {
@@ -77,7 +81,11 @@ pub fn cidr_contains(cidr: string, ip: string) -> bool {
 /// # Examples
 ///
 /// ```
-/// ipnet.cidr_network("192.168.1.0/24")  // "192.168.1.0"
+/// import std.net.ipnet;
+///
+/// fn main() {
+///     println(ipnet.cidr_network("192.168.1.0/24"));   // "192.168.1.0"
+/// }
 /// ```
 pub fn cidr_network(cidr: string) -> string {
     unsafe {
@@ -90,7 +98,11 @@ pub fn cidr_network(cidr: string) -> string {
 /// # Examples
 ///
 /// ```
-/// ipnet.cidr_broadcast("192.168.1.0/24")  // "192.168.1.255"
+/// import std.net.ipnet;
+///
+/// fn main() {
+///     println(ipnet.cidr_broadcast("192.168.1.0/24"));   // "192.168.1.255"
+/// }
 /// ```
 pub fn cidr_broadcast(cidr: string) -> string {
     unsafe {
@@ -103,7 +115,11 @@ pub fn cidr_broadcast(cidr: string) -> string {
 /// # Examples
 ///
 /// ```
-/// ipnet.cidr_hosts("192.168.1.0/24")  // 254
+/// import std.net.ipnet;
+///
+/// fn main() {
+///     println(ipnet.cidr_hosts("192.168.1.0/24"));   // 254
+/// }
 /// ```
 pub fn cidr_hosts(cidr: string) -> i64 {
     let hosts = unsafe {

--- a/std/net/mime/mime.hew
+++ b/std/net/mime/mime.hew
@@ -26,9 +26,13 @@
 /// # Examples
 ///
 /// ```
-/// mime.from_path("photo.jpg")   // "image/jpeg"
-/// mime.from_path("style.css")   // "text/css"
-/// mime.from_path("data.json")   // "application/json"
+/// import std.net.mime;
+///
+/// fn main() {
+///     println(mime.from_path("photo.jpg"));   // "image/jpeg"
+///     println(mime.from_path("style.css"));   // "text/css"
+///     println(mime.from_path("data.json"));   // "application/json"
+/// }
 /// ```
 pub fn from_path(path: string) -> string {
     let ext = extract_extension(path);
@@ -40,8 +44,12 @@ pub fn from_path(path: string) -> string {
 /// # Examples
 ///
 /// ```
-/// mime.from_ext("html")  // "text/html"
-/// mime.from_ext("png")   // "image/png"
+/// import std.net.mime;
+///
+/// fn main() {
+///     println(mime.from_ext("html"));   // "text/html"
+///     println(mime.from_ext("png"));   // "image/png"
+/// }
 /// ```
 pub fn from_ext(ext: string) -> string {
     // Text

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -20,8 +20,8 @@
 //!
 //! fn main() {
 //!     match dial("localhost:9000") {
-//!         Ok(conn) => println("connected"),
-//!         Err(e) => {
+//!         .Ok(conn) => println("connected"),
+//!         .Err(e) => {
 //!             match e {
 //!                 NetError.ConnectionRefused(_) => println("nobody home"),
 //!                 NetError.TimedOut(_)          => println("timed out"),
@@ -567,8 +567,8 @@ trait ConnectionMethods {
 /// actor InboundLogger {
 ///     receive fn start(conn: Connection) {
 ///         match conn.attach(this) {
-///             Ok(()) => {},
-///             Err(AttachError.Refused) => println("attach refused"),
+///             .Ok(()) => {},
+///             .Err(AttachError.Refused) => println("attach refused"),
 ///         }
 ///     }
 ///     receive fn on_data(data: bytes) {
@@ -712,7 +712,11 @@ impl Connection {
 /// # Examples
 ///
 /// ```
-/// let listener = net.listen(":9000");
+/// import std.net;
+///
+/// fn main() {
+///     let listener = net.listen(":9000");
+/// }
 /// ```
 pub fn listen(addr: string) -> Listener {
     unsafe {
@@ -755,7 +759,11 @@ pub fn try_listen(addr: string) -> Result<Listener, NetError> {
 /// # Examples
 ///
 /// ```
-/// let conn = net.connect("localhost:9000");
+/// import std.net;
+///
+/// fn main() {
+///     let conn = net.connect("localhost:9000");
+/// }
 /// ```
 pub fn connect(addr: string) -> Connection {
     unsafe {

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -14,7 +14,7 @@
 //! ```
 //! import std.net;
 //!
-//! fn dial(addr: string) -> Result<Connection, net.NetError> {
+//! fn dial(addr: string) -> Result<net.Connection, net.NetError> {
 //!     net.try_connect(addr)
 //! }
 //!
@@ -243,9 +243,11 @@ fn try_endpoint_port(context: string, addr: string, text: string) -> Result<i64,
 /// ```
 /// import std.net;
 ///
-/// match net.try_parse_endpoint("net.connect_timeout", "[::1]:9000") {
-///     Ok(ep) => println(f"{ep.host} {ep.port}"),
-///     Err(err) => println(net.net_error_message(err)),
+/// fn main() {
+///     match net.try_parse_endpoint("net.connect_timeout", "[::1]:9000") {
+///         .Ok(ep) => println(f"{ep.host} {ep.port}"),
+///         .Err(err) => println(net.net_error_message(err)),
+///     }
 /// }
 /// ```
 pub fn try_parse_endpoint(context: string, addr: string) -> Result<Endpoint, NetError> {
@@ -564,18 +566,23 @@ trait ConnectionMethods {
 /// # Example
 ///
 /// ```
+/// import std.net;
+///
 /// actor InboundLogger {
-///     receive fn start(conn: Connection) {
-///         match conn.attach(this) {
-///             .Ok(()) => {},
-///             .Err(AttachError.Refused) => println("attach refused"),
-///         }
-///     }
 ///     receive fn on_data(data: bytes) {
 ///         println(f"received {data.len()} bytes");
 ///     }
 ///     receive fn on_close() {
 ///         println("client disconnected");
+///     }
+/// }
+///
+/// fn main() {
+///     let conn = net.connect("localhost:9000");
+///     let handler: LocalPid<InboundLogger> = spawn InboundLogger;
+///     match conn.attach(handler) {
+///         .Ok(()) => {},
+///         .Err(net.AttachError.Refused) => println("attach refused"),
 ///     }
 /// }
 /// ```
@@ -733,10 +740,12 @@ pub fn listen(addr: string) -> Listener {
 /// ```
 /// import std.net;
 ///
-/// match net.try_listen(":9000") {
-///     Ok(ln) => { /* accept connections */ },
-///     Err(NetError.AddressInUse(_)) => println("port already taken"),
-///     Err(e) => println("bind failed"),
+/// fn main() {
+///     match net.try_listen(":9000") {
+///         .Ok(ln) => { /* accept connections */ },
+///         .Err(net.NetError.AddressInUse(_)) => println("port already taken"),
+///         .Err(e) => println("bind failed"),
+///     }
 /// }
 /// ```
 pub fn try_listen(addr: string) -> Result<Listener, NetError> {
@@ -780,10 +789,12 @@ pub fn connect(addr: string) -> Connection {
 /// ```
 /// import std.net;
 ///
-/// match net.try_connect("localhost:9000") {
-///     Ok(conn) => { /* use conn */ },
-///     Err(NetError.ConnectionRefused(_)) => println("nothing listening"),
-///     Err(e) => println("connect failed"),
+/// fn main() {
+///     match net.try_connect("localhost:9000") {
+///         .Ok(conn) => { /* use conn */ },
+///         .Err(net.NetError.ConnectionRefused(_)) => println("nothing listening"),
+///         .Err(e) => println("connect failed"),
+///     }
 /// }
 /// ```
 pub fn try_connect(addr: string) -> Result<Connection, NetError> {

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -35,12 +35,12 @@
 //!     let stream = conn.accept_stream();
 //!     let data = stream.recv();
 //!     match stream.send(data) {
-//!         Ok(_) => {},
-//!         Err(err) => panic(err),
+//!         .Ok(_) => {},
+//!         .Err(err) => panic(err),
 //!     }
 //!     match stream.finish() {
-//!         Ok(_) => {},
-//!         Err(err) => panic(err),
+//!         .Ok(_) => {},
+//!         .Err(err) => panic(err),
 //!     }
 //!     stream.close();
 //!     // Drain connection events so the peer has received all in-flight data
@@ -51,8 +51,8 @@
 //!     let ev1 = conn.on_event(); ev1.close();
 //!     let ev2 = conn.on_event(); ev2.close();
 //!     match conn.disconnect() {
-//!         Ok(_) => {},
-//!         Err(err) => panic(err),
+//!         .Ok(_) => {},
+//!         .Err(err) => panic(err),
 //!     }
 //!     ep.close();
 //! }
@@ -68,13 +68,13 @@
 //!     let conn = ep.connect("127.0.0.1:4433", "localhost");
 //!     let stream = conn.open_stream();
 //!     match stream.send(b"hello quic") {
-//!         Ok(_) => {},
-//!         Err(err) => panic(err),
+//!         .Ok(_) => {},
+//!         .Err(err) => panic(err),
 //!     }
 //!     let reply = stream.recv();
 //!     match stream.finish() {
-//!         Ok(_) => {},
-//!         Err(err) => panic(err),
+//!         .Ok(_) => {},
+//!         .Err(err) => panic(err),
 //!     }
 //!     // Drain to EOF before closing.  Without this recv() the local close
 //!     // can race the server's final STREAM_FIN frame and the reply may be
@@ -82,8 +82,8 @@
 //!     let eof = stream.recv();
 //!     stream.close();
 //!     match conn.disconnect() {
-//!         Ok(_) => {},
-//!         Err(err) => panic(err),
+//!         .Ok(_) => {},
+//!         .Err(err) => panic(err),
 //!     }
 //!     ep.close();
 //! }
@@ -420,8 +420,12 @@ impl QUICEvent {
 /// # Examples
 ///
 /// ```
-/// let ep = quic.new_client();
-/// let conn = ep.connect("node2.example.com:4433", "node2.example.com");
+/// import std.net.quic;
+///
+/// fn main() {
+///     let ep = quic.new_client();
+///     let conn = ep.connect("node2.example.com:4433", "node2.example.com");
+/// }
 /// ```
 pub fn new_client() -> QUICEndpoint {
     unsafe {
@@ -446,8 +450,12 @@ pub fn new_client_with_ca(ca_pem: string) -> QUICEndpoint {
 /// # Examples
 ///
 /// ```
-/// let ep = quic.new_server(":4433");
-/// let conn = ep.accept();
+/// import std.net.quic;
+///
+/// fn main() {
+///     let ep = quic.new_server(":4433");
+///     let conn = ep.accept();
+/// }
 /// ```
 pub fn new_server(addr: string) -> QUICEndpoint {
     unsafe {

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -7,7 +7,7 @@
 //!
 //! # Architecture
 //!
-//! ```
+//! ```text
 //!  ┌──────────────────────────────────────────────────────────┐
 //!  │ QUICEndpoint                                             │
 //!  │  bound to a local UDP address (client or server)         │
@@ -27,6 +27,7 @@
 //! ## Server
 //!
 //! ```
+//! import std.net;
 //! import std.net.quic;
 //!
 //! fn main() {
@@ -36,11 +37,11 @@
 //!     let data = stream.recv();
 //!     match stream.send(data) {
 //!         .Ok(_) => {},
-//!         .Err(err) => panic(err),
+//!         .Err(err) => panic(net.net_error_message(err)),
 //!     }
 //!     match stream.finish() {
 //!         .Ok(_) => {},
-//!         .Err(err) => panic(err),
+//!         .Err(err) => panic(net.net_error_message(err)),
 //!     }
 //!     stream.close();
 //!     // Drain connection events so the peer has received all in-flight data
@@ -52,7 +53,7 @@
 //!     let ev2 = conn.on_event(); ev2.close();
 //!     match conn.disconnect() {
 //!         .Ok(_) => {},
-//!         .Err(err) => panic(err),
+//!         .Err(err) => panic(net.net_error_message(err)),
 //!     }
 //!     ep.close();
 //! }
@@ -61,6 +62,7 @@
 //! ## Client
 //!
 //! ```
+//! import std.net;
 //! import std.net.quic;
 //!
 //! fn main() {
@@ -69,12 +71,12 @@
 //!     let stream = conn.open_stream();
 //!     match stream.send(b"hello quic") {
 //!         .Ok(_) => {},
-//!         .Err(err) => panic(err),
+//!         .Err(err) => panic(net.net_error_message(err)),
 //!     }
 //!     let reply = stream.recv();
 //!     match stream.finish() {
 //!         .Ok(_) => {},
-//!         .Err(err) => panic(err),
+//!         .Err(err) => panic(net.net_error_message(err)),
 //!     }
 //!     // Drain to EOF before closing.  Without this recv() the local close
 //!     // can race the server's final STREAM_FIN frame and the reply may be
@@ -83,7 +85,7 @@
 //!     stream.close();
 //!     match conn.disconnect() {
 //!         .Ok(_) => {},
-//!         .Err(err) => panic(err),
+//!         .Err(err) => panic(net.net_error_message(err)),
 //!     }
 //!     ep.close();
 //! }

--- a/std/net/smtp/smtp.hew
+++ b/std/net/smtp/smtp.hew
@@ -131,9 +131,13 @@ fn smtp_err(fallback: string) -> string {
 /// # Examples
 ///
 /// ```
-/// match smtp.connect("smtp.example.com", 587, "user", "pass") {
-///     Ok(conn) => conn.close(),
-///     Err(reason) => println(f"connect failed: {reason}"),
+/// import std.net.smtp;
+///
+/// fn main() {
+///     match smtp.connect("smtp.example.com", 587, "user", "pass") {
+///         .Ok(conn) => conn.close(),
+///         .Err(reason) => println(f"connect failed: {reason}"),
+///     }
 /// }
 /// ```
 pub fn connect(host: string, port: i64, username: string, password: string) -> Result<Conn, string> {
@@ -159,9 +163,13 @@ pub fn connect(host: string, port: i64, username: string, password: string) -> R
 /// # Examples
 ///
 /// ```
-/// match smtp.connect_tls("smtp.example.com", 465, "user", "pass") {
-///     Ok(conn) => conn.close(),
-///     Err(reason) => println(f"connect failed: {reason}"),
+/// import std.net.smtp;
+///
+/// fn main() {
+///     match smtp.connect_tls("smtp.example.com", 465, "user", "pass") {
+///         .Ok(conn) => conn.close(),
+///         .Err(reason) => println(f"connect failed: {reason}"),
+///     }
 /// }
 /// ```
 pub fn connect_tls(host: string, port: i64, username: string, password: string) -> Result<Conn, string> {

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -14,12 +14,12 @@
 //!     let stream = tls.connect("example.com", 443);
 //!     let request = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n";
 //!     match tls.try_write(stream, hew_string_to_bytes(request)) {
-//!         Ok(_) => {},
-//!         Err(err) => panic(net.net_error_message(err)),
+//!         .Ok(_) => {},
+//!         .Err(err) => panic(net.net_error_message(err)),
 //!     }
 //!     let response = match tls.read(stream, 4096) {
-//!         Ok(data) => data,
-//!         Err(err) => panic(net.net_error_message(err)),
+//!         .Ok(data) => data,
+//!         .Err(err) => panic(net.net_error_message(err)),
 //!     };
 //!     tls.close(stream);
 //! }
@@ -190,7 +190,11 @@ impl TlsStream {
 /// # Examples
 ///
 /// ```
-/// let stream = tls.connect("example.com", 443);
+/// import std.net.tls;
+///
+/// fn main() {
+///     let stream = tls.connect("example.com", 443);
+/// }
 /// ```
 pub fn connect(host: string, port: i64) -> TlsStream {
     let checked = match net.try_port_arg("tls.connect", port) {

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -13,11 +13,11 @@
 //! fn main() {
 //!     let stream = tls.connect("example.com", 443);
 //!     let request = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n";
-//!     match tls.try_write(stream, hew_string_to_bytes(request)) {
+//!     match tls.try_write(stream, request.to_bytes()) {
 //!         .Ok(_) => {},
 //!         .Err(err) => panic(net.net_error_message(err)),
 //!     }
-//!     let response = match tls.read(stream, 4096) {
+//!     let _response = match tls.read(stream, 4096) {
 //!         .Ok(data) => data,
 //!         .Err(err) => panic(net.net_error_message(err)),
 //!     };

--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -12,8 +12,8 @@
 //!     let u = url.parse("https://example.com:8080/path?key=val#frag");
 //!     println(u.host());
 //!     match u.port() {
-//!         Some(port) => println(port),
-//!         None => println("no port"),
+//!         .Some(port) => println(port),
+//!         .None => println("no port"),
 //!     }
 //!     u.close();
 //! }
@@ -146,7 +146,11 @@ impl Url {
 /// # Examples
 ///
 /// ```
-/// let u = url.parse("https://example.com/api/v1");
+/// import std.net.url;
+///
+/// fn main() {
+///     let u = url.parse("https://example.com/api/v1");
+/// }
 /// ```
 pub fn parse(s: string) -> Url {
     unsafe {

--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -170,7 +170,9 @@ pub fn parse(s: string) -> Url {
 /// ```
 /// import std.net.url;
 ///
-/// let encoded = url.encode("hello world");  // "hello%20world"
+/// fn main() {
+///     let encoded = url.encode("hello world");  // "hello%20world"
+/// }
 /// ```
 pub fn encode(s: string) -> string {
     encode_impl(s)
@@ -201,7 +203,9 @@ fn encode_impl(s: string) -> string {
 /// ```
 /// import std.net.url;
 ///
-/// let decoded = url.decode("hello%20world");  // "hello world"
+/// fn main() {
+///     let decoded = url.decode("hello%20world");  // "hello world"
+/// }
 /// ```
 pub fn decode(s: string) -> string {
     decode_impl(s)
@@ -247,8 +251,10 @@ fn decode_impl(s: string) -> string {
 /// ```
 /// import std.net.url;
 ///
-/// let pairs = url.decode_query("name=hello+world&x=a%2Bb");
-/// // [("name", "hello world"), ("x", "a+b")]
+/// fn main() {
+///     let pairs = url.decode_query("name=hello+world&x=a%2Bb");
+///     // [("name", "hello world"), ("x", "a+b")]
+/// }
 /// ```
 pub fn decode_query(params: string) -> Vec<(string, string)> {
     decode_query_impl(params)
@@ -381,8 +387,10 @@ fn valid_percent_utf8(data: bytes) -> bool {
 /// ```
 /// import std.net.url;
 ///
-/// let qs = url.encode_query("name=hello world\npage=1");
-/// // "name=hello%20world&page=1"
+/// fn main() {
+///     let qs = url.encode_query("name=hello world\npage=1");
+///     // "name=hello%20world&page=1"
+/// }
 /// ```
 pub fn encode_query(params: string) -> string {
     encode_query_impl(params)

--- a/std/net/websocket/websocket.hew
+++ b/std/net/websocket/websocket.hew
@@ -11,13 +11,13 @@
 //!
 //! fn main() {
 //!     match websocket.connect("ws://localhost:8080/ws") {
-//!         Ok(ws) => {
+//!         .Ok(ws) => {
 //!             ws.send_text("hello");
 //!             let msg = ws.recv();
 //!             msg.close();
 //!             ws.close();
 //!         },
-//!         Err(_err) => {
+//!         .Err(_err) => {
 //!             println(websocket.last_error());
 //!         },
 //!     }
@@ -31,14 +31,14 @@
 //!
 //! fn main() {
 //!     match websocket.listen("0.0.0.0:8080") {
-//!         Ok(server) => {
+//!         .Ok(server) => {
 //!             let conn = server.accept();
 //!             let msg = conn.recv();
 //!             conn.send_text("got it");
 //!             conn.close();
 //!             server.close();
 //!         },
-//!         Err(_err) => {
+//!         .Err(_err) => {
 //!             println(websocket.last_error());
 //!         },
 //!     }

--- a/std/net/websocket/websocket.hew
+++ b/std/net/websocket/websocket.hew
@@ -260,8 +260,10 @@ impl Server {
 /// # Example
 ///
 /// ```
+/// import std.net.websocket;
+///
 /// actor Echo {
-///     let conn: Conn;
+///     let conn: websocket.Conn;
 ///     receive fn on_message(text: string) {
 ///         conn.send_text("echo: " + text);
 ///     }
@@ -297,9 +299,14 @@ pub fn last_error() -> string {
 /// # Examples
 ///
 /// ```
-/// match websocket.connect("ws://127.0.0.1:9001/") {
-///     Ok(conn) => conn.close(),
-///     Err(err) => println(f"connect failed: {net.net_error_message(err)}"),
+/// import std.net;
+/// import std.net.websocket;
+///
+/// fn main() {
+///     match websocket.connect("ws://127.0.0.1:9001/") {
+///         .Ok(conn) => conn.close(),
+///         .Err(err) => println(f"connect failed: {net.net_error_message(err)}"),
+///     }
 /// }
 /// ```
 pub fn connect(url: string) -> Result<Conn, net.NetError> {
@@ -332,9 +339,14 @@ pub fn connect(url: string) -> Result<Conn, net.NetError> {
 /// # Examples
 ///
 /// ```
-/// match websocket.listen("127.0.0.1:0") {
-///     Ok(server) => server.close(),
-///     Err(err) => println(f"listen failed: {net.net_error_message(err)}"),
+/// import std.net;
+/// import std.net.websocket;
+///
+/// fn main() {
+///     match websocket.listen("127.0.0.1:0") {
+///         .Ok(server) => server.close(),
+///         .Err(err) => println(f"listen failed: {net.net_error_message(err)}"),
+///     }
 /// }
 /// ```
 pub fn listen(addr: string) -> Result<Server, net.NetError> {

--- a/std/os.hew
+++ b/std/os.hew
@@ -30,8 +30,12 @@ pub fn args_count() -> i64 {
 /// # Examples
 ///
 /// ```
-/// let program = os.args(0);
-/// let first_arg = os.args(1);
+/// import std.os;
+///
+/// fn main() {
+///     let program = os.args(0);
+///     let first_arg = os.args(1);
+/// }
 /// ```
 pub fn args(index: i64) -> string {
     let count = args_count();
@@ -50,7 +54,11 @@ pub fn args(index: i64) -> string {
 /// # Examples
 ///
 /// ```
-/// let path = os.env("PATH");
+/// import std.os;
+///
+/// fn main() {
+///     let path = os.env("PATH");
+/// }
 /// ```
 pub fn env(name: string) -> string {
     unsafe {
@@ -138,8 +146,12 @@ pub fn pid() -> i64 {
 /// # Examples
 ///
 /// ```
-/// let tmp = os.temp_dir();
-/// let path = tmp + "/myfile.txt";
+/// import std.os;
+///
+/// fn main() {
+///     let tmp = os.temp_dir();
+///     let path = tmp + "/myfile.txt";
+/// }
 /// ```
 pub fn temp_dir() -> string {
     unsafe {

--- a/std/path.hew
+++ b/std/path.hew
@@ -143,9 +143,13 @@ pub fn glob(pattern: string) -> GlobResult {
 /// # Examples
 ///
 /// ```
-/// match path.try_glob("src/**/*.hew") {
-///     Ok(files) => println(f"{files.len()} match(es)"),
-///     Err(err) => println(path.path_error_message(err)),
+/// import std.path;
+///
+/// fn main() {
+///     match path.try_glob("src/**/*.hew") {
+///         .Ok(files) => println(f"{files.len()} match(es)"),
+///         .Err(err) => println(path.path_error_message(err)),
+///     }
 /// }
 /// ```
 pub fn try_glob(pattern: string) -> Result<GlobResult, PathError> {
@@ -312,10 +316,12 @@ pub fn absolute(p: string) -> string {
 /// ```
 /// import std.path;
 ///
-/// path.normalize("/var/www/../../etc/passwd")  // "/etc/passwd"
-/// path.normalize("a/./b/../c")                 // "a/c"
-/// path.normalize("../../etc/passwd")           // "../../etc/passwd"
-/// path.normalize("")                           // "."
+/// fn main() {
+///     path.normalize("/var/www/../../etc/passwd");  // "/etc/passwd"
+///     path.normalize("a/./b/../c");                 // "a/c"
+///     path.normalize("../../etc/passwd");           // "../../etc/passwd"
+///     path.normalize("");                           // "."
+/// }
 /// ```
 pub fn normalize(p: string) -> string {
     if p == "" {

--- a/std/path.hew
+++ b/std/path.hew
@@ -115,7 +115,11 @@ impl GlobResult {
 /// # Examples
 ///
 /// ```
-/// let files = path.glob("src/**/*.hew");
+/// import std.path;
+///
+/// fn main() {
+///     let files = path.glob("src/**/*.hew");
+/// }
 /// ```
 pub fn glob(pattern: string) -> GlobResult {
     unsafe {
@@ -166,7 +170,11 @@ pub fn try_glob(pattern: string) -> Result<GlobResult, PathError> {
 /// # Examples
 ///
 /// ```
-/// path.combine("/home/user", "file.txt")  // "/home/user/file.txt"
+/// import std.path;
+///
+/// fn main() {
+///     println(path.combine("/home/user", "file.txt"));   // "/home/user/file.txt"
+/// }
 /// ```
 pub fn combine(a: string, b: string) -> string {
     if b.starts_with("/") {
@@ -190,7 +198,11 @@ pub fn combine(a: string, b: string) -> string {
 /// # Examples
 ///
 /// ```
-/// path.dirname("/home/user/file.txt")  // "/home/user"
+/// import std.path;
+///
+/// fn main() {
+///     println(path.dirname("/home/user/file.txt"));   // "/home/user"
+/// }
 /// ```
 pub fn dirname(p: string) -> string {
     let s = strip_trailing_slash(p);
@@ -209,7 +221,11 @@ pub fn dirname(p: string) -> string {
 /// # Examples
 ///
 /// ```
-/// path.basename("/home/user/file.txt")  // "file.txt"
+/// import std.path;
+///
+/// fn main() {
+///     println(path.basename("/home/user/file.txt"));   // "file.txt"
+/// }
 /// ```
 pub fn basename(p: string) -> string {
     let s = strip_trailing_slash(p);
@@ -233,7 +249,11 @@ pub fn basename(p: string) -> string {
 /// # Examples
 ///
 /// ```
-/// path.extension("photo.jpg")  // "jpg"
+/// import std.path;
+///
+/// fn main() {
+///     println(path.extension("photo.jpg"));   // "jpg"
+/// }
 /// ```
 pub fn extension(p: string) -> string {
     let base = basename(p);

--- a/std/random/random.hew
+++ b/std/random/random.hew
@@ -8,10 +8,12 @@
 //! # Examples
 //!
 //! ```
+//! import std.random;
+//!
 //! fn main() {
 //!     random.seed(42);
-//!     let r = random.random();   // ≈ 0.6394267984578837
-//!     let n = random.randint(0, 10);
+//!     println(random.random());   // ≈ 0.6394267984578837
+//!     println(random.randint(0, 10));
 //! }
 //! ```
 

--- a/std/semaphore.hew
+++ b/std/semaphore.hew
@@ -100,7 +100,11 @@ impl Semaphore {
 /// # Examples
 ///
 /// ```
-/// let sem = semaphore.new(5);
+/// import std.semaphore;
+///
+/// fn main() {
+///     let sem = semaphore.new(5);
+/// }
 /// ```
 pub fn new(count: i64) -> Semaphore {
     if count < 0 || count > 2147483647 {

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -18,8 +18,9 @@
 //! Current stdlib scope:
 //! - `bytes_pipe()` is the canonical in-memory constructor
 //! - `pipe()` remains the text convenience constructor
-//! - `from_file()` / `to_file()` remain `Stream<string>` / `Sink<string>`
-//! - `lines()` remains a `Stream<string>` adapter today
+//! - `from_file()` / `to_file()` remain `Stream<string>` / `Sink<string>`;
+//!   `from_file()` yields fixed-size chunks, not lines — split with
+//!   `string.lines()` on an accumulated buffer if you need line boundaries
 //!
 //! # Example
 //!
@@ -139,8 +140,20 @@ pub fn try_bytes_pipe(capacity: i64) -> Result<(Sink<bytes>, Stream<bytes>), str
 /// # Examples
 ///
 /// ```
-/// let file = stream.from_file("data.txt")?;
-/// for await line in file.lines() { println(line); }
+/// import std.stream;
+///
+/// fn run() -> Result<(), string> {
+///     let file = stream.from_file("data.txt")?;
+///     for await chunk in file { println(chunk); }
+///     Ok(())
+/// }
+///
+/// fn main() {
+///     match run() {
+///         .Ok(()) => {},
+///         .Err(e) => println(e),
+///     }
+/// }
 /// ```
 pub fn from_file(path: string) -> Result<Stream<string>, string> {
     unsafe {
@@ -187,9 +200,21 @@ pub fn try_from_file(path: string) -> Result<Stream<string>, fs.IoError> {
 /// # Examples
 ///
 /// ```
-/// let sink = stream.to_file("output.txt")?;
-/// sink.write("hello");
-/// // sink auto-closes when dropped
+/// import std.stream;
+///
+/// fn run() -> Result<(), string> {
+///     let sink = stream.to_file("output.txt")?;
+///     sink.write("hello");
+///     // sink auto-closes when dropped
+///     Ok(())
+/// }
+///
+/// fn main() {
+///     match run() {
+///         .Ok(()) => {},
+///         .Err(e) => println(e),
+///     }
+/// }
 /// ```
 pub fn to_file(path: string) -> Result<Sink<string>, string> {
     unsafe {
@@ -232,9 +257,26 @@ pub fn try_to_file(path: string) -> Result<Sink<string>, fs.IoError> {
 /// # Examples
 ///
 /// ```
-/// let file = stream.from_file("data.txt")?;
-/// let body = req.respond_stream(200, "text/plain")?;
-/// stream.forward(file, body);  // streams file directly to HTTP response
+/// import std.net.http;
+/// import std.stream;
+///
+/// fn main() {
+///     match http.listen(":8080") {
+///         .Ok(server) => {
+///             let req = server.accept();
+///             match stream.from_file("data.txt") {
+///                 .Ok(file) => {
+///                     let body = req.respond_stream(200, "text/plain");
+///                     stream.forward(file, body);  // streams file directly to HTTP response
+///                 },
+///                 .Err(e) => println(e),
+///             }
+///             req.close();
+///             server.close();
+///         },
+///         .Err(_err) => println(http.listen_error()),
+///     }
+/// }
 /// ```
 pub fn forward(consume source: Stream<string>, consume dest: Sink<string>) {
     unsafe {

--- a/std/string.hew
+++ b/std/string.hew
@@ -24,7 +24,11 @@
 /// # Examples
 ///
 /// ```
-/// let s = string.from_int(42);  // "42"
+/// import std.string;
+///
+/// fn main() {
+///     let s = string.from_int(42);  // "42"
+/// }
 /// ```
 pub fn from_int(n: i64) -> string {
     f"{n}"
@@ -49,7 +53,11 @@ pub fn from_bool(b: bool) -> string {
 /// # Examples
 ///
 /// ```
-/// let newline = string.from_char(10);
+/// import std.string;
+///
+/// fn main() {
+///     let newline = string.from_char(10);
+/// }
 /// ```
 pub fn from_char(code: i64) -> string {
     if code < 0 || code > 0x10FFFF || code >= 0xD800 && code <= 0xDFFF {
@@ -73,10 +81,14 @@ pub fn from_char(code: i64) -> string {
 /// # Examples
 ///
 /// ```
-/// let n = string.to_int("42");     // Some(42)
-/// let z = string.to_int("0");      // Some(0)
-/// let m = string.to_int("42abc");  // None — partial numbers do not parse
-/// let e = string.to_int("");       // None
+/// import std.string;
+///
+/// fn main() {
+///     let n = string.to_int("42");     // Some(42)
+///     let z = string.to_int("0");      // Some(0)
+///     let m = string.to_int("42abc");  // None — partial numbers do not parse
+///     let e = string.to_int("");       // None
+/// }
 /// ```
 pub fn to_int(s: string) -> Option<i64> {
     match try_to_int(s) {
@@ -147,9 +159,13 @@ pub fn try_to_int(s: string) -> Result<i64, string> {
 /// # Examples
 ///
 /// ```
-/// let pi = string.to_float("3.14");   // 3.14
-/// let n = string.to_float("-2e3");    // -2000.0
-/// let z = string.to_float("3.14x");   // 0.0
+/// import std.string;
+///
+/// fn main() {
+///     let pi = string.to_float("3.14");   // 3.14
+///     let n = string.to_float("-2e3");    // -2000.0
+///     let z = string.to_float("3.14x");   // 0.0
+/// }
 /// ```
 pub fn to_float(s: string) -> f64 {
     match try_to_float(s) {
@@ -431,8 +447,12 @@ fn digit_to_float(digit: i64) -> f64 {
 /// # Examples
 ///
 /// ```
-/// string.is_empty("")    // true
-/// string.is_empty("hi")  // false
+/// import std.string;
+///
+/// fn main() {
+///     println(string.is_empty(""));   // true
+///     println(string.is_empty("hi"));   // false
+/// }
 /// ```
 pub fn is_empty(s: string) -> bool {
     s.is_empty()
@@ -443,7 +463,11 @@ pub fn is_empty(s: string) -> bool {
 /// # Examples
 ///
 /// ```
-/// let stars = string.repeat("*", 5);  // "*****"
+/// import std.string;
+///
+/// fn main() {
+///     let stars = string.repeat("*", 5);  // "*****"
+/// }
 /// ```
 pub fn repeat(s: string, n: i64) -> string {
     s.repeat(n)
@@ -456,8 +480,12 @@ pub fn repeat(s: string, n: i64) -> string {
 /// # Examples
 ///
 /// ```
-/// string.pad_left("42", 5, " ")   // "   42"
-/// string.pad_left("42", 5, "0")   // "00042"
+/// import std.string;
+///
+/// fn main() {
+///     println(string.pad_left("42", 5, " "));   // "   42"
+///     println(string.pad_left("42", 5, "0"));   // "00042"
+/// }
 /// ```
 pub fn pad_left(s: string, width: i64, pad: string) -> string {
     let pad_len = pad.char_count_utf8();
@@ -478,7 +506,11 @@ pub fn pad_left(s: string, width: i64, pad: string) -> string {
 /// # Examples
 ///
 /// ```
-/// string.pad_right("hi", 5, " ")  // "hi   "
+/// import std.string;
+///
+/// fn main() {
+///     println(string.pad_right("hi", 5, " "));   // "hi   "
+/// }
 /// ```
 pub fn pad_right(s: string, width: i64, pad: string) -> string {
     let pad_len = pad.char_count_utf8();
@@ -499,9 +531,13 @@ pub fn pad_right(s: string, width: i64, pad: string) -> string {
 /// # Examples
 ///
 /// ```
-/// string.is_numeric("123")   // true
-/// string.is_numeric("12a")   // false
-/// string.is_numeric("")      // false
+/// import std.string;
+///
+/// fn main() {
+///     println(string.is_numeric("123"));   // true
+///     println(string.is_numeric("12a"));   // false
+///     println(string.is_numeric(""));   // false
+/// }
 /// ```
 pub fn is_numeric(s: string) -> bool {
     let slen = s.len();
@@ -522,8 +558,12 @@ pub fn is_numeric(s: string) -> bool {
 /// # Examples
 ///
 /// ```
-/// string.count("abcabc", "abc")  // 2
-/// string.count("hello", "x")     // 0
+/// import std.string;
+///
+/// fn main() {
+///     println(string.count("abcabc", "abc"));   // 2
+///     println(string.count("hello", "x"));   // 0
+/// }
 /// ```
 pub fn count(haystack: string, needle: string) -> i64 {
     let nlen = needle.len();
@@ -550,8 +590,12 @@ pub fn count(haystack: string, needle: string) -> i64 {
 /// # Examples
 ///
 /// ```
-/// string.starts_with("hello", "he")   // true
-/// string.starts_with("hello", "lo")   // false
+/// import std.string;
+///
+/// fn main() {
+///     println(string.starts_with("hello", "he"));   // true
+///     println(string.starts_with("hello", "lo"));   // false
+/// }
 /// ```
 pub fn starts_with(s: string, prefix: string) -> bool {
     s.starts_with(prefix)
@@ -562,8 +606,12 @@ pub fn starts_with(s: string, prefix: string) -> bool {
 /// # Examples
 ///
 /// ```
-/// string.ends_with("hello", "lo")   // true
-/// string.ends_with("hello", "he")   // false
+/// import std.string;
+///
+/// fn main() {
+///     println(string.ends_with("hello", "lo"));   // true
+///     println(string.ends_with("hello", "he"));   // false
+/// }
 /// ```
 pub fn ends_with(s: string, suffix: string) -> bool {
     s.ends_with(suffix)
@@ -574,8 +622,12 @@ pub fn ends_with(s: string, suffix: string) -> bool {
 /// # Examples
 ///
 /// ```
-/// string.contains("hello world", "world")  // true
-/// string.contains("hello", "xyz")          // false
+/// import std.string;
+///
+/// fn main() {
+///     println(string.contains("hello world", "world"));   // true
+///     println(string.contains("hello", "xyz"));   // false
+/// }
 /// ```
 pub fn contains(s: string, sub: string) -> bool {
     s.contains(sub)
@@ -586,8 +638,12 @@ pub fn contains(s: string, sub: string) -> bool {
 /// # Examples
 ///
 /// ```
-/// string.is_ascii("hello")  // true
-/// string.is_ascii("héllo")  // false
+/// import std.string;
+///
+/// fn main() {
+///     println(string.is_ascii("hello"));   // true
+///     println(string.is_ascii("héllo"));   // false
+/// }
 /// ```
 pub fn is_ascii(s: string) -> bool {
     let len = s.len();

--- a/std/string.hew
+++ b/std/string.hew
@@ -682,10 +682,12 @@ pub fn replace(s: string, old: string, new_val: string) -> string {
 /// ```
 /// import std.string;
 ///
-/// let parts = string.split("a,b,c", ",");  // ["a", "b", "c"]
-/// let trail = string.split("a,b,", ",");   // ["a", "b", ""]
-/// let chars = string.split("café", "");    // ["c", "a", "f", "é"]
-/// let empty = string.split("", "");        // []
+/// fn main() {
+///     let parts = string.split("a,b,c", ",");  // ["a", "b", "c"]
+///     let trail = string.split("a,b,", ",");   // ["a", "b", ""]
+///     let chars = string.split("café", "");    // ["c", "a", "f", "é"]
+///     let empty = string.split("", "");        // []
+/// }
 /// ```
 pub fn split(s: string, sep: string) -> Vec<string> {
     // Delegate to the method, which routes to hew_string_split FFI.
@@ -705,9 +707,11 @@ pub fn split(s: string, sep: string) -> Vec<string> {
 /// ```
 /// import std.string;
 ///
-/// let lines = string.lines("foo\nbar");   // ["foo", "bar"]
-/// let crlf  = string.lines("a\r\nb");    // ["a", "b"]
-/// let trail = string.lines("foo\n");     // ["foo", ""]
+/// fn main() {
+///     let lines = string.lines("foo\nbar");   // ["foo", "bar"]
+///     let crlf  = string.lines("a\r\nb");    // ["a", "b"]
+///     let trail = string.lines("foo\n");     // ["foo", ""]
+/// }
 /// ```
 pub fn lines(s: string) -> Vec<string> {
     let result: Vec<string> = Vec.new();
@@ -745,8 +749,10 @@ pub fn lines(s: string) -> Vec<string> {
 /// ```
 /// import std.string;
 ///
-/// let s = string.join(["a", "b", "c"], ", ");  // "a, b, c"
-/// let e = string.join([], ",");                // ""
+/// fn main() {
+///     let s = string.join(["a", "b", "c"], ", ");  // "a, b, c"
+///     let e = string.join([], ",");                // ""
+/// }
 /// ```
 pub fn join(parts: Vec<string>, sep: string) -> string {
     let n = parts.len();

--- a/std/text/regex/regex.hew
+++ b/std/text/regex/regex.hew
@@ -46,9 +46,13 @@ trait PatternMethods {
     /// # Examples
     ///
     /// ```
-    /// let re = regex.new("^[a-z]+$");
-    /// assert(re.is_match("hello"));
-    /// re.close();
+    /// import std.text.regex;
+    ///
+    /// fn main() {
+    ///     let re = regex.new("^[a-z]+$");
+    ///     assert(re.is_match("hello"));
+    ///     re.close();
+    /// }
     /// ```
     fn is_match(self, input: string) -> bool;
 
@@ -68,10 +72,14 @@ trait PatternMethods {
     /// # Examples
     ///
     /// ```
-    /// let re = regex.new("[0-9]+");
-    /// let result = re.replace("abc123def456", "N");
-    /// // result == "abcNdefN"
-    /// re.close();
+    /// import std.text.regex;
+    ///
+    /// fn main() {
+    ///     let re = regex.new("[0-9]+");
+    ///     let result = re.replace("abc123def456", "N");
+    ///     // result == "abcNdefN"
+    ///     re.close();
+    /// }
     /// ```
     fn replace(self, input: string, replacement: string) -> string;
 
@@ -253,8 +261,12 @@ impl CaptureMatchesMethods for CaptureMatches {
 /// # Examples
 ///
 /// ```
-/// let email_re = regex.new("[a-z]+@[a-z]+\\.[a-z]+");
-/// email_re.close();
+/// import std.text.regex;
+///
+/// fn main() {
+///     let email_re = regex.new("[a-z]+@[a-z]+\\.[a-z]+");
+///     email_re.close();
+/// }
 /// ```
 pub fn new(pattern: string) -> Pattern {
     unsafe {

--- a/std/text/template/template.hew
+++ b/std/text/template/template.hew
@@ -69,7 +69,7 @@
 //!     let result = template.render_try(t, ctx);
 //!     match result {
 //!         .Ok(s) => println(s),
-//!         .Err(e) => println(e),
+//!         .Err(_e) => println("template render failed"),
 //!     }
 //! }
 //! ```
@@ -573,7 +573,12 @@ pub fn new_ctx() -> Ctx {
 /// # Examples
 ///
 /// ```
-/// template.ctx_set_str(ctx, "name", "Alice");
+/// import std.text.template;
+///
+/// fn main() {
+///     let ctx = template.new_ctx();
+///     template.ctx_set_str(ctx, "name", "Alice");
+/// }
 /// ```
 pub fn ctx_set_str(ctx: Ctx, key: string, val: string) {
     ctx.skeys.push(key);
@@ -585,7 +590,12 @@ pub fn ctx_set_str(ctx: Ctx, key: string, val: string) {
 /// # Examples
 ///
 /// ```
-/// template.ctx_set_int(ctx, "count", 42);
+/// import std.text.template;
+///
+/// fn main() {
+///     let ctx = template.new_ctx();
+///     template.ctx_set_int(ctx, "count", 42);
+/// }
 /// ```
 pub fn ctx_set_int(ctx: Ctx, key: string, val: i64) {
     ctx.skeys.push(key);
@@ -597,7 +607,12 @@ pub fn ctx_set_int(ctx: Ctx, key: string, val: i64) {
 /// # Examples
 ///
 /// ```
-/// template.ctx_set_bool(ctx, "active", true);
+/// import std.text.template;
+///
+/// fn main() {
+///     let ctx = template.new_ctx();
+///     template.ctx_set_bool(ctx, "active", true);
+/// }
 /// ```
 pub fn ctx_set_bool(ctx: Ctx, key: string, val: bool) {
     ctx.skeys.push(key);
@@ -615,10 +630,15 @@ pub fn ctx_set_bool(ctx: Ctx, key: string, val: bool) {
 /// # Examples
 ///
 /// ```
-/// let colours: Vec<string> = Vec.new();
-/// colours.push("red");
-/// colours.push("blue");
-/// template.ctx_set_list(ctx, "colours", colours);
+/// import std.text.template;
+///
+/// fn main() {
+///     let ctx = template.new_ctx();
+///     let colours: Vec<string> = Vec.new();
+///     colours.push("red");
+///     colours.push("blue");
+///     template.ctx_set_list(ctx, "colours", colours);
+/// }
 /// ```
 pub fn ctx_set_list(ctx: Ctx, key: string, items: Vec<string>) {
     let n = items.len();

--- a/std/text/template/template.hew
+++ b/std/text/template/template.hew
@@ -68,8 +68,8 @@
 //!     let t = template.parse("Hello {{.name}}, age {{.age}}!");
 //!     let result = template.render_try(t, ctx);
 //!     match result {
-//!         Ok(s) => println(s),
-//!         Err(e) => println(e),
+//!         .Ok(s) => println(s),
+//!         .Err(e) => println(e),
 //!     }
 //! }
 //! ```
@@ -648,8 +648,8 @@ pub fn ctx_set_list(ctx: Ctx, key: string, items: Vec<string>) {
 ///     let t = template.parse("hello {{.who}}!");
 ///     let r = template.render_try(t, ctx);
 ///     match r {
-///         Ok(s) => println(s),    // "hello world!"
-///         Err(_) => println("template error"),
+///         .Ok(s) => println(s),    // "hello world!"
+///         .Err(_) => println("template error"),
 ///     }
 /// }
 /// ```

--- a/std/text/unicode/unicode.hew
+++ b/std/text/unicode/unicode.hew
@@ -18,7 +18,7 @@
 //!
 //! fn main() {
 //!     // Char classification
-//!     let cp = unicode.codepoint_at("café", 3);   // Some(233) ('é')
+//!     let cp = unicode.codepoint_at("café", 3).unwrap_or(0);  // 233 ('é')
 //!     println(unicode.is_lower(cp));              // true
 //!     println(unicode.is_upper(cp));              // false
 //!     println(unicode.to_upper(cp));              // 201 ('É')
@@ -323,9 +323,13 @@ pub fn to_title(cp: i64) -> i64 {
 /// # Examples
 ///
 /// ```
-/// unicode.codepoint_at("café", 3)  // Some(233) ('é', U+00E9)
-/// unicode.codepoint_at("ABC", 1)   // Some(66)  ('B')
-/// unicode.codepoint_at("hi", 5)    // None      (out of bounds)
+/// import std.text.unicode;
+///
+/// fn main() {
+///     unicode.codepoint_at("café", 3);  // Some(233) ('é', U+00E9)
+///     unicode.codepoint_at("ABC", 1);   // Some(66)  ('B')
+///     unicode.codepoint_at("hi", 5);    // None      (out of bounds)
+/// }
 /// ```
 pub fn codepoint_at(s: string, i: i64) -> Option<i64> {
     s.codepoint_at_utf8(i)
@@ -336,8 +340,12 @@ pub fn codepoint_at(s: string, i: i64) -> Option<i64> {
 /// # Examples
 ///
 /// ```
-/// unicode.try_codepoint_at("café", 3)  // Ok(233)
-/// unicode.try_codepoint_at("hi", 2)    // Err(...)
+/// import std.text.unicode;
+///
+/// fn main() {
+///     unicode.try_codepoint_at("café", 3);  // Ok(233)
+///     unicode.try_codepoint_at("hi", 2);    // Err(...)
+/// }
 /// ```
 pub fn try_codepoint_at(s: string, i: i64) -> Result<i64, string> {
     match codepoint_at(s, i) {
@@ -394,9 +402,13 @@ pub fn rune_len(cp: i64) -> i64 {
 /// # Examples
 ///
 /// ```
-/// unicode.try_rune_len(65)      // Ok(1)
-/// unicode.try_rune_len(0x1F642) // Ok(4)
-/// unicode.try_rune_len(-1)      // Err(...)
+/// import std.text.unicode;
+///
+/// fn main() {
+///     unicode.try_rune_len(65);      // Ok(1)
+///     unicode.try_rune_len(0x1F642); // Ok(4)
+///     unicode.try_rune_len(-1);      // Err(...)
+/// }
 /// ```
 pub fn try_rune_len(cp: i64) -> Result<i64, string> {
     match cp {

--- a/std/text/unicode/unicode.hew
+++ b/std/text/unicode/unicode.hew
@@ -47,10 +47,14 @@ extern "C" {
 /// # Examples
 ///
 /// ```
-/// unicode.is_valid_rune(65)        // true  ('A')
-/// unicode.is_valid_rune(0x10FFFF)  // true  (highest scalar)
-/// unicode.is_valid_rune(0xD800)    // false (surrogate)
-/// unicode.is_valid_rune(-1)        // false
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.is_valid_rune(65));   // true  ('A')
+///     println(unicode.is_valid_rune(0x10FFFF));   // true  (highest scalar)
+///     println(unicode.is_valid_rune(0xD800));   // false (surrogate)
+///     println(unicode.is_valid_rune(-1));   // false
+/// }
 /// ```
 pub fn is_valid_rune(cp: i64) -> bool {
     match cp {
@@ -68,9 +72,13 @@ pub fn is_valid_rune(cp: i64) -> bool {
 /// # Examples
 ///
 /// ```
-/// unicode.is_upper(65)   // true  ('A')
-/// unicode.is_upper(97)   // false ('a')
-/// unicode.is_upper(201)  // true  ('É', U+00C9)
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.is_upper(65));   // true  ('A')
+///     println(unicode.is_upper(97));   // false ('a')
+///     println(unicode.is_upper(201));   // true  ('É', U+00C9)
+/// }
 /// ```
 pub fn is_upper(cp: i64) -> bool {
     if !is_valid_rune(cp) {
@@ -88,9 +96,13 @@ pub fn is_upper(cp: i64) -> bool {
 /// # Examples
 ///
 /// ```
-/// unicode.is_lower(97)   // true  ('a')
-/// unicode.is_lower(65)   // false ('A')
-/// unicode.is_lower(233)  // true  ('é', U+00E9)
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.is_lower(97));   // true  ('a')
+///     println(unicode.is_lower(65));   // false ('A')
+///     println(unicode.is_lower(233));   // true  ('é', U+00E9)
+/// }
 /// ```
 pub fn is_lower(cp: i64) -> bool {
     if !is_valid_rune(cp) {
@@ -109,9 +121,13 @@ pub fn is_lower(cp: i64) -> bool {
 /// # Examples
 ///
 /// ```
-/// unicode.is_digit(48)  // true  ('0')
-/// unicode.is_digit(57)  // true  ('9')
-/// unicode.is_digit(65)  // false ('A')
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.is_digit(48));   // true  ('0')
+///     println(unicode.is_digit(57));   // true  ('9')
+///     println(unicode.is_digit(65));   // false ('A')
+/// }
 /// ```
 pub fn is_digit(cp: i64) -> bool {
     if !is_valid_rune(cp) {
@@ -130,9 +146,13 @@ pub fn is_digit(cp: i64) -> bool {
 /// # Examples
 ///
 /// ```
-/// unicode.is_space(32)  // true  (space)
-/// unicode.is_space(9)   // true  (\t)
-/// unicode.is_space(65)  // false ('A')
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.is_space(32));   // true  (space)
+///     println(unicode.is_space(9));   // true  (\t)
+///     println(unicode.is_space(65));   // false ('A')
+/// }
 /// ```
 pub fn is_space(cp: i64) -> bool {
     if !is_valid_rune(cp) {
@@ -151,9 +171,13 @@ pub fn is_space(cp: i64) -> bool {
 /// # Examples
 ///
 /// ```
-/// unicode.is_letter(65)      // true  ('A')
-/// unicode.is_letter(0x65E5)  // true  ('日')
-/// unicode.is_letter(48)      // false ('0')
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.is_letter(65));   // true  ('A')
+///     println(unicode.is_letter(0x65E5));   // true  ('日')
+///     println(unicode.is_letter(48));   // false ('0')
+/// }
 /// ```
 pub fn is_letter(cp: i64) -> bool {
     if !is_valid_rune(cp) {
@@ -172,9 +196,13 @@ pub fn is_letter(cp: i64) -> bool {
 /// # Examples
 ///
 /// ```
-/// unicode.is_alnum(65)   // true  ('A')
-/// unicode.is_alnum(48)   // true  ('0')
-/// unicode.is_alnum(32)   // false (space)
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.is_alnum(65));   // true  ('A')
+///     println(unicode.is_alnum(48));   // true  ('0')
+///     println(unicode.is_alnum(32));   // false (space)
+/// }
 /// ```
 pub fn is_alnum(cp: i64) -> bool {
     if !is_valid_rune(cp) {
@@ -190,9 +218,13 @@ pub fn is_alnum(cp: i64) -> bool {
 /// # Examples
 ///
 /// ```
-/// unicode.is_punct(33)      // true  ('!')
-/// unicode.is_punct(0x3002)  // true  (IDEOGRAPHIC FULL STOP)
-/// unicode.is_punct(65)      // false ('A')
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.is_punct(33));   // true  ('!')
+///     println(unicode.is_punct(0x3002));   // true  (IDEOGRAPHIC FULL STOP)
+///     println(unicode.is_punct(65));   // false ('A')
+/// }
 /// ```
 ///
 /// Punctuation is the Unicode general category group `P*` — `Pc`, `Pd`, `Ps`,
@@ -219,9 +251,13 @@ pub fn is_punct(cp: i64) -> bool {
 /// # Examples
 ///
 /// ```
-/// unicode.to_upper(97)   // 65   ('a' -> 'A')
-/// unicode.to_upper(65)   // 65   ('A' unchanged)
-/// unicode.to_upper(233)  // 201  ('é' -> 'É')
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.to_upper(97));   // 65   ('a' -> 'A')
+///     println(unicode.to_upper(65));   // 65   ('A' unchanged)
+///     println(unicode.to_upper(233));   // 201  ('é' -> 'É')
+/// }
 /// ```
 pub fn to_upper(cp: i64) -> i64 {
     if !is_valid_rune(cp) {
@@ -241,9 +277,13 @@ pub fn to_upper(cp: i64) -> i64 {
 /// # Examples
 ///
 /// ```
-/// unicode.to_lower(65)   // 97   ('A' -> 'a')
-/// unicode.to_lower(97)   // 97   ('a' unchanged)
-/// unicode.to_lower(201)  // 233  ('É' -> 'é')
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.to_lower(65));   // 97   ('A' -> 'a')
+///     println(unicode.to_lower(97));   // 97   ('a' unchanged)
+///     println(unicode.to_lower(201));   // 233  ('É' -> 'é')
+/// }
 /// ```
 pub fn to_lower(cp: i64) -> i64 {
     if !is_valid_rune(cp) {
@@ -262,9 +302,13 @@ pub fn to_lower(cp: i64) -> i64 {
 /// # Examples
 ///
 /// ```
-/// unicode.to_title(97)   // 65   ('a' -> 'A')
-/// unicode.to_title(233)  // 201  ('é' -> 'É')
-/// unicode.to_title(49)   // 49   ('1' unchanged)
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.to_title(97));   // 65   ('a' -> 'A')
+///     println(unicode.to_title(233));   // 201  ('é' -> 'É')
+///     println(unicode.to_title(49));   // 49   ('1' unchanged)
+/// }
 /// ```
 pub fn to_title(cp: i64) -> i64 {
     to_upper(cp)
@@ -311,10 +355,14 @@ pub fn try_codepoint_at(s: string, i: i64) -> Result<i64, string> {
 /// # Examples
 ///
 /// ```
-/// unicode.rune_count("hello")  // 5
-/// unicode.rune_count("café")   // 4
-/// unicode.rune_count("日本語")  // 3
-/// unicode.rune_count("")       // 0
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.rune_count("hello"));   // 5
+///     println(unicode.rune_count("café"));   // 4
+///     println(unicode.rune_count("日本語"));   // 3
+///     println(unicode.rune_count(""));   // 0
+/// }
 /// ```
 pub fn rune_count(s: string) -> i64 {
     s.char_count_utf8()
@@ -325,10 +373,14 @@ pub fn rune_count(s: string) -> i64 {
 /// # Examples
 ///
 /// ```
-/// unicode.rune_len(65)      // 1
-/// unicode.rune_len(233)     // 2
-/// unicode.rune_len(0x65E5)  // 3
-/// unicode.rune_len(-1)      // -1
+/// import std.text.unicode;
+///
+/// fn main() {
+///     println(unicode.rune_len(65));   // 1
+///     println(unicode.rune_len(233));   // 2
+///     println(unicode.rune_len(0x65E5));   // 3
+///     println(unicode.rune_len(-1));   // -1
+/// }
 /// ```
 pub fn rune_len(cp: i64) -> i64 {
     match try_rune_len(cp) {
@@ -364,14 +416,18 @@ pub fn try_rune_len(cp: i64) -> Result<i64, string> {
 /// # Examples
 ///
 /// ```
-/// let cps = unicode.runes("AB");
-/// // cps == [65, 66]
+/// import std.text.unicode;
 ///
-/// let cps2 = unicode.runes("日");
-/// // cps2.get(0) == 0x65E5
+/// fn main() {
+///     let cps = unicode.runes("AB");
+///     // cps == [65, 66]
 ///
-/// let empty = unicode.runes("");
-/// // empty.len() == 0
+///     let cps2 = unicode.runes("日");
+///     // cps2.get(0) == 0x65E5
+///
+///     let empty = unicode.runes("");
+///     // empty.len() == 0
+/// }
 /// ```
 pub fn runes(s: string) -> Vec<i64> {
     let n = s.char_count_utf8();

--- a/std/time/cron/cron.hew
+++ b/std/time/cron/cron.hew
@@ -128,8 +128,12 @@ impl Expr {
 /// # Examples
 ///
 /// ```
-/// let every_minute = cron.parse("* * * * *");
-/// let weekdays_9am = cron.parse("0 9 * * 1-5");
+/// import std.time.cron;
+///
+/// fn main() {
+///     let every_minute = cron.parse("* * * * *");
+///     let weekdays_9am = cron.parse("0 9 * * 1-5");
+/// }
 /// ```
 pub fn parse(expr: string) -> Expr {
     unsafe {

--- a/std/time/datetime/datetime.hew
+++ b/std/time/datetime/datetime.hew
@@ -179,8 +179,12 @@ pub fn diff_secs(a: i64, b: i64) -> i64 {
 /// # Examples
 ///
 /// ```
-/// let iso = datetime.to_iso8601(datetime.now_ms());
-/// // e.g. "2025-07-10T14:30:00Z"
+/// import std.time.datetime;
+///
+/// fn main() {
+///     let iso = datetime.to_iso8601(datetime.now_ms());
+///     // e.g. "2025-07-10T14:30:00Z"
+/// }
 /// ```
 pub fn to_iso8601(epoch_ms: i64) -> string {
     format(epoch_ms, "%Y-%m-%dT%H:%M:%SZ")

--- a/std/time/datetime/datetime.hew
+++ b/std/time/datetime/datetime.hew
@@ -38,7 +38,12 @@ pub fn now_secs() -> i64 {
 /// # Examples
 ///
 /// ```
-/// let s = datetime.format(now, "%Y-%m-%d");
+/// import std.time.datetime;
+///
+/// fn main() {
+///     let now = datetime.now_ms();
+///     let s = datetime.format(now, "%Y-%m-%d");
+/// }
 /// ```
 pub fn format(epoch_ms: i64, fmt: string) -> string {
     match try_format(epoch_ms, fmt) {

--- a/std/vec.hew
+++ b/std/vec.hew
@@ -32,11 +32,21 @@ pub fn index_of_i64(v: Vec<i64>, val: i64) -> Option<i64> { // INTERNAL-ABI: i64
 /// # Examples
 ///
 /// ```
-/// let v: Vec<f64> = Vec.new();
-/// v.push(1.5);
-/// v.push(2.5);
-/// println(vec.index_of_f64(v, 2.5));  // Some(1)
-/// println(vec.index_of_f64(v, 9.9));  // None
+/// import std.vec;
+///
+/// fn main() {
+///     let v: Vec<f64> = Vec.new();
+///     v.push(1.5);
+///     v.push(2.5);
+///     match vec.index_of_f64(v, 2.5) {
+///         .Some(i) => println(i),  // 1
+///         .None => println("not found"),
+///     }
+///     match vec.index_of_f64(v, 9.9) {
+///         .Some(i) => println(i),
+///         .None => println("not found"),  // not found
+///     }
+/// }
 /// ```
 pub fn index_of_f64(v: Vec<f64>, val: f64) -> Option<i64> {
     let n = v.len();
@@ -53,11 +63,21 @@ pub fn index_of_f64(v: Vec<f64>, val: f64) -> Option<i64> {
 /// # Examples
 ///
 /// ```
-/// let v: Vec<string> = Vec.new();
-/// v.push("a");
-/// v.push("b");
-/// println(vec.index_of_str(v, "b"));   // Some(1)
-/// println(vec.index_of_str(v, "z"));   // None
+/// import std.vec;
+///
+/// fn main() {
+///     let v: Vec<string> = Vec.new();
+///     v.push("a");
+///     v.push("b");
+///     match vec.index_of_str(v, "b") {
+///         .Some(i) => println(i),  // 1
+///         .None => println("not found"),
+///     }
+///     match vec.index_of_str(v, "z") {
+///         .Some(i) => println(i),
+///         .None => println("not found"),  // not found
+///     }
+/// }
 /// ```
 pub fn index_of_str(v: Vec<string>, val: string) -> Option<i64> {
     let n = v.len();


### PR DESCRIPTION
## Why

The doc-fence ratchet (`make test-doc-examples`, run in `ci-shard-1`) only
sourced the language guide, the spec, and `docs/language/*.hew`, so std's
232 doc-comment fences never compiled as part of CI. A stale std example
could sit broken indefinitely with nothing catching it.

## What

- **corpus-ratchet.sh**: added a `std/**/*.hew` enumerator and a std-specific
  fence extractor (`doc_fence_extract_std`) alongside the existing
  guide/spec extractor. std fences differ from the guide/spec ones on two
  axes the existing extractor doesn't handle: item-level `///` comments (not
  only module-level `//!`), and a bare ` ``` ` open (implicit hew) instead of
  an explicit ` ```hew ` tag. The extractor tracks a third "inside a
  non-hew-tagged fence" state so a bare ` ``` ` that closes e.g. a
  ` ```text ` block is never mistaken for the open of the next real fence.
  It also trims leading whitespace before matching `///`/`//!` markers, so
  indented item-level docs on trait/impl members are extracted correctly
  instead of being blanked to nothing.
- **std/**: fixed every std doc fence that failed to compile. Most were
  terse call-and-comment snippets missing the `import` + `fn main()`
  wrapper the module-level examples already use, or bare `Ok`/`Err`/enum
  patterns missing their leading dot. A few had real content bugs — see the
  `docs(std): fix the remaining std doc fences` commits for the list
  (`Stream<string>` chunking vs. a nonexistent `.lines()`, an opaque handle
  passed through a `receive fn`, `respond_stream`'s return type, an
  untagged ASCII diagram, `panic` given a `NetError` instead of a string).
- **Makefile**: wired the new `scripts/tests/test_std_doc_fence_extraction.sh`
  self-test into `doc-ratchet-selftest` — it existed but no target ran it.

## Test

- `make test-doc-examples` passes: the doc-fence ratchet's expected-failure
  set is unchanged from `origin/main`, all pre-existing guide/spec fences,
  so every std fence either compiles or was already a tracked expected
  failure before this branch touched it.
- `scripts/tests/test_std_doc_fence_extraction.sh` (now run via
  `make doc-ratchet-selftest`) pins the tri-state extractor with a fixture
  containing a `//!` fence, a column-0 `///` fence, a `text`-tagged fence
  between them, and an indented `///` fence on a trait member. Forcing
  `in_other=0` reds the fence-count and post-`text`-fence content
  assertions; reverting the indentation trim (`local trimmed="$line"`)
  reds the fence-count and fourth-fence content assertions. Both negative
  controls confirmed.
- `make doc-ratchet-selftest` and `make hew-fmt-check` both pass.
