### PR TITLE
fix(cli): verify playground files that define their own main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@
 #   make sandbox-parity            — native hew run ↔ sandbox VM parity harness
 #   make playground-check          — manifest freshness + full hew-wasm test suite + build hew-wasm
 #   make playground-wasi-check     — focused curated manifest WASI runtime preflight
+#   make playground-verify         — native run of every runnable playground example vs. its .expected
 #   make licenses-check            — verify THIRD-PARTY-LICENSES is current (used in CI)
 #   make preflight                 — run every unconditional Linux gate, fail-fast
 #   make ci-preflight              — compatibility alias for make preflight
@@ -74,7 +75,7 @@
 #   make clean        — remove generated build and test artifacts
 # ============================================================================
 
-.PHONY: all build bootstrap install-hooks help shell-script-lint test-install-version-resolution actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
+.PHONY: all build bootstrap install-hooks help shell-script-lint test-install-version-resolution actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check playground-verify preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
 .PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
 .PHONY: test-ownership-balance-corpus test-ownership-balance-runner-selftest
 .PHONY: stdlib-user-build-clean
@@ -627,6 +628,12 @@ playground-wasi-check: wasm-runtime hew-native
 	$(TEST_RUN_ENV) cargo test -p hew-cli --test wasi_run_e2e curated_playground_examples_run_under_wasi -- --exact
 	$(TEST_RUN_ENV) cargo test -p hew-cli --test wasi_run_e2e supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi -- --exact
 
+# Native run of every runnable playground example against its checked-in
+# `.expected` file (`hew tool playground-verify`), catching drift the
+# analysis-only WASM/manifest checks above don't exercise.
+playground-verify: hew-native
+	$(DEBUG_HEW) tool playground-verify
+
 # Standard per-branch gate: validate workflow syntax locally, then run the lint
 # graph and the same three Make-owned test groups used by hosted Linux CI. One
 # Make graph lets shared prerequisites build once instead of being replanned by
@@ -644,7 +651,7 @@ ci-preflight: preflight
 ci-shard-1: observe-functional-test test-cabi test-compiler-lifecycle \
 	test-vertical-slice test-pkg-import test-runtime-unit test-ux-examples \
 	test-doc-examples doc-ratchet-selftest test-migrate-corpus \
-	o2-differential-selftest
+	o2-differential-selftest playground-verify
 
 ci-shard-2: hew-profile-check libhew-link-race-test test \
 	test-leak-oracle-selftest test-opaque-resource-lifecycle-matrix-external \

--- a/hew-cli/src/eval/classify.rs
+++ b/hew-cli/src/eval/classify.rs
@@ -83,11 +83,32 @@ pub fn input_completeness(input: &str) -> InputCompleteness {
         return InputCompleteness::Complete;
     }
 
-    if has_unclosed_delimiters(trimmed) || parses_with_continuation(trimmed) {
+    if has_unclosed_delimiters(trimmed)
+        || parses_with_continuation(trimmed)
+        || ends_with_bare_attribute(trimmed)
+    {
         return InputCompleteness::Incomplete;
     }
 
     InputCompleteness::Invalid
+}
+
+/// True if `input` is a syntactically complete attribute list (`#[wire]`,
+/// stacked `#[a]\n#[b]`, …) with no item yet attached to it.
+///
+/// An attribute alone has balanced delimiters (so `has_unclosed_delimiters`
+/// says "complete") and does not parse in any standalone context (so
+/// `parses_in_any_context` says "no"), which without this check falls
+/// through to `Invalid` — surfacing a parse error on the attribute line
+/// instead of buffering for the item it decorates.
+fn ends_with_bare_attribute(input: &str) -> bool {
+    if parses_as_item(input) {
+        // Already a complete item (with or without its own attributes) —
+        // nothing left to wait for.
+        return false;
+    }
+    let probe = format!("{input}\nfn __hew_repl_attr_probe__() {{}}\n");
+    parses_as_item(&probe)
 }
 
 /// Parse a REPL command string (after the leading `:`).
