### PR TITLE
fix(types): anchor stdlib and import-credit resolution on source facts

### DIFF
--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -142,6 +142,14 @@ impl Checker {
                 is_pub,
             ));
         }
+        // `fn_def_spans` is a `HashMap`, so its iteration order is
+        // unspecified and varies run to run. Sort findings by (span,
+        // fn_name) so diagnostic emission order — and therefore the
+        // rendered warning order a user sees — is deterministic (#3169).
+        findings.sort_by(|(a_span, a_name, ..), (b_span, b_name, ..)| {
+            (a_span.start, a_span.end, a_name).cmp(&(b_span.start, b_span.end, b_name))
+        });
+
         // A root module with no `fn main` cannot link as a binary, so it is
         // a library unit: every `pub fn` in it is public API for another
         // crate/module to call, not dead code from this compilation unit's

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -6830,6 +6830,7 @@ impl Checker {
                 field,
                 &DottedTypeMemberUse::Reference { span },
             ) {
+                self.mark_resolved_nominal_owner_used(&head.canonical_type);
                 return result;
             }
         }

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -3825,6 +3825,99 @@ fn check_qualified_variant_root(root_source: &str) -> TypeCheckOutput {
     })
 }
 
+/// Harness for the selective-imported-machine rule (#3175): a module `m`
+/// exporting `machine Light`, checked from a root that reaches `Light` only
+/// by referencing one of its states as a bare dotted literal (`Light.On`),
+/// never by calling `.step(...)` or constructing a payload.
+fn check_qualified_machine_state_root(root_source: &str) -> (Checker, TypeCheckOutput) {
+    let module = hew_parser::parse(
+        "machine Light {\n    events {\n        Flip;\n    }\n\n    state On;\n    state Off;\n\n    on Flip: On => Off {\n        .Off\n    }\n    on Flip: Off => On {\n        .On\n    }\n}\n",
+    );
+    assert!(module.errors.is_empty(), "parse: {:?}", module.errors);
+    let mut root = hew_parser::parse(root_source);
+    assert!(root.errors.is_empty(), "parse: {:?}", root.errors);
+    for (item, _) in &mut root.program.items {
+        if let Item::Import(import) = item {
+            if import.path.as_slice() == ["m"] {
+                import.resolved_items = Some(module.program.items.clone());
+            }
+        }
+    }
+    let root_id = ModuleId::root();
+    let m_id = ModuleId::new(vec!["m".to_string()]);
+    let mut module_graph = ModuleGraph::new(root_id.clone());
+    module_graph
+        .add_module(Module {
+            id: m_id.clone(),
+            items: module.program.items,
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        })
+        .expect("add module m");
+    module_graph
+        .add_module(Module {
+            id: root_id.clone(),
+            items: root.program.items.clone(),
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        })
+        .expect("add root");
+    module_graph.topo_order = vec![m_id, root_id];
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&Program {
+        items: root.program.items,
+        module_graph: Some(module_graph),
+        module_doc: None,
+    });
+    (checker, output)
+}
+
+/// A selective import of a machine, referenced only as a bare dotted state
+/// literal (`Light.On`, never `.step(...)` or a constructed payload), must
+/// credit the import binding exactly as the Call-path dispatch does — the
+/// Reference-path dispatch was the one caller of `dispatch_dotted_type_member`
+/// that never called `mark_resolved_nominal_owner_used` (#3175).
+#[test]
+fn selective_import_used_only_as_bare_state_literal_is_not_unused() {
+    let (_, output) = check_qualified_machine_state_root(
+        "import m.{ Light };\n\nfn main() {\n    var s = Light.On;\n    s = Light.Off;\n    print(\"ok\");\n}\n",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "bare state literal must resolve canonically: {:?}",
+        output.errors
+    );
+    assert!(
+        !output
+            .warnings
+            .iter()
+            .any(|warning| warning.kind == TypeErrorKind::UnusedImport),
+        "a selective machine import used only as a bare state literal must not be \
+         reported unused: {:?}",
+        output.warnings
+    );
+}
+
+/// Negative control: a selective import that is never referenced at all must
+/// still be reported unused. This proves the assertion above is not merely
+/// vacuous (every selective import always passing).
+#[test]
+fn selective_import_never_referenced_is_still_unused() {
+    let (_, output) = check_qualified_machine_state_root(
+        "import m.{ Light };\n\nfn main() {\n    print(\"ok\");\n}\n",
+    );
+    assert!(
+        output
+            .warnings
+            .iter()
+            .any(|warning| warning.kind == TypeErrorKind::UnusedImport),
+        "a genuinely unreferenced selective import must still warn: {:?}",
+        output.warnings
+    );
+}
+
 /// A selected import publishes a bare type spelling while its declaration is
 /// retained only under the module-owned key. Dotted construction must follow
 /// that exact binding to the canonical enum rather than probing a retired leaf

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -208,6 +208,55 @@ fn main() {
     );
 }
 
