### PR TITLE
feat(cli): run the journeys as a ratcheted acceptance harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,9 +446,18 @@ jobs:
 
       - name: Run day-one.sh
         shell: bash
+        # HEW_BIN stays relative (run-journeys.sh resolves it against the
+        # repo root in POSIX form); an absolute github.workspace value is
+        # Windows-style (D:\a\hew\hew) and git-bash's `cd`/mktemp calls
+        # inside the journey script cannot use it. `shell: bash` here is
+        # git-bash with --noprofile --norc, so TMPDIR is unset and
+        # RUNNER_TEMP is a Windows path -- convert it to POSIX form first.
         env:
-          HEW_BIN: ${{ github.workspace }}/target/release/hew.exe
-        run: bash scripts/run-journeys.sh day-one
+          HEW_BIN: target/release/hew.exe
+        run: |
+          TMPDIR="$(cygpath -u "$RUNNER_TEMP")"
+          export TMPDIR
+          bash scripts/run-journeys.sh day-one
 
   # ─────────────────────────────────────────────────────────────────────────
   # Build & test — Rust workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,8 +411,17 @@ jobs:
         run: npm install -g wrangler
 
       - name: Run ${{ matrix.journey }}
+        # HEW_STD: the compiled-hew-linux artifact ships only the binary and
+        # libhew.a, no std/ sibling (hew-types/src/module_registry.rs's
+        # dev-build fallback needs std/builtins.hew two directories above
+        # the executable, which the unpacked artifact tree doesn't have).
+        # Every existing consumer of this artifact runs with cwd = the
+        # checkout root, where cwd/std resolves before that fallback is
+        # ever needed; the journey scripts `cd` into a scratch tempdir, so
+        # this job is the first to need the explicit override.
         env:
           HEW_BIN: ${{ runner.temp }}/compiled-hew-artifact/compiled-hew/debug/hew
+          HEW_STD: ${{ github.workspace }}/std
         run: bash scripts/run-journeys.sh ${{ matrix.journey }}
 
   # windows-2022 has no compiled-hew artifact (compiled-hew-linux is
@@ -442,7 +451,12 @@ jobs:
           cache-shared-key: journeys-windows-day-one
 
       - name: Build hew
-        run: cargo build -p hew-cli --release
+        # hew-lib alongside hew-cli, not hew-cli alone: `hew build`/`hew run`
+        # link user programs against libhew (hew.lib on Windows), so day
+        # one's later steps need it beside the binary the same way
+        # build-and-test-windows's own PDB step does (cargo build -p
+        # hew-lib --release, immediately before `hew.exe build -g`).
+        run: cargo build -p hew-lib -p hew-cli --release
 
       - name: Run day-one.sh
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,86 @@ jobs:
           check_name: Compiled Hew Test Results
 
   # ─────────────────────────────────────────────────────────────────────────