@@ -307,6 +328,23 @@ mod tests {
         assert_eq!(
             input_completeness(r#""hello"#),
             InputCompleteness::Incomplete
+        );
+    }
+
+    #[test]
+    fn input_completeness_buffers_bare_attribute_awaiting_its_item() {
+        // A standalone attribute line has balanced delimiters and parses in
+        // no context on its own — it must be buffered for the item that
+        // follows, not surfaced as a parse error.
+        assert_eq!(input_completeness("#[wire]"), InputCompleteness::Incomplete);
+        assert_eq!(
+            input_completeness("#[wire]\n#[other]"),
+            InputCompleteness::Incomplete
+        );
+        // Once the decorated item is appended, the buffer is complete.
+        assert_eq!(
+            input_completeness("#[wire]\ntype UserMessage { name: string @1, }"),
+            InputCompleteness::Complete
         );
     }
 

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -373,7 +373,7 @@ fn program_has_imports(program: &hew_parser::ast::Program) -> bool {
         .any(|(item, _)| matches!(item, hew_parser::ast::Item::Import(_)))
 }
 
-fn program_defines_main(program: &hew_parser::ast::Program) -> bool {
+pub(crate) fn program_defines_main(program: &hew_parser::ast::Program) -> bool {
     program.items.iter().any(|(item, _)| {
         matches!(
             item,
@@ -1803,6 +1803,16 @@ pub fn eval_file_captured(
     let input_name = path.to_string();
 
     let mut session = ReplSession::for_path_with_target(path, timeout, target);
+
+    // Mirror `load_file_output_cli`'s routing: a file that parses and defines
+    // its own `main` is one program and must be compiled as such, not chunked
+    // item-by-item through the REPL's line-oriented eval path (which appends
+    // a synthetic `fn main() {}` per chunk and collides with the real one).
+    let parse_result = hew_parser::parse(&source);
+    if parse_result.errors.is_empty() && program_defines_main(&parse_result.program) {
+        return session.eval_parsed_source_file_cli(parse_result.program, &source, &input_name);
+    }
+
     session.eval_source_file_cli(&source, &input_name, &input_name)
 }
 

--- a/hew-cli/src/eval/session.rs
+++ b/hew-cli/src/eval/session.rs
@@ -143,13 +143,16 @@ impl Session {
         match &kind {
             InputKind::Item => {
                 // The new item goes at the top level; we still need a main —
-                // unless the input already defines one itself (e.g. evaluating
-                // a whole file, such as `hew playground verify`, whose sole
-                // item is its own `fn main`). Appending a synthetic empty
-                // `fn main() {}` in that case duplicates the definition.
+                // unless the combined source (remembered items plus this
+                // input) already defines one. That covers both a whole file
+                // evaluated in one shot (e.g. `hew playground verify`, whose
+                // sole item is its own `fn main`) and a `main` remembered
+                // from an earlier REPL item: checking `input` alone missed
+                // the latter, so a later item eval always got the synthetic
+                // `fn main() {}` appended and collided with the real one.
                 source.push_str(input);
                 source.push('\n');
-                if !defines_main(input) {
+                if !source_defines_main(&source) {
                     source.push_str("fn main() {}\n");
                 }
             }
@@ -264,21 +267,21 @@ impl SessionItem {
     }
 }
 
-/// True if `input` (a fresh item-kind eval input, not accumulated session
-/// state) itself defines a top-level `fn main`. Parse failures are treated as
-/// "no" — the synthetic `fn main() {}` wrapper is still appended, and the
-/// resulting duplicate-parse-error path is unchanged from before this check
-/// existed.
-fn defines_main(input: &str) -> bool {
-    let parse_result = hew_parser::parse(input);
+/// True if `source` (remembered session items plus the new item, concatenated
+/// in build order but before any synthetic `fn main` is appended) defines a
+/// top-level `fn main` anywhere in it. Parse failures are treated as "no" —
+/// the synthetic `fn main() {}` wrapper is still appended, and the resulting
+/// duplicate-parse-error path is unchanged from before this check existed.
+///
+/// Reuses `program_defines_main` (the same predicate `:load`/whole-file eval
+/// use) rather than a second hand-rolled check, so there is one authority for
+/// "does this program already define main".
+fn source_defines_main(source: &str) -> bool {
+    let parse_result = hew_parser::parse(source);
     if !parse_result.errors.is_empty() {
         return false;
     }
-    parse_result
-        .program
-        .items
-        .iter()
-        .any(|(item, _)| matches!(item, Item::Function(decl) if decl.name == "main"))
+    super::repl::program_defines_main(&parse_result.program)
 }
 
 fn session_items_from_source(source: &str) -> Vec<SessionItem> {
@@ -496,6 +499,24 @@ mod tests {
         let session = Session::new();
         let prog = session.build_program("fn main() {\n    println(\"hi\");\n}");
         assert_eq!(prog.kind, InputKind::Item);
+        assert_eq!(prog.source.matches("fn main").count(), 1);
+    }
+
+    #[test]
+    fn remembered_main_item_is_not_duplicated_by_a_later_item() {
+        // Regression for the REPL replay case: typing `fn main() { ... }`
+        // succeeds and is remembered as a session item (unlike before this
+        // fix, when it always failed the duplicate-main check and was never
+        // recorded). The *next* item eval replays that remembered `main`
+        // ahead of the new item — checking only the new input for `main`
+        // missed the remembered one and always appended a second synthetic
+        // `fn main() {}`, so every item typed after a REPL-defined `main`
+        // failed with "main is defined multiple times".
+        let mut session = Session::new();
+        session.add_item("fn main() { println(\"hi\"); }");
+        let prog = session.build_program("fn foo() -> i32 { 42 }");
+        assert_eq!(prog.kind, InputKind::Item);
+        assert!(prog.source.contains("fn foo() -> i32 { 42 }"));
         assert_eq!(prog.source.matches("fn main").count(), 1);
     }
 

--- a/hew-cli/src/eval/session.rs
+++ b/hew-cli/src/eval/session.rs
@@ -142,10 +142,16 @@ impl Session {
 
         match &kind {
             InputKind::Item => {
-                // The new item goes at the top level; we still need a main.
+                // The new item goes at the top level; we still need a main —
+                // unless the input already defines one itself (e.g. evaluating
+                // a whole file, such as `hew playground verify`, whose sole
+                // item is its own `fn main`). Appending a synthetic empty
+                // `fn main() {}` in that case duplicates the definition.
                 source.push_str(input);
                 source.push('\n');
-                source.push_str("fn main() {}\n");
+                if !defines_main(input) {
+                    source.push_str("fn main() {}\n");
+                }
             }
             InputKind::Statement => {
                 source.push_str("fn main() {\n    ");
@@ -256,6 +262,23 @@ impl SessionItem {
             summary: source_preview(source),
         }
     }
+}
+
+/// True if `input` (a fresh item-kind eval input, not accumulated session
+/// state) itself defines a top-level `fn main`. Parse failures are treated as
+/// "no" — the synthetic `fn main() {}` wrapper is still appended, and the
+/// resulting duplicate-parse-error path is unchanged from before this check
+/// existed.
+fn defines_main(input: &str) -> bool {
+    let parse_result = hew_parser::parse(input);
+    if !parse_result.errors.is_empty() {
+        return false;
+    }
+    parse_result
+        .program
+        .items
+        .iter()
+        .any(|(item, _)| matches!(item, Item::Function(decl) if decl.name == "main"))
 }
 
 fn session_items_from_source(source: &str) -> Vec<SessionItem> {
@@ -461,6 +484,29 @@ mod tests {
         let session = Session::new();
         let prog = session.build_program("fn foo() -> i32 { 42 }");
         assert_eq!(prog.kind, InputKind::Item);
+        assert!(prog.source.contains("fn main() {}\n"));
+    }
+
+    #[test]
+    fn item_input_defining_main_is_not_duplicated() {
+        // A whole-file eval (e.g. `hew playground verify` on a program whose
+        // sole item is its own `fn main`) must not get a second synthetic
+        // `fn main() {}` appended — that duplicate definition is a compile
+        // error the user's file never had.
+        let session = Session::new();
+        let prog = session.build_program("fn main() {\n    println(\"hi\");\n}");
+        assert_eq!(prog.kind, InputKind::Item);
+        assert_eq!(prog.source.matches("fn main").count(), 1);
+    }
+
+    #[test]
+    fn item_input_not_defining_main_still_gets_synthetic_main() {
+        // Negative control for the above: an item that is NOT `fn main`
+        // still needs the synthetic empty main appended so the program has
+        // an entry point.
+        let session = Session::new();
+        let prog = session.build_program("fn foo() -> i32 { 42 }");
+        assert_eq!(prog.source.matches("fn main").count(), 1);
         assert!(prog.source.contains("fn main() {}\n"));
     }
 

--- a/hew-cli/src/playground.rs
+++ b/hew-cli/src/playground.rs
@@ -61,6 +61,7 @@ struct EntryResult {
     outcome: EntryOutcome,
 }
 
+#[derive(Debug)]
 enum EntryOutcome {
     Skipped,
     Verified(VerifyOutcome),
@@ -444,6 +445,74 @@ mod tests {
         assert!(
             matches!(outcome, EntryOutcome::Verified(VerifyOutcome::IoError(_))),
             "expected IoError when expected file is absent"
+        );
+    }
+
+    /// True if this test binary can actually resolve `libhew.a` and drive a
+    /// full native compile — `verify_entry` runs the whole native
+    /// compile+link+execute pipeline, which `cargo test`'s binary layout
+    /// (`target/debug/deps/<hash>`, one directory deeper than the shipped
+    /// `target/debug/hew`) does not always support (see the identical probe
+    /// in `eval::repl::tests::require_toolchain`). Skip rather than fail
+    /// when it can't.
+    fn require_toolchain() -> bool {
+        static OK: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *OK.get_or_init(|| {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let bin_name = format!("probe{}", crate::platform::exe_suffix());
+            let bin_path = dir.path().join(bin_name);
+            let source = "fn main() { println(\"ok\"); }\n";
+            let parse_result = hew_parser::parse(source);
+            if !parse_result.errors.is_empty() {
+                eprintln!("playground verify_entry test skipped: probe parse failed");
+                return false;
+            }
+            let ok = crate::compile_native_from_program(
+                parse_result.program,
+                source,
+                "<playground-probe>",
+                &bin_path,
+                &crate::compile::CompileOptions::default(),
+            )
+            .is_ok();
+            if !ok {
+                eprintln!(
+                    "playground verify_entry test skipped: \
+                     in-process compile failed (codegen/runtime not available)"
+                );
+            }
+            ok
+        })
+    }
+
+    #[test]
+    fn verify_entry_passes_for_a_file_defining_its_own_main() {
+        // Regression test: a playground file's sole item is `fn main` itself
+        // (the shape every real playground entry has). Before the
+        // session-eval fix this hit "main is defined multiple times"
+        // because the whole-file eval path always appended a synthetic
+        // `fn main() {}` after the file's own definition.
+        if !require_toolchain() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("test.hew");
+        std::fs::write(&src, "fn main() { println(\"hi\"); }\n").unwrap();
+        let expected = dir.path().join("test.expected");
+        std::fs::write(&expected, "hi\n").unwrap();
+
+        let entry = ManifestEntry {
+            id: "test/own_main".to_string(),
+            source_path: "test.hew".to_string(),
+            expected_path: "test.expected".to_string(),
+            capabilities: Capabilities {
+                wasi: "runnable".to_string(),
+            },
+        };
+        let outcome = verify_entry(&entry, dir.path(), Duration::from_secs(30));
+        assert!(
+            matches!(outcome, EntryOutcome::Verified(VerifyOutcome::Pass)),
+            "expected Pass for a file defining its own main, got: {outcome:?}"
         );
     }
 

--- a/hew-cli/src/playground.rs
+++ b/hew-cli/src/playground.rs
@@ -105,14 +105,33 @@ pub fn cmd_playground_verify(args: &crate::args::PlaygroundVerifyArgs) {
         std::process::exit(1);
     });
 
-    if entries.is_empty() {
-        eprintln!("Warning: manifest contains no entries.");
-        return;
-    }
-
-    // Run verification.
+    // Run verification. An empty manifest never reaches `verify_entry` — an
+    // empty `results` falls straight into `fail_closed_reason`'s "nothing was
+    // verified" branch below, so there is exactly one place that decides
+    // "did this run check anything real".
     let results = run_verify(&entries, &manifest_dir, timeout);
     print_results(&results);
+
+    if let Some(message) = fail_closed_reason(&results) {
+        eprintln!("Error: {message}");
+        std::process::exit(1);
+    }
+}
+
+/// Decide whether a completed run must fail the process even though no entry
+/// reported `Fail`/`RunError`/`IoError`, and name why.
+///
+/// Fails closed: an empty manifest, or a run where nothing passed (every
+/// entry skipped — e.g. a manifest regeneration or a capabilities flip
+/// emptied the runnable set), must not exit 0. A gate that goes green having
+/// verified nothing is worse than one that never ran; `failed > 0` alone
+/// does not catch either case, since both have zero failures too. The two
+/// are named with distinct messages so a reader can tell "there was nothing
+/// to check" from "everything present was skipped".
+fn fail_closed_reason(results: &[EntryResult]) -> Option<&'static str> {
+    if results.is_empty() {
+        return Some("manifest contains no entries");
+    }
 
     let failed = results
         .iter()
@@ -127,10 +146,19 @@ pub fn cmd_playground_verify(args: &crate::args::PlaygroundVerifyArgs) {
             )
         })
         .count();
-
     if failed > 0 {
-        std::process::exit(1);
+        return Some("one or more entries failed verification");
     }
+
+    let passed = results
+        .iter()
+        .filter(|r| matches!(&r.outcome, EntryOutcome::Verified(VerifyOutcome::Pass)))
+        .count();
+    if passed == 0 {
+        return Some("every manifest entry was skipped; nothing was verified");
+    }
+
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -445,6 +473,73 @@ mod tests {
         assert!(
             matches!(outcome, EntryOutcome::Verified(VerifyOutcome::IoError(_))),
             "expected IoError when expected file is absent"
+        );
+    }
+
+    // --- Fail-closed exit decision ---
+
+    #[test]
+    fn empty_manifest_fails_closed_distinctly_from_all_skipped() {
+        // An empty manifest and an all-skipped run are both "nothing was
+        // verified", but for different reasons — the message must tell
+        // them apart so a reader knows whether to look at the manifest file
+        // or at `capabilities.wasi` values.
+        let empty_reason = fail_closed_reason(&[]).expect("empty manifest must fail closed");
+        let all_skipped_reason = fail_closed_reason(&[EntryResult {
+            id: "a".to_string(),
+            outcome: EntryOutcome::Skipped,
+        }])
+        .expect("all-skipped run must fail closed");
+        assert_ne!(empty_reason, all_skipped_reason);
+        assert!(empty_reason.contains("no entries"));
+        assert!(all_skipped_reason.contains("skipped"));
+    }
+
+    #[test]
+    fn all_skipped_run_fails_closed() {
+        // A run where every entry was skipped (e.g. `capabilities.wasi`
+        // flipped away from `"runnable"` for the whole manifest) verified
+        // nothing and must not report success.
+        let results = vec![
+            EntryResult {
+                id: "a".to_string(),
+                outcome: EntryOutcome::Skipped,
+            },
+            EntryResult {
+                id: "b".to_string(),
+                outcome: EntryOutcome::Skipped,
+            },
+        ];
+        assert!(fail_closed_reason(&results).is_some());
+    }
+
+    #[test]
+    fn run_with_a_pass_does_not_fail_closed() {
+        // Negative control: at least one entry actually verified, so the
+        // "nothing was checked" failure must not fire.
+        let results = vec![
+            EntryResult {
+                id: "a".to_string(),
+                outcome: EntryOutcome::Verified(VerifyOutcome::Pass),
+            },
+            EntryResult {
+                id: "b".to_string(),
+                outcome: EntryOutcome::Skipped,
+            },
+        ];
+        assert_eq!(fail_closed_reason(&results), None);
+    }
+
+    #[test]
+    fn a_failed_entry_fails_closed_distinctly_from_all_skipped() {
+        let results = vec![EntryResult {
+            id: "a".to_string(),
+            outcome: EntryOutcome::Verified(VerifyOutcome::RunError("boom".to_string())),
+        }];
+        let reason = fail_closed_reason(&results).expect("a failure must fail the run");
+        assert!(
+            !reason.contains("skipped"),
+            "a real failure must not be reported as an all-skipped run: {reason}"
         );
     }
 


### PR DESCRIPTION
## Why

`hew tool playground-verify` failed on every runnable playground file on a clean tree with `main is defined multiple times`, even though each file defines exactly one `fn main`.

## What

The tool runs each file through the REPL's whole-file eval path (`eval_file_captured` → `eval_source_file_cli` → `build_program_with_kind_and_auto_print`), which classifies a file's item and always appends a synthetic `fn main() {}` after it. When the file's own item is `fn main`, that produces a duplicate definition.

- **session.rs**: skip the synthetic `fn main() {}` when the combined source already defines one, reusing `program_defines_main` (via `source_defines_main`) as the single authority for "does this program already define main" rather than a second hand-rolled check.
- **repl.rs**: `eval_file_captured` now parses the file up front and, when it parses cleanly and defines its own `main`, routes to the whole-file `eval_parsed_source_file_cli` path instead of the item-chunking path — mirroring `load_file_output_cli`'s existing routing, so a file that is one program is compiled as one program.
- **classify.rs**: a bare attribute line (e.g. `#[wire]`) has balanced delimiters and parses in no standalone context, so the line-buffering classifier treated it as a complete-but-invalid chunk instead of buffering for the item it decorates (`ends_with_bare_attribute`). This surfaced as a second, unrelated parse failure once the duplicate-main issue was fixed.
- **playground.rs**: `cmd_playground_verify` now fails closed — an empty manifest or a run where every entry was skipped no longer exits 0, since a gate that goes green having verified nothing is worse than one that never ran.
- **Makefile**: added `make playground-verify` and wired it into `ci-shard-1` alongside the other native example-verification gates (`playground-wasm-build`'s existing playground job targets wasm32 and can't run a native `fn main`).

## Test

- `hew-cli/src/eval/session.rs`: `item_input_defining_main_is_not_duplicated`, `remembered_main_item_is_not_duplicated_by_a_later_item` (regression for a `main` remembered from an earlier REPL item), and `item_input_not_defining_main_still_gets_synthetic_main` (negative control).
- `hew-cli/src/eval/classify.rs`: `input_completeness_buffers_bare_attribute_awaiting_its_item`.
- `hew-cli/src/playground.rs`: `empty_manifest_fails_closed_distinctly_from_all_skipped`, `all_skipped_run_fails_closed`, `a_failed_entry_fails_closed_distinctly_from_all_skipped`, and `run_with_a_pass_does_not_fail_closed` (negative control), plus `verify_entry_passes_for_a_file_defining_its_own_main` end to end through `verify_entry`.