+/// Dead-code findings are collected from `fn_def_spans`, a `HashMap` whose
+/// iteration order is unspecified. Emission must sort by `(span, fn_name)`
+/// before pushing warnings so the diagnostic order a user sees is
+/// deterministic and matches source order, not hash-bucket order (#3169).
+#[test]
+fn dead_code_warnings_are_emitted_in_source_span_order() {
+    const SOURCE: &str = r"
+fn zeta() -> i64 { 1 }
+fn mike() -> i64 { 2 }
+fn alpha() -> i64 { 3 }
+fn quebec() -> i64 { 4 }
+fn india() -> i64 { 5 }
+fn charlie() -> i64 { 6 }
+
+fn main() {}
+";
+    let parsed = hew_parser::parse(SOURCE);
+    assert!(
+        parsed.errors.is_empty(),
+        "fixture should parse cleanly, got: {:?}",
+        parsed.errors
+    );
+
+    let mut checker = Checker::new(test_registry());
+    let output = checker.check_program(&parsed.program);
+
+    let dead_code_spans: Vec<usize> = output
+        .warnings
+        .iter()
+        .filter(|w| w.kind == TypeErrorKind::Lint(LintId::DeadCode))
+        .map(|w| w.span.start)
+        .collect();
+
+    assert_eq!(
+        dead_code_spans.len(),
+        6,
+        "expected one dead_code warning per unreferenced function, got: {:?}",
+        output.warnings
+    );
+    let mut expected_sorted = dead_code_spans.clone();
+    expected_sorted.sort_unstable();
+    assert_eq!(
+        dead_code_spans, expected_sorted,
+        "dead_code warnings must be emitted in ascending source-span order, \
+         not HashMap iteration order: {:?}",
+        output.warnings
+    );
+}
+
 #[test]
 fn where_clause_assoc_binding_projects_iterator_item_in_generic_body() {
     let result = hew_parser::parse(

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -85,12 +85,14 @@ pub fn find_enclosing_hew_root(from: &std::path::Path) -> Option<PathBuf> {
 
 /// Resolve the standard-library root owned by the running compiler binary.
 ///
-/// Installed binaries use `<bin>/../share/hew`; development binaries use the
-/// checkout above `target/<profile>`. Rust test executables add a `deps/`
-/// component below the same development layout. No project path, cwd, or
-/// environment override participates in this decision. If neither layout has
-/// the compiler's `std/builtins.hew`, authority is unavailable and callers
-/// must fail closed.
+/// Installed binaries use `<bin>/../share/hew`; development binaries (and
+/// their `deps/`-nested Rust test executables) resolve from the compile-time
+/// source tree, walking up from `CARGO_MANIFEST_DIR` rather than a fixed
+/// parent-count offset from the executable's runtime path — that offset
+/// breaks whenever `CARGO_TARGET_DIR` points out of tree. No project path,
+/// cwd, or environment override participates in this decision. If neither
+/// layout has the compiler's `std/builtins.hew`, authority is unavailable
+/// and callers must fail closed.
 #[must_use]
 pub fn compiler_stdlib_root() -> Option<PathBuf> {
     let executable = std::env::current_exe().ok()?.canonicalize().ok()?;
@@ -98,23 +100,32 @@ pub fn compiler_stdlib_root() -> Option<PathBuf> {
 }
 
 fn compiler_stdlib_root_for_executable(executable: &std::path::Path) -> Option<PathBuf> {
+    compiler_stdlib_root_impl(executable, std::path::Path::new(env!("CARGO_MANIFEST_DIR")))
+}
+
+/// Resolve the compiler-owned stdlib root from an installed-layout probe and
+/// a source-tree anchor.
+///
+/// `manifest_dir` anchors the development tier. It must be a compile-time
+/// constant (`env!("CARGO_MANIFEST_DIR")`) rather than derived from
+/// `executable`'s runtime path: a fixed parent-count offset from the
+/// executable assumes `target/<profile>[/deps]` sits directly under the
+/// workspace root, which breaks whenever `CARGO_TARGET_DIR` points out of
+/// tree — the executable then lives an arbitrary depth below the actual
+/// source tree (#3086). The manifest directory is baked into the binary at
+/// compile time and always names this crate's own directory in the source
+/// tree, independent of where cargo placed the build output.
+fn compiler_stdlib_root_impl(
+    executable: &std::path::Path,
+    manifest_dir: &std::path::Path,
+) -> Option<PathBuf> {
     let executable_dir = executable.parent()?;
     let installed = executable_dir.parent()?.join("share/hew");
-    let development = if executable_dir
-        .file_name()
-        .is_some_and(|name| name == "deps")
-    {
-        executable_dir.parent()?.parent()?.parent()?.to_path_buf()
-    } else {
-        executable_dir.parent()?.parent()?.to_path_buf()
-    };
+    if installed.join("std/builtins.hew").is_file() {
+        return installed.canonicalize().ok();
+    }
 
-    [installed, development].into_iter().find_map(|root| {
-        root.join("std/builtins.hew")
-            .is_file()
-            .then(|| root.canonicalize().ok())
-            .flatten()
-    })
+    find_enclosing_hew_root(manifest_dir)
 }
 
 /// Build the stdlib search-path list, applying exclusive precedence tiers.
@@ -1100,7 +1111,7 @@ mod tests {
     }
 
     #[test]
-    fn compiler_stdlib_root_uses_only_binary_relative_layouts() {
+    fn compiler_stdlib_root_prefers_installed_layout_over_source_anchor() {
         let installed = TestDir::new("compiler-stdlib-installed");
         let installed_root = installed.root.join("share/hew");
         fs::create_dir_all(installed_root.join("std")).unwrap();
@@ -1110,11 +1121,24 @@ mod tests {
         )
         .unwrap();
         let installed_executable = installed.root.join("bin/hew");
+        // The manifest_dir anchor is irrelevant here: the installed tier
+        // wins whenever the executable's own `../share/hew` layout exists.
+        let unrelated_manifest_dir = TestDir::new("compiler-stdlib-unrelated-manifest");
         assert_eq!(
-            compiler_stdlib_root_for_executable(&installed_executable),
+            compiler_stdlib_root_impl(&installed_executable, &unrelated_manifest_dir.root),
             installed_root.canonicalize().ok()
         );
+    }
 
+    #[test]
+    fn compiler_stdlib_root_anchors_development_tier_on_source_tree_not_executable_offset() {
+        // A development stdlib root is discovered by walking up from the
+        // compile-time manifest directory, never from a fixed parent-count
+        // offset baked onto the executable's runtime location. Proof: an
+        // executable path nested arbitrarily deep below an unrelated
+        // directory (simulating an out-of-tree CARGO_TARGET_DIR) still
+        // resolves correctly because only manifest_dir determines the
+        // development tier.
         let development = TestDir::new("compiler-stdlib-development");
         fs::create_dir_all(development.root.join("std")).unwrap();
         fs::write(
@@ -1122,16 +1146,41 @@ mod tests {
             "// development compiler std\n",
         )
         .unwrap();
-        let development_executable = development.root.join("target/debug/hew");
-        assert_eq!(
-            compiler_stdlib_root_for_executable(&development_executable),
-            development.root.canonicalize().ok()
-        );
+        let child_manifest_dir = development.root.join("some-crate");
+        fs::create_dir_all(&child_manifest_dir).unwrap();
 
-        let missing = TestDir::new("compiler-stdlib-missing");
+        let out_of_tree_executable = TestDir::new("compiler-stdlib-out-of-tree-targets")
+            .root
+            .join("deeply/nested/unrelated/path/deps/hew_types-abc123");
         assert_eq!(
-            compiler_stdlib_root_for_executable(&missing.root.join("bin/hew")),
-            None,
+            compiler_stdlib_root_impl(&out_of_tree_executable, &child_manifest_dir),
+            development.root.canonicalize().ok(),
+            "the development tier must resolve from manifest_dir, not the executable path"
+        );
+    }
+
+    #[test]
+    fn compiler_stdlib_root_fails_closed_without_either_layout() {
+        // `TestDir` lives under this checkout's own `target/`, so the
+        // ancestor walk would otherwise find this repo's real
+        // `std/builtins.hew` and defeat the fail-closed proof. Anchor the
+        // manifest_dir outside the checkout, exactly like
+        // `find_enclosing_hew_root_returns_none_outside_checkout` does.
+        let missing = TestDir::new("compiler-stdlib-missing");
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let missing_manifest_dir = std::env::temp_dir().join(format!(
+            "hew-test-compiler-stdlib-missing-manifest-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&missing_manifest_dir).unwrap();
+        let result =
+            compiler_stdlib_root_impl(&missing.root.join("bin/hew"), &missing_manifest_dir);
+        let _ = fs::remove_dir_all(&missing_manifest_dir);
+        assert_eq!(
+            result, None,
             "a compiler without its own stdlib layout must fail closed"
         );
     }


### PR DESCRIPTION
### Why

Three checker-layer bugs shared a root cause of deriving a fact from
position or iteration order instead of from an authoritative source.
`compiler_stdlib_root` walked a fixed parent-count offset from the
running executable's path, which finds the wrong directory (or none)
whenever `CARGO_TARGET_DIR` points out of tree. A selective machine
import referenced only as a bare state literal (`Light.On`) was never
credited as used. Dead-code findings were pushed in `HashMap`
iteration order, so warning order varied run to run.

### What

- **module_registry**: anchor the compiler's development stdlib root
  on the compile-time `CARGO_MANIFEST_DIR` source-tree location via
  `find_enclosing_hew_root`, not a fixed parent-count offset from the
  executable's runtime path
- **check/expressions**: credit the import binding after a
  Reference-path dotted-member dispatch (`check_field_access`),
  matching the two existing Call-path callers of
  `dispatch_dotted_type_member`
- **check/diagnostics**: sort dead-code findings by `(span, fn_name)`
  before pushing warnings

### Test

- `module_registry::tests::compiler_stdlib_root_anchors_development_tier_on_source_tree_not_executable_offset`
- `module_registry::tests::compiler_stdlib_root_fails_closed_without_either_layout`
- `module_registry::tests::compiler_stdlib_root_prefers_installed_layout_over_source_anchor`
- `check::tests::imports::selective_import_used_only_as_bare_state_literal_is_not_unused`
  (negative control: `selective_import_never_referenced_is_still_unused`)
- `check::tests::lints::dead_code_warnings_are_emitted_in_source_span_order`
- `check::tests::imports::canonical_builtin_source_owns_intrinsic_impls_for_coherence` and
  `project_local_std_builtins_source_cannot_claim_intrinsic_coherence` now pass under an
  out-of-tree `CARGO_TARGET_DIR`

Fixes #3086
Fixes #3175
Fixes #3169
