### PR TITLE
ci: make macOS and Windows PR legs informational

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,6 +506,13 @@ jobs:
     name: Build & test (Windows)
     runs-on: windows-2022
     timeout-minutes: 60
+    # Informational on pull requests until V060-RELEASE (#3236): Windows CI is
+    # flaky enough that a red leg here is not reliably the PR's own fault, and
+    # required-check policy narrowed to Clippy & format + Build & test (Linux).
+    # Stays blocking on push-to-main (this job still gates a red main) and on
+    # release-gate.yml, which defines its own jobs and does not read this
+    # continue-on-error.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     env:
       # aws-lc-sys (rustls under hew-runtime, jsonwebtoken under hew-lib) wants
       # NASM on windows-msvc; the documented escape consumes the crate's
@@ -667,6 +674,13 @@ jobs:
     name: Build & test (macOS arm64)
     runs-on: macos-14
     timeout-minutes: 60
+    # Informational on pull requests until V060-RELEASE (#3222): macOS CI is
+    # flaky enough that a red leg here is not reliably the PR's own fault, and
+    # required-check policy narrowed to Clippy & format + Build & test (Linux).
+    # Stays blocking on push-to-main (this job still gates a red main) and on
+    # release-gate.yml, which defines its own jobs and does not read this
+    # continue-on-error.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 


### PR DESCRIPTION
## Why

D351/D352 narrow required-check policy to `Clippy & format` and `Build & test
(Linux)` so PRs merge with `gh pr merge --squash --auto` on green, retiring
the ID-diff protocol used to adjudicate whether a red macOS or Windows leg was
a PR's own fault. That policy needs main's known-failure ratchets to actually
match current reality, and needs the informational-on-PR behaviour encoded in
the workflow rather than left to reviewer judgement.

## What

- Audited every ratchet-consuming gate against the latest green push-to-main
  run (7c14903, run 33694567649, all jobs `success`): `nextest-expected-failures.tsv`
  (linux 38 / macos 21 / windows 4 known non-pass outcomes matched),
  `hew-corpus-expected-failures.txt` (163 tracked, exact match),
  `doc-test-expected-failures.txt` (exact match, no recoveries),
  `tests/vertical-slice` accept corpus (85 tracked, exact match), and
  `tests/fuzz-oracle/expected-failures.txt` (777 combined vertical-slice +
  regression files, 77 non-clean, all pinned, no `NOW-PASSES`). None of the
  five carried a stale (recovered) row, so no ratchet file changes in this PR.
- `.github/workflows/ci.yml`: `Build & test (macOS arm64)` and
  `Build & test (Windows)` get `continue-on-error: ${{ github.event_name ==
  'pull_request' }}` — informational on pull requests, still blocking on
  push-to-main and on `release-gate.yml` (which defines its own jobs and
  never reads this workflow). Comment on each job names #3222 (Windows) /
  #3236 (macOS) and "until V060-RELEASE".

## Test

- `make actionlint` — workflow syntax and expression check, clean.
- `make hew-native`, `make test-vertical-slice`, `make test-doc-examples`,
  `make hew-check-all`, `make fuzz-oracle`, `make sandbox-parity`,
  `make asan-fixtures`, `make test` in the worktree, each ratchet gate
  reporting its expected set matched.
- Real effect of the `continue-on-error` change is only observable in GitHub
  Actions; this PR's own CI run is the verification for that part.

## Notes

- The many `macos`-scoped `*_leak_oracle` rows in `nextest-expected-failures.tsv`
  (`under_malloc_scribble` / `leak_slope_below_tolerance` names) don't appear
  in this workflow's `Build & test (macOS arm64)` nextest run at all (0 hits
  in the job log) — they run under a different gate this PR doesn't exercise
  (sanitizer/leak-oracle build), so their current state is unverified here and
  untouched.
- `freebsd`-scoped rows have no leg in `ci.yml` at all and are likewise
  unverified/untouched by this PR.
- Ledger D352 states GitHub branch protection "now requires only 'Clippy &
  format' and 'Build & test (Linux)'"; the live ruleset (`Protect main`, id
  13115582) still lists all four `Build & test (*)` contexts as required.
  That's a GitHub setting slepp changes directly, not something this PR's
  files control — flagging the gap rather than acting on it.
