### PR TITLE
fix(types): register a module's impls regardless of how the type is imported

### DIFF
--- a/examples/http_server.hew
+++ b/examples/http_server.hew
@@ -17,16 +17,6 @@ import std.net.mime;
 
 import std.net;
 
-// WHY: `to_string(err)` below needs `impl Display for NetError` in scope.
-// The checker only registers a module's `impl` blocks for a type named in
-// an explicit `{...}` import; a bare `import std.net;` publishes the
-// `net.` namespace for calls but not the Display impl for bound-checking.
-// WHEN obsolete: once module-level imports register the whole module's
-// impls (checker fix), not just explicitly named types.
-// WHAT the real fix looks like: `hew-types` registration change so
-// `import std.net;` alone is enough for `to_string`/f-string Display use.
-import std.net.{NetError};
-
 fn serve_forever(root: string, srv: Server) {
     loop {
         let req = srv.accept();

--- a/examples/static_server.hew
+++ b/examples/static_server.hew
@@ -18,16 +18,6 @@ import std.net.mime;
 
 import std.net;
 
-// WHY: `to_string(err)` below needs `impl Display for NetError` in scope.
-// The checker only registers a module's `impl` blocks for a type named in
-// an explicit `{...}` import; a bare `import std.net;` publishes the
-// `net.` namespace for calls but not the Display impl for bound-checking.
-// WHEN obsolete: once module-level imports register the whole module's
-// impls (checker fix), not just explicitly named types.
-// WHAT the real fix looks like: `hew-types` registration change so
-// `import std.net;` alone is enough for `to_string`/f-string Display use.
-import std.net.{NetError};
-
 fn resolve_path(root: string, url_path: string) -> string {
     let path = root + url_path;
     if url_path.ends_with("/") {

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -7619,29 +7619,6 @@ impl Checker {
         // declaration must not become a live intrinsic dispatch target.
     }
 
-    fn register_registry_source_intrinsic_declarations(
-        &mut self,
-        module_owner: &str,
-        items: &[Spanned<Item>],
-    ) {
-        for (item, _) in items {
-            let Item::Function(function) = item else {
-                continue;
-            };
-            let Some(intrinsic_key) = &function.intrinsic else {
-                continue;
-            };
-            let saved_importer_module = self.current_module.replace(module_owner.to_string());
-            self.register_intrinsic_declaration(
-                format!("{module_owner}.{}", function.name),
-                intrinsic_key,
-                &function.name,
-                function,
-            );
-            self.current_module = saved_importer_module;
-        }
-    }
-
     fn validate_receiver_identity_method(
         &mut self,
         type_name: &str,
@@ -11089,15 +11066,19 @@ impl Checker {
                         }
                     }
 
-                    // A selected named/glob import needs the Hew declaration,
-                    // not just the registry ABI summary: it is the authority
-                    // for the bare binding's original source identity. Plain
-                    // module imports retain the established registry path so
-                    // their module-level capability classification cannot be
-                    // perturbed by unrelated internal source declarations.
+                    // An import needs the Hew declaration, not just the
+                    // registry ABI summary: the declaration is the authority
+                    // for a bare binding's original source identity and it is
+                    // the only place a module's `impl Trait for T` blocks
+                    // exist.  Which declarations a module owns is a property
+                    // of the module, not of how the importer spelled the
+                    // import, so a bare `import std.net;` registers the same
+                    // source items a selected `import std.net.{NetError};`
+                    // does.  Bare-name publication stays gated on the spec in
+                    // `publish_imported_hew_bindings`, so a plain module import
+                    // still publishes only the `net.` namespace.
                     let resolved_items = decl.resolved_items.as_ref().or_else(|| {
-                        (decl.spec.is_some() && !registry_source_items.is_empty())
-                            .then_some(&registry_source_items)
+                        (!registry_source_items.is_empty()).then_some(&registry_source_items)
                     });
                     if let Some(resolved_items) = resolved_items.filter(|items| !items.is_empty()) {
                         let module_full_path = canonical_owner.clone();
@@ -11108,19 +11089,6 @@ impl Checker {
                             &module_full_path,
                             resolved_items,
                             StdlibBarePublication::Import(&decl.spec),
-                        );
-                    } else if decl.spec.is_none() && !registry_source_items.is_empty() {
-                        // A plain module import intentionally does not publish
-                        // the module's full source declaration surface, but
-                        // compiler intrinsic metadata is attached to those
-                        // exact parsed declarations and cannot be reconstructed
-                        // from the ABI wrapper summary. Publish only that
-                        // metadata under the already-proven canonical source
-                        // owner; ordinary functions/types remain on the
-                        // established registry path.
-                        self.register_registry_source_intrinsic_declarations(
-                            &canonical_owner,
-                            &registry_source_items,
                         );
                     }
 
@@ -11474,6 +11442,13 @@ impl Checker {
         let saved_local_type_defs = self.local_type_defs.clone();
         let saved_source_type_defs = self.source_type_defs.clone();
         for (item, _) in items {
+            // The program-wide type-parameter harvest in `collect_types` walks
+            // `program.module_graph`, which is empty on the registry-only
+            // checker path (LSP, browser compiler, inline checks). Without the
+            // harvest a declaration's own parameters are unknown while its
+            // members resolve, so `pub type ScopeError<E> { primary: E; }`
+            // reports `unknown type E` against the module's own source.
+            self.collect_item_type_param_names(item);
             match item {
                 Item::TypeDecl(td) => {
                     self.local_type_defs.insert(td.name.clone());

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -2592,10 +2592,19 @@ fn stdlib_import_keeps_stream_from_file_stream_typed_after_fs_import() {
         "the stdlib function registry must not retain a leaf-qualified declaration identity"
     );
 
+    // The element type carries the declaring module's own identity, matching
+    // the leaf-qualified-identity rule the assertion above pins for functions.
     assert_eq!(
         stream_from_file.return_type,
-        Ty::result(Ty::stream(Ty::String), Ty::String),
-        "std::stream import should keep from_file() typed as Result<Stream<string>, string>"
+        Ty::result(
+            Ty::Named {
+                name: "std.stream.Stream".to_string(),
+                args: vec![Ty::String],
+                builtin: Some(BuiltinType::Stream),
+            },
+            Ty::String
+        ),
+        "std::stream import should keep from_file() typed as Result<std.stream.Stream<string>, string>"
     );
 }
 

--- a/hew-types/src/check/tests/output.rs
+++ b/hew-types/src/check/tests/output.rs
@@ -325,7 +325,7 @@ fn checker_output_contract_prunes_method_call_metadata_for_leaked_inference_var_
 }
 
 #[test]
-fn module_qualified_call_rewrites_record_registry_c_symbol_metadata() {
+fn module_qualified_call_rewrites_record_owning_module_endpoint() {
     let parsed = hew_parser::parse(
         r#"
 import std.fs;
@@ -351,9 +351,9 @@ fn main() {
         output.method_call_rewrites.values().any(|rewrite| matches!(
             rewrite,
             MethodCallRewrite::RewriteModuleQualifiedToFunction { c_symbol, .. }
-                if c_symbol == "hew_file_exists"
+                if c_symbol == "std.fs.exists"
         )),
-        "expected checker-owned module-qualified rewrite metadata, got: {:?}",
+        "expected the module-qualified rewrite to name the owning module endpoint, got: {:?}",
         output.method_call_rewrites
     );
 }
@@ -385,7 +385,7 @@ fn main() {
         output.method_call_rewrites.values().any(|rewrite| matches!(
             rewrite,
             MethodCallRewrite::RewriteModuleQualifiedToFunction { c_symbol, .. }
-                if c_symbol == "path.dirname"
+                if c_symbol == "std.path.dirname"
         )),
         "expected pure-Hew stdlib wrapper to rewrite to module-qualified symbol, got: {:?}",
         output.method_call_rewrites

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -79,6 +79,55 @@ fn typecheck_top_level_networking_demos() {
     }
 }
 
+// A module's `impl Trait for T` blocks are registered when the module is
+// loaded, not when the importer names `T` in an explicit `{...}` selection.
+// A bare `import std.net;` plus a qualified `net.NetError` therefore
+// satisfies the `Display` bound that `to_string` and f-string interpolation
+// require, with no `import std.net.{NetError};` line to prop it up.
+#[test]
+fn bare_module_import_satisfies_the_display_bound_from_the_modules_impl() {
+    assert_inline_typechecks_cleanly(
+        r#"
+import std.net;
+
+fn describe(err: net.NetError) -> string {
+    to_string(err)
+}
+
+fn interpolate(err: net.NetError) -> string {
+    f"{err}"
+}
+"#,
+        "bare module import with a qualified error type",
+    );
+}
+
+// Counterfactual for the test above: the same import spelling, the same
+// module, and the same qualified-type shape, on a type the module declares no
+// `impl Display` for, is still refused. Registration follows the module's
+// impls, not the import spelling.
+#[test]
+fn bare_module_import_without_a_display_impl_still_refuses_interpolation() {
+    let output = typecheck_inline(
+        r#"
+import std.net;
+
+fn interpolate(endpoint: net.Endpoint) -> string {
+    f"{endpoint}"
+}
+"#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::BoundsNotSatisfied
+                && e.message.contains("std.net.Endpoint")
+                && e.message.contains("Display")
+        }),
+        "expected a Display bound refusal for `std.net.Endpoint`, got: {:#?}",
+        output.errors
+    );
+}
+
 fn assert_typechecks(path: &Path, label: &str) {
     let source = fs::read_to_string(path).unwrap();
     let program = parse_program(&source);
@@ -732,14 +781,18 @@ fn respond(req: http.Request) -> i64 {
         output.errors
     );
     assert!(
-        output.method_call_rewrites.is_empty(),
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            MethodCallRewrite::RewriteToFunction { target: hew_types::check::CallTarget::ImplMethod(def), .. }
+                if def.full_path().ends_with("::respond_text")
+        )),
         "resource-wrapper methods must dispatch through their impl body, got: {:?}",
         output.method_call_rewrites
     );
 }
 
 #[test]
-fn module_qualified_call_rewrites_record_registry_c_symbol_metadata() {
+fn module_qualified_call_rewrites_record_owning_module_endpoint() {
     let output = typecheck_inline(
         r#"
 import std.fs;
@@ -758,9 +811,9 @@ fn main() {
         output.method_call_rewrites.values().any(|rewrite| matches!(
             rewrite,
             hew_types::MethodCallRewrite::RewriteModuleQualifiedToFunction { c_symbol, .. }
-                if c_symbol == "hew_file_exists"
+                if c_symbol == "std.fs.exists"
         )),
-        "expected checker-owned module-qualified rewrite metadata, got: {:?}",
+        "expected the module-qualified rewrite to name the owning module endpoint, got: {:?}",
         output.method_call_rewrites
     );
 }
@@ -2683,8 +2736,21 @@ fn http_request_close_dispatches_through_resource_impl() {
         output.errors
     );
     assert!(
-        output.method_call_rewrites.is_empty(),
-        "resource-wrapper close must not use the opaque-handle fallback rewrite, got: {:?}",
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            MethodCallRewrite::RewriteToFunction { target: hew_types::check::CallTarget::ImplMethod(def), .. }
+                if def.full_path().starts_with("std.net.http.Request::")
+        )),
+        "resource-wrapper close must dispatch through the authored impl, got: {:?}",
+        output.method_call_rewrites
+    );
+    assert!(
+        !output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            MethodCallRewrite::RewriteToFunction { c_symbol, .. }
+                if c_symbol.starts_with("hew_")
+        )),
+        "resource-wrapper close must not fall back to a raw FFI rewrite, got: {:?}",
         output.method_call_rewrites
     );
 }
@@ -2734,16 +2800,12 @@ fn http_request_unknown_method_is_undefined() {
 
 #[test]
 fn net_connection_write_arg_type_checked() {
-    // `write` is now a Hew wrapper function (`write_result_from_status(unsafe {
-    // hew_tcp_write(...) })`), not a direct single-call C shim. The stdlib
-    // loader's handle-method extractor only recognises single-call shims, so
-    // `write` no longer appears in `handle_methods` in the inline typecheck
-    // context (no module graph, no `resolved_items` path). As a result, the
-    // type checker correctly reports `UndefinedMethod` — the method is simply
-    // not visible in this path. The full compilation path (with a module graph
-    // that populates `resolved_items`) registers the Hew signature and enforces
-    // the `bytes` arg-type constraint; the `tcp_write_backpressure` vertical
-    // slice and the refactored examples validate the real call-site behaviour.
+    // `write` is a Hew wrapper function (`write_result_from_status(unsafe {
+    // hew_tcp_write(...) })`), not a direct single-call C shim, so the
+    // registry's handle-method extractor cannot see it. The module's own
+    // source declarations supply the signature on every import spelling, so
+    // the registry-only checker path enforces the same `bytes` argument type
+    // the full module-graph path does.
     let output = typecheck_inline(
         r#"
         import std.net;
@@ -2754,12 +2816,12 @@ fn net_connection_write_arg_type_checked() {
         "#,
     );
     assert!(
-        output
-            .errors
-            .iter()
-            .any(|error| error.kind == TypeErrorKind::UndefinedMethod),
-        "expected UndefinedMethod for conn.write in inline typecheck path \
-         (write is a Hew wrapper not a direct C shim), got: {:#?}",
+        output.errors.iter().any(|error| matches!(
+            &error.kind,
+            TypeErrorKind::Mismatch { expected, actual }
+                if expected == "bytes" && actual == "string"
+        )),
+        "expected conn.write to reject a string where `bytes` is required, got: {:#?}",
         output.errors
     );
 }

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -28,7 +28,6 @@
 //!
 //! ```
 //! import std.net;
-//! import std.net.{NetError};
 //! import std.net.quic;
 //!
 //! fn main() {
@@ -64,7 +63,6 @@
 //!
 //! ```
 //! import std.net;
-//! import std.net.{NetError};
 //! import std.net.quic;
 //!
 //! fn main() {

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -8,7 +8,6 @@
 //!
 //! ```
 //! import std.net;
-//! import std.net.{NetError};
 //! import std.net.tls;
 //!
 //! fn main() {

--- a/tests/hew/net_try_api_test.hew
+++ b/tests/hew/net_try_api_test.hew
@@ -5,8 +5,6 @@
 
 import std.net;
 
-import std.net.{WriteError};
-
 import std.testing;
 
 // ── try_connect ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

`import std.net;` plus `to_string(err)` on a `net.NetError` was refused as
`type std.net.NetError does not implement trait Display`, although
`impl Display for NetError` sits in `std/net/net.hew`. The refusal appeared
wherever the checker runs without a resolved module graph - the LSP,
`hew-wasm`/`hew-sandbox-wasm`, and inline checks - while `hew check` on the same
program passed, so the same file was clean on the command line and red in the
editor. Adding `import std.net.{NetError};` cleared it, which is why the std
error `Display` work had to prop up two example servers and two doc fences.

## What

- **types**: `register_resolved_stdlib_hew_source` only received a module's
  parsed source items when `decl.spec.is_some()`, so a bare module import fell
  through to an intrinsic-only fallback and the module's `impl` blocks were
  never registered. Source items now register on every import spelling and the
  fallback is deleted; bare-name publication stays gated on the selection, so a
  plain module import still publishes only the qualified namespace.
- **types**: the program-wide type-parameter harvest walks `program.module_graph`,
  which is empty on that path, so a declaration's own parameters were unknown
  while its members resolved (`pub type ScopeError<E> { primary: E; }` reported
  `unknown type E` against std's own source). The harvest now runs over the
  items being registered.
- **types**: bare imports now agree with named imports on rewrite metadata - a
  module-qualified call names its owning module endpoint instead of the registry
  C symbol, resource-wrapper methods dispatch through their authored impl, and
  `Connection.write` enforces its `bytes` argument. The tests that pinned the
  divergent behaviour assert the unified behaviour instead.
- **std, examples, e2e**: the named-import shims are removed from
  `examples/http_server.hew`, `examples/static_server.hew`, the `std/net/quic`
  and `std/net/tls` doc fences, and `tests/hew/net_try_api_test.hew`.

## Test

- `bare_module_import_satisfies_the_display_bound_from_the_modules_impl` fails
  without the registration change and passes with it;
  `bare_module_import_without_a_display_impl_still_refuses_interpolation` is its
  counterfactual on `net.Endpoint`, a type in the same module with no `Display`.
- `typecheck_top_level_networking_demos` now covers the two example servers with
  the bare import.
- Updated: `net_connection_write_arg_type_checked`,
  `http_request_close_dispatches_through_resource_impl`,
  `method_call_dispatches_resource_wrapper_through_impl`,
  `module_qualified_call_rewrites_record_owning_module_endpoint` (both the unit
  and integration copies), `stdlib_import_keeps_stream_from_file_stream_typed_after_fs_import`,
  `module_qualified_pure_hew_stdlib_wrapper_rewrites_to_qualified_symbol`.
- `make test`, `make test-doc-examples`, `make test-stdlib-ratchet`,
  `make hew-check-all`, `make test-vertical-slice`, and workspace clippy in JSON
  mode.