### PR TITLE
docs(spec): make errors compose through dyn Error and fallible mean Result

### DIFF
--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -1,0 +1,94 @@
+# Diagnostic codes
+
+Every refusal the compiler prints carries a code, and every code belongs to one
+of three channels. The channel decides the exit code and the prefix, so a
+script can tell "your program is wrong" from "the compiler cannot do this yet"
+without parsing prose.
+
+| Channel    | Exit | Prefix                     | Meaning                                                                                                                           |
+| ---------- | ---- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| User       | 1    | none                       | The program is wrong. Fix the program.                                                                                            |
+| Limitation | 3    | `compiler limitation:`     | The program is within the language as specified; this build cannot lower it. The code names the release that removes the refusal. |
+| Internal   | 4    | `internal compiler error:` | Two compiler facts disagree. Never the program's fault; the message prints both facts and a bug-report line.                      |
+
+Usage errors keep exit 2. These codes belong to `hew check`, `hew build`, and
+the compile phase of `hew test`. `hew run` exits with the program's own code
+once the program starts (HEW-SPEC-2026 §5.8), so a script that must distinguish
+a limitation from a program's own `exit(3)` runs `hew check` first.
+
+## No internal error reaches a user
+
+`E_HIR`, `E_MIR_CHECK`, and `E_NOT_YET_IMPLEMENTED` are the compiler's own
+channels. A program that reaches one of them was admitted by a checker that
+should have refused it: the checker and the lowering disagree about what the
+language accepts, which is a one-authority violation regardless of what the
+program was trying to do.
+
+So every known member of that set gets a refusal of its own, with a Limitation
+code that names the release removing it, placed where the fact lives — at the
+checker when the shape is syntactic, at the MIR diagnostic site when the
+refusal needs a liveness fact only MIR holds. The refusal is deleted in the
+same change that lands the mechanism.
+
+## The `E_LIMIT_*` family
+
+| Code                               | Channel    | Removed by | Refuses                                                                                                                                                                                                       |
+| ---------------------------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `E_LIMIT_COLLECTION_COPY`          | Limitation | v0.7.0     | A whole-binding copy of a value-category collection (`let b = a` on a `Vec`, then a use of `a`). The rule says retain; this lowering consumes. Relabelled at the MIR site, not re-derived in the checker.     |
+| `E_LIMIT_GENERIC_RETURN_INFERENCE` | Limitation | v0.7.0     | A generic return type inferred through `?` or `.unwrap()`. The turbofish form is the accepted spelling.                                                                                                       |
+| `E_LIMIT_SUPERVISED_STATE`         | Limitation | v0.7.0     | Supervised child state beyond scalars, `string`, and `bytes`. One code for the checker refusal, the init-arg MIR gap, and the init-thunk codegen backstop.                                                    |
+| `E_LIMIT_SELF_NAMED_ALIAS`         | Limitation | v0.7.0     | An alias import of a file whose name repeats its directory (`import std.net.http.http as h;`). The unaliased file, the directory module, and a sibling file under the directory's name all compile.           |
+| `E_LIMIT_RC_FIELD`                 | Limitation | v0.7.0     | A field read through an `Rc<T>` (§3.7.5). `.get()` on a `T: Copy` payload is the accepted form until the borrow-projection lowering lands.                                                                    |
+| `E_LIMIT_DYN_SEND`                 | Limitation | v0.7.0     | Sending a `dyn Trait` value whose concrete type is not `#[wire]`.                                                                                                                                             |
+| `E_LIMIT_MAIN_CONTEXT`             | Limitation | v0.7.0     | A suspension `main` cannot carry, because `main` has no execution context in this build.                                                                                                                      |
+| `E_LIMIT_INHERENT_VAR_SELF`        | Limitation | v0.7.0     | A `var self` receiver on an inherent `impl` method. The trait form is accepted.                                                                                                                               |
+| `E_LIMIT_OPAQUE_ACTOR`             | Limitation | v0.7.0     | An `#[opaque]` value, or a `#[resource]` wrapper around one, as an actor's init field.                                                                                                                        |
+| `E_LIMIT_DERIVED_ORD`              | Limitation | v0.7.0     | A derived `Ord`/`PartialOrd` comparison the current lowering cannot generate.                                                                                                                                 |
+| `E_ASSOC_BOUND_UNSUPPORTED`        | Limitation | v0.7.0     | An associated-type bound in a `where` clause (`where T.Item: Bound`, §3.8.3). It parses and type-checks but never reaches method resolution, so writing it is an error rather than a bound that does nothing. |
+
+## User-channel codes in the same family
+
+These refuse a program the language does not accept, so no release removes
+them.
+
+| Code                                           | Refuses                                                                                                                     |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `E_RANGE_VALUE`                                | A range in value position. Ranges are `for` iterables, by design.                                                           |
+| `E_DYN_SUPERTRAIT`                             | A supertrait method reached through a trait object in a shape the checker cannot resolve (HEW-SPEC-2026 §2.2.1).            |
+| `E_BARE_VARIANT_PATTERN`                       | A bare variant in pattern position (`Ok(v)`). Write `.Ok(v)` when the scrutinee selects the enum, `Result.Ok(v)` otherwise. |
+| `E_BARE_VARIANT_EXPR`                          | A bare variant in expression position, under the same rule.                                                                 |
+| `E_VISIBILITY_PRIVATE`, `E_VISIBILITY_PACKAGE` | A cross-module reference to a private or package item.                                                                      |
+| `E_MODULE_NOT_FOUND`                           | An `import` no search path resolves.                                                                                        |
+
+The remaining v0.6.0 surface codes are named by the decision that introduces
+them, and their rule lives in the spec section that decision writes — not
+here. Each row is added by the lane that lands the refusal:
+`E_IS_VALUE_TYPE`, `E_OPAQUE_MESSAGE_PAYLOAD`, `E_CALLABLE_MESSAGE_PAYLOAD`,
+`E_USE_AFTER_SEND`, `E_UNKNOWN_ATTRIBUTE`, `E_RESERVED_HANDLER_NAME`,
+`E_ACTOR_CONTEXT_REQUIRED`, `E_BREAK_VALUE`, `E_SCOPE_IS_STATEMENT`,
+`E_GEN_RETURN_SPELLING`, `E_NO_ASYNC_FN`, `E_NO_ASYNC_GEN`,
+`E_FOR_STREAM_NEEDS_AWAIT`, `E_AWAIT_NOT_STREAM`.
+
+## Refusals with no code yet
+
+Each of these is a known member of the internal-error set whose refusal has not
+been written. The code is assigned in the change that adds the refusal, and it
+is listed here then — not before, so this table never names a code the compiler
+does not emit.
+
+| Refusal                                                                   | Removed by |
+| ------------------------------------------------------------------------- | ---------- |
+| Skip-level (transitive) closure capture                                   | v0.7.0     |
+| `if let` with a nested tuple pattern                                      | v0.7.0     |
+| A guarded tuple pattern with a binding                                    | v0.7.0     |
+| `for` over an iterator adapter                                            | v0.7.0     |
+| `println` of an `Option<T>` or `Result<T, E>` — neither has `Display` yet | v0.7.0     |
+| `duration.from_*` constructors                                            | v0.7.0     |
+
+## Where this list is going
+
+This file is written by hand. At v0.7.0 the per-code pages under
+`docs/diagnostics/E_*.md` are generated from one registry table in the compiler,
+`hew check --explain E_CODE` renders them, and a gate fails when a code is
+emitted without a page or without a reject fixture that produces it. Until
+then, a lane that adds a code adds its row here in the same change.

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -3816,9 +3816,10 @@ test` — no warning, no error, it's simply never found. If a suite's pass
 
 `assert(condition: bool)` panics when `condition` is `false`. `assert_eq(a,
 b)` and `assert_ne(a, b)` panic with a diff of the two values on failure —
-prefer them over `assert(a == b)` for the readable failure message. Both are
-generic over `T: Eq + Display`, so a value has to be able to print itself to be
-compared this way; `Option` and `Result` gain `Display` at v0.7.0, and until
+prefer them over `assert(a == b)` for the readable failure message. Both take
+`dyn Display` values, so a value has to be able to print itself to be compared
+this way — the same constraint `std.testing`'s generic `assert_eq<T: Eq +
+Display>` carries. `Option` and `Result` gain `Display` at v0.7.0, and until
 then a test compares one by matching on it:
 
 ```

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -2300,7 +2300,49 @@ fn main() {
 }
 ```
 
-For a fallible operation with no meaningful success value, return `Result<i64, E>` and `Ok(0)`; match the success arm with `Ok(_)`. (Avoid `Ok(())` / `Result<(), E>`.)
+For a fallible operation with no meaningful success value, `Result<(), E>` and `Ok(())` are the shapes to reach for — that is what `os.set_env` and a `main` that can fail both return. The `Result<i64, E>` with `Ok(0)` form above is a payload nobody reads; it appears here because older stdlib signatures used it, not because it is the shape to copy.
+
+### Errors that compose: `dyn Error`
+
+`?` is exact. The error type of the operand has to be the error type of the enclosing function — there is no `From`, no `#[from]`, and no conversion the compiler inserts on your behalf, so two concrete error enums never flow into one another by accident.
+
+A function that calls into several modules names `dyn Error` as its error type instead:
+
+```hew
+import std.fs;
+
+enum PortError {
+    NotANumber(string);
+}
+
+impl Display for PortError {
+    fn fmt(self) -> string {
+        match self { .NotANumber(s) => f"NotANumber: {s} is not a port number" }
+    }
+}
+
+impl Error for PortError {}
+
+fn parse_port(text: string) -> Result<i64, PortError> {
+    Err(PortError.NotANumber(text))
+}
+
+fn load_port(path: string) -> Result<i64, dyn Error> {
+    let text = fs.read(path)?;        // IoError coerces into dyn Error
+    let port = parse_port(text)?;     // PortError coerces into the same
+    Ok(port)
+}
+```
+
+`Error` is a prelude trait whose supertrait is `Display`, so every std error type prints itself and a `dyn Error` prints through the supertrait: `f"{e}"` works on the erased value. Where you want a concrete error type instead of the trait object, convert explicitly with `.map_err(f)` on a `Result` or `.ok_or(e)` on an `Option`. Crash on the spot with `.unwrap()` or `.expect(msg)`.
+
+`fn main() -> Result<(), E>` needs `E: Error`. On `Err(e)` the runtime writes `error: {e}` to stderr and exits 1.
+
+### Fallible means `Result`
+
+Standard-library functions report failure in the type system. A fallible call returns `Result<T, E>` under its plain name — there is no `try_read` beside `read` — and a lookup that can miss returns `Option<T>`, so `os.env("PORT")` gives you `None` rather than an empty string you have to guess about. Nothing returns a status integer or a sentinel value.
+
+The exception is indexing: `v[i]` and `m[k]` trap when the index or key is absent, because that is a bug in the program rather than a condition to handle. Use `.get()` when a miss is expected.
 
 ## Strings
 
