### PR TITLE
test(e2e): pin the actor-state stream for-await ownership limit from #3218

### DIFF
--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -72,6 +72,13 @@
 #       through its descriptor clone thunk, drops both Vecs, and explicitly
 #       closes the paired Receiver. An under-retained clone or duplicate close
 #       is an ASan failure; a missing sender-slot release is an LSan failure.
+#   actor-state stream for-await ownership (#3218, KNOWN v0.6.0 limit)
+#       A `for await` loop over an actor-state `Stream<T>` field. Loop
+#       exhaustion mints a second close authority for the cursor while the
+#       field's own state-drop close authority stays intact, so the runtime
+#       stream pointer is closed twice at teardown. Registered through
+#       `run_asan_fixture_expect_leak` as an EXPECTED finding rather than a
+#       zero-findings probe; flip it once P1-L3/P1-L5 land.
 #
 # SHIM: Linux-only gate.  On macOS the leak oracle is the `leaks --atExit`
 # path in hew-cli/tests/*_leak_oracle.rs; ASan + LSan on Darwin does not
@@ -413,6 +420,12 @@ ENUM_PAYLOAD_LOOP_SRC="${ROOT}/tests/vertical-slice/accept/enum_payload_call_loo
 CALL_SCRUTINEE_FRESH_SRC="${ROOT}/tests/vertical-slice/accept/call_scrutinee_fresh_forwarder_release.hew"
 ENUM_RESOURCE_MATCH_SRC="${ROOT}/tests/vertical-slice/accept/enum_resource_heap_sibling_asan.hew"
 ENUM_RESOURCE_STATE_SRC="${ROOT}/tests/vertical-slice/accept/enum_resource_state_overwrite_asan.hew"
+# Actor-state stream for-await ownership (#3218, KNOWN v0.6.0 limit): a
+# `for await` loop draining an actor-state `Stream<T>` field double-closes the
+# stream at teardown on the current lowerer, so this is registered below as an
+# EXPECTED ASan finding via `run_asan_fixture_expect_leak`. Flip it to
+# `compile_asan_fixture` + `run_asan_fixture ... 0` once #3218 is fixed.
+STREAM_STATE_FIELD_FOR_AWAIT_SRC="${ROOT}/tests/vertical-slice/accept/stream_state_field_for_await_asan.hew"
 # Owned-Vec element-store temp-leak (Linux arm of vec_push_temp_leak_oracle.rs):
 # a fresh unbound aggregate rvalue used as a `Vec::push` / `Vec::set` element
 # source is routed to the MOVE-in siblings (hew_vec_push_owned_move /
@@ -492,6 +505,9 @@ compile_asan_fixture "resource enum match-consume (#2641)" "${ENUM_RESOURCE_MATC
 
 ENUM_RESOURCE_STATE_BIN="${WORK_DIR}/enum_resource_state_overwrite_asan"
 compile_asan_fixture "resource enum actor-state overwrite (#2641)" "${ENUM_RESOURCE_STATE_SRC}" "${ENUM_RESOURCE_STATE_BIN}"
+
+STREAM_STATE_FIELD_FOR_AWAIT_BIN="${WORK_DIR}/stream_state_field_for_await_asan"
+compile_asan_fixture "actor-state stream for-await ownership (#3218)" "${STREAM_STATE_FIELD_FOR_AWAIT_SRC}" "${STREAM_STATE_FIELD_FOR_AWAIT_BIN}"
 
 VEC_ELEM_STORE_TEMP_BIN="${WORK_DIR}/vec_elem_store_owned_temp_no_leak"
 HASHMAP_ENTRIES_BIN="${WORK_DIR}/hashmap_entries"
@@ -629,6 +645,18 @@ else
 fi
 
 if run_asan_fixture "resource enum actor-state overwrite (#2641)" "${ENUM_RESOURCE_STATE_BIN}" 0; then
