### PR TITLE
fix(cli): verify playground files that define their own main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@
 #   make sandbox-parity            — native hew run ↔ sandbox VM parity harness
 #   make playground-check          — manifest freshness + full hew-wasm test suite + build hew-wasm
 #   make playground-wasi-check     — focused curated manifest WASI runtime preflight
+#   make playground-verify         — focused curated manifest native eval preflight
 #   make licenses-check            — verify THIRD-PARTY-LICENSES is current (used in CI)
 #   make preflight                 — run every unconditional Linux gate, fail-fast
 #   make ci-preflight              — compatibility alias for make preflight
@@ -74,7 +75,7 @@
 #   make clean        — remove generated build and test artifacts
 # ============================================================================
 
-.PHONY: all build bootstrap install-hooks help shell-script-lint actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
+.PHONY: all build bootstrap install-hooks help shell-script-lint actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check playground-verify sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
 .PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
 .PHONY: test-ownership-balance-corpus test-ownership-balance-runner-selftest
 .PHONY: stdlib-user-build-clean
@@ -558,6 +559,13 @@ playground-manifest: wasm-capability
 playground-manifest-check: wasm-capability-check
 	$(PYTHON) scripts/gen-playground-manifest.py --check
 
+# Compile and run every "runnable" curated playground example natively and
+# diff its stdout against the checked-in .expected file. Complements
+# playground-wasi-check (same manifest, WASI target) by exercising the
+# native `hew tool playground-verify` path directly.
+playground-verify: hew-native
+	$(DEBUG_DIR)/hew tool playground-verify
+
 sandbox-fixtures:
 	cargo run -p xtask -- sandbox-fixtures
 
@@ -644,7 +652,7 @@ ci-shard-2: hew-profile-check libhew-link-race-test test \
 	test-asan-fixture-selftest hew-fmt-property stdlib-lint \
 	sir-coverage sir-parity
 
-ci-shard-3: mqtt-broker-e2e sandbox-parity \
+ci-shard-3: mqtt-broker-e2e sandbox-parity playground-verify \
 	fuzz-oracle fuzz-oracle-selftest test-package-install \
 	checked-mir-verify checked-mir-run \
 	test-core-matrix test-stdlib-ratchet \

--- a/hew-cli/src/eval/classify.rs
+++ b/hew-cli/src/eval/classify.rs
@@ -83,11 +83,39 @@ pub fn input_completeness(input: &str) -> InputCompleteness {
         return InputCompleteness::Complete;
     }
 
-    if has_unclosed_delimiters(trimmed) || parses_with_continuation(trimmed) {
+    if has_unclosed_delimiters(trimmed)
+        || parses_with_continuation(trimmed)
+        || is_attribute_only(trimmed)
+    {
         return InputCompleteness::Incomplete;
     }
 
     InputCompleteness::Invalid
+}
+
+/// True when `input` is one or more complete attribute lines (`#[wire]`, …)
+/// with no item declaration after them yet.
+///
+/// An attribute alone (e.g. `#[wire]`) is syntactically balanced — its own
+/// brackets close — so [`has_unclosed_delimiters`] does not see it as an
+/// incomplete buffer, and it does not parse standalone as an item,
+/// statement, or expression either. Without this check the chunked file
+/// evaluator (`eval_source_file_cli`) reports it `Invalid` and evaluates the
+/// bare attribute on its own, which is a parse error the user never wrote —
+/// it must instead keep buffering until the attributed item follows.
+fn is_attribute_only(input: &str) -> bool {
+    let mut saw_line = false;
+    for line in input.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if !line.starts_with("#[") || !line.ends_with(']') {
+            return false;
+        }
+        saw_line = true;
+    }
+    saw_line
 }
 
 /// Parse a REPL command string (after the leading `:`).