@@ -2614,24 +2656,24 @@ import std.sort;
 fn main() {
     let nums: Vec<i64> = Vec.new();
     nums.push(3); nums.push(1); nums.push(4); nums.push(1); nums.push(5);
-    let sorted   = sort.sort_ints(nums);       // returns new Vec — original unchanged
-    let reversed = sort.reverse_ints(sorted);
+    let sorted   = sort.sort(nums);            // returns new Vec — original unchanged
+    let reversed = sort.reverse(sorted);
     println(sorted[0]);    // 1
     println(reversed[0]);  // 5
 
     let words: Vec<string> = Vec.new();
     words.push("banana"); words.push("apple"); words.push("cherry");
-    let sw = sort.sort_strings(words);
+    let sw = sort.sort(words);
     println(sw[0]);        // apple
 
     let floats: Vec<f64> = Vec.new();
     floats.push(3.14); floats.push(1.41); floats.push(2.72);
-    let sf = sort.sort_floats(floats);
+    let sf = sort.sort(floats);
     println(sf[0]);        // 1.41
 }
 ```
 
-`sort_ints` / `sort_strings` / `sort_floats` return new sorted Vecs (ascending); `reverse_ints` / `reverse_strings` / `reverse_floats` return new reversed Vecs. The original is never modified. Integer and string sorting use iterative merge passes, so their comparison count is O(n log n); float sorting retains its total-order runtime implementation.
+`sort<T: Ord>` returns a new sorted Vec (ascending) and `reverse<T>` returns a new reversed one; the original is never modified. One generic function covers every element type — the `sort_ints` / `sort_strings` / `sort_floats` family it replaces is listed in [the v0.6.0 migration note](migrations/v0.6.0.md). Integer and string sorting use iterative merge passes, so their comparison count is O(n log n); float sorting retains its total-order runtime implementation.
 
 ### std.random — pseudo-random number generation
 
@@ -2643,10 +2685,7 @@ fn main() {
     let n = random.randint(1, 7);      // i64 in [1, 7)  — like a d6 roll
     let g = random.gauss(0.0, 1.0);   // Gaussian sample
 
-    let v: Vec<i64> = Vec.new();
-    v.push(10); v.push(20); v.push(30);
-    random.shuffle(v);                 // in-place Fisher-Yates shuffle
-    println(v[0]);                     // non-deterministic (seeded above)
+    println(f"{r} {n} {g}");
 }
 ```
 