+  # Journeys — the day-one/day-two/week-one-local acceptance harness
+  # (V060-FD-1). Independent of the ci-shard-* Make targets and the
+  # compiled-hew-shards matrix above: a journey behind a red gate would
+  # produce no evidence, so it runs as its own job against the already-
+  # built compiled Hew artifact.
+  # ─────────────────────────────────────────────────────────────────────────
+  journeys:
+    name: Journeys (${{ matrix.journey }})
+    needs: compiled-hew-linux
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        journey: [day-one, day-two, week-one-local]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download compiled Hew bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: compiled-hew-linux-${{ github.sha }}
+          path: ${{ runner.temp }}/compiled-hew-download
+
+      - name: Unpack compiled Hew bundle
+        run: |
+          mkdir -p "${{ runner.temp }}/compiled-hew-artifact"
+          tar -xzf "${{ runner.temp }}/compiled-hew-download/compiled-hew-linux.tar.gz" \
+            -C "${{ runner.temp }}/compiled-hew-artifact"
+
+      - name: Install wrangler
+        # day-two is the only journey with registry-gated steps
+        # (scripts/registry-harness.sh); no sibling hew-registry checkout
+        # exists in this job, so the harness exits 75 and those steps
+        # record the no_registry() failure -- the same outcome
+        # scripts/journeys-expected.tsv is seeded against.
+        if: matrix.journey == 'day-two'
+        run: npm install -g wrangler
+
+      - name: Run ${{ matrix.journey }}
+        env:
+          HEW_BIN: ${{ runner.temp }}/compiled-hew-artifact/compiled-hew/debug/hew
+        run: bash scripts/run-journeys.sh ${{ matrix.journey }}
+
+  # windows-2022 has no compiled-hew artifact (compiled-hew-linux is
+  # Linux-only) and no `make`, so this builds hew fresh and runs day one's
+  # script directly -- day one is the journey most representative of a
+  # newcomer's first minutes and needs no registry, unlike day two.
+  journeys-windows-day-one:
+    name: Journeys (day-one, Windows)
+    runs-on: windows-2022
+    timeout-minutes: 45
+    env:
+      AWS_LC_SYS_PREBUILT_NASM: "1"
+      CARGO_BUILD_JOBS: "2"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup MSVC environment
+        uses: ./.github/actions/setup-msvc
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
+        uses: ./.github/actions/setup-llvm
+        with:
+          version: ${{ env.LLVM_VERSION }}
+
+      - uses: ./.github/actions/setup-rust-build
+        with:
+          cache-shared-key: journeys-windows-day-one
+
+      - name: Build hew
+        run: cargo build -p hew-cli --release
+
+      - name: Run day-one.sh
+        shell: bash
+        env:
+          HEW_BIN: ${{ github.workspace }}/target/release/hew.exe
+        run: bash scripts/run-journeys.sh day-one
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Build & test — Rust workspace
   # Produces JUnit XML for GitHub Actions test reporting.
   # ─────────────────────────────────────────────────────────────────────────

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,8 @@ Use `test-runtime-unit` for no-network runtime iteration and `test-compiler-pipe
 
 `make preflight` runs the lint graph and the same Make-owned test groups as Linux CI; it is the standard manual gate before opening a PR. `make ci-preflight` remains a compatibility alias.
 
+`make test-journeys JOURNEY=day-one|day-two|week-one-local` runs one of the newcomer-facing acceptance journeys under `repros/journeys/` against `HEW_BIN` (the built `hew` by default) and ratchets its step-by-step outcome against `scripts/journeys-expected.tsv`; it fails when a step outside that file fails or a listed step starts passing (the fixing lane deletes that row). `make check-time-ratchet` fails when the median wall-clock of `hew check` on a fixed std fixture exceeds twice the baseline recorded in `scripts/check-time-baseline.tsv`; `make check-time-ratchet-record` writes that baseline for the current host.
+
 ### E2E test workflow
 
 When adding new language features, add an end-to-end test:

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@
 .PHONY: checked-mir-verify checked-mir-golden checked-mir-run checked-mir-expect
 .PHONY: hew-check-all
 .PHONY: sir-coverage sir-parity
+.PHONY: test-journeys check-time-ratchet check-time-ratchet-record
 
 help:
 	@$(PYTHON) scripts/make-help.py
@@ -1664,6 +1665,27 @@ hew-fmt-property: hew
 hew-check-all: hew-native
 	@echo "==> hew-check-all: compiling full .hew corpus"
 	HEW_BIN="$(DEBUG_HEW)" scripts/corpus-ratchet.sh hew-corpus
+
+# Runs one journey script under repros/journeys/ (day-one, day-two, or
+# week-one-local) against HEW_BIN and ratchets its `step <id>: pass|fail`
+# lines against scripts/journeys-expected.tsv: the target fails when a
+# step outside that file fails, or a step listed in it now passes (V060-FD-1).
+# inputs: repros/journeys/*.sh scripts/run-journeys.sh scripts/journeys-expected.tsv
+test-journeys: hew ## Test: run a repros/journeys script and ratchet its steps (JOURNEY=day-one|day-two|week-one-local)
+	@if [ -z "$(JOURNEY)" ]; then echo "usage: make test-journeys JOURNEY=day-one|day-two|week-one-local" >&2; exit 64; fi
+	HEW_BIN="$(HEW_BIN)" bash scripts/run-journeys.sh $(JOURNEY)
+
+# Five runs of `hew check` on the largest std module a newcomer's program
+# pulls in; the median wall-clock cannot exceed 2x the recorded baseline
+# for this host class (uname -m plus the CI runner label when CI is set,
+# else "local"). A class with no baseline records one and passes: a first
+# run on a new runner class cannot be compared against itself (V060-FD-1).
+# inputs: scripts/check-time-ratchet.sh scripts/check-time-baseline.tsv std/net/http/http.hew
+check-time-ratchet: hew ## Test: fail when hew check's median time on the fixture exceeds 2x baseline
+	HEW_BIN="$(HEW_BIN)" bash scripts/check-time-ratchet.sh check
+
+check-time-ratchet-record: hew ## Build: record scripts/check-time-baseline.tsv's median for this host class
+	HEW_BIN="$(HEW_BIN)" bash scripts/check-time-ratchet.sh record
 
 .PHONY: codegen-trap-inventory-check
 LINT_GATES += codegen-trap-inventory-check

--- a/repros/journeys/day-one.sh
+++ b/repros/journeys/day-one.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# repros/journeys/day-one.sh
+# Day one: a machine with `hew` and a C driver (the one dependency §6.1 names)
+# gets a green, testable, deployable project in six commands.
+# Source: hew-orchestration/plans/hew-platform-program.md §0.1 (the bash
+# fence starting at that document's line 145), copied verbatim except for
+# the step-reporting harness described below (V060-FD-1).
+#
+# Run: make test-journeys JOURNEY=day-one   (HEW_BIN on PATH, TMPDIR outside any hew root)
+# On the windows-2022 CI job, which has no make, run: bash repros/journeys/day-one.sh
+#
+# Every assertion is a numbered step (`day-one.<n>`), printed to stdout as
+# `step day-one.<n>: pass` or `step day-one.<n>: fail`. A failing step is
+# recorded and the script continues; scripts/journeys-expected.tsv is the
+# ratchet that decides whether a given failure is already known. No `-e`:
+# a failure here must never abort the script before every step is reported.
+set -uo pipefail
+HEW=${HEW_BIN:-hew}
+WORK=$(mktemp -d "${TMPDIR:?TMPDIR must point outside the checkout}/journey-day-one-XXXXXX") || exit 1
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK" || exit 1
+
+NAME=day-one
+N=0
+ok() {
+    N=$((N + 1))
+    echo "step ${NAME}.${N}: pass"
+}
+bad() {
+    N=$((N + 1))
+    echo "step ${NAME}.${N}: fail"
+    echo "${NAME}: step ${N} FAIL: $*" >&2
+}
+
+# A hang is a failure, not a wait: run a command under a watchdog (bash only; no coreutils `timeout`).
+with_timeout() {
+    local secs=$1
+    shift
+    "$@" &
+    local pid=$!
+    (
+        sleep "$secs"
+        kill "$pid" 2>/dev/null
+    ) &
+    local wd=$!
+    wait "$pid"
+    local rc=$?
+    kill "$wd" 2>/dev/null
+    wait "$wd" 2>/dev/null || true
+    return "$rc"
+}
+# `producer | grep -q` under pipefail fails whenever the producer writes after the
+# match (SIGPIPE), so every assertion captures first and greps the capture.
+
+# 1. Scaffold. `hew new <name>` is the verb; `hew init` stays for in-place. Like
+#    `cargo new`, it initializes a repository unless it is already inside one.
+if "$HEW" new svc >"$WORK/.log.new-svc" 2>&1; then ok; else bad "hew new: $(cat "$WORK/.log.new-svc")"; fi
+cd svc 2>/dev/null || true # a failed cd leaves later checks in $WORK, where each still reports its own fail
+if [ -f main_test.hew ]; then ok; else bad "scaffold ships a test file"; fi
+if [ "$(git rev-parse --show-toplevel 2>/dev/null)" = "$PWD" ]; then ok; else bad "hew new initializes a repository of its own (TMPDIR under a repository defeats this step)"; fi
+if grep -qx 'target/' .gitignore 2>/dev/null; then ok; else bad "artifact directory is ignored by the scaffold"; fi
+
+# 2. Bare run / test / build are manifest-aware and green.
+OUT=$("$HEW" run 2>&1)
+if echo "$OUT" | grep -q 'Hello from svc'; then ok; else bad "hew run: $OUT"; fi
+OUT=$("$HEW" test 2>&1)
+if echo "$OUT" | grep -q '1 passed; 0 failed'; then ok; else bad "scaffold test is green: $OUT"; fi
+# Build status lines go to stderr (§6.1), cargo's convention; stdout stays free for machine output.
+BUILD_OUT=$("$HEW" build --release 2>&1)
+if echo "$BUILD_OUT" | grep -q 'target/release/svc'; then ok; else bad "build names its artifact: $BUILD_OUT"; fi
+if [ -x target/release/svc ]; then ok; else bad "artifact is where build said"; fi
+OUT=$(./target/release/svc 2>&1)
+if echo "$OUT" | grep -q 'Hello from svc'; then ok; else bad "release binary runs: $OUT"; fi
+
+# 3. The binary never reaches git.
+git add -A 2>/dev/null
+if git ls-files 2>/dev/null | grep -q '^target/'; then bad "target/ was staged"; else ok; fi
+
+# 4. Every scaffold variant compiles and tests green (a source-text pin cannot catch this).
+#    The actor template's main sends three messages and exits (§6.1); a template that blocks fails here.
+cd "$WORK" || true
+if "$HEW" new --actor counter >"$WORK/.log.new-actor" 2>&1; then ok; else bad "actor scaffold: $(cat "$WORK/.log.new-actor")"; fi
+if (cd counter 2>/dev/null && with_timeout 60 "$HEW" run >/dev/null 2>&1 && OUT=$("$HEW" test 2>&1) && echo "$OUT" | grep -q '1 passed; 0 failed'); then ok; else bad "actor scaffold is not green"; fi
+if "$HEW" new --lib mylib >"$WORK/.log.new-lib" 2>&1; then ok; else bad "lib scaffold: $(cat "$WORK/.log.new-lib")"; fi
+if (cd mylib 2>/dev/null && OUT=$("$HEW" test 2>&1) && echo "$OUT" | grep -q '1 passed; 0 failed'); then ok; else bad "lib scaffold is not green"; fi
+
+# 5. The two most likely first mistakes get the right message, once.
+cd "$WORK" || true
+printf 'fn main() { let mut x = 1; println(f"{x}"); }\n' >letmut.hew
+OUT=$("$HEW" check letmut.hew 2>&1)
+RC=$?
+if [ "$RC" -eq 1 ]; then ok; else bad "let mut exits 1 (got $RC)"; fi
+if echo "$OUT" | grep -q 'var x'; then ok; else bad "let mut names the fix: $OUT"; fi
+if [ "$(echo "$OUT" | grep -c 'error:')" -eq 1 ]; then ok; else bad "let mut is one error, not a cascade"; fi
+
+# `hew check --format json` pretty-prints: the key/value pair carries a space.
+printf 'import std.htp;\nfn main() { }\n' >badimport.hew
+OUT=$("$HEW" check --format json badimport.hew 2>&1)
+RC=$?
+if [ "$RC" -eq 1 ]; then ok; else bad "module-not-found exits 1 (got $RC)"; fi
+if echo "$OUT" | grep -q '"code": "E_MODULE_NOT_FOUND"'; then ok; else bad "module-not-found is a coded diagnostic: $OUT"; fi
+if echo "$OUT" | grep -q '"start_line": 1'; then ok; else bad "module-not-found carries the import span: $OUT"; fi
+if echo "$OUT" | grep -q 'std.net.http'; then ok; else bad "module-not-found suggests the nearest module"; fi
+
+# 6. A missing C driver is named, with the package to install. On Windows the only driver is
+#    clang.exe and the package is the LLVM release (link.rs:506-512, :544-547); `clang` matches there.
+printf 'fn main() { println("hi"); }\n' >hello.hew
+OUT=$(HEW_CC=/nonexistent/cc "$HEW" build hello.hew 2>&1)
+RC=$?
+if [ "$RC" -eq 1 ]; then ok; else bad "missing C driver exits 1 (got $RC)"; fi
+if echo "$OUT" | grep -q '/nonexistent/cc'; then ok; else bad "missing C driver is named: $OUT"; fi
+if echo "$OUT" | grep -qiE 'clang|gcc|build-essential|xcode'; then ok; else bad "missing C driver names the package: $OUT"; fi
+
+# 7. The three diagnostic channels are distinguishable by exit code and prefix.
+printf 'fn main() { let x: i64 = "s"; }\n' >user.hew
+"$HEW" check user.hew >/dev/null 2>&1
+RC=$?
+if [ "$RC" -eq 1 ]; then ok; else bad "a user error exits 1 (got $RC)"; fi
+# D9 freezes the rule; V060-DIAG ships the refusal as E_LIMIT_MAIN_CONTEXT, whose text
+# names the actor-hosted loop (the Book's first service) and `join {}` (the fan-out from main).
+printf 'fn main() { scope { fork { println("x"); } } }\n' >limit.hew
+OUT=$("$HEW" check limit.hew 2>&1)
+RC=$?
+if [ "$RC" -eq 3 ]; then ok; else bad "a compiler limitation exits 3 (got $RC): $OUT"; fi
+if echo "$OUT" | grep -q 'compiler limitation:'; then ok; else bad "limitation channel is prefixed: $OUT"; fi
+if echo "$OUT" | grep -q 'E_LIMIT_MAIN_CONTEXT'; then ok; else bad "the refusal carries its code: $OUT"; fi
+if echo "$OUT" | grep -q 'actor'; then ok; else bad "the refusal names the actor-hosted loop: $OUT"; fi
+if echo "$OUT" | grep -q 'join'; then ok; else bad "the refusal names the fan-out that works from main: $OUT"; fi
+
+echo "day-one: ${N} steps reported"
+exit 0

--- a/repros/journeys/day-two.sh
+++ b/repros/journeys/day-two.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# repros/journeys/day-two.sh
+# Day two: a crash says where; a dependency installs from a clean cache and a
+# wrong one is refused at the manifest; the release binary deploys as one
+# static file.
+# Source: hew-orchestration/plans/hew-platform-program.md §0.1 (the bash
+# fence starting at that document's line 253), copied verbatim except for
+# the step-reporting harness described below (V060-FD-1).
+#
+# Run: make test-journeys JOURNEY=day-two   (HEW_BIN on PATH, TMPDIR outside any hew root)
+# The registry-dependent steps (search/add/install/info) run against a local
+# registry started by scripts/registry-harness.sh, which exports HEW_REGISTRY;
+# scripts/run-journeys.sh routes this script through that harness. When no
+# registry is reachable, those steps fail closed instead of hanging (below).
+# Day two on Windows is tier 2 until scripts/registry-harness.sh runs on the windows-2022 job (§0.1).
+set -uo pipefail
+HEW=${HEW_BIN:-hew}
+WORK=$(mktemp -d "${TMPDIR:?TMPDIR must point outside the checkout}/journey-day-two-XXXXXX") || exit 1
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK" || exit 1
+
+NAME=day-two
+N=0
+ok() {
+    N=$((N + 1))
+    echo "step ${NAME}.${N}: pass"
+}
+bad() {
+    N=$((N + 1))
+    echo "step ${NAME}.${N}: fail"
+    echo "${NAME}: step ${N} FAIL: $*" >&2
+}
+# A registry-touching step that can't even attempt its command when no
+# registry is reachable (avoids hanging on a dead endpoint).
+no_registry() { bad "$* (HEW_REGISTRY not set: scripts/registry-harness.sh found no local registry)"; }
+# Every assertion captures first and greps the capture (pipefail + `grep -q` is a false failure).
+
+# 1. A trap names file, line, and function; HEW_BACKTRACE=1 lists frames;
+#    release builds keep line tables. Exit code stays 1 (HEW-SPEC-2026 §5.8).
+#    On Windows the reader is dbghelp over the PDB; the assertions are the same (§6.1).
+cat >crash.hew <<'HEW'
+fn boom(v: Vec<i64>, i: i64) -> i64 {
+    v[i]
+}
+fn main() { let v: Vec<i64> = [1, 2, 3]; println(f"{boom(v, 5)}"); }
+HEW
+OUT=$("$HEW" run crash.hew 2>&1)
+RC=$?
+if [ "$RC" -eq 1 ]; then ok; else bad "trap exits 1 (got $RC)"; fi
+if echo "$OUT" | grep -q 'IndexOutOfBounds'; then ok; else bad "trap kind is named: $OUT"; fi
+if echo "$OUT" | grep -q 'crash.hew:2'; then ok; else bad "trap names file:line: $OUT"; fi
+if echo "$OUT" | grep -q 'boom'; then ok; else bad "trap names the function: $OUT"; fi
+OUT=$(HEW_BACKTRACE=1 "$HEW" run crash.hew 2>&1)
+if echo "$OUT" | grep -q 'main (crash.hew:4)'; then ok; else bad "backtrace lists the caller frame: $OUT"; fi
+if "$HEW" build --release crash.hew -o crash_rel >"$WORK/.log.build-crash" 2>&1; then ok; else bad "release build of crash.hew: $(cat "$WORK/.log.build-crash")"; fi
+OUT=$(./crash_rel 2>&1)
+if echo "$OUT" | grep -q 'crash.hew:2'; then ok; else bad "release trap still names file:line: $OUT"; fi
+
+# 2. Add a dependency from a clean package cache; refuse a wrong one at the manifest.
+export HEW_HOME="$WORK/hew-home"
+if "$HEW" new app >"$WORK/.log.new-app" 2>&1 && cd app; then ok; else bad "hew new app: $(cat "$WORK/.log.new-app")"; fi
+if [ -n "${HEW_REGISTRY:-}" ]; then
+    OUT=$("$HEW" search stats 2>&1)
+    if echo "$OUT" | grep -q 'hew.math.stats'; then ok; else bad "search prints the dotted name add accepts: $OUT"; fi
+else
+    no_registry "search prints the dotted name add accepts"
+fi
+if [ -n "${HEW_REGISTRY:-}" ]; then
+    if "$HEW" add hew.math.stats >"$WORK/.log.add-stats" 2>&1; then ok; else bad "add resolves against the registry: $(cat "$WORK/.log.add-stats")"; fi
+else
+    no_registry "add resolves against the registry"
+fi
+if grep -q '"hew.math.stats"' hew.toml 2>/dev/null; then ok; else bad "add wrote the quoted dotted key"; fi
+if [ -n "${HEW_REGISTRY:-}" ]; then
+    "$HEW" add hew.does.not.exist >/dev/null 2>&1
+    RC=$?
+    if [ "$RC" -eq 1 ]; then ok; else bad "unknown package is refused at add with exit 1 (got $RC)"; fi
+else
+    no_registry "unknown package is refused at add with exit 1"
+fi
+if grep -q 'does.not.exist' hew.toml 2>/dev/null; then bad "unknown package must not reach the manifest"; else ok; fi
+# An unquoted dotted key is a nested TOML table, which today reads as a dependency on `hew@*`
+# (fable3/probes.md); the manifest refuses it and names the quoted form (§6.2).
+printf '\n[dev-dependencies]\nhew.math.stats = "0.3"\n' >>hew.toml
+OUT=$("$HEW" check 2>&1)
+RC=$?
+if [ "$RC" -eq 1 ]; then ok; else bad "unquoted dotted dependency key is refused (got $RC): $OUT"; fi
+if echo "$OUT" | grep -q '"hew.math.stats"'; then ok; else bad "manifest refusal names the quoted form: $OUT"; fi
+sed -i.bak '/dev-dependencies/,$d' hew.toml && rm -f hew.toml.bak
+if [ -n "${HEW_REGISTRY:-}" ]; then
+    if "$HEW" install >"$WORK/.log.install" 2>&1; then ok; else bad "install fetches from the registry: $(cat "$WORK/.log.install")"; fi
+else
+    no_registry "install fetches from the registry"
+fi
+if [ -f hew.lock ]; then ok; else bad "install writes hew.lock"; fi
+cat >main.hew <<'HEW'
+import hew.math.stats as stats;
+fn main() -> Result<(), stats.StatsError> {
+    let m = stats.mean([1.0, 2.0, 3.0])?;
+    println(f"mean={m}");
+    .Ok(())
+}
+HEW
+if [ -n "${HEW_REGISTRY:-}" ]; then
+    OUT=$("$HEW" run 2>&1)
+    if echo "$OUT" | grep -q 'mean=2'; then ok; else bad "dependency is usable from main: $OUT"; fi
+else
+    no_registry "dependency is usable from main"
+fi
+cat >main_test.hew <<'HEW'
+import std.testing;
+import hew.math.stats as stats;
+#[test]
+fn mean_of_three() { testing.assert_eq(stats.mean([1.0, 2.0, 3.0]).unwrap(), 2.0); }
+HEW
+if [ -n "${HEW_REGISTRY:-}" ]; then
+    OUT=$("$HEW" test 2>&1)
+    if echo "$OUT" | grep -q '1 passed; 0 failed'; then ok; else bad "tests see dependencies: $OUT"; fi
+else
+    no_registry "tests see dependencies"
+fi
+if [ -n "${HEW_REGISTRY:-}" ]; then
+    "$HEW" info hew.nope >/dev/null 2>&1
+    RC=$?
+    if [ "$RC" -eq 1 ]; then ok; else bad "info not-found is exit 1, a data answer, not usage exit 2 (got $RC)"; fi
+else
+    no_registry "info not-found is exit 1, a data answer, not usage exit 2"
+fi
+
+# 3. A main that returns Err prints the error and exits 1 (today: silent).
+#    D4: main's error type implements Error; Display supplies the text.
+cat >mainerr.hew <<'HEW'
+enum AErr { Bad }
+impl Display for AErr { fn fmt(self) -> string { "bad thing" } }
+impl Error for AErr {}
+fn f() -> Result<(), AErr> { .Err(AErr.Bad) }
+fn main() -> Result<(), AErr> { f()?; .Ok(()) }
+HEW
+OUT=$("$HEW" run mainerr.hew 2>&1)
+RC=$?
+if [ "$RC" -eq 1 ]; then ok; else bad "main returning Err exits 1 (got $RC)"; fi
+if echo "$OUT" | grep -q 'error: bad thing'; then ok; else bad "main returning Err prints the Display text: $OUT"; fi
+
+# 4. Deploy: one static binary; cross-object emission in both modes; container smoke where docker exists.
+BUILD_OUT=$("$HEW" build --release 2>&1)
+if echo "$BUILD_OUT" | grep -q 'target/release/app'; then ok; else bad "build names its artifact: $BUILD_OUT"; fi
+if command -v ldd >/dev/null 2>&1; then
+    EXTRA=$(ldd target/release/app 2>/dev/null | grep -vE 'linux-vdso|libc\.so|libm\.so|libgcc_s|ld-linux|libpthread|libdl' || true)
+    if [ -z "$EXTRA" ]; then ok; else bad "release binary links beyond libc/libm/libgcc: $EXTRA"; fi
+else
+    ok # ldd unavailable on this host; nothing to assert
+fi
+# `-o` is honoured from inside a package (today: dropped silently, main.o appears) ...
+if "$HEW" build --release --target aarch64-unknown-linux-gnu --emit-obj -o app-aarch64.o >"$WORK/.log.obj-pkg" 2>&1; then ok; else bad "cross object emission: $(cat "$WORK/.log.obj-pkg")"; fi
+if [ -f app-aarch64.o ]; then ok; else bad "cross object emission wrote the named file"; fi
+if [ -f main.o ]; then bad "cross object emission must not also write main.o"; else ok; fi
+if command -v file >/dev/null 2>&1; then
+    if [ -f app-aarch64.o ] && file app-aarch64.o | grep -qi 'aarch64'; then ok; else bad "cross object is not aarch64: $(file app-aarch64.o 2>&1)"; fi
+else
+    ok # `file` unavailable on this host; nothing to assert
+fi
+# ... and in file mode (today: `--emit-obj hello.hew -o x.o` writes hello.o and drops -o; a binary -o works).
+cd "$WORK" || true
+printf 'fn main() { println("hi"); }\n' >obj.hew
+if "$HEW" build --release --target aarch64-unknown-linux-gnu --emit-obj obj.hew -o obj-aarch64.o >"$WORK/.log.obj-file" 2>&1; then ok; else bad "file-mode cross object emission: $(cat "$WORK/.log.obj-file")"; fi
+if [ -f obj-aarch64.o ]; then ok; else bad "file-mode -o was dropped"; fi
+if [ -f obj.o ]; then bad "file-mode cross object emission must not write obj.o"; else ok; fi
+cd app 2>/dev/null || true # a failed cd leaves the docker guard below false (no target/release), which skips cleanly
+# Guard on target/release existing before invoking docker: a `-v` bind mount
+# of a path that is not there yet is auto-created by the docker daemon as
+# root (observed live during grounding), which a later `rm -rf "$WORK"`
+# then cannot clean up. Skip cleanly instead of leaving root-owned garbage.
+if [ -d target/release ] && command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    OUT=$(docker run --rm -v "$PWD/target/release:/app:ro" debian:bookworm-slim /app/app 2>&1)
+    if echo "$OUT" | grep -q 'mean=2'; then ok; else bad "container run: $OUT"; fi
+else
+    ok # docker unavailable, or target/release was never built; the static-link check above stands in
+fi
+
+echo "day-two: ${N} steps reported"
+exit 0

--- a/repros/journeys/week-one-local.sh
+++ b/repros/journeys/week-one-local.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# repros/journeys/week-one-local.sh
+# Day three: the first service. One node, a supervised store, the HTTP loop in
+# an actor with a timed ask, a bad request answered without an exit, an operator
+# crash the supervisor recovers from, and the metrics that show it. Standard
+# library only, no registry, no cluster.
+# Source: hew-orchestration/plans/hew-platform-program.md §0.1 (the bash
+# fence starting at that document's line 665), copied verbatim except for
+# the step-reporting harness described below (V060-FD-1). The package under
+# repros/journeys/week-one-local/ (hew.toml, main.hew, main_test.hew) is
+# copied the same way from that section's file-headered fences (lines 434,
+# 447, 638) — Sites for V060-FD-1 name only the three *.sh scripts, but
+# week-one-local.sh has no journey to run without its own package, so this
+# fixture directory travels with it.
+#
+# Run: make test-journeys JOURNEY=week-one-local   (HEW_BIN on PATH, TMPDIR outside any hew root)
+# Ports come from JOURNEY_PORT_BASE (default 8080) so a busy port or a parallel shard cannot fail the gate.
+#
+# Every assertion is a numbered step (`week-one-local.<n>`), printed to stdout
+# as `step week-one-local.<n>: pass` or `step week-one-local.<n>: fail`. A
+# failing step is recorded and the script continues; scripts/journeys-expected.tsv
+# is the ratchet that decides whether a given failure is already known. No
+# `-e`: a failure here must never abort the script before every step is reported.
+set -uo pipefail
+HEW=${HEW_BIN:-hew}
+SRC=$(cd "$(dirname "$0")/week-one-local" && pwd) || exit 1
+PORT=${JOURNEY_PORT_BASE:-8080}
+WORK=$(mktemp -d "${TMPDIR:?TMPDIR must point outside the checkout}/journey-week-one-local-XXXXXX") || exit 1
+SVC=
+# shellcheck disable=SC2329 # invoked indirectly via `trap cleanup EXIT` below
+cleanup() {
+    if [ -n "$SVC" ]; then
+        kill "$SVC" 2>/dev/null || true
+        wait "$SVC" 2>/dev/null || true
+    fi
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+NAME=week-one-local
+N=0
+ok() {
+    N=$((N + 1))
+    echo "step ${NAME}.${N}: pass"
+}
+bad() {
+    N=$((N + 1))
+    echo "step ${NAME}.${N}: fail"
+    echo "${NAME}: step ${N} FAIL: $*" >&2
+}
+until_ok() {
+    local tries=$1
+    shift
+    for _ in $(seq "$tries"); do
+        "$@" && return 0
+        sleep 1
+    done
+    return 1
+}
+# `producer | grep -q` under pipefail fails when the producer writes after the match; capture first.
+code() { curl -s -m 5 -o /dev/null -w '%{http_code}' "$@"; }
+has() {
+    local out
+    out=$(curl -s -m 5 "$1") || return 1
+    echo "$out" | grep -qE "$2"
+}
+# Per-handler attribution is opt-in (§4.6); the service runs with it on.
+export HEW_OBSERVE=1
+
+cp -r "$SRC" "$WORK/kvlocal" && cd "$WORK/kvlocal" || exit 1
+OUT=$("$HEW" test 2>&1)
+if echo "$OUT" | grep -q '3 passed; 0 failed'; then ok; else bad "package tests: $OUT"; fi
+OUT=$("$HEW" build --release 2>&1)
+if echo "$OUT" | grep -q 'target/release/kvlocal'; then ok; else bad "build: $OUT"; fi
+
+# 1. Up: one binary hosts the supervised store and the HTTP actor.
+KV_DB="$WORK/kv.json" KV_ADDR="127.0.0.1:$PORT" ./target/release/kvlocal >"$WORK/svc.log" 2>&1 &
+SVC=$!
+HEALTH_URL="localhost:${PORT}/health"
+if until_ok 20 sh -c "[ \"\$(curl -s -m 2 -o /dev/null -w '%{http_code}' $HEALTH_URL)\" = 200 ]"; then ok; else bad "service never came up: $(cat "$WORK/svc.log" 2>/dev/null)"; fi
+
+# 2. http + json + the store, through a timed ask (`await .. | after 2s` inside the Api actor).
+if [ "$(code -X POST -d '{"key":"a","val":"1"}' localhost:"$PORT"/items)" = 201 ]; then ok; else bad "POST /items"; fi
+if has localhost:"$PORT"/items/a '"val":"1"'; then ok; else bad "GET /items/a"; fi
+if [ "$(code localhost:"$PORT"/items/zzz)" = 404 ]; then ok; else bad "GET missing is 404"; fi
+
+# 3. A bad request is a response, never an exit: 400, and the service is still up.
+if [ "$(code -X POST -d 'not json' localhost:"$PORT"/items)" = 400 ]; then ok; else bad "bad body is a 400"; fi
+if [ "$(code localhost:"$PORT"/health)" = 200 ]; then ok; else bad "service died on a bad body: $(cat "$WORK/svc.log" 2>/dev/null)"; fi
+
+# 4. The operator's view: per-handler attribution under the declaration-dotpath label (§4.6, v0.6.0).
+if has localhost:"$PORT"/metrics 'handler="Store.handle"'; then ok; else bad "per-handler attribution"; fi
+
+# 5. Crash the store: the supervisor restarts it, #[on(start)] reloads the snapshot, the data is
+#    intact, and the restart is counted per child (§4.4, v0.6.0).
+if [ "$(code -X POST localhost:"$PORT"/admin/crash)" = 202 ]; then ok; else bad "POST /admin/crash"; fi
+if until_ok 10 has localhost:"$PORT"/items/a '"val":"1"'; then ok; else bad "store did not come back with its data: $(cat "$WORK/svc.log" 2>/dev/null)"; fi
+if has localhost:"$PORT"/metrics 'supervisor_restarts_by_child_total\{[^}]*child="store"[^}]*\} 1'; then ok; else bad "restart is not visible in /metrics"; fi
+if [ "$(grep -c 'store: up' "$WORK/svc.log" 2>/dev/null)" -eq 2 ]; then ok; else bad "log does not show the second start: $(cat "$WORK/svc.log" 2>/dev/null)"; fi
+
+# 6. The snapshot on disk is the store's state: a second process started on it serves the data.
+kill "$SVC" 2>/dev/null
+wait "$SVC" 2>/dev/null || true
+SVC=
+KV_DB="$WORK/kv.json" KV_ADDR="127.0.0.1:$PORT" ./target/release/kvlocal >"$WORK/svc2.log" 2>&1 &
+SVC=$!
+if until_ok 20 has localhost:"$PORT"/items/a '"val":"1"'; then ok; else bad "restarted process did not serve the snapshot: $(cat "$WORK/svc2.log" 2>/dev/null)"; fi
+
+echo "week-one-local: ${N} steps reported"
+exit 0

--- a/repros/journeys/week-one-local/hew.toml
+++ b/repros/journeys/week-one-local/hew.toml
@@ -1,0 +1,8 @@
+[package]
+name = "kvlocal"
+edition = "2026"
+version = "0.1.0"
+
+# Standard library only, no [dependencies], no [cluster]: the first service is
+# one node, and the north star's "one binary and the standard library" is what
+# this journey tests (§0.1, §6.3).

--- a/repros/journeys/week-one-local/main.hew
+++ b/repros/journeys/week-one-local/main.hew
@@ -1,0 +1,186 @@
+// repros/journeys/week-one-local/main.hew - the first service, and the Book's
+// "Your first service" chapter (§6.4). One node, one binary: a supervised Store
+// actor that persists a JSON snapshot, and an Api actor that hosts the HTTP
+// accept loop and asks the store with a deadline. Standard library only.
+// Every surface used here is decided in hew-platform-program.md; the deciding
+// item is named beside each first use. fable4/probes/local_svc.hew is this
+// program in today's dialect and runs on hew 0.6.0-rc3-dev.148 (fable4/probes.md).
+import std.net;                        // net.NetError
+import std.net.http.server as http;   // D22: net/http/server (was net/http/http)
+import std.encoding.wire as wire;
+import std.encoding.json as json;     // request and response bodies at 0.6.0 (B5 note below)
+import std.observe;
+import std.log;                        // D22: log (was misc/log)
+import std.os;
+import std.fs;
+
+#[wire] pub type Item { key: string @1; val: string @2; }
+#[wire] enum KvReq { Put(Item); Get(string); }          // variants carry no tags (review1/wrec.hew)
+#[wire] enum KvResp { Done; Found(Item); Missing; Failed(string); }
+
+/// The supervisor's construction-time config: a supervised child's owned init
+/// state comes from here and is deep-cloned per incarnation (§4.4).
+type StoreCfg { db_path: string; seed: string; }
+
+/// Index of `key` in `items`, or -1. A linear scan is the whole database.
+pub fn find(items: Vec<Item>, key: string) -> i64 {
+    for i in 0..items.len() {
+        if items[i].key == key { return i; }
+    }
+    -1
+}
+
+/// The snapshot text as items; an empty snapshot is an empty store. `boot`
+/// validated the text, so a decode failure here is unreachable.
+pub fn load(snapshot: string) -> Vec<Item> {
+    if snapshot == "" { return []; }
+    match wire.from_json<Vec<Item>>(snapshot) {                 // F10: a Vec of #[wire] records; the turbofish, never inference through `?` (D8)
+        .Ok(items) => items,
+        .Err(_) => [],
+    }
+}
+
+/// The store: a supervised actor whose whole state is the snapshot text,
+/// reloaded from `path` on every start (the first and every restart;
+/// fable3/sup_onstart.hew). A supervised child's state is scalars, `string`,
+/// and `bytes` on the current lowerer (D8: E_LIMIT_SUPERVISED_STATE, P2); the
+/// two-node service keeps a `Vec<Item>` field once P2 lands.
+actor Store {
+    var path: string;
+    var snapshot: string;
+
+    #[on(start)]
+    fn boot() {
+        match fs.read(path) {                                      // D20: Result<string, IoError>
+            .Ok(text) => match wire.from_json<Vec<Item>>(text) {   // D21: Result<T, wire.DecodeError>
+                .Ok(items) => {
+                    snapshot = text;
+                    log.info_with("store: up", [log.field_int("items", items.len())]);
+                },
+                .Err(e) => panic(f"kv: {path} is not a snapshot: {e}"),
+            },
+            .Err(.NotFound(_)) => log.info_with("store: up", [log.field_int("items", 0)]),   // first start
+            .Err(e) => panic(f"kv: cannot read {path}: {e}"),
+        }
+    }
+
+    receive fn handle(req: KvReq) -> KvResp {
+        match req {
+            .Put(item) => {
+                var items = load(snapshot);                        // D1: `var`, because `push` and index assignment mutate
+                let i = find(items, item.key);
+                if i >= 0 { items[i] = item; } else { items.push(item); }
+                snapshot = wire.to_json(items);
+                match fs.write(path, snapshot) {                   // D20: Result<(), IoError>
+                    .Ok(_) => .Done,
+                    .Err(e) => .Failed(f"{e}"),
+                }
+            },
+            .Get(key) => {
+                let items = load(snapshot);
+                let i = find(items, key);
+                if i >= 0 { .Found(items[i]) } else { .Missing }
+            },
+        }
+    }
+
+    /// The operator's crash lever (POST /admin/crash): `panic` is the crash
+    /// primitive (std/builtins.hew:1090) and the supervisor's restart is the recovery.
+    receive fn crash_now() {
+        panic("operator-requested crash");
+    }
+}
+
+supervisor StoreSup(config: StoreCfg) {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+    child store: Store(path: config.db_path, snapshot: config.seed);
+}
+
+/// JSON bodies through `std.encoding.json` at 0.6.0: a bare `#[wire]` record is
+/// `Serializable` at P2 (B5), when `wire.to_json(item)` replaces these two.
+fn item_json(item: Item) -> string {
+    json.object().with_string("key", item.key).with_string("val", item.val).stringify()
+}
+fn error_json(msg: string) -> string {
+    json.object().with_string("error", msg).stringify()
+}
+
+/// A response the client did not wait for is logged, never an exit: the
+/// request loop answers requests; it does not return to `main` (§0.1, §6.4).
+fn reply(req: http.Request, status: i64, body: string) {
+    match req.respond_json(status, body) {                        // D20: Result<(), NetError>
+        .Ok(_) => {},
+        .Err(e) => log.debug(f"client went away: {e}"),
+    }
+}
+
+/// The HTTP loop lives in an actor: `await .. | after d` needs an actor
+/// context until D9 lands (v0.7.0), and one request is served at a time, so a
+/// slow store request delays `/health` by at most the ask deadline.
+actor Api {
+    var sup: LocalPid<StoreSup>;
+    var addr: string;
+
+    receive fn serve() -> Result<(), net.NetError> {
+        let srv = http.listen(addr)?;                             // the one `?`: no listener, no service
+        loop {
+            let req = match srv.accept() {                        // D20: Result<Request, NetError>
+                .Ok(r) => r,
+                .Err(e) => { log.warn(f"accept: {e}"); continue; },
+            };
+            let method = req.method();
+            let path = req.path();
+            if method == "POST" && path == "/items" {
+                match json.try_parse(req.body("utf-8")) {         // a bad body is a 400, never an exit
+                    .Ok(v) => {
+                        let item = Item { key: v.get_field("key").get_string(), val: v.get_field("val").get_string() };
+                        match await sup.store.handle(.Put(item)) | after 2s {
+                            .Ok(.Done) => reply(req, 201, "{}"),
+                            .Ok(.Failed(msg)) => reply(req, 500, error_json(msg)),
+                            .Ok(_) => reply(req, 500, "{}"),
+                            .Err(e) => reply(req, 503, error_json(f"{e}")),   // D21: AskError prints its variant
+                        }
+                    },
+                    .Err(e) => reply(req, 400, error_json(f"{e}")),
+                }
+            } else if method == "GET" && path.starts_with("/items/") {
+                match await sup.store.handle(.Get(path.slice(7, path.len()))) | after 2s {
+                    .Ok(.Found(item)) => reply(req, 200, item_json(item)),
+                    .Ok(.Missing) => reply(req, 404, "{}"),
+                    .Ok(_) => reply(req, 500, "{}"),
+                    .Err(e) => reply(req, 503, error_json(f"{e}")),
+                }
+            } else if method == "POST" && path == "/admin/crash" {
+                match sup.store.crash_now() {                     // D11: a send is Result<(), SendError>
+                    .Ok(_) => reply(req, 202, "{}"),
+                    .Err(e) => reply(req, 503, error_json(f"{e}")),
+                }
+            } else if method == "GET" && path == "/health" {
+                reply(req, 200, "{\"ok\":true}");
+            } else if method == "GET" && path == "/metrics" {
+                match req.respond(200, "text/plain", observe.scrape()) {   // §4.4: supervisor.* and actors.* series
+                    .Ok(_) => {},
+                    .Err(e) => log.debug(f"client went away: {e}"),
+                }
+            } else {
+                reply(req, 404, "{}");
+            }
+        }
+    }
+}
+
+fn main() -> Result<(), dyn Error> {
+    log.setup();
+    let db = os.env("KV_DB").unwrap_or("kv.json");               // D20: env -> Option<string>
+    let addr = os.env("KV_ADDR").unwrap_or("127.0.0.1:8080");
+    let sup = spawn StoreSup(config: StoreCfg { db_path: db, seed: "" });
+    let api = spawn Api(sup: sup, addr: addr);
+    // `main` parks on the server's ask and returns only when the server stops or
+    // dies: the process's exit path is the `Err` arm (fable4/probes/main_await_serve3.hew).
+    match await api.serve() {
+        .Ok(.Ok(_)) => .Ok(()),
+        .Ok(.Err(e)) => .Err(e),                                   // listen failed; D4 coerces NetError to dyn Error
+        .Err(e) => .Err(e),                                        // the Api actor died: AskError
+    }
+}

