### PR TITLE
feat(cli): classify every diagnostic into a User/Limitation/Internal channel

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -148,10 +148,28 @@ fn render_frontend_type_diagnostic(diagnostic: &FrontendDiagnostic, error: &hew_
     }
 }
 
-pub(crate) fn render_frontend_diagnostics(diagnostics: &[FrontendDiagnostic]) {
+/// Render every frontend diagnostic and return the worst channel among them
+/// (`None` when `diagnostics` is empty). Parse and type errors are always
+/// User; a free-form `Message` diagnostic is always User (see
+/// [`crate::diagnostic_json::message_diagnostic`]); an HIR diagnostic's
+/// channel is `kind.channel()`. Computed once here — callers propagate the
+/// returned channel rather than re-deriving it from the diagnostics list.
+pub(crate) fn render_frontend_diagnostics(
+    diagnostics: &[FrontendDiagnostic],
+) -> Option<hew_types::error::DiagChannel> {
+    use hew_types::error::DiagChannel;
+    let worst = diagnostics
+        .iter()
+        .map(|diagnostic| match &diagnostic.kind {
+            FrontendDiagnosticKind::Hir(error) => error.kind.channel(),
+            FrontendDiagnosticKind::Message(_)
+            | FrontendDiagnosticKind::Parse(_)
+            | FrontendDiagnosticKind::Type(_) => DiagChannel::User,
+        })
+        .max();
     if crate::diagnostic_json::json_output_active() {
         push_frontend_diagnostics_json(diagnostics);
-        return;
+        return worst;
     }
     for diagnostic in diagnostics {
         match &diagnostic.kind {
@@ -204,6 +222,7 @@ pub(crate) fn render_frontend_diagnostics(diagnostics: &[FrontendDiagnostic]) {
             }
         }
     }
+    worst
 }
 
 /// Append every frontend diagnostic to the JSON sink, reusing the per-kind
@@ -219,9 +238,11 @@ fn push_frontend_diagnostics_json(diagnostics: &[FrontendDiagnostic]) {
         let source = diagnostic.source.as_deref();
         let filename = diagnostic.filename.as_deref();
         let json = match &diagnostic.kind {
-            FrontendDiagnosticKind::Message(diagnostic) => {
-                coded_message_diagnostic(&diagnostic.code, &diagnostic.message)
-            }
+            FrontendDiagnosticKind::Message(diagnostic) => coded_message_diagnostic(
+                &diagnostic.code,
+                &diagnostic.message,
+                hew_types::error::DiagChannel::User,
+            ),
             FrontendDiagnosticKind::Parse(error) => match (source, filename) {
                 (Some(source), Some(filename)) => from_parse_error(source, filename, error),
                 _ => message_diagnostic(&error.message),

--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -77,17 +77,6 @@ pub(crate) fn hir_diagnostic_prefix(kind: &hew_hir::HirDiagnosticKind) -> &'stat
     }
 }
 
-/// Stable, user-facing string identifier for an HIR diagnostic kind.
-///
-/// Returns the variant name (e.g. `NotYetImplemented`, `UnresolvedSymbol`)
-/// without any of the Rust `{:?}` struct payload. Used as the `code` field in
-/// JSON diagnostics and matches the LSP's `hir_diagnostic_kind_string`.
-pub(crate) fn hir_diagnostic_kind_string(kind: &hew_hir::HirDiagnosticKind) -> String {
-    let debug = format!("{kind:?}");
-    let end = debug.find([' ', '{', '(']).unwrap_or(debug.len());
-    debug[..end].to_string()
-}
-
 /// Build the user-facing message for an HIR diagnostic.
 ///
 /// For a `NotYetImplemented` gap, the message frames the gap as a current
@@ -147,6 +136,12 @@ pub(crate) fn mir_diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'stat
         hew_mir::MirDiagnosticKind::RemotePayloadUnsupported { .. } => {
             "E_REMOTE_PAYLOAD_UNSUPPORTED"
         }
+        // D9: every function may suspend in the target design; today only an
+        // actor handler, a ctx-aware closure invocation, or a task-entry
+        // adapter carries an execution context. `main` (and any other plain
+        // function) cannot yet spawn — a limitation of this release's
+        // runtime substrate, not the user's program.
+        hew_mir::MirDiagnosticKind::MainContextRequired { .. } => "E_LIMIT_MAIN_CONTEXT",
         hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { .. } => "E_INVALID_SPAWN_ARGUMENT",
         hew_mir::MirDiagnosticKind::MissingActorSpawnArgument { .. } => "E_MISSING_SPAWN_ARGUMENT",
         hew_mir::MirDiagnosticKind::UnknownType { .. }
@@ -201,12 +196,45 @@ pub(crate) fn codegen_diagnostic_prefix(error: &hew_codegen_rs::CodegenError) ->
     }
 }
 
+/// Which diagnostic channel a codegen-front failure reports on.
+///
+/// `hew-codegen-rs/src` is fenced (D342): the classification lives here in
+/// `hew-cli`, beside [`codegen_diagnostic_prefix`], rather than as a method
+/// on `CodegenError` itself. `LlvmVerify`/`FailClosed`/`FailClosedAt` are the
+/// compiler disagreeing with the LLVM module it built (Internal).
+/// `Unsupported`/`UnsupportedAt`/`WasmUnsupportedSubstrate` are legal Hew
+/// this backend does not lower yet (Limitation). `Link`/`Io`/`TargetSetup`/
+/// `Llvm` are the build environment (a missing linker, a full disk, an
+/// unresolvable target triple) — nobody's channel but the user's, since
+/// there is no fourth channel for "the environment is wrong".
+#[must_use]
+pub(crate) fn codegen_channel(
+    error: &hew_codegen_rs::CodegenError,
+) -> hew_types::error::DiagChannel {
+    use hew_types::error::DiagChannel;
+    match error {
+        hew_codegen_rs::CodegenError::LlvmVerify(_)
+        | hew_codegen_rs::CodegenError::FailClosed(_)
+        | hew_codegen_rs::CodegenError::FailClosedAt { .. } => DiagChannel::Internal,
+        hew_codegen_rs::CodegenError::Unsupported(_)
+        | hew_codegen_rs::CodegenError::UnsupportedAt { .. }
+        | hew_codegen_rs::CodegenError::WasmUnsupportedSubstrate { .. } => DiagChannel::Limitation,
+        hew_codegen_rs::CodegenError::Link(_)
+        | hew_codegen_rs::CodegenError::Io(_)
+        | hew_codegen_rs::CodegenError::TargetSetup { .. }
+        | hew_codegen_rs::CodegenError::Llvm(_) => DiagChannel::User,
+    }
+}
+
 pub(crate) fn render_codegen_front_diagnostic(
     error: &hew_codegen_rs::CodegenError,
     source: Option<(&str, &str)>,
 ) {
     let prefix = codegen_diagnostic_prefix(error);
-    let msg = format!("{prefix}: codegen-front validation failed: {error}");
+    let msg = format!(
+        "{}{prefix}: codegen-front validation failed: {error}",
+        codegen_channel(error).prefix()
+    );
     // FAIL-CLOSED RENDER RULE: only render a `^^^` caret when ALL conditions hold:
     //   1. The error carries a source byte-range (FailClosedAt / UnsupportedAt).
     //   2. The caller supplied source text + filename (the root compilation unit).
@@ -253,6 +281,7 @@ pub(crate) fn render_codegen_emit_error(
     error: &hew_codegen_rs::CodegenError,
     source_path: Option<&std::path::Path>,
 ) {
+    let prefix = codegen_channel(error).prefix();
     if let Some((span_start, span_end)) = error.span() {
         if let Some(path) = source_path {
             if let Ok(text) = std::fs::read_to_string(path) {
@@ -261,13 +290,20 @@ pub(crate) fn render_codegen_emit_error(
                 if start < text.len() {
                     let filename = path.to_str().unwrap_or("<unknown>");
                     let span = start..end.min(text.len());
-                    render_diagnostic(&text, filename, &span, &format!("{error}"), &[], &[]);
+                    render_diagnostic(
+                        &text,
+                        filename,
+                        &span,
+                        &format!("{prefix}{error}"),
+                        &[],
+                        &[],
+                    );
                     return;
                 }
             }
         }
     }
-    emit_plain_diagnostic_line(&format!("E_NOT_YET_IMPLEMENTED: {error}"));
+    emit_plain_diagnostic_line(&format!("{prefix}E_NOT_YET_IMPLEMENTED: {error}"));
 }
 
 // ANSI colour helpers
@@ -644,6 +680,7 @@ fn mir_kind_name(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
         hew_mir::MirDiagnosticKind::ClosureCapturesDuplexHandle { .. } => {
             "ClosureCapturesDuplexHandle"
         }
+        hew_mir::MirDiagnosticKind::MainContextRequired { .. } => "MainContextRequired",
     }
 }
 
@@ -715,7 +752,11 @@ fn mir_primary_site(kind: &hew_mir::MirDiagnosticKind) -> Option<hew_hir::SiteId
         | hew_mir::MirDiagnosticKind::ActorStateCloneClassificationFailed { .. }
         | hew_mir::MirDiagnosticKind::OwnedHandleAggregateExtractionUnsupported { .. }
         | hew_mir::MirDiagnosticKind::ActorProtocolDescriptorMissing { .. }
-        | hew_mir::MirDiagnosticKind::MailboxOverflowCoalesceKeyFieldInvalid { .. } => None,
+        | hew_mir::MirDiagnosticKind::MailboxOverflowCoalesceKeyFieldInvalid { .. }
+        // D9: `MainContextRequired` carries no `SiteId` (see the variant's
+        // doc comment) — the raise site never had a site-anchored caret and
+        // this keeps that shape rather than inventing one.
+        | hew_mir::MirDiagnosticKind::MainContextRequired { .. } => None,
     }
 }
 
@@ -811,6 +852,11 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
              block {block}, so it refuses to emit a partial one (this is a \
              current Hew limitation, not your code): {reason}"
         ),