@@ -316,5 +344,46 @@ mod tests {
         // completed by more input.
         assert_eq!(input_completeness("1 + )"), InputCompleteness::Invalid);
         assert_eq!(input_completeness("let = 1;"), InputCompleteness::Invalid);
+    }
+
+    /// A bare attribute line is a valid prefix of an attributed item and
+    /// must keep buffering, not report `Invalid` (its brackets are already
+    /// balanced, so it would otherwise be evaluated on its own and fail to
+    /// parse — regression test for the `#[wire]`-prefixed playground type).
+    #[test]
+    fn input_completeness_buffers_bare_attribute() {
+        assert_eq!(input_completeness("#[wire]"), InputCompleteness::Incomplete);
+    }
+
+    /// Stacked attributes on separate lines must also keep buffering.
+    #[test]
+    fn input_completeness_buffers_stacked_attributes() {
+        assert_eq!(
+            input_completeness("#[wire]\n#[other]"),
+            InputCompleteness::Incomplete
+        );
+    }
+
+    /// Once the attributed item follows, the buffer is complete — proves
+    /// the attribute check does not force perpetual buffering.
+    #[test]
+    fn input_completeness_completes_attributed_item() {
+        assert_eq!(
+            input_completeness("#[wire]\ntype Msg {\n    name: string @1,\n}"),
+            InputCompleteness::Complete
+        );
+    }
+
+    /// Negative control for `is_attribute_only`: input with balanced
+    /// brackets that is not attribute-shaped (does not start with `#[`)
+    /// must still report `Invalid` when it is otherwise malformed — proves
+    /// the check is specific to genuine attribute lines, not "anything with
+    /// balanced `[...]`".
+    #[test]
+    fn input_completeness_does_not_buffer_non_attribute_bracket_line() {
+        assert_eq!(
+            input_completeness("let = [wire];"),
+            InputCompleteness::Invalid
+        );
     }
 }

