### PR TITLE
fix(cli): diagram the machines a file reaches through an import

### DIFF
--- a/hew-cli/src/machine.rs
+++ b/hew-cli/src/machine.rs
@@ -65,16 +65,16 @@ fn parse_machines(path: &str, source: &str) -> Vec<MachineDecl> {
 }
 
 /// Run the checker and HIR lowering + static checks on the file.  Returns the
-/// checked HIR machines declared by the file itself, or exits the process on
-/// failure.
+/// checked HIR machines the program contains, or exits the process on failure.
 ///
 /// HIR lowering resolves every declaration through the checker's identity
 /// table, so the file goes through the same import-resolving frontend as
 /// `hew check`; a default `TypeCheckOutput` would fail closed on every item.
-/// Import resolution flattens file-imported items into the checked program,
-/// so the result is narrowed to the machines the raw parse of this file
-/// declared (`ast_machines`).
-fn check_and_lower(path: &str, ast_machines: &[MachineDecl]) -> Vec<HirMachineDecl> {
+/// The checked module is the one authority for which machines a program has:
+/// it carries the machines the file declares (`defining_module` is `None`)
+/// beside the machines it imports, so a file whose only machine arrives
+/// through an import still has one to render.
+fn check_and_lower(path: &str) -> Vec<HirMachineDecl> {
     let state = match hew_compile::run_file_frontend_to_typecheck(path, &FrontendOptions::default())
     {
         Ok(state) => state,
@@ -109,7 +109,7 @@ fn check_and_lower(path: &str, ast_machines: &[MachineDecl]) -> Vec<HirMachineDe
         .items
         .into_iter()
         .filter_map(|item| match item {
-            HirItem::Machine(m) if ast_machines.iter().any(|ast| ast.name == m.name) => Some(m),
+            HirItem::Machine(m) => Some(m),
             _ => None,
         })
         .collect()
@@ -118,6 +118,56 @@ fn check_and_lower(path: &str, ast_machines: &[MachineDecl]) -> Vec<HirMachineDe
 enum MachineCheckResult {
     Checked(Vec<HirMachineDecl>),
     AstFallback,
+}
+
+/// One machine to render: its checked HIR declaration paired with the
+/// presentation facts HIR does not carry.
+struct MachineView<'a> {
+    hir: &'a HirMachineDecl,
+    /// Composite grouping of this machine's states, from the AST of the file
+    /// under inspection.
+    groups: &'a [hew_parser::ast::CompositeGroup],
+    /// The machine's `emits { … }` manifest, from the same AST.
+    emits: &'a [String],
+}
+
+/// Pair every checked machine with the AST facts HIR is flat about.
+///
+/// The join is by name within the root namespace, which the checker keeps
+/// unique: an AST machine is by construction declared by the file under
+/// inspection, so it can only describe a HIR machine whose `defining_module`
+/// is `None`.
+///
+/// WHY this shortcut: composite grouping and the `emits` manifest live only on
+/// `MachineDecl`, so a machine that arrives through an import renders with
+/// neither. No importable machine that ships declares either
+/// (`std/machines/toggle.hew`, `std/concurrency/lifecycle.hew`), so no diagram
+/// loses a fact today.
+/// WHEN obsolete: when the machine desugar (#3073) lands and HIR carries
+/// grouping and the emits manifest on the declaration.
+/// WHAT the real fix is: put both on `HirMachineDecl` beside `states` and
+/// `transitions` and delete this join, so every machine renders from the one
+/// authority regardless of which module declared it.
+fn machine_views<'a>(
+    hir_machines: &'a [HirMachineDecl],
+    ast_machines: &'a [MachineDecl],
+) -> Vec<MachineView<'a>> {
+    hir_machines
+        .iter()
+        .map(|hir| {
+            let ast = hir.defining_module.is_none().then(|| {
+                ast_machines
+                    .iter()
+                    .find(|candidate| candidate.name == hir.name)
+            });
+            let ast = ast.flatten();
+            MachineView {
+                hir,
+                groups: ast.map_or(&[][..], |m| m.composite_groups.as_slice()),
+                emits: ast.map_or(&[][..], |m| m.emits.as_slice()),
+            }
+        })
+        .collect()
 }
 
 fn check_machines_or_ast_fallback(
@@ -135,7 +185,7 @@ fn check_machines_or_ast_fallback(
         return MachineCheckResult::AstFallback;
     }
 
-    let hir_machines = check_and_lower(path, ast_machines);
+    let hir_machines = check_and_lower(path);
     if hir_machines.is_empty() {
         eprintln!("No machines found in {path}");
         std::process::exit(1);
@@ -144,46 +194,117 @@ fn check_machines_or_ast_fallback(
     MachineCheckResult::Checked(hir_machines)
 }
 
+/// Print one `machine Name { … }` entry.  Both the checked and the
+/// AST-fallback paths render through here so the two agree line for line.
+fn print_list_entry(
+    name: &str,
+    states: &[(&str, Vec<&str>)],
+    events: &[(&str, Vec<&str>)],
+    transitions: usize,
+    has_default: bool,
+    emits: &[String],
+) {
+    println!("machine {name} {{");
+    println!("  States:");
+    for (state, fields) in states {
+        if fields.is_empty() {
+            println!("    {state}");
+        } else {
+            println!("    {} {{ {} }}", state, fields.join(", "));
+        }
+    }
+    println!("  Events:");
+    for (event, fields) in events {
+        if fields.is_empty() {
+            println!("    {event}");
+        } else {
+            println!("    {} {{ {} }}", event, fields.join(", "));
+        }
+    }
+    println!("  Transitions: {transitions}");
+    if has_default {
+        println!("  Default: unhandled events stay in current state");
+    }
+    // fix 3: Emits section in cmd_list.
+    if !emits.is_empty() {
+        println!("  Emits: {}", emits.join(", "));
+    }
+    println!("}}");
+    println!();
+}
+
 fn cmd_list(path: &str) {
     let source = read_source(path);
-    let machines = parse_machines(path, &source);
+    let ast_machines = parse_machines(path, &source);
 
-    // `list` renders from the AST below, but keeps fail-closed HIR validation
-    // for non-generic machines.
-    check_machines_or_ast_fallback(path, &machines, false);
-
-    for md in &machines {
-        println!("machine {} {{", md.name);
-        println!("  States:");
-        for state in &md.states {
-            if state.fields.is_empty() {
-                println!("    {}", state.name);
-            } else {
-                let fields: Vec<String> =
-                    state.fields.iter().map(|(name, _)| name.clone()).collect();
-                println!("    {} {{ {} }}", state.name, fields.join(", "));
+    match check_machines_or_ast_fallback(path, &ast_machines, false) {
+        MachineCheckResult::Checked(hir_machines) => {
+            for view in machine_views(&hir_machines, &ast_machines) {
+                let states: Vec<(&str, Vec<&str>)> = view
+                    .hir
+                    .states
+                    .iter()
+                    .map(|s| {
+                        (
+                            s.name.as_str(),
+                            s.fields.iter().map(|f| f.name.as_str()).collect(),
+                        )
+                    })
+                    .collect();
+                let events: Vec<(&str, Vec<&str>)> = view
+                    .hir
+                    .events
+                    .iter()
+                    .map(|e| {
+                        (
+                            e.name.as_str(),
+                            e.fields.iter().map(|f| f.name.as_str()).collect(),
+                        )
+                    })
+                    .collect();
+                print_list_entry(
+                    &view.hir.name,
+                    &states,
+                    &events,
+                    view.hir.transitions.len(),
+                    view.hir.has_default,
+                    view.emits,
+                );
             }
         }
-        println!("  Events:");
-        for event in &md.events {
-            if event.fields.is_empty() {
-                println!("    {}", event.name);
-            } else {
-                let fields: Vec<String> =
-                    event.fields.iter().map(|(name, _)| name.clone()).collect();
-                println!("    {} {{ {} }}", event.name, fields.join(", "));
+        // Generic machines skip HIR lowering, so the AST is all there is.
+        MachineCheckResult::AstFallback => {
+            for md in &ast_machines {
+                let states: Vec<(&str, Vec<&str>)> = md
+                    .states
+                    .iter()
+                    .map(|s| {
+                        (
+                            s.name.as_str(),
+                            s.fields.iter().map(|(name, _)| name.as_str()).collect(),
+                        )
+                    })
+                    .collect();
+                let events: Vec<(&str, Vec<&str>)> = md
+                    .events
+                    .iter()
+                    .map(|e| {
+                        (
+                            e.name.as_str(),
+                            e.fields.iter().map(|(name, _)| name.as_str()).collect(),
+                        )
+                    })
+                    .collect();
+                print_list_entry(
+                    &md.name,
+                    &states,
+                    &events,
+                    md.transitions.len(),
+                    md.has_default,
+                    &md.emits,
+                );
             }
         }
-        println!("  Transitions: {}", md.transitions.len());
-        if md.has_default {
-            println!("  Default: unhandled events stay in current state");
-        }
-        // fix 3: Emits section in cmd_list.
-        if !md.emits.is_empty() {
-            println!("  Emits: {}", md.emits.join(", "));
-        }
-        println!("}}");
-        println!();
     }
 }
 
@@ -205,50 +326,30 @@ fn cmd_diagram(path: &str, args: &MachineDiagramArgs) {
                 // Fall through to AST rendering below.
             }
             MachineCheckResult::Checked(hir_machines) => {
-                // HIR is flat by invariant — composite grouping and the emits
-                // manifest live only on the AST. Build both side-tables keyed by
-                // machine name, threaded alongside the HIR (same pattern as
-                // groups_by_name that already existed for composites).
-                let groups_by_name: std::collections::HashMap<
-                    &str,
-                    &[hew_parser::ast::CompositeGroup],
-                > = ast_machines
-                    .iter()
-                    .map(|m| (m.name.as_str(), m.composite_groups.as_slice()))
-                    .collect();
-                // fix 3: emits manifest side-table for the HIR path.
-                let emits_by_name: std::collections::HashMap<&str, &[String]> = ast_machines
-                    .iter()
-                    .map(|m| (m.name.as_str(), m.emits.as_slice()))
-                    .collect();
+                let views = machine_views(&hir_machines, &ast_machines);
 
                 // Filter by --machine if specified.
-                let filtered: Vec<&HirMachineDecl> = if let Some(name) = &args.machine_name {
-                    let matched: Vec<_> = hir_machines.iter().filter(|m| &m.name == name).collect();
+                let filtered: Vec<&MachineView<'_>> = if let Some(name) = &args.machine_name {
+                    let matched: Vec<_> =
+                        views.iter().filter(|view| &view.hir.name == name).collect();
                     if matched.is_empty() {
                         eprintln!("No machine named `{name}` found in {path}");
                         std::process::exit(1);
                     }
                     matched
                 } else {
-                    hir_machines.iter().collect()
+                    views.iter().collect()
                 };
 
-                for machine in filtered {
-                    let groups = groups_by_name
-                        .get(machine.name.as_str())
-                        .copied()
-                        .unwrap_or(&[]);
-                    let emits = emits_by_name
-                        .get(machine.name.as_str())
-                        .copied()
-                        .unwrap_or(&[]);
+                for view in filtered {
                     match format {
-                        MachineFormat::Mermaid => print_mermaid_hir(machine, groups, emits),
-                        MachineFormat::Graphviz | MachineFormat::Dot => {
-                            print_dot_hir(machine, groups, emits);
+                        MachineFormat::Mermaid => {
+                            print_mermaid_hir(view.hir, view.groups, view.emits);
                         }
-                        MachineFormat::Json => print_json_hir(machine, groups, emits),
+                        MachineFormat::Graphviz | MachineFormat::Dot => {
+                            print_dot_hir(view.hir, view.groups, view.emits);
+                        }
+                        MachineFormat::Json => print_json_hir(view.hir, view.groups, view.emits),
                     }
                 }
                 return;

--- a/hew-cli/src/machine.rs
+++ b/hew-cli/src/machine.rs
@@ -155,12 +155,13 @@ fn machine_views<'a>(
     hir_machines
         .iter()
         .map(|hir| {
-            let ast = hir.defining_module.is_none().then(|| {
+            let ast = if hir.defining_module.is_none() {
                 ast_machines
                     .iter()
                     .find(|candidate| candidate.name == hir.name)
-            });
-            let ast = ast.flatten();
+            } else {
+                None
+            };
             MachineView {
                 hir,
                 groups: ast.map_or(&[][..], |m| m.composite_groups.as_slice()),

--- a/hew-cli/tests/machine_e2e.rs
+++ b/hew-cli/tests/machine_e2e.rs
@@ -819,3 +819,214 @@ fn machine_diagram_json_event_fields_present() {
         "JSON must include empty fields array for payload-free events; stdout:\n{stdout}"
     );
 }
+
+// ── machines reached through an import (#3229) ───────────────────────────────
+
+/// A file whose only machine arrives through an import: the machine lives in
+/// `std/machines/toggle.hew` and the root declares none of its own.
+fn imported_only_fixture() -> &'static str {
+    "import std.machines.toggle.{Toggle, ToggleEvent};\n\
+     fn main() {\n\
+     \x20   var t: Toggle = .Off;\n\
+     \x20   t.step(ToggleEvent.Flip);\n\
+     \x20   println(t.state_name());\n\
+     }\n"
+}
+
+/// A root machine beside an imported one, so the command has to render both.
+fn local_and_imported_fixture() -> &'static str {
+    "import std.machines.toggle.{Toggle, ToggleEvent};\n\
+     machine Door {\n\
+     \x20   events { Push; }\n\
+     \x20   state Closed;\n\
+     \x20   state Open;\n\
+     \x20   on Push: Closed => Open { .Open }\n\
+     \x20   on Push: Open => Closed { .Closed }\n\
+     }\n\
+     fn main() {\n\
+     \x20   var d: Door = .Closed;\n\
+     \x20   d.step(.Push);\n\
+     \x20   var t: Toggle = .Off;\n\
+     \x20   t.step(ToggleEvent.Flip);\n\
+     \x20   println(f\"{d.state_name()} {t.state_name()}\");\n\
+     }\n"
+}
+
+#[test]
+fn machine_diagram_renders_a_machine_reached_only_through_an_import() {
+    let dir = support::tempdir();
+    let input = dir.path().join("driver.hew");
+    std::fs::write(&input, imported_only_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["machine", "diagram"])
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "a file that only drives an imported machine must diagram it; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("stateDiagram-v2"), "stdout:\n{stdout}");
+    assert!(stdout.contains("[*] --> Off"), "stdout:\n{stdout}");
+    assert!(stdout.contains("Off --> On : Flip"), "stdout:\n{stdout}");
+    assert!(stdout.contains("On --> Off : Flip"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn machine_list_renders_a_machine_reached_only_through_an_import() {
+    let dir = support::tempdir();
+    let input = dir.path().join("driver.hew");
+    std::fs::write(&input, imported_only_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["machine", "list"])
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("machine Toggle {"), "stdout:\n{stdout}");
+    assert!(stdout.contains("    Off"), "stdout:\n{stdout}");
+    assert!(stdout.contains("    On"), "stdout:\n{stdout}");
+    assert!(stdout.contains("    Flip"), "stdout:\n{stdout}");
+    assert!(stdout.contains("  Transitions: 2"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn machine_diagram_renders_the_local_and_the_imported_machine() {
+    // Counterpart to the import-only case: rendering imported machines must not
+    // cost the file its own, and `--machine` still selects one of the two.
+    let dir = support::tempdir();
+    let input = dir.path().join("both.hew");
+    std::fs::write(&input, local_and_imported_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["machine", "diagram"])
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.matches("stateDiagram-v2").count(),
+        2,
+        "one diagram for the local machine and one for the imported; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Closed --> Open : Push"),
+        "stdout:\n{stdout}"
+    );
+    assert!(stdout.contains("Off --> On : Flip"), "stdout:\n{stdout}");
+
+    let selected = Command::new(hew_binary())
+        .args(["machine", "diagram"])
+        .arg(&input)
+        .args(["--machine", "Toggle"])
+        .output()
+        .unwrap();
+    assert!(selected.status.success());
+    let selected = String::from_utf8_lossy(&selected.stdout);
+    assert_eq!(
+        selected.matches("stateDiagram-v2").count(),
+        1,
+        "--machine must select one; stdout:\n{selected}"
+    );
+    assert!(
+        !selected.contains("Closed --> Open : Push"),
+        "--machine Toggle must not render Door; stdout:\n{selected}"
+    );
+}
+
+#[test]
+fn machine_diagram_renders_no_machine_a_file_does_not_reach() {
+    // Negative control for the import path: the standard library declares
+    // machines, and a file that imports none of them must diagram none.
+    let dir = support::tempdir();
+    let input = dir.path().join("light.hew");
+    std::fs::write(&input, machine_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["machine", "diagram"])
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.matches("stateDiagram-v2").count(),
+        1,
+        "only the file's own machine may render; stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Flip"),
+        "no unimported standard-library machine may appear; stdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn machine_diagram_succeeds_on_every_compiling_machine_example() {
+    // The shipped examples are the front door: every one that compiles must
+    // diagram. The `reject_*` fixtures are deliberate compile errors and are
+    // this test's negative control — they must keep failing, not be skipped.
+    let examples = support::repo_root().join("examples/machine");
+    let mut sources: Vec<std::path::PathBuf> = std::fs::read_dir(&examples)
+        .unwrap_or_else(|e| panic!("read {}: {e}", examples.display()))
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "hew"))
+        .collect();
+    sources.sort();
+    assert!(
+        sources.len() > 1,
+        "expected machine examples under {}",
+        examples.display()
+    );
+
+    let mut rejected = 0usize;
+    for source in &sources {
+        let name = source.file_name().unwrap().to_string_lossy().into_owned();
+        let output = Command::new(hew_binary())
+            .args(["machine", "diagram"])
+            .arg(source)
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        if name.starts_with("reject_") {
+            rejected += 1;
+            assert!(
+                !output.status.success(),
+                "{name} is a reject fixture and must not diagram; stdout:\n{stdout}"
+            );
+            continue;
+        }
+
+        assert!(
+            output.status.success(),
+            "{name}: `hew machine diagram` must succeed; stderr:\n{stderr}"
+        );
+        assert!(
+            stdout.contains("stateDiagram-v2"),
+            "{name}: must emit a state diagram; stdout:\n{stdout}"
+        );
+    }
+    assert!(
+        rejected > 0,
+        "the reject fixtures are this test's negative control; none were found"
+    );
+}

--- a/hew-cli/tests/machine_e2e.rs
+++ b/hew-cli/tests/machine_e2e.rs
@@ -979,10 +979,12 @@ fn machine_diagram_renders_no_machine_a_file_does_not_reach() {
 }
 
 #[test]
-fn machine_diagram_succeeds_on_every_compiling_machine_example() {
+fn machine_commands_succeed_on_every_compiling_machine_example() {
     // The shipped examples are the front door: every one that compiles must
-    // diagram. The `reject_*` fixtures are deliberate compile errors and are
-    // this test's negative control — they must keep failing, not be skipped.
+    // diagram and list. The `reject_*` fixtures are deliberate compile errors
+    // and are this test's negative control — they must keep failing, not be
+    // skipped. `select_on_transition.hew` carries an imported machine beside an
+    // f-string interpolation, so the pairing is covered here too.
     let examples = support::repo_root().join("examples/machine");
     let mut sources: Vec<std::path::PathBuf> = std::fs::read_dir(&examples)
         .unwrap_or_else(|e| panic!("read {}: {e}", examples.display()))
@@ -999,31 +1001,38 @@ fn machine_diagram_succeeds_on_every_compiling_machine_example() {
     let mut rejected = 0usize;
     for source in &sources {
         let name = source.file_name().unwrap().to_string_lossy().into_owned();
-        let output = Command::new(hew_binary())
-            .args(["machine", "diagram"])
-            .arg(source)
-            .output()
-            .unwrap();
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-
-        if name.starts_with("reject_") {
+        let reject_fixture = name.starts_with("reject_");
+        if reject_fixture {
             rejected += 1;
-            assert!(
-                !output.status.success(),
-                "{name} is a reject fixture and must not diagram; stdout:\n{stdout}"
-            );
-            continue;
         }
 
-        assert!(
-            output.status.success(),
-            "{name}: `hew machine diagram` must succeed; stderr:\n{stderr}"
-        );
-        assert!(
-            stdout.contains("stateDiagram-v2"),
-            "{name}: must emit a state diagram; stdout:\n{stdout}"
-        );
+        for (subcommand, marker) in [("diagram", "stateDiagram-v2"), ("list", "machine ")] {
+            let output = Command::new(hew_binary())
+                .args(["machine", subcommand])
+                .arg(source)
+                .output()
+                .unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            if reject_fixture {
+                assert!(
+                    !output.status.success(),
+                    "{name} is a reject fixture; `machine {subcommand}` must refuse it; \
+                     stdout:\n{stdout}"
+                );
+                continue;
+            }
+
+            assert!(
+                output.status.success(),
+                "{name}: `hew machine {subcommand}` must succeed; stderr:\n{stderr}"
+            );
+            assert!(
+                stdout.contains(marker),
+                "{name}: `machine {subcommand}` must render a machine; stdout:\n{stdout}"
+            );
+        }
     }
     assert!(
         rejected > 0,


### PR DESCRIPTION
## Why

`hew machine diagram` and `hew machine list` filtered the checked HIR module down to the machines whose name matched one the file's own parse declared. A file that drives a machine it imported declares none, so both commands reached an empty set and exited 1 with `No machines found` - `examples/machine/run_cross_module_toggle.hew`, `run_lifecycle.hew`, `select_on_transition.hew` and `transition_watch_baseline.hew` all failed that way while `hew run` on the same files worked.

## What

- **cli**: `check_and_lower` returns every machine the checked module carries instead of joining the lowered items back against the file's raw parse; the module already marks its own declarations (`defining_module` is `None`) apart from imported ones, so it is the one authority for which machines a program has.
- **cli**: `machine list` renders the checked HIR declaration rather than the raw AST, so an imported machine lists its states, events and transition count like a local one. The generic-machine fallback still renders from the AST, and both paths print through one entry printer. Transition counts now come from the checked declaration; `machine list` over `examples/machine/*.hew` is byte-identical to `main` for every file that already worked.
- **cli**: the two name-keyed side tables that carried composite grouping and the `emits` manifest over the flat HIR become one join, marked with why it exists, what makes it obsolete (the machine desugar, #3073) and what the real fix is. A machine that arrives through an import renders without grouping or emits; no importable machine that ships declares either.

## Test

`hew-cli/tests/machine_e2e.rs`: `machine_diagram_renders_a_machine_reached_only_through_an_import` and `machine_list_renders_a_machine_reached_only_through_an_import` cover the reported shape; `machine_diagram_renders_the_local_and_the_imported_machine` pins that rendering imports does not cost the file its own machine and that `--machine` still selects one; `machine_diagram_renders_no_machine_a_file_does_not_reach` is the negative control that an unimported standard-library machine stays out; and `machine_commands_succeed_on_every_compiling_machine_example` runs both subcommands over `examples/machine/*.hew`, holding the `reject_*` fixtures to refusing both as its own negative control. Restoring the old `machine.rs` under the new tests fails every one of them except the leak-in control.

Fixes #3229