--- a/repros/journeys/week-one-local/main_test.hew
+++ b/repros/journeys/week-one-local/main_test.hew
@@ -1,0 +1,21 @@
+// repros/journeys/week-one-local/main_test.hew - a peer test module of the package (D17).
+import std.testing;
+import std.encoding.wire as wire;
+
+#[test]
+fn items_round_trip_through_json() {
+    let back = wire.from_json<Vec<Item>>(wire.to_json([Item { key: "a", val: "1" }])).unwrap();
+    testing.assert_eq(back[0].val, "1");                          // D22: one generic assert_eq
+}
+
+#[test]
+fn empty_snapshot_loads_as_empty_store() {
+    testing.assert_eq(load("").len(), 0);
+}
+
+#[test]
+fn find_reports_absence_as_minus_one() {
+    let items: Vec<Item> = [Item { key: "a", val: "1" }];
+    testing.assert_eq(find(items, "a"), 0);
+    testing.assert_eq(find(items, "zzz"), -1);
+}

--- a/scripts/check-time-baseline.tsv
+++ b/scripts/check-time-baseline.tsv
@@ -1,0 +1,9 @@
+# host_class	median_ms	recorded_at
+#
+# One row per host_class (`uname -m` plus the CI runner label when CI is
+# set, else "local"): the median of five `hew check std/net/http/http.hew`
+# runs. `make check-time-ratchet` fails when a fresh median exceeds 2x
+# this row's median_ms; `make check-time-ratchet-record` rewrites the row
+# for the current host_class. A host_class with no row is recorded on its
+# first `check` run and passed, not failed (V060-FD-1).
+x86_64-local	677	2026-09-03T03:23:31Z

