### PR TITLE
fix(codegen): keep std handle types distinct from plain records in sandbox bytecode

### DIFF
--- a/hew-sandbox-vm/fixtures/08-regex-match/bytecode.json
+++ b/hew-sandbox-vm/fixtures/08-regex-match/bytecode.json
@@ -4,9 +4,7 @@
       "disposition": "allowed",
       "id": "core.stdout",
       "reason": "stdout is captured by the educational sandbox trace",
-      "required_by": [
-        "sym:core.stdout.println"
-      ]
+      "required_by": ["sym:core.stdout.println"]
     },
     {
       "disposition": "reserved",
@@ -424,9 +422,19 @@
         "name": "std.failure.CrashNotification"
       },
       {
+        "id": "type:std.text.regex.CaptureMatches",
+        "kind": "record",
+        "name": "std.text.regex.CaptureMatches"
+      },
+      {
         "id": "type:std.text.regex.Pattern",
         "kind": "regex",
         "name": "std.text.regex.Pattern"
+      },
+      {
+        "id": "type:std.text.regex.PatternHandle",
+        "kind": "record",
+        "name": "std.text.regex.PatternHandle"
       },
       {
         "id": "type:string",
@@ -449,9 +457,7 @@
     "entry": "mod:main",
     "modules": [
       {
-        "functions": [
-          "fn:main"
-        ],
+        "functions": ["fn:main"],
         "id": "mod:main",
         "imports": [
           {
@@ -464,7 +470,7 @@
       }
     ]
   },
-  "package_id": "pkg:5a43ea225b4cafb8",
+  "package_id": "pkg:73691b5fc7a7bf4d",
   "profile": "sandbox.sandbox-vm-export.v0",
   "schema_version": "hew.sandbox.bytecode.v0",
   "source_map": {
@@ -625,9 +631,7 @@
       "id": "sym:core.stdout.println",
       "module": "core.stdout",
       "name": "println",
-      "params": [
-        "type:string"
-      ],
+      "params": ["type:string"],
       "result": "type:unit"
     },
     {

--- a/hew-sandbox-wasm/src/emit.rs
+++ b/hew-sandbox-wasm/src/emit.rs
@@ -344,11 +344,12 @@ impl<'a> PackageEmitter<'a> {
             let type_id = self.type_id_for_named(name, &[]);
             match type_def.kind {
                 TypeDefKind::Struct | TypeDefKind::Record => {
+                    let kind = self.named_layout_kind(name, &type_id).to_string();
                     self.type_layouts
                         .entry(type_id.clone())
                         .or_insert(TypeLayout {
                             id: type_id,
-                            kind: "record".to_string(),
+                            kind,
                             name: name.clone(),
                             parameters: Vec::new(),
                         });
@@ -846,15 +847,7 @@ impl<'a> PackageEmitter<'a> {
             Ty::Named { name, args, .. } => {
                 let params: Vec<_> = args.iter().map(|arg| self.type_id_for_ty(arg)).collect();
                 let named_id = self.type_id_for_named(name, args);
-                let kind = if name == "Vec" {
-                    "vector"
-                } else if name == REGEX_HANDLE_TYPE {
-                    "regex"
-                } else if self.enum_layouts.contains_key(&named_id) {
-                    "enum"
-                } else {
-                    "record"
-                };
+                let kind = self.named_layout_kind(name, &named_id);
                 (named_id, kind.to_string(), name.clone(), params)
             }
             Ty::Tuple(items) => {
@@ -951,6 +944,26 @@ impl<'a> PackageEmitter<'a> {
             parameters,
         });
         id
+    }
+
+    /// The bytecode layout kind of a named type.
+    ///
+    /// The one authority for the two sites that register a `TypeLayout` for a
+    /// named type: the declaration sweep over `type_defs` and the on-demand
+    /// `type_id_for_ty`. They disagreed on a stdlib handle whose declaration is
+    /// an ordinary struct - the sweep runs first and `or_insert` keeps its
+    /// answer, so `std.text.regex.Pattern` reached the VM as a plain record and
+    /// lost the handle kind its ops are keyed on.
+    fn named_layout_kind(&self, name: &str, named_id: &str) -> &'static str {
+        if name == "Vec" {
+            "vector"
+        } else if name == REGEX_HANDLE_TYPE {
+            "regex"
+        } else if self.enum_layouts.contains_key(named_id) {
+            "enum"
+        } else {
+            "record"
+        }
     }
 
     fn type_id_for_named(&mut self, name: &str, args: &[Ty]) -> String {


### PR DESCRIPTION
## Why

`main` was red: the sandbox-wasm regex layout identity test failed on
Linux, which cascaded into the `Linux gates (shard 3/3)` gate, the
`Playground WASM build` (`make sandbox-fixtures-check`) gate, and the
required `Build & test (Linux)` roll-up (which requires every shard,
including gates, to succeed).

Two sites in the bytecode emitter answered "what layout kind is this
named type" and disagreed: the declaration sweep over `type_defs`
defaulted every struct-shaped declaration to `"record"`, while the
on-demand `type_id_for_ty` path special-cased the stdlib regex handle
as `"regex"`. The sweep runs first and its `or_insert` wins, so
`std.text.regex.Pattern` reached the sandbox VM as a plain record and
lost the handle kind its ops are keyed on.

## What

- `hew-sandbox-wasm/src/emit.rs`: both sites now read the layout kind
  through one `named_layout_kind` method, so a handle type gets the
  same answer wherever it is registered first.
- Regenerated `hew-sandbox-vm/fixtures/08-regex-match/bytecode.json`
  via `make baselines` to reflect the corrected layout.

## Test

- `cargo test -p hew-sandbox-wasm --lib`, including
  `user_regex_record_and_std_regex_handle_keep_distinct_layout_identities`
- `make sandbox-fixtures-check`
- `make sandbox-parity`

## Notes

`Build & test (macOS arm64)` also failed on this run, on an unrelated
ratchet miss (`hew-cli::dwarf_debugger_locals_e2e ::
debugger_renders_only_active_enum_variant_payload` is not in
`scripts/nextest-expected-failures.tsv` for macOS). That failure is in
a different subsystem (DWARF debugger locals rendering) and macOS is
not part of required branch protection, so it is out of this fix's
scope; left as a follow-up.
