### PR TITLE
fix(types): exempt a library unit's pub fns from dead_code

### DIFF
--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -119,12 +119,27 @@ impl Checker {
                 is_pub,
             ));
         }
+        // A root module with no `fn main` cannot link as a binary, so it is
+        // a library unit: every `pub fn` in it is public API for another
+        // crate/module to call, not dead code from this compilation unit's
+        // point of view. Reuses the same root lookup the BFS above tests
+        // `main` with (`root_owned_fn_leaf`), so "library" and "has no root
+        // main" stay one fact instead of two derivations of it.
+        let has_root_main = self
+            .fn_def_spans
+            .keys()
+            .any(|fn_name| self.root_owned_fn_leaf(fn_name) == Some("main"));
+        let library_unit = !self.repl_fragment && !has_root_main;
+
         // Route through the lint registry so `dead_code` is configurable
         // (`-A/-W/-D`) and suppressible (`// hew:allow(dead_code)`). The
         // collect-then-emit split releases the `&self.fn_def_spans` borrow
         // before the `&mut self` emit calls. Default level is `Warn`, so the
         // warning still appears exactly as before unless reconfigured.
         for (def_span, fn_name, stored_module, is_pub) in findings {
+            if is_pub && library_unit {
+                continue;
+            }
             // An unreferenced `pub fn` is dead only from THIS compilation
             // unit's point of view — it is public API another crate/module
             // may call. `_`-prefixing it would rename the public surface

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -2685,6 +2685,23 @@ fn dead_code_library_unit_exempts_pub_fn() {
 }
 
 #[test]
+fn dead_code_binary_unit_still_reports_pub_fn() {
+    // Negative control for `dead_code_library_unit_exempts_pub_fn`: the same
+    // two functions plus a root `fn main` make this a binary unit, so both
+    // the pub and private unused functions are still reported.
+    let source = "pub fn a() -> i32 { 1 } fn b() -> i32 { 2 } fn main() {}";
+    let result = hew_parser::parse(source);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert_eq!(
+        count_dead_code(&output.warnings),
+        2,
+        "expected two dead_code warnings (`a` and `b`) once `main` makes this a binary unit, got: {:?}",
+        output.warnings
+    );
+}
+
+#[test]
 fn no_warn_dead_code_main() {
     let source = "fn main() { println(1); }";
     let result = hew_parser::parse(source);

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -2651,6 +2651,40 @@ fn dead_code_private_fn_still_suggests_underscore() {
 }
 
 #[test]
+fn dead_code_library_unit_exempts_pub_fn() {
+    // #3273: a compilation unit whose root module declares no `fn main`
+    // cannot link as a binary, so it is a library unit — its `pub fn`s
+    // are public API, not dead code from this unit's point of view.
+    // Only the private `b` should still be reported.
+    let source = "pub fn a() -> i32 { 1 } fn b() -> i32 { 2 }";
+    let result = hew_parser::parse(source);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert_eq!(
+        count_dead_code(&output.warnings),
+        1,
+        "expected exactly one dead_code warning (for `b`), got: {:?}",
+        output.warnings
+    );
+    assert!(
+        output
+            .warnings
+            .iter()
+            .any(|w| w.kind == TypeErrorKind::Lint(LintId::DeadCode) && w.message.contains("`b`")),
+        "expected the dead_code warning to name `b`: {:?}",
+        output.warnings
+    );
+    assert!(
+        !output
+            .warnings
+            .iter()
+            .any(|w| w.kind == TypeErrorKind::Lint(LintId::DeadCode) && w.message.contains("`a`")),
+        "a library unit's pub fn must not be reported dead_code: {:?}",
+        output.warnings
+    );
+}
+
+#[test]
 fn no_warn_dead_code_main() {
     let source = "fn main() { println(1); }";
     let result = hew_parser::parse(source);


### PR DESCRIPTION
## Why

`dead_code` fires on a `pub fn` of a compilation unit that is a library, not a program entry point — the checker's own help text ("suppress with `-A dead_code`") already admits it knows the fn is public API, but warns anyway. A root module with no `fn main` cannot link as a binary, so it is a library unit by construction: nothing is misclassified by treating it as one.

## What

- `emit_dead_code_warnings` (`hew-types/src/check/diagnostics.rs`) now computes `library_unit` once, before the findings loop, by checking whether any root-owned fn is named `main` (the same `root_owned_fn_leaf` lookup the reachability BFS already uses to recognize `main`). When the unit is a library, `pub` findings are skipped; private functions keep firing as before, and a unit with `fn main` is unaffected.
- No new lint id, no manifest field, no second dead-code pass — the lint id, level, and suppression machinery (`-A/-W/-D`, `// hew:allow(dead_code)`) are unchanged.

## Test

- `dead_code_library_unit_exempts_pub_fn`: a two-fn unit (`pub fn a()`, `fn b()`, no `main`) reports exactly one `dead_code`, for `b`.
- `dead_code_binary_unit_still_reports_pub_fn` (negative control): the same unit plus `fn main() {}` reports two.
- Manual negative control: with the `library_unit` guard removed, `dead_code_library_unit_exempts_pub_fn` goes red while `no_warn_dead_code_main` stays green.
- Reproduced the issue's own commands against this branch's build:
  - `hew check /tmp/pkgtest/mylib.hew` (a `pub fn helper()`, no `main`): warned before, `OK` after.
  - A copy of `std/fs.hew` checked outside the bundled std path: before, every `pub fn` warned as dead code (including `delete` and `io_error_from_errno`, named in the issue); after, only the pre-existing private `last_io_error` warns. That file also raises an unrelated `E_HIR: ResourceBoundaryParamMustConsume` on an FFI boundary — outside this fix's scope, pre-existing to checking any resource-holding module outside its own package.

Fixes #3273
