### PR TITLE
docs(spec): fix the receiver set and name the ownership categories

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -48,16 +48,16 @@ for the documented resolver precedence.
 - Interpolate `Display` values with `f"x={x}"`; use `f"x={x:?}"` for structural debugging.
 - Convert numbers with `as`: `x as i64`, `pi as i32`. It is the only conversion mechanism.
 - Never mix integer widths in one expression; cast the narrower operand up first: `x as i64 + 1`.
-- **`var` for mutable bindings, `let` for immutable.** Hew does not have `let mut` — use `var` whenever you need to reassign a name or mutate a scalar field. `let` bindings are immutable (but `let` collections have interior mutability).
+- **`var` for mutable bindings, `let` for immutable.** Hew does not have `let mut` — use `var` whenever you need to reassign a name, assign through a place (`p.x`, `v[0]`, `m["k"]`, `t.0`), or call a method that mutates its receiver. Collections are values, so `var v: Vec<i64> = Vec.new(); v.push(1)` is the mutating form and `let v` refuses it. Handles are the exception by category, not by syntax: `let d = deque.new(); d.push_back(1)` is fine because `d` names a resource rather than holding a value.
 - Dispatch with `match`, not if/else chains — `match` on a closed enum enforces exhaustiveness.
 - Iterate counts with `for i in 0..n` (exclusive) or `0..=n` (inclusive); the binding must be a named identifier.
 - Read collection elements with `v[i]` (returns `T`, traps on out-of-bounds) or `.get(i)` (returns `Option<T>`, never traps) — both universal across element types.
 - `Vec<string>` supports `v[i]` (returns a fresh owned `string`; the Vec stays usable), `.get(i)`, range-slices, and for-in. Both accessors work for `Vec<enum>` too.
-- Build maps/sets with `Type.new()` + `.insert()`; bind with `let` (interior mutability, not reassignment).
+- Build maps/sets with `Type.new()` + `.insert()`; bind with `var`, since `.insert()` mutates the receiver.
 - Look up `HashMap`/`Option`/`Result` with `match`, not subscript or `.unwrap()`.
 - **Enum variants use `;` separators; record fields also use `;` in type definitions but `,` in construction literals.** These are different — `type T { a: i64; b: i64; }` defines, `T { a: 1, b: 2 }` constructs.
 - Declare records with `type Name { field: T; }` (semicolons); enum variants are `;`-separated.
-- Access actor state by bare field name inside handlers — no `self.` or `this.`.
+- Access actor state by bare field name inside handlers — no prefix. Inside an actor body `self` is the actor's own handle (`LocalPid<Self>`), not a field prefix.
 - Fire-and-forget actor sends have no return type and no `await`: `ref.method(arg);`.
 - Ask (request-reply) is `await ref.method(arg)` and returns `Result<R, AskError>` — match `Ok`/`Err`.
 - Sending a value into an actor delivers a logical snapshot; the sender's binding stays valid afterward — no `clone` needed to keep using it. Types that cannot be sent are rejected at compile time.
