### PR TITLE
fix(parser): refuse a break operand and scope in value position

### DIFF
--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -61,15 +61,17 @@ them.
 | `E_MODULE_NOT_FOUND`                           | An `import` no search path resolves.                                                                                          |
 | `E_GEN_RETURN_SPELLING`                        | A `gen fn` return type spelling the generator handle (`Generator<Y, R>`) instead of the yield type `Y` (HEW-SPEC-2026 §4.12). |
 | `E_UNKNOWN_ATTRIBUTE`                          | An attribute whose name is not in the closed table of HEW-SPEC-2026 §12.6, or that appears in a position the table does not list for it — on a type declaration, function, parameter, field, actor member, or `impl` block alike. Supersedes the retired `E_UNKNOWN_TYPE_MARKER`. |
+| `E_BREAK_VALUE`                                | An operand on `break` (§12.4). A loop produces no value, so assign to a `var` before breaking.                               |
+| `E_SCOPE_IS_STATEMENT`                         | `scope { .. }` in a value position (§4.2). It brackets structured concurrency; `join { .. }` is the value-producing fan-out. |
 
 The remaining v0.6.0 surface codes are named by the decision that introduces
 them, and their rule lives in the spec section that decision writes — not
 here. Each row is added by the lane that lands the refusal:
 `E_IS_VALUE_TYPE`, `E_OPAQUE_MESSAGE_PAYLOAD`, `E_CALLABLE_MESSAGE_PAYLOAD`,
-`E_USE_AFTER_SEND`, `E_RESERVED_HANDLER_NAME`,
+`E_USE_AFTER_SEND`, `E_UNKNOWN_ATTRIBUTE`, `E_RESERVED_HANDLER_NAME`,
 `E_ACTOR_CONTEXT_REQUIRED`, `E_BREAK_VALUE`, `E_SCOPE_IS_STATEMENT`,
-`E_NO_ASYNC_FN`, `E_NO_ASYNC_GEN`,
-`E_FOR_STREAM_NEEDS_AWAIT`, `E_AWAIT_NOT_STREAM`.
+`E_GEN_RETURN_SPELLING`, `E_NO_ASYNC_FN`,
+`E_NO_ASYNC_GEN`, `E_FOR_STREAM_NEEDS_AWAIT`, `E_AWAIT_NOT_STREAM`.
 
 ## Refusals with no code yet
 

--- a/examples/services/rate_limiter.hew
+++ b/examples/services/rate_limiter.hew
@@ -66,7 +66,7 @@ actor ApiWorker {
                     println(f"  [worker {id}] request {request_id}: UNAVAILABLE (limiter ask failed)");
                 },
             }