@@ -3685,7 +3724,7 @@ fn main() {
 ```
 
 Use the FREE-FUNCTION surface — `tls.connect(host, port)` (system-root verified),
-`tls.write` / `tls.try_write`, `tls.read`, `tls.close`. Request/response bodies
+`tls.write`, `tls.read`, `tls.close` — each returning a `Result`. Request/response bodies
 are `bytes`: build a payload with the public `string.to_bytes()` surface and decode
 with `bytes.to_string()`. There is also a method form (`stream.read(n)` /
 `stream.write(payload)`, from `trait TlsStreamMethods`) — it type-checks and
@@ -3777,7 +3816,10 @@ test` — no warning, no error, it's simply never found. If a suite's pass
 
 `assert(condition: bool)` panics when `condition` is `false`. `assert_eq(a,
 b)` and `assert_ne(a, b)` panic with a diff of the two values on failure —
-prefer them over `assert(a == b)` for the readable failure message:
+prefer them over `assert(a == b)` for the readable failure message. Both are
+generic over `T: Eq + Display`, so a value has to be able to print itself to be
+compared this way; `Option` and `Result` gain `Display` at v0.7.0, and until
+then a test compares one by matching on it:
 
 ```
 ---- wrong_expectation_fails ----

--- a/docs/migrations/v0.6.0.md
+++ b/docs/migrations/v0.6.0.md
@@ -1,0 +1,70 @@
+# Migrating to Hew v0.6.0
+
+v0.6.0 freezes the language surface before edition 2026 stabilizes. Breaking a
+name is cheap at today's audience and unaffordable later, so the renames and
+deletions that were going to happen eventually happen now, once.
+
+This file is the only place the retired spellings are written down. The
+specification and the guide describe the surface as it is; a reader who meets
+an old name in someone else's code finds it here.
+
+## Errors and fallibility
+
+Every fallible standard-library function returns `Result<T, E>` with
+`E: Error`, and the bare name carries it (HEW-SPEC-2026 §3.10.3). The `try_`
+prefix is gone, along with the panicking twin that used to sit beside it.
+
+| Retired                                                                                                                                                 | Current                                                             | Notes                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `fs.try_read(p)`                                                                                                                                        | `fs.read(p)`                                                        | Returns `Result<string, IoError>`                                                     |
+| `fs.try_write`, `try_append`, `try_delete`, `try_mkdir`, `try_mkdir_all`, `try_list_dir`, `try_rename`, `try_copy`, `try_read_bytes`, `try_write_bytes` | the same name without `try_`                                        | Same shape throughout `std.fs`                                                        |
+| `net.try_connect`, `net.try_connect_timeout`, `net.try_read`, `net.try_read_string`                                                                     | `net.connect`, `net.connect_timeout`, `net.read`, `net.read_string` | The bare names now carry `Result<T, NetError>`                                        |
+| `process.try_run`, `try_run_argv`, `try_start`, `try_start_argv`                                                                                        | `process.run`, `run_argv`, `start`, `start_argv`                    | The bare names now carry `Result<T, ProcessError>`                                    |
+| `tls.try_write`                                                                                                                                         | `tls.write`                                                         |                                                                                       |
+| `fs.read(p)` returning a bare `string`                                                                                                                  | `fs.read(p)?` or `fs.read(p).expect("…")`                           | The former bare form silently returned an empty value on failure                      |
+| `os.env(name)` returning `string`                                                                                                                       | `os.env(name)` returning `Option<string>`                           | The unset case used to return a zero-length string that did not compare equal to `""` |
+| `os.set_env` returning a status integer                                                                                                                 | `os.set_env -> Result<(), EnvError>`                                |                                                                                       |
+| `observe.read` returning a sentinel                                                                                                                     | `observe.read -> Option<i64>`                                       |                                                                                       |
+| `observe.barrier` returning a status integer                                                                                                            | `observe.barrier -> Result<(), ObserveError>`                       |                                                                                       |
+| `AskError.NoError`                                                                                                                                      | (deleted)                                                           | An error enum has no "no error" variant                                               |
+| `fs.io_error_message`, `path.path_error_message`, `net.net_error_message`, `net.write_error_message`, `encrypt.error_message`, `jwt.error_message`      | `f"{e}"`                                                            | Every public error type implements `Display` and `Error`                              |
+| `wire.from_json` returning `Result<T, string>`                                                                                                          | `Result<T, wire.DecodeError>`                                       |                                                                                       |
+
+Indexing is the one place a failure still traps rather than returning a
+`Result`: `v[i]`, `m[k]`, and `Vec.set` out of bounds are program errors, and
+`.get()` is the `Option`-returning accessor for the case where a miss is
+expected.
+
+## Module paths
+
+| Retired                                                            | Current                          |
+| ------------------------------------------------------------------ | -------------------------------- |
+| `std.misc.log`                                                     | `std.log`                        |
+| `std.misc.uuid`                                                    | `std.uuid`                       |
+| `std.crypto.crypto`                                                | `std.crypto.hash`                |
+| `std.net.http.http`                                                | `std.net.http.server`            |
+| `std.net.http.http_client`                                         | `std.net.http.client`            |
+| `std.net.http.http_async_server`, `std.net.http.http_async_client` | internal to `std.net.http.codec` |
+| `std.pipeline`, `std.machines.toggle`                              | (deleted — no consumer)          |
+| `std.lambda_actor`, `std.value_trait`, `std.mem`                   | off the documented path          |
+
+`std.deque` and `std.arena` stay where they are. Both are handle types
+(HEW-SPEC-2026 §3.4.3), not collections, so they never move under a
+`collections/` path.
+
+## One form per operation
+
+| Retired                                                                                     | Current                                                                                   |
+| ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `sort.sort_ints`, `sort_strings`, `sort_floats`                                             | `sort.sort<T: Ord>`                                                                       |
+| `sort.reverse_ints`, `reverse_strings`, `reverse_floats`                                    | `sort.reverse<T>`                                                                         |
+| `testing.assert_true` and the per-type assertion family                                     | `testing.assert(cond, msg)`, `testing.assert_eq<T: Eq + Display>`, `testing.assert_ne<T>` |
+| the monomorphic helpers in `std.vec`, `std.option`, `std.result`                            | the generic function of the same name                                                     |
+| `random.shuffle`                                                                            | (deleted)                                                                                 |
+| the `string_*` builtin family, `substring`, the free `len`, the four `*_to_string` builtins | methods on `string`, and `Display` for rendering                                          |
+| the free-function twins in `std.string` and the aliases in `std.fmt`                        | the method of the same name                                                               |
+| `csv.Table.free`, `semver.Version.free`, `json.Value.free`                                  | `close()`, or scope-exit drop glue                                                        |
+| the `Closable` trait                                                                        | a `#[resource]` type's `close` method                                                     |
+
+Comparing an `Option` or a `Result` with `assert_eq` needs `Display` for those
+two types, which lands at v0.7.0. Until then a test matches on the value.

--- a/docs/specs/HEW-FUTURE.md
+++ b/docs/specs/HEW-FUTURE.md
@@ -39,17 +39,20 @@ forms, but the bounded MPSC surface itself is no longer a future item.
 
 ### 1.2 Cancellation tokens
 
-**[Target: v0.6]**
+**[REJECTED]**
 
-Edition 2026 cancellation is **scope-structural only**: a `scope {}`
-block cancels its children when any child fails or when the scope exits. No
-user-visible `CancellationToken` type, no `Token.cancel()`, no
-`#[noncancellable]` attribute as a stabilised surface (it parses today
-but is gated to future-edition status).
+Hew cancellation is **scope-structural only**: a `scope {}` block cancels its
+children when any child fails or when the scope exits. There is no
+user-visible `CancellationToken` type, no `Token.cancel()`, and no
+`#[noncancellable]` attribute — the attribute is deleted from the parser
+rather than left parsing as a mark that marks nothing, and an unknown
+attribute is an error everywhere (`E_UNKNOWN_ATTRIBUTE`).
 
-A first-class token vocabulary lets a parent abort *one* child without
-unwinding the whole scope. Useful for long-running computations the
-caller can preempt mid-flight. Defer until a real need arises.
+A first-class token vocabulary would let a parent abort *one* child without
+unwinding the whole scope. It is refused: it gives cancellation a second
+authority beside the scope, and a token that can be held past its scope is a
+liveness fact the compiler cannot check. A caller who needs to preempt one
+computation gives it its own scope.
 
 ### 1.3 Actor await and read-after-send barrier (former §4.10)
 
@@ -80,10 +83,11 @@ for the shipped arms):
   and a bare `Stream<T>.recv()` is not yet ABI-wired in codegen. Returns
   once stream-handle binding lands.
 - **Task-await arm** (`<id> from await <task>`, binding `T` for
-  `Task<T>`). Deferred because `Task<T>` is not nameable (§4.3) and
-  `fork name = expr;` is parser-only in this build, so there is no
-  bindable first-class task handle to select on. Returns with the
-  `fork`/`Task` substrate.
+  `Task<T>`). Deferred because there is no way to consume a bound task:
+  `fork name = expr;` parses and type-checks, but awaiting the resulting
+  `Task<T>` in a value position is refused at HIR
+  (`AwaitOutOfPosition`), so the binding reaches its scope exit unconsumed
+  and MIR refuses it. Returns with the `fork`/`Task` substrate.
 
 Both forms are rejected at **check** time today (the type checker
 restricts the arm set; codegen is not involved), so re-introducing them
@@ -91,23 +95,30 @@ is purely additive.
 
 ### 1.5 Supervision extras beyond ask / restart / escalation
 
-**[Target: v0.6]**
+**[Hot-swap REJECTED / remainder target: v0.8]**
 
 Edition 2026 ships supervisor strategies (`one_for_one`, `one_for_all`,
 `rest_for_one`), restart classifications (`permanent`, `transient`,
-`temporary`), and restart-budget escalation. Surfaces beyond this —
-hot-swap upgrades, dynamic strategy changes, supervisor introspection
-APIs — are deferred.
+`temporary`), and restart-budget escalation.
+
+**Hot-swap upgrades are refused.** Hew compiles to native code; there is no
+loadable unit to swap and no representation of a running actor's state that
+survives a code change the compiler did not see. The mechanism Hew offers
+instead is the one it already has: restart the supervised subtree under a new
+binary, with the child spec's `restart:` clause deciding what comes back.
+
+Dynamic strategy changes and supervisor introspection APIs remain deferred to
+v0.8 with the rest of the supervision ergonomics work.
 
 ### 1.6 Generators (`Lazy<T>`, `#[prefetch(N)]`)
 
-**[`gen fn`, `async gen fn`, and `receive gen fn` live in v0.5 / remaining forms deferred]**
+**[`gen fn` and `receive gen fn` live / remaining forms deferred]**
 
 `gen fn` functions compile and run, including parameterized forms with scalar
 parameters (e.g. `n: i64`) and fn-typed parameters. The LLVM coroutine
 machinery, `yield`, `.next()`, and `for x in generator()` are all live.
