### PR TITLE
fix: close the small issues from the last three days

### DIFF
--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -1276,6 +1276,8 @@ pub struct ImplDecl {
     #[serde(default)]
     pub type_aliases: Vec<ImplTypeAlias>,
     pub methods: Vec<FnDecl>,
+    #[serde(default)]
+    pub doc_comment: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -943,6 +943,7 @@ impl<'a> Formatter<'a> {
     }
 
     fn format_impl(&mut self, decl: &ImplDecl, span_end: usize) {
+        self.write_outer_doc(decl.doc_comment.as_ref());
         self.write_indent();
         self.write("impl");
         self.format_opt_type_params(decl.type_params.as_ref());
@@ -4235,6 +4236,30 @@ mod tests {
     #[test]
     fn simple_function() {
         let src = "fn main() -> i32 {\n    0\n}\n";
+        let formatted = roundtrip(src);
+        assert_eq!(formatted, src);
+    }
+
+    #[test]
+    fn doc_comment_before_impl_block_is_preserved() {
+        // Regression test for #3238: the formatter's item model attached
+        // `doc_comment` to every other item kind (fn/struct/enum/trait) but
+        // not to `impl`, so a `///` comment immediately preceding an `impl`
+        // block was collected by the parser and then dropped on the floor.
+        let src = "\
+enum Foo {
+    A;
+}
+
+/// Doc comment for Foo Display.
+impl Display for Foo {
+    fn fmt(f: Foo) -> string {
+        match f {
+            .A => \"a\",
+        }
+    }
+}
+";
         let formatted = roundtrip(src);
         assert_eq!(formatted, src);
     }

--- a/hew-parser/src/parser/items.rs
+++ b/hew-parser/src/parser/items.rs
@@ -536,7 +536,9 @@ impl Parser<'_> {
             }
             Some(Token::Impl) => {
                 self.advance();
-                Item::Impl(self.parse_impl_decl()?)
+                let mut i = self.parse_impl_decl()?;
+                i.doc_comment = doc_comment;
+                Item::Impl(i)
             }
             Some(Token::Actor) => {
                 self.advance();
@@ -1533,6 +1535,7 @@ impl Parser<'_> {
             where_clause,
             type_aliases,
             methods,
+            doc_comment: None,
         })
     }
 

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -3274,6 +3274,7 @@ fn orphan_impl_emits_warning() {
         where_clause: None,
         type_aliases: vec![],
         methods: vec![],
+        doc_comment: None,
     };
     let output = check_items(vec![(Item::Impl(impl_decl), 0..0)]);
 
@@ -3328,6 +3329,7 @@ fn noncanonical_builtin_spelling_does_not_own_intrinsic_impls() {
         where_clause: None,
         type_aliases: vec![],
         methods: vec![],
+        doc_comment: None,
     };
     let mut checker = Checker {
         current_module: Some("std.builtins".to_string()),
@@ -3590,6 +3592,7 @@ fn local_type_impl_no_orphan_warning() {
         where_clause: None,
         type_aliases: vec![],
         methods: vec![],
+        doc_comment: None,
     };
     let output = check_items(vec![
         (Item::TypeDecl(type_decl), 0..0),
@@ -3644,6 +3647,7 @@ fn local_actor_impl_no_orphan_warning() {
         where_clause: None,
         type_aliases: vec![],
         methods: vec![],
+        doc_comment: None,
     };
     let output = check_items(vec![
         (Item::Actor(actor), 0..0),

--- a/hew-types/src/check/tests/infer.rs
+++ b/hew-types/src/check/tests/infer.rs
@@ -661,6 +661,7 @@ mod non_root_module_inference_scope {
             where_clause: None,
             type_aliases: vec![],
             methods: vec![],
+            doc_comment: None,
         };
         let program = Program {
             module_graph: None,

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -126,24 +126,21 @@ pub fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
     }
 }
 
-// Print an `IoError`'s variant name and raw OS errno.
-//
-// For network errors see `impl Display for net.NetError` in `std.net`.
-//
-// ```
-// import std.fs;
-//
-// fn main() {
-//     let result: Result<i64, fs.IoError> = fs.try_delete("/tmp/scratch-file");
-//     match result {
-//         .Err(e) => panic(f"operation failed: {e}"),
-//         .Ok(_) => {},
-//     }
-// }
-// ```
-//
-// Plain `//`, not `///`: `hew fmt` deletes a doc comment immediately
-// preceding an `impl` block. Restore `///` once hew-lang/hew#3238 lands.
+/// Print an `IoError`'s variant name and raw OS errno.
+///
+/// For network errors see `impl Display for net.NetError` in `std.net`.
+///
+/// ```
+/// import std.fs;
+///
+/// fn main() {
+///     let result: Result<i64, fs.IoError> = fs.try_delete("/tmp/scratch-file");
+///     match result {
+///         .Err(e) => panic(f"operation failed: {e}"),
+///         .Ok(_) => {},
+///     }
+/// }
+/// ```
 impl Display for IoError {
     fn fmt(e: IoError) -> string {
         match e {

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -135,10 +135,7 @@ pub fn net_error_from_errno(errno: i64) -> NetError {
     }
 }
 
-// Print a `NetError`'s variant name and raw OS errno.
-//
-// Plain `//`, not `///`: `hew fmt` deletes a doc comment immediately
-// preceding an `impl` block. Restore `///` once hew-lang/hew#3238 lands.
+/// Print a `NetError`'s variant name and raw OS errno.
 impl Display for NetError {
     fn fmt(e: NetError) -> string {
         match e {
@@ -391,10 +388,7 @@ pub fn write_error_from_errno(errno: i64) -> WriteError {
     }
 }
 
-// Print a `WriteError`'s variant name and raw OS errno.
-//
-// Plain `//`, not `///`: `hew fmt` deletes a doc comment immediately
-// preceding an `impl` block. Restore `///` once hew-lang/hew#3238 lands.
+/// Print a `WriteError`'s variant name and raw OS errno.
 impl Display for WriteError {
     fn fmt(e: WriteError) -> string {
         match e {

--- a/std/path.hew
+++ b/std/path.hew
@@ -43,10 +43,7 @@ pub enum PathError {
     IndexOutOfRange(string);
 }
 
-// Print the human-readable detail carried by a `PathError`.
-//
-// Plain `//`, not `///`: `hew fmt` deletes a doc comment immediately
-// preceding an `impl` block. Restore `///` once hew-lang/hew#3238 lands.
+/// Print the human-readable detail carried by a `PathError`.
 impl Display for PathError {
     fn fmt(err: PathError) -> string {
         match err {


### PR DESCRIPTION
## Why

`hew fmt` deletes a `///` doc comment immediately preceding an `impl Trait for Type` block, while a plain `//` comment in the same position survives. `ImplDecl` never carried a `doc_comment` field, so the parser collected the comment and discarded it instead of attaching it like it does for every other item kind.

## What

- Add `doc_comment` to `ImplDecl`, attach it in the parser's `impl` dispatch arm, and emit it in `format_impl`.
- Restore `///` on the three `impl Display for <Error>` blocks in `std/fs.hew`, `std/net/net.hew`, and `std/path.hew` that were worked around with `//` pending this fix.

Fixes #3238

## Test

`hew-parser::fmt::tests::doc_comment_before_impl_block_is_preserved` — round-trips a doc comment on an `impl` block through the formatter; fails without the fix (confirmed) and passes with it.