-        }
+        };
     }
     receive fn stats() -> i64 {
         println(f"  [worker {id}] accepted={accepted} rejected={rejected}");

--- a/hew-hir/tests/lowering_core/loop_break_continue_lower.rs
+++ b/hew-hir/tests/lowering_core/loop_break_continue_lower.rs
@@ -198,11 +198,13 @@ fn bare_loop_with_break_lowers_to_loop_node() {
 }
 
 #[test]
-fn break_with_value_lowers_and_carries_operand() {
-    // `break <value>` — Stage 1 carries the operand on the node so Stage 2
-    // can lower it for side-effects before the jump (LESSONS
-    // `cleanup-all-exits`). Loop-as-expression value return is out of scope.
-    let output = typecheck_and_lower(
+fn break_with_operand_never_reaches_lowering() {
+    // `break <value>` is refused at the parser (`E_BREAK_VALUE`,
+    // HEW-SPEC-2026 §12.4): a loop produces no value, so the operand has
+    // nowhere to go. This is the counterfactual for the bare-`break` tests
+    // above — they must keep lowering, while this spelling never arrives, so
+    // `HirExprKind::Break`'s operand slot has no producer left.
+    let parsed = hew_parser::parse(
         r"
         fn main() {
             loop {
@@ -212,23 +214,12 @@ fn break_with_value_lowers_and_carries_operand() {
         ",
     );
     assert!(
-        !has_not_yet_implemented(&output),
-        "`break <value>;` must not emit NotYetImplemented: {:#?}",
-        output.diagnostics
-    );
-    let body = main_body(&output);
-    assert!(
-        block_has_kind(body, |k| matches!(
-            k,
-            HirExprKind::Break { value: Some(_), .. }
-        )),
-        "expected a HirExprKind::Break carrying a value operand"
-    );
-    // The operand expression must be lowered (not dropped): the `1 + 2`
-    // Binary node is reachable through the Break node's value.
-    assert!(
-        block_has_kind(body, |k| matches!(k, HirExprKind::Binary { .. })),
-        "expected the break operand `1 + 2` to be lowered into a Binary node"
+        parsed
+            .errors
+            .iter()
+            .any(|e| e.message.contains("E_BREAK_VALUE")),
+        "expected the parser to refuse `break <value>;`, got: {:#?}",
+        parsed.errors
     );
 }
 

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -4896,9 +4896,11 @@ extern \"C\" {
 
     #[test]
     fn scope_block_roundtrips() {
+        // `scope { .. }` is a statement, so the formatted form is a
+        // statement-expression, not a `let` initialiser (HEW-SPEC-2026 §4.2).
         let src = "\
 fn main() {
-    let value = scope {
+    scope {
         1
     };
 }
@@ -4921,7 +4923,7 @@ fn main() {
     fn nested_scope_roundtrips() {
         let src = "\
 fn main() {
-    let value = scope {
+    scope {
         fork worker = run();
         fork audit();
         worker

--- a/hew-parser/src/parser/expressions.rs
+++ b/hew-parser/src/parser/expressions.rs
@@ -1335,14 +1335,10 @@ impl Parser<'_> {
                 // into that shape, so this introduces no new tree for the
                 // break-detection soundness argument to cover.
                 let label = self.parse_control_flow_label();
-                let value = if self.break_value_is_absent(BreakValuePosition::Expression) {
-                    None
-                } else {
-                    Some(self.parse_expr()?)
-                };
+                self.refuse_break_operand(BreakValuePosition::Expression);
                 let stmt_span = start..self.peek_span().start;
                 Expr::Block(Block {
-                    stmts: vec![(Stmt::Break { label, value }, stmt_span)],
+                    stmts: vec![(Stmt::Break { label, value: None }, stmt_span)],
                     trailing_expr: None,
                 })
             }
@@ -1358,26 +1354,20 @@ impl Parser<'_> {
                 })
             }
             Token::Scope => {
-                self.advance();
-                // Reject obsolete surfaces: `scope.method()` and `scope |s| { ... }`.
-                if self.eat(&Token::Dot) {
-                    self.error(
-                        "'scope.method()' syntax has been removed; use 'scope { ... }' with `fork name = expr;` bindings instead"
-                            .to_string(),
-                    );
-                    return None;
-                }
-                if self.peek() == Some(&Token::Pipe) {
-                    self.error(
-                        "'scope |s| { s.launch / s.spawn / s.cancel }' has been removed; use 'scope { fork name = call(...); }' instead"
-                            .to_string(),
-                    );
-                    return None;
-                }
-                self.scope_expr_depth += 1;
-                let body = self.parse_block()?;
-                self.scope_expr_depth -= 1;
-                Expr::Scope { body }
+                // `scope` is not a `Primary` (HEW-SPEC-2026 §4.2). Reaching it
+                // here means a value was expected — a `let` initialiser, a call
+                // argument, a match-arm body, an operand, a block's trailing
+                // expression — and `scope { .. }` produces none. Naming that
+                // beats the generic "expected expression, found scope", which
+                // reads as though the keyword were unknown. The statement
+                // spelling lives in `parse_stmt`.
+                self.error_with_hint(
+                    "E_SCOPE_IS_STATEMENT: `scope` cannot be used as a value; \
+                     `scope { .. }` is a statement that produces nothing"
+                        .to_string(),
+                    "use `join { .. }` for a value-producing fan-out",
+                );
+                return None;
             }
             Token::Fork => {
                 let fork_span = self.peek_span();

--- a/hew-parser/src/parser/statements.rs
+++ b/hew-parser/src/parser/statements.rs
@@ -6,17 +6,17 @@
 )]
 use super::*;
 
-/// Where a `break`/`continue` is being parsed — controls where its optional
-/// operand ends. Shared by the statement parser (`parse_stmt`) and the
-/// expression-position desugar (`parse_primary`'s `Token::Break` arm) so the
-/// two spellings can never drift apart.
+/// Where a `break` is being parsed — controls where a (refused) operand ends.
+/// Shared by the statement parser (`parse_stmt`) and the expression-position
+/// desugar (`parse_primary`'s `Token::Break` arm) so the two spellings can
+/// never drift apart.
 #[derive(Clone, Copy)]
 pub(crate) enum BreakValuePosition {
-    /// `break [expr];` — the operand ends at the mandatory `;`.
+    /// `break;` — an operand would end at the mandatory `;`.
     Statement,
-    /// `break [expr]` in expression position (e.g. a match-arm body) — no
-    /// trailing `;`; the operand ends at whatever ends the surrounding
-    /// expression, mirroring `Token::Return` in `parse_primary`.
+    /// `break` in expression position (e.g. a match-arm body) — no trailing
+    /// `;`; an operand would end at whatever ends the surrounding expression,
+    /// mirroring `Token::Return` in `parse_primary`.
     Expression,
 }
 
@@ -35,12 +35,12 @@ impl Parser<'_> {
         }
     }
 
-    /// True when the next token ends `break`'s optional value operand without
-    /// starting an expression. `position` decides the terminator set: `;` or
-    /// a block-closing `}` (the tail-of-block case, mirroring
-    /// `Token::Return`'s statement-position handling below) in statement
-    /// position, or the same "cannot begin an expression" stop set `return`
-    /// uses in expression position.
+    /// True when the next token ends a `break` without starting an operand
+    /// expression. `position` decides the terminator set: `;` or a
+    /// block-closing `}` (the tail-of-block case, mirroring `Token::Return`'s
+    /// statement-position handling below) in statement position, or the same
+    /// "cannot begin an expression" stop set `return` uses in expression
+    /// position.
     pub(crate) fn break_value_is_absent(&self, position: BreakValuePosition) -> bool {
         match position {
             BreakValuePosition::Statement => {
@@ -58,6 +58,34 @@ impl Parser<'_> {
                 ) | None
             ),
         }
+    }
+
+    /// Refuses an operand on `break` with `E_BREAK_VALUE` (HEW-SPEC-2026
+    /// §12.4). `break` is a pure control-flow statement: a loop never produces
+    /// a value, so an operand has nowhere to go, and accepting it taught a
+    /// loop-as-expression model the language does not have.
+    ///
+    /// The operand is parsed and discarded rather than left on the cursor, so
+    /// a refused `break total;` reports one diagnostic instead of cascading
+    /// token-mismatch errors through the rest of the statement. Both spellings
+    /// of `break` (statement and expression position) route through here, so
+    /// neither can accept what the other refuses.
+    pub(crate) fn refuse_break_operand(&mut self, position: BreakValuePosition) {
+        if self.break_value_is_absent(position) {
+            return;
+        }
+        let operand_start = self.peek_span();
+        let span = match self.parse_expr() {
+            Some((_, operand_span)) => operand_start.start..operand_span.end,
+            // `parse_expr` has already reported why the operand is unparseable;
+            // still name the surface so the reader learns `break` takes none.
+            None => operand_start,
+        };
+        self.error_at_with_hint(
+            "E_BREAK_VALUE: `break` carries no operand; a loop never produces a value".to_string(),
+            span,
+            "assign to a `var` before `break`",
+        );
     }
 
     pub(crate) fn parse_block(&mut self) -> Option<Block> {
@@ -586,14 +614,43 @@ impl Parser<'_> {
                     body,
                 }
             }
+            // `scope { .. }` is a statement, not a `Primary` (HEW-SPEC-2026
+            // §4.2): it brackets structured concurrency and produces no value,
+            // so it gets a dedicated arm here the way `if`/`while`/`for` do.
+            // `parse_primary` refuses the token outright, which is what closes
+            // every value position — a `let` initialiser, a call argument, a
+            // match-arm body, a block's trailing expression.
+            Some(Token::Scope) => {
+                self.advance();
+                // Reject obsolete surfaces: `scope.method()` and `scope |s| { ... }`.
+                if self.eat(&Token::Dot) {
+                    self.error(
+                        "'scope.method()' syntax has been removed; use 'scope { ... }' with `fork name = expr;` bindings instead"
+                            .to_string(),
+                    );
+                    return None;
+                }
+                if self.peek() == Some(&Token::Pipe) {
+                    self.error(
+                        "'scope |s| { s.launch / s.spawn / s.cancel }' has been removed; use 'scope { fork name = call(...); }' instead"
+                            .to_string(),
+                    );
+                    return None;
+                }
+                self.scope_expr_depth += 1;
+                let body = self.parse_block()?;
+                self.scope_expr_depth -= 1;
+                let expr_span = start..self.peek_span().start;
+                // A trailing `;` after the closing brace is the idiomatic
+                // spelling and is absorbed here, so `parse_block`'s stray-semicolon
+                // warning stays about actually stray semicolons.
+                self.eat(&Token::Semicolon);
+                Stmt::Expression((Expr::Scope { body }, expr_span))
+            }
             Some(Token::Break) => {
                 self.advance();
                 let label = self.parse_control_flow_label();
-                let value = if self.break_value_is_absent(BreakValuePosition::Statement) {
-                    None
-                } else {
-                    Some(self.parse_expr()?)
-                };
+                self.refuse_break_operand(BreakValuePosition::Statement);
                 // Mirrors `Token::Return` below: a statement-position `break`
                 // normally ends with `;`, but not when it is the last item in
                 // a block (`}` follows) — the `else { break }` / `if c {
@@ -601,7 +658,17 @@ impl Parser<'_> {
                 if self.peek() != Some(&Token::RightBrace) {
                     self.expect(&Token::Semicolon)?;
                 }
-                Stmt::Break { label, value }
+                Stmt::Break {
+                    label,
+                    // WHY: `Stmt::Break`'s `value` slot survives the refusal
+                    // above because HIR lowering, the checker, `fmt`, and the
+                    // sandbox emitter all still match on it.
+                    // WHEN OBSOLETE: once those consumers drop the operand
+                    // arm, the parser being its only producer.
+                    // WHAT: delete the field and the lowering that reads it,
+                    // so no layer below the parser can express a break value.
+                    value: None,
+                }
             }
             Some(Token::Continue) => {
                 self.advance();

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -3150,6 +3150,17 @@ fn parse_let_expr(source: &str) -> Expr {
     expr.clone()
 }
 
+/// Parses a statement-position `scope { .. };` inside `fn main` and returns the
+/// scope block's own body. `scope` is not a `Primary`, so a scope body is only
+/// reachable through a statement.
+fn parse_scope_stmt_body(source: &str) -> Block {
+    let body = parse_main_body(source);
+    let Stmt::Expression((Expr::Scope { body: inner }, _)) = &body.stmts[0].0 else {
+        panic!("expected scope statement: {:?}", body.stmts[0]);
+    };
+    inner.clone()
+}
+
 fn parse_main_body(source: &str) -> Block {
     let full = format!("fn main() {{ {source} }}");
     let result = parse(&full);
@@ -3401,8 +3412,13 @@ fn parse_block_still_works() {
 }
 
 #[test]
-fn scope_keyword_emits_scope_ast_variant() {
-    let expr = parse_let_expr("scope { 1 }");
+fn scope_statement_emits_scope_ast_variant() {
+    // `scope { .. }` is a statement, so the AST variant is reached through a
+    // statement-expression, never a `let` initialiser (HEW-SPEC-2026 §4.2).
+    let body = parse_main_body("scope { 1 };");
+    let Stmt::Expression((expr, _)) = &body.stmts[0].0 else {
+        panic!("expected statement-expression: {:?}", body.stmts[0]);
+    };
     assert!(
         matches!(expr, Expr::Scope { .. }),
         "expected Scope, got {expr:?}"
@@ -3410,17 +3426,25 @@ fn scope_keyword_emits_scope_ast_variant() {
 }
 
 #[test]
+fn scope_in_let_initialiser_is_refused() {
+    // Negative control for the test above: `scope` out of `Primary` means the
+    // value position is closed, not that the statement spelling moved.
+    let result = parse("fn main() { let r = scope { 1 }; }");
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("E_SCOPE_IS_STATEMENT")),
+        "expected E_SCOPE_IS_STATEMENT, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn parser_scope_block_distinct_from_fork_child() {
-    let body = parse_main_body("let block = scope { 1 };\nscope { fork child = run(); };\n");
-    let Stmt::Let {
-        value: Some((Expr::Scope { .. }, _)),
-        ..
-    } = &body.stmts[0].0
-    else {
-        panic!(
-            "expected let binding to use scope block: {:?}",
-            body.stmts[0]
-        );
+    let body = parse_main_body("scope { 1 };\nscope { fork child = run(); };\n");
+    let Stmt::Expression((Expr::Scope { .. }, _)) = &body.stmts[0].0 else {
+        panic!("expected scope statement: {:?}", body.stmts[0]);
     };
     let Stmt::Expression((Expr::Scope { body: inner }, _)) = &body.stmts[1].0 else {
         panic!("expected outer scope block: {:?}", body.stmts[1]);
@@ -3461,10 +3485,7 @@ fn parse_fork_child_bare() {
 
 #[test]
 fn parse_nested_scope_block_and_child() {
-    let expr = parse_let_expr("scope { fork run(); fork child = work(); child }");
-    let Expr::Scope { body } = expr else {
-        panic!("expected scope block");
-    };
+    let body = parse_scope_stmt_body("scope { fork run(); fork child = work(); child };");
     assert_eq!(body.stmts.len(), 2, "expected two child statements");
     assert!(matches!(
         &body.stmts[0].0,
@@ -3488,10 +3509,7 @@ fn parse_nested_scope_block_and_child() {
 
 #[test]
 fn parse_scope_fork_block_after_deadline() {
-    let expr = parse_let_expr("scope { fork { long_op(); } after(5s) { } }");
-    let Expr::Scope { body } = expr else {
-        panic!("expected scope block");
-    };
+    let body = parse_scope_stmt_body("scope { fork { long_op(); } after(5s) { } };");
     assert_eq!(body.stmts.len(), 2, "expected fork block and deadline");
     let Stmt::Expression((Expr::ForkBlock { body: fork_body }, _)) = &body.stmts[0].0 else {
         panic!("expected fork block: {:?}", body.stmts[0]);

--- a/hew-parser/src/parser/types.rs
+++ b/hew-parser/src/parser/types.rs
@@ -772,6 +772,12 @@ impl Parser<'_> {
     }
 
     /// Returns true if the expression is a block-like construct that doesn't need a trailing semicolon.
+    ///
+    /// `Expr::Scope` is deliberately absent: `scope { .. }` is a statement, not
+    /// a `Primary` (HEW-SPEC-2026 §4.2), so it never reaches an expression
+    /// position this predicate gates — a block tail or a match-arm body are
+    /// both value positions. `parse_stmt` owns the statement spelling and its
+    /// optional trailing `;`.
     pub(crate) fn is_block_expr(expr: &Expr) -> bool {
         matches!(
             expr,
@@ -779,7 +785,6 @@ impl Parser<'_> {
                 | Expr::If { .. }
                 | Expr::IfLet { .. }
                 | Expr::Match { .. }
-                | Expr::Scope { .. }
                 | Expr::ForkBlock { .. }
                 | Expr::ScopeDeadline { .. }
                 | Expr::UnsafeBlock(_)
@@ -799,10 +804,12 @@ impl Parser<'_> {
     pub(crate) fn arm_body_opens_block(&self) -> bool {
         match self.peek() {
             // `if` → Expr::If / Expr::IfLet, `match` → Expr::Match,
-            // `scope` → Expr::Scope, `unsafe` → Expr::UnsafeBlock,
-            // `select` → Expr::Select. Each of these openers has exactly one
-            // expression form, so the token alone settles it.
-            Some(Token::If | Token::Match | Token::Scope | Token::Unsafe | Token::Select) => true,
+            // `unsafe` → Expr::UnsafeBlock, `select` → Expr::Select. Each of
+            // these openers has exactly one expression form, so the token alone
+            // settles it. `scope` is absent for the reason `is_block_expr`
+            // gives: it opens a statement, and every caller of this predicate
+            // is asking about a value position.
+            Some(Token::If | Token::Match | Token::Unsafe | Token::Select) => true,
             // Expr::Block — but a `{` that opens a map literal is not a block,
             // and `parse_primary` splits the two on exactly this lookahead.
             Some(Token::LeftBrace) => {

--- a/hew-parser/tests/break_expr.rs
+++ b/hew-parser/tests/break_expr.rs
@@ -6,6 +6,12 @@
 //! position compiled. The parser now desugars the expression-position
 //! spelling to the same one-statement-block AST the working `{ break; }`
 //! form already produces, mirroring how `return` was made expression-capable.
+//!
+//! Where `break` may be *written* is separate from what it may *carry*: a
+//! `break` carries no operand in either position (`E_BREAK_VALUE`), and
+//! `scope { .. }` is a statement rather than a `Primary`
+//! (`E_SCOPE_IS_STATEMENT`), so the block-opening arm-body set below covers
+//! only the openers that actually produce a value.
 
 use hew_parser::ast::{Block, Expr, Item, MatchArm, Stmt};
 use hew_parser::{parse, ParseDiagnosticKind};
@@ -80,34 +86,38 @@ fn bare_break_in_match_arm_parses() {
     );
 }
 
-#[test]
-fn break_with_value_in_match_arm_parses() {
-    let body = parse_fn_body("loop { let x = match 1 { 1 => break 42, _ => 0 }; }");
-    let Stmt::Loop { body, .. } = &body.stmts[0].0 else {
-        panic!("expected Stmt::Loop, got {:?}", body.stmts[0].0);
-    };
-    let Stmt::Let { value, .. } = &body.stmts[0].0 else {
-        panic!("expected Stmt::Let, got {:?}", body.stmts[0].0);
-    };
-    let value = value.as_ref().expect("expected let initialiser");
-    let Expr::Match { arms, .. } = &value.0 else {
-        panic!("expected Expr::Match, got {:?}", value.0);
-    };
-    let Expr::Block(Block { stmts, .. }) = &arms[0].body.0 else {
-        panic!("expected Expr::Block, got {:?}", arms[0].body.0);
-    };
-    let Stmt::Break { label, value } = &stmts[0].0 else {
-        panic!("expected Stmt::Break, got {:?}", stmts[0].0);
-    };
-    assert!(label.is_none());
-    let Some(value) = value else {
-        panic!("expected Stmt::Break value, got None");
-    };
+/// Parse a full source string and assert `E_BREAK_VALUE` is among the errors,
+/// so a test that means "the operand is refused" cannot pass on an unrelated
+/// syntax error.
+fn parse_err_break_value(src: &str) {
+    let result = parse(src);
     assert!(
-        matches!(value.0, Expr::Literal(_)),
-        "expected an integer literal operand, got {:?}",
-        value.0
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("E_BREAK_VALUE")),
+        "expected E_BREAK_VALUE for `{src}`, got: {:#?}",
+        result.errors
     );
+}
+
+#[test]
+fn break_with_operand_in_expression_position_is_refused() {
+    // A loop produces no value, so an operand on `break` has nowhere to go
+    // (HEW-SPEC-2026 §12.4). Before this refusal the operand was parsed,
+    // evaluated for its side effects and discarded, which taught a
+    // loop-as-expression model the language does not have.
+    parse_err_break_value("fn f() { loop { let x = match 1 { 1 => break 42, _ => 0 }; } }");
+}
+
+#[test]
+fn break_with_operand_in_statement_position_is_refused() {
+    parse_err_break_value("fn f() { var total: i64 = 0; loop { total = 1; break total; } }");
+}
+
+#[test]
+fn labelled_break_with_operand_is_refused() {
+    parse_err_break_value("fn f() { @outer: loop { break @outer 42; } }");
 }
 
 #[test]
@@ -259,8 +269,6 @@ fn comma_less_block_opening_arms_parse() {
     parse_ok("fn f() { match 1 { 1 => unsafe { 1 } _ => 0 } }");
     // Expr::Select
     parse_ok("fn f() { match 1 { 1 => select { m from ch => m, } _ => 0 } }");
-    // Expr::Scope
-    parse_ok("fn f() { match 1 { 1 => scope { 1 } _ => 0 } }");
     // Expr::ForkBlock — a brace must follow `fork`, and `fork`/`after` blocks
     // are only legal inside a `scope`.
     parse_ok("fn f() { scope { let v = match 1 { 1 => fork { 1 } _ => 0 }; } }");
@@ -277,4 +285,44 @@ fn comma_less_non_block_arms_still_error() {
     parse_err_missing_comma("fn f() { match 1 { 1 => {\"a\": 1} _ => 0 } }");
     parse_err_missing_comma("fn f() { match 1 { 1 => gen { yield 1; } _ => 0 } }");
     parse_err_missing_comma("fn f() { scope { let v = match 1 { 1 => fork g() _ => 0 }; } }");
+}
+
+#[test]
+fn scope_as_match_arm_body_is_refused() {
+    // A match-arm body is a value position, so `scope` leaving `Primary`
+    // closes it. This is why `Token::Scope` had to leave
+    // `arm_body_opens_block` in the same change: the token-side predicate must
+    // not promise a block-bodied arm the expression grammar no longer parses.
+    let result = parse("fn f() { match 1 { 1 => scope { 1 } _ => 0 } }");
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("E_SCOPE_IS_STATEMENT")),
+        "expected E_SCOPE_IS_STATEMENT for a scope arm body, got: {:#?}",
+        result.errors
+    );
+}
+
+#[test]
+fn scope_as_bare_statement_and_block_tail_parses() {
+    // The accept twin: the statement spelling is untouched, with or without the
+    // trailing `;`, and a scope in tail position is not promoted to the
+    // block's trailing expression — it produces no value to promote.
+    parse_ok("fn f() { scope { fork g(); }; }");
+
+    let body = parse_fn_body("scope { fork g(); }");
+    assert!(
+        body.trailing_expr.is_none(),
+        "an unterminated tail `scope` must stay a statement, got trailing expr {:?}",
+        body.trailing_expr
+    );
+    assert!(
+        matches!(
+            &body.stmts[..],
+            [(Stmt::Expression((Expr::Scope { .. }, _)), _)]
+        ),
+        "expected a single scope statement, got {:?}",
+        body.stmts
+    );
 }

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -2251,9 +2251,11 @@ fn fmt_channel_half_handle_roundtrip() {
 
 #[test]
 fn fmt_scope_fork_named_binding_roundtrip() {
-    // scope block with a named fork binding — the canonical structured-concurrency form.
+    // scope block with a named fork binding — the canonical
+    // structured-concurrency form. `scope` is a statement, not a `Primary`
+    // (HEW-SPEC-2026 §4.2), so the canonical spelling is a statement-expression.
     exact_roundtrip(
-        "fn main() {\n    let result = scope {\n        fork worker = compute();\n        fork auditor = audit();\n        worker\n    };\n}\n",
+        "fn main() {\n    scope {\n        fork worker = compute();\n        fork auditor = audit();\n        worker\n    };\n}\n",
     );
 }
 

--- a/hew-types/src/check/tests/wasm.rs
+++ b/hew-types/src/check/tests/wasm.rs
@@ -1401,7 +1401,9 @@ fn main() {
     }
 
     fn structured_concurrency_scope_source() -> &'static str {
-        "fn main() { let result = scope { 1 + 2 }; println(result); }"
+        // `scope { .. }` is a statement, not a `Primary` (HEW-SPEC-2026 §4.2),
+        // so the WASM admission check sees it through a statement-expression.
+        "fn main() { var result: i64 = 0; scope { result = 1 + 2; }; println(result); }"
     }
 
     fn scope_tasks_source() -> &'static str {

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3471,32 +3471,10 @@ fn rc_param_explicit_return_errors_borrowed_rc() {
     );
 }
 
-/// `break <rc_param>` inside a loop must trigger the error — the broken value
-/// escapes to the enclosing scope with the same aliasing hazard as `return`.
-#[test]
-fn rc_param_break_value_errors_borrowed_rc() {
-    let output = typecheck_inline(
-        r"
-        fn escape(r: Rc<i64>) -> Rc<i64> {
-            loop {
-                break r;
-            }
-        }
-        fn main() {}
-        ",
-    );
-    // Note: the type checker currently types `loop { break v; }` as Unit,
-    // so this also gets a ReturnTypeMismatch.  The BorrowedParamReturn error
-    // must still fire independently of that.
-    assert!(
-        output
-            .errors
-            .iter()
-            .any(|e| e.kind == hew_types::error::TypeErrorKind::BorrowedParamReturn),
-        "break-with-value of Rc param should emit BorrowedParamReturn error, got errors: {:#?}",
-        output.errors
-    );
-}
+// `break <rc_param>` is gone from the language: `break` carries no operand
+// (`E_BREAK_VALUE`, HEW-SPEC-2026 §12.4), so the escape route this checker
+// rule once had to cover cannot be written. The remaining escapes — an
+// explicit `return`, a block tail, a match arm — are covered above and below.
 
 /// Block-wrapped return `{ r }` must be caught — `Expr::Block` descent.
 #[test]

--- a/tests/vertical-slice/accept/break_control_flow_only.expected
+++ b/tests/vertical-slice/accept/break_control_flow_only.expected
@@ -1,0 +1,3 @@
+multiple=9
+hit=11
+arm=3

--- a/tests/vertical-slice/accept/break_control_flow_only.hew
+++ b/tests/vertical-slice/accept/break_control_flow_only.hew
@@ -1,0 +1,51 @@
+// Accept twin for reject/break_value_operand.hew.
+//
+// Refusing `break expr;` must not narrow where `break` may be written. All
+// three spellings that carry no operand stay legal: a bare `break` ending a
+// `loop`, a labelled `break @outer` leaving a nested `for`, and a `break` as a
+// match-arm body, where its `!` type unifies with the other arm
+// (HEW-SPEC-2026 §12.4).
+
+fn first_multiple(step: i64, limit: i64) -> i64 {
+    var found: i64 = -1;
+    var i: i64 = 1;
+    loop {
+        if i * step > limit {
+            break;
+        }
+        found = i * step;
+        i = i + 1;
+    }
+    return found;
+}
+
+fn grid_hit(rows: i64, cols: i64) -> i64 {
+    var hit: i64 = -1;
+    @outer: for r in 0..rows {
+        for c in 0..cols {
+            if r * cols + c == 5 {
+                hit = r * 10 + c;
+                break @outer;
+            }
+        }
+    }
+    return hit;
+}
+
+fn arm_break() -> i64 {
+    var seen: i64 = 0;
+    loop {
+        seen = seen + 1;
+        match seen {
+            3 => break,
+            _ => (),
+        }
+    }
+    return seen;
+}
+
+fn main() {
+    println(f"multiple={first_multiple(3, 10)}");
+    println(f"hit={grid_hit(3, 4)}");
+    println(f"arm={arm_break()}");
+}

--- a/tests/vertical-slice/accept/scope_statement_tail.expected
+++ b/tests/vertical-slice/accept/scope_statement_tail.expected
@@ -1,0 +1,2 @@
+guarded=7
+announce=8

--- a/tests/vertical-slice/accept/scope_statement_tail.hew
+++ b/tests/vertical-slice/accept/scope_statement_tail.hew
@@ -1,0 +1,46 @@
+// Accept twin for reject/scope_in_value_position.hew.
+//
+// `scope` leaving `Primary` closes every value position without touching the
+// statement spelling. `guarded` ends with a `scope { .. }` that carries no
+// trailing `;`: it must stay a statement and must NOT be promoted to the
+// block's trailing expression, so the explicit `return fired` still decides
+// the handler's value. `announce` uses the `scope { .. };` spelling.
+
+fn nap() {
+    sleep(1ms);
+}
+
+actor Worker {
+    var fired: i64 = 0;
+
+    receive fn guarded() -> i64 {
+        fired = 7;
+        // No trailing `;`, and still a statement: the block's value is the
+        // `return` below, not the scope.
+        scope {
+            fork nap();
+        }
+        return fired;
+    }
+
+    receive fn announce() -> i64 {
+        scope {
+            fork nap();
+        };
+        return fired + 1;
+    }
+}
+
+fn main() {
+    let w = spawn Worker(fired: 0);
+    let r = await w.guarded();
+    match r {
+        .Ok(v) => println(f"guarded={v}"),
+        .Err(_) => println("guarded failed"),
+    }
+    let a = await w.announce();
+    match a {
+        .Ok(v) => println(f"announce={v}"),
+        .Err(_) => println("announce failed"),
+    }
+}

--- a/tests/vertical-slice/reject/break_value_operand.hew
+++ b/tests/vertical-slice/reject/break_value_operand.hew
@@ -1,0 +1,18 @@
+// Reject fixture: `break expr;` is E_BREAK_VALUE (User).
+//
+// A loop never produces a value, so an operand on `break` has nowhere to go.
+// The parser used to accept it and evaluate it for its side effects only, so
+// `hew check` reported OK on a program that reads as a loop-as-expression —
+// a model Hew does not have (HEW-SPEC-2026 §12.4).
+//
+// The accept twin is accept/break_control_flow_only.hew: bare `break`,
+// `break @label`, and a `break` arm body all stay legal.
+
+fn main() {
+    var total: i64 = 0;
+    loop {
+        total = 1;
+        break total;
+    }
+    println(f"{total}");
+}

--- a/tests/vertical-slice/reject/scope_in_value_position.hew
+++ b/tests/vertical-slice/reject/scope_in_value_position.hew
@@ -1,0 +1,15 @@
+// Reject fixture: `scope` in a value position is E_SCOPE_IS_STATEMENT (User).
+//
+// `scope { .. }` brackets structured concurrency and produces nothing, so it
+// is a statement rather than a `Primary` (HEW-SPEC-2026 §4.2). Binding it used
+// to succeed and silently give the binding `()`; the value-producing fan-out
+// is `join { .. }`.
+//
+// The accept twin is accept/scope_statement_tail.hew: the statement spelling,
+// with and without its trailing `;`, stays legal.
+
+fn main() {
+    let r = scope {
+    };
+    println(f"{r}");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -6407,3 +6407,39 @@ fi
 # consume of the same binding elsewhere in the loop body neither hides nor
 # duplicates it.
 reject_check_use_after_consume "vec_index_assign_reuse_after_rebind"
+
+# ---------------------------------------------------------------------------
+# `break` carries no operand and `scope` is not a value (#3263).
+#
+# Both surfaces used to accept a value where none can go: `break expr;` parsed
+# the operand and discarded it, and `let r = scope { .. }` bound `()`. The
+# refusals are parser-level, so each reject also asserts its hint — the code
+# alone would pass on a message that names the wrong replacement.
+# ---------------------------------------------------------------------------
+expect_check_fail_error_count \
+    "${ROOT}/tests/vertical-slice/reject/break_value_operand.hew" \
+    1 "break_value_operand"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/break_value_operand.hew" \
+    "E_BREAK_VALUE" \
+    "break_value_operand_code"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/break_value_operand.hew" \
+    "assign to a \`var\` before \`break\`" \
+    "break_value_operand_hint"
+
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/scope_in_value_position.hew" \
+    "E_SCOPE_IS_STATEMENT" \
+    "scope_in_value_position_code"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/scope_in_value_position.hew" \
+    "use \`join { .. }\` for a value-producing fan-out" \
+    "scope_in_value_position_hint"
+
+# Accept twins: refusing the operand and the value position must not narrow
+# where `break` may be written or how a `scope` statement may end. The scope
+# fixture's tail `scope { .. }` carries no `;` and must stay a statement, so
+# the handler's value is still its explicit `return`.
+run_accept_expect_stdout "break_control_flow_only"
+run_accept_expect_stdout "scope_statement_tail"


### PR DESCRIPTION
## Why

I need invalid value-position syntax to be refused explicitly: `break expr` must not silently discard its operand, and `scope { .. }` is statement-only.

## What

I reject break operands with `E_BREAK_VALUE` and scope blocks in value position with `E_SCOPE_IS_STATEMENT`, while preserving valid control-flow forms.

## Test

I cover this with `hew-parser/tests/break_expr.rs` and the focused vertical-slice fixtures `break_value_operand` and `scope_in_value_position`.