-`async gen fn` returning `AsyncGenerator<Y>` consumed with `for await` is
-also live. `receive gen fn` on actors returning `Stream<Y>` backed by
+A generator whose body suspends carries no signature marker; `for await`
+consumes one. `receive gen fn` on actors returning `Stream<Y>` backed by
 mailbox protocol (cross-actor streaming with natural backpressure) is live
 as well — the `receive_gen_fn_*` vertical-slice fixtures pass.
 
@@ -167,7 +178,7 @@ works.
 
 ### 2.2 Advanced trait surface (dyn, object safety, associated-type bounds, heavy where-clauses)
 
-**[Target: v0.6 / gated on coherence rules]**
+**[Target: v0.7 / gated on coherence rules]**
 
 Edition 2026 ships a deliberately small trait surface:
 
@@ -181,7 +192,9 @@ Out of scope for edition 2026:
   `examples/types_and_traits.hew`). Remaining partial: object-safety
   enforcement, associated-type bounds in `dyn` position, and higher-ranked
   trait bounds.
-- Associated-type bounds in where-clauses (`where T::Item: Display`).
+- Associated-type bounds in where-clauses (`where T.Item: Display`). Writing
+  one today is an error, `E_ASSOC_BOUND_UNSUPPORTED` (HEW-SPEC-2026 §3.8.3),
+  rather than a bound that parses and never resolves a method.
 - Trait coherence (orphan rule) across crates — the current single-crate
   coherence rule stays; multi-crate coherence depends on the package
   system maturing.

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -354,7 +354,7 @@ Specifically:
 
 Actors may declare `#[max_heap(N)]` to cap their per-actor arena. If an arena allocation would exceed that cap, the runtime fails closed with the `ExitReason::HeapExceeded` crash variant and the `HEW_TRAP_HEAP_EXCEEDED` trap-kind discriminator. Supervisors receive that heap-exhaustion payload through the same crash-report routing path as other traps, so restart policy, escalation, and `#[on(crash)]` observation all see the cap breach as an unrecoverable actor failure rather than a recoverable `Result`.
 
-> **Error propagation:** `Result<T, E>` and `Option<T>` are first-class. User functions may return either type and use `?` for propagation. The `?` operator is available in any function whose return type is `Result` or `Option` with a compatible error type.
+> **Error propagation:** `Result<T, E>` and `Option<T>` are first-class. User functions may return either type and use `?` for propagation. The `?` operator is available in any function whose return type is `Result` or `Option` with the same error type, or with `dyn Error` (§2.2.1).
 
 ### 2.2.1 Error Propagation
 
@@ -373,6 +373,47 @@ When a `receive fn` message handler returns `Err`, the error is:
 1. Logged to the actor's supervision context
 2. Returned to the caller (if request-response pattern)
 3. May cause trap if unhandled and configured to do so
+
+**`?` is exact (normative).** The error type of the operand must be the error
+type of the enclosing function. Two concrete error enums never convert into one
+another, implicitly or otherwise: there is no `From`-driven `?`, no `#[from]`
+attribute, and no compiler-inserted conversion call. A `?` whose operand error
+type differs from the function's is a type error.
+
+**`dyn Error` is the one composition point.** `Error` is a prelude trait
+declared in `std/builtins.hew`:
+
+```text
+trait Error: Display {}
+```
+
+Every public error enum in `std` and in a `hew::` package implements `Display`
+and `Error`. When the enclosing function's error type is `dyn Error`, `?`
+applies the ordinary `dyn Trait` coercion the language already performs in any
+`dyn Trait` value position — the concrete error is erased into the trait
+object, and nothing else about `?` changes. `dyn Error` is therefore the type a
+function names when it composes errors from several modules, and a concrete
+enum is what it names when it does not.
+
+`Display` resolves through the supertrait on a `dyn Error` value, so
+`f"{e}"` and `println(e)` work on one. Supertrait shapes the checker cannot yet
+resolve through a trait object are refused with `E_DYN_SUPERTRAIT` (User
+channel) rather than silently losing the method.
+
+**Explicit conversion is a call.** A concrete error becomes another error, or
+an absent value becomes an error, through methods the caller writes:
+
+| Call | Meaning |
+| --- | --- |
+| `Result<T, E>.map_err(f)` | `f: fn(E) -> F` applied to the `Err` payload, yielding `Result<T, F>` |
+| `Option<T>.ok_or(e)` | `Some(v)` becomes `Ok(v)`; `None` becomes `Err(e)` |
+| `Result<T, E>.expect(msg)` | the `Ok` payload, or a trap carrying `msg` |
+| `Result<T, E>.unwrap()` | the `Ok` payload, or a trap naming the error |
+
+**`main` returning a `Result`.** `fn main() -> Result<(), E>` requires
+`E: Error`. On `Err(e)` the runtime writes `error: {e}` to stderr using the
+error's `Display` text and exits with `user_code` 1 (§5.8). On `Ok(())` it
+exits 0.
 
 ### 2.2.2 Bind-and-Propagate Sugar (`let r? = expr`)
 
@@ -393,9 +434,10 @@ let r?: T = expr;       ≡  let r: T = expr?;
 - The expression `expr` must evaluate to `Result<T, E>` or `Option<T>`.
   Any other type is a type error (`InvalidOperation`), identical to the
   diagnostic produced by a bare `expr?` on a non-Result/Option expression.
-- The enclosing function must return `Result<_, E>` or `Option<_>` with a
-  compatible error type. If it does not, the checker reports the same
-  "`?` cannot be used in a function returning …`" diagnostic as for bare `?`.
+- The enclosing function must return `Result<_, E>` or `Option<_>` with the
+  same error type, or with `dyn Error` (§2.2.1). If it does not, the checker
+  reports the same "`?` cannot be used in a function returning …`" diagnostic
+  as for bare `?`.
 - The type annotation `T` in `let r?: T = expr` describes the *unwrapped*
   Ok-payload (type of `r` after propagation), not the Result itself — the
   same convention as `let r: T = expr?;`.
@@ -448,7 +490,7 @@ to use `type`.
 
 - Bindings are immutable by default: `let`.
 - Mutable bindings: `var`.
-- Type fields have no mutability qualifier. Field mutation is governed by the binding: a `var`-bound value allows `p.x = …`; a `let`-bound value rejects it.
+- Type fields have no mutability qualifier. Field mutation is governed by the binding: a `var`-bound value allows `p.x = …`; a `let`-bound value rejects it. The same wall covers every place rooted at the binding — `p.x = …`, `v[0] = …`, `m["k"] = …`, and `t.0 = …` — and calling a method declared `var self` (§3.7.1), which is how a value-category type is mutated.
 
 ### 3.3 Sendability / isolation rule
 
@@ -488,7 +530,11 @@ The compiler automatically determines `Send` and `Frozen` for user-defined types
 > and `fn f(xs: [T])` both type-check and lower as `Vec<T>`, so an `[T; N]`
 > value does not satisfy an `[T]` annotation (``expected `Vec<i64>`, found
 > `[i64; 3]` ``). Prefer the explicit `Vec<T>` spelling for dynamically-sized
-> sequences.
+> sequences. `.len()` reads an array's length through the `Vec<T>` method
+> surface, so it is available on an inferred or `[T]`-annotated binding; a
+> binding annotated `[T; N]` does not resolve methods and is refused
+> (``no method `len` on `[i64; 3]` ``). Removing that asymmetry is a
+> checker fix, not a surface change.
 
 **Frozen derivation:**
 
@@ -514,7 +560,7 @@ let buf: bytes = bytes.new();
 buf.push(0x48);    // push a byte value (i64)
 buf.push(72);      // same as 'H' in ASCII
 let n = buf.len(); // i64
-let b = buf.get(0); // i64 — first byte
+let b = buf.get(0); // Option<u8> — first byte, or None when out of range
 buf.set(1, 0xFF);   // overwrite byte at index 1
 let last = buf.pop(); // i64 — removes and returns last byte
 println(buf.is_empty()); // bool
@@ -528,7 +574,7 @@ println(buf.contains(72)); // bool — linear scan
 | `bytes::new()` | `() -> bytes`      | Create an empty byte buffer     |
 | `.push(b)`     | `(i64) -> ()`      | Append a byte                   |
 | `.pop()`       | `() -> i64`        | Remove and return the last byte |