--- a/scripts/check-time-ratchet.sh
+++ b/scripts/check-time-ratchet.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# scripts/check-time-ratchet.sh check|record
+#
+# Fixture: `hew check std/net/http/http.hew`, the largest std module a
+# newcomer's program pulls in. Runs it five times and takes the median
+# wall-clock time in milliseconds. `host_class` is `uname -m` plus the CI
+# runner label when CI is set, else "local" — the same binary run on
+# different hardware has a different budget, so the ratchet is per class.
+#
+# record: writes/replaces scripts/check-time-baseline.tsv's row for this
+# host_class with the measured median.
+# check: fails when the measured median exceeds 2x that row's median_ms.
+# A host_class with no row yet cannot be compared against itself, so
+# `check` records one and passes, printing that it did — CI records on
+# `main` pushes and checks on PRs, so a new runner class is compared from
+# its second run on (V060-FD-1).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASELINE_TSV="$REPO_ROOT/scripts/check-time-baseline.tsv"
+FIXTURE="std/net/http/http.hew"
+HEW_BIN="${HEW_BIN:-hew}"
+
+MODE="${1:-}"
+case "$MODE" in
+check | record) ;;
+*)
+    echo "usage: check-time-ratchet.sh check|record" >&2
+    exit 64
+    ;;
+esac
+
+command -v "$HEW_BIN" >/dev/null 2>&1 || {
+    echo "check-time-ratchet: HEW_BIN '$HEW_BIN' not found" >&2
+    exit 1
+}
+[ -f "$REPO_ROOT/$FIXTURE" ] || {
+    echo "check-time-ratchet: fixture missing: $FIXTURE" >&2
+    exit 1
+}
+
+runner_label="local"
+if [ -n "${CI:-}" ]; then
+    runner_label="${RUNNER_OS:-ci}"
+fi
+HOST_CLASS="$(uname -m)-${runner_label}"
+
+# Millisecond wall-clock: `date +%s%3N` is GNU-only, but this repo's CI and
+# dev hosts are all GNU coreutils or a Bash-only fallback would double the
+# script's surface for no real gain (macOS/BSD add `gdate`, not stdlib date
+# flags) — WHEN this needs a native macOS/BSD host without gdate, WHAT: use
+# bash's $EPOCHREALTIME (bash 5+) instead of shelling out to `date`.
+now_ms() {
+    if [ -n "${EPOCHREALTIME:-}" ]; then
+        awk -v t="$EPOCHREALTIME" 'BEGIN { printf "%d", t * 1000 }'
+    else
+        date +%s%3N
+    fi
+}
+
+TIMES=()
+for _ in 1 2 3 4 5; do
+    START=$(now_ms)
+    "$HEW_BIN" check "$REPO_ROOT/$FIXTURE" >/dev/null 2>&1
+    RC=$?
+    END=$(now_ms)
+    [ "$RC" -eq 0 ] || {
+        echo "check-time-ratchet: hew check exited $RC on $FIXTURE" >&2
+        exit 1
+    }
+    TIMES+=("$((END - START))")
+done
+
+# Median of 5: sort, take the middle.
+MEDIAN=$(printf '%s\n' "${TIMES[@]}" | sort -n | sed -n '3p')
+
+record_baseline() {
+    local tmp
+    tmp=$(mktemp "${TMPDIR:-/tmp}/check-time-baseline-XXXXXX")
+    # Keep the header comment block and every other host_class's row
+    # unchanged; drop this host_class's old row (if any) and append its
+    # freshly measured one.
+    awk -F'\t' -v h="$HOST_CLASS" '/^#/ || $1 != h' "$BASELINE_TSV" >"$tmp"
+    printf '%s\t%s\t%s\n' "$HOST_CLASS" "$MEDIAN" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$tmp"
+    mv "$tmp" "$BASELINE_TSV"
+}
+
+if [ "$MODE" = "record" ]; then
+    record_baseline
+    echo "check-time-ratchet: recorded ${HOST_CLASS} median=${MEDIAN}ms over 5 runs of hew check ${FIXTURE}"
+    exit 0
+fi
+
+# check
+BASELINE_MS=$(awk -F'\t' -v h="$HOST_CLASS" '!/^#/ && $1==h {print $2}' "$BASELINE_TSV" | tail -1)
+if [ -z "$BASELINE_MS" ]; then
+    record_baseline
+    echo "check-time-ratchet: no baseline for host_class=${HOST_CLASS}; recorded median=${MEDIAN}ms and passing (nothing to compare against yet)"
+    exit 0
+fi
+
+CEILING=$((BASELINE_MS * 2))
+echo "check-time-ratchet: host_class=${HOST_CLASS} median=${MEDIAN}ms baseline=${BASELINE_MS}ms ceiling=${CEILING}ms"
+if [ "$MEDIAN" -gt "$CEILING" ]; then
+    echo "check-time-ratchet: FAIL — median ${MEDIAN}ms exceeds 2x baseline ${BASELINE_MS}ms" >&2
+    exit 1
+fi
+echo "check-time-ratchet: ok"