--- a/hew-cli/src/eval/session.rs
+++ b/hew-cli/src/eval/session.rs
@@ -142,10 +142,16 @@ impl Session {
 
         match &kind {
             InputKind::Item => {
-                // The new item goes at the top level; we still need a main.
+                // The new item goes at the top level. Only synthesise an
+                // empty `fn main() {}` driver when the item itself does not
+                // already define one — an input that is itself `fn main`
+                // (a whole-file eval/playground-verify run) must not get a
+                // second, duplicate main appended after it.
                 source.push_str(input);
                 source.push('\n');
-                source.push_str("fn main() {}\n");
+                if !item_declares_main(input) {
+                    source.push_str("fn main() {}\n");
+                }
             }
             InputKind::Statement => {
                 source.push_str("fn main() {\n    ");
@@ -256,6 +262,31 @@ impl SessionItem {
             summary: source_preview(source),
         }
     }
+}
+
+/// True when `input` parses as item(s) that already include a top-level
+/// `fn main` definition.
+///
+/// The `InputKind::Item` branch of [`Session::build_program_with_kind_and_auto_print`]
+/// otherwise always appends a synthetic `fn main() {}` driver after the new
+/// item so the resulting program has an entry point. That is correct for a
+/// bare declaration (`fn helper() {}`) evaluated on its own, but when the
+/// item chunk being evaluated is itself the program's real `fn main` (e.g.
+/// a whole `.hew` file run through `hew playground verify`, chunked by the
+/// REPL evaluator), appending another `fn main() {}` produces a duplicate
+/// definition. A parse failure here is not fatal — it is reported by the
+/// caller's own parse of the full synthesised program, so this simply falls
+/// back to the pre-existing "always append" behaviour.
+fn item_declares_main(input: &str) -> bool {
+    let parse_result = hew_parser::parse(input);
+    if !parse_result.errors.is_empty() {
+        return false;
+    }
+    parse_result
+        .program
+        .items
+        .iter()
+        .any(|(item, _)| matches!(item, Item::Function(decl) if decl.name == "main"))
 }
 
 fn session_items_from_source(source: &str) -> Vec<SessionItem> {
@@ -462,6 +493,63 @@ mod tests {
         let prog = session.build_program("fn foo() -> i32 { 42 }");
         assert_eq!(prog.kind, InputKind::Item);
         assert!(prog.source.contains("fn main() {}\n"));
+    }
+
+    /// An item chunk that already defines `fn main` (a whole-file eval, as
+    /// used by `hew playground verify`) must not get a synthetic `fn main`
+    /// appended after it — that would produce a duplicate definition.
+    #[test]
+    fn item_input_declaring_main_gets_no_synthetic_main() {
+        let session = Session::new();
+        let prog = session.build_program("fn main() { println(\"hi\"); }");
+        assert_eq!(prog.kind, InputKind::Item);
+        assert_eq!(
+            prog.source.matches("fn main").count(),
+            1,
+            "expected exactly one fn main in: {}",
+            prog.source
+        );
+    }
+
+    /// Negative control for the above: an item that is NOT `fn main` still
+    /// gets the synthetic driver appended, proving the check is specific to
+    /// items that declare `main` rather than suppressing the driver for all
+    /// items.
+    #[test]
+    fn item_input_not_declaring_main_still_gets_synthetic_main() {
+        let session = Session::new();
+        let prog = session.build_program("fn helper() -> i32 { 42 }");
+        assert_eq!(prog.kind, InputKind::Item);
+        assert_eq!(
+            prog.source.matches("fn main").count(),
+            1,
+            "expected the synthetic driver to still be appended: {}",
+            prog.source
+        );
+    }
+
+    /// A prior accumulated item (e.g. a helper function from an earlier
+    /// chunk) followed by a chunk that is itself `fn main` — the shape
+    /// `hew playground verify` produces for a multi-item playground file —
+    /// must still parse to exactly one `main`.
+    #[test]
+    fn accumulated_item_then_own_main_has_single_main() {
+        let mut session = Session::new();
+        session.add_item("fn fib(n: i64) -> i64 { n }");
+        let prog = session.build_program("fn main() { println(fib(1)); }");
+        let parsed = hew_parser::parse(&prog.source);
+        assert!(
+            parsed.errors.is_empty(),
+            "expected clean parse: {:?}",
+            parsed.errors
+        );
+        let main_count = parsed
+            .program
+            .items
+            .iter()
+            .filter(|(item, _)| matches!(item, Item::Function(decl) if decl.name == "main"))
+            .count();
+        assert_eq!(main_count, 1, "expected exactly one fn main definition");
     }
 
     #[test]

--- a/hew-cli/tests/playground_verify_e2e.rs
+++ b/hew-cli/tests/playground_verify_e2e.rs
@@ -1,0 +1,153 @@
+//! End-to-end coverage for `hew tool playground-verify` against real spawned
+//! `hew` processes.
+//!
+//! These exercise the fix for the bug where a curated playground source file
+//! that defines its own `fn main` was rejected with "`main` is defined
+//! multiple times": `hew tool playground-verify` runs each manifest entry
+//! through the REPL-chunked eval path (`hew-cli/src/eval/session.rs`), which
+//! used to append a synthetic `fn main() {}` after every top-level item chunk
+//! unconditionally — including a chunk that was itself the file's real
+//! `fn main`. A companion case also covers the `#[wire]`-attribute chunking
+//! fix in `hew-cli/src/eval/classify.rs`.
+//!
+//! Run as process-level integration tests (not in-process unit tests) because
+//! `hew tool playground-verify` compiles and links a real native binary per
+//! entry; the `CARGO_BIN_EXE_hew` binary sits at the on-disk depth the
+//! linker's `libhew.a` search assumes, while a `cargo test`/`nextest` unit
+//! test binary (built one directory deeper, under `target/debug/deps/`) does
+//! not.
+
+mod support;
+
+use std::fs;
+
+use support::{hew_command, repo_root, require_codegen, run_bounded_command, tempdir};
+
+/// Write a manifest.json plus its listed source/.expected files into `dir`,
+/// return the manifest path.
+fn write_manifest(
+    dir: &std::path::Path,
+    entries: &[(&str, &str, &str, &str)],
+) -> std::path::PathBuf {
+    // entries: (id, source_filename, source_contents, expected_contents)
+    let mut manifest_entries = Vec::new();
+    for (id, filename, source, expected) in entries {
+        fs::write(dir.join(filename), source).expect("write source fixture");
+        let expected_filename = format!("{filename}.expected");
+        fs::write(dir.join(&expected_filename), expected).expect("write expected fixture");
+        manifest_entries.push(format!(
+            r#"{{"id": "{id}", "source_path": "{filename}", "expected_path": "{expected_filename}", "capabilities": {{"wasi": "runnable"}}}}"#
+        ));
+    }
+    let manifest_path = dir.join("manifest.json");
+    fs::write(&manifest_path, format!("[{}]", manifest_entries.join(",")))
+        .expect("write manifest.json");
+    manifest_path
+}
+
+fn run_playground_verify(manifest_path: &std::path::Path) -> std::process::Output {
+    let mut command = hew_command();
+    command
+        .arg("tool")
+        .arg("playground-verify")
+        .arg("--manifest")
+        .arg(manifest_path)
+        .current_dir(repo_root());
+    run_bounded_command(command, "hew tool playground-verify")
+}
+
+/// A source file that defines its own `fn main` (the shape of every curated
+/// playground example) must verify successfully.
+#[test]
+fn source_with_own_main_verifies() {
+    require_codegen();
+    let dir = tempdir();
+    let manifest = write_manifest(
+        dir.path(),
+        &[(
+            "own_main",
+            "own_main.hew",
+            "fn main() {\n    println(\"hi\");\n}\n",
+            "hi\n",
+        )],
+    );
+
+    let output = run_playground_verify(&manifest);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected success for a source file defining its own main\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("PASS own_main"),
+        "expected a PASS line\nstdout:\n{stdout}"
+    );
+}
+
+/// A source file with a helper function and a `#[wire]`-attributed type
+/// declared before its own `fn main` — the multi-chunk REPL-eval shape —
+/// must also verify. Covers both fixes together: the duplicate-main
+/// synthesis and the bare-attribute-line chunking.
+#[test]
+fn source_with_helper_wire_type_and_own_main_verifies() {
+    require_codegen();
+    let dir = tempdir();
+    let manifest = write_manifest(
+        dir.path(),
+        &[(
+            "helper_wire_main",
+            "helper_wire_main.hew",
+            "fn fib(n: i64) -> i64 {\n    if n <= 1 { n } else { fib(n - 1) + fib(n - 2) }\n}\n\n#[wire]\ntype Msg {\n    name: string @1,\n}\n\nfn main() {\n    println(fib(6));\n}\n",
+            "8\n",
+        )],
+    );
+
+    let output = run_playground_verify(&manifest);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected success for a helper + wire type + own main\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("PASS helper_wire_main"),
+        "expected a PASS line\nstdout:\n{stdout}"
+    );
+}
+
+/// Negative control: a source file with a genuine duplicate `fn main` (two
+/// literal definitions, not one synthesised by the evaluator) must still be
+/// rejected. Proves the fix only suppresses the *synthetic* main, not real
+/// duplicate-main detection.
+#[test]
+fn source_with_genuine_duplicate_main_fails() {
+    require_codegen();
+    let dir = tempdir();
+    let manifest = write_manifest(
+        dir.path(),
+        &[(
+            "duplicate_main",
+            "duplicate_main.hew",
+            "fn main() {\n    println(\"first\");\n}\n\nfn main() {\n    println(\"second\");\n}\n",
+            "first\n",
+        )],
+    );
+
+    let output = run_playground_verify(&manifest);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "expected failure for a genuinely duplicated main\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    // `print_results` writes PASS/SKIP to stdout but FAIL to stderr.
+    assert!(
+        stderr.contains("FAIL duplicate_main"),
+        "expected a FAIL line\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("defined multiple times"),
+        "expected the real duplicate-main diagnostic\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Why

`hew tool playground-verify` reported 0 passed / 37 failed against a clean
tree, every entry failing with "`main` is defined multiple times" even
though each source file defines exactly one `fn main`.

## What

- **eval session**: `hew-cli/src/eval/session.rs` chunks a whole file through
  the REPL evaluator and always appended a synthetic `fn main() {}` after any
  top-level item chunk. When the chunk was itself the file's own `fn main`,
  that produced a real duplicate. Skip the synthetic driver when the item
  chunk already declares `main`.
- **eval classify**: fixing the above surfaced a second, independent bug —
  `hew-cli/src/eval/classify.rs`'s completeness check saw a standalone
  attribute line (`#[wire]`) as syntactically balanced and evaluated it on
  its own, producing "expected expression, found `#[`". Buffer one or more
  bare attribute lines until the attributed item follows.
- **CI**: added `make playground-verify` beside `playground-manifest-check`
  and wired it into `ci-shard-3`, next to `sandbox-parity`, which already
  builds the native `hew` driver — the added step only costs a native
  link+run per curated example.

## Test

- `hew-cli/src/eval/session.rs`: unit tests for an item chunk that declares
  its own `main` (no synthetic driver), one that does not (driver still
  appended — negative control), and an accumulated helper item followed by
  its own `main` (the multi-chunk shape).
- `hew-cli/src/eval/classify.rs`: unit tests that a bare attribute line
  buffers as incomplete, stacked attributes buffer, the attributed item
  completes the buffer, and a balanced-bracket non-attribute line that is
  otherwise malformed still reports `Invalid` (negative control).
- `hew-cli/tests/playground_verify_e2e.rs` (new): spawns the real built
  `hew` binary against a temporary manifest — a source file with its own
  `main` verifies, one with a helper and a `#[wire]`-attributed type before
  its own `main` verifies, and a source file with a genuinely duplicated
  `main` still fails with the real "defined multiple times" diagnostic
  (negative control proving the fix does not suppress real duplicate-main
  detection).
- `make playground-verify` now passes 37/0/7 (passed/failed/skipped)
  against the real curated manifest.

### Notes

Reproducing the native-link integration test in-process (calling
`verify_entry` directly from a `#[cfg(test)]` unit test) hit a separate,
pre-existing gap: `hew-cli/src/link.rs`'s `libhew.a` search-path candidates
assume the running exe sits at `target/<profile>/<exe>`, but a
`cargo test`/`nextest` unit-test binary for a bin crate sits one level
deeper at `target/<profile>/deps/<exe>`, so every candidate resolves one
`target/` segment too deep. Every native-compile REPL test in
`hew-cli/src/eval/repl.rs` is gated behind a `require_toolchain()` probe
that hits the same gap and silently skips under `cargo nextest run` even
with `libhew.a` already built. Left untouched here — out of scope for this
fix — and noted in `.tmp/TODO.md`; the real end-to-end proof was moved to a
process-spawning integration test instead, which does not sit at the
affected depth.