-| `.get(i)`      | `(i64) -> i64`     | Get the byte at index `i`       |
+| `.get(i)`      | `(i64) -> Option<u8>` | Byte at index `i`; `None` out of range |
 | `.set(i, b)`   | `(i64, i64) -> ()` | Overwrite the byte at index `i` |
 | `.len()`       | `() -> i64`        | Number of bytes                 |
 | `.is_empty()`  | `() -> bool`       | True if len is 0                |
@@ -890,14 +936,14 @@ This provides clean, namespaced access to stdlib functionality. The module name 
 
 | Module             | Example functions                                                                                                                                            |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `std.net.http`     | `http.listen`, `http.accept`, `http.path`, `http.method`, `http.body`, `http.header`, `http.respond`, `http.respond_text`, `http.respond_json`, `http.close` |
+| `std.net.http.server` | `http.listen`, `http.accept`, `http.path`, `http.method`, `http.body`, `http.header`, `http.respond`, `http.respond_text`, `http.respond_json`, `http.close` |
 | `std.fs`           | `fs.read`, `fs.write`, `fs.append`, `fs.exists`, `fs.delete`, `fs.size`                                                                                     |
 | `std.io`           | `io.read_line`, `io.write`, `io.write_err`, `io.read_all`                                                                                                   |
 | `std.os`           | `os.args_count`, `os.args`, `os.env`, `os.set_env`, `os.has_env`, `os.cwd`, `os.home_dir`, `os.hostname`, `os.pid`                                          |
-| `std.net`          | `net.listen`, `net.accept`, `net.connect`, `net.try_connect_timeout`, `net.try_parse_endpoint`, `net.read`, `net.try_read`, `net.write`, `net.close`         |
+| `std.net`          | `net.listen`, `net.accept`, `net.connect`, `net.connect_timeout`, `net.parse_endpoint`, `net.read`, `net.write`, `net.close`                                 |
 | `std.text.regex`   | `regex.new`, `regex.is_match`, `regex.find`, `regex.replace`                                                                                                |
 | `std.net.mime`     | `mime.from_path`, `mime.from_ext`, `mime.is_text`                                                                                                           |
-| `std.process`      | `process.run`, `process.try_run`, `process.run_argv`, `process.try_run_argv`, `process.start`, `process.try_start`, `process.try_start_argv`                |
+| `std.process`      | `process.run`, `process.run_argv`, `process.start`, `process.start_argv`                                                                                     |
 
 Predicate functions (`fs.exists`, `path.exists`, `regex.is_match`, `os.has_env`, `mime.is_text`) return `bool`.
 
@@ -1502,6 +1548,13 @@ fn main() {
 }
 ```
 
+**Field reads through an `Rc`.** Reading one field of an `Rc<T>` payload —
+`rc.field` where `T` is a record — is a `copy_value` through a borrow: the
+payload is not moved and the refcount does not change. Until that lowering
+lands, the checker refuses the projection with `E_LIMIT_RC_FIELD`
+(Limitation channel); `.get()` on a `T: Copy` payload is the accepted form in
+the meantime.
+
 Strong `Rc` cycles leak because Hew does not run a tracing collector. Use weak
 back-edges to break cycles. `Rc.new_cyclic`, dereference/borrow access to an Rc
 payload, and cross-actor transfer are not supported in edition 2026.
@@ -1594,7 +1647,7 @@ Semantics:
    single live binding.
 
 Typical example — file I/O with implicit cleanup (illustrative; no `File` type
-exists in stdlib — for file reading use `fs::try_read`):
+exists in stdlib — for file reading use `fs::read`):
 
 <!-- doctest: skip -->
 ```hew
@@ -1897,8 +1950,13 @@ where
 
 **Associated type bounds:**
 
-> See HEW-FUTURE.md §2.2 for `where T::Item: Display`-style associated-
-> type bounds — targeted for v0.6.
+An associated-type bound in a `where` clause — `where T.Item: Bound` — is
+**refused**, with `E_ASSOC_BOUND_UNSUPPORTED` (Limitation channel, target
+v0.7.0). The bound parses and type-checks today but never participates in
+method resolution, so a program that writes one is admitted and then behaves
+as though the bound were absent. A surface that does not act is not a surface:
+until the bound reaches method resolution, writing it is an error rather than
+a promise kept by nothing. See HEW-FUTURE.md §2.2.
 
 #### 3.8.4 Associated Types in Traits
 
@@ -2326,13 +2384,24 @@ Normative in edition 2026:
   `std.time`.
 - Formatting: `std.fmt`.
 - Encoding: `std.encoding.json`, `std.encoding.msgpack`.
-- HTTP: `std.net.http` (server + client at the request/response level).
+- HTTP: `std.net.http.server` and `std.net.http.client`, at the
+  request/response level.
 - Utilities: `std.math`, `std.testing`.
 
 See HEW-FUTURE.md §3 for modules that exist in `std/` today but are not yet
 normative — `std.net.dns`, `std.net.tls`, `std.net.quic`,
 `std.net.websocket`, `std.encoding.xml`/`yaml`/`toml`/`csv`,
 `std.text.regex`, `std.process`, `std.encoding.compress`.
+
+**Nothing is a grab-bag.** There is no `misc` namespace and no module whose
+job is "the rest": a module that cannot be named for what it holds is deleted,
+or its contents move to a module that can. `std.crypto.hash` names the hashing
+module; `std.log` and `std.uuid` sit at the top level. `std.deque` and
+`std.arena` are handle types (§3.4.3) rather than collections, so they stay at
+the top level and never move under a `collections/` path. Modules with no
+consumer are deleted rather than kept for symmetry. Retired spellings are
+recorded in [`docs/migrations/v0.6.0.md`](../migrations/v0.6.0.md) and nowhere
+else.
 
 #### 3.10.2 Core Traits
 
@@ -2353,6 +2422,26 @@ trait Releasable {
 }
 ```
 
+**`Error` (normative).** `Error` is a prelude trait declared in
+`std/builtins.hew` with `Display` as its supertrait and no members of its own:
+
+```text
+trait Error: Display {}
+```
+
+Every public error enum in `std` and in a `hew::` package implements both
+`Display` and `Error`. An error type that cannot print itself is not a
+finished error type: `f"{e}"`, `println(e)`, a log line, and a JSON error body
+all reach the same `Display` text, and `dyn Error` (§2.2.1) is the type that
+composes errors across modules.
+
+**`Display` style for errors (normative).** An error's `Display` text names its
+variant first, then the detail, separated by `": "` — for example
+`Partition: the route to the monitored peer is unavailable or the peer is
+suspect`. A log line or a JSON error body is then searchable by the same name
+the program matches on in a `match`. Prose-only text that omits the variant
+name is not conforming.
+
 #### 3.10.3 Core Types and Error Handling
 
 **Option and Result** are first-class generic enums:
@@ -2370,7 +2459,7 @@ enum Result<T, E> {
 ```
 
 User-authored functions may return `Result<T, E>` or `Option<T>` and use `?`
-for propagation. Any error type `E` may be used with `Result<T, E>`. The recommended pattern is for each module to define its own structured error enum, as demonstrated by the canonical `std::fs::IoError`:
+for propagation. Any error type `E` may be used with `Result<T, E>`. Each module defines its own structured error enum, as demonstrated by the canonical `std::fs::IoError`:
 
 ```hew
 pub enum IoError {
@@ -2379,13 +2468,51 @@ pub enum IoError {
     AlreadyExists(i64);
     Other(i64);
 }
-
-pub fn io_error_from_message(message: string) -> IoError {
-    IoError.Other(0)
-}
 ```
 