--- a/scripts/check-time-ratchet.sh
+++ b/scripts/check-time-ratchet.sh
@@ -11,9 +11,9 @@
 # host_class with the measured median.
 # check: fails when the measured median exceeds 2x that row's median_ms.
 # A host_class with no row yet cannot be compared against itself, so
-# `check` records one and passes, printing that it did — CI records on
-# `main` pushes and checks on PRs, so a new runner class is compared from
-# its second run on (V060-FD-1).
+# `check` records one and passes, printing that it did; the recorded row
+# is only durable once someone commits it, so a new runner class is
+# compared from the first run after that (V060-FD-1).
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/journeys-expected.tsv
+++ b/scripts/journeys-expected.tsv
@@ -1,0 +1,82 @@
+# step_id	issue_or_lane	reason
+#
+# The ratchet for `make test-journeys JOURNEY=<name>` (scripts/run-journeys.sh):
+# exactly the step ids listed here may fail. A listed step that starts
+# passing is a stale row — the lane that fixed it deletes the row in the
+# same PR (never leave it for a later lane to notice). A failing step with
+# no row here is a new regression and fails the gate. Seeded from a real
+# run against `hew 0.6.0-rc3-dev.155+7c1490375` on 2026-09-02 (V060-FD-1);
+# day-two ran under scripts/registry-harness.sh against a local
+# hew-registry checkout with wrangler dev.
+#
+# day-one: hew new/--actor/--lib do not exist yet (V060-FD-5), so every
+# step downstream of scaffolding a package fails too.
+day-one.1	V060-FD-5	hew new: unrecognized subcommand
+day-one.2	V060-FD-5	hew new does not exist; scaffold ships no test file
+day-one.3	V060-FD-5	hew new does not exist; no repository to check
+day-one.4	V060-FD-5	hew new does not exist; no .gitignore to check
+day-one.5	V060-FD-5	hew new does not exist; hew run finds no hew.toml
+day-one.6	V060-FD-5	hew new does not exist; hew test finds no test files
+day-one.7	V060-FD-5	hew new does not exist; hew build finds no hew.toml
+day-one.8	V060-FD-5	hew new does not exist; no target/release/svc artefact
+day-one.9	V060-FD-5	hew new does not exist; no release binary to run
+day-one.11	V060-FD-5	hew new --actor: unrecognized subcommand
+day-one.12	V060-FD-5	hew new --actor does not exist; actor scaffold never created
+day-one.13	V060-FD-5	hew new --lib: unrecognized subcommand
+day-one.14	V060-FD-5	hew new --lib does not exist; lib scaffold never created
+day-one.16	V060-FD-4	let mut error text says "rename this binding", not "var x"
+day-one.17	V060-FD-4	let mut is a three-error cascade, not one error
+day-one.20	V060-FD-4	module-not-found JSON carries a zero span (start_line: 0)
+day-one.21	V060-FD-4	module-not-found JSON carries no nearest-module suggestion
+day-one.22	V060-FD-3	HEW_CC=/nonexistent/cc build exits 0, not 1
+day-one.23	V060-FD-3	missing C driver: no error output naming the bad path
+day-one.24	V060-FD-3	missing C driver: no error output naming a package to install
+day-one.26	V060-DIAG-1	scope { fork {..} } in main exits 1 (E_NOT_YET_IMPLEMENTED), not 3
+day-one.27	V060-DIAG-1	limitation output has no "compiler limitation:" prefix
+day-one.28	V060-DIAG-1	refusal carries no E_LIMIT_MAIN_CONTEXT code
+day-one.30	V060-DIAG-1	refusal text does not name join {} as the fan-out that works from main
+#
+# day-two: trap symbolization (V060-FD-7) is unimplemented; hew new
+# (V060-FD-5) cascades through the whole dependency/build/deploy chain
+# once app/ is never created; two -o-in-file-mode bugs are V060-FD-2.
+day-two.3	V060-FD-7	trap message has no crash.hew:2 file:line
+day-two.4	V060-FD-7	trap message does not name the function (boom)
+day-two.5	V060-FD-7	HEW_BACKTRACE=1 output has no caller frame line
+day-two.7	V060-FD-7	release-build trap has no file:line either
+day-two.8	V060-FD-5	hew new: unrecognized subcommand
+day-two.9	V060-FD-5	search prints hew::math::stats, not the dotted hew.math.stats that add accepts
+day-two.10	V060-FD-5	hew new never created app/; add runs with no hew.toml
+day-two.11	V060-FD-5	cascades from day-two.8/10: no hew.toml to write the dependency into
+day-two.15	V060-FD-5	cascades from day-two.8: hew.toml never had a [package] table to append to
+day-two.16	V060-FD-5	cascades from day-two.8/15: install has no valid manifest to read
+day-two.17	V060-FD-5	cascades: no hew.lock without a working install
+day-two.18	V060-FD-5	cascades: main.hew never compiles without the dependency installed
+day-two.19	V060-FD-5	cascades: tests never compile without the dependency installed
+day-two.22	V060-SURFACE	.Err(AErr.Bad)/.Ok(()) construction refused: "no variant Err/Ok" on Result<(), AErr> (D3 bare-variant expression construction, unshipped; owning S-lane not yet assigned)
+day-two.23	V060-FD-5	cascades from day-two.8: build has no [package] table
+day-two.25	V060-FD-5	cascades from day-two.8: cross-object emission has no [package] table
+day-two.26	V060-FD-5	cascades from day-two.8: app-aarch64.o never written
+day-two.28	V060-FD-5	cascades from day-two.8: app-aarch64.o never written
+day-two.30	V060-FD-2	file-mode --emit-obj -o obj-aarch64.o did not write the named file
+day-two.31	V060-FD-2	file-mode --emit-obj wrote obj.o instead of honouring -o
+#
+# week-one-local: the decided-dialect program does not run today by design
+# (hew-platform-program.md §0.1: it is fable4/probes/local_svc.hew rewritten
+# by exactly ten substitutions into the decided dialect); this journey joins
+# the gate set at V060-RELEASE, after V060-STDLIB and the SURFACE lanes it
+# depends on land (plan lifecycle table, v0.6.0 row). Peer test compilation
+# (week-one-local.1) is the one row a single lane, V060-FD-6, can flip early.
+week-one-local.1	V060-FD-6	main_test.hew cannot see Item/load/find declared in main.hew (D17 peer test modules)
+week-one-local.2	V060-RELEASE	std.net.http.server does not exist yet (D22 rename net/http/http -> net/http/server, V060-STDLIB)
+week-one-local.3	V060-RELEASE	cascades from week-one-local.2: kvlocal binary never built
+week-one-local.4	V060-RELEASE	cascades from week-one-local.2
+week-one-local.5	V060-RELEASE	cascades from week-one-local.2
+week-one-local.6	V060-RELEASE	cascades from week-one-local.2
+week-one-local.7	V060-RELEASE	cascades from week-one-local.2
+week-one-local.8	V060-RELEASE	cascades from week-one-local.2
+week-one-local.9	V060-RELEASE	cascades from week-one-local.2
+week-one-local.10	V060-RELEASE	cascades from week-one-local.2
+week-one-local.11	V060-RELEASE	cascades from week-one-local.2
+week-one-local.12	V060-RELEASE	cascades from week-one-local.2
+week-one-local.13	V060-RELEASE	cascades from week-one-local.2
+week-one-local.14	V060-RELEASE	cascades from week-one-local.2

