### PR TITLE
docs(spec): make the actor, runtime, and node surfaces fail closed

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1651,7 +1651,7 @@ actor Worker {
         ticks = ticks + 1;
     }
 
-    receive fn stop() {
+    receive fn halt() {
         running = false;
     }
 
@@ -1663,7 +1663,7 @@ actor Worker {
 fn main() {
     let worker = spawn Worker(running: true, ticks: 0);
     sleep(150ms);
-    worker.stop();
+    worker.halt();
     sleep(150ms);
     let r = await worker.total();
     match r {
@@ -1673,11 +1673,20 @@ fn main() {
 }
 ```
 
-Here `receive fn stop()` is a user-defined actor message. It is unrelated to the
-`#[on(stop)]` lifecycle hook, which is a plain `fn` invoked when the actor is
-tearing down. The `sleep_loop_blocks_mailbox` lint warns on the mailbox
-starvation shape where a receive handler loops around `sleep`/`sleep_until`
-without an in-loop exit path.
+Here `receive fn halt()` is a user-defined actor message, and it is the flag
+flip, not the actor's death. It is unrelated to the `#[on(stop)]` lifecycle
+hook, which is a plain `fn` invoked when the actor is tearing down. The
+`sleep_loop_blocks_mailbox` lint warns on the mailbox starvation shape where a
+receive handler loops around `sleep`/`sleep_until` without an in-loop exit path.
+
+`stop` is a reserved handler name, so the handler above is `halt`, not `stop`.
+Stopping is a method with one signature: inside the actor, `self.stop()`
+finishes the current handler, runs `#[on(stop)]`, and stops; from outside,
+`pid.stop()` requests the same and returns `()`, doing nothing if the actor has
+already stopped or crashed. A `receive fn stop()` is `E_RESERVED_HANDLER_NAME`,
+whose fix-it is to rename the handler or to call `self.stop()`. The shipped
+compiler still exposes the older free-function `stop(actor)` builtin
+(hew-lang/hew#3193).
 
 ### Accepting connections and reading in a receive handler: use `await`
 
@@ -3636,9 +3645,9 @@ and [`examples/distributed/kv_server.hew`](../examples/distributed/kv_server.hew
 #### Key-backed node identity and peer authentication (native only)
 
 Every distributed node identity is derived from its stable authenticated public
-credential. `Node.load_keys(path)` loads or creates that credential, and
-`Node.identity_key()` returns the public half as lowercase hexadecimal for
-out-of-band exchange.
+credential. `NodeConfig.key` names the file that holds it, `Node.start` loads or
+creates it, and `Node.identity_key()` returns the public half as lowercase
+hexadecimal for out-of-band exchange.
 
 The runtime computes:
 
@@ -3656,39 +3665,55 @@ credential-kind byte is `1` for a TCP Noise static key and `2` for a canonical
 TLS leaf SPKI. Keeping the key preserves the `NodeId`; rotating the key rotates
 the identity.
 
-`Node.allow_peer(route_slot, credential)` binds a peer credential to a
-receiver-local non-zero `u16` route slot. Slot `0` is reserved for local
+`NodeConfig.peers` lists the peer credentials this node will accept, and a
+peer's receiver-local non-zero `u16` route slot is its one-based position in
+that list, so the first entry is slot `1`. Slot `0` is reserved for local
 dispatch. A route slot is only a compact alias inside the configuring process:
 it never becomes the peer's identity and may differ on every node.
 
-Call all identity and pinning operations before `Node.start`:
+Starting a node is one call, and it returns `Result<(), NodeError>`, so a
+refused start stops the program instead of printing and carrying on:
 
 <!-- doctest: skip -->
 
 ```hew
-Node.set_transport("quic-mesh");
-Node.load_keys("node.key");
+var config = NodeConfig.at("0.0.0.0:9000");
+config.transport = "quic-mesh";
+config.key = "node.key";
+config.peers = ["3059301306072a8648ce3d020106082a8648ce3d030107"];
 println(f"pin this credential on peers: {Node.identity_key()}");
 
-// This process chooses local route slot 2 for the peer.
-Node.allow_peer(2, "3059301306072a8648ce3d020106082a8648ce3d030107");
-Node.start("0.0.0.0:9000");
+match Node.start(config) {
+    .Ok(_) => println("node up"),
+    .Err(e) => println(f"node refused: {e}"),
+}
 ```
+
+`Node.set_transport`, `Node.load_keys`, and `Node.allow_peer` are gone: each
+carried one fact that is now a `NodeConfig` field. The shipped compiler still
+has the older call sequence and an untyped `Node.start(addr)`
+(hew-lang/hew#3256).
 
 On TCP, the pinned credential is the peer's 32-byte Noise public key. On
 quic-mesh, it is the peer certificate's canonical SPKI. An unbound or mismatched
 credential is rejected before the peer becomes routable.
 
-A client selects its local pin when connecting:
+A client selects its local pin when connecting. The slot it names is the
+server's position in the client's own `NodeConfig.peers`, so a client that
+lists the server first dials slot `1`:
 
 <!-- doctest: skip -->
 
 ```hew
-Node.connect("2@127.0.0.1:9000");
+match Node.connect("1@127.0.0.1:9000") {
+    .Ok(_) => {},
+    .Err(e) => println(f"dial refused: {e}"),
+}
 ```
 
-The `2@` prefix is the client's route slot for that server. The authenticated
-key, not the numeric prefix, determines the server's `NodeId`.
+The `1@` prefix is the client's route slot for that server, and it is local to
+the client: the same server may sit at a different slot on every node. The
+authenticated key, not the numeric prefix, determines the server's `NodeId`.
 
 Each successful start also advances a durable non-zero session incarnation in
 the key's journal. A same-key restart therefore has the same `NodeId` and a
@@ -3706,6 +3731,14 @@ if the replacement process reuses the same actor slot.
 Registry names are discovery aliases. Repointing a name affects future
 `Node.lookup` calls but does not rewrite or revoke a previously issued
 `RemotePid`.
+
+The registry knows what it holds. `Node.register(name, pid)` returns
+`Result<(), RegisterError>` and records the actor's declaration identity beside
+its location; `Node.lookup<A>(name)` compares that record against `A` and
+answers `Err(LookupError.TypeMismatch)` when they disagree, so the type
+argument on a lookup is checked rather than trusted. `Node.register` is the one
+registration verb: it registers locally whether or not a node has started, and
+publishes cluster-wide once one has.
 
 Remote monitors deliver one typed notification through `#[on(down)]`:
 

--- a/docs/language/actors.hew
+++ b/docs/language/actors.hew
@@ -28,10 +28,12 @@
 //!
 //! `spawn Counter(...)` returns a typed `LocalPid<Counter>`. Calling a
 //! no-result receive function on an unbounded or `overflow block` actor has
-//! type `()`. A `drop_new`, `drop_old`, `fail`, or `coalesce` declaration makes
-//! those sends `Result<(), SendError>`, so loss or rejection is visible at the
-//! call site. A result-bearing receive function creates a request; `await`
-//! yields the `Result`, never the bare reply.
+//! type `()` today. A `drop_new`, `drop_old`, `fail`, or `coalesce` declaration
+//! makes those sends `Result<(), SendError>`, so loss or rejection is visible
+//! at the call site. That split closes: every send widens to
+//! `Result<(), SendError>` so a dead target is reported too (hew-lang/hew#3254,
+//! and "Stopping" below). A result-bearing receive function creates a request;
+//! `await` yields the `Result`, never the bare reply.
 //!
 //! ```hew
 //! actor Sampler {
@@ -53,6 +55,28 @@
 //! Policy-sensitive results cannot be discarded as a bare statement. Handle
 //! them with `match` or `?`; `let _ = sampler.sample(value);` is the explicit
 //! acknowledgement when an application intentionally accepts the loss.
+//!
+//! ## Stopping
+//!
+//! Stopping is a method with one signature. Inside an actor body `self` is the
+//! actor handle, and `self.stop()` finishes the current handler, runs the
+//! `#[on(stop)]` hook, and stops. From outside, `pid.stop()` requests the same
+//! and returns `()`; it is idempotent, so a stop addressed to an actor that
+//! has already stopped or crashed does nothing. `stop` is a reserved handler
+//! name: a user `receive fn stop()` is `E_RESERVED_HANDLER_NAME`, and the
+//! fix-it is to rename the handler or to call `self.stop()`.
+//!
+//! Messages queued behind a stop are dropped, and the drop is disclosed: the
+//! `DOWN` record carries `dropped: n` and the runtime counts the same drops in
+//! `mailbox.dropped_on_stop_total{actor}`. A sender that needs per-message
+//! certainty asks rather than tells. A send that arrives after the stop has
+//! latched, or that addresses a supervised role with no live occupant, is
+//! `Err(SendError.Dead)`: resolution never hands back a dead address, and a
+//! send to one neither traps nor returns `Ok(())`.
+//!
+//! The shipped compiler exposes a free-function `stop(actor)` builtin and a
+//! unit-typed send to a terminal actor that is silently a no-op; the method
+//! surface is hew-lang/hew#3193 and the dead-target shape is hew-lang/hew#3254.
 //!
 //! ## Actor-to-actor dispatch
 //!

--- a/docs/language/concurrency.hew
+++ b/docs/language/concurrency.hew
@@ -34,10 +34,16 @@
 //!
 //! Two placement rules govern where this form is legal today.
 //!
-//! First, `scope { fork ... }` needs a ctx-bearing execution context, so it
-//! belongs in a `receive fn` body or an actor-internal helper. A `fork` written
-//! directly in `fn main` is refused: `fn main` has no execution-context
-//! parameter, so there is no scope owner to attach children to.
+//! First, `scope { fork ... }` suspends, and every suspension point needs an
+//! execution context to park. Every Hew function may suspend and none is
+//! marked as suspending, so the rule is about the context a call runs on, not
+//! about the function it sits in: an actor handler and a task body carry a
+//! coroutine context, and a free function inherits its caller's. `fn main`
+//! gains a context whose park and unpark are the main thread's parker; until
+//! it does, a `fork` written directly in `fn main`, or in a free function
+//! `main` calls, is refused with `E_LIMIT_MAIN_CONTEXT` rather than parked on
+//! a contextless wait. Host the loop in an actor and park `main` on its ask,
+//! or use `join {}` for a fan-out from `main`.
 //!
 //! Second, a statement in a `scope` body that is a bare call is read as a task
 //! spawn, not as an ordinary call. `println(f"{a},{b}")` inside the scope is

--- a/docs/language/supervision.hew
+++ b/docs/language/supervision.hew
@@ -42,3 +42,24 @@
 //! `await_restart supervisor.child` is the blocking restart barrier for a
 //! contextless caller such as `main`; it returns a fresh typed child handle.
 //! Inside an actor, use the normal suspension-aware `await` forms.
+//!
+//! ## Pools
+//!
+//! A `pool` child under `simple_one_for_one` declares several fungible
+//! children from one template, and its arity is a clause rather than an init
+//! field: `pool workers: Worker(value: 7) count: 2;`. The parenthesised list
+//! stays the actor's own field namespace, so an actor that declares a field
+//! named `count` pools like any other. `count:` is required on a `pool` child
+//! and rejected on a `child` declaration.
+//!
+//! The shipped parser still reads `count` out of the parenthesised list, so
+//! `pool workers: Worker(count: 2, value: 7);` is what compiles today; the
+//! clause form is hew-lang/hew#3253.
+//!
+//! ## Dead children
+//!
+//! A supervised role whose occupant is gone resolves closed. `sup.child` keeps
+//! re-resolving the current incarnation, and once the restart budget is spent
+//! a send through the `ChildRef` is `Err(SendError.Dead)` rather than a
+//! successful-looking return. Liveness is reported, never guessed
+//! (hew-lang/hew#3254).

--- a/docs/specs/HEW-DIST-SPEC.md
+++ b/docs/specs/HEW-DIST-SPEC.md
@@ -55,8 +55,11 @@ A route slot is a non-zero `u16` alias local to one receiving node. Slot `0` is
 reserved for local dispatch and MUST NOT be assigned to a peer.
 
 Route slots are not distributed identity and do not appear in `Location`.
-Different nodes MAY assign different route slots to the same peer. APIs that
-accept a route-slot argument, including `Node::allow_peer`, interpret it only in
+Different nodes MAY assign different route slots to the same peer. A route slot
+is assigned by position: the slot a peer occupies is its one-based position in
+the `NodeConfig.peers` vector the local node started with, so the first entry is
+slot `1` and slot `0` stays reserved (§3). APIs that accept a route-slot
+argument, including the `slot@addr` form of `Node.connect`, interpret it only in
 the caller's local routing namespace.
 
 The peer-binding table is one-to-one:
@@ -103,12 +106,39 @@ that already carries a validated location.
 
 ## 3. Stable credentials and peer configuration
 
-`Node::load_keys(path)` loads or creates the stable credential for the selected
-native transport. `Node::identity_key()` returns the corresponding public
-credential as lowercase hexadecimal for out-of-band exchange.
+Node setup is one call. `Node.start(config: NodeConfig) -> Result<(), NodeError>`
+is the only start, and a refusal is an `Err` the caller must handle, never a
+message on stderr under a program that keeps running.
 
-`Node::allow_peer(route_slot, credential_hex)` pins a peer credential to a
-receiver-local route slot. It MUST be called before `Node::start`.
+`NodeConfig` is a prelude record:
+
+```text
+NodeConfig {
+    bind: string,          // listen address
+    transport: string,     // "tcp" | "quic-mesh"
+    key: string,           // path to the stable credential
+    trust: string,         // "pinned"
+    peers: Vec<string>,    // pinned peer credentials, slot = position
+    seeds: Vec<string>     // addresses dialled once at start
+}
+```
+
+`NodeConfig.at(addr)` fills the defaults around a bind address.
+`NodeConfig.load() -> Result<NodeConfig, NodeError>` reads `[cluster]` plus
+`HEW_NODE_*` overrides and is deferred to v0.8.0.
+
+No field is inert. `Node.start` loads or creates the stable credential named by
+`key` for the transport named by `transport`, pins every `peers` entry to the
+route slot that is its one-based position in that vector, dials every `seeds`
+entry once while skipping its own `bind` address, and admits `trust = "pinned"`
+only, returning `Err(NodeError.Config)` for any other value. Re-dial with
+backoff is v0.8.0.
+
+`Node::identity_key()` returns the local public credential as lowercase
+hexadecimal for out-of-band exchange. There is no separate `Node::load_keys`,
+`Node::set_transport`, or `Node::allow_peer`: each carried one fact that is now
+a `NodeConfig` field, and a setup sequence whose steps can be reordered or
+skipped is a second configuration authority.
 
 For TCP, the credential is the peer's 32-byte Noise static public key. For
 quic-mesh, it is the peer certificate's canonical SPKI.
@@ -198,9 +228,23 @@ that authority.
 
 ## 7. Registry and names
 
-`Node::register(name, actor)` publishes the actor's exact `Location`.
-`Node::lookup<T>(name)` returns a typed `RemotePid<T>` discovered through the
-authenticated registry.
+`Node.register(name, pid: LocalPid<A>) -> Result<(), RegisterError>` publishes
+the actor's exact `Location` and records `A`'s declaration identity beside it.
+`Node.lookup<A>(name)` returns a typed `RemotePid<A>` discovered through the
+authenticated registry, and MUST compare the recorded identity against `A`
+before returning one: a disagreement is `Err(LookupError.TypeMismatch)`, never
+a handle. Without that comparison the type argument is the reader's wish and
+the returned handle is an unchecked cast.
+
+`Node.register` is the one registration verb. It registers locally whether or
+not a node has started, and publishes cluster-wide once one has.
+`Node.unregister(name)` withdraws the name. `whereis<A>(name) ->
+Result<LocalPid<A>, LookupError>` is the local view of the same registry and
+performs the same comparison.
+
+At v0.6.0 the declaration identity is recorded and compared on the registering
+node. The gossiped identity rides the wire-version bump, and the cluster-wide
+comparison is v0.8.0.
 
 Names are discovery aliases, not identity:
 
@@ -311,26 +355,41 @@ these surfaces. There is no wasm networking shim and no success-shaped fallback.
 ## 13. Configuration example
 
 Each operator exchanges the output of `Node::identity_key()` out of band and
-assigns the peer any free local route slot:
+lists the peer's credential in `NodeConfig.peers`. A peer's route slot is its
+one-based position in that vector, so the single peer below occupies slot `1`
+and slot `0` stays reserved for local dispatch:
 
 <!-- doctest: skip -->
 ```hew
-Node.set_transport("tcp");
-Node.load_keys("server.key");
+var config = NodeConfig.at("0.0.0.0:9000");
+config.transport = "tcp";
+config.key = "server.key";
+config.peers = ["8f4c...64-hex-digits-total"];
 println(f"pin this credential on peers: {Node.identity_key()}");
 
-// Slot 0 is reserved. Slot 1 is this process's local alias for this peer.
-Node.allow_peer(1, "8f4c...64-hex-digits-total");
-Node.start("0.0.0.0:9000");
+match Node.start(config) {
+    .Ok(_) => println("node up"),
+    .Err(e) => println(f"node refused: {e}"),
+}
 ```
 
 A client that pinned the server at local route slot `1` connects with:
 
 <!-- doctest: skip -->
 ```hew
-Node.connect("1@127.0.0.1:9000");
+match Node.connect("1@127.0.0.1:9000") {
+    .Ok(_) => {},
+    .Err(e) => println(f"dial refused: {e}"),
+}
 let found: Result<RemotePid<Counter>, LookupError> = Node.lookup("counter");
 ```
 
 The route-slot prefix selects the local credential pin. The authenticated key
-derives the peer's `NodeId`; the numeric prefix is never the peer identity.
+derives the peer's `NodeId`; the numeric prefix is never the peer identity. A
+`found` of `Err(LookupError.TypeMismatch)` means the name resolved to an actor
+whose declaration is not `Counter` (§7).
+
+> **Implementation status.** The shipped surface is still the call sequence
+> `Node.set_transport`, `Node.load_keys`, `Node.allow_peer`, `Node.start(addr)`,
+> with an untyped `Node.register` and a `Node.lookup<T>` that compares nothing.
+> Tracked in hew-lang/hew#3256.

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -87,11 +87,40 @@ Rules:
 - Actors do not share mutable state. They communicate by sending **messages**.
 - All actors are isolated by definition in Hew's actor model. No separate `isolated` modifier is needed — isolation is a fundamental property of all actors.
 
+**Stopping an actor (normative).**
+
+Stopping is a method, and it has one signature. Inside an actor body `self`
+is the actor handle, and `self.stop()` finishes the current handler, runs the
+`#[on(stop)]` hook, and stops the actor. From outside, `pid.stop()` on a
+`LocalPid<A>` requests the same stop and returns `()`. It is idempotent: a
+`stop()` addressed to an actor that has already stopped or crashed is a
+no-op, not an error, so a caller that must know whether it was the one to end
+the actor takes a monitor instead. There is no free-function `stop`, and
+`this` is not a receiver token in Hew.
+
+Messages queued behind a stop are dropped, and the drop is disclosed rather
+than silent. The stopped actor's `DOWN` record carries the count as
+`dropped: n`, and the runtime counts the same drops in
+`mailbox.dropped_on_stop_total{actor}`, so a delivery whose send already
+returned `Ok(())` still has a typed event and a series behind it. A sender
+that needs per-message certainty asks rather than tells. A send that arrives
+after the stop has latched reports `SendError.Dead` (§5.6).
+
+`stop` is a reserved handler name. A user-declared `receive fn stop()` is
+`E_RESERVED_HANDLER_NAME`, whose fix-it is to rename the handler or to call
+`self.stop()`.
+
+> **Implementation status.** The shipped compiler registers a free-function
+> `stop(actor)` builtin and rejects both `self.stop()` and `pid.stop()`. The
+> method surface, the reserved-name refusal, and the enumeration of every
+> registered builtin against its lowering target are tracked in
+> hew-lang/hew#3193.
+
 ### 2.1.1 Actor Message Protocol
 
 Actors expose message handlers using `receive fn`. Named actor `receive fn` methods are callable directly — no `.send()` or `.ask()` required.
 
-Named actor `receive fn` methods are called directly — there is no `.send()` or `.ask()` call site. The distinguishing axes are the callee's signature and its actor's declared mailbox policy. A `receive fn` with a return type `R` produces a request-reply call (type `Result<R, AskError>`). A `receive fn` without a return type is fire-and-forget: its call has type `()` for an unbounded mailbox or bounded `block` mailbox, and `Result<(), SendError>` for a `drop_new`, `drop_old`, `fail`, or `coalesce` mailbox. Because `LocalPid<T>` preserves the actor's nominal identity, this policy-sensitive result is visible in the handle's inferred method surface without adding a caller-side send keyword.
+Named actor `receive fn` methods are called directly — there is no `.send()` or `.ask()` call site. The distinguishing axes are the callee's signature and its actor's declared mailbox policy. A `receive fn` with a return type `R` produces a request-reply call (type `Result<R, AskError>`). A `receive fn` without a return type is fire-and-forget: at v0.6.0 its call has type `()` for an unbounded mailbox or bounded `block` mailbox, and `Result<(), SendError>` for a `drop_new`, `drop_old`, `fail`, or `coalesce` mailbox — a split the frozen rule of §5.6 closes by widening every send to `Result<(), SendError>`. Because `LocalPid<T>` preserves the actor's nominal identity, this policy-sensitive result is visible in the handle's inferred method surface without adding a caller-side send keyword.
 
 The token `ask` does not appear at actor call sites. Request-reply against a named actor is written `await <ref>.<method>(<args>)` and has result type `Result<R, AskError>`. Fire-and-forget is written `<ref>.<method>(<args>)` (no `await`) and has the policy-derived type above. `ask` is not lexer-recognised at any position in edition 2026 (reserved for a future syntactic marker; see §4.11.1 and HEW-FUTURE).
 
@@ -118,7 +147,7 @@ actor Counter {
 
 - `receive fn` declares a message handler (entry point for actor messages)
 - `fn` declares a private internal method
-- **`receive fn` without return type** → fire-and-forget. The caller does not use `await`. Unbounded and bounded-`block` calls return `()`; policy-sensitive calls return `Result<(), SendError>` (see *Fire-and-forget delivery*, below).
+- **`receive fn` without return type** → fire-and-forget. The caller does not use `await`. At v0.6.0 unbounded and bounded-`block` calls return `()` and policy-sensitive calls return `Result<(), SendError>`; §5.6's frozen rule widens all four to `Result<(), SendError>` (see *Fire-and-forget delivery*, below).
 - **`receive fn` with return type** → request-response. The call produces `R` and waits for the reply. Inside `select`/`join`, the actor call is treated as an implicit concurrent reply source; writing `await` there is accepted but redundant.
 
 **Calling named actors:**
@@ -179,18 +208,30 @@ and handle type whether the declared policy can lose work:
 - A `fail` mailbox returns `Result<(), SendError>`. Full-mailbox rejection is
   `Err(SendError.Full)` and transfers no message ownership.
 
+That split is the v0.6.0 typing. The frozen dead-target rule of §5.6 widens
+every send to `Result<(), SendError>`, so the `()` rows above become
+`Result<(), SendError>` whose only `Err` inhabitant is `SendError.Dead`; the
+policy rows keep the variants listed here and gain `Dead`. Nothing about the
+`must_use` split below changes with that widening: a discarded
+unbounded-mailbox send stays a warning and a discarded policy-sensitive send
+stays an error (hew-lang/hew#3254).
+
 A bare statement that discards a policy-sensitive result is a compile error.
 The caller MUST handle it with `match` or `?`, or explicitly acknowledge the
 decision with `let _ = target.method(...);`. This explicit discard exists for
 metrics/sampling workloads, but loss can no longer be introduced by changing an
 actor declaration while leaving an ordinary bare send apparently successful.
 
-A unit-typed send to an actor that is already terminal — stopped or crashed —
-is a **no-op**: nothing is enqueued, the payload is released at the send site,
-and the caller continues. Sending is not a liveness test for this lossless
-surface. A policy-sensitive send instead reports `Err(SendError.Closed)`,
-because its result already exists to state whether this particular delivery
-completed. Other unit-surface runtime failures trap the sender.
+A send to an actor that is already terminal — stopped or crashed — is not a
+no-op and does not trap. It reports `Err(SendError.Dead)`; §5.6 gives the rule
+in full, including the `must_use` split that keeps statement-position sends
+compiling. Nothing is enqueued and the payload is released at the send site,
+but the caller is told. Other unit-surface runtime failures trap the sender.
+
+> **Implementation status.** Today a unit-typed send to a terminal actor is a
+> silent no-op and a policy-sensitive send reports `Err(SendError.Closed)`. The
+> `Dead` shape and the widened send type land with the v0.7.0 mechanism
+> (hew-lang/hew#3254).
 
 Named-actor request-response uses `await` on the receive method (see §2.1.4); an
 `ask` of a terminal actor is NOT a no-op — it yields `Err`, because the caller
@@ -3349,6 +3390,25 @@ Task<T>
 > yet accepted. Each of these refuses with a named diagnostic rather than
 > miscompiling.
 
+> **Execution context (normative).** Every Hew function may suspend. There is
+> no suspending-function colour: a function is never marked as one, and a
+> `scope { fork .. }` block is legal wherever a statement is legal, `fn main`
+> included. What carries the difference is the execution context the call
+> runs on. `fn main` runs on the process main thread with an
+> `ExecutionContext` whose park and unpark are that thread's parker; an actor
+> handler keeps its coroutine context; a free function inherits its caller's
+> context, so the same helper suspends one way when an actor calls it and
+> another way when `main` does. One mechanism serves every awaitable, so a
+> new awaitable is a new readiness source rather than a new lowering.
+>
+> At v0.6.0 `main` has no execution context yet. A suspension point (§4.3)
+> reached from `main`, or from a free function `main` calls, is refused with
+> `E_LIMIT_MAIN_CONTEXT` (Limitation, exit 3) rather than parked on a
+> contextless wait. The refusal names the two shapes that work today: host the
+> request loop in an actor and park `main` on its ask, or use `join {}` for a
+> fan-out from `main`. The context lands at v0.7.0 (hew-lang/hew#3195,
+> hew-lang/hew#3196).
+
 A `scope` block creates a structured concurrency boundary. All child tasks
 forked within the block must complete before the block returns.
 
@@ -3504,6 +3564,22 @@ A child task MUST yield at:
 - IO operations — cancellation is observed at the syscall boundary.
 
 Yield points are also where cooperative cancellation is delivered (§4.5).
+
+**Suspension points (normative):**
+
+The suspension points of the language are a closed set: `await expr`,
+`await expr | after d`, `select`, a `scope { fork .. }` block, an
+`after(d) { }` scope deadline, a channel `recv`, a stream `recv`, a listener
+`accept`, and `sleep`. Each one suspends the execution context of the
+function it appears in (§4.2), and each one is legal in any function. In an
+actor handler, a task body, or a closure, the coroutine frame yields to the
+scheduler and the readiness source resumes it. In `fn main` the process main
+thread parks, and the reactor, the timer wheel, or a mailbox unparks it; no
+Hew scheduler worker waits on an OS condition variable on either path.
+
+At v0.6.0 only the coroutine half of that rule is implemented. Every
+suspension point in the set above is accepted in a suspendable context and
+refused with `E_LIMIT_MAIN_CONTEXT` when it is reached from `main` (§4.2).
 
 ### 4.4 Awaiting Tasks
 
@@ -4136,18 +4212,37 @@ supervisor MyPool {
 
 - `child <name>: <ActorType>(<field>: <expr>, ...)` — a static supervised child.
   Init args are named (positional args are rejected with a migration diagnostic).
-- `pool <name>: <ActorType>(...)` — a dynamic pool child (only under
-  `simple_one_for_one`); the args are the per-spawn template.
-- Optional per-child suffix clauses, accepted in any order:
-  - `restart: permanent | transient | temporary` (default `permanent`). This is
-    the only restart spelling — bare `T permanent` and `with restart:` are not
-    accepted.
-  - `shutdown: <duration> | brutal_kill | infinity` — the graceful-stop
-    deadline (default `5s`). `infinity` is accepted but not yet enforced (no
-    per-child deadline wheel).
-  - `wired_to: { <param>: <sibling>, ... }` — passes a sibling child's handle to
-    this child's init param.
+- `pool <name>: <ActorType>(<field>: <expr>, ...) count: <N>;` — a pool of `N`
+  fungible children (only under `simple_one_for_one`). The parenthesised args
+  are the per-spawn template, exactly as for `child`; `count:` is the arity.
+- Per-child suffix clauses, accepted in any order:
+  - `restart: permanent | transient | temporary` (optional, default
+    `permanent`). This is the only restart spelling — bare `T permanent` and
+    `with restart:` are not accepted.
+  - `shutdown: <duration> | brutal_kill | infinity` (optional) — the
+    graceful-stop deadline (default `5s`). `infinity` is accepted but not yet
+    enforced (no per-child deadline wheel).
+  - `count: <N>` — pool arity. Required on a `pool` child, rejected on a
+    `child` declaration; it has no default, because a pool with a guessed size
+    is a guess about capacity.
+  - `wired_to: { <param>: <sibling>, ... }` (optional) — passes a sibling
+    child's handle to this child's init param.
 - Child actor types must be declared before the supervisor.
+
+**Pool arity is a clause, not an init field (normative).** `count:` sits
+beside `restart:` and `shutdown:` in the child's clause namespace, and the
+parenthesised argument list stays the actor's own field namespace. An actor
+that happens to declare a field named `count` is therefore poolable like any
+other, and its `count` field is set the same way every other field is. The
+two namespaces never collide, so no diagnostic about pool arity can land on a
+user's field.
+
+> **Implementation status.** The shipped parser reads `count` out of the
+> parenthesised list as an init field, so `pool ws: A(count: N, ..)` is what
+> compiles today and the clause form is refused with
+> `unknown supervisor field`. The migration is a fix-it —
+> `pool ws: A(count: N, ..)` becomes `pool ws: A(..) count: N;` — tracked in
+> hew-lang/hew#3253.
 
 ### 5.2 Restart Semantics (normative)
 
@@ -4235,6 +4330,37 @@ fn main() {
   match one of the `child` declarations in the supervisor definition.
 - `supervisor_stop(sup)` — gracefully stops the supervisor and all its children
 
+**A dead target has one shape (normative).**
+
+Resolution never hands back a dead address. A supervised role whose occupant is
+gone resolves closed, not open: a `ChildRef` send reports `Dead`,
+`whereis(name)` is `None`, and `Node.lookup(name)` is
+`Err(LookupError.NotFound)`. A `ChildRef` re-resolves the current incarnation
+on every ask or tell precisely so that this is decidable at the call and not
+guessed from a stale address.
+
+A handle that is already held reports the same fact at the send. Every send
+expression has type `Result<(), SendError>`. For an unbounded mailbox the only
+inhabitant of `Err` is `SendError.Dead`; for a bounded or policy-sensitive
+mailbox `Dead` joins the policy variants of §9.3. A send to a dead target never
+traps, and it never returns `Ok(())`.
+
+Discarding that result is the `must_use` split of §2.1.1, unchanged: a
+discarded unbounded-mailbox send is a warning, and a discarded
+policy-sensitive send is an error. Statement-position sends therefore keep
+compiling, and the warning is what tells an author that liveness has become
+visible where it was silent before.
+
+`AskError` carries `Dead` and `StaleRef` for the same reason, so a remote ask's
+failure kinds are one enum rather than a split between the ask path and the
+send path.
+
+> **Implementation status.** Today an unbounded send is unit-typed, `SendError`
+> spells the closed case `Closed`, and a send to a supervised child whose
+> restart budget is exhausted returns normally from `main` and from an actor
+> holding a `ChildRef`. The `Dead` shape lands with the v0.7.0 mechanism and is
+> tracked in hew-lang/hew#3254.
+
 ### 5.7 Crash Isolation
 
 On native unwind-capable targets, language-level actor panics unwind through the
@@ -4261,6 +4387,34 @@ spawning thread with no recovery frame beneath it; a panic there is
 process-fatal without cleanup, and the OS reclaims what is left.
 
 The `panic()` builtin triggers the recoverable language-panic path for testing.
+
+#### 5.7.1 Links and Monitors
+
+`link(pid) -> Result<(), LinkError>` and
+`monitor(pid) -> Result<MonitorRef, LinkError>` subscribe the caller to another
+actor's exit. Both report failure in the type system, and both share one error
+type. `LinkError` has three inhabitants — `Dead`, `Partition`, and `NoContext`
+— and they cover local and remote pids alike: a cross-node link carries a
+`PartitionPolicy`, so the remote form needs the typed failure as much as the
+local one does. `monitor` on an already-dead pid is not a failure; it delivers
+`DOWN` at once, which leaves `NoContext` as its only `Err`.
+
+Both are actor-context operations, because only an actor can receive the `DOWN`
+record or the linked exit the call subscribes to. A `link` or `monitor` written
+directly in `main` is `E_ACTOR_CONTEXT_REQUIRED`, refused at compile time. The
+same call reached through a free function that `main` happens to call is the
+same fact decided at run time: `Err(LinkError.NoContext)`. It is decided at run
+time deliberately — the execution context is dynamic (§4.2), and a static
+"actor-only function" marker would colour every function that might one day
+link. Neither form succeeds silently, which is the property that matters: a
+subscription with no reader is always reported.
+
+> **Implementation status.** Today `LinkError` carries ten variants and names
+> the missing context `NoCurrentActor`, `monitor` returns
+> `Result<MonitorRef, MonitorError>`, and a `link` reached through a free
+> function called from `main` succeeds and prints. The `Dead` arm is never
+> produced until dead-target resolution lands (§5.6). Tracked in
+> hew-lang/hew#3255.
 
 ### 5.8 Process Exit Status (normative)
 
@@ -5109,6 +5263,11 @@ Actors start `Idle` after spawn. There is no separate `Blocked` state — actors
 for messages are `Idle` (or `Suspended` during a cooperative suspension) and become
 `Runnable` when a message arrives.
 
+The `Running ──► Stopping` edge has exactly two sources: the supervisor, and
+the actor's own `self.stop()`. `pid.stop()` from outside requests the same
+edge; because `Stopped` and `Crashed` are terminal, a request that arrives
+once the actor is already there changes nothing and returns `()` (§2.1).
+
 **Key distinctions from task states (§4.1):**
 
 | Aspect          | Actor State Machine                                                        | Task State Machine (§4.1)                     |
@@ -5244,7 +5403,7 @@ Transitions:
 
 For a bounded actor mailbox with capacity `N`:
 
-States: `HasSpace`, `Full`, `Closed`
+States: `HasSpace`, `Full`, `Closed`, `Dead`
 
 Events:
 
@@ -5264,6 +5423,13 @@ Behaviour:
   - `coalesce(field_name)`: replace existing work or apply a non-blocking
     fallback, reporting every discard/replacement as `SendError.MessageLost`
     (see §6.3 for full semantics).
+- `Dead` is terminal and is reached whenever the destination actor has stopped
+  or crashed, or the supervised role addressed has no live occupant. Every send
+  to a `Dead` target returns `Err(SendError.Dead)`, whatever the mailbox
+  capacity or overflow policy: the policy table above decides only what a live
+  mailbox does with a message it cannot hold, and is never consulted for a
+  target that cannot receive at all (§5.6). An unbounded mailbox has no `Full`
+  state, so `Dead` is the only `Err` a send to it can produce.
 
 **Coalesce syntax example:**
 
@@ -5298,6 +5464,37 @@ runtime mode when a Hew program runs as a cluster node. The normative
 specification is [`HEW-DIST-SPEC.md`](./HEW-DIST-SPEC.md); this section
 summarises what is shipped and stable.
 
+**Node setup (normative).** Starting a node is one call, and it reports failure
+in the type system:
+
+- `Node.start(config: NodeConfig) -> Result<(), NodeError>` is the only start.
+  `NodeConfig { bind: string, transport: string, key: string, trust: string,
+  peers: Vec<string>, seeds: Vec<string> }` is a prelude record, and
+  `NodeConfig.at(addr)` fills the defaults around a bind address. No field is
+  inert: `Node.start` pins every `peers` entry — the slot a peer occupies is
+  its one-based position in that vector, so slot `0` stays reserved for local
+  dispatch — dials every `seeds` entry once while skipping its
+  own bind address, and admits `trust = "pinned"` only, answering
+  `Err(NodeError.Config)` for anything else.
+- `Node.set_transport`, `Node.load_keys`, and `Node.allow_peer` do not exist.
+  Each carried one fact that is a field of `NodeConfig`, and a setup sequence
+  whose steps can be reordered or skipped is a second configuration authority.
+- `Node.connect(addr) -> Result<(), NodeError>` stays for explicit dials.
+  `Node.shutdown()` stays `()`.
+
+**The registry knows the actor's type (normative).**
+`Node.register(name, pid: LocalPid<A>) -> Result<(), RegisterError>` records
+`A`'s declaration identity beside the location, and `Node.lookup<A>(name)`
+compares the two, answering `Err(LookupError.TypeMismatch)` when they
+disagree. Without that record a lookup's type argument is the reader's wish and
+the handle it produces is an unchecked cast.
+
+`Node.register` is the one registration verb: it registers locally whether or
+not a node has started, and publishes cluster-wide once one has.
+`Node.unregister(name)` withdraws the name. `whereis<A>(name) ->
+Result<LocalPid<A>, LookupError>` is the local view of the same registry, and
+carries the same identity comparison.
+
 **Shipped cross-node surface:**
 
 - Remote `send` and `ask` (`<- actor.method()` / `<id> from actor.method()`)
@@ -5316,6 +5513,17 @@ Authentication tokens and supervisor-capability enforcement are not yet
 runtime-enforced; see `HEW-DIST-SPEC.md` §rc1-notes for the current
 status. The SWIM quarantine/readmission surface is stable and in the
 proving gate.
+
+> **Implementation status.** The shipped surface is still the call sequence:
+> `Node.set_transport`, `Node.load_keys`, `Node.allow_peer`, then
+> `Node.start(addr)`, whose refusal prints to stderr and lets the program run
+> on; `Node.register` returns `i32`; `Node.lookup<T>` is registered with `T`
+> free and the registry entry is name to location, so no identity is compared;
+> and `Node.unregister` is hand-declared `extern "C"` where it is used.
+> `NodeConfig`, `NodeError`, `RegisterError`, and `LookupError.TypeMismatch`
+> are tracked in hew-lang/hew#3256. At v0.6.0 the declaration identity is
+> recorded and compared on the registering node; the gossiped identity rides
+> the wire-version bump, and the cluster-wide comparison is v0.8.0.
 
 ---
 
@@ -5518,6 +5726,14 @@ Duration values are required for timeout expressions (`| after`) and `select` ti
 ```hew
 let result = await task | after 5s;        // Timeout after 5 seconds
 ```
+
+`await task | after 5s` is a suspension point (§4.3), so the rule that governs
+it is the execution-context rule of §4.2 and not a rule about `after` itself:
+it is legal in any function, and it parks whichever context the call runs on.
+At v0.6.0 that context exists only inside an actor handler, a task body, or a
+closure; written in `main`, or in a free function `main` calls, the deadline
+form is `E_LIMIT_MAIN_CONTEXT` until `main` gains its execution context at
+v0.7.0.
 
 ```ebnf
 DurationLit = IntLit ("ns" | "us" | "ms" | "s" | "m" | "h") ;

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -211,22 +211,22 @@ and handle type whether the declared policy can lose work:
 That split is the v0.6.0 typing. The frozen dead-target rule of §5.6 widens
 every send to `Result<(), SendError>`, so the `()` rows above become
 `Result<(), SendError>` whose only `Err` inhabitant is `SendError.Dead`; the
-policy rows keep the variants listed here and gain `Dead`. Nothing about the
-`must_use` split below changes with that widening: a discarded
-unbounded-mailbox send stays a warning and a discarded policy-sensitive send
-stays an error (hew-lang/hew#3254).
+policy rows keep the variants listed here and gain `Dead`. A statement-position
+send or ask whose `Result` is discarded is `E_SEND_RESULT_DROPPED`, a compile
+error; there is no `must_use` lint tier below that widening (hew-lang/hew#3254).
 
-A bare statement that discards a policy-sensitive result is a compile error.
-The caller MUST handle it with `match` or `?`, or explicitly acknowledge the
-decision with `let _ = target.method(...);`. This explicit discard exists for
-metrics/sampling workloads, but loss can no longer be introduced by changing an
-actor declaration while leaving an ordinary bare send apparently successful.
+A bare statement that discards any send or ask result is
+`E_SEND_RESULT_DROPPED`, a compile error. The caller MUST handle it with
+`match` or `?`, or explicitly acknowledge the decision with the fix-it
+`_ = pid.m();`. This explicit discard exists for metrics/sampling workloads,
+but loss can no longer be introduced by changing an actor declaration while
+leaving an ordinary bare send apparently successful.
 
 A send to an actor that is already terminal — stopped or crashed — is not a
-no-op and does not trap. It reports `Err(SendError.Dead)`; §5.6 gives the rule
-in full, including the `must_use` split that keeps statement-position sends
-compiling. Nothing is enqueued and the payload is released at the send site,
-but the caller is told. Other unit-surface runtime failures trap the sender.
+no-op and does not trap. It reports `Err(SendError.Dead)`, the value a send to
+a dead target returns; §5.6 gives the `E_SEND_RESULT_DROPPED` rule in full.
+Nothing is enqueued and the payload is released at the send site, but the
+caller is told. Other unit-surface runtime failures trap the sender.
 
 > **Implementation status.** Today a unit-typed send to a terminal actor is a
 > silent no-op and a policy-sensitive send reports `Err(SendError.Closed)`. The
@@ -4345,11 +4345,11 @@ inhabitant of `Err` is `SendError.Dead`; for a bounded or policy-sensitive
 mailbox `Dead` joins the policy variants of §9.3. A send to a dead target never
 traps, and it never returns `Ok(())`.
 
-Discarding that result is the `must_use` split of §2.1.1, unchanged: a
-discarded unbounded-mailbox send is a warning, and a discarded
-policy-sensitive send is an error. Statement-position sends therefore keep
-compiling, and the warning is what tells an author that liveness has become
-visible where it was silent before.
+Discarding that result is `E_SEND_RESULT_DROPPED`, a compile error, matching
+§2.1.1: a statement-position send or ask whose `Result` is discarded is an
+error, with the fix-it `_ = pid.m()`. There is no `must_use` lint tier — the
+rule is the same for an unbounded mailbox and a policy-sensitive one, because
+both can now report `Dead`.
 
 `AskError` carries `Dead` and `StaleRef` for the same reason, so a remote ask's
 failure kinds are one enum rather than a split between the ask path and the

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -85,8 +85,8 @@
 # guide-0107 was removed 2026-06-23: std::string.from_int fence now passes;
 # the NYI label was stale (fence renumbered as guide grew).
 
-guide-0153   4278824673   # SURFACE-PENDING: `close(consume self)` — the parser still spells the consuming receiver `consuming self` (#3257)
-guide-0154   144626557   # SURFACE-PENDING: `commit`/`rollback(consume self)` — same receiver spelling (#3257)
+guide-0154   4278824673   # SURFACE-PENDING: `close(consume self)` — the parser still spells the consuming receiver `consuming self` (#3257)
+guide-0155   144626557   # SURFACE-PENDING: `commit`/`rollback(consume self)` — same receiver spelling (#3257)
 
 
 # ─── Spec failures (86) ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Six of the ratified v0.6.0 surface decisions govern actors, the runtime, and
the distributed node, and none of them was written down. The spec still said an
actor enters `Stopping` through a bare `stop()`, that a send to a terminal actor
is a silent no-op, that pool arity is an init field, and that starting a node is
a sequence of untyped calls whose refusal prints to stderr. Those are the
fail-open readings the decisions replace, and a reader who follows the spec today
writes the surface that is going away.

## What

- **§2.1, §9.1 (D10, A379)**: stop is a method with one signature. `self.stop()`
  inside the actor, `pid.stop()` from outside returning `()` and idempotent on
  an actor that has already stopped or crashed. `stop` becomes a reserved
  handler name (`E_RESERVED_HANDLER_NAME`). Messages queued behind a stop are
  dropped and the drop is disclosed through the `DOWN` record's `dropped: n`
  and `mailbox.dropped_on_stop_total{actor}`. The §9.1 transition line names
  `self.stop()` as the second source of the `Running` to `Stopping` edge.
- **§4.2, §4.3, §12.3 (D9, A372)**: every function may suspend and none is
  marked as suspending; what differs is the execution context the call runs on.
  §4.3 gains a closed suspension-point set, and the v0.6.0 refusal from `main`
  is `E_LIMIT_MAIN_CONTEXT` with the two shapes that work today named in it.
- **§2.1.1, §5.6, §9.3 (D11, A365)**: resolution never hands back a dead
  address, and a held handle reports the fact at the send as
  `Err(SendError.Dead)` under the existing must_use split. `Dead` joins the
  mailbox send state machine as a terminal state the policy table is never
  consulted for. §2.1.1's typing lines now say which half is the v0.6.0 typing
  and which is the frozen rule, so the two sections agree.
- **§5.7.1 (D12)**: `link` and `monitor` share one typed error with three
  inhabitants and are actor-context only. Direct from `main` is
  `E_ACTOR_CONTEXT_REQUIRED`; through a free function it is
  `Err(LinkError.NoContext)` decided at run time, because the execution context
  is dynamic and a static actor-only marker would be colouring.
- **§5.1 (D13)**: pool arity is a `count:` child clause beside `restart:` and
  `shutdown:`, so the parenthesised list stays the actor's field namespace and
  an actor with a field named `count` pools like any other.
- **§11, HEW-DIST-SPEC §2.2, §3, §7, §13 (D23)**: node setup is
  `Node.start(NodeConfig) -> Result<(), NodeError>`, `set_transport` /
  `load_keys` / `allow_peer` are gone into `NodeConfig` fields, a peer's route
  slot is its index in `NodeConfig.peers`, and the registry records the actor's
  declaration identity so `Node.lookup<A>` compares rather than casts
  (`RegisterError`, `LookupError.TypeMismatch`).
- **guide and `docs/language/`**: the cancellable-worker example renames its
  handler off the reserved `stop`, the actors and supervision modules gain the
  stop, dead-target, and pool-clause rules, the concurrency module names
  `E_LIMIT_MAIN_CONTEXT` instead of describing `main` as lacking a parameter,
  and the distributed chapter builds a `NodeConfig`.

Every rule the shipped compiler does not accept carries an
implementation-status note naming its tracking issue: #3193 (D10, with the
A379 scope recorded on it), #3195 and #3196 (D9), #3254 (D11), #3255 (D12),
#3253 (D13), #3256 (D23). No compiler code changes.

## Test

`make test-doc-examples` and `make hew-check-all` pass with the same extracted
fence set and the same expected-failure set as the branch point, so no fence
was added, removed, or newly broken and no expected-failures entry was needed:
the new surface appears only in fences already marked `<!-- doctest: skip -->`
and in `HEW-DIST-SPEC.md`, which the harness does not scan.
`make doc-ratchet-selftest` passes. The three refusals the status notes claim
were reproduced against the branch's own build before the notes were written:
`self.stop()` / `pid.stop()`, `pool ws: A(..) count: N;`, and
`NodeConfig.at(..)`.

Decisions D9, D10, D11, D12, D13, D23; ledger A365, A372, A379.