-This pattern is used across every `try_*` function in the `std::fs` module and pairs with the `?` operator for ergonomic error propagation. Each stdlib module defines its own error type following this shape; there is no single cross-module error enum. Future stdlib modules (under #1247) will adopt the same per-module structured error approach.
+Each stdlib module defines its own error type following this shape; there is no single cross-module error enum. A function that composes errors from several modules names `dyn Error` as its error type (§2.2.1) rather than declaring a union enum.
+
+**Fallible means `Result` (normative).** A standard-library function reports
+failure in the type system or not at all. Three rules cover the whole surface:
+
+1. **Fallible is `Result<T, E>` with `E: Error`.** The bare name carries the
+   `Result`; there is no `try_`-prefixed twin beside it. A caller that wants a
+   crash on failure writes `unwrap()` or `expect(msg)` at the call site, where
+   the decision is visible.
+2. **Absence is `Option<T>`.** A lookup that can miss returns `None`, never a
+   zero value, an empty string, or a designated "not found" variant of the
+   success type.
+3. **Nothing returns a status integer or a sentinel.** A negative `i64`, a
+   zero-length string standing for "unset", and an error enum variant meaning
+   "no error" are all fail-open shapes: the caller who forgets to test them
+   runs on with wrong data. `AskError` has no `NoError` variant.
+
+The one stated exception is **indexing**. `v[i]`, `m[k]`, and `Vec.set` out of
+bounds trap ("Bracket indexing" below), because a bounds failure is a
+program error rather than a fallible operation. `Vec.get` and `HashMap.get`
+remain the `Option`-returning forms for the case where a miss is expected.
+
+Signatures the rules fix:
+
+| Function | Signature |
+| --- | --- |
+| `os.env(name)` | `-> Option<string>` |
+| `os.args()` | `-> Vec<string>` |
+| `os.set_env(name, value)` | `-> Result<(), EnvError>` |
+| `fs.read(path)` | `-> Result<string, IoError>` |
+| `observe.read(key)` | `-> Option<i64>` |
+| `observe.barrier()` | `-> Result<(), ObserveError>` |
+| `http.Server.accept()` | `-> Result<Request, NetError>` |
+| `Request.respond*(…)` | `-> Result<(), NetError>` |
+| `wire.from_json(text)` | `-> Result<T, wire.DecodeError>` |
+
+**No error is reported by a side channel.** A module does not expose a
+`*_message(e) -> string` function beside its error type — `Display` is the one
+rendering authority (§3.10.2). A module does not expose a `last_error()` poll
+backed by a thread-local slot: an error that is returned cannot be missed,
+while an error that must be fetched can. The `*_message` family is gone at
+edition 2026; the remaining `last_error()` polls and the slots behind them are
+deleted with the FFI ownership table at v0.7.0.
 
 **`string` and Vec** are built-in generic/runtime-backed types with dot-syntax
 methods:
@@ -2525,7 +2652,7 @@ let dq = deque.new();
 println(math.abs(-5));
 println(fmt.to_hex(255));
 println(iter.sum(ints));
-testing.assert_true(true);
+testing.assert(true, "the set starts empty");
 println(io.read_all());
 ```
 
@@ -2543,12 +2670,28 @@ Important current details:
   any `Iterator`, driven by terminal helpers (`fold`, `count`, `collect`,
   `any`, `all`, `sum`, `sum_f64`, `product`, `product_f64`); drive a
   `Vec<T>` through it via `.iter()` or `.into_iter()`
-- `std::sort` exposes concrete helpers like `sort_ints`, `sort_strings`,
-  `sort_floats`, `reverse_ints`, `reverse_strings`, and `reverse_floats`;
-  integer and string sorts copy their input and use iterative merge passes
-  with O(n log n) comparisons, while float sorting retains its total-order
-  runtime implementation
-- `std::testing` is a pure-Hew assertion library layered on top of `panic()`
+- `std::sort` exposes generic helpers — one `sort<T: Ord>` and one
+  `reverse<T>` over `Vec<T>` — rather than a per-element-type family. Both
+  copy their input and leave the original unchanged; integer and string sorts
+  use iterative merge passes with O(n log n) comparisons, and float sorting
+  retains its total-order runtime implementation
+- `std::testing` is a pure-Hew assertion library layered on top of `panic()`.
+  Its whole surface is `assert(cond, msg)`, `assert_eq<T: Eq + Display>`, and
+  `assert_ne<T: Eq + Display>`; the monomorphic per-type assertion family
+  (`assert_true`, `assert_eq_int`, and the rest) is deleted. A generic
+  assertion needs `Display` to report a mismatch, so comparing an `Option` or
+  a `Result` is done by matching on it until `Display` for those two types
+  lands at v0.7.0
+
+**One form per operation (normative).** Where a generic form compiles, the
+monomorphic twins beside it do not exist: `std::vec`, `std::option`,
+`std::result`, `std::sort`, and `std::testing` expose the generic function and
+nothing per element type. A module exposes an operation once — a method or a
+free function, never both — and a `#[resource]` type's release is its `close`
+method, so there is no `Closable` trait and no per-type `free` function
+(`csv.Table.free`, `semver.Version.free`, `json.Value.free` are all deleted;
+scope-exit drop glue and an early `close()` are the two ways a resource ends,
+§3.7.8).
 
 #### 3.10.5 Printing, Formatting, and Strings
 
@@ -2567,6 +2710,15 @@ let nested = f"len: {name.len()}";
 
 F-strings are the sole string interpolation syntax in Hew.
 
+**One string surface (normative).** String operations are methods on `string`.
+The `string_*` builtin family — the `string_*`-prefixed names, `substring`,
+the free `len`, and the four `*_to_string` conversions — is deleted, together
+with the free-function twins in `std::string` that shadowed the same methods
+and the aliases in `std::fmt` that shadowed them again. `s.len()`,
+`s.slice(a, b)`, `s.contains(t)`, and `f"{v}"` are the spellings; there is no
+second name for any of them. A type renders itself through `Display`
+(§3.10.2), never through a per-type `to_string` builtin.
+
 #### 3.10.6 Prelude (Automatically Imported)
 
 The following are automatically available in every Hew module:
@@ -2580,7 +2732,7 @@ string, Vec, Box
 // Traits
 Clone, Copy, Drop
 Send, Frozen
-Debug, Display
+Debug, Display, Error
 Iterator, IntoIterator
 Eq, Ord, Hash
 
@@ -2591,19 +2743,22 @@ panic, assert, debug_assert
 
 #### 3.10.7 Typed Handles
 
-Standard library functions return opaque typed handle objects. Callers
-**must** invoke `close()` explicitly to release the underlying
-resource. Dropping without `close()` is a resource leak; the compiler
-does not synthesise an implicit drop for these types in the current
-implementation.
+Standard library functions return opaque typed handle objects. A handle is
+released by its `close()` method or by scope-exit drop glue, whichever comes
+first: a `#[resource]` handle is closed at scope exit (§3.7.8), and `close()`
+is the way to release one early. A handle that is neither `#[resource]` nor
+closed is a leak, so a new handle type carries the attribute.
+
+Every acquisition and every operation that can fail reports it as a `Result`
+(§3.10.3); there is no `try_`-prefixed twin beside any of these names.
 
 | Type             | Created by                                 | Methods                                                                                                                              |
 | ---------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `http.Server`    | `http.listen(addr) -> Result<Server, NetError>` | `.accept()` → `http.Request`, `.close()`                                                                                              |
-| `http.Request`   | `server.accept()` or `http.accept(server)` | `.path`, `.method`, `.body`, `.header(name)`, `.respond(status, body, len, type)`, `.respond_text(status, body)`, `.respond_json(status, body)`, `.close()` |
-| `net.Listener`   | `net.listen(addr)`                         | `.accept()` → `net.Connection`, `await ln.accept() \| after d` → `Result<net.Connection, IoError>`, `.close()`                        |
-| `net.Connection` | `listener.accept()` or `net.connect(addr)` | `.read()` → `bytes`, `.try_read()` → `Result<bytes, net.NetError>`, `.read_string()` → `string`, `.try_read_string()` → `Result<string, net.NetError>`, `await conn.read_string() \| after d` → `Result<string, IoError>`, `.write(data)`, `.write_string(data)`, `.close()` |
-| `process.Child`  | `process.start(cmd)`, `process.try_start(cmd)`, `process.try_start_argv(cmd, argv)` | `.wait()`, `.kill()`                                                                                 |
+| `http.Server`    | `http.listen(addr) -> Result<Server, NetError>` | `.accept()` → `Result<http.Request, NetError>`, `.close()`                                                                       |
+| `http.Request`   | `server.accept()` or `http.accept(server)` | `.path`, `.method`, `.body`, `.header(name)`, `.respond(status, body, len, type)` → `Result<(), NetError>`, `.respond_text(status, body)` → `Result<(), NetError>`, `.respond_json(status, body)` → `Result<(), NetError>`, `.close()` |
+| `net.Listener`   | `net.listen(addr) -> Result<Listener, NetError>` | `.accept()` → `Result<net.Connection, NetError>`, `await ln.accept() \| after d` → `Result<net.Connection, IoError>`, `.close()` |
+| `net.Connection` | `listener.accept()` or `net.connect(addr)` | `.read()` → `Result<bytes, net.NetError>`, `.read_string()` → `Result<string, net.NetError>`, `await conn.read_string() \| after d` → `Result<string, IoError>`, `.write(data)` → `Result<(), net.NetError>`, `.write_string(data)` → `Result<(), net.NetError>`, `.close()` |
+| `process.Child`  | `process.start(cmd) -> Result<Child, ProcessError>`, `process.start_argv(cmd, argv) -> Result<Child, ProcessError>` | `.wait()`, `.kill()`                     |
 
 Handle types are opaque — their internal representation is not accessible.
 They can be stored in variables, passed as function arguments, and
@@ -2999,10 +3154,14 @@ Task<T>
 > `scope { fork { call(); } }` in suspendable contexts (actor handlers,
 > closures, task entries), where the forked call takes no arguments and the
 > scope joins all children at its closing brace. The name-bound form
-> `fork name = call(...)` described below, argument-bearing forks, awaiting a
-> child's value, sibling cancellation on child failure, and the `?`
-> propagation sugar are specified here but not yet accepted — each refuses
-> with a named diagnostic rather than miscompiling.
+> `fork name = call(...)` described below parses and type-checks; what is
+> missing is the consuming half — awaiting the bound `Task<T>` in a value
+> position is refused at HIR (`AwaitOutOfPosition`), so the task binding
+> reaches its scope exit unconsumed and MIR refuses it
+> (`E_MIR_CHECK`, `MustConsume`). Argument-bearing forks, sibling cancellation
+> on child failure, and the `?` propagation sugar are specified here but not
+> yet accepted. Each of these refuses with a named diagnostic rather than
+> miscompiling.
 
 A `scope` block creates a structured concurrency boundary. All child tasks
 forked within the block must complete before the block returns.
@@ -3042,9 +3201,10 @@ scope {
 
 `fork name = expr` (or bare `fork expr`) is only legal dynamically inside a
 `scope` block. `scope { ... }` opens the structured-concurrency block;
-`fork` is exclusively the child-start verb. Today the accepted child
-form is the block form `fork { call(); }` with a zero-argument callee; the
-name-bound form parses but is rejected pending its type-checking slice.
+`fork` is exclusively the child-start verb. Today the runnable child form is
+the block form `fork { call(); }` with a zero-argument callee; the name-bound
+form is accepted by the checker and blocked further down the pipeline, at the
+`await` that would consume the task (see the callout above).
 Outside a scope-block, a child-form `fork` is a `ForkOutsideScopeBlock`
 error.
 
@@ -3380,13 +3540,13 @@ scope {
 ### 4.7 IO and Effects
 
 All IO operations in Hew are explicit and return `Result` types. Use
-`fs::try_read` (not `fs::open`) for file reading; the stdlib has no `File`
+`fs::read` (not `fs::open`) for file reading; the stdlib has no `File`
 handle type — reads and writes are free functions:
 
 <!-- doctest: skip -->
 ```hew
 fn read_config(path: string) -> Result<Config, string> {
-    let content = fs.try_read(path)?;
+    let content = fs.read(path)?;
     json.parse(content)
 }
 ```
@@ -3745,8 +3905,10 @@ generator environment is an alias; it must be cloned explicitly before being
 yielded or otherwise moved into another owner.
 
 > See HEW-FUTURE.md §1.6 for the remaining deferred generator forms
-> (`Lazy<T>`, `#[prefetch(N)]`). `gen fn`, `gen {}`, `async gen fn`, and
-> `receive gen fn` use the snapshot semantics above.
+> (`Lazy<T>`, `#[prefetch(N)]`). `gen fn`, `gen {}`, and `receive gen fn` use
+> the snapshot semantics above. There is no `async gen fn` form: a generator
+> whose body suspends carries no marker, because suspension is inferred from
+> the body rather than declared on the signature (§12).
 
 ---
 
@@ -3757,7 +3919,10 @@ Hew's supervision is modeled after OTP concepts with first-class language syntax
 - Supervisor owns children; children fail independently.
 - Restart classification: `permanent`, `transient`, `temporary`. ([Erlang.org][2])
 - Supervisor strategy: `one_for_one`, `one_for_all`, `rest_for_one`, `simple_one_for_one`.
-- Crash isolation via signal handling: SEGV/BUS/FPE/ILL in an actor is caught by the runtime, the actor is marked as Crashed, and the supervisor is notified for restart.
+- Crash isolation covers traps raised by the program — `panic`, an arithmetic
+  or bounds fault the runtime detects, an exhausted `#[max_heap(N)]` arena.
+  Synchronous hardware faults (SEGV, SIGBUS, SIGFPE, SIGILL) are process-fatal
+  and are NOT converted into a supervised crash (§5.7).
 
 ### 5.1 Supervisor Declaration
 
@@ -3926,6 +4091,12 @@ final = user_code                    if user_code != 0
 failure and carries more information than `1`. A zero never masks a fault. This
 rule applies on EVERY termination path — returning from `main`, and an explicit
 `exit(code)` anywhere — so `exit(0)` cannot report success over a crashed actor.
+
+**`fn main() -> Result<(), E>`** requires `E: Error` (§2.2.1). Returning
+`Ok(())` sets `user_code` to 0. Returning `Err(e)` writes one line to stderr —
+`error: ` followed by the error's `Display` text — and sets `user_code` to 1.
+The error reaches the operator through the same `Display` a log line uses; a
+program that returns `Err` and prints nothing is not conforming.
 
 **Each supervised crash carries a record**, opened at the crash site and settled
 by exactly ONE ruling. A crash is HANDLED only when a recovery took EFFECT — the
@@ -4701,7 +4872,7 @@ Hew uses an **M:N work-stealing scheduler** inspired by Go, Tokio, and BEAM:
 **Fairness guarantees (3-level preemption hierarchy):**
 
 1. **Message budget (256 msgs/activation):** Coarse scheduler preemption — after processing 256 messages, the actor yields to the scheduler so other actors can run.
-2. **Reduction budget (4000/dispatch):** The compiler inserts `cooperate` safepoints at function entry and loop back-edges. Each operation decrements a reduction counter; when exhausted, the actor yields to the scheduler.
+2. **Reduction budget (4000/dispatch) — v0.7.0.** The intended second level is a reduction counter decremented per operation, with compiler-inserted `cooperate` safepoints at function entry and loop back-edges, so a compute-bound actor yields without an `await`. Edition 2026 ships the message budget and the cooperative yield below; safepoint preemption lands with the coroutine work at v0.7.0.
 3. **Cooperative task yield:** `await` and compiler-inserted `cooperate` safepoints suspend on the `llvm.coro` switched-resume continuation substrate (see §4.3 "Substrate" — internal to `hew-runtime`, not a source-level distinction), parking the current coroutine so the actor's executor can resume the next ready one.
 
 - Round-robin within priority levels
@@ -4718,8 +4889,6 @@ Hew uses an **M:N work-stealing scheduler** inspired by Go, Tokio, and BEAM:
 **I/O integration:**
 
 - Platform-specific event loops (epoll/kqueue/IOCP)
-- io_uring support on Linux for high-performance I/O
-- Separate thread pools for blocking operations
 - Timer wheels for supervision windows and timeouts
 
 ### 9.1 Actor lifecycle state machine
@@ -4741,7 +4910,7 @@ Runnable ──► Running        scheduler picks actor for execution on a worke
 Running ───► Idle           message budget exhausted or no more messages; yields to scheduler
 Running ───► Suspended      dispatch suspends at a non-final coro.suspend (slice-4 executor)
 Suspended ─► Running        readiness source fires; executor resumes the continuation
-Running ───► Stopping       supervisor requests shutdown, or actor calls stop()
+Running ───► Stopping       supervisor requests shutdown, or actor calls self.stop()
 Running ───► Sleeping       actor parks in the cooperative WASM sleep queue
 Sleeping ──► Runnable       sleep timer fires
 Stopping ──► Stopped        cleanup finished, normal exit

--- a/examples/observe_supervisor_showcase.hew
+++ b/examples/observe_supervisor_showcase.hew
@@ -39,10 +39,11 @@
 // supported path: children boot cleanly, the supervisor registers, and the
 // profiler serves a real tree.
 //
-// NOTE: #[on(start)] lifecycle hooks are also skipped for supervised
-//       children today (the supervisor bootstrap does not run them), so we
-//       deliberately avoid them here — all child setup is via field
-//       defaults and constructor arguments only.
+// NOTE: #[on(start)] does run for a supervised child — on its first start
+//       and again after every restart. This example still sets everything up
+//       through field defaults and constructor arguments, because that is
+//       what the init() workaround above needs; the hook is available if you
+//       want one.
 
 // ── Actor types ─────────────────────────────────────────────────────────
 

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -87,7 +87,7 @@ spec-0009   4166606024   # SNIPPET: bare `worker.send` + `await counter.get()` �
 spec-0010   3633579472   # NYI: bare `scope { ... }` — scope/structured-concurrency not yet lowered
 spec-0011   3107872017   # FRAGMENT: calls `open(path)` with no import — context-dependent snippet
 spec-0012   3219419134   # SNIPPET: bare before/after code — ? operator syntax illustration
-spec-0013   506748282   # SNIPPET: bare `let buf: bytes = bytes::new()` — bytes type illustration
+spec-0013   1440186796   # SNIPPET: bare `let buf: bytes = bytes::new()` — bytes type illustration (re-verified after the `bytes.get -> Option<u8>` correction, D18)
 spec-0014   3221762372   # SNIPPET: bare `let x = 5` / `var y = 0` — binding modes illustration
 spec-0015   1507524389   # SNIPPET: bare `type Point { ... }` + bare `var` — struct mutable field illustration
 spec-0020   3005964102   # SNIPPET: bare `let config = load_config()` — actor capture illustration
@@ -118,9 +118,9 @@ spec-0073   820125999   # SPEC-BUG: enum variants separated by `,` not `;` — i
 spec-0075   4120679691   # SPEC-BUG: malformed struct `impl` syntax — aspirational (re-verified after Vec<T> method-table correction, still fails identically: signature-only `;`-terminated impl bodies, no `{ }`)
 spec-0076   3414934173   # SNIPPET: bare `var`/`let` — HashMap bracket-indexing illustration (re-verified after the dotted-path migration and the corrected index-read result type: `m[k]` yields bare `V`, not `Option<V>`)
 spec-0077   3711765580   # SNIPPET: bare `let`/`var` — machine state illustration
-spec-0078   1861586926   # SNIPPET: bare `let` after machine transitions — illustration
+spec-0078   1632573552   # SNIPPET: bare `let`/`import` — stdlib module tour (re-verified after `testing.assert_true` became the generic `testing.assert`, D22)
 spec-0079   3943447574   # SNIPPET: bare `let m = ...` — machine instantiation illustration
-spec-0080   249349858   # SNIPPET: bare `Option` identifier — option-type illustration
+spec-0080   70193944   # SNIPPET: bare identifier list — prelude illustration (re-verified after the `Error` trait joined the prelude, D21)
 spec-0081   3231394512   # SNIPPET: placeholder `field: Type` on `StateB` — target has a required field so `.StateB` (fine for a unit state) hits E_PATH_KIND_MISMATCH; the fence never supplies a real field value
 spec-0082   3707425012   # SPEC-BUG: interleaved `event` declarations — old machine syntax pre-`events {}`
 spec-0083   813722226   # SNIPPET: bare `on event { ... }` — machine transition illustration
@@ -163,3 +163,5 @@ spec-0132   1635702216   # SNIPPET: bare labeled loop — labeled break/continue
 spec-0133   796057876   # SNIPPET: bare `var` — loop statement result-accumulator illustration
 spec-0134   642644102   # SNIPPET: bare `if let` — Option pattern-match illustration
 spec-0135   1695617851   # SNIPPET: bare `while let` — HashMap pattern-match illustration
+guide-0113   3703526555   # SPEC-BUG: shows D4's `dyn Error` composition and D20's `fs.read -> Result`; `?` into `dyn Error` and `Display` through the supertrait are refused today — tracked in #3258 and #3259
+guide-0132   1835391093   # SPEC-BUG: shows D22's generic `sort.sort` / `sort.reverse`; only the `sort_ints` family exists today — tracked in #3259


### PR DESCRIPTION
## Why

The spec had no rule for composing errors across modules, so a service that
called into two of them could not be typed at all. It described a standard
library that reports failure five different ways — a bare `read` that swallows
the error beside a `try_read` that returns it, status integers, and an
`os.env` whose unset case is a zero-length string that does not compare equal
to `""`. And it carried a set of facts the binary contradicts: `bytes.get`
returning `i64`, an `async gen fn` form, a supervisor that recovers hardware
faults, io_uring, an associated-type bound that parses and never resolves a
method, a name-bound `fork` rejected at the checker.

## What

- **lexer/parser/types**: unchanged. This is documentation only.
- **§2.2, §2.2.1, §2.2.2** (D4): `?` is exact — no `From`, no `#[from]`, no
  compiler-inserted conversion — with `dyn Error` as the one composition
  point, applying the `dyn Trait` coercion the language already performs.
  `trait Error: Display {}` is a prelude trait; explicit conversion is
  `map_err`/`ok_or`; `fn main() -> Result<(), E>` requires `E: Error`.
- **§3.10.2, §3.10.3, §3.10.7** (D20, D21): fallible means `Result<T, E>` with
  `E: Error` under the plain name, absence means `Option<T>`, and nothing
  returns a status integer or a sentinel; indexing stays the one trapping form
  because a bounds failure is a program error. Every public error enum
  implements `Display` and `Error`, its text names the variant first, and the
  `*_message` functions are gone. The handle table takes the `Result`
  signatures.
- **§3.10.1, §3.10.4, §3.10.5** (D22): one form per operation — a generic
  `sort<T: Ord>`, a three-function `std::testing`, string operations as
  methods — and no grab-bag namespace. Retired spellings live in
  `docs/migrations/v0.6.0.md` and nowhere else.
- **§3.8.3, HEW-FUTURE §2.2** (D14): `where T.Item: Bound` is
  `E_ASSOC_BOUND_UNSUPPORTED` rather than a bound that never acts.
- **§3.3, §3.3.2, §3.7.5** (D18): `bytes.get` returns `Option<u8>`; an
  `[T; N]` annotation blocks the `.len()` a `Vec` binding resolves; an `Rc`
  field read is `E_LIMIT_RC_FIELD` until the borrow projection lands.
- **§3.2, §4.2, §4.12, §5, §5.8, §9.0, §9.1, HEW-FUTURE §1.2/§1.4/§1.5/§1.6**
  (D24): the truth sweep, including hot-swap upgrades and cancellation tokens
  marked REJECTED, and the stale `examples/observe_supervisor_showcase.hew`
  note that supervised children skip `#[on(start)]`.
- **docs/diagnostics/** (D8): the three channels with their exit codes and
  prefixes, and the `E_LIMIT_*` family one line each. Members whose refusal
  has no code assigned are listed by member and phase rather than given an
  invented name.

Ledger: A366 sign-off, with A379, D339, D340, and D341 applied.

## Test

`make test-doc-examples` and `make hew-check-all` both pass. The two guide
fences that show the frozen surface ahead of the compiler — `dyn Error`
composition and generic `sort` — enter
`scripts/doc-test-expected-failures.txt` with the issues that remove them,
and three spec entries take new checksums after the `bytes.get`, prelude, and
assertion corrections.

Refs #3258, #3259 — the compiler work those rules describe.