--- a/scripts/journeys-expected.tsv
+++ b/scripts/journeys-expected.tsv
@@ -37,9 +37,9 @@ day-one.16	V060-FD-4	let mut error text says "rename this binding", not "var x"
 day-one.17	V060-FD-4	let mut is a three-error cascade, not one error
 day-one.20	V060-FD-4	module-not-found JSON carries a zero span (start_line: 0)
 day-one.21	V060-FD-4	module-not-found JSON carries no nearest-module suggestion
-day-one.22	V060-FD-3	HEW_CC=/nonexistent/cc build exits 0, not 1
-day-one.23	V060-FD-3	missing C driver: no error output naming the bad path
-day-one.24	V060-FD-3	missing C driver: no error output naming a package to install
+day-one.22	V060-FD-3	HEW_CC has no reader in the compiler (grep -rn HEW_CC --include=*.rs is empty); the env var is silently ignored and build falls through to system cc, exit 0
+day-one.23	V060-FD-3	HEW_CC unimplemented (see day-one.22): no error output naming the bad path
+day-one.24	V060-FD-3	HEW_CC unimplemented (see day-one.22): no error output naming a package to install
 day-one.26	V060-DIAG-1	scope { fork {..} } in main exits 1 (E_NOT_YET_IMPLEMENTED), not 3
 day-one.27	V060-DIAG-1	limitation output has no "compiler limitation:" prefix
 day-one.28	V060-DIAG-1	refusal carries no E_LIMIT_MAIN_CONTEXT code