@@ -237,7 +237,7 @@ fn main() {
 
 > **Coming from Rust?** Hew does not have `let mut`. Use `var` for any binding you will reassign; use `let` for everything else. Writing `let mut x = 0` is a compile error — the parser rejects `mut` as unexpected.
 
-Use `var` when the name will be reassigned or when a scalar field on a `var`-bound record will be mutated. `let` collections (`Vec`, `HashMap`, `HashSet`) have interior mutability — `.push()`/`.insert()` work on a `let` binding because you are not reassigning the binding itself. Use `var` only when you need to rebind the name to a new value.
+Use `var` when the name will be reassigned, when a field or element under it will be assigned, or when you will call a method that mutates the receiver. Collections are values, so `.push()`/`.insert()` are `var self` methods: `var v: Vec<i64> = Vec.new(); v.push(1)` is the working form and a `let` binding refuses the call. Handles are different — `let d = deque.new(); d.push_back(1)` is fine, because `d` names a resource instead of holding a value.
 
 Compound-assign operators (`+=`, `-=`, `*=`, `/=`) are available for `var` bindings.
 
@@ -638,14 +638,14 @@ fn main() {
 
 ```hew
 fn main() {
-    let m: HashMap<string, i64> = HashMap.new();
+    var m: HashMap<string, i64> = HashMap.new();
     m.insert("alice", 10);
     m.insert("bob", 20);
     println(m.len());   // 2
 }
 ```
 
-Use `let` (not `var`) — these have interior mutability so the binding is never reassigned. The annotation is required for inference. `.insert` returns unit and overwrites on duplicate key.
+Use `var` — `.insert` mutates the receiver, and a mutating method needs a `var` binding. The annotation is required for inference. `.insert` returns unit and overwrites on duplicate key.
 
 ### Look up a key (returns Option)
 
@@ -1273,7 +1273,7 @@ actor Counter {
 }
 ```
 
-Reference and assign state fields by bare name — no `self`/`this` prefix. State persists across invocations. Keep handler param names distinct from field names (shadowing is an error).
+Reference and assign state fields by bare name — there is no field prefix. State persists across invocations. Keep handler param names distinct from field names (shadowing is an error). Inside an actor body, `self` is the actor's own handle of type `LocalPid<Self>`: send it to another actor, store it in a field, or call `self.stop()` to stop the actor. It is read-only and it is never a way to reach a field.
 
 ### spawn returns LocalPid<ActorType>
 
@@ -1905,9 +1905,9 @@ Pass machines by value into and out of free functions and mutate a local `var`. 
 ### Generic function with a trait bound
 
 ```hew
-trait Named { fn name(val: Self) -> string; }
+trait Named { fn name(self) -> string; }
 type User { name: string; }
-impl Named for User { fn name(u: User) -> string { u.name } }
+impl Named for User { fn name(self) -> string { self.name } }
 fn announce<T: Named>(item: T) { println(item.name()); }
 fn main() { announce(User { name: "Bob" }); }   // Bob
 ```
@@ -1917,11 +1917,11 @@ Declare the impl as `impl Trait for Type`, bound the parameter `<T: Trait>`, and
 ### Multi-bound and where-clause functions
 
 ```hew
-trait HasName { fn name(val: Self) -> string; }
-trait HasScore { fn score(val: Self) -> i64; }
+trait HasName { fn name(self) -> string; }
+trait HasScore { fn score(self) -> i64; }
 type Player { name: string; score: i64; }
-impl HasName for Player { fn name(p: Player) -> string { p.name } }
-impl HasScore for Player { fn score(p: Player) -> i64 { p.score } }
+impl HasName for Player { fn name(self) -> string { self.name } }
+impl HasScore for Player { fn score(self) -> i64 { self.score } }
 fn report<T: HasName + HasScore>(item: T) {
     print(item.name()); print(": "); println(item.score());
 }
@@ -2066,12 +2066,12 @@ Methods on a generic record need the impl itself to carry the type parameter —
 type Stack<T> { items: Vec<T> }
 
 impl<T> Stack<T> {
-    fn push_item(s: Stack<T>, v: T) -> Stack<T> {
-        s.items.push(v);
-        s
+    fn push_item(self, v: T) -> Stack<T> {
+        self.items.push(v);
+        self
     }
-    fn len(s: Stack<T>) -> i64 {
-        s.items.len()
+    fn len(self) -> i64 {
+        self.items.len()
     }
 }
 
@@ -2146,8 +2146,8 @@ interpolation:
 type Celsius { degrees: f64; }
 
 impl Display for Celsius {
-    fn fmt(c: Celsius) -> string {
-        f"{c.degrees}°C"
+    fn fmt(self) -> string {
+        f"{self.degrees}°C"
     }
 }
 
@@ -2431,21 +2431,33 @@ Build strings with `+`. `char_at` returns `Option<char>` — `Some` of the byte 
 
 ```hew
 trait Greet {
-    fn greet(val: Self) -> string;
+    fn greet(self) -> string;
 }
 type Person { name: string }
 impl Greet for Person {
-    fn greet(p: Person) -> string {
-        f"Hello, {p.name}!"
+    fn greet(self) -> string {
+        f"Hello, {self.name}!"
     }
 }
 fn main() {
     let p = Person { name: "Ada" };
     println(p.greet());   // Hello, Ada!
+    println(p.greet());   // still valid — `self` borrows
 }
 ```
 
-Use Go-style named receivers: the first parameter whose type matches the impl target is the receiver (no `self` keyword required — the parameter can be named anything, including `self`). The receiver is consumed by value.
+There are three receivers and one spelling each. `self` borrows: the caller's
+binding stays valid, so `p.greet()` twice is ordinary code. `var self` mutates
+the receiver in place and requires a `var` binding — `let p = ...; p.bump()` is
+refused with "requires a mutable binding receiver". `consume self` takes the
+value, and any later use of the binding is a use-after-consume error. Naming the
+first parameter after the target type (`fn greet(p: Person)`) is not a receiver
+form; the fix-it rewrites it to `self`.
+
+`var self` is available on trait methods. On an inherent `impl` method it is
+refused today (`E_LIMIT_INHERENT_VAR_SELF`), because an inherent method receives
+the value and the mutation would not reach the caller — declare the method on a
+trait with a `var self` receiver and implement that trait for your type.
 
 A trait method can carry a default body (`fn shout(self) -> string { self.greet() + "!!!" }` inside the trait declaration); an `impl` only needs to supply the methods it overrides, and an uncalled default falls back to the trait's body, dispatching through `self.method()` like any other trait call. Defaults work within a single file and across a file import (`import "other.hew";`, including a default that dispatches back through a required method declared in another file). Defaults also work when only the _trait_ comes from a directory module (`import mymod.{ Greet };`) and the implementing type is local. They do not yet resolve when the implementing type is ALSO imported from a directory module (e.g. `import gm.{ Dog };` where `Dog` and its `impl Greet for Dog` both live in `gm`) — calling an inherited default on that receiver fails with `no method 'greet' on 'gm.Dog'` rather than falling back to the trait's default body; that gap is tracked separately.
 
@@ -2454,8 +2466,8 @@ A trait method can carry a default body (`fn shout(self) -> string { self.greet(
 ```hew
 type Point { x: f64; y: f64 }
 impl Display for Point {
-    fn fmt(p: Point) -> string {
-        f"({p.x}, {p.y})"
+    fn fmt(self) -> string {
+        f"({self.x}, {self.y})"
     }
 }
 fn main() {
@@ -2471,8 +2483,8 @@ Implement `Display` via the `fmt` method and interpolate with f-strings. To prin
 ```hew
 type Tag { id: i64 }
 impl Display for Tag {
-    fn fmt(t: Tag) -> string {
-        f"#{t.id}"
+    fn fmt(self) -> string {
+        f"#{self.id}"
     }
 }
 fn main() {
@@ -2489,13 +2501,13 @@ An explicitly-implemented trait method is callable directly with dot-syntax.
 ```hew
 trait Counter {
     type Item;
-    fn next_val(c: Self) -> Self.Item;
+    fn next_val(self) -> Self.Item;
 }
 type Ticker { current: i64 }
 impl Counter for Ticker {
     type Item = i64;
-    fn next_val(t: Ticker) -> i64 {
-        t.current + 1
+    fn next_val(self) -> i64 {
+        self.current + 1
     }
 }
 fn main() {
@@ -2510,12 +2522,12 @@ Declare `type Item;` in the trait, bind it with `type Item = <concrete>;` in the
 
 ```hew
 trait Summable {
-    fn total(v: Self) -> i64;
+    fn total(self) -> i64;
 }
 impl Summable for Vec<i64> {
-    fn total(v: Vec<i64>) -> i64 {
+    fn total(self) -> i64 {
         var acc = 0;
-        for x in v { acc += x; }
+        for x in self { acc += x; }
         acc
     }
 }
@@ -3192,8 +3204,8 @@ type Conn {
     fd: i64
 }
 impl Conn {
-    fn close(c: Conn) {
-        println(f"closing fd {c.fd}");
+    fn close(consume self) {
+        println(f"closing fd {self.fd}");
     }
 }
 
@@ -3208,8 +3220,8 @@ fn main() {
 #[linear]
 type Tx { id: i64 }
 impl Tx {
-    fn commit(consuming self) { println(f"commit {self.id}"); }
-    fn rollback(consuming self) { println(f"rollback {self.id}"); }
+    fn commit(consume self) { println(f"commit {self.id}"); }
+    fn rollback(consume self) { println(f"rollback {self.id}"); }
 }
 
 fn main() {
@@ -3225,7 +3237,7 @@ early; a `#[linear]` type has **no** implicit drop at all — leaving one
 unconsumed at scope exit is a compile error. Neither supports a
 user-defined `impl Drop`.
 
-The `close` method (for `#[resource]`) and any `consuming self` method (for
+The `close` method (for `#[resource]`) and any `consume self` method (for
 `#[linear]`) must be declared in a sibling `impl` block, never inline in the
 type body — an inline declaration is rejected at parse time. A factory
 function that constructs and returns a `#[resource]` or `#[linear]` value
@@ -3252,6 +3264,22 @@ including `Deque`, `json.Value`, `csv.Reader`, and `net.Connection`.
 `std/deque.hew`'s `#[opaque]\npub type Deque { }` plus its sibling `trait
 DequeMethods` / `impl DequeMethods for Deque` is the canonical shape to
 copy for a new opaque type.
+
+An opaque handle is a **handle**, not a value: a second binding is a second
+name for the same resource, methods act through it whether the binding is `let`
+or `var`, and `is` compares two names for identity. It may live inside an
+actor — an opaque handle (or the `#[resource]` wrapper around one) may be an
+actor's init field, moved in at `spawn` and closed by the actor's drop glue at
+stop, and may be a `receive fn` parameter on a local send, where the send
+consumes it and a later use of the sender's binding is `E_USE_AFTER_SEND`.
+That is how one actor owns one connection and serves many requests over it.
+Sending a handle to a remote actor stays refused: a remote payload must be
+CBOR-serializable (`E_OPAQUE_MESSAGE_PAYLOAD`).
+
+Today the local case is refused too, under `E_LIMIT_OPAQUE_ACTOR`: an opaque
+type in a `receive fn` parameter or an actor init field gets the wire rule's
+message applied to a send that never serializes. Until that lifts, open the
+handle inside the handler.
 
 ### Typed streams — `await sink.send(x)` / `await stream.recv()`
 

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -862,7 +862,7 @@ fn main() {
 }
 ```
 
-To have a helper build a collection, pass it and mutate in place — the caller observes the result. This is reference semantics; `let`/`var` only controls rebinding the name, not interior mutation.
+To have a helper build a collection, pass it and mutate in place — the caller observes the result. A call borrows, so the caller's binding stays valid either way; the binding mode governs assignment through the name and calls to `var self` methods on it, not what a callee does with a collection it borrowed.
 
 ### Reuse a passed value without clone (intra-actor)
 

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -1309,10 +1309,10 @@ not how actor state is read.
 `this` is not a keyword and carries no actor meaning; the handle is `self`
 everywhere.
 
-A plain `fn` in an actor body is an associated function of the actor type. It
-has no receiver and no view of the fields, so a helper over actor state is a
-`receive fn`, a lifecycle hook, or a free function that takes the state as a
-parameter.
+A plain `fn` in an actor body has no receiver. Its body is checked against the
+actor's fields by bare name like a handler's, but no call form reaches it today
+(#3285), so a helper over actor state is a `receive fn`, a lifecycle hook, or a
+free function that takes the state as a parameter.
 
 **Variable shadowing:**
 

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -146,6 +146,21 @@ worker.send(42);                // fire-and-forget
 counter.increment(10);
 ```
 
+**Message payloads (normative):**
+
+A `receive fn` parameter is a **value** (snapshotted on send, §3.4.4), a **pid
+handle** (`LocalPid`, `RemotePid`, `ChildRef` — copied, both sides address the
+one actor), or an **opaque or resource handle** on a local send. A handle
+payload is a move: the send consumes it and the sender's binding is dead
+afterwards (`E_USE_AFTER_SEND`, §3.9.6). Such a handle may also be an actor's
+init field, moved in at `spawn` and closed by the actor's drop glue at stop, so
+one actor can own one connection and serve many requests over it. Across nodes
+the rule is the wire rule: a remote payload must be CBOR-serializable, and a
+handle is not (`E_OPAQUE_MESSAGE_PAYLOAD`). Counted handles (`Rc`, `Weak`,
+`LambdaPid`) are never payloads, local or remote, because an actor's heap is its
+own; closures, generators, and tasks are never payloads either
+(`E_CALLABLE_MESSAGE_PAYLOAD`).
+
 **Fire-and-forget delivery (normative):**
 
 A fire-and-forget send enqueues a logical snapshot of the message. On enqueue
@@ -450,6 +465,31 @@ to use `type`.
 - Mutable bindings: `var`.
 - Type fields have no mutability qualifier. Field mutation is governed by the binding: a `var`-bound value allows `p.x = …`; a `let`-bound value rejects it.
 
+**The binding wall (normative).** A `let` binding cannot be reassigned, and no
+place rooted at it can be assigned. `p.x = …`, `v[0] = …`, `m["k"] = …`, and
+`t.0 = …` on a `let` binding are all `MutabilityError` (User channel) carrying
+the `let`→`var` fix-it. The wall is about the binding, not about the syntax
+used to reach through it.
+
+**The mutating receiver.** A method that mutates its receiver declares
+`var self` (§3.6). Calling one needs a `var` binding: `let p = Counter { n: 0 };
+p.bump()` is refused with "requires a mutable binding receiver". The mutating
+builtin collection methods are declared the same way —
+`Vec.push`/`pop`/`set`/`insert`/`remove`/`clear`/`sort`/`reverse`/`truncate`/`swap`,
+`HashMap.insert`/`remove`/`clear`, `HashSet.insert`/`remove`, and `bytes.push`
+all take `var self` — so `let v: Vec<i64> = Vec.new(); v.push(1)` is refused
+and `var v` accepts it. There is no separate "interior mutability" rule for
+collections.
+
+Handles are the exception by category, not by syntax (§3.4.3). A method on a
+handle is declared `self` and acts through the handle, so `let pid`, `let rc`,
+and `let d = deque.new()` remain legal receivers of `send`, `set`, and
+`push_back` — the binding is not what changes.
+
+The "declared mutable but never reassigned" warning reads "declared `var` but
+never mutated; use `let`" and counts a `var self` call as a mutation, so
+`var v: Vec<i64> = Vec.new(); v.push(1)` warns nothing.
+
 ### 3.3 Sendability / isolation rule
 
 A value may cross an actor boundary only if it satisfies **Send**.
@@ -593,7 +633,10 @@ y = 10;          // ok
 // x = 10;       // compile error: cannot reassign immutable binding
 ```
 
-This is similar to JavaScript's `const`/`let` or Swift's `let`/`var`. It controls whether the _binding_ can be reassigned, not whether the underlying data is mutable.
+The closest analogue is Swift's `let`/`var` paired with `mutating func`: the
+binding mode controls both reassignment of the _binding_ and whether a mutating
+method (`var self`, §3.6) may be called on it. It is not JavaScript's
+`const`/`let`, which says nothing about the value's own methods.
 
 For type fields:
 
@@ -636,6 +679,45 @@ actor Counter {
 A `let` (or bare) actor field is immutable after construction: it may be assigned only inside the `init { }` block, where its initial value is established. Any assignment to a `let` field from a `receive fn`, a plain actor method, or a lifecycle hook is rejected at check time with a diagnostic that names the field and suggests declaring it with `var`. A `var` field is mutable and may be assigned anywhere in the actor body.
 
 This distinction exists because actor fields are stateful (they change over the actor's lifetime) and use initialization syntax similar to variable declarations, while type fields are data layout declarations.
+
+**Value, handle, and callable categories (normative).**
+
+Every type belongs to exactly one of the categories below. The category — not
+the binding mode and not the spelling of the type — decides what a second
+binding means, what a send does, whether `is` admits the type, and how the
+value closes.
+
+| Category | Members | `let b = a` | send | `is` | close |
+| --- | --- | --- | --- | --- | --- |
+| value | scalars, `string`, `bytes`, records, enums, tuples, arrays, `Vec`, `HashMap`, `HashSet`, `dyn Trait` objects | a second value: copy-on-write, `==` structural | a snapshot; a `dyn Trait` value is sendable only when its concrete type is `#[wire]` (`E_LIMIT_DYN_SEND`, Limitation, until the object-type work lands) | `E_IS_VALUE_TYPE` (User) | none |
+| `#[linear]` value | user types marked `#[linear]` | a move: `a` is consumed | a move, the same wall | `E_IS_VALUE_TYPE` | must be consumed by a `consume self` method before scope exit; no drop glue |
+| pid handle | `LocalPid`, `RemotePid`, `ChildRef` | a second name for one actor | the pid is copied; both sides address the same actor | identity | none; an actor stops |
+| counted handle | `Rc`, `Weak`, `LambdaPid` | a second name; the count rises (a `LambdaPid` copy is a refcounted retain) | refused: an actor's heap is its own (`E_OPAQUE_MESSAGE_PAYLOAD`, User) | identity | the count falls; drop glue releases the last (for `LambdaPid`, the last release drops the captured environment) |
+| opaque handle | plain `#[opaque]` types (channel `Sender`/`Receiver`) | a second name for one resource; methods act on the resource | local: a move, and the sender's binding is dead (`E_USE_AFTER_SEND`, User, §3.9.6); remote: `E_OPAQUE_MESSAGE_PAYLOAD` (User) | identity | `close(consume self)` where the type declares it |
+| resource handle | `#[resource]` wrappers (`http.Server`, `http.Request`, `Deque`, `Arena`, `process.Child`, `Semaphore`, `regex.Pattern`, `MonitorRef`, `json.Value`) and `Stream`/`Sink` (move-only, §6.5) | a move: `a` is dead, and a later use is the consume wall | local: a move; remote: `E_OPAQUE_MESSAGE_PAYLOAD` | identity | drop glue closes at scope exit, or `close(consume self)` early |
+| callable | closures, generators, tasks | a value (a `move` closure consumes its captures) | refused, `E_CALLABLE_MESSAGE_PAYLOAD` (User) | `E_IS_VALUE_TYPE` | none; a task must be awaited |
+
+`LambdaPid` is a counted handle, not a pid handle: its release is the captured
+environment's release, so a copy retains and the last release drops the
+environment.
+
+`#[resource]` and `#[linear]` are two disciplines, affine and linear, and both
+stay (§3.7.8): a resource may be dropped and its drop glue closes it; a linear
+value may not be dropped. `resource` is an ordinary identifier and never was a
+token.
+
+`is` admits handles only. It answers "are these two names the same actor,
+count, or resource?" — see §12.2. There is no `expr is TypeName` form.
+
+> **Limitation at edition 2026 (`E_LIMIT_COLLECTION_COPY`, Limitation
+> channel).** The rule above says a second binding of a value-category type is a
+> copy-on-write copy and both names stay live. Today the whole-binding copy of a
+> value-category type consumes the source, so `let b = a;` followed by a use of
+> `a` is refused where the rule says retain. The refusal is reported against the
+> consuming bind. It is a limit of the current lowering, not the rule, and it
+> lifts when the ownership ladder derives copies from the ownership event
+> stream. The same refusal on a resource handle is **not** a limitation: a
+> `#[resource]` copy is a move and the later use is the wall.
 
 #### 3.4.4 The Boundary Rule: Snapshot on Send
 
@@ -772,25 +854,28 @@ This is enforced at compile time: any captured value in a `spawn` expression mus
 actor Example {
     var data: Vec<i64> = Vec.new();
 
-    receive fn demo() {
-        // Multiple mutable references - ALLOWED (single-threaded)
-        let ref1 = data;
-        let ref2 = data;
-        ref1.push(1);
-        ref2.push(2);     // ok - no data race possible
+    receive fn demo(incoming: Vec<i64>) {
+        // Mutating the actor's own state - ALLOWED, no locks, no ceremony
+        data.push(1);
+        data.push(2);
 
-        // Aliasing mutable data - ALLOWED
-        var x = data;
-        var y = x;
-        x.push(3);
-        y.push(4);        // ok - same actor, sequential execution
+        // A `var` local mutates in place; a `let` local does not (§3.2)
+        var scratch: Vec<i64> = Vec.new();
+        scratch.push(3);
 
-        // Returning references to local data - ALLOWED
-        let local = Vec.new();
-        process(local);   // works because single-threaded
+        // Passing a value to a function borrows it - the binding stays valid
+        process(incoming);
+        process(incoming);   // ok - calls borrow, they do not consume
     }
 }
 ```
+
+A second binding of a value-category type is a **copy**, not an alias:
+`var copy = incoming;` gives two independent values, and pushing to one does not
+change the other (§3.4.3). There is no way to obtain two mutable names for one
+value, so the question of aliased mutation does not arise; what the absence of a
+borrow checker buys is that calls borrow, so a value stays usable after being
+passed, and mutation inside an actor needs no annotation beyond `var`.
 
 #### 3.4.7 What is NOT Allowed
 
@@ -814,10 +899,10 @@ containing one — is a fail-closed compile error, never a silent copy.
 
 #### 3.4.8 Summary
 
-| Context       | Aliasing     | Mutation     | Boundary rule    |
-| ------------- | ------------ | ------------ | ---------------- |
-| Within actor  | Unrestricted | Unrestricted | None             |
-| Across actors | Not allowed  | N/A          | Snapshot on send |
+| Context       | Aliasing                        | Mutation                          | Boundary rule    |
+| ------------- | ------------------------------- | --------------------------------- | ---------------- |
+| Within actor  | Values copy; handles alias      | Through a `var` binding or `var self` | None         |
+| Across actors | Not allowed                     | N/A                               | Snapshot on send |
 
 **Hew's guarantee:** No data races between actors, enforced at compile time through `Send` and snapshot-on-send semantics. No borrow checker complexity for local code.
 
@@ -1063,16 +1148,16 @@ Traits define shared behaviour that types can implement. Hew has built-in marker
 
 ```hew
 trait Renderable {
-    fn fmt(val: Self) -> string;
+    fn fmt(self) -> string;
 }
 
 trait Sequence {
     type Item;
-    fn next(iter: Self) -> Option<Self.Item>;
+    fn next(var self) -> Option<Self.Item>;
 }
 
 trait Duplicable {
-    fn clone(val: Self) -> Self;
+    fn clone(self) -> Self;
 }
 ```
 
@@ -1080,14 +1165,14 @@ trait Duplicable {
 
 ```hew
 trait PointRenderer {
-    fn fmt(val: Self) -> string;
+    fn fmt(self) -> string;
 }
 
 type Point { x: f64; y: f64 }
 
 impl PointRenderer for Point {
-    fn fmt(p: Point) -> string {
-        f"({p.x}, {p.y})"
+    fn fmt(self) -> string {
+        f"({self.x}, {self.y})"
     }
 }
 ```
@@ -1110,47 +1195,97 @@ impl PointRenderer for Point {
   - Only value types (integers, floats, bool, char)
   - Small fixed-size aggregates
 
-- `PartialOrd` - Type supports `<`, `<=`, `>`, `>=` comparisons. In edition 2026, satisfied only by primitive numeric types (`i8`–`i64`, `u8`–`u64`, `f32`, `f64`, `isize`, `usize`, `char`); user-defined types do not derive it automatically.
+**Comparison and hashing traits (normative):**
 
-**Named receivers (Go-style):**
+`Eq`, `Ord`, `PartialOrd`, and `Hash` are **derived by default**, and a user
+`impl` is allowed and is what `==`, the ordering operators, and hashing dispatch
+to for that type.
 
-Hew uses **named receivers** instead of a `self` keyword. In trait declarations and `impl` blocks, the first parameter whose type matches the implementing type (or `Self` in traits) is the **receiver**. The receiver is what makes a function callable with dot-syntax:
+- Records and enums are `Eq` and `Hash` structurally: field by field, variant by
+  variant, with no declaration.
+- `Ord` and `PartialOrd` are derived lexicographically by field order when every
+  field is itself ordered. Primitive numeric types (`i8`–`i64`, `u8`–`u64`,
+  `f32`, `f64`, `isize`, `usize`, `char`) are ordered.
+- Writing `impl Eq for T { … }` (likewise `Ord`, `PartialOrd`, `Hash`) is legal
+  and **overrides** the derived implementation for `T`. A type with a real
+  invariant — a case-insensitive key, a tolerance-based float comparison — states
+  its own rule rather than being walled off from the operators. There is no
+  `E_DERIVED_TRAIT_IMPL`: an `impl` body for these traits is never refused for
+  being an "implementation of a derived trait".
+- Derived comparison is structural, so it never observes handle identity; `is`
+  is the operator that does (§12.2).
+
+> **Limitation at edition 2026 (`E_LIMIT_DERIVED_ORD`, Limitation channel).**
+> The derived `Ord`/`PartialOrd` for records and enums is not yet available to a
+> generic bound, so `T: Ord` does not resolve for a user type and the refusal
+> reads "type `T` does not implement trait `Ord`". Use an explicit comparator
+> (`sort_by`) or a user `impl Ord` until the derive reaches generic bounds.
+
+**The three receivers (normative):**
+
+A method's receiver is written `self`, and the receiver token set is fixed at
+one member each:
+
+| Receiver | Meaning | Caller's binding |
+| --- | --- | --- |
+| `self` | borrows the receiver | stays valid and unchanged |
+| `var self` | mutates the receiver in place | must be declared `var` |
+| `consume self` | consumes the receiver | is dead after the call |
 
 ```hew
 type Point { x: f64; y: f64 }
 
 trait Formattable {
-    fn fmt(val: Self) -> string;       // val is the receiver (type Self)
+    fn fmt(self) -> string;
 }
 
 impl Formattable for Point {
-    fn fmt(p: Point) -> string {       // p is the receiver (type Point)
-        f"({p.x}, {p.y})"
+    fn fmt(self) -> string {
+        f"({self.x}, {self.y})"
     }
 }
 ```
 
-The compiler identifies the receiver by matching the parameter type against the impl target. The parameter name is chosen by the programmer — use short, descriptive names (`p` for Point, `v` for Vec, `iter` for Iterator, etc.).
+`self` is the receiver's name inside the body; its type is the implementing type
+(or `Self` in a trait declaration). There is no `&self` or `&mut self` — Hew has
+no references in its surface syntax (§3.4.1) — and there is no implicit receiver
+anywhere else in the language.
+
+The **named-first-parameter** receiver form is not part of the language. A
+method whose first parameter is spelled with a name and the target type
+(`fn fmt(p: Point)`, `fn push(v: Vec<T>, value: T)`, the trait declaration
+`fn fmt(val: Self)`) is rejected, with a fix-it that rewrites the parameter to
+`self` — or to `var self` when the body assigns through it. This applies in
+`impl` blocks and in trait declarations alike, including for the builtin
+collection methods.
 
 **Calling methods:**
 
 ```hew
 let p = Point { x: 1.0, y: 2.0 };
-p.fmt();    // desugars to Point.fmt(p) — p is consumed (by-value)
-// p is no longer valid here
+p.fmt();    // `self` borrows: p is still valid
+p.fmt();    // and may be called again
 ```
 
-**In `impl` blocks for types/enums (by-value):**
+A `var self` method needs a `var` binding. `let c = Counter { n: 0 }; c.bump()`
+is refused with "requires a mutable binding receiver" and the `let`→`var`
+fix-it (§3.2). A `consume self` method takes the value: any later use of the
+binding is a use-after-consume diagnostic.
 
-The receiver is passed by value — the receiver is consumed (ownership transfer):
+> **Limitation at edition 2026 (`E_LIMIT_INHERENT_VAR_SELF`, Limitation
+> channel).** On a **user type**, `var self` is available on trait methods but
+> refused on an inherent `impl` method, because an inherent method receives the
+> receiver by value and the mutation would not be observable to the caller. The
+> fix-it is to declare the method on a trait whose receiver is `var self` and
+> implement that trait for the type, so a user type gets its trait-mediated
+> in-place method now and its inherent one when the ownership ladder lands the
+> borrow-mutate receiver. The builtin collections (§3.10.3) are unaffected: their
+> inherent `var self` methods are compiler-provided and mutate in place today.
 
-- `fn fmt(p: Point)` takes `p` by value in an `impl` for `Point`
-- The caller gives up ownership of the value
-- After calling a consuming method, the original binding is no longer usable
+**In actor bodies (bare fields, `self` is the handle):**
 
-**In actor `receive fn` and `fn` methods (bare field access):**
-
-Actors do not use receivers at all. Actor handler methods access fields by their bare names — no prefix, no receiver parameter. The actor's persistent state is implicitly available:
+An actor's own state is reached by **bare field name** — no prefix, no receiver
+parameter — and the actor persists across handler invocations:
 
 ```hew
 actor Counter {
@@ -1161,17 +1296,23 @@ actor Counter {
 }
 ```
 
-There is no `&self` or `&mut self` syntax — Hew does not have references in its surface syntax (see §3.4.1). The by-value vs implicit-state distinction is determined by the context (`type`/`enum` `impl` vs actor body), not by annotation.
+Inside an actor body, `self` is the **actor handle**: a read-only value of type
+`LocalPid<Self>` naming the enclosing actor. This is the one meaning `self`
+carries in an actor body — it is not a prefix for fields, and `self.count` is
+not how actor state is read.
 
-**The `this` keyword (actor self-reference):**
+- Available in `receive fn` and `fn` methods and in lifecycle hooks
+- Sendable: it may be passed as a message argument or stored in a field
+- Read-only: assignment to `self` is rejected at check time
+- `self.stop()` stops the enclosing actor (§9.1)
 
-Inside an actor body, the `this` keyword provides a read-only handle to the actor itself:
+`this` is not a keyword and carries no actor meaning; the handle is `self`
+everywhere.
 
-- Available only inside actor bodies (`receive fn` and `fn` methods)
-- Type `LocalPid<Self>` — a sendable handle to the enclosing actor
-- Can be passed as a message argument or stored in a field
-- Read-only — assignment to `this` is rejected at compile time
-- Not valid in `type`/`enum` `impl` blocks or free functions
+A plain `fn` in an actor body is an associated function of the actor type. It
+has no receiver and no view of the fields, so a helper over actor state is a
+`receive fn`, a lifecycle hook, or a free function that takes the state as a
+parameter.
 
 **Variable shadowing:**
 
@@ -1275,7 +1416,7 @@ type Connection { fd: i64; }
 
 impl Connection {
     fn open(host: string) -> Connection { Connection { fd: 0 } }
-    fn close(c: Connection) {}
+    fn close(consume self) {}
 }
 
 fn main() {
@@ -1389,7 +1530,7 @@ type FileHandle {
 }
 
 impl FileHandle {
-    fn close(fh: FileHandle) {
+    fn close(consume self) {
         // release the file descriptor
     }
 }
@@ -1571,7 +1712,7 @@ descriptor, socket, allocator handle, GPU context, libc pointer) and
 type File { fd: i64 }
 
 impl File {
-    fn close(self) {}   // plain self, unit return, sibling impl
+    fn close(consume self) {}   // consuming receiver, unit return, sibling impl
 }
 ```
 
@@ -1589,9 +1730,9 @@ Semantics:
 3. **Early close is a normal method call.** `f.close()?` consumes `f` and
    surfaces the error via `?` like any other method. Any subsequent use
    of `f` is a use-after-consume diagnostic from Checked MIR.
-4. **Affine in the move-checker.** Sends, moves, and method calls with a
-   consuming receiver all consume the value; the move-checker tracks the
-   single live binding.
+4. **Affine in the move-checker.** Sends, moves, and method calls declared
+   `consume self` all consume the value; the move-checker tracks the single
+   live binding.
 
 Typical example — file I/O with implicit cleanup (illustrative; no `File` type
 exists in stdlib — for file reading use `fs::try_read`):
@@ -1627,8 +1768,8 @@ go out of scope without consuming it is a compile error.
 ```hew
 #[linear]
 type Transaction {
-    fn commit(consuming self) -> Result<(), DbError>
-    fn rollback(consuming self) -> Result<(), DbError>
+    fn commit(consume self) -> Result<(), DbError>
+    fn rollback(consume self) -> Result<(), DbError>
 }
 ```
 
@@ -1638,7 +1779,7 @@ Semantics:
    Scope exit with an unconsumed `@linear` value is a
    `MustConsumeAtScopeExit` diagnostic.
 2. **Consumption discharges the obligation.** Calling any declared
-   consuming method (one whose receiver is `consuming self`) is enough to
+   consuming method (one whose receiver is `consume self`) is enough to
    satisfy the must-consume check.
 3. **No canonical method name.** The type declares which methods are
    valid consumers. `Transaction` requires `commit` or `rollback`; a
@@ -1776,7 +1917,7 @@ type, and fail closed before any subsequent stage can silently miss a drop:
    type Conn { fd: i64 }
 
    impl Conn {
-       fn close(c: Conn) { /* release fd */ }
+       fn close(consume self) { /* release fd */ }
    }
    ```
 
@@ -1907,19 +2048,19 @@ Traits can declare associated types that implementors must specify:
 ```hew
 trait Iterator {
     type Item;
-    fn next(iter: Self) -> Option<Self.Item>;
+    fn next(var self) -> Option<Self.Item>;
 }
 
 impl Iterator for RangeIter {
     type Item = i32;
 
-    fn next(iter: RangeIter) -> Option<i32> {
-        if iter.current < iter.end {
-            let value = iter.current;
-            iter.current = iter.current + 1;
-            Some(value)
+    fn next(var self) -> Option<i32> {
+        if self.current < self.end {
+            let value = self.current;
+            self.current = self.current + 1;
+            .Some(value)
         } else {
-            None
+            .None
         }
     }
 }
@@ -2294,11 +2435,49 @@ impl File {
         }
     }
 
-    fn close(f: File) {
-        unsafe { close(f.fd); }
+    fn close(consume self) {
+        unsafe { close(self.fd); }
     }
 }
 ```
+
+#### 3.9.6 `#[opaque]` handle types
+
+`#[opaque]` marks a type that is a **handle to something the FFI owns**. Its
+body is empty — an opaque handle has no fields and no struct-literal
+constructor, so values come only from a foreign function
+(`E_OPAQUE_TYPE_SHAPE` rejects a non-empty body). Opaque handles are the
+opaque-handle category of §3.4.3: a second binding is a second name for one
+resource, `is` compares identity, and methods act through the handle regardless
+of whether the binding is `let` or `var`.
+
+**An opaque handle may live inside an actor (normative).** An `#[opaque]`
+value, or the `#[resource]` wrapper around one, may be
+
+- an actor's init field, moved in at `spawn`, owned by that actor's heap and
+  closed by the actor's drop glue when the actor stops; and
+- a `receive fn` parameter on a **local** send, where the send consumes the
+  handle.
+
+This is what lets one actor hold one connection and serve many requests over it
+instead of re-opening the resource per message.
+
+A use of the sender's binding after such a send is `E_USE_AFTER_SEND` (User).
+This is a rule, not a limitation: a handle that is still live at the send cannot
+be snapshotted, because there is nothing to snapshot but the resource itself.
+It is the fourth wall of the ownership model, and it applies to handles only.
+
+A handle is never `#[wire]`, so sending one to a `RemotePid` stays
+`E_OPAQUE_MESSAGE_PAYLOAD` (User): a remote payload must be CBOR-serializable
+and a handle has no serializable layout.
+
+> **Limitation at edition 2026 (`E_LIMIT_OPAQUE_ACTOR`, Limitation channel).**
+> The local case above is refused today: an `#[opaque]` type in a `receive fn`
+> parameter or an actor init field is rejected with the message that a message
+> payload must be CBOR-serializable, applied to a local send that never
+> serializes. The refusal rides the Limitation channel under its own code so
+> that one code has one channel, and it lifts when local sends carry the
+> transfer-last-use move.
 
 ---
 
@@ -2336,20 +2515,24 @@ normative — `std.net.dns`, `std.net.tls`, `std.net.quic`,
 
 #### 3.10.2 Core Traits
 
-The language supports user-defined traits, associated types, and named
-receivers. The current stdlib does **not** ship a full generic
+The language supports user-defined traits, associated types, and the three
+receivers of §3.6. The current stdlib does **not** ship a full generic
 iterator-trait hierarchy; modules such as `std::iter` expose concrete helper
 functions instead.
+
+`Eq`, `Ord`, `PartialOrd`, and `Hash` are derived by default and may be
+overridden by a user `impl`, which `==`, the ordering operators, and hashing
+then dispatch to (§3.6).
 
 The following traits are representative of the current trait style:
 
 ```hew
 trait Printable {
-    fn fmt(val: Self) -> string;
+    fn fmt(self) -> string;
 }
 
 trait Releasable {
-    fn drop(val: Self);
+    fn drop(consume self);
 }
 ```
 
@@ -2396,14 +2579,14 @@ type Vec<T> {}
 
 impl<T> Vec<T> {
     fn new() -> Vec<T>;
-    fn push(v: Vec<T>, item: T);
-    fn pop(v: Vec<T>) -> T;                     // traps on empty vec
-    fn len(v: Vec<T>) -> i64;
-    fn get(v: Vec<T>, index: i64) -> Option<T>;
-    fn set(v: Vec<T>, index: i64, item: T);      // traps out of bounds
-    fn contains(v: Vec<T>, item: T) -> bool;
-    fn clear(v: Vec<T>);
-    fn append(v: Vec<T>, other: Vec<T>);
+    fn push(var self, item: T);
+    fn pop(var self) -> T;                     // traps on empty vec
+    fn len(self) -> i64;
+    fn get(self, index: i64) -> Option<T>;
+    fn set(var self, index: i64, item: T);      // traps out of bounds
+    fn contains(self, item: T) -> bool;
+    fn clear(var self);
+    fn append(var self, other: Vec<T>);
 }
 ```
 
@@ -2607,7 +2790,10 @@ implementation.
 
 Handle types are opaque — their internal representation is not accessible.
 They can be stored in variables, passed as function arguments, and
-returned from functions.
+returned from functions. They are handles in the sense of §3.4.3, so a second
+binding is a second name for one resource, `is` compares them for identity, a
+method acts through the handle whether the binding is `let` or `var`, and the
+rules of §3.9.6 apply for holding one inside an actor.
 
 `net.Listener.accept()` and `net.Connection.read()`'s plain (non-`await`)
 forms block the calling thread; inside an actor receive handler this stalls
@@ -3086,7 +3272,7 @@ safepoint before its body reaches a consuming or close call.
 1. **`@resource` capture.** A `@resource` value moved into a child task
    has its drop discipline run on whichever exit path the child takes:
    normal completion, recoverable `Err(E)`, trap, or cancellation. The
-   declared `close(consuming self) -> Result<(), E>` is invoked through
+   declared `close(consume self) -> Result<(), E>` is invoked through
    the child's stack-unwind path (§4.5), and its returned error is
    discarded per the §3.4 `@resource` semantics. This is the *same*
    discipline a `@resource` would receive in a non-task context; the
@@ -5092,7 +5278,7 @@ The methods `.try_to_i8()`, `.try_to_i16()`, `.try_to_i32()`, `.try_to_i64()`, `
 7. Bitwise XOR: `^`
 8. Bitwise OR: `|`
 9. Relational: `<`, `<=`, `>`, `>=`
-10. Equality: `==`, `!=`, `is` (`is` = reference identity on heap handles; `expr is TypeName` = static-only type check; rejected with `E_IS_VALUE_TYPE` on scalars, `string`, tuples, and `type Name { ... }` record declarations — records are copy-on-write values with no pointer identity, so `==` is the comparison for them; regex matching is via `Pattern.is_match`)
+10. Equality: `==`, `!=`, `is` (`is` is **handle identity only** — it admits the pid, counted, opaque, and resource handle categories of §3.4.3 and answers whether two names denote the same actor, count, or resource. Every value-category and callable-category operand is rejected with `E_IS_VALUE_TYPE`, including scalars, `string`, `bytes`, tuples, records, enums, `Vec`, `HashMap`, and `HashSet`: these are copy-on-write values with no identity to compare, so `==` is their comparison. There is no `expr is TypeName` form; regex matching is via `Pattern.is_match`)
 11. Logical AND: `&&`
 12. Logical OR: `||`
 13. Range: `..`, `..=` (only lowered inside `for` loop iterables; standalone range value expressions are not lowered)

--- a/docs/v05/ownership.md
+++ b/docs/v05/ownership.md
@@ -9,9 +9,10 @@ gets an immutable copy-on-write view. Reuse after a call (`f(p); g(p)`) and
 value-receiver method chains are legal. There is no use-of-moved-value error for
 function calls, no ordinary reference syntax, and no lifetimes — ownership and
 sharing are inferred. The entire binding surface is two keywords, `let`
-(immutable) and `var` (mutable); there are no ownership annotations to write.
-Lifetimes, mutable references, and a capability lattice are permanent refusals,
-not deferred features.
+(immutable) and `var` (mutable), and a method that mutates its receiver says so
+with `var self`; there are no ownership annotations to write. Lifetimes, mutable
+references, and a capability lattice are permanent refusals, not deferred
+features.
 
 ```hew
 let p = build_point();
@@ -75,9 +76,9 @@ copy-on-write's lazy, on-demand fork. `clone x` (prefix form, the natural and
 primary spelling) and `x.clone()` (method form) are equivalent:
 
 ```hew
-let a: Vec<i64> = Vec.new();
+var a: Vec<i64> = Vec.new();
 a.push(1); a.push(2);
-let b = clone a;      // == a.clone() — independent copy, forked eagerly now
+var b = clone a;      // == a.clone() — independent copy, forked eagerly now
 b.push(99);
 println(a.len());     // 2
 println(b.len());     // 3
@@ -142,67 +143,123 @@ today, converging to retain-share-plus-copy-on-write as the model completes. Eac
 tier is indistinguishable from the others at the source level — the sender always
 keeps a valid, independent value.
 
-Move-on-send returns only for a provably-unique or `resource`-kind value as a
-runtime optimization (the pointer-transfer fast path above), never as a surface
-rule you must reason about. Sending a **non-sendable** value — a resource-shaped
-type, before the `resource` kind ships (see below) — is a fail-closed compile
-error, not a silent copy. See HEW-SPEC-2026.md §3.4.4 and §3.7.2 for the full
-model.
+Move-on-send returns only for a provably-unique value as a runtime optimization
+(the pointer-transfer fast path above), never as a surface rule you must reason
+about. Sending a **handle** is the one place a move is the rule rather than an
+optimization, and that is the next section. See HEW-SPEC-2026.md §3.4.4 and
+§3.7.2 for the full model.
 
-## `resource` — reserved for a future affine kind
+## Values, handles, and callables
 
-`resource` is a **reserved word**. It names an affine (move-only) kind that will
-ship after the first release: a `resource type` — a file, a socket, a unique
-handle — is never clonable, never implicitly shared, has a deterministic
-exactly-once destructor, and moves on send (the sender is invalidated, because a
-unique resource genuinely cannot exist in two places). That is the _one_ place a
-surface move will ever return.
+Everything above describes **values**. Not every type is one, and the difference
+is what a second name means. Three categories cover the language:
 
-At rc1 the feature is not yet user-visible; only the **seam** is reserved:
+- A **value** is copied. `let b = a` gives you two independent values (lazily,
+  by copy-on-write), `==` compares them structurally, and a send delivers a
+  snapshot. Scalars, `string`, `bytes`, records, enums, tuples, arrays, `Vec`,
+  `HashMap`, `HashSet`, and `dyn Trait` objects are values.
+- A **handle** is a name for something that lives elsewhere — an actor, a
+  refcount, a resource. A second binding is a second name for the same thing,
+  and methods act through the handle no matter whether the binding is `let` or
+  `var`, which is why `let pid`, `let rc`, and `let d = deque.new()` are all
+  legal receivers of `send`, `set`, and `push_back`.
+- A **callable** is a closure, a generator, or a task. It behaves as a value
+  locally and is never a message payload.
 
-- the word `resource` is reserved in the grammar;
-- no generic or stdlib code may assume universal clonability — `clone` stays a
-  capability-gated operation, so a future non-clonable kind slots in without a
-  breaking retrofit;
-- sending a resource-shaped value is a fail-closed compile error today (there is
-  no unsound window before the kind ships).
+Handles come in four flavours, and the flavour is the whole difference:
 
-Use the [owning-actor pattern](../hew-language-guide.md#own-a-resource-with-an-actor):
-open the resource inside one actor, keep it in that actor's state, and send the
-actor ordinary operation messages instead of sending the resource.
+| Handle   | Members                                  | What a copy does                     | What closes it                                   |
+| -------- | ---------------------------------------- | ------------------------------------ | ------------------------------------------------ |
+| pid      | `LocalPid`, `RemotePid`, `ChildRef`      | another name for one actor           | nothing; the actor stops                         |
+| counted  | `Rc`, `Weak`, `LambdaPid`                | a refcounted retain; the count rises | the last release, through drop glue              |
+| opaque   | `#[opaque]` types, such as a channel end | another name for one resource        | `close(consume self)` where the type declares it |
+| resource | `#[resource]` wrappers, `Stream`, `Sink` | a move; the source binding is dead   | drop glue at scope exit, or an early `close`     |
 
-Reserving the seam now — rather than the whole feature — closes the retrofit
-danger (generics silently assuming every type is copyable) while keeping the
-affine kind itself severable as the first post-rc1 ownership feature.
+`LambdaPid` is a **counted** handle, not a plain pid: releasing the last copy
+releases the closure environment the lambda actor captured.
 
-## The complete rejection surface: three walls
+`resource` is an ordinary identifier — `let resource = 3` is a legal binding.
+The affine kind shipped as the `#[resource]` attribute, and the linear
+discipline beside it as `#[linear]`: a `#[resource]` value may be dropped and
+its drop glue closes it, a `#[linear]` value may not be dropped and must be
+consumed by one of its own `consume self` methods.
 
-The entire ownership model rejects your program in exactly **three** places. Each
+## `is` — identity, for handles only
+
+`is` asks whether two names denote the same actor, the same count, or the same
+resource. It admits handles and nothing else. On a value — a scalar, a
+`string`, a record, a `Vec` — it is a compile error (`E_IS_VALUE_TYPE`), because
+a value has no identity to compare: `let b = a` gives you a copy whose address
+is a cost detail, so an identity answer would report the copy-on-write tier
+rather than anything about your program. Compare values with `==`.
+
+```hew
+let p = spawn Worker();
+let q = p;
+println(f"{p is q}");   // true — one actor, two names
+```
+
+There is no `expr is TypeName` form.
+
+## An opaque handle may live inside an actor
+
+The way to own a resource is to give it to one actor: open the connection
+inside the actor, keep it in that actor's state, and send the actor ordinary
+operation messages. An `#[opaque]` handle, or the `#[resource]` wrapper around
+one, may be an actor's init field — moved in at `spawn`, owned by that actor's
+heap, closed by its drop glue when the actor stops — and may be a `receive fn`
+parameter on a local send, where the send consumes it. That is how one actor
+holds one connection and serves many requests over it.
+
+> **Not yet: `E_LIMIT_OPAQUE_ACTOR`.** Today an `#[opaque]` type in a
+> `receive fn` parameter or an actor init field is refused, with the wire rule's
+> "message payloads must be CBOR-serializable" applied to a local send that
+> never serializes. The refusal carries this Limitation code so it is
+> distinguishable from the rule, and it lifts when local sends carry the
+> transfer-last-use move. Until then, open the handle inside the handler.
+
+## The complete rejection surface: four walls
+
+The entire ownership model rejects your program in exactly **four** places. Each
 wall names the binding, its state, and the span that put it there, and each ships
 a one-line escape:
 
-| Wall                     | When it fires                         | Escape                                                                                                                      |
-| ------------------------ | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| mutation of a `let`      | you mutate a value bound with `let`   | declare it `var`                                                                                                            |
-| clone of a non-cloneable | you `clone` a value with no copy path | restructure now; the `resource` lifecycle later                                                                             |
-| send of a non-sendable   | you send a resource-shaped value      | use the [owning-actor pattern](../hew-language-guide.md#own-a-resource-with-an-actor); lifts when `resource` transfer ships |
+| Wall                       | When it fires                                                                                     | Escape                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| mutation of a `let`        | you mutate a value bound with `let`, or call a `var self` method on it                            | declare it `var`                                                                      |
+| clone of a non-cloneable   | you `clone` a value with no copy path                                                             | restructure, or hold the resource in an actor                                         |
+| send of a non-sendable     | you send an `Rc`, a `Weak`, a `LambdaPid`, or a closure, or you send any handle to a remote actor | use the [owning-actor pattern](../hew-language-guide.md#own-a-resource-with-an-actor) |
+| use after send of a handle | you send an opaque or resource handle locally and then use the binding                            | send it last, or reopen the handle in the receiving actor                             |
 
-There is no fourth wall. Use-after-send of a value is **not** an error (send takes
-a snapshot); use-after-call is **not** an error (calls borrow). The model has no
+The fourth wall is for **handles only**. Use-after-send of a _value_ is still
+not an error (send takes a snapshot) and use-after-call is still not an error
+(calls borrow) — but a handle cannot be snapshotted, because there is nothing to
+snapshot but the resource itself, so a local send of one is a move and the
+sender's binding is dead afterwards (`E_USE_AFTER_SEND`). The model still has no
 lifetime errors, no borrow-checker vocabulary, and no capability terms to learn.
 
-## Equality: structural only (Q322)
+## Equality: structural by default, yours if you say so (Q322)
 
-`==` in Hew compares **values**, not object identity:
+`==` in Hew compares **values**, not addresses:
 
 ```hew
 let a = "hello";
 let b = "hello";
-a == b  // true — structural equality, always
+a == b  // true — structural equality, derived for free
 ```
 
-There is no pointer-equality operator. Two distinct heap allocations holding the same bytes
-compare equal. This invariant holds even after COW splits a shared buffer.
+`Eq`, `Ord`, `PartialOrd`, and `Hash` are derived for records and enums with no
+declaration: field by field, variant by variant, and ordering lexicographically
+by field order. Two distinct heap allocations holding the same bytes compare
+equal, and that holds even after copy-on-write splits a shared buffer.
+
+You can override the derived rule. `impl Eq for T { .. }` is legal, and `==`,
+the ordering operators, and hashing all dispatch to your body for `T` — which is
+what a case-insensitive key or a tolerance-based float comparison needs. The
+derived implementation is a default, not a wall.
+
+Identity is a separate question with a separate operator: `is`, on handles only
+(above). There is no address comparison for values.
 
 ## Reference cycles (Q321)
 

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -59,6 +59,16 @@
 #             dispatched for it — the fences come OUT of the expected-failures
 #             file when it lands).
 #
+# SURFACE-PENDING — The fence shows ratified v0.6.0 surface that the parser or
+#             checker does not accept yet. The docs are the authority on the
+#             surface, so the fence carries the new spelling and the compiler
+#             follows; each entry names the issue that lands it.
+#             WHY here: keeping the old spelling in the doc would make the
+#             normative text and its own example disagree.
+#             WHEN it goes: when the named issue lands; the entry is deleted in
+#             that same change.
+#             WHAT the real fix is: the compiler change, not a wider list.
+#
 # Baseline: 172 pass, 86 fail, 19 skip (NYI/skip-annotated) out of 277 total fences.
 # Updated 2026-06-22: fixed spec-0033/0038/0073 (now PASS) and annotated
 # spec-0048/0049/0051/0052/0066/0067/0069/0070/0097/0099/0113 (now SKIP).
@@ -74,6 +84,9 @@
 
 # guide-0107 was removed 2026-06-23: std::string.from_int fence now passes;
 # the NYI label was stale (fence renumbered as guide grew).
+
+guide-0153   4278824673   # SURFACE-PENDING: `close(consume self)` — the parser still spells the consuming receiver `consuming self` (#3257)
+guide-0154   144626557   # SURFACE-PENDING: `commit`/`rollback(consume self)` — same receiver spelling (#3257)
 
 
 # ─── Spec failures (86) ──────────────────────────────────────────────────────────
@@ -92,7 +105,7 @@ spec-0014   3221762372   # SNIPPET: bare `let x = 5` / `var y = 0` — binding m
 spec-0015   1507524389   # SNIPPET: bare `type Point { ... }` + bare `var` — struct mutable field illustration
 spec-0020   3005964102   # SNIPPET: bare `let config = load_config()` — actor capture illustration
 spec-0021   667087144   # SNIPPET: bare `let local_ref = ...` — non-Send capture illustration
-spec-0022   2513387504   # FRAGMENT: actor calls undefined `process()` — allowed-ops illustration
+spec-0022   3131879152   # FRAGMENT: actor calls undefined `process()` — allowed-ops illustration
 spec-0023   3898239403   # ERROR-DEMO: intentionally shows non-Send send and non-Send capture errors
 spec-0024   2265846331   # SPEC-BUG: type mismatch in aspirational TCP module example
 spec-0025   3406269624   # FRAGMENT: imports `network.tcp` — hypothetical module, not in stdlib
@@ -100,22 +113,26 @@ spec-0026   838045753   # SNIPPET: bare code after import statement — illustra
 spec-0027   2603276079   # FRAGMENT: imports `greeting` — multi-file example, module not found
 spec-0030   53697221   # SNIPPET: bare code outside declarations — trait method dispatch illustration
 spec-0031   158863422   # SNIPPET: bare `let` + trait call — trait dispatch illustration
-spec-0035   1203364263   # SNIPPET: bare `let` — type inference illustration
+spec-0035   2589017280   # SNIPPET: bare `let` — type inference illustration
+spec-0038   1582764949   # SURFACE-PENDING: `close(consume self)` — the parser still spells the consuming receiver `consuming self` (#3257)
+spec-0042   4053237619   # SURFACE-PENDING: `close(consume self)` on `#[resource] FileHandle` — same receiver spelling (#3257)
 spec-0044   60603610   # SNIPPET: bare `let f = |...| ...` — lambda illustration
 spec-0045   1914272309   # SPEC-BUG: references variant `Lit` not defined in the fence
 spec-0046   1607851950   # SNIPPET: bare `let` — fn-type variable illustration
-spec-0051   4288056281   # SPEC-BUG: struct `impl` using wrong syntax form (stray `;` before `fn`)
+spec-0048   1274472534   # SURFACE-PENDING: `close(consume self)` in the `#[resource]` section — same receiver spelling (#3257)
+spec-0051   3977789670   # SURFACE-PENDING: `commit`/`rollback(consume self)` on `#[linear] Transaction` — the parser still spells the consuming receiver `consuming self` (#3257); the fence is also a signature-only `impl` body, so it stays SPEC-BUG behind that
 spec-0054   4266594633   # SNIPPET: bare identifier `max` after trait definition — illustration
 spec-0056   1757877651   # SPEC-BUG: type mismatch in aspirational HashMap construction
-spec-0057   2693165546   # ERROR-DEMO: intentionally shows `cannot assign to immutable iter`
+spec-0057   3755535258   # FRAGMENT: associated-type illustration — `trait Iterator` collides with the prelude binding and `RangeIter` is undefined in the fence; `.Some(value)` additionally hits the prelude-variant path gap
 spec-0060   2014515248   # ERROR-DEMO: intentionally shows missing Send bound on actor-boundary call
 spec-0061   484878998   # SNIPPET: bare `let` after struct definitions — trait usage illustration
 spec-0062   3690728588   # SNIPPET: bare `let f: fn(i64) -> i64 = ...` — fn-type illustration
 spec-0063   286908305   # SNIPPET: bare code — trait implementation illustration
 spec-0064   3032467602   # SNIPPET: bare `let` — generic function call illustration
 spec-0066   4058908296   # SNIPPET: bare `let` — generic function illustration
+spec-0072   2591582798   # SURFACE-PENDING: `trait Releasable { fn drop(consume self); }` — same receiver spelling (#3257)
 spec-0073   820125999   # SPEC-BUG: enum variants separated by `,` not `;` — illustrates wrong syntax
-spec-0075   4120679691   # SPEC-BUG: malformed struct `impl` syntax — aspirational (re-verified after Vec<T> method-table correction, still fails identically: signature-only `;`-terminated impl bodies, no `{ }`)
+spec-0075   1673587477   # SPEC-BUG: malformed struct `impl` syntax — aspirational (re-verified after Vec<T> method-table correction, still fails identically: signature-only `;`-terminated impl bodies, no `{ }`)
 spec-0076   3414934173   # SNIPPET: bare `var`/`let` — HashMap bracket-indexing illustration (re-verified after the dotted-path migration and the corrected index-read result type: `m[k]` yields bare `V`, not `Option<V>`)
 spec-0077   3711765580   # SNIPPET: bare `let`/`var` — machine state illustration
 spec-0078   1861586926   # SNIPPET: bare `let` after machine transitions — illustration


### PR DESCRIPTION
## Why

The spec taught Go-style named receivers, `this` as the actor self-reference,
and `let` collections with interior mutability, while the ratified v0.6.0
surface is three receivers with one token each and a binding wall that covers
mutating methods. It also had no place that said what a handle is, so `is`,
`LambdaPid`, and the rule that an opaque handle may live inside an actor had
nowhere to be normative.

## What

- **§3.2**: the binding wall covers every place rooted at a `let` binding
  (`p.x`, `v[0]`, `m["k"]`, `t.0`) and every `var self` call, with
  `MutabilityError` and the `let`→`var` fix-it. Mutating builtin collection
  methods are `var self`; handles are the exception by category.
- **§3.4.3**: the value / `#[linear]` / pid / counted / opaque / resource /
  callable table, with `LambdaPid` in the counted-handle row and the
  `E_LIMIT_COLLECTION_COPY` limit stated against the rule. The JavaScript
  comparison is replaced by Swift's `let` plus `mutating func`.
- **§3.4.6, §3.4.8**: the "multiple mutable references" example taught aliasing
  the model does not have; it now teaches copies, `var` locals, and borrowing
  calls.
- **§3.6**: three receivers - `self` borrows, `var self` mutates,
  `consume self` consumes - with the named-first-parameter form deleted and
  `E_LIMIT_INHERENT_VAR_SELF` named for user types. Inside an actor body `self`
  is the actor handle (`LocalPid<Self>`, read-only, `self.stop()`), stated once
  here; `this` carries no actor meaning. `Eq`/`Ord`/`PartialOrd`/`Hash` are
  derived by default and a user impl is honoured, with `E_LIMIT_DERIVED_ORD`
  named and no `E_DERIVED_TRAIT_IMPL`. A plain `fn` in an actor body sees the
  fields by bare name and has no call form (#3285).
- **§3.7.1, §3.7.8, §4.6**: `consuming self` becomes `consume self`.
- **§3.9.6** (new): `#[opaque]` handle types, the rule that a handle may be an
  actor init field or a local `receive fn` parameter, `E_USE_AFTER_SEND` as the
  fourth wall, and `E_LIMIT_OPAQUE_ACTOR` as the v0.6.0 limit. §2.1.1 gains the
  message-payload paragraph, which admits pid handles and local opaque or
  resource handles and refuses counted handles and callables.
- **§12.2**: `is` is handle identity only; `expr is TypeName` is gone and
  `E_IS_VALUE_TYPE` covers collections.
- **`docs/v05/ownership.md`**: values/handles/callables, `is`, the opaque handle
  inside an actor, a fourth wall, and equality as derive-with-override. The
  "`resource` is a reserved word" section is corrected to the shipped
  `#[resource]` attribute, because the category table contradicts it directly.
- **`docs/hew-language-guide.md`**: the receiver rule, the actor handle, the
  binding rule for collections, and `consume self`. The
  mutation-through-a-parameter note gives borrowing as the reason a helper can
  fill a `let`-bound collection, in place of interior mutability.

Decisions D1, D2, D15, D25, D26, with ledger amendments A379 (receiver tokens,
`this` deleted, `self` is the actor handle), D339 (`LambdaPid` counted, extern
`consume`), D340 (user comparison impls honoured), D341 (bare variant patterns).

## Test

`make test-doc-examples` and `make hew-check-all` both pass. The fences that now
carry `consume self` are tracked under a new `SURFACE-PENDING` category in
`scripts/doc-test-expected-failures.txt` and come out when #3257 lands. Fence
checksums the edits invalidated were re-verified against the error each fence
now reports, and `spec-0051` and `spec-0057` were relabelled because the cause
changed.

The actor-body `fn` claim was checked against the compiler rather than carried
over: a bare field name resolves in that body and an unknown one is
`undefined variable`, while both call forms fail, one of them into an internal
error. That is #3285, and the spec cites it instead of asserting the body sees
nothing.