+        hew_mir::MirDiagnosticKind::MainContextRequired { spawned } => format!(
+            "spawning `{spawned}` needs an execution context and `main` has none \
+             in this release; run it inside an actor, or use `join {{ .. }}` for \
+             fan-out from `main`"
+        ),
         hew_mir::MirDiagnosticKind::ObligationUnderReleased {
             function,
             name,
@@ -825,7 +871,7 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
                 format!("owned value `{name}` of type `{local_ty}`")
             };
             format!(
-                "internal compiler error: the drop plan the compiler built for \
+                "the drop plan the compiler built for \
                  `{function}` never releases {typed_name} on {} of its exit \
                  path(s) (leak): {reason}",
                 blocks.len(),
@@ -839,7 +885,7 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
             ..
         } => {
             format!(
-                "internal compiler error: the drop plan the compiler built for \
+                "the drop plan the compiler built for \
                  `{function}` releases owned value `{name}` more than once on \
                  {} of its exit path(s) (double-free): {reason}",
                 blocks.len(),
@@ -852,7 +898,7 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
             ..
         } => {
             format!(
-                "internal compiler error: the ownership lowering of `{function}` \
+                "the ownership lowering of `{function}` \
                  violates its `{rule}` invariant ({detail})"
             )
         }
@@ -1138,7 +1184,8 @@ fn mir_context_notes(diagnostic: &hew_mir::MirDiagnostic) -> Vec<String> {
         | hew_mir::MirDiagnosticKind::CallableKeyCollision { .. }
         | hew_mir::MirDiagnosticKind::TraitObjectStorageUndetermined { .. }
         | hew_mir::MirDiagnosticKind::ActorProtocolDescriptorMissing { .. }
-        | hew_mir::MirDiagnosticKind::CallTraitMethodSignatureUnresolved { .. } => {}
+        | hew_mir::MirDiagnosticKind::CallTraitMethodSignatureUnresolved { .. }
+        | hew_mir::MirDiagnosticKind::MainContextRequired { .. } => {}
         hew_mir::MirDiagnosticKind::OwnedHandleAggregateExtractionUnsupported {
             handle_ty, ..
         } => {
@@ -1204,7 +1251,11 @@ fn render_mir_diagnostic_without_source(
     diagnostic: &hew_mir::MirDiagnostic,
     site: Option<&hew_hir::HirSiteSource>,
 ) {
-    emit_plain_diagnostic_line(&format!("error: {}", mir_diagnostic_message(diagnostic)));
+    let prefix = diagnostic.kind.channel().prefix();
+    emit_plain_diagnostic_line(&format!(
+        "error: {prefix}{}",
+        mir_diagnostic_message(diagnostic)
+    ));
     for note in mir_context_notes(diagnostic) {
         emit_plain_diagnostic_line(&format!("  = note: {note}"));
     }
@@ -1222,16 +1273,28 @@ fn render_mir_diagnostic_without_source(
 /// Routes through the JSON sink when `--format=json` is active so MIR
 /// diagnostics participate in machine-readable output identically to frontend
 /// diagnostics. The user-facing message is always the `mir_diagnostic_message`
-/// rendering — never the raw `MirDiagnostic` `{:?}` payload.
+/// rendering — never the raw `MirDiagnostic` `{:?}` payload. The channel
+/// prefix (`compiler limitation:` / `internal compiler error:`, empty for
+/// User) is applied only in text mode, ahead of the message's own `E_*`
+/// code — `mir_diagnostic_message` itself stays byte-identical so the JSON
+/// `message` field (which strips only the `E_*: ` lead-in) never picks up
+/// the channel prefix as part of the diagnostic's own code.
+///
+/// Returns the worst channel among the rendered diagnostics (`None` when
+/// `diagnostics` is empty), computed once here rather than re-derived by
+/// the caller.
 pub(crate) fn render_mir_diagnostics(
     root_source: &str,
     root_filename: &str,
     module_source_map: &ModuleSourceMap,
     site_spans: &HashMap<hew_hir::SiteId, hew_hir::HirSiteSource>,
     diagnostics: &[hew_mir::MirDiagnostic],
-) {
+) -> Option<hew_types::error::DiagChannel> {
     let json = crate::diagnostic_json::json_output_active();
+    let mut worst: Option<hew_types::error::DiagChannel> = None;
     for diagnostic in diagnostics {
+        let channel = diagnostic.kind.channel();
+        worst = Some(worst.map_or(channel, |w| w.max(channel)));
         let primary_site = mir_primary_site(&diagnostic.kind)
             .and_then(|site| site_spans.get(&site).map(|source| (site, source)));
         let Some((_, site)) = primary_site else {
@@ -1266,12 +1329,13 @@ pub(crate) fn render_mir_diagnostics(
                 source,
                 filename,
                 &site.span,
-                &mir_diagnostic_message(diagnostic),
+                &format!("{}{}", channel.prefix(), mir_diagnostic_message(diagnostic)),
                 &secondary_spans,
                 &suggestions,
             );
         }
     }
+    worst
 }
 
 /// Push a MIR diagnostic into the JSON sink, stripping the `E_*` prefix from
@@ -1301,6 +1365,7 @@ fn push_mir_json_diagnostic(
         message,
         secondary_spans,
         &mir_context_notes(diagnostic),
+        diagnostic.kind.channel(),
     ));
 }
 
@@ -1438,10 +1503,14 @@ pub(crate) fn render_hir_diagnostic(
         return;
     }
 
-    let message = hir_diagnostic_message(diagnostic);
-    let kind_note = format!("HIR kind: {}", hir_diagnostic_kind_string(&diagnostic.kind));
+    let channel = diagnostic.kind.channel();
+    let message = format!("{}{}", channel.prefix(), hir_diagnostic_message(diagnostic));
+    let kind_note = format!("HIR kind: {}", diagnostic.kind.kind_string());
+    let mut suggestions = vec![kind_note];
+    if channel == hew_types::error::DiagChannel::Internal {
+        push_lowering_invariant_notes(&mut suggestions, None);
+    }
     if let (Some(source), Some(filename)) = (source, filename) {
-        let suggestions = [kind_note];
         render_diagnostic_with_raw_notes(
             source,
             filename,
@@ -1454,7 +1523,9 @@ pub(crate) fn render_hir_diagnostic(
     }
 
     emit_plain_diagnostic_line(&format!("error: {message}"));
-    emit_plain_diagnostic_line(&format!("  = note: {kind_note}"));
+    for note in &suggestions {
+        emit_plain_diagnostic_line(&format!("  = note: {note}"));
+    }
     emit_plain_diagnostic_line(&format!(
         "  = note: {}",
         hir_source_context_unavailable_note(diagnostic)
@@ -1612,6 +1683,10 @@ mod tests {
         };
 
         assert_eq!(mir_diagnostic_prefix(&diagnostic.kind), "E_MIR_ICE");
+        assert_eq!(
+            diagnostic.kind.channel(),
+            hew_types::error::DiagChannel::Internal
+        );
         let message = mir_diagnostic_message(&diagnostic);
         let notes = mir_context_notes(&diagnostic);
         let rendered = std::iter::once(message.as_str())
@@ -1619,10 +1694,11 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
 
-        assert!(
-            message.starts_with("E_MIR_ICE: internal compiler error"),
-            "{message}"
-        );
+        // The `internal compiler error:` prose is supplied once, by the
+        // channel prefix at the render call site — never duplicated into the
+        // message body itself.
+        assert!(message.starts_with("E_MIR_ICE: "), "{message}");
+        assert!(!message.contains("internal compiler error"), "{message}");
         assert!(rendered.contains("`same_projection`"), "{rendered}");
         assert!(rendered.contains("`ownership-generation`"), "{rendered}");
         assert!(rendered.contains("b4294967210#2"), "{rendered}");
@@ -1657,6 +1733,10 @@ mod tests {
         };
 
         assert_eq!(mir_diagnostic_prefix(&diagnostic.kind), "E_MIR_ICE");
+        assert_eq!(
+            diagnostic.kind.channel(),
+            hew_types::error::DiagChannel::Internal
+        );
         let message = mir_diagnostic_message(&diagnostic);
         let notes = mir_context_notes(&diagnostic);
         let rendered = std::iter::once(message.as_str())
@@ -1664,10 +1744,11 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
 
-        assert!(
-            message.starts_with("E_MIR_ICE: internal compiler error"),
-            "{message}"
-        );
+        // The `internal compiler error:` prose is supplied once, by the
+        // channel prefix at the render call site — never duplicated into the
+        // message body itself.
+        assert!(message.starts_with("E_MIR_ICE: "), "{message}");
+        assert!(!message.contains("internal compiler error"), "{message}");
         assert!(
             message.contains("3 of its exit path(s)"),
             "the exit count travels with the one diagnostic: {message}"
@@ -1735,6 +1816,47 @@ mod tests {
         assert_eq!(diagnostic.kind.internal_compiler_error_function(), None);
         let message = mir_diagnostic_message(&diagnostic);
         assert!(message.contains("not your code"), "{message}");
+    }
+
+    /// `DiagChannel::Internal` exits 4 and its rendered text carries the
+    /// bug-report note exactly once — the channel prefix and the per-kind
+    /// message body must not both supply `internal compiler error:`.
+    #[test]
+    fn internal_channel_exit_code_and_prefix() {
+        assert_eq!(hew_types::error::DiagChannel::Internal.exit_code(), 4);
+        assert_eq!(
+            hew_types::error::DiagChannel::Internal.prefix(),
+            "internal compiler error: "
+        );
+
+        let diagnostic = hew_mir::MirDiagnostic {
+            kind: hew_mir::MirDiagnosticKind::LoweringInvariant {
+                function: "f".to_owned(),
+                rule: "ownership-place".to_owned(),
+                block: Some(1),
+                detail: "detail".to_owned(),
+            },
+            note: "a carried ownership fact disagrees with the re-derived one".to_owned(),
+        };
+        assert_eq!(
+            diagnostic.kind.channel(),
+            hew_types::error::DiagChannel::Internal
+        );
+
+        start_diagnostic_capture();
+        render_mir_diagnostic_without_source(&diagnostic, None);
+        let rendered = finish_diagnostic_capture();
+
+        assert_eq!(
+            rendered.matches("internal compiler error:").count(),
+            1,
+            "the channel prefix and the message body must not both render \
+             `internal compiler error:`: {rendered}"
+        );
+        assert!(
+            rendered.contains("please report it"),
+            "an Internal diagnostic must carry the bug-report note: {rendered}"
+        );
     }
 
     fn sample_type_error() -> hew_types::TypeError {
@@ -1903,12 +2025,9 @@ mod tests {
             hir_diagnostic_prefix(&constructor.kind),
             "E_ENUM_VARIANT_CONSTRUCTOR"
         );
+        assert_eq!(tuple.kind.kind_string(), "TuplePatternArityMismatch");
         assert_eq!(
-            hir_diagnostic_kind_string(&tuple.kind),
-            "TuplePatternArityMismatch"
-        );
-        assert_eq!(
-            hir_diagnostic_kind_string(&constructor.kind),
+            constructor.kind.kind_string(),
             "EnumVariantConstructorArityMismatch"
         );
         assert_eq!(

--- a/hew-cli/src/diagnostic_json.rs
+++ b/hew-cli/src/diagnostic_json.rs
@@ -28,6 +28,7 @@ use serde::Serialize;
 
 use crate::args::DiagnosticFormat;
 use crate::diagnostic::offset_to_line_col;
+use hew_types::error::DiagChannel;
 
 // ---------------------------------------------------------------------------
 // Output-format + JSON accumulator thread-locals
@@ -180,6 +181,10 @@ pub(crate) struct JsonDiagnostic {
     pub code: String,
     /// `"error"` or `"warning"`.
     pub severity: String,
+    /// Which of the three diagnostic channels this finding reports on:
+    /// `"user"`, `"limitation"`, or `"internal"`. See
+    /// [`hew_types::error::DiagChannel`].
+    pub channel: String,
     /// Compiler stage that emitted the diagnostic (`hew-parser`, `hew-types`,
     /// `hew-hir`, `hew-mir`).
     pub source: String,
@@ -236,16 +241,24 @@ fn fixes_from_code_actions(
 
 /// Build a [`JsonDiagnostic`] from a free-form message that carries no source
 /// span (e.g. import-resolution failures, manifest errors). The code is the
-/// generic `E_MESSAGE` family and the span is zero.
+/// generic `E_MESSAGE` family and the span is zero. Always User channel: a
+/// free-form frontend message never carries a compiler-invariant or
+/// unsupported-lowering classification.
 pub(crate) fn message_diagnostic(message: &str) -> JsonDiagnostic {
-    coded_message_diagnostic("E_MESSAGE", message)
+    coded_message_diagnostic("E_MESSAGE", message, DiagChannel::User)
 }
 
-/// Build a source-less diagnostic with a stable frontend-authored code.
-pub(crate) fn coded_message_diagnostic(code: &str, message: &str) -> JsonDiagnostic {
+/// Build a source-less diagnostic with a stable frontend-authored code and
+/// caller-supplied channel.
+pub(crate) fn coded_message_diagnostic(
+    code: &str,
+    message: &str,
+    channel: DiagChannel,
+) -> JsonDiagnostic {
     JsonDiagnostic {
         code: code.to_string(),
         severity: SEVERITY_ERROR.to_string(),
+        channel: channel.as_json_str().to_string(),
         source: "hew".to_string(),
         file: String::new(),
         span: JsonSpan::zero(),
@@ -276,6 +289,7 @@ pub(crate) fn from_parse_error(
     JsonDiagnostic {
         code: error.kind.as_kind_str().to_string(),
         severity: severity.to_string(),
+        channel: DiagChannel::User.as_json_str().to_string(),
         source: "hew-parser".to_string(),
         file: filename.to_string(),
         span: JsonSpan::from_range(source, &error.span),
@@ -315,6 +329,7 @@ pub(crate) fn from_type_error(
     JsonDiagnostic {
         code: code.to_string(),
         severity: severity.to_string(),
+        channel: DiagChannel::User.as_json_str().to_string(),
         source: "hew-types".to_string(),
         file: filename.to_string(),
         span: JsonSpan::from_range(source, &error.span),
@@ -345,8 +360,9 @@ pub(crate) fn from_hir_diagnostic(
             .collect()
     });
     JsonDiagnostic {
-        code: crate::diagnostic::hir_diagnostic_kind_string(&diagnostic.kind),
+        code: diagnostic.kind.kind_string(),
         severity: SEVERITY_ERROR.to_string(),
+        channel: diagnostic.kind.channel().as_json_str().to_string(),
         source: "hew-hir".to_string(),
         file: filename.unwrap_or("<unknown>").to_string(),
         span,
@@ -357,7 +373,13 @@ pub(crate) fn from_hir_diagnostic(
 }
 
 /// Build a [`JsonDiagnostic`] from a MIR diagnostic, located at its primary
-/// site when source context is available.
+/// site when source context is available. `channel` is the caller's
+/// `kind.channel()` — computed once at the render site, not re-derived here.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "each arg is a direct field of the constructed JsonDiagnostic; grouping would \
+              obscure the one-to-one mapping"
+)]
 pub(crate) fn from_mir_diagnostic(
     source: Option<&str>,
     filename: Option<&str>,
@@ -366,6 +388,7 @@ pub(crate) fn from_mir_diagnostic(
     message: &str,
     notes: &[(Range<usize>, String)],
     context_notes: &[String],
+    channel: DiagChannel,
 ) -> JsonDiagnostic {
     let primary_span = match (source, span) {
         (Some(src), Some(span)) => JsonSpan::from_range(src, span),
@@ -389,6 +412,7 @@ pub(crate) fn from_mir_diagnostic(
     JsonDiagnostic {
         code: code.to_string(),
         severity: SEVERITY_ERROR.to_string(),
+        channel: channel.as_json_str().to_string(),
         source: "hew-mir".to_string(),
         file: filename.unwrap_or("<unknown>").to_string(),
         span: primary_span,
@@ -403,7 +427,10 @@ pub(crate) fn from_mir_diagnostic(
 /// Unlike [`from_mir_diagnostic`] — which is always the hard `error` family —
 /// a lint carries its configured severity: `warning` by default, `error` when
 /// promoted by `--deny`. The `code` is the lint's stable name (`dead_store`),
-/// matching the `-A/-W/-D` selector and the HIR-stage lint codes.
+/// matching the `-A/-W/-D` selector and the HIR-stage lint codes. `channel`
+/// is always User at every call site: a lint never reports a compiler
+/// defect or an unsupported lowering, only a configurable finding about the
+/// user's program.
 pub(crate) fn from_mir_lint(
     source: &str,
     filename: &str,
@@ -411,6 +438,7 @@ pub(crate) fn from_mir_lint(
     code: &str,
     message: &str,
     is_error: bool,
+    channel: DiagChannel,
 ) -> JsonDiagnostic {
     JsonDiagnostic {
         code: code.to_string(),
@@ -420,6 +448,7 @@ pub(crate) fn from_mir_lint(
             SEVERITY_WARNING
         }
         .to_string(),
+        channel: channel.as_json_str().to_string(),
         source: "hew-mir".to_string(),
         file: filename.to_string(),
         span: JsonSpan::from_range(source, span),
@@ -447,6 +476,7 @@ mod tests {
         let diag = from_type_error(source, "main.hew", &error);
         assert_eq!(diag.code, "Mismatch");
         assert_eq!(diag.severity, "error");
+        assert_eq!(diag.channel, "user");
         assert_eq!(diag.file, "main.hew");
         assert_eq!(diag.span.start_line, 2);
         assert!(diag.message.contains("type mismatch"));
@@ -485,6 +515,7 @@ mod tests {
         );
         let diag = from_hir_diagnostic(Some("abcd"), Some("main.hew"), &diagnostic);
         assert_eq!(diag.code, "NotYetImplemented");
+        assert_eq!(diag.channel, "limitation");
         assert!(
             !diag.message.contains("owning_pass"),
             "message must not leak the Rust field name: {}",
@@ -513,9 +544,11 @@ mod tests {
              is not implemented yet",
             &[],
             &["MIR kind: NotYetImplemented".to_string()],
+            DiagChannel::Limitation,
         );
         assert_eq!(diag.code, "NotYetImplemented");
         assert_eq!(diag.severity, SEVERITY_ERROR);
+        assert_eq!(diag.channel, "limitation");
         assert_eq!(diag.span, JsonSpan::zero());
         assert!(!diag.message.contains("SiteId"));
         assert_eq!(diag.notes.len(), 1);
@@ -531,10 +564,15 @@ mod tests {
             "obligation balance in `decode`: owned value `out` is never released",
             &[],
             &["MIR kind: ObligationUnderReleased".to_string()],
+            DiagChannel::Internal,
         );
         assert_eq!(
             diag.severity, SEVERITY_ERROR,
             "an ownership under-release must block LLVM emission"
+        );
+        assert_eq!(
+            diag.channel, "internal",
+            "an obligation imbalance is a compiler defect, not a program fault"
         );
     }
 }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1496,7 +1496,7 @@ fn run_inprocess_compiled(
         &bin_path,
         &eval_compile_options(project_dir, backend),
     )
-    .map_err(|()| CompiledEvalError::DiagnosticsRendered)?;
+    .map_err(|_channel| CompiledEvalError::DiagnosticsRendered)?;
 
     match crate::process::run_binary_with_timeout(&bin_path, timeout) {
         Ok(crate::process::BinaryRunOutcome::Success { stdout }) => {
@@ -1605,7 +1605,7 @@ fn run_wasm_eval_compiled(
         &module_path,
         &eval_compile_options(project_dir, backend),
     )
-    .map_err(|()| CompiledEvalError::DiagnosticsRendered)?;
+    .map_err(|_channel| CompiledEvalError::DiagnosticsRendered)?;
 
     match crate::wasi_runner::run_module_captured(&module_path, timeout) {
         Ok(crate::wasi_runner::WasiCapturedOutcome::Success { stdout }) => Ok(stdout),

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -59,6 +59,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use args::Cli;
+use hew_types::error::DiagChannel;
 
 /// Stack budget for threads that run the in-process compiler pipeline.
 ///
@@ -168,14 +169,13 @@ fn render_pipeline_mir_diagnostics(
     label: &str,
     module: &hew_hir::HirModule,
     diagnostics: &[hew_mir::MirDiagnostic],
-) -> bool {
+) -> Option<hew_types::error::DiagChannel> {
     if diagnostics.is_empty() {
-        return false;
+        return None;
     }
     let module_source_map = diagnostic::build_module_source_map(program);
     let site_spans = hew_hir::collect_site_spans(module);
-    diagnostic::render_mir_diagnostics(source, label, &module_source_map, &site_spans, diagnostics);
-    true
+    diagnostic::render_mir_diagnostics(source, label, &module_source_map, &site_spans, diagnostics)
 }
 
 /// Surface the MIR-stage lint warnings recorded on `pipeline`, applying the
@@ -226,6 +226,7 @@ fn render_pipeline_mir_lints(
                         warning.lint.as_str(),
                         &warning.message,
                         false,
+                        hew_types::error::DiagChannel::User,
                     ));
                 } else {
                     diagnostic::render_warning_with_raw_notes(
@@ -247,6 +248,7 @@ fn render_pipeline_mir_lints(
                         warning.lint.as_str(),
                         &warning.message,
                         true,
+                        hew_types::error::DiagChannel::User,
                     ));
                 } else {
                     diagnostic::render_diagnostic_with_raw_notes(
@@ -286,7 +288,7 @@ fn lower_verified_hir_to_pipeline(
     tco: &hew_types::TypeCheckOutput,
     target: &target::TargetSpec,
     sir_mode: compile::SirMode,
-) -> Result<(hew_mir::IrPipeline, Option<SirLaneReport>), ()> {
+) -> Result<(hew_mir::IrPipeline, Option<SirLaneReport>), DiagChannel> {
     match sir_mode {
         compile::SirMode::Disabled => {
             let output = compiler_session(target).lower_hir_module(module, tco);
@@ -298,12 +300,13 @@ fn lower_verified_hir_to_pipeline(
             let component = session.lower_sir_module(&sir.module).map_err(|error| {
                 eprintln!("SIR strict lowering failed: {error}");
                 report_strict_sir_missing_body(&sir, error.missing_body);
+                DiagChannel::User
             })?;
             let callables = component.callables().to_vec();
             let pipeline = component.into_pipeline();
             if let Some(error) = session.check_pipeline(&pipeline) {
                 eprintln!("SIR strict backend-front validation failed: {error}");
-                return Err(());
+                return Err(DiagChannel::User);
             }
             Ok((pipeline, Some(SirLaneReport { sir, callables })))
         }
@@ -355,12 +358,14 @@ fn sir_unsupported_reason(status: Option<&hew_sir::SirLoweringStatus>) -> Option
     }
 }
 
-fn lower_verified_hir_to_sir(module: &hew_hir::HirModule) -> Result<hew_sir::LoweredModule, ()> {
+fn lower_verified_hir_to_sir(
+    module: &hew_hir::HirModule,
+) -> Result<hew_sir::LoweredModule, DiagChannel> {
     let mut sir = hew_sir::lower_module(module);
     let diagnostics = hew_sir::verify_module(&sir.module);
     if !diagnostics.is_empty() {
         render_sir_diagnostics("verifier", diagnostics);
-        return Err(());
+        return Err(DiagChannel::User);
     }
     if let Err(error) = hew_sir::canonicalize_module_constant_cfg(&mut sir.module) {
         let (stage, diagnostics) = match error {
@@ -372,7 +377,7 @@ fn lower_verified_hir_to_sir(module: &hew_hir::HirModule) -> Result<hew_sir::Low
             }
         };
         render_sir_diagnostics(stage, diagnostics);
-        return Err(());
+        return Err(DiagChannel::User);
     }
     Ok(sir)
 }
@@ -410,14 +415,15 @@ fn lower_file_to_verified_hir(
     input_path: &Path,
     target: &target::TargetSpec,
     options: &compile::CompileOptions,
-) -> Result<VerifiedFileHir, ()> {
+) -> Result<VerifiedFileHir, DiagChannel> {
     let input = input_path.display().to_string();
     let fopts = compile::frontend_options(target, options);
     let state = hew_compile::run_file_frontend_to_typecheck(&input, &fopts).map_err(|failure| {
-        compile::render_frontend_diagnostics(&failure.diagnostics);
+        let channel = compile::render_frontend_diagnostics(&failure.diagnostics);
         if failure.diagnostics.is_empty() {
             eprintln!("Error: {}", failure.message);
         }
+        channel.unwrap_or(DiagChannel::User)
     })?;
     compile::render_frontend_diagnostics(&state.diagnostics);
 
@@ -427,6 +433,7 @@ fn lower_file_to_verified_hir(
                 "Error: Hew lowering requires a type-checked program; \\
                  this path should be unreachable (no_typecheck = false)"
             );
+            DiagChannel::User
         })?;
         hew_hir::lower_program(
             &state.program,
@@ -454,8 +461,8 @@ fn lower_file_to_verified_hir(
             &input,
             hir_diagnostics,
         );
-        compile::render_frontend_diagnostics(&frontend_diagnostics);
-        return Err(());
+        let channel = compile::render_frontend_diagnostics(&frontend_diagnostics);
+        return Err(channel.unwrap_or(DiagChannel::User));
     }
 
     Ok(VerifiedFileHir {
@@ -471,9 +478,10 @@ fn lower_file_to_sir(
     input_path: &Path,
     requested_target: Option<&str>,
     options: &compile::CompileOptions,
-) -> Result<hew_sir::LoweredModule, ()> {
+) -> Result<hew_sir::LoweredModule, DiagChannel> {
     let target = target::TargetSpec::from_requested(requested_target).map_err(|error| {
         eprintln!("Error: {error}");
+        DiagChannel::User
     })?;
     let verified = lower_file_to_verified_hir(input_path, &target, options)?;
     lower_verified_hir_to_sir(&verified.lower_output.module)
@@ -483,9 +491,10 @@ fn lower_file_to_mir_with_options(
     input_path: &Path,
     requested_target: Option<&str>,
     options: &compile::CompileOptions,
-) -> Result<(hew_mir::IrPipeline, Option<SirLaneReport>), ()> {
+) -> Result<(hew_mir::IrPipeline, Option<SirLaneReport>), DiagChannel> {
     let target = target::TargetSpec::from_requested(requested_target).map_err(|e| {
         eprintln!("Error: {e}");
+        DiagChannel::User
     })?;
     let verified = lower_file_to_verified_hir(input_path, &target, options)?;
     let (pipeline, sir_report) = lower_verified_hir_to_pipeline(
@@ -494,14 +503,14 @@ fn lower_file_to_mir_with_options(
         &target,
         options.sir_mode,
     )?;
-    if render_pipeline_mir_diagnostics(
+    if let Some(channel) = render_pipeline_mir_diagnostics(
         &verified.state.program,
         &verified.state.source,
         &verified.input,
         &verified.lower_output.module,
         &pipeline.diagnostics,
     ) {
-        return Err(());
+        return Err(channel);
     }
 
     // `hew compile` exposes no `-A/-W/-D` flags, so MIR lints surface at their
@@ -512,7 +521,7 @@ fn lower_file_to_mir_with_options(
         &pipeline,
         &hew_types::LintLevels::default(),
     ) {
-        return Err(());
+        return Err(DiagChannel::User);
     }
 
     Ok((pipeline, sir_report))
@@ -527,7 +536,7 @@ fn lower_file_to_mir_for_target(
     input_path: &Path,
     target: &target::TargetSpec,
     options: &compile::CompileOptions,
-) -> Result<(hew_mir::IrPipeline, Vec<std::path::PathBuf>), ()> {
+) -> Result<(hew_mir::IrPipeline, Vec<std::path::PathBuf>), DiagChannel> {
     let verified = lower_file_to_verified_hir(input_path, target, options)?;
     let (pipeline, sir_report) = lower_verified_hir_to_pipeline(
         &verified.lower_output.module,
@@ -538,14 +547,14 @@ fn lower_file_to_mir_for_target(
     if let Some(report) = sir_report.as_ref() {
         report_sir_lane(report);
     }
-    if render_pipeline_mir_diagnostics(
+    if let Some(channel) = render_pipeline_mir_diagnostics(
         &verified.state.program,
         &verified.state.source,
         &verified.input,
         &verified.lower_output.module,
         &pipeline.diagnostics,
     ) {
-        return Err(());
+        return Err(channel);
     }
 
     if render_pipeline_mir_lints(
@@ -554,7 +563,7 @@ fn lower_file_to_mir_for_target(
         &pipeline,
         &options.lint_levels,
     ) {
-        return Err(());
+        return Err(DiagChannel::User);
     }
 
     let native_pkg_dirs = native_link::collect_import_pkg_dirs(&verified.state.program);
@@ -611,7 +620,7 @@ fn run_check_deep_gates(
     target: &target::TargetSpec,
     state: &hew_compile::FileFrontendState,
     levels: &hew_types::LintLevels,
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     // `std/builtins.hew` is compiler-embedded, while `std/prelude.hew` is an
     // import-only authority manifest. Neither has a standalone lowering
     // surface: the former is pre-registered by the checker and the latter's
@@ -650,21 +659,21 @@ fn run_check_deep_gates(
             input,
             hir_diagnostics,
         );
-        compile::render_frontend_diagnostics(&frontend_diagnostics);
-        return Err(());
+        let channel = compile::render_frontend_diagnostics(&frontend_diagnostics);
+        return Err(channel.unwrap_or(DiagChannel::User));
     }
 
     let output = compiler_session(target).lower_hir_module(&lower_output.module, tco);
     let codegen_error = output.codegen_error;
     let pipeline = output.pipeline;
-    if render_pipeline_mir_diagnostics(
+    if let Some(channel) = render_pipeline_mir_diagnostics(
         &state.program,
         &state.source,
         input,
         &lower_output.module,
         &pipeline.diagnostics,
     ) {
-        return Err(());
+        return Err(channel);
     }
 
     // Surface MIR lint warnings before the codegen-front gate so they read in
@@ -674,11 +683,11 @@ fn run_check_deep_gates(
 
     if let Some(error) = codegen_error {
         diagnostic::render_codegen_front_diagnostic(&error, Some((state.source.as_str(), input)));
-        return Err(());
+        return Err(diagnostic::codegen_channel(&error));
     }
 
     if lint_denied {
-        return Err(());
+        return Err(DiagChannel::User);
     }
 
     Ok(())
@@ -714,7 +723,7 @@ fn emit_module(
     link_freestanding_wasm: bool,
     opt_level: hew_codegen_rs::OptLevel,
     emit_llvm: bool,
-) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
+) -> Result<hew_codegen_rs::EmitArtefacts, DiagChannel> {
     emit_module_with_triple(
         pipeline,
         module_name,
@@ -750,7 +759,7 @@ fn emit_module_with_triple(
     opt_level: hew_codegen_rs::OptLevel,
     emit_llvm: bool,
     source_path: Option<&Path>,
-) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
+) -> Result<hew_codegen_rs::EmitArtefacts, DiagChannel> {
     let options = hew_codegen_rs::EmitOptions {
         module_name,
         out_dir: emit_dir,
@@ -775,12 +784,14 @@ fn emit_module_with_triple(
     match result {
         Ok(artefacts) => Ok(artefacts),
         Err(e @ hew_codegen_rs::CodegenError::WasmUnsupportedSubstrate { .. }) => {
-            eprintln!("Error: {e}");
-            Err(())
+            let channel = diagnostic::codegen_channel(&e);
+            eprintln!("{}Error: {e}", channel.prefix());
+            Err(channel)
         }
         Err(e) => {
+            let channel = diagnostic::codegen_channel(&e);
             diagnostic::render_codegen_emit_error(&e, source_path);
-            Err(())
+            Err(channel)
         }
     }
 }
@@ -809,7 +820,7 @@ fn emit_module_for_target(
     opt_level: hew_codegen_rs::OptLevel,
     emit_llvm: bool,
     source_path: Option<&Path>,
-) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
+) -> Result<hew_codegen_rs::EmitArtefacts, DiagChannel> {
     let codegen_triple = match emit_target {
         CompileEmitTarget::Native => Some(target.linker_triple()),
         CompileEmitTarget::Wasm => None,
@@ -828,7 +839,7 @@ fn emit_module_for_target(
     )
 }
 
-fn link_native_object(obj: &Path, bin_path: &Path) -> Result<(), ()> {
+fn link_native_object(obj: &Path, bin_path: &Path) -> Result<(), DiagChannel> {
     link_native_object_with_hew_lib(obj, bin_path, None)
 }
 
@@ -836,7 +847,7 @@ fn link_native_object_with_hew_lib(
     obj: &Path,
     bin_path: &Path,
     hew_lib: Option<&Path>,
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     link_native_object_with_hew_lib_and_extra(obj, bin_path, hew_lib, &[])
 }
 
@@ -845,19 +856,23 @@ fn link_native_object_with_hew_lib_and_extra(
     bin_path: &Path,
     hew_lib: Option<&Path>,
     extra_libs: &[String],
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     let target = target::TargetSpec::from_requested(None).map_err(|e| {
         eprintln!("Error: cannot determine host target: {e}");
+        DiagChannel::User
     })?;
     let obj_str = obj.to_str().ok_or_else(|| {
         eprintln!("Error: object path is not valid UTF-8");
+        DiagChannel::User
     })?;
     let bin_str = bin_path.to_str().ok_or_else(|| {
         eprintln!("Error: output path is not valid UTF-8");
+        DiagChannel::User
     })?;
     crate::link::link_executable_with_hew_lib(obj_str, bin_str, &target, extra_libs, false, hew_lib)
         .map_err(|e| {
             crate::diagnostic::emit_plain_diagnostic_line(&e);
+            DiagChannel::User
         })
 }
 
@@ -865,7 +880,7 @@ pub(crate) fn compile_native_binary(
     input: &Path,
     bin_path: &Path,
     options: &compile::CompileOptions,
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     let (pipeline, sir_report) = lower_file_to_mir_with_options(input, None, options)?;
     if let Some(report) = sir_report.as_ref() {
         report_sir_lane(report);
@@ -886,6 +901,7 @@ pub(crate) fn compile_native_binary(
     )?;
     let obj = artefacts.native_obj_path.as_deref().ok_or_else(|| {
         eprintln!("E_NOT_YET_IMPLEMENTED: native codegen did not produce an object");
+        DiagChannel::User
     })?;
     link_native_object(obj, bin_path)
 }
@@ -903,7 +919,7 @@ pub(crate) fn compile_native_from_program(
     source_label: &str,
     output_path: &Path,
     options: &compile::CompileOptions,
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     compile_native_from_program_with_paths(
         program,
         source,
@@ -928,9 +944,10 @@ pub(crate) fn compile_native_from_program_with_paths(
     options: &compile::CompileOptions,
     paths: Option<&NativeBuildPaths>,
     extra_libs: &[String],
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     let target = target::TargetSpec::from_requested(options.target.as_deref()).map_err(|e| {
         eprintln!("Error: {e}");
+        DiagChannel::User
     })?;
     let mut frontend_options = compile::frontend_options(&target, options);
     frontend_options.module_search_paths = paths.map(|paths| paths.module_search_paths.clone());
@@ -941,10 +958,11 @@ pub(crate) fn compile_native_from_program_with_paths(
         &frontend_options,
     )
     .map_err(|failure| {
-        compile::render_frontend_diagnostics(&failure.diagnostics);
+        let channel = compile::render_frontend_diagnostics(&failure.diagnostics);
         if failure.diagnostics.is_empty() {
             eprintln!("Error: {}", failure.message);
         }
+        channel.unwrap_or(DiagChannel::User)
     })?;
     compile::render_frontend_diagnostics(&state.diagnostics);
 
@@ -953,6 +971,7 @@ pub(crate) fn compile_native_from_program_with_paths(
             "Error: eval compilation requires a type-checked program; \
              this path should be unreachable (no_typecheck = false)"
         );
+        DiagChannel::User
     })?;
 
     let lower_output = hew_hir::lower_program(
@@ -977,8 +996,8 @@ pub(crate) fn compile_native_from_program_with_paths(
             source_label,
             hir_diagnostics,
         );
-        compile::render_frontend_diagnostics(&frontend_diagnostics);
-        return Err(());
+        let channel = compile::render_frontend_diagnostics(&frontend_diagnostics);
+        return Err(channel.unwrap_or(DiagChannel::User));
     }
 
     let (pipeline, sir_report) =
@@ -986,18 +1005,18 @@ pub(crate) fn compile_native_from_program_with_paths(
     if let Some(report) = sir_report.as_ref() {
         report_sir_lane(report);
     }
-    if render_pipeline_mir_diagnostics(
+    if let Some(channel) = render_pipeline_mir_diagnostics(
         &state.program,
         &state.source,
         source_label,
         &lower_output.module,
         &pipeline.diagnostics,
     ) {
-        return Err(());
+        return Err(channel);
     }
 
     if render_pipeline_mir_lints(&state.source, source_label, &pipeline, &options.lint_levels) {
-        return Err(());
+        return Err(DiagChannel::User);
     }
 
     let emit_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
@@ -1011,7 +1030,7 @@ pub(crate) fn compile_native_from_program_with_paths(
         CompileEmitTarget::Native
     } else {
         eprintln!("{}", target.unsupported_native_link_error());
-        return Err(());
+        return Err(DiagChannel::User);
     };
     let artefacts = emit_module(
         &pipeline,
@@ -1027,6 +1046,7 @@ pub(crate) fn compile_native_from_program_with_paths(
         CompileEmitTarget::Native => {
             let obj = artefacts.native_obj_path.as_deref().ok_or_else(|| {
                 eprintln!("E_NOT_YET_IMPLEMENTED: native codegen did not produce an object");
+                DiagChannel::User
             })?;
             link_native_object_with_hew_lib_and_extra(
                 obj,
@@ -1038,15 +1058,19 @@ pub(crate) fn compile_native_from_program_with_paths(
         CompileEmitTarget::Wasm => {
             let obj = artefacts.wasm_obj_path.as_deref().ok_or_else(|| {
                 eprintln!("E_NOT_YET_IMPLEMENTED: WASM codegen did not produce an object");
+                DiagChannel::User
             })?;
             let obj_str = obj.to_str().ok_or_else(|| {
                 eprintln!("Error: WASM object path is not valid UTF-8");
+                DiagChannel::User
             })?;
             let output_str = output_path.to_str().ok_or_else(|| {
                 eprintln!("Error: WASM output path is not valid UTF-8");
+                DiagChannel::User
             })?;
             crate::link::link_executable(obj_str, output_str, &target, &[], false).map_err(|e| {
                 eprintln!("{e}");
+                DiagChannel::User
             })
         }
     }
@@ -1092,16 +1116,19 @@ fn link_native_object_for_target_with_hew_lib(
     debug: bool,
     extra_libs: &[String],
     hew_lib: Option<&Path>,
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     let obj_str = obj.to_str().ok_or_else(|| {
         eprintln!("Error: object path is not valid UTF-8");
+        DiagChannel::User
     })?;
     let bin_str = bin_path.to_str().ok_or_else(|| {
         eprintln!("Error: output path is not valid UTF-8");
+        DiagChannel::User
     })?;
     crate::link::link_executable_with_hew_lib(obj_str, bin_str, target, extra_libs, debug, hew_lib)
         .map_err(|e| {
             crate::diagnostic::emit_plain_diagnostic_line(&e);
+            DiagChannel::User
         })
 }
 
@@ -1120,7 +1147,7 @@ fn compile_build_binary(
     emit_llvm: bool,
     extra_libs: &[String],
     options: &compile::CompileOptions,
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     compile_build_binary_with_hew_lib(
         input,
         output_path,
@@ -1148,7 +1175,7 @@ fn compile_build_binary_with_hew_lib(
     extra_libs: &[String],
     options: &compile::CompileOptions,
     hew_lib: Option<&Path>,
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     let wall_started = std::time::Instant::now();
     let lower_started = std::time::Instant::now();
     let (pipeline, native_pkg_dirs) = lower_file_to_mir_for_target(input, target, options)?;
@@ -1184,12 +1211,14 @@ fn compile_build_binary_with_hew_lib(
         CompileEmitTarget::Native => {
             let obj = artefacts.native_obj_path.as_deref().ok_or_else(|| {
                 eprintln!("E_NOT_YET_IMPLEMENTED: native codegen did not produce an object");
+                DiagChannel::User
             })?;
             // Auto-link native (FFI) staticlibs declared by imported packages
             // (`[native]` in their `hew.toml`), built on demand, in addition to
             // any explicit `--link-lib` archives.
             let auto_libs = native_link::build_native_link_libs(&native_pkg_dirs).map_err(|e| {
                 eprintln!("Error: {e}");
+                DiagChannel::User
             })?;
             let all_libs: Vec<String> = extra_libs.iter().cloned().chain(auto_libs).collect();
             link_native_object_for_target_with_hew_lib(
@@ -1205,6 +1234,7 @@ fn compile_build_binary_with_hew_lib(
         CompileEmitTarget::Wasm => {
             let wasm = artefacts.wasm_path.as_deref().ok_or_else(|| {
                 eprintln!("E_NOT_YET_IMPLEMENTED: WASM codegen did not produce a module");
+                DiagChannel::User
             })?;
             // `link_wasm_module` writes `<dir>/<name>.wasm`; rename to the
             // requested output path when they differ.
@@ -1214,10 +1244,12 @@ fn compile_build_binary_with_hew_lib(
                         "Error: cannot move wasm output to {}: {e}",
                         output_path.display()
                     );
+                    DiagChannel::User
                 })?;
             }
             let obj = artefacts.wasm_obj_path.as_deref().ok_or_else(|| {
                 eprintln!("E_NOT_YET_IMPLEMENTED: WASM codegen did not produce an object");
+                DiagChannel::User
             })?;
             remove_intermediate_object(obj)
         }
@@ -1237,12 +1269,13 @@ fn measure_compile_phase(phase: &str, elapsed: std::time::Duration) {
     }
 }
 
-fn remove_intermediate_object(path: &Path) -> Result<(), ()> {
+fn remove_intermediate_object(path: &Path) -> Result<(), DiagChannel> {
     std::fs::remove_file(path).map_err(|error| {
         eprintln!(
             "Error: cannot remove intermediate object {}: {error}",
             path.display()
         );
+        DiagChannel::User
     })
 }
 
@@ -1258,7 +1291,7 @@ fn emit_obj_only(
     opt_level: hew_codegen_rs::OptLevel,
     emit_llvm: bool,
     options: &compile::CompileOptions,
-) -> Result<(), ()> {
+) -> Result<(), DiagChannel> {
     let (pipeline, _native_pkg_dirs) = lower_file_to_mir_for_target(input, target, options)?;
     let stem = input
         .file_stem()
@@ -1291,6 +1324,7 @@ fn emit_obj_only(
     }
     .ok_or_else(|| {
         eprintln!("E_NOT_YET_IMPLEMENTED: codegen did not produce an object");
+        DiagChannel::User
     })?;
 
     // Codegen writes `<dir>/<stem>.o` (or `.wasm.o`); rename to the
@@ -1299,6 +1333,7 @@ fn emit_obj_only(
     if produced != final_path {
         std::fs::rename(&produced, &final_path).map_err(|e| {
             eprintln!("Error: cannot move object to {}: {e}", final_path.display());
+            DiagChannel::User
         })?;
     }
     Ok(())
@@ -1392,7 +1427,7 @@ fn cmd_build_run(a: &args::BuildArgs) -> i32 {
     if a.emit_obj {
         return match emit_obj_only(input, &target, a.debug, opt_level, a.emit_llvm, &options) {
             Ok(()) => 0,
-            Err(()) => 1,
+            Err(channel) => channel.exit_code(),
         };
     }
 
@@ -1415,7 +1450,7 @@ fn cmd_build_run(a: &args::BuildArgs) -> i32 {
         &options,
     ) {
         Ok(()) => 0,
-        Err(()) => 1,
+        Err(channel) => channel.exit_code(),
     }
 }
 
@@ -1442,12 +1477,13 @@ fn cmd_compile(a: &args::CompileArgs) {
 /// caller holds and would drop accumulated advisories). Every failure path is a
 /// `return <code>`, so the caller's single flush chokepoint runs regardless.
 fn cmd_dump_sir(a: &args::CompileArgs, json: bool) -> i32 {
-    let Ok(sir) = lower_file_to_sir(
+    let sir = match lower_file_to_sir(
         &a.input,
         a.target.as_deref(),
         &compile::CompileOptions::default(),
-    ) else {
-        return 1;
+    ) {
+        Ok(sir) => sir,
+        Err(channel) => return channel.exit_code(),
     };
     let dump = hew_sir::dump_lowering(&sir);
     if json {
@@ -1469,11 +1505,11 @@ fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
         sir_mode,
         ..compile::CompileOptions::default()
     };
-    let Ok((pipeline, sir_report)) =
-        lower_file_to_mir_with_options(&a.input, a.target.as_deref(), &options)
-    else {
-        return 1;
-    };
+    let (pipeline, sir_report) =
+        match lower_file_to_mir_with_options(&a.input, a.target.as_deref(), &options) {
+            Ok(result) => result,
+            Err(channel) => return channel.exit_code(),
+        };
 
     if let Some(report) = sir_report.as_ref() {
         report_sir_lane(report);
@@ -1528,7 +1564,7 @@ fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
     let Ok(emit_target) = resolve_compile_emit_target(a.target.as_deref()) else {
         return 2;
     };
-    let Ok(artefacts) = emit_module(
+    let artefacts = match emit_module(
         &pipeline,
         module_name,
         emit_dir,
@@ -1536,8 +1572,9 @@ fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
         true,
         opt_level,
         a.emit_llvm,
-    ) else {
-        return 1;
+    ) {
+        Ok(artefacts) => artefacts,
+        Err(channel) => return channel.exit_code(),
     };
 
     // Link the native object into an executable using the shared
@@ -1562,8 +1599,8 @@ fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
             }
         };
         let bin_path = host_target.executable_path(emit_dir, module_name);
-        if link_native_object(obj, &bin_path).is_err() {
-            return 1;
+        if let Err(channel) = link_native_object(obj, &bin_path) {
+            return channel.exit_code();
         }
         if !json {
             println!("native: {}", bin_path.display());
@@ -1675,7 +1712,7 @@ fn compile_temp_debug_artifact(
     options: &compile::CompileOptions,
     target: &target::ExecutionTarget,
     extra_libs: &[String],
-) -> Result<CompiledTempExecutable, ()> {
+) -> Result<CompiledTempExecutable, DiagChannel> {
     // `hew debug` launches a native debugger on the artifact, so it must carry
     // DWARF debug info — emit it even though the shared `hew run` path does not.
     compile_temp_artifact(
@@ -1692,7 +1729,7 @@ fn compile_temp_run_artifact(
     options: &compile::CompileOptions,
     target: &target::ExecutionTarget,
     extra_libs: &[String],
-) -> Result<CompiledTempExecutable, ()> {
+) -> Result<CompiledTempExecutable, DiagChannel> {
     // `hew run` is the fast-exec path; no debug info.
     compile_temp_artifact(
         input,
@@ -1714,7 +1751,7 @@ fn compile_temp_wasi_module(
     input: &str,
     options: &compile::CompileOptions,
     target: &target::ExecutionTarget,
-) -> Result<CompiledTempExecutable, ()> {
+) -> Result<CompiledTempExecutable, DiagChannel> {
     // Compute the target spec before allocating temp files so that an early
     // `process::exit` does not leak a temp directory.
     let target_spec =
@@ -1738,7 +1775,7 @@ fn compile_temp_wasi_module(
         _cleanup: TempExecutableCleanup::TempDir { _temp_dir: tmp_dir },
     };
 
-    let result = (|| -> Result<(), ()> {
+    let result = (|| -> Result<(), DiagChannel> {
         let (pipeline, _native_pkg_dirs) =
             lower_file_to_mir_for_target(Path::new(input), &target_spec, options)?;
         let emit_dir = tmp_dir_of_path(&wasm_path);
@@ -1760,24 +1797,28 @@ fn compile_temp_wasi_module(
         )?;
         let obj = artefacts.wasm_obj_path.as_deref().ok_or_else(|| {
             eprintln!("E_NOT_YET_IMPLEMENTED: WASM codegen did not produce an object");
+            DiagChannel::User
         })?;
         let obj_str = obj.to_str().ok_or_else(|| {
             eprintln!("Error: WASM object path is not valid UTF-8");
+            DiagChannel::User
         })?;
         let out_str = wasm_path.to_str().ok_or_else(|| {
             eprintln!("Error: WASM output path is not valid UTF-8");
+            DiagChannel::User
         })?;
         crate::link::link_executable(obj_str, out_str, &target_spec, &[], false).map_err(|e| {
             eprintln!("{e}");
+            DiagChannel::User
         })
     })();
 
-    if let Err(()) = result {
+    if let Err(channel) = result {
         drop(artifact);
         if diagnostic_json::json_output_active() {
             diagnostic_json::flush_json_diagnostics();
         }
-        return Err(());
+        return Err(channel);
     }
 
     Ok(artifact)
@@ -1793,7 +1834,7 @@ fn compile_temp_artifact(
     options: &compile::CompileOptions,
     debug: bool,
     extra_libs: &[String],
-) -> Result<CompiledTempExecutable, ()> {
+) -> Result<CompiledTempExecutable, DiagChannel> {
     // Route through the same path as `hew build` so `hew run` honours
     // `--pkg-path` (resolving `hew::<pkg>` imports), auto-links the native
     // (FFI) staticlibs declared by imported packages, and threads explicit
@@ -1806,7 +1847,7 @@ fn compile_temp_artifact(
             std::process::exit(1);
         }
     };
-    if compile_build_binary(
+    match compile_build_binary(
         Path::new(input),
         artifact.path(),
         &target,
@@ -1817,18 +1858,17 @@ fn compile_temp_artifact(
         false,
         extra_libs,
         options,
-    )
-    .is_ok()
-    {
-        Ok(artifact)
-    } else {
-        drop(artifact);
-        // Flush any collected JSON diagnostics before the caller exits.
-        // No-op when JSON output is not active (e.g. `hew debug`).
-        if diagnostic_json::json_output_active() {
-            diagnostic_json::flush_json_diagnostics();
+    ) {
+        Ok(()) => Ok(artifact),
+        Err(channel) => {
+            drop(artifact);
+            // Flush any collected JSON diagnostics before the caller exits.
+            // No-op when JSON output is not active (e.g. `hew debug`).
+            if diagnostic_json::json_output_active() {
+                diagnostic_json::flush_json_diagnostics();
+            }
+            Err(channel)
         }
-        Err(())
     }
 }
 
@@ -1958,8 +1998,8 @@ fn cmd_run_wasi(
     target: &target::ExecutionTarget,
     timeout: Option<std::time::Duration>,
 ) -> ! {
-    let artifact =
-        compile_temp_wasi_module(input, options, target).unwrap_or_else(|()| std::process::exit(1));
+    let artifact = compile_temp_wasi_module(input, options, target)
+        .unwrap_or_else(|channel| std::process::exit(channel.exit_code()));
 
     match wasi_runner::run_module(artifact.path(), &a.program_args, timeout) {
         Ok(wasi_runner::WasiRunOutcome::Exited(status)) => {
@@ -1990,7 +2030,7 @@ fn cmd_run_native(
     timeout: Option<std::time::Duration>,
 ) -> ! {
     let artifact = compile_temp_run_artifact(input, options, target, link_libs)
-        .unwrap_or_else(|()| std::process::exit(1));
+        .unwrap_or_else(|channel| std::process::exit(channel.exit_code()));
 
     let mut command = std::process::Command::new(artifact.path());
     command.args(&a.program_args);
@@ -2135,11 +2175,11 @@ fn cmd_check_run(a: &args::CheckArgs) -> i32 {
     let (result, state) = match hew_compile::check_file_with_state(&input, &frontend_options) {
         Ok(result) => result,
         Err(failure) => {
-            compile::render_frontend_diagnostics(&failure.diagnostics);
+            let channel = compile::render_frontend_diagnostics(&failure.diagnostics);
             if !json && failure.diagnostics.is_empty() {
                 eprintln!("{}", failure.message);
             }
-            return 1;
+            return channel.unwrap_or(DiagChannel::User).exit_code();
         }
     };
 
@@ -2156,8 +2196,8 @@ fn cmd_check_run(a: &args::CheckArgs) -> i32 {
         }
     }
 
-    if run_check_deep_gates(&input, &target, &state, &options.lint_levels).is_err() {
-        return 1;
+    if let Err(channel) = run_check_deep_gates(&input, &target, &state, &options.lint_levels) {
+        return channel.exit_code();
     }
 
     if !json {
@@ -2177,7 +2217,7 @@ fn cmd_debug(a: &args::DebugArgs) {
     let options = a.to_compile_options();
     let target = resolve_debug_target(options.target.as_deref());
     let artifact = compile_temp_debug_artifact(&input, &options, &target, &a.link_libs)
-        .unwrap_or_else(|()| std::process::exit(1));
+        .unwrap_or_else(|channel| std::process::exit(channel.exit_code()));
     let (debugger, debugger_args) =
         match resolve_debugger_invocation(artifact.path(), &a.program_args) {
             Ok(invocation) => invocation,

--- a/hew-cli/src/watch.rs
+++ b/hew-cli/src/watch.rs
@@ -377,7 +377,7 @@ fn run_check_and_program(
             );
             run_compiled_binary(&tmp_bin, palette);
         }
-        Err(()) => emit_watch_status("✗ Build failed", palette.red, elapsed, palette),
+        Err(_channel) => emit_watch_status("✗ Build failed", palette.red, elapsed, palette),
     }
 
     drop(tmp_path);

--- a/hew-cli/tests/diag_channels.rs
+++ b/hew-cli/tests/diag_channels.rs
@@ -1,0 +1,123 @@
+//! End-to-end coverage for the three diagnostic channels (V060-DIAG-1):
+//! exit code, text prefix, and the `--format json` `channel` field.
+//!
+//! User and Limitation are exercised here from the CLI. No `.hew` program on
+//! `main` reaches the Internal channel through the CLI (it requires a
+//! compiler-invariant failure, not a legal program), so Internal is asserted
+//! at unit level instead: see `hew-mir/src/model.rs`'s
+//! `mir_diagnostic_channel_*` tests for `channel()` classification, and
+//! `hew-cli/src/diagnostic.rs`'s `internal_channel_exit_code_and_prefix` for
+//! the exit code and rendered bug-report note.
+
+mod support;
+
+use std::fs;
+use std::process::Command;
+
+use serde_json::Value;
+use support::{describe_output, hew_binary, strip_ansi};
+
+fn write_fixture(source: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = support::tempdir();
+    let path = dir.path().join("main.hew");
+    fs::write(&path, source).expect("write fixture");
+    (dir, path)
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(hew_binary())
+        .args(args)
+        .output()
+        .expect("hew binary must run")
+}
+
+fn parse_json_array(output: &std::process::Output) -> Vec<Value> {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout must be a parseable JSON array; parse error: {error}\nstdout:\n{stdout}\n{}",
+            describe_output(output)
+        )
+    });
+    value
+        .as_array()
+        .unwrap_or_else(|| panic!("top-level JSON must be an array; got:\n{stdout}"))
+        .clone()
+}
+
+/// A plain type error: the User channel. Exit 1, no channel prefix on the
+/// rendered text (today's rendering), and `"channel": "user"` in JSON.
+const USER_FIXTURE: &str = "fn main() {\n    let x: i64 = \"oops\";\n}\n";
+
+/// D9: a `fork` inside `scope { .. }` reached from `main`, which carries no
+/// execution context in this release. The Limitation channel's first code,
+/// `E_LIMIT_MAIN_CONTEXT` (ledger D340).
+const LIMITATION_FIXTURE: &str = "fn main() {\n    scope { fork { println(\"x\"); } }\n}\n";
+
+#[test]
+fn user_channel_exits_1_with_no_prefix_and_json_channel_user() {
+    let (_dir, path) = write_fixture(USER_FIXTURE);
+
+    let text_output = run(&["check", path.to_str().unwrap()]);
+    assert_eq!(
+        text_output.status.code(),
+        Some(1),
+        "a User-channel diagnostic must exit 1\n{}",
+        describe_output(&text_output),
+    );
+    let stderr = strip_ansi(&String::from_utf8_lossy(&text_output.stderr));
+    assert!(
+        !stderr.contains("compiler limitation:") && !stderr.contains("internal compiler error:"),
+        "a User-channel diagnostic must carry no channel prefix; got:\n{stderr}",
+    );
+
+    let json_output = run(&["check", "--format=json", path.to_str().unwrap()]);
+    assert_eq!(json_output.status.code(), Some(1));
+    let diagnostics = parse_json_array(&json_output);
+    let mismatch = diagnostics
+        .iter()
+        .find(|d| d["code"] == "Mismatch")
+        .expect("expected a Mismatch diagnostic");
+    assert_eq!(
+        mismatch["channel"], "user",
+        "a type error's JSON channel field must be \"user\": {mismatch}",
+    );
+}
+
+#[test]
+fn limitation_channel_exits_3_with_prefix_and_json_channel_limitation() {
+    let (_dir, path) = write_fixture(LIMITATION_FIXTURE);
+
+    let text_output = run(&["check", path.to_str().unwrap()]);
+    assert_eq!(
+        text_output.status.code(),
+        Some(3),
+        "a Limitation-channel diagnostic must exit 3\n{}",
+        describe_output(&text_output),
+    );
+    let stderr = strip_ansi(&String::from_utf8_lossy(&text_output.stderr));
+    assert!(
+        stderr.contains("compiler limitation:"),
+        "must render the Limitation channel prefix; got:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("E_LIMIT_MAIN_CONTEXT"),
+        "must name the D9 code; got:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("actor") && stderr.contains("join"),
+        "the day-one journey asserts the words `actor` and `join`; got:\n{stderr}",
+    );
+
+    let json_output = run(&["check", "--format=json", path.to_str().unwrap()]);
+    assert_eq!(json_output.status.code(), Some(3));
+    let diagnostics = parse_json_array(&json_output);
+    let main_context = diagnostics
+        .iter()
+        .find(|d| d["code"] == "MainContextRequired")
+        .expect("expected a MainContextRequired diagnostic");
+    assert_eq!(
+        main_context["channel"], "limitation",
+        "D9's JSON channel field must be \"limitation\": {main_context}",
+    );
+}

--- a/hew-cli/tests/diagnostic_source_e2e.rs
+++ b/hew-cli/tests/diagnostic_source_e2e.rs
@@ -403,8 +403,11 @@ fn root_hir_diagnostic_rendered_with_source_context() {
     );
 
     let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    // `NotYetImplemented` is a Limitation-channel HIR kind (V060-DIAG-1): the
+    // rendered line carries the channel prefix ahead of the diagnostic's own
+    // code, `main.hew:3:15: error: compiler limitation: E_NOT_YET_IMPLEMENTED`.
     assert!(
-        stderr.contains("main.hew:3:15: error: E_NOT_YET_IMPLEMENTED"),
+        stderr.contains("main.hew:3:15: error: compiler limitation: E_NOT_YET_IMPLEMENTED"),
         "root HIR diagnostic must include file:line:col; got:\n{stderr}"
     );
     assert!(
@@ -443,8 +446,11 @@ fn imported_hir_diagnostic_rendered_with_imported_source_context() {
     );
 
     let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    // `NotYetImplemented` is a Limitation-channel HIR kind (V060-DIAG-1): the
+    // rendered line carries the channel prefix ahead of the diagnostic's own
+    // code, `dep.hew:3:15: error: compiler limitation: E_NOT_YET_IMPLEMENTED`.
     assert!(
-        stderr.contains("dep.hew:3:15: error: E_NOT_YET_IMPLEMENTED"),
+        stderr.contains("dep.hew:3:15: error: compiler limitation: E_NOT_YET_IMPLEMENTED"),
         "imported HIR diagnostic must name dep.hew; got:\n{stderr}"
     );
     assert!(

--- a/hew-cli/tests/json_diagnostics_e2e.rs
+++ b/hew-cli/tests/json_diagnostics_e2e.rs
@@ -138,8 +138,8 @@ fn check_not_yet_implemented_json_has_no_debug_payload() {
 
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "NYI program must exit 1\n{}",
+        Some(3),
+        "NYI program is a Limitation-channel diagnostic and must exit 3\n{}",
         describe_output(&output),
     );
     let diagnostics = parse_json_array(&output);
@@ -260,8 +260,8 @@ fn compile_mir_gate_failure_json_has_no_debug_payload() {
 
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "compile MIR gate failure must exit 1\n{}",
+        Some(3),
+        "compile MIR gate failure is a Limitation-channel diagnostic and must exit 3\n{}",
         describe_output(&output),
     );
     let diagnostics = parse_json_array(&output);
@@ -284,7 +284,12 @@ fn compile_mir_gate_failure_text_has_no_debug_payload() {
     let output = run(&["compile", path.to_str().unwrap()]);
     let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
 
-    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "NYI is a Limitation-channel diagnostic and must exit 3\n{}",
+        describe_output(&output),
+    );
     assert!(
         !stderr.contains("MirDiagnostic")
             && !stderr.contains("NotYetImplemented {")

--- a/hew-hir/src/diagnostic.rs
+++ b/hew-hir/src/diagnostic.rs
@@ -1,4 +1,5 @@
 use hew_parser::ast::Span;
+use hew_types::error::DiagChannel;
 use hew_types::ResolvedTy;
 
 use crate::ids::{BindingId, HirNodeId, ResolvedRef, SiteId};
@@ -823,4 +824,47 @@ pub enum HirDiagnosticKind {
         /// Human-readable rendering of the receiver's type.
         receiver_ty: String,
     },
+}
+
+impl HirDiagnosticKind {
+    /// Which of the three diagnostic channels this kind reports on.
+    ///
+    /// Internal: the checker/HIR boundary contract was violated — two
+    /// compiler facts disagree, never a fault in the user's program.
+    /// Limitation: legal Hew this lowering does not support yet, including
+    /// every registry cap (a cap is a limit of this compiler, not a
+    /// contradiction). Every other variant is a genuine user-authored
+    /// contract violation (`#[resource]`/`#[linear]`/`await` misuse, an
+    /// arity mismatch, an unresolved symbol, ...) and stays User.
+    ///
+    /// This is the HIR-side counterpart of
+    /// [`crate::MirDiagnosticKind::internal_compiler_error_function`]/
+    /// `channel()` — the one authority for this classification; `hew-cli`
+    /// and `hew-lsp` both call it rather than re-deriving the split.
+    #[must_use]
+    pub const fn channel(&self) -> DiagChannel {
+        match self {
+            Self::CheckerBoundaryViolation { .. }
+            | Self::MonomorphisationCallTypeArgsViolation { .. }
+            | Self::RecordLayoutTypeArgsViolation { .. } => DiagChannel::Internal,
+            Self::NotYetImplemented { .. }
+            | Self::MonomorphisationCapExceeded { .. }
+            | Self::RecordLayoutCapExceeded { .. }
+            | Self::MachineMonomorphisationCapExceeded { .. } => DiagChannel::Limitation,
+            _ => DiagChannel::User,
+        }
+    }
+
+    /// Stable, user-facing string identifier for this diagnostic kind.
+    ///
+    /// Returns the variant name (e.g. `NotYetImplemented`, `UnresolvedSymbol`)
+    /// without any of the Rust `{:?}` struct payload. Used as the `code`
+    /// field in JSON diagnostics and by the LSP's diagnostic rendering — the
+    /// one authority both `hew-cli` and `hew-lsp` call.
+    #[must_use]
+    pub fn kind_string(&self) -> String {
+        let debug = format!("{self:?}");
+        let end = debug.find([' ', '{', '(']).unwrap_or(debug.len());
+        debug[..end].to_string()
+    }
 }

--- a/hew-hir/src/lib.rs
+++ b/hew-hir/src/lib.rs
@@ -21,6 +21,7 @@ pub mod verify;
 
 pub use diagnostic::{HirDiagnostic, HirDiagnosticKind, ImportedItemKind};
 pub use dump::dump_hir;
+pub use hew_types::error::DiagChannel;
 pub use hew_types::stdlib_authority;
 pub use ids::{BindingId, HirNodeId, ItemId, ResolvedRef, ScopeId, SiteId};
 pub use intent::IntentKind;

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -1421,9 +1421,7 @@ fn build_hir_lsp_diagnostics(
             Diagnostic {
                 range,
                 severity: Some(DiagnosticSeverity::ERROR),
-                code: Some(NumberOrString::String(hir_diagnostic_kind_string(
-                    &diagnostic.kind,
-                ))),
+                code: Some(NumberOrString::String(diagnostic.kind.kind_string())),
                 source: Some("hew-hir".to_string()),
                 message,
                 related_information,
@@ -1442,7 +1440,7 @@ fn hir_diagnostic_message(kind: &HirDiagnosticKind, note: &str) -> String {
             construct,
             owning_pass,
         } => format!("not yet implemented: {construct} (planned: {owning_pass})"),
-        _ => hir_diagnostic_kind_string(kind),
+        _ => kind.kind_string(),
     };
 
     if note.is_empty() {
@@ -1454,15 +1452,9 @@ fn hir_diagnostic_message(kind: &HirDiagnosticKind, note: &str) -> String {
 
 fn hir_diagnostic_data(kind: &HirDiagnosticKind) -> serde_json::Value {
     serde_json::json!({
-        "kind": hir_diagnostic_kind_string(kind),
+        "kind": kind.kind_string(),
         "source": "hir",
     })
-}
-
-fn hir_diagnostic_kind_string(kind: &HirDiagnosticKind) -> String {
-    let debug = format!("{kind:?}");
-    let end = debug.find([' ', '{', '(']).unwrap_or(debug.len());
-    debug[..end].to_string()
 }
 
 fn zero_range() -> tower_lsp_server::lsp_types::Range {

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -2126,6 +2126,9 @@ fn render_diag_kind(kind: &MirDiagnosticKind) -> String {
         MirDiagnosticKind::ClosureCapturesDuplexHandle { name, site } => {
             format!("ClosureCapturesDuplexHandle {name} site={site:?}")
         }
+        MirDiagnosticKind::MainContextRequired { spawned } => {
+            format!("MainContextRequired {spawned}")
+        }
     }
 }
 

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -56,6 +56,7 @@ pub fn drop_kind_for_test(
 }
 pub use dump::{dump_mir, DumpStage};
 pub use hew_hir::sanitize_for_symbol;
+pub use hew_types::error::DiagChannel;
 pub use hew_types::short_name;
 pub use model::{
     classify_extern_string_ownership, container_ingress_is_copy_in, indirect_closure_callee,

--- a/hew-mir/src/lower/task.rs
+++ b/hew-mir/src/lower/task.rs
@@ -515,12 +515,8 @@ impl Builder {
                 _ => "<callee>",
             };
             self.diagnostics.push(MirDiagnostic {
-                kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: format!(
-                        "cannot spawn `{callee_name}` from `{}`",
-                        self.current_function_symbol
-                    ),
-                    site,
+                kind: MirDiagnosticKind::MainContextRequired {
+                    spawned: callee_name.to_string(),
                 },
                 note: format!(
                     "`scope {{ fork ... }}` requires an enclosing ctx-bearing execution context, \
@@ -1215,12 +1211,8 @@ impl Builder {
         };
         if !self.current_function_call_conv.carries_execution_context() {
             self.diagnostics.push(MirDiagnostic {
-                kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: format!(
-                        "cannot spawn fork block from `{}`",
-                        self.current_function_symbol
-                    ),
-                    site,
+                kind: MirDiagnosticKind::MainContextRequired {
+                    spawned: "fork block".to_string(),
                 },
                 note: "fork blocks require an enclosing execution context".to_string(),
             });

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use hew_hir::{sanitize_for_symbol, BindingId, IntentKind, ItemId, SiteId, ValueClass};
+use hew_types::error::DiagChannel;
 use hew_types::{
     BuiltinType, NumericWidth, RcIntrinsicOp, ResolvedTy, TryConversionKind, WireCodecDirection,
     WireLayoutTable,
@@ -8285,6 +8286,16 @@ pub enum MirDiagnosticKind {
     /// When the full env-materialization protocol for Duplex captures is
     /// implemented, remove this guard AND the checker gate in `check_call`.
     ClosureCapturesDuplexHandle { name: String, site: SiteId },
+    /// D9: a `fork`/spawn reached MIR inside a function whose call-conv
+    /// carries no execution context (`main`, or any other plain
+    /// `Default`-callconv function). Every function may suspend in the
+    /// target design; today only an actor handler, a closure invoked in a
+    /// ctx-aware position, or a task-entry adapter carries one. `spawned`
+    /// names the callee symbol for a named-callee spawn, or the literal
+    /// `fork block` for an inline fork-block spawn. Limitation channel,
+    /// `E_LIMIT_MAIN_CONTEXT`: the program is legal Hew, this release's
+    /// runtime substrate has no execution context for `main`.
+    MainContextRequired { spawned: String },
 }
 
 impl MirDiagnosticKind {
@@ -8311,6 +8322,88 @@ impl MirDiagnosticKind {
             | Self::ObligationOverReleased { function, .. } => Some(function),
             _ => None,
         }
+    }
+
+    /// Which of the three diagnostic channels this kind reports on.
+    ///
+    /// Reuses [`Self::internal_compiler_error_function`] as the sole
+    /// authority for "compiler defect" rather than re-deriving the same
+    /// three-variant set: `Some(_)` means Internal. `NotYetImplemented`,
+    /// `DropPlanUndetermined`, and `OwnedHandleAggregateExtractionUnsupported`
+    /// are refusals, not defects — the elaborator proved nothing wrong, it
+    /// declined to emit a partial/unsafe lowering — so they are Limitation.
+    /// `MainContextRequired` (D9) is Limitation for the same reason: legal
+    /// Hew this release's runtime substrate cannot yet run. Every other kind
+    /// is the program's own ownership/move/init/actor-argument error: User.
+    #[must_use]
+    pub fn channel(&self) -> DiagChannel {
+        if self.internal_compiler_error_function().is_some() {
+            return DiagChannel::Internal;
+        }
+        match self {
+            Self::NotYetImplemented { .. }
+            | Self::DropPlanUndetermined { .. }
+            | Self::OwnedHandleAggregateExtractionUnsupported { .. }
+            | Self::MainContextRequired { .. } => DiagChannel::Limitation,
+            _ => DiagChannel::User,
+        }
+    }
+}
+
+#[cfg(test)]
+mod diag_channel_tests {
+    use super::*;
+
+    /// The three kinds `internal_compiler_error_function` recognises — an
+    /// obligation-balance or lowering-invariant compiler defect — must report
+    /// Internal, never User or Limitation.
+    #[test]
+    fn ice_kinds_are_internal_channel() {
+        let lowering_invariant = MirDiagnosticKind::LoweringInvariant {
+            function: "f".to_string(),
+            rule: "obligation-balance-unverified".to_string(),
+            block: None,
+            detail: "detail".to_string(),
+        };
+        let under_released = MirDiagnosticKind::ObligationUnderReleased {
+            function: "f".to_string(),
+            blocks: vec![0],
+            site: SiteId(0),
+            name: "x".to_string(),
+            local_ty: "i64".to_string(),
+            reason: "reason".to_string(),
+        };
+        let over_released = MirDiagnosticKind::ObligationOverReleased {
+            function: "f".to_string(),
+            blocks: vec![0],
+            site: SiteId(0),
+            name: "x".to_string(),
+            reason: "reason".to_string(),
+        };
+        assert_eq!(lowering_invariant.channel(), DiagChannel::Internal);
+        assert_eq!(under_released.channel(), DiagChannel::Internal);
+        assert_eq!(over_released.channel(), DiagChannel::Internal);
+    }
+
+    /// A refusal — the elaborator declined to emit a partial/unsupported
+    /// lowering, proving nothing wrong — is Limitation, not Internal or User.
+    #[test]
+    fn not_yet_implemented_is_limitation_channel() {
+        let kind = MirDiagnosticKind::NotYetImplemented {
+            construct: "some gap".to_string(),
+            site: SiteId(0),
+        };
+        assert_eq!(kind.channel(), DiagChannel::Limitation);
+    }
+
+    /// D9: `main` has no execution context in this release — legal Hew this
+    /// runtime substrate cannot run yet, so Limitation.
+    #[test]
+    fn main_context_required_is_limitation_channel() {
+        let kind = MirDiagnosticKind::MainContextRequired {
+            spawned: "println_str".to_string(),
+        };
+        assert_eq!(kind.channel(), DiagChannel::Limitation);
     }
 }
 

--- a/hew-mir/tests/actor/cancellation_scope.rs
+++ b/hew-mir/tests/actor/cancellation_scope.rs
@@ -685,10 +685,10 @@ fn scope_fork_after_lowers_to_executable_task_and_deadline_abi() {
 fn value_task_await_in_default_callconv_caller_fails_closed() {
     // A value-returning `fork x = compute(); let v = await x;` in a
     // Default-callconv function (here `main`) must be refused at MIR: the
-    // fork spawn itself emits `NotYetImplemented` (no execution-context to
-    // park a continuation on), and `lower_await_task` is an additional
+    // fork spawn itself emits `MainContextRequired` (D9: no execution-context
+    // to park a continuation on), and `lower_await_task` is an additional
     // defence-in-depth gate. This test asserts the pipeline emits a
-    // `NotYetImplemented` diagnostic — the value-task result-read path is
+    // `MainContextRequired` diagnostic — the value-task result-read path is
     // not wired for blocking callers.
     let source = r"
         fn compute() -> i64 { 42 }
@@ -701,16 +701,23 @@ fn value_task_await_in_default_callconv_caller_fails_closed() {
         }
     ";
     let mir = lower_to_mir(source);
+    let has_main_context_required = mir.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::MainContextRequired { spawned } if spawned == "compute"
+        )
+    });
     let has_nyi = mir.diagnostics.iter().any(|d| {
         matches!(
             &d.kind,
             MirDiagnosticKind::NotYetImplemented { construct, .. }
-                if construct.contains("cannot spawn") || construct.contains("await task result")
+                if construct.contains("await task result")
         )
     });
     assert!(
-        has_nyi,
-        "value-task await from a Default-callconv caller must emit NotYetImplemented; \
+        has_main_context_required || has_nyi,
+        "value-task await from a Default-callconv caller must emit \
+         MainContextRequired; \
          capabilities: hew_mir::ModuleCapabilities::EMPTY,
          diagnostics: {:#?}",
         mir.diagnostics

--- a/hew-mir/tests/actor/task_entry_adapter_lowering.rs
+++ b/hew-mir/tests/actor/task_entry_adapter_lowering.rs
@@ -144,8 +144,7 @@ fn default_callconv_spawn_rejects_before_spawn_task_direct() {
         pipeline.diagnostics.iter().any(|diag| {
             matches!(
                 &diag.kind,
-                MirDiagnosticKind::NotYetImplemented { construct, .. }
-                    if construct.contains("cannot spawn `worker` from `main`")
+                MirDiagnosticKind::MainContextRequired { spawned } if spawned == "worker"
             ) && diag.note.contains("ctx-bearing execution context")
                 && diag.note.contains("Default call-conv")
                 && diag.note.contains("W4.010-followup-caller-ctx-routing")

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -56,6 +56,66 @@ pub enum Severity {
     Warning,
 }
 
+/// Which of the three diagnostic channels a compile-time diagnostic belongs
+/// to. Every diagnostic the compiler prints — parse, type, HIR, MIR, lint,
+/// codegen-front — carries exactly one channel, and the channel decides the
+/// process exit code, the rendered text prefix, and the `--format json`
+/// `channel` field.
+///
+/// Variant order is `User < Limitation < Internal` (see the derived `Ord`):
+/// the worst channel among a batch of diagnostics is `Iterator::max`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiagChannel {
+    /// The program is wrong. Exit 1, no special text prefix (today's
+    /// rendering).
+    User,
+    /// Legal Hew that this lowering cannot do yet. Exit 3, prefix
+    /// `compiler limitation:`; the diagnostic's own code names the phase
+    /// (`E_LIMIT_*`).
+    Limitation,
+    /// Two compiler facts disagree — a defect in the compiler, not the
+    /// user's program. Exit 4, prefix `internal compiler error:`; the
+    /// message carries a bug-report line.
+    Internal,
+}
+
+impl DiagChannel {
+    /// The process exit code a compile failure on this channel reports,
+    /// before the program has started running. Usage/configuration errors
+    /// stay exit 2 and never construct a `DiagChannel` (there is nothing to
+    /// classify: they never reach a diagnostic renderer at all).
+    #[must_use]
+    pub const fn exit_code(self) -> i32 {
+        match self {
+            Self::User => 1,
+            Self::Limitation => 3,
+            Self::Internal => 4,
+        }
+    }
+
+    /// The text prefix rendered ahead of the diagnostic's own `E_*` code.
+    /// Empty for `User` (today's rendering carries no channel prefix).
+    #[must_use]
+    pub const fn prefix(self) -> &'static str {
+        match self {
+            Self::User => "",
+            Self::Limitation => "compiler limitation: ",
+            Self::Internal => "internal compiler error: ",
+        }
+    }
+
+    /// The stable lowercase name used as the `--format json` `channel`
+    /// field (`"user"`, `"limitation"`, `"internal"`).
+    #[must_use]
+    pub const fn as_json_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Limitation => "limitation",
+            Self::Internal => "internal",
+        }
+    }
+}
+
 /// A secondary diagnostic location with its own source-file attribution.
 pub type TypeErrorNote = (Span, String, Option<String>);
 

--- a/tests/vertical-slice/reject/free_fn_scope_spawn_in_default.hew
+++ b/tests/vertical-slice/reject/free_fn_scope_spawn_in_default.hew
@@ -4,8 +4,8 @@
 //
 // Harness verb: hew compile
 // Expected diagnostics:
-//   - E_NOT_YET_IMPLEMENTED
-//   - "cannot spawn `worker` from `main`"
+//   - E_LIMIT_MAIN_CONTEXT (compiler limitation channel, exit 3)
+//   - "spawning `worker` needs an execution context"
 //   - "ctx-bearing execution context"
 //   - "W4.010-followup-caller-ctx-routing"
 

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3064,8 +3064,9 @@ if "${HEW}" compile "${ROOT}/tests/vertical-slice/reject/free_fn_scope_spawn_in_
     echo "expected free-fn-scope-spawn-in-default fixture to fail" >&2
     exit 1
 fi
-grep -q 'E_NOT_YET_IMPLEMENTED' "${reject_output}"
-grep -qF "cannot spawn \`worker\` from \`main\`" "${reject_output}"
+grep -qF 'compiler limitation:' "${reject_output}"
+grep -q 'E_LIMIT_MAIN_CONTEXT' "${reject_output}"
+grep -qF "spawning \`worker\` needs an execution context" "${reject_output}"
 grep -qF 'ctx-bearing execution context' "${reject_output}"
 grep -qF 'W4.010-followup-caller-ctx-routing' "${reject_output}"
 


### PR DESCRIPTION
## Why

Every diagnostic the compiler prints today collapses into one bucket at exit
1, so a script cannot tell "the program is wrong" from "the compiler cannot
do this yet" or "the compiler disagrees with itself" without parsing prose.
V060-DIAG-1 (plan `hew-platform-program.md` §2.1, `v060-surface-review.md`
decisions D8/D9) gives every diagnostic one of three channels — User, Limitation,
Internal — each with its own exit code, text prefix, and `--format json`
field, and adds the first Limitation-channel code,
`E_LIMIT_MAIN_CONTEXT`, for a `scope { fork ... }` reached from a
Default-callconv caller such as `main`.

## What

- **hew-types**: `DiagChannel` (`User`/`Limitation`/`Internal`) with
  `exit_code()`, `prefix()`, and `as_json_str()`, defined once beside
  `Severity`.
- **hew-hir**: `HirDiagnosticKind::channel()` and `kind_string()` — the
  latter moved from `hew-cli`/`hew-lsp`, which each had their own copy; both
  crates now call the one authority.
- **hew-mir**: `MirDiagnosticKind::channel()`. The two `scope { fork ... }`
  sites that reject a spawn with no enclosing execution context now raise
  `MainContextRequired` (`E_LIMIT_MAIN_CONTEXT`) instead of a generic
  `NotYetImplemented` built from a hand-written "cannot spawn ... from ..."
  string.
- **hew-cli**: `codegen_channel` classifies codegen-front errors; the
  channel prefix renders ahead of every diagnostic's own code; `--format
  json` diagnostics gain a `channel` field; every `Result<_, ()>` along the
  compile pipeline whose `Err(())` meant "a diagnostic was already printed"
  becomes `Result<_, DiagChannel>`, so the six exit points (`hew check`,
  `hew compile`, `hew build`, `hew run` native/WASI, `hew debug`) map the
  diagnostic's real channel to its exit code instead of hardcoding 1.
- **hew-lsp**: drops its duplicate `hir_diagnostic_kind_string`; severity
  mapping is unchanged — Limitation and Internal still show as LSP errors.
- **docs**: `docs/diagnostics/README.md` landed from #3267 while this branch
  was in flight and already carries the channel table and the
  `E_LIMIT_MAIN_CONTEXT` row; nothing further to add there.

## Test

- `hew-cli/tests/diag_channels.rs` (new): a User-channel type error and the
  D9 Limitation fixture, each asserted end to end — exit code, text prefix,
  and the JSON `channel` field.
- `hew-mir/src/model.rs`'s `diag_channel_tests`: the three ICE kinds classify
  Internal, `NotYetImplemented`/`MainContextRequired` classify Limitation.
- `hew-cli/src/diagnostic.rs`'s `internal_channel_exit_code_and_prefix`:
  `DiagChannel::Internal.exit_code() == 4`, and the channel prefix and the
  message body never both render `internal compiler error:` (an actual
  duplication bug caught and fixed along the way).
- Updated the pinned exit-1 assertions in `json_diagnostics_e2e.rs` (now 3),
  two pinned message substrings in `diagnostic_source_e2e.rs`, and the two
  `hew-mir` tests plus one vertical-slice fixture that pinned the old
  `NotYetImplemented` "cannot spawn" text to assert `MainContextRequired`
  instead.