--- a/scripts/journeys-expected.tsv
+++ b/scripts/journeys-expected.tsv
@@ -15,8 +15,8 @@
 # (day-two.12, day-two.20) happen to pass there today because they never
 # reach the registry either (no hew.toml, cascading from day-two.8) --
 # `make test-journeys JOURNEY=day-two` on such a machine reports those
-# two as stale rows even though nothing regressed; this is a known
-# environment difference, not a bug in the ratchet.
+# two as stale rows even though nothing regressed. Tracked as #3297:
+# the gate should be green in its default configuration either way.
 #
 # day-one: hew new/--actor/--lib do not exist yet (V060-FD-5), so every
 # step downstream of scaffolding a package fails too.

--- a/scripts/journeys-expected.tsv
+++ b/scripts/journeys-expected.tsv
@@ -6,8 +6,17 @@
 # same PR (never leave it for a later lane to notice). A failing step with
 # no row here is a new regression and fails the gate. Seeded from a real
 # run against `hew 0.6.0-rc3-dev.155+7c1490375` on 2026-09-02 (V060-FD-1);
-# day-two ran under scripts/registry-harness.sh against a local
-# hew-registry checkout with wrangler dev.
+# day-two ran through scripts/registry-harness.sh with no hew-registry
+# checkout reachable (the CI job installs wrangler but does not check out
+# a sibling hew-registry, and most local worktrees have none either), so
+# every registry-gated step records the no_registry() failure. A dev
+# machine with a real local hew-registry checkout sibling gets a real
+# search/add/install run instead: two of its registry-gated steps
+# (day-two.12, day-two.20) happen to pass there today because they never
+# reach the registry either (no hew.toml, cascading from day-two.8) --
+# `make test-journeys JOURNEY=day-two` on such a machine reports those
+# two as stale rows even though nothing regressed; this is a known
+# environment difference, not a bug in the ratchet.
 #
 # day-one: hew new/--actor/--lib do not exist yet (V060-FD-5), so every
 # step downstream of scaffolding a package fails too.
@@ -47,11 +56,13 @@ day-two.8	V060-FD-5	hew new: unrecognized subcommand
 day-two.9	V060-FD-5	search prints hew::math::stats, not the dotted hew.math.stats that add accepts
 day-two.10	V060-FD-5	hew new never created app/; add runs with no hew.toml
 day-two.11	V060-FD-5	cascades from day-two.8/10: no hew.toml to write the dependency into
+day-two.12	V060-FD-5	no local registry (registry-harness.sh exit 75): unknown-package refusal never attempted
 day-two.15	V060-FD-5	cascades from day-two.8: hew.toml never had a [package] table to append to
 day-two.16	V060-FD-5	cascades from day-two.8/15: install has no valid manifest to read
 day-two.17	V060-FD-5	cascades: no hew.lock without a working install
 day-two.18	V060-FD-5	cascades: main.hew never compiles without the dependency installed
 day-two.19	V060-FD-5	cascades: tests never compile without the dependency installed
+day-two.20	V060-FD-5	no local registry (registry-harness.sh exit 75): info not-found never attempted
 day-two.22	V060-SURFACE	.Err(AErr.Bad)/.Ok(()) construction refused: "no variant Err/Ok" on Result<(), AErr> (D3 bare-variant expression construction, unshipped; owning S-lane not yet assigned)
 day-two.23	V060-FD-5	cascades from day-two.8: build has no [package] table
 day-two.25	V060-FD-5	cascades from day-two.8: cross-object emission has no [package] table

--- a/scripts/registry-harness.sh
+++ b/scripts/registry-harness.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# scripts/registry-harness.sh <cmd...>
+#
+# Starts a disposable local hew-registry dev server (`wrangler dev`, local
+# simulated KV/R2/Durable Objects, no cloud credentials), exports
+# HEW_REGISTRY to point at it, runs <cmd...> with that in its environment,
+# and tears the server down afterwards regardless of how <cmd...> exited.
+#
+# The registry checkout is a sibling of this repo by convention
+# (HEW_SYNC_REGISTRY overrides), matching scripts/sync-downstream.sh's
+# sibling-directory pattern for the other downstream repos. When `wrangler`
+# is not on PATH, the checkout is missing, or the dev server never comes up,
+# this prints one line explaining why and exits 75 (EX_UNAVAILABLE) without
+# running <cmd...> — the caller (scripts/run-journeys.sh, day-two's own
+# per-step registry guards) treats that as "no local registry" and records
+# the registry-dependent steps as failed rather than hanging on a dead
+# endpoint (V060-FD-1).
+set -uo pipefail
+
+EX_UNAVAILABLE=75
+
+if [ "$#" -eq 0 ]; then
+    echo "registry-harness: usage: registry-harness.sh <cmd...>" >&2
+    exit 64
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# The sibling-repos directory is the main checkout's parent, not this
+# script's own parent: a worktree under <repo>/.claude/worktrees/<name>/
+# has REPO_ROOT there, whose parent is .claude/worktrees, never the
+# sibling checkouts. `git rev-parse --git-common-dir` names the main
+# repo's .git regardless of which worktree runs this script, so two
+# levels up from it is the sibling-repos parent in every worktree.
+GIT_COMMON_DIR="$(cd "$REPO_ROOT" && git rev-parse --git-common-dir 2>/dev/null)"
+case "$GIT_COMMON_DIR" in
+/*) ;;
+"") ;;
+*) GIT_COMMON_DIR="$REPO_ROOT/$GIT_COMMON_DIR" ;;
+esac
+if [ -n "$GIT_COMMON_DIR" ]; then
+    DOWNSTREAM_PARENT="$(dirname "$(dirname "$GIT_COMMON_DIR")")"
+else
+    DOWNSTREAM_PARENT="$(dirname "$REPO_ROOT")"
+fi
+REGISTRY_DIR="${HEW_SYNC_REGISTRY:-$DOWNSTREAM_PARENT/hew-registry}"
+WORKER_DIR="$REGISTRY_DIR/registry-worker"
+
+unavailable() {
+    echo "registry-harness: $* — registry-dependent journey steps run as failed" >&2
+    exit "$EX_UNAVAILABLE"
+}
+
+command -v wrangler >/dev/null 2>&1 || unavailable "wrangler not found on PATH"
+[ -d "$WORKER_DIR" ] || unavailable "no hew-registry checkout at $REGISTRY_DIR"
+command -v python3 >/dev/null 2>&1 || unavailable "python3 not found on PATH (needed to pick a free port)"
+
+PORT=$(python3 -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()' 2>/dev/null)
+[ -n "$PORT" ] || unavailable "could not find a free port"
+
+LOG=$(mktemp "${TMPDIR:-/tmp}/registry-harness-log-XXXXXX")
+(cd "$WORKER_DIR" && exec wrangler dev --port "$PORT" >"$LOG" 2>&1) &
+WRANGLER_PID=$!
+
+cleanup() {
+    kill "$WRANGLER_PID" 2>/dev/null || true
+    wait "$WRANGLER_PID" 2>/dev/null || true
+    rm -f "$LOG"
+}
+trap cleanup EXIT
+
+# A hang is a failure, not a wait: give the dev server 30s to accept connections.
+UP=0
+for _ in $(seq 1 30); do
+    if curl -s -m 1 -o /dev/null "http://127.0.0.1:$PORT/"; then
+        UP=1
+        break
+    fi
+    kill -0 "$WRANGLER_PID" 2>/dev/null || break
+    sleep 1
+done
+if [ "$UP" -ne 1 ]; then
+    echo "registry-harness: wrangler dev on port $PORT did not come up:" >&2
+    cat "$LOG" >&2
+    exit "$EX_UNAVAILABLE"
+fi
+
+export HEW_REGISTRY="http://127.0.0.1:${PORT}/api/v1"
+"$@"

--- a/scripts/run-journeys.sh
+++ b/scripts/run-journeys.sh
@@ -57,6 +57,17 @@ esac
 OUT="$(mktemp "${TMPDIR}/run-journeys-out-XXXXXX")"
 trap 'rm -f "$OUT"' EXIT
 
+# week-one-local binds JOURNEY_PORT_BASE (default 8080, per its own header
+# comment); a caller who leaves it unset can collide with an unrelated
+# service already on 8080 on a shared/dev machine, producing a false pass
+# (the stray service answers /health with 200) or a false fail. Pick a
+# free port the same way scripts/registry-harness.sh does, unless the
+# caller set one explicitly.
+if [ "$JOURNEY" = "week-one-local" ] && [ -z "${JOURNEY_PORT_BASE:-}" ] && command -v python3 >/dev/null 2>&1; then
+    FREE_PORT=$(python3 -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()' 2>/dev/null)
+    [ -n "$FREE_PORT" ] && export JOURNEY_PORT_BASE="$FREE_PORT"
+fi
+
 if [ "$JOURNEY" = "day-two" ]; then
     if bash "$REPO_ROOT/scripts/registry-harness.sh" bash "$SCRIPT" >"$OUT" 2>&1; then
         :

--- a/scripts/run-journeys.sh
+++ b/scripts/run-journeys.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# scripts/run-journeys.sh <day-one|day-two|week-one-local>
+#
+# Runs one journey script under repros/journeys/, captures its `step
+# <id>: pass|fail` lines, and compares the set of failing step ids
+# against scripts/journeys-expected.tsv (columns: step_id, issue_or_lane,
+# reason). Exits 0 exactly when the two sets are equal: every step listed
+# for this journey in the expected file failed, and no step outside that
+# list failed. The ratchet only tightens (V060-FD-1): a step that starts
+# passing must have its row deleted by the lane that fixed it; a step
+# that starts failing without a row is a new regression, not a pass.
+#
+# day-two runs under scripts/registry-harness.sh so its registry-dependent
+# steps get a real local registry when one is available; when the harness
+# reports no registry (exit 75), day-two.sh still runs, without
+# HEW_REGISTRY, so its own no_registry() guards record those steps failed
+# for the right reason instead of the runner treating a hung command as a
+# harness bug.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+JOURNEYS_DIR="$REPO_ROOT/repros/journeys"
+EXPECTED_TSV="$REPO_ROOT/scripts/journeys-expected.tsv"
+EX_UNAVAILABLE=75
+
+JOURNEY="${1:-}"
+case "$JOURNEY" in
+day-one | day-two | week-one-local) ;;
+*)
+    echo "usage: run-journeys.sh <day-one|day-two|week-one-local>" >&2
+    exit 64
+    ;;
+esac
+
+SCRIPT="$JOURNEYS_DIR/$JOURNEY.sh"
+[ -x "$SCRIPT" ] || {
+    echo "run-journeys: missing or non-executable: $SCRIPT" >&2
+    exit 1
+}
+
+# The journey scripts require TMPDIR outside the checkout; CI runners
+# (ubuntu-latest has no TMPDIR by default) get RUNNER_TEMP, then /tmp.
+export TMPDIR="${TMPDIR:-${RUNNER_TEMP:-/tmp}}"
+export HEW_BIN="${HEW_BIN:-hew}"
+# A relative HEW_BIN (the Makefile's default is target/release-lib/hew,
+# relative to the repo root) stops resolving the moment a journey script
+# `cd`s into its scratch dir. Canonicalize it here, before that happens;
+# a bare command name (no `/`) is left to resolve via PATH as today.
+case "$HEW_BIN" in
+*/*)
+    if [ "${HEW_BIN#/}" = "$HEW_BIN" ]; then
+        HEW_BIN="$REPO_ROOT/$HEW_BIN"
+    fi
+    ;;
+esac
+
+OUT="$(mktemp "${TMPDIR}/run-journeys-out-XXXXXX")"
+trap 'rm -f "$OUT"' EXIT
+
+if [ "$JOURNEY" = "day-two" ]; then
+    if bash "$REPO_ROOT/scripts/registry-harness.sh" bash "$SCRIPT" >"$OUT" 2>&1; then
+        :
+    else
+        RC=$?
+        if [ "$RC" -eq "$EX_UNAVAILABLE" ]; then
+            bash "$SCRIPT" >"$OUT" 2>&1
+        fi
+        # Any other nonzero exit from day-two.sh itself is a harness/runner bug,
+        # not a step failure: day-two.sh always exits 0 by design (never `set -e`).
+    fi
+else
+    bash "$SCRIPT" >"$OUT" 2>&1
+fi
+
+cat "$OUT"
+
+# Collect every step id this run reported, split by pass/fail.
+PASSED=$(grep -oE "^step ${JOURNEY}\.[0-9]+: pass$" "$OUT" | sed -E 's/^step (.*): pass$/\1/' | sort -u)
+FAILED=$(grep -oE "^step ${JOURNEY}\.[0-9]+: fail$" "$OUT" | sed -E 's/^step (.*): fail$/\1/' | sort -u)
+SEEN_COUNT=$(printf '%s\n%s\n' "$PASSED" "$FAILED" | grep -c . || true)
+
+if [ "$SEEN_COUNT" -eq 0 ]; then
+    echo "run-journeys: $JOURNEY reported zero steps — the script died before its first assertion; treating as failure, not an empty-set pass" >&2
+    exit 1
+fi
+
+# Expected-failing step ids for this journey (column 1, ignoring comments/blank lines).
+EXPECTED=$(awk -F'\t' -v j="$JOURNEY." '!/^#/ && NF>=2 && index($1, j)==1 {print $1}' "$EXPECTED_TSV" | sort -u)
+
+UNEXPECTED_FAILURES=$(comm -23 <(printf '%s\n' "$FAILED" | sed '/^$/d') <(printf '%s\n' "$EXPECTED" | sed '/^$/d'))
+STALE_EXPECTATIONS=$(comm -23 <(printf '%s\n' "$EXPECTED" | sed '/^$/d') <(printf '%s\n' "$FAILED" | sed '/^$/d'))
+
+STATUS=0
+if [ -n "$UNEXPECTED_FAILURES" ]; then
+    echo "run-journeys: failing steps with no row in journeys-expected.tsv (new regression, or the row's id is wrong):" >&2
+    echo "  ${UNEXPECTED_FAILURES//$'\n'/$'\n  '}" >&2
+    STATUS=1
+fi
+if [ -n "$STALE_EXPECTATIONS" ]; then
+    echo "run-journeys: journeys-expected.tsv rows for steps that now pass (delete these rows in the fixing lane's PR):" >&2
+    echo "  ${STALE_EXPECTATIONS//$'\n'/$'\n  '}" >&2
+    STATUS=1
+fi
+
+if [ "$STATUS" -eq 0 ]; then
+    echo "run-journeys: $JOURNEY — $(printf '%s\n' "$PASSED" | grep -c .) passed, $(printf '%s\n' "$FAILED" | grep -c .) failed (all expected), 0 unexpected"
+fi
+
+exit "$STATUS"