+    pass=$((pass + 1))
+else
+    fail=$((fail + 1))
+fi
+
+# KNOWN (#3218, v0.6.0 documented limit): `for await` over an actor-state
+# `Stream<T>` field mints a second close authority for the loop cursor while
+# the field's own state-drop close authority stays intact, so the runtime
+# stream pointer is closed twice at teardown. Registered as an EXPECTED
+# finding until #3218 is fixed. When it is, this must flip to
+# `run_asan_fixture ... 0` and the ledger note above must be removed.
+if run_asan_fixture_expect_leak "actor-state stream for-await ownership (#3218)" "${STREAM_STATE_FIELD_FOR_AWAIT_BIN}"; then
     pass=$((pass + 1))
 else
     fail=$((fail + 1))

--- a/tests/vertical-slice/accept/stream_state_field_for_await_asan.hew
+++ b/tests/vertical-slice/accept/stream_state_field_for_await_asan.hew
@@ -1,0 +1,42 @@
+// ASan fixture gate: `for await` over an actor-state `Stream<T>` field closes
+// the stream exactly once (#3218).
+//
+// This fixture is compiled against an ASan/LSan-instrumented libhew.a by
+// `scripts/asan-fixture-check.sh` and run with ASAN_OPTIONS=detect_leaks=1.
+//
+// W7 shape (docs/internal/ir-ladder-worked-examples.md): `for await` over an
+// actor-state `Stream` field is a consuming use of an affine runtime-owned
+// place. Under the ladder it lowers to `load.take %input` with the taken bit
+// set, so `hew_drop$State` skips the field at teardown. The legacy lowerer
+// instead mints a second owner for the `for await` desugar's cursor
+// (`hew-mir/src/lower/expr.rs`, the synthetic `FOR_ITER_CURSOR_NAME_PREFIX`
+// binding) while leaving the field's own `RuntimeDropDescriptor::StreamClose`
+// drop authority intact. Two owners end up closing the one runtime `Stream`
+// pointer: once when the loop exhausts the stream, again when the actor's
+// state-field drop thunk runs at teardown.
+//
+// KNOWN FAILURE (#3218, D342/D343, v0.6.0 documented limit): a compiler
+// ownership defect in the legacy lowerer, not a proportional v0.6.0 fix (two
+// competing drop authorities). This fixture is registered as an EXPECTED ASan
+// finding via `run_asan_fixture_expect_leak` rather than a zero-findings
+// probe; flip it to a clean probe once P1-L3/P1-L5 land.
+import std.stream;
+
+actor Consumer {
+    var input: Stream<string>;
+
+    receive fn drain() {
+        for await item in input {
+            let _ = item;
+        }
+        println("drained");
+    }
+}
+
+fn main() -> i64 {
+    let (_sink, input) = stream.pipe(4);
+    let c = spawn Consumer(input: input);
+    c.drain();
+    println("done");
+    0
+}


### PR DESCRIPTION
## Why

#3218's minimal reduction (an actor holding `Stream<string>` state, drained by `for await`) double-closes the runtime stream pointer at teardown: the loop-exhaustion cursor and the field's own state-drop each claim close authority. Triage on the issue (D342/D343) classes this with the W7 shape from `docs/internal/ir-ladder-worked-examples.md` and defers the fix to the v0.7.0 ladder (P1-L3/P1-L5) as not proportional to a v0.6.0 lowerer patch. This lands the known limit as a pinned fixture so a regression in the other direction is visible.

## What

- `tests/vertical-slice/accept/stream_state_field_for_await_asan.hew`: the issue's minimal program, with a header naming #3218 and the W7 shape.
- `scripts/asan-fixture-check.sh`: registers the fixture through `run_asan_fixture_expect_leak`, the same mechanism used for `composite_resource_close_once_asan.hew` (#3070) — the gate expects, rather than forbids, the finding until the fix lands.

## Test

`make asan-fixtures`:
```
RUN      actor-state stream for-await ownership (#3218) (expect LSan finding)
    PASS actor-state stream for-await ownership (#3218): gate correctly caught deliberate generated-code leak (exit 1)
```

The full gate run also surfaces two pre-existing, unrelated ASan failures (`string retain-on-share`, `owned-Vec retained param-embed temp`) and `make test-vertical-slice` hits a pre-existing, unrelated failure (`await_accept_shutdown_abandoned`, off-by-one exit code). Reproduced on this branch's `origin/main` base without touching the affected files; noted in `.tmp/TODO.md` for separate triage.
