### PR TITLE
fix(cli,compile,runtime): close four silent-failure gaps in check, migrate, restart, and doc tests

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -2798,6 +2798,27 @@ fn migrate_source_file(file_path: &Path, file: &str, source: &str) -> Result<Str
                 _ => None,
             })?
         }) else {
+            // `hew_lexer::lex` emits an entire f-string interpolation
+            // (`f"...{expr}..."`) as one `InterpolatedString` token; the
+            // identifier inside `{}` never appears as its own top-level
+            // `Identifier` token, so a bare-variant warning whose span falls
+            // inside one is a token-lookup miss, not a genuine
+            // checker/lexer disagreement. The automatic migration does not
+            // rewrite inside f-string interpolations yet, so skip this
+            // occurrence rather than refusing the whole file (#3243).
+            let inside_interpolated_string = tokens.iter().any(|(token, span)| {
+                matches!(token, hew_lexer::Token::InterpolatedString(_))
+                    && span.start <= error.span.start
+                    && error.span.end <= span.end
+            });
+            if inside_interpolated_string {
+                eprintln!(
+                    "{}:{}-{}: skipping bare-variant migration inside an f-string \
+                     interpolation (not yet supported by the automatic migration)",
+                    file, error.span.start, error.span.end
+                );
+                continue;
+            }
             refusals.push(format!(
                 "{}:{}-{}: checker-selected variant has no identifier token",
                 file, error.span.start, error.span.end

--- a/hew-cli/tests/bare_variant_e2e.rs
+++ b/hew-cli/tests/bare_variant_e2e.rs
@@ -113,6 +113,28 @@ fn main() {
 }
 ";
 
+/// `hew_lexer::lex` emits an entire f-string interpolation as one
+/// `InterpolatedString` token, so the migrator's flat token scan for the
+/// identifier behind a `BareVariantExpr` warning cannot find one whose span
+/// falls inside `{...}` here. Before #3243 that token-lookup miss produced a
+/// hard refusal that aborted the whole migration.
+const FSTRING_INTERPOLATION: &str = r#"enum Choice {
+    Present(i64);
+    Absent;
+}
+
+fn accept(c: Choice) -> i64 {
+    match c {
+        .Present(n) => n,
+        .Absent => 0,
+    }
+}
+
+fn main() {
+    println(f"{accept(Absent)}");
+}
+"#;
+
 fn write_source(dir: &Path, name: &str, source: &str) -> std::path::PathBuf {
     let path = dir.join(name);
     std::fs::write(&path, source).expect("fixture must be writable");
@@ -301,5 +323,37 @@ fn migrate_rewrites_both_spellings_and_is_idempotent() {
         migrate_check.status.success(),
         "`fmt --migrate --check` must be clean on an already-migrated source:\n{}",
         strip_ansi(&String::from_utf8_lossy(&migrate_check.stderr))
+    );
+}
+
+/// A bare-variant warning whose span falls inside an f-string interpolation
+/// must be skipped, not treated as a hard refusal that aborts the whole
+/// file's migration (#3243).
+#[test]
+fn migrate_skips_bare_variant_inside_fstring_interpolation_without_aborting() {
+    let dir = tempdir();
+    let path = write_source(dir.path(), "fstring.hew", FSTRING_INTERPOLATION);
+    let source = path.to_str().expect("UTF-8 path").to_string();
+
+    let migrated = run_hew_in(dir.path(), &["fmt", "--migrate", &source]);
+    let stderr = strip_ansi(&String::from_utf8_lossy(&migrated.stderr));
+    assert!(
+        migrated.status.success(),
+        "migration must not abort on a bare variant inside an f-string interpolation:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("skipping bare-variant migration inside an f-string interpolation"),
+        "migration must report the f-string skip, not a hard token-lookup refusal:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("checker-selected variant has no identifier token"),
+        "the f-string case must not fall through to the generic hard refusal:\n{stderr}"
+    );
+
+    let rewritten = std::fs::read_to_string(&path).expect("migrated source must be readable");
+    assert!(
+        rewritten.contains("f\"{accept(Absent)}\""),
+        "the bare variant inside the f-string interpolation must be left \
+         unrewritten (skip-not-abort, not a silent rewrite):\n{rewritten}"
     );
 }

--- a/hew-cli/tests/doc_stdlib_e2e.rs
+++ b/hew-cli/tests/doc_stdlib_e2e.rs
@@ -5,60 +5,51 @@
 //! called out in hew-lang/hew#1278. These are invariant checks, not
 //! snapshot comparisons — they should survive unrelated stdlib edits.
 
-use std::path::PathBuf;
 use std::process::Command;
-use std::sync::OnceLock;
 
 mod support;
 use support::{describe_output, hew_binary, repo_root};
 
-/// Generate the stdlib docs once per test process and hand back the
-/// output directory. The `TempDir` handle is held in a `OnceLock` so
-/// all three tests share a single generation pass and cleanup runs
-/// when the process exits.
-fn stdlib_docs() -> &'static PathBuf {
-    static CELL: OnceLock<(tempfile::TempDir, PathBuf)> = OnceLock::new();
-    &CELL
-        .get_or_init(|| {
-            let dir = support::tempdir();
-            let out_dir = dir.path().to_path_buf();
-
-            let std_dir = repo_root().join("std");
-            let output = Command::new(hew_binary())
-                .arg("doc")
-                .arg(std_dir)
-                .arg("--output-dir")
-                .arg(&out_dir)
-                .output()
-                .expect("spawn hew doc");
-
-            assert!(
-                output.status.success(),
-                "hew doc failed:\n{}",
-                describe_output(&output),
-            );
-            (dir, out_dir)
-        })
-        .1
-}
-
-fn read_module(name: &str) -> String {
-    let path = stdlib_docs().join(name);
+fn read_module(docs_dir: &std::path::Path, name: &str) -> String {
+    let path = docs_dir.join(name);
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
 }
 
+/// Generates the stdlib docs once and asserts every invariant against that
+/// one pass. A single test-owned `TempDir` (rather than a `OnceLock<TempDir>`
+/// static shared across three `#[test]` fns) means its `Drop` — and the
+/// `fs::remove_dir_all` cleanup it runs — actually fires at scope exit:
+/// `static` values are never dropped, so the previous three-test split leaked
+/// its generated-docs directory on every run (#3129).
 #[test]
-fn private_items_do_not_leak_into_stdlib_docs() {
-    let datetime = read_module("std.time.datetime.html");
+fn stdlib_docs_invariants() {
+    let dir = support::tempdir();
+    let out_dir = dir.path();
+
+    let std_dir = repo_root().join("std");
+    let output = Command::new(hew_binary())
+        .arg("doc")
+        .arg(std_dir)
+        .arg("--output-dir")
+        .arg(out_dir)
+        .output()
+        .expect("spawn hew doc");
+    assert!(
+        output.status.success(),
+        "hew doc failed:\n{}",
+        describe_output(&output),
+    );
+
+    // Private items must not leak into stdlib docs.
+    let datetime = read_module(out_dir, "std.time.datetime.html");
     assert!(
         !datetime.contains("parse_error_message"),
         "private helper leaked into std::time::datetime HTML",
     );
-}
 
-#[test]
-fn enum_variants_render_in_stdlib_docs() {
-    let json = read_module("std.encoding.json.html");
+    let json = read_module(out_dir, "std.encoding.json.html");
+
+    // Enum variants render in stdlib docs.
     assert!(
         json.contains("Invalid"),
         "ParseError::Invalid variant missing from std::encoding::json HTML",
@@ -67,14 +58,10 @@ fn enum_variants_render_in_stdlib_docs() {
         json.contains("Variants"),
         "Variants section missing from std::encoding::json HTML",
     );
-}
 
-#[test]
-fn trait_method_docstrings_render_in_stdlib_docs() {
-    let json = read_module("std.encoding.json.html");
-    // `ValueMethods::stringify` keeps the JSON-facing docstring while extending
-    // the shared canonical Value contract. Verify the docstring reaches the
-    // rendered HTML.
+    // Trait method docstrings render in stdlib docs. `ValueMethods::stringify`
+    // keeps the JSON-facing docstring while extending the shared canonical
+    // Value contract; verify the docstring reaches the rendered HTML.
     assert!(
         json.contains("Serialize the value back to a JSON string."),
         "trait method docstring missing from std::encoding::json HTML",

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -862,6 +862,20 @@ pub fn hir_diagnostics_to_frontend(
         .collect()
 }
 
+/// Resolve the checker's module search paths for one type-checking pass.
+///
+/// Anchors Tier 2 in-worktree discovery on the source file being checked
+/// (`input`), exactly as the HIR import-resolution path does (see the
+/// `build_module_search_paths_for(Some(source_file))` call in this crate's
+/// import candidate search). `options.project_dir` is `None` for a bare
+/// `hew check <file>` invocation with no project manifest — using it here
+/// silently dropped Tier 2 and fell through to worse search tiers (#3245).
+fn checker_search_paths(options: &FrontendOptions, input: &str) -> Vec<PathBuf> {
+    options.module_search_paths.clone().unwrap_or_else(|| {
+        hew_types::module_registry::build_module_search_paths_for(Some(Path::new(input)))
+    })
+}
+
 fn typecheck_program_with_diagnostics(
     program: &Program,
     source: &str,
@@ -869,9 +883,7 @@ fn typecheck_program_with_diagnostics(
     options: &FrontendOptions,
     mode: FrontendParseMode,
 ) -> Result<(TypeCheckResult, Vec<FrontendDiagnostic>), FrontendFailure> {
-    let search_paths = options.module_search_paths.clone().unwrap_or_else(|| {
-        hew_types::module_registry::build_module_search_paths_for(options.project_dir.as_deref())
-    });
+    let search_paths = checker_search_paths(options, input);
     let module_registry = hew_types::module_registry::ModuleRegistry::new(search_paths);
 
     if options.no_typecheck {
@@ -2297,9 +2309,9 @@ fn load_dependencies(dir: &Path) -> Result<Option<Vec<String>>, FrontendFailure>
 #[cfg(test)]
 mod tests {
     use super::{
-        check_file, check_file_with_state, check_program, hir_diagnostics_to_frontend,
-        load_dependencies, load_lockfile, load_package_name, parse_source,
-        retain_user_facing_diagnostics, run_file_frontend_to_typecheck,
+        check_file, check_file_with_state, check_program, checker_search_paths,
+        hir_diagnostics_to_frontend, load_dependencies, load_lockfile, load_package_name,
+        parse_source, retain_user_facing_diagnostics, run_file_frontend_to_typecheck,
         run_file_frontend_to_typecheck_for_migration, FrontendDiagnostic, FrontendDiagnosticKind,
         FrontendOptions,
     };
@@ -2324,6 +2336,63 @@ mod tests {
         file.write_all(content.as_bytes())
             .expect("write source file");
         path.display().to_string()
+    }
+
+    /// The checker's module search paths must anchor Tier 2 in-worktree
+    /// discovery on the file being checked, not on `options.project_dir`
+    /// (`None` for a bare `hew check <file>`), matching the HIR
+    /// import-resolution path (#3245). Proof: a source file physically
+    /// inside a fake checkout root (marked by `std/builtins.hew`) resolves
+    /// that root as the sole search path, even though nothing in
+    /// `FrontendOptions` names it.
+    #[test]
+    fn checker_search_paths_anchors_on_source_file_not_project_dir() {
+        let root = tempfile::tempdir().expect("create fake checkout root");
+        fs::create_dir_all(root.path().join("std")).expect("create std dir");
+        fs::write(root.path().join("std/builtins.hew"), "// marker\n")
+            .expect("write builtins marker");
+        let input = write_source(root.path(), "main.hew", "fn main() {}\n");
+
+        let paths = checker_search_paths(&FrontendOptions::default(), &input);
+
+        assert_eq!(
+            paths,
+            vec![root.path().to_path_buf()],
+            "a source file inside a checkout root must resolve that root as \
+             the sole search path"
+        );
+    }
+
+    /// Negative control: `project_dir` must NOT be able to substitute for
+    /// the source file as the Tier 2 anchor. A source file outside any
+    /// checkout, paired with `project_dir` pointing at a real checkout
+    /// root, must not pick up that unrelated root — proving the anchor is
+    /// genuinely the file being checked, not merely "some path in
+    /// `FrontendOptions`".
+    #[test]
+    fn checker_search_paths_ignores_project_dir_as_tier2_anchor() {
+        let unrelated_root = tempfile::tempdir().expect("create unrelated checkout root");
+        fs::create_dir_all(unrelated_root.path().join("std")).expect("create std dir");
+        fs::write(
+            unrelated_root.path().join("std/builtins.hew"),
+            "// marker\n",
+        )
+        .expect("write builtins marker");
+
+        let outside = tempfile::tempdir().expect("create dir outside any checkout");
+        let input = write_source(outside.path(), "main.hew", "fn main() {}\n");
+
+        let options = FrontendOptions {
+            project_dir: Some(unrelated_root.path().to_path_buf()),
+            ..FrontendOptions::default()
+        };
+        let paths = checker_search_paths(&options, &input);
+
+        assert!(
+            !paths.contains(&unrelated_root.path().to_path_buf()),
+            "project_dir must not stand in for the source file as the \
+             Tier 2 anchor: {paths:?}"
+        );
     }
 
     /// A diamond of module imports (`main` -> `left`, `right` -> `base`)

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -2806,29 +2806,31 @@ unsafe fn restart_child_from_spec_expected(
                 // SAFETY: opts is valid; ownership of `cloned` is transferred.
                 unsafe { actor::hew_actor_spawn_opts_adopt(&raw const opts, cloned) }
             }
+        } else if state_drop_fn.is_some() {
+            // No `state_clone_fn` registered, but `state_drop_fn` IS: the
+            // legacy byte-copy path below is only sound for BitCopy actor
+            // state (plain-old-data fields with no owned heap pointers). A
+            // registered `state_drop_fn` means the actor's state owns heap
+            // fields, so byte-copying the template would alias those owned
+            // pointers between the template and every spawned incarnation —
+            // a double-free on teardown. The checker
+            // (E_SUPERVISOR_INIT_ARG_NON_BITCOPY) rejects this at compile
+            // time for codegen-emitted actors; a C-ABI caller that bypasses
+            // the checker and registers `state_drop_fn` without
+            // `state_clone_fn` gets a refused restart here instead of a
+            // silent alias (#1893).
+            set_last_error(format!(
+                "hew_supervisor_set_child_state_drop: child {index} registered a state-drop \
+                 function without a matching state-clone function; restart refused rather than \
+                 byte-copying owned heap state"
+            ));
+            fail_restart_snapshot(sup, index, spec_identity, spec_revision, &template);
+            return ptr::null_mut();
         } else {
-            // Legacy byte-copy path: no `state_clone_fn` registered.
-            //
-            // SAFETY boundary: this byte-copy is only sound for BitCopy actor state
-            // (plain-old-data fields with no owned heap pointers).  If `state_drop_fn`
-            // is also set, the template and the spawned actor share heap pointer aliases
-            // → double-free on teardown.
-            //
-            // The checker (E_SUPERVISOR_INIT_ARG_NON_BITCOPY) is the primary authority
-            // and rejects owned-handle init args at compile time before this path is
-            // reached.  Out-of-tree / hand-rolled C ABI callers that bypass the checker
-            // and register `state_drop_fn` without `state_clone_fn` receive borrowed
-            // provenance: typed drop is suppressed and the aliased owned fields leak
-            // fail-closed rather than being freed through multiple incarnations.
-            //
-            // WHY this is not a debug_assert: the assert would fire in existing tests
-            // that probe the legacy byte-copy path directly (see
-            // `state_clone_fn_null_falls_back_to_bytecopy`), which are present to
-            // document backward compatibility for out-of-tree consumers.
-            // WHEN obsolete: when the v0.6 init-closure restart model lands and
-            // every supervised actor with owned-heap state registers `state_clone_fn`.
-            // REAL FIX: extend the checker wall to cover all paths, then make
-            // `state_clone_fn` mandatory for any actor with owned-heap fields.
+            // Legacy byte-copy path: neither `state_clone_fn` nor
+            // `state_drop_fn` is registered, so the actor's state is BitCopy
+            // (plain-old-data fields with no owned heap pointers) and a flat
+            // byte-copy of the template is sound.
             //
             // SAFETY: opts is valid.
             unsafe { actor::hew_actor_spawn_opts(&raw const opts) }
@@ -7942,12 +7944,14 @@ mod tests {
     }
 
     #[test]
-    fn state_clone_fn_null_falls_back_to_bytecopy() {
+    fn state_drop_fn_without_state_clone_fn_refuses_restart() {
         let _rt = crate::runtime_test_guard();
-        // No state_clone_fn registered: restart must still succeed via the
-        // legacy `hew_actor_spawn_opts` byte-copy path. This preserves
-        // backward compatibility for children whose codegen has not yet
-        // emitted a clone fn (out-of-tree consumers, hand-rolled actors).
+        // A `state_drop_fn` registered without a `state_clone_fn` means the
+        // actor's state owns heap fields but has no sound way to clone the
+        // spec template for a restart. Byte-copying it would alias those
+        // owned heap pointers between the template and the restarted actor
+        // (double-free at teardown). The restart must refuse rather than
+        // silently fall back to that unsound byte-copy (#1893).
         let _serial = CLONE_TEST_SERIAL
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -7963,22 +7967,40 @@ mod tests {
 
             let restarted = restart_child_from_spec(sup, 0);
             assert!(
-                !restarted.is_null(),
-                "legacy byte-copy restart must still succeed"
+                restarted.is_null(),
+                "a state_drop_fn registered without state_clone_fn must refuse the restart"
             );
             assert_eq!(
                 CLONE_CALL_COUNT.load(Ordering::SeqCst),
                 0,
-                "legacy byte-copy path must NOT invoke clone_fn"
+                "a refused restart must NOT invoke clone_fn either"
             );
             assert!(
-                !(*restarted).init_state.is_null(),
-                "legacy path must populate actor.init_state via deep_copy_state"
+                locked_roster!(sup).children[0].is_null(),
+                "a refused restart must leave the child slot null"
             );
 
-            // Pin: the spec stayed in legacy mode (no in-place re-clone).
-            // No assertion on spec.init_state value — just that the test
-            // doesn't UAF.
+            hew_supervisor_stop(sup);
+        }
+    }
+
+    /// Negative control for `state_drop_fn_without_state_clone_fn_refuses_restart`:
+    /// a genuinely `BitCopy` actor (neither `state_drop_fn` nor `state_clone_fn`
+    /// registered — no owned heap fields at all) must still restart via the
+    /// legacy byte-copy path. The refusal above is specific to the dangerous
+    /// drop-without-clone combination, not to "no clone fn" in general.
+    #[test]
+    fn no_state_ops_registered_still_uses_legacy_bytecopy_restart() {
+        let _rt = crate::runtime_test_guard();
+        // SAFETY: test owns the supervisor tree.
+        unsafe {
+            let (sup, _child, _self_actor) = make_supervisor_with_child();
+            let restarted = restart_child_from_spec(sup, 0);
+            assert!(
+                !restarted.is_null(),
+                "a BitCopy actor with neither state_drop_fn nor state_clone_fn \
+                 registered must still restart via the legacy byte-copy path"
+            );
             hew_supervisor_stop(sup);
         }
     }
@@ -8071,31 +8093,28 @@ mod tests {
     }
 
     unsafe fn run_forced_bytecopy_freed_spec_payload_probe() -> ! {
-        // Install a runtime so spawn/track resolve; this subprocess faults
-        // intentionally (GuardMalloc SIGSEGV) before the guard would drop.
+        // Install a runtime so spawn/track resolve. Before #1893 this
+        // subprocess faulted intentionally (GuardMalloc SIGSEGV) by forcing
+        // the legacy byte-copy path to alias a freed spec payload. That
+        // path is no longer reachable: a `state_drop_fn` registered without
+        // a `state_clone_fn` now refuses the restart outright, so this
+        // probe proves the refusal instead of the fault.
         let _rt = crate::runtime_test_guard();
         let (sup, _template) = make_supervisor_with_heap_child(false);
-        let dangling_payload = free_spec_template_payload(sup);
+        let _dangling_payload = free_spec_template_payload(sup);
 
         let restarted = restart_child_from_spec(sup, 0);
         assert!(
-            !restarted.is_null(),
-            "legacy byte-copy restart must produce an actor"
-        );
-        let restarted_state = &mut *(*restarted).state.cast::<HeapState>();
-        assert_eq!(
-            restarted_state.payload, dangling_payload,
-            "legacy byte-copy restart must preserve the freed payload alias"
+            restarted.is_null(),
+            "a state_drop_fn registered without state_clone_fn must refuse the restart, \
+             not byte-copy a freed spec payload"
         );
 
-        *restarted_state.payload = 0xCC;
         std::process::exit(0);
     }
 
     #[cfg(target_os = "macos")]
     fn assert_forced_bytecopy_freed_spec_faults_under_guard_malloc(test_name: &str) {
-        use std::os::unix::process::ExitStatusExt as _;
-
         if !std::path::Path::new(GUARD_MALLOC_DYLIB).exists() {
             eprintln!("skipping GuardMalloc alias-fault probe: {GUARD_MALLOC_DYLIB} not found");
             return;
@@ -8111,10 +8130,9 @@ mod tests {
             .stderr(std::process::Stdio::null())
             .status()
             .expect("spawn GuardMalloc alias-fault helper");
-        assert_eq!(
-            status.signal(),
-            Some(libc::SIGSEGV),
-            "forced byte-copy of freed spec.init_state payload must SIGSEGV under GuardMalloc; status={status:?}"
+        assert!(
+            status.success(),
+            "the refused restart must exit cleanly under GuardMalloc, never fault; status={status:?}"
         );
     }
 


### PR DESCRIPTION
### Why

Four small bugs shared the same shape: a code path either derived a
fact from the wrong source or silently accepted an unsound combination.
`hew check <file>` anchored its module search paths on
`options.project_dir` (`None` for a bare file check) instead of the
source file, unlike the HIR import-resolution path. The bare-variant
migrator's token-lookup scan cannot find identifiers inside an
f-string interpolation, so it hit a hard refusal that aborted the
whole file's migration. A supervised child actor could register a
`state_drop_fn` without a `state_clone_fn`, and the restart path
silently fell back to a byte-copy that aliases owned heap pointers
between the template and every restarted incarnation. Three
`doc_stdlib_e2e` tests shared a `TempDir` in a `OnceLock` static, whose
`Drop` never runs, leaking the generated-docs directory on every run.

### What

- **hew-compile**: anchor the checker's module search paths on the
  file being checked (extracted into `checker_search_paths`), matching
  the HIR import-resolution path
- **hew-cli**: detect a bare-variant warning whose span falls inside
  an f-string interpolation and skip it with a specific message
  instead of falling through to the generic hard refusal
- **hew-runtime**: refuse a restart when `state_drop_fn` is registered
  without `state_clone_fn`, instead of byte-copying owned heap state
- **hew-cli tests**: merge `doc_stdlib_e2e`'s three `OnceLock`-sharing
  tests into one test-owned `TempDir` so `Drop` actually runs

### Test

- `hew-compile::tests::checker_search_paths_anchors_on_source_file_not_project_dir`
  (negative control: `checker_search_paths_ignores_project_dir_as_tier2_anchor`)
- `hew-cli::bare_variant_expr_e2e::migrate_skips_bare_variant_inside_fstring_interpolation_without_aborting`
- `hew-runtime::supervisor::tests::state_drop_fn_without_state_clone_fn_refuses_restart`
  (negative control: `no_state_ops_registered_still_uses_legacy_bytecopy_restart`)
- `hew-cli::doc_stdlib_e2e::stdlib_docs_invariants`

Fixes #3245
Fixes #3243
Fixes #1893
Fixes #3129