### PR DESCRIPTION
## Why

V060-FD-1: `hew-platform-program.md` defines three journeys (day one, day
two, week-one-local) that stand in for a newcomer's first sessions with
the compiler, and a size/check-time budget for the same document, but
none of it is runnable: the scripts exist only as fenced shell blocks in
a planning document, and no ratchet, Makefile target, or CI job exists
for any of it. Every other v0.6.0 lane cites these gates as its
acceptance mechanism, so this lane lands first (V060-ORDER).

## What

- **journeys harness**: `repros/journeys/{day-one,day-two,week-one-local}.sh`
  and the `week-one-local/` fixture package, copied verbatim from the
  plan's own fenced blocks except that `set -e`'s abort-on-first-failure
  is replaced with counting `ok()`/`bad()` helpers so every assertion is
  reported as `step <id>: pass|fail` before the script exits 0.
- **registry harness**: `scripts/registry-harness.sh` starts a disposable
  local `hew-registry` dev server (`wrangler dev`) for day two's
  registry-dependent steps; when no sibling checkout is reachable it
  exits 75 and those steps record their own `no_registry()` failure.
- **runner + ratchet**: `scripts/run-journeys.sh` compares a run's
  failing step ids against `scripts/journeys-expected.tsv`, seeded from a
  real run against `0.6.0-rc3-dev.155+7c1490375`. `make test-journeys
  JOURNEY=<name>` wraps it; it also picks a free port for week-one-local
  unless the caller sets `JOURNEY_PORT_BASE`, so an unrelated service on
  8080 cannot produce a false step result.
- **check-time ratchet**: `scripts/check-time-ratchet.sh` /
  `scripts/check-time-baseline.tsv` compare the median of five `hew
  check std/net/http/http.hew` runs against a per-host-class baseline;
  `make check-time-ratchet[-record]`.
- **CI**: a `journeys` matrix job (ubuntu, against the existing
  `compiled-hew-linux` artifact) and `journeys-windows-day-one` (builds
  `hew-cli` fresh and runs day one directly under `shell: bash`),
  independent of the `ci-shard-*` jobs.
- **docs**: names the three targets in `CONTRIBUTING.md`'s test suite
  overview (the repo's contributor guide; it lives at the repo root, not
  under `docs/`).

**Not delivered: the size ratchet (`make size-ratchet`, `scripts/size-ratchet.tsv`).**
The brief's Decision 4 seeds `hew-types`/`hew-runtime`/`hew-pkg` at
93,350/142,850/10,300 lines from the plan's v0.6.0 target row, with the
acceptance criterion `make size-ratchet` exiting 0 on `main`. Measuring
the brief's own command (`find <crate>/src -name '*.rs' | xargs wc -l`)
against this PR's base commit gives 155,274/214,915/15,804 -- 50-67%
over every one of those ceilings. The plan's own table records
91,565/141,073/10,375 at ~PR #3210 (three commits before this base),
so the plan's instrument is not `wc -l` on `<crate>/src`; excluding
`hew-types/src/check/tests/` (47,384 lines) alone still leaves it over.
§2.4 names the real instrument, `python3 scripts/crate-size.py <crate>`
(from `platform/rev4/crate_size.py`), and neither file is in this repo;
two independent reconstructions of its prose rule during review gave
`hew-pkg` 10,277 and 10,375, straddling that crate's 10,300 ceiling, so
the counting rule cannot safely be rewritten from the description.
Seeding the brief's numbers ships a gate that is red for every other
v0.6.0 lane to inherit; seeding higher ceilings inverts what a ratchet
is. This PR omits the size ratchet rather than improvising either.
Tracked as #3296, which names the two calls the architect owns: moving
the instrument into the repo, and `hew-pkg` against V060-FD-5's
`index.rs` deletion.

**Also not wired: `check-time-ratchet` in CI.** Decision 5 describes CI
recording the baseline on `main` pushes and checking it on PRs; Decision
6 specifies only the journeys job, so the target ships runnable by hand
and unwired, and the script's header no longer claims otherwise.

**Environment note on day-two**: `hew-registry` is private, so the CI
job installs `wrangler` but checks out no sibling registry, and
`journeys-expected.tsv` is seeded against that (no-registry) outcome --
every registry-gated step fails via `no_registry()`. On a machine that
does have a `hew-registry` checkout as a sibling of the repo root (this
one included), two of those steps (`add`'s unknown-package refusal,
`info`'s not-found answer) pass instead, since a fresh local registry
still answers both correctly; `make test-journeys JOURNEY=day-two`
there reports those two rows as stale. Point `HEW_SYNC_REGISTRY` at a
nonexistent path to reproduce the CI/seeded outcome locally. That the
gate is red in the harness's own default configuration is tracked as
#3297.

## Test

`make test-journeys JOURNEY=day-one|day-two|week-one-local` and `make
check-time-ratchet-record && make check-time-ratchet`, run both directly
and through `make`. `day-one` and `week-one-local` are exit 0 with no
environment setup; `day-two` needs `HEW_SYNC_REGISTRY` pointed at a
nonexistent path on a machine with a real `hew-registry` checkout (see
the environment note above). Negative controls verified by hand:
deleting a failing step's row, adding a row for a passing step, and
setting a baseline `median_ms` to 1 each flip the corresponding target's
exit code from 0 to nonzero.

