### PR TITLE
fix(fmt): preserve doc comments on impl blocks

### DIFF
--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -5556,4 +5556,28 @@ machine Socket {
         );
         assert_eq!(roundtrip(&formatted), formatted);
     }
+
+    #[test]
+    fn impl_block_doc_comment_is_preserved() {
+        let src = "\
+enum Foo {
+    A;
+}
+
+/// Doc comment for Foo Display.
+impl Display for Foo {
+    fn fmt(f: Foo) -> string {
+        match f {
+            .A => \"a\",
+        }
+    }
+}
+";
+        let formatted = roundtrip(src);
+        assert!(
+            formatted.contains("/// Doc comment for Foo Display."),
+            "doc comment on an impl block must survive formatting; got:\n{formatted}"
+        );
+        assert_eq!(roundtrip(&formatted), formatted);
+    }
 }


### PR DESCRIPTION
## Why

`hew fmt` deletes a `///` doc comment that immediately precedes an `impl Trait for Type` block, while a plain `//` comment in the same position survives. `format_impl` never called `write_outer_doc`, unlike every sibling `format_*` for struct/enum/fn.

## What

- `ImplDecl` gains a `doc_comment` field (matching every other item shape).
- The parser's item dispatch attaches the doc comment it already collects to `Item::Impl` instead of discarding it.
- `format_impl` writes the doc comment through `write_outer_doc`, the same call every other item's formatter makes.

## Test

- `hew-parser::fmt::tests::impl_block_doc_comment_is_preserved`: a doc comment before `impl Display for Foo` survives `format_program` and the formatted output re-formats to a fixed point. Verified it fails without the `write_outer_doc` call (reverted locally, reran) before restoring the fix.

Fixes #3238
