### PR TITLE
Make pool arity a child clause

### DIFF
--- a/docs/language/supervision.hew
+++ b/docs/language/supervision.hew
@@ -52,10 +52,6 @@
 //! named `count` pools like any other. `count:` is required on a `pool` child
 //! and rejected on a `child` declaration.
 //!
-//! The shipped parser still reads `count` out of the parenthesised list, so
-//! `pool workers: Worker(count: 2, value: 7);` is what compiles today; the
-//! clause form is hew-lang/hew#3253.
-//!
 //! ## Dead children
 //!
 //! A supervised role whose occupant is gone resolves closed. `sup.child` keeps

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -4301,13 +4301,6 @@ other, and its `count` field is set the same way every other field is. The
 two namespaces never collide, so no diagnostic about pool arity can land on a
 user's field.
 
-> **Implementation status.** The shipped parser reads `count` out of the
-> parenthesised list as an init field, so `pool ws: A(count: N, ..)` is what
-> compiles today and the clause form is refused with
-> `unknown supervisor field`. The migration is a fix-it —
-> `pool ws: A(count: N, ..)` becomes `pool ws: A(..) count: N;` — tracked in
-> hew-lang/hew#3253.
-
 ### 5.2 Restart Semantics (normative)
 
 Let child exit reason be one of:

--- a/docs/syntax-data.json
+++ b/docs/syntax-data.json
@@ -201,6 +201,7 @@
     "shutdown": "Supervisor child graceful-stop deadline clause",
     "infinity": "Supervisor child shutdown: wait indefinitely (accepted-only)",
     "wired_to": "Supervisor child sibling-wiring clause",
+    "count": "Supervisor pool arity clause (pool ws: Worker(..) count: N)",
     "export": "FFI export attribute",
     "resource": "Type-decl ownership attribute — move-only, non-duplicable value",
     "linear": "Type-decl ownership attribute — must be consumed exactly once",

--- a/examples/v05/checked-mir/supervisor_pool_child_ref_get.hew
+++ b/examples/v05/checked-mir/supervisor_pool_child_ref_get.hew
@@ -10,7 +10,7 @@ actor Worker {
 supervisor Pool {
     strategy: simple_one_for_one;
 
-    pool workers: Worker(count: 2);
+    pool workers: Worker count: 2;
 }
 
 fn inspect(sup: LocalPid<Pool>) -> i64 {

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -7847,7 +7847,7 @@ pub(crate) fn emit_supervisor_bootstrap_body<'ctx>(
     // occupy static slots.
     let mut actor_child_index = 0usize;
     for child in &layout.children {
-        // Pool children (`pool name: Type(count: N)`) reserve a slot in the
+        // Pool children (`pool name: Type count: N`) reserve a slot in the
         // runtime's disjoint `pool_slots[]` space, then spawn N fungible members
         // as static children (registered into `children[]` via add_child_spec)
         // and bind each member's static index into the pool via
@@ -8769,8 +8769,8 @@ fn emit_supervisor_child_spec_and_register<'ctx>(
     Ok(())
 }
 
-/// Emit the bootstrap registration for a static pool (`pool name: Type(count:
-/// N)`): reserve the pool slot, spawn N fungible members as static children, and
+/// Emit the bootstrap registration for a static pool (`pool name: Type count:
+/// N`): reserve the pool slot, spawn N fungible members as static children, and
 /// bind each member's static index into the pool via `pool_member_add_static`.
 ///
 /// Members are homogeneous (A204): one shared init template / init thunk, the

--- a/hew-codegen-rs/tests/emission/supervisor_child_get_emission.rs
+++ b/hew-codegen-rs/tests/emission/supervisor_child_get_emission.rs
@@ -189,7 +189,7 @@ actor Worker {
 
 supervisor Pool {
     strategy: simple_one_for_one,
-    pool workers: Worker(count: 2)
+    pool workers: Worker count: 2
 }
 
 fn inspect(sup: LocalPid<Pool>) -> i64 {

--- a/hew-codegen-rs/tests/emission/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/emission/supervisor_emission.rs
@@ -1075,7 +1075,7 @@ fn pool_then_static_pipeline() -> IrPipeline {
     })
 }
 
-/// A static pool (`pool name: Type(count: N)`) now spawns its N members as
+/// A static pool (`pool name: Type count: N`) now spawns its N members as
 /// static children and binds them into a pool slot. For a [pool(count: 2),
 /// static] layout, codegen emits: ONE `pool_add_slot`, TWO member registrations
 /// (`add_child_spec` + `pool_member_add_static`), then ONE more `add_child_spec`

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -14451,34 +14451,25 @@ impl LowerCtx {
                     is_pool: child.is_pool,
                     slot_index,
                     // Lower named init args from AST `(field, expr)` pairs.
-                    // These were previously silently dropped at this boundary.
-                    //
-                    // For a pool child the reserved `count:` arg designates the
-                    // pool size, not a per-member init field; split it out into
-                    // `pool_count` so `init_args` carries only the per-member
-                    // init template. `count` is reserved only on pool decls — a
-                    // static child keeps any `count:` arg as an ordinary init
-                    // field (e.g. `spawn Counter(count: 0)` stays a state field).
+                    // The parenthesised list is the actor's own field namespace
+                    // in full — pool arity arrives separately as the `count:`
+                    // clause, so an actor field named `count` lowers here like
+                    // any other.
                     init_args: child
                         .args
                         .iter()
-                        .filter(|(field_name, _)| !(child.is_pool && field_name == "count"))
                         .map(|(field_name, spanned_expr)| {
                             let hir_expr = self.lower_expr(spanned_expr, IntentKind::Read);
                             (field_name.clone(), hir_expr)
                         })
                         .collect(),
-                    pool_count: if child.is_pool {
-                        child
-                            .args
-                            .iter()
-                            .find(|(field_name, _)| field_name == "count")
-                            .map(|(_, spanned_expr)| {
-                                self.lower_expr(spanned_expr, IntentKind::Read)
-                            })
-                    } else {
-                        None
-                    },
+                    // Pool arity comes from the `count:` clause. The parser
+                    // refuses the clause on a static child, so `count` is only
+                    // ever populated on a pool.
+                    pool_count: child
+                        .count
+                        .as_ref()
+                        .map(|spanned_expr| self.lower_expr(spanned_expr, IntentKind::Read)),
                     shutdown: child.shutdown.as_ref().map(|s| match s {
                         ShutdownDirective::Timeout(d) => HirShutdownDirective::Timeout(d.clone()),
                         ShutdownDirective::BrutalKill => HirShutdownDirective::BrutalKill,

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -973,7 +973,7 @@ pub struct HirSupervisorChild {
     /// all N fungible members.
     pub init_args: Vec<(String, HirExpr)>,
     /// Reserved pool-size expression, lowered from the `count:` named arg on a
-    /// `pool name: Type(count: N, ...)` declaration. `None` for a static child
+    /// `pool name: Type(...) count: N` declaration. `None` for a static child
     /// or a pool child that omitted `count:` (which the checker rejects). The
     /// expression yields the number of fungible members the bootstrap spawns
     /// into the pool slot. `count` is a reserved arg name on pool declarations,

--- a/hew-hir/tests/concurrency/supervisor_child_accessor_gates.rs
+++ b/hew-hir/tests/concurrency/supervisor_child_accessor_gates.rs
@@ -57,7 +57,7 @@ fn pool_field_access_lowers_as_first_class_view() {
 
         supervisor Pool {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: 2)
+            pool workers: Worker count: 2
         }
 
         fn inspect(sup: LocalPid<Pool>) -> i64 {

--- a/hew-hir/tests/concurrency/supervisor_hir.rs
+++ b/hew-hir/tests/concurrency/supervisor_hir.rs
@@ -70,7 +70,7 @@ fn pool_child_gets_pool_slot_index_zero() {
 
         supervisor Pool {
             strategy: simple_one_for_one,
-            pool worker: Worker(count: 2)
+            pool worker: Worker count: 2
         }
         ",
     );
@@ -81,19 +81,19 @@ fn pool_child_gets_pool_slot_index_zero() {
     assert_eq!(worker.slot_index, 0, "pool child slot index is 0");
 }
 
-/// A `pool worker: Worker(count: 3)` declaration splits the reserved `count`
-/// arg into `pool_count` (the pool size) and leaves it OUT of `init_args` (the
-/// per-member init template). The discriminator carries the count expr so the
+/// A `pool worker: Worker count: 3` declaration lowers the arity clause into
+/// `pool_count` (the pool size) and leaves `init_args` (the per-member init
+/// template) untouched. The discriminator carries the count expr so the
 /// checker and codegen can read it (verify-ast-carries-discriminator).
 #[test]
-fn pool_count_arg_is_extracted_into_pool_count() {
+fn pool_count_clause_lowers_into_pool_count() {
     let output = lower(
         r"
         actor Worker { receive fn ping() {} }
 
         supervisor Pool {
             strategy: simple_one_for_one,
-            pool worker: Worker(count: 3)
+            pool worker: Worker count: 3
         }
         ",
     );
@@ -107,7 +107,7 @@ fn pool_count_arg_is_extracted_into_pool_count() {
     );
     assert!(
         !worker.init_args.iter().any(|(name, _)| name == "count"),
-        "the reserved `count` arg must NOT appear in the per-member init template"
+        "the arity clause must NOT appear in the per-member init template"
     );
 }
 
@@ -124,7 +124,7 @@ fn pool_count_and_member_init_arg_are_separated() {
 
         supervisor Pool {
             strategy: simple_one_for_one,
-            pool worker: Worker(count: 4, id: 7)
+            pool worker: Worker(id: 7) count: 4
         }
         ",
     );
@@ -140,9 +140,10 @@ fn pool_count_and_member_init_arg_are_separated() {
     assert_eq!(worker.init_args[0].0, "id");
 }
 
-/// A static child keeps a `count:` arg as an ordinary init field — `count` is
-/// reserved only on POOL declarations (so `spawn Counter(count: 0)` stays a
-/// state field).
+/// An actor field named `count` is an ordinary init field: arity lives in the
+/// child's clause namespace, so the parenthesised list never reserves the
+/// name. Here a static child sets `count: 0` as state, and a pool of the same
+/// actor would too.
 #[test]
 fn static_child_keeps_count_as_init_field() {
     let output = lower(
@@ -168,7 +169,7 @@ fn static_child_keeps_count_as_init_field() {
     assert_eq!(
         counter.init_args.len(),
         1,
-        "the `count` arg stays a per-child init field on a static child"
+        "`count` stays a per-child init field, arity clause or not"
     );
     assert_eq!(counter.init_args[0].0, "count");
 }

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1223,7 +1223,7 @@ impl SupervisorChildLayout {
     }
 }
 
-/// The size of a static supervisor pool (`pool name: Type(count: N)`).
+/// The size of a static supervisor pool (`pool name: Type count: N`).
 ///
 /// Carried on [`SupervisorChildLayout::pool_count`] so codegen can emit the
 /// member-spawn loop. A literal count is a compile-time constant N; a

--- a/hew-mir/tests/actor/supervisor_child_accessor.rs
+++ b/hew-mir/tests/actor/supervisor_child_accessor.rs
@@ -532,7 +532,7 @@ fn pool_child_field_and_get_lower_end_to_end() {
 
         supervisor Pool {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: 2)
+            pool workers: Worker count: 2
         }
 
         fn inspect(sup_pid: LocalPid<Pool>) -> i64 {

--- a/hew-mir/tests/actor/supervisor_lowering.rs
+++ b/hew-mir/tests/actor/supervisor_lowering.rs
@@ -461,7 +461,7 @@ fn pool_supervisor_emits_layout_with_pool_flag() {
 
         supervisor Pool {
             strategy: simple_one_for_one,
-            pool worker: Worker(count: 2)
+            pool worker: Worker count: 2
         }
         ",
     );

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -1511,6 +1511,15 @@ pub struct ChildSpec {
     /// brutal_kill | infinity`.  `None` means the supervisor default applies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shutdown: Option<ShutdownDirective>,
+    /// Pool arity, written as the per-child clause `count: <expr>` after the
+    /// init-arg parentheses (`pool ws: Worker(value: 7) count: 2;`). Arity
+    /// lives in the child's clause namespace, never in the parenthesised list,
+    /// so an actor that declares a field named `count` pools like any other.
+    /// Required on a `pool` child (`hew-types` reports
+    /// `E_SUPERVISOR_POOL_COUNT_MISSING` when it is absent) and refused by the
+    /// parser on a `child` declaration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub count: Option<Spanned<Expr>>,
     /// Byte span of the whole child declaration, from the `child`/`pool`
     /// keyword through the clause's terminating `;`/`,`. HIR lowering mints a
     /// real `SiteId` registered against this span so MIR diagnostics that have

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -1831,6 +1831,13 @@ impl<'a> Formatter<'a> {
             });
             self.write(")");
         }
+        // Pool arity is a clause, so it prints outside the parentheses. It
+        // comes first among the clauses because arity binds to the template the
+        // parentheses just described.
+        if let Some(count) = &spec.count {
+            self.write(" count: ");
+            self.format_expr(&count.0);
+        }
         if let Some(restart) = &spec.restart {
             self.write(" restart: ");
             match restart {

--- a/hew-parser/src/parser/actor_machine_supervisor.rs
+++ b/hew-parser/src/parser/actor_machine_supervisor.rs
@@ -1371,6 +1371,13 @@ impl Parser<'_> {
                         self.expect(&Token::RightParen)?;
                     }
 
+                    // Pool arity is a clause, not an init field, so a `count:`
+                    // entry in the parenthesised list is the actor's own field.
+                    // On a pool child with no arity clause it is instead the
+                    // retired arity spelling; the decision needs the clause
+                    // loop's result, so remember the position for now.
+                    let paren_count_pos = args.iter().position(|(name, _)| name == "count");
+
                     // A supervisor child accepts restart policy only through the
                     // `restart: <policy>` clause.
                     if matches!(
@@ -1401,7 +1408,9 @@ impl Parser<'_> {
                     //   restart: permanent | transient | temporary
                     //   shutdown: <duration> | brutal_kill | infinity
                     //   wired_to: { param: sibling, bare_sibling }
+                    //   count: <expr>            (pool children only)
                     let mut restart: Option<RestartPolicy> = None;
+                    let mut count: Option<Spanned<Expr>> = None;
                     let mut shutdown: Option<ShutdownDirective> = None;
                     let mut wired_to: Option<std::collections::HashMap<String, String>> = None;
                     loop {
@@ -1502,7 +1511,59 @@ impl Parser<'_> {
                                 self.expect(&Token::RightBrace)?;
                                 wired_to = if map.is_empty() { None } else { Some(map) };
                             }
+                            // `count: <expr>` clause — pool arity. Contextual,
+                            // like `shutdown` and `wired_to`, so `count` stays
+                            // an ordinary identifier everywhere else (including
+                            // as an actor field name inside the init-arg list).
+                            Some(Token::Identifier(s)) if *s == "count" => {
+                                self.advance();
+                                self.expect(&Token::Colon)?;
+                                let count_expr = self.parse_expr()?;
+                                if is_pool {
+                                    count = Some(count_expr);
+                                } else {
+                                    // A static child is one actor, so it has no
+                                    // arity to declare. Refuse rather than
+                                    // accept-and-ignore.
+                                    self.error_with_hint(
+                                        "`count:` is a pool clause; a `child` declaration \
+                                         has no arity"
+                                            .to_string(),
+                                        format!(
+                                            "write `pool {child_name}: {actor_type}(..) \
+                                             count: N;` to declare a pool, or drop `count:`"
+                                        ),
+                                    );
+                                }
+                            }
                             _ => break,
+                        }
+                    }
+
+                    // A pool child that carries `count:` in its parentheses and
+                    // no arity clause is written in the retired spelling. With
+                    // an arity clause present the parenthesised entry is
+                    // unambiguously the actor's own `count` field, which is
+                    // exactly the collision the clause form removes, so it is
+                    // left alone.
+                    if is_pool && count.is_none() {
+                        if let Some(pos) = paren_count_pos {
+                            let (_, count_expr) = args.remove(pos);
+                            self.error_at_with_hint(
+                                "pool arity is a child clause, not an init field: \
+                                 `count:` in the init-arg list is no longer the arity"
+                                    .to_string(),
+                                count_expr.1.clone(),
+                                format!(
+                                    "write `pool {child_name}: {actor_type}(..) count: N;` \
+                                     — the parenthesised list is the actor's own fields"
+                                ),
+                            );
+                            // Carry the expr into the clause slot regardless:
+                            // the refusal above already fails the compile, and a
+                            // well-formed child keeps the checker from stacking
+                            // a missing-arity cascade on top of it.
+                            count = Some(count_expr);
                         }
                     }
 
@@ -1517,6 +1578,7 @@ impl Parser<'_> {
                         wired_to,
                         is_pool,
                         shutdown,
+                        count,
                         span: child_start..self.last_token_end,
                     });
                 }

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -140,6 +140,118 @@ fn parse_supervisor_construction_time_config_params() {
     assert_eq!(sd.children[0].args[0].0, "capacity");
 }
 
+/// Pool arity is the per-child `count:` clause, parsed beside `restart:` and
+/// `shutdown:` and kept out of the parenthesised init-arg list.
+#[test]
+fn parse_pool_count_clause_lands_beside_the_init_args() {
+    let source = "supervisor Farm {\n\
+                      \x20   strategy: simple_one_for_one;\n\
+                      \x20   intensity: 3 within 60s;\n\
+                      \x20   pool workers: Worker(value: 7) count: 2 restart: transient;\n\
+                      }\n";
+    let result = parse(source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let Item::Supervisor(sd) = &result.program.items[0].0 else {
+        panic!("expected supervisor, got {:?}", result.program.items[0].0);
+    };
+    let child = &sd.children[0];
+    assert!(child.is_pool);
+    assert!(child.count.is_some(), "the arity clause parsed");
+    assert_eq!(
+        child.args.len(),
+        1,
+        "the parenthesised list holds only the actor's own fields"
+    );
+    assert_eq!(child.args[0].0, "value");
+    assert_eq!(child.restart, Some(RestartPolicy::Transient));
+}
+
+/// The clause namespace and the field namespace are separate, so an actor with
+/// a field named `count` pools with its field set like any other. This is the
+/// collision the clause form removes.
+#[test]
+fn parse_pool_child_sets_an_actor_field_named_count() {
+    let source = "supervisor Farm {\n\
+                      \x20   strategy: simple_one_for_one;\n\
+                      \x20   pool tickers: Ticker(count: 9) count: 2;\n\
+                      }\n";
+    let result = parse(source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let Item::Supervisor(sd) = &result.program.items[0].0 else {
+        panic!("expected supervisor");
+    };
+    let child = &sd.children[0];
+    assert_eq!(child.args.len(), 1, "the `count` field stays an init arg");
+    assert_eq!(child.args[0].0, "count");
+    assert!(child.count.is_some(), "arity comes from the clause");
+}
+
+/// `count:` in a pool child's parentheses with no arity clause is the retired
+/// spelling. It is refused with the new one rather than passed on as an init
+/// field that the checker would then blame on the actor.
+#[test]
+fn parse_pool_count_as_init_arg_is_refused_with_the_clause_spelling() {
+    let source = "supervisor Farm {\n\
+                      \x20   strategy: simple_one_for_one;\n\
+                      \x20   pool workers: Worker(count: 2, value: 7);\n\
+                      }\n";
+    let result = parse(source);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("pool arity is a child clause")
+                && e.hint
+                    .as_deref()
+                    .is_some_and(|h| h.contains("Worker(..) count: N"))),
+        "expected the migration fix-it, got: {:?}",
+        result.errors
+    );
+}
+
+/// A `child` declaration is one actor, so it has no arity to declare. The
+/// clause is refused there rather than accepted and ignored.
+#[test]
+fn parse_count_clause_on_a_static_child_is_refused() {
+    let source = "supervisor Farm {\n\
+                      \x20   strategy: one_for_one;\n\
+                      \x20   child worker: Worker(value: 7) count: 2;\n\
+                      }\n";
+    let result = parse(source);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("`count:` is a pool clause")),
+        "expected the non-pool refusal, got: {:?}",
+        result.errors
+    );
+    let Item::Supervisor(sd) = &result.program.items[0].0 else {
+        panic!("expected supervisor");
+    };
+    assert!(
+        sd.children[0].count.is_none(),
+        "a refused clause carries no arity downstream"
+    );
+}
+
+/// A static child's `count:` init arg is an ordinary field, untouched by the
+/// pool migration.
+#[test]
+fn parse_static_child_count_init_arg_stays_a_field() {
+    let source = "supervisor Farm {\n\
+                      \x20   strategy: one_for_one;\n\
+                      \x20   child ticker: Ticker(count: 9);\n\
+                      }\n";
+    let result = parse(source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let Item::Supervisor(sd) = &result.program.items[0].0 else {
+        panic!("expected supervisor");
+    };
+    assert_eq!(sd.children[0].args[0].0, "count");
+    assert!(sd.children[0].count.is_none());
+}
+
 /// A supervisor without a `(...)` clause has no params (back-compat).
 #[test]
 fn parse_supervisor_without_params_has_empty_param_list() {

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -2103,11 +2103,12 @@ fn fmt_supervisor_pool_keyword_roundtrip() {
 
 #[test]
 fn fmt_supervisor_static_pool_count_roundtrip() {
-    // The static-pool `count:` arg (A212) must round-trip exactly — it rides the
-    // same named-arg slot as per-member init args, so the formatter must not drop
-    // or reorder it (the C4/C5 B3 formatter-drops-new-syntax lesson).
+    // The static-pool `count:` clause must round-trip exactly, outside the
+    // init-arg parentheses and beside the other per-child clauses, so the
+    // formatter neither drops it nor folds it back into the parenthesised
+    // field list (the C4/C5 B3 formatter-drops-new-syntax lesson).
     exact_roundtrip(
-        "supervisor Pool {\n    strategy: simple_one_for_one;\n    intensity: 5 within 60s;\n\n    pool workers: Worker(count: 3, value: 7);\n}\n",
+        "supervisor Pool {\n    strategy: simple_one_for_one;\n    intensity: 5 within 60s;\n\n    pool workers: Worker(value: 7) count: 3;\n}\n",
     );
 }
 

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -329,7 +329,7 @@ struct InternalPoolSpec {
     max_members: usize,
     /// Static-child indices backing this pool's members, in member order.
     ///
-    /// A STATIC pool (`pool name: Type(count: N)`) registers its N members as
+    /// A STATIC pool (`pool name: Type count: N`) registers its N members as
     /// ordinary static children in `HewSupervisor.children[]` and records each
     /// member's static-child index here via
     /// [`hew_supervisor_pool_member_add_static`]. The accessor
@@ -10532,7 +10532,7 @@ pub unsafe extern "C" fn hew_supervisor_pool_member_add(
 /// Register a STATIC-backed pool member: a pool member whose actor lives in the
 /// supervisor's `children[]` table at `static_idx`.
 ///
-/// A static pool (`pool name: Type(count: N)`) spawns its N members as ordinary
+/// A static pool (`pool name: Type count: N`) spawns its N members as ordinary
 /// static children, then records each member's static-child index here (in
 /// member order). The accessor [`hew_supervisor_pool_child_get`] resolves member
 /// `i` through the LIVE static slot `children[static_idx]`, so a restarted member
@@ -10686,7 +10686,7 @@ pub unsafe extern "C" fn hew_supervisor_pool_child_get(
         return ChildLookupResult::dead(ChildSlotReason::UnknownSlot);
     }
 
-    // ── Static-backed pool path (`pool name: Type(count: N)`) ────────────────
+    // ── Static-backed pool path (`pool name: Type count: N`) ────────────────
     //
     // A static pool resolves member `i` through the LIVE static child slot, NOT
     // a cached PID. This is the restart re-resolution contract: the restart

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -241,14 +241,10 @@ impl Checker {
         // Pool children now route their per-member init args through the same
         // init-closure thunk path as static children (one shared template,
         // re-run per member), so their init-arg exprs are type-checked here too.
-        // The reserved `count:` arg designates the pool size — it is checked
-        // separately by `check_supervisor_pool_count`, not as a per-member init
-        // field — so it is excluded from the per-member synthesis here.
+        // Pool arity is not an init arg at all — it is the `count:` clause,
+        // synthesised by `check_supervisor_pool_count` below.
         for child in &sd.children {
-            for (arg_name, arg_expr) in &child.args {
-                if child.is_pool && arg_name == "count" {
-                    continue;
-                }
+            for (_arg_name, arg_expr) in &child.args {
                 self.synthesize(&arg_expr.0, &arg_expr.1);
             }
         }
@@ -257,18 +253,18 @@ impl Checker {
         // the config params are still in scope.
         self.check_supervisor_init_args_bitcopy(sd, span);
 
-        // Validate every pool child's reserved `count:` arg (presence, integer
-        // type, positive literal) while config params are still in scope so a
+        // Validate every pool child's `count:` clause (presence, integer type,
+        // positive literal) while config params are still in scope so a
         // `count: config.workers` expr resolves.
         self.check_supervisor_pool_count(sd, span);
 
         self.env.pop_scope();
     }
 
-    /// Validate the reserved `count:` arg on every `pool` child declaration.
+    /// Validate the `count:` clause on every `pool` child declaration.
     ///
-    /// A static pool (`pool workers: Worker(count: N)`) spawns exactly N
-    /// fungible members at bootstrap. The `count` arg is REQUIRED on a pool
+    /// A static pool (`pool workers: Worker(..) count: N`) spawns exactly N
+    /// fungible members at bootstrap. The clause is REQUIRED on a pool
     /// declaration, must type as an integer, and — when a compile-time integer
     /// literal — must be positive. A non-literal expr (`count: config.workers`)
     /// is accepted here (the type resolves through the config record layout),
@@ -285,9 +281,7 @@ impl Checker {
                 continue;
             }
 
-            let count_arg = child.args.iter().find(|(name, _)| name == "count");
-
-            let Some((_, count_expr)) = count_arg else {
+            let Some(count_expr) = child.count.as_ref() else {
                 // A pool declares a fixed-size fleet; without `count:` the size
                 // is undefined. Fail closed rather than defaulting to a silent 1.
                 self.errors.push(TypeError::new(
@@ -297,8 +291,8 @@ impl Checker {
                     span.clone(),
                     format!(
                         "E_SUPERVISOR_POOL_COUNT_MISSING: supervisor `{}` pool child `{}` is \
-                         missing the required `count:` argument; a static pool declares a \
-                         fixed-size fleet, e.g. `pool {}: {}(count: 5)`",
+                         missing the required `count:` clause; a static pool declares a \
+                         fixed-size fleet, e.g. `pool {}: {}(..) count: 5`",
                         sd.name, child.name, child.name, child.actor_type
                     ),
                 ));
@@ -437,13 +431,6 @@ impl Checker {
             };
 
             for (arg_name, _arg_expr) in &child.args {
-                // A pool child's reserved `count:` arg is the pool size, not a
-                // per-member init field — it is validated by
-                // `check_supervisor_pool_count`, not the reproducibility wall.
-                if child.is_pool && arg_name == "count" {
-                    continue;
-                }
-
                 // Find the matching init parameter by name.
                 let Some(param) = init_params.iter().find(|param| param.name == *arg_name) else {
                     // Missing-param errors are reported elsewhere (wired_to check

--- a/hew-types/src/check/tests/control_flow.rs
+++ b/hew-types/src/check/tests/control_flow.rs
@@ -255,7 +255,7 @@ mod supervisor_child_slot_tests {
 
             supervisor Pool {
                 strategy: simple_one_for_one,
-                pool worker: Worker(count: 2)
+                pool worker: Worker count: 2
             }
 
             fn main() {
@@ -293,7 +293,7 @@ mod supervisor_child_slot_tests {
 
             supervisor Pool {
                 strategy: simple_one_for_one,
-                pool workers: Worker(count: 2)
+                pool workers: Worker count: 2
             }
 
             fn inspect(sup: LocalPid<Pool>) {

--- a/hew-types/src/check/tests/supervisor.rs
+++ b/hew-types/src/check/tests/supervisor.rs
@@ -320,7 +320,7 @@ fn supervisor_pool_child_permanent_vec_ok() {
 
         supervisor App {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: 2)
+            pool workers: Worker count: 2
         }
         ",
     );
@@ -814,7 +814,7 @@ fn supervisor_pool_child_string_init_arg_exempt() {
 
         supervisor App {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: 2)
+            pool workers: Worker count: 2
         }
         ",
     );
@@ -859,7 +859,7 @@ fn supervisor_pool_count_zero_literal_is_rejected() {
 
         supervisor App {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: 0)
+            pool workers: Worker count: 0
         }
         ",
     );
@@ -881,7 +881,7 @@ fn supervisor_pool_count_negative_literal_is_rejected() {
 
         supervisor App {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: -3)
+            pool workers: Worker count: -3
         }
         ",
     );
@@ -903,7 +903,7 @@ fn supervisor_pool_count_positive_literal_is_accepted() {
 
         supervisor App {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: 5)
+            pool workers: Worker count: 5
         }
         ",
     );
@@ -925,7 +925,7 @@ fn supervisor_pool_count_string_literal_is_rejected() {
 
         supervisor App {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: "five")
+            pool workers: Worker count: "five"
         }
         "#,
     );
@@ -953,7 +953,7 @@ fn supervisor_pool_count_dynamic_config_is_accepted() {
 
         supervisor App(config: AppConfig) {
             strategy: simple_one_for_one,
-            pool workers: Worker(count: config.workers)
+            pool workers: Worker count: config.workers
         }
         ",
     );

--- a/hew-types/tests/registry_core/supervisor_check.rs
+++ b/hew-types/tests/registry_core/supervisor_check.rs
@@ -53,7 +53,7 @@ fn simple_one_for_one_with_pool_accepted() {
             strategy: simple_one_for_one
             intensity: 10 within 60s
 
-            pool worker: Worker(count: 3)
+            pool worker: Worker count: 3
         }
 
         fn main() {}
@@ -122,7 +122,7 @@ fn await_restart_on_pool_member_rejected() {
             strategy: simple_one_for_one
             intensity: 10 within 60s
 
-            pool worker: Worker(count: 3)
+            pool worker: Worker count: 3
         }
 
         fn main() {
@@ -276,7 +276,7 @@ fn simple_one_for_one_with_child_decl_rejected() {
             strategy: simple_one_for_one
 
             child helper: Helper
-            pool worker: Worker(count: 3)
+            pool worker: Worker count: 3
         }
 
         fn main() {}
@@ -304,7 +304,7 @@ fn one_for_one_with_pool_decl_rejected() {
         supervisor StaticApp {
             strategy: one_for_one
 
-            pool worker: Worker(count: 3)
+            pool worker: Worker count: 3
         }
 
         fn main() {}

--- a/tests/vertical-slice/accept/imported_generics_resolve/lib.hew
+++ b/tests/vertical-slice/accept/imported_generics_resolve/lib.hew
@@ -38,7 +38,7 @@ supervisor Pool {
     strategy: simple_one_for_one;
     intensity: 5 within 60s;
 
-    pool workers: Echo(count: 2, n: 7);
+    pool workers: Echo(n: 7) count: 2;
 }
 
 pub fn entry() -> i64 {

--- a/tests/vertical-slice/accept/supervisor_childref_value_flow_states.hew
+++ b/tests/vertical-slice/accept/supervisor_childref_value_flow_states.hew
@@ -58,7 +58,7 @@ supervisor StaticPool {
     strategy: simple_one_for_one;
     intensity: 2 within 60s;
 
-    pool workers: Worker(count: 1, value: 7);
+    pool workers: Worker(value: 7) count: 1;
 }
 
 type Holder {

--- a/tests/vertical-slice/accept/supervisor_pool_count_clause.hew
+++ b/tests/vertical-slice/accept/supervisor_pool_count_clause.hew
@@ -30,25 +30,25 @@ fn main() -> i64 {
     var total = tickers.len();
 
     match await tickers[0].ticks() {
-        Ok(value) => {
+        .Ok(value) => {
             if value != 9 {
                 return 1;
             }
             total = total + value;
         },
-        Err(_) => {
+        .Err(_) => {
             return 2;
         },
     }
 
     match await tickers[1].ticks() {
-        Ok(value) => {
+        .Ok(value) => {
             if value != 9 {
                 return 3;
             }
             total = total + value;
         },
-        Err(_) => {
+        .Err(_) => {
             return 4;
         },
     }

--- a/tests/vertical-slice/accept/supervisor_pool_count_clause.hew
+++ b/tests/vertical-slice/accept/supervisor_pool_count_clause.hew
@@ -1,0 +1,57 @@
+// Pool arity is a per-child clause, not an init field (#3253).
+//
+// `pool tickers: Ticker(count: 9) count: 2;` sets the actor's OWN field named
+// `count` to 9 through the parenthesised list and declares an arity of 2
+// through the clause. The two namespaces are separate, so an actor with a
+// field named `count` pools like any other — under the retired spelling this
+// program could not be written at all.
+//
+// Exit 20 = len(2) + two members × count(9). A dropped clause would change the
+// length, and a clause read as the field would make each member report 2.
+
+actor Ticker {
+    var count: i64;
+
+    receive fn ticks() -> i64 {
+        count
+    }
+}
+
+supervisor Farm {
+    strategy: simple_one_for_one;
+    intensity: 3 within 60s;
+
+    pool tickers: Ticker(count: 9) count: 2;
+}
+
+fn main() -> i64 {
+    let sup = spawn Farm;
+    let tickers = sup.tickers;
+    var total = tickers.len();
+
+    match await tickers[0].ticks() {
+        Ok(value) => {
+            if value != 9 {
+                return 1;
+            }
+            total = total + value;
+        },
+        Err(_) => {
+            return 2;
+        },
+    }
+
+    match await tickers[1].ticks() {
+        Ok(value) => {
+            if value != 9 {
+                return 3;
+            }
+            total = total + value;
+        },
+        Err(_) => {
+            return 4;
+        },
+    }
+
+    total
+}

--- a/tests/vertical-slice/accept/supervisor_pool_field_access.hew
+++ b/tests/vertical-slice/accept/supervisor_pool_field_access.hew
@@ -10,7 +10,7 @@ supervisor Pool {
     strategy: simple_one_for_one;
     intensity: 5 within 60s;
 
-    pool workers: Worker(count: 3, value: 7);
+    pool workers: Worker(value: 7) count: 3;
 }
 
 fn main() -> i64 {

--- a/tests/vertical-slice/accept/supervisor_pool_get_option.hew
+++ b/tests/vertical-slice/accept/supervisor_pool_get_option.hew
@@ -10,7 +10,7 @@ supervisor Pool {
     strategy: simple_one_for_one;
     intensity: 5 within 60s;
 
-    pool workers: Worker(count: 2, value: 7);
+    pool workers: Worker(value: 7) count: 2;
 }
 
 fn main() -> i64 {

--- a/tests/vertical-slice/accept/supervisor_static_pool.hew
+++ b/tests/vertical-slice/accept/supervisor_static_pool.hew
@@ -1,6 +1,6 @@
 // v0.6 static supervisor pool — the Vec-like accessor (A209/A212).
 //
-// `pool workers: Worker(count: 3)` declares a `simple_one_for_one` pool of 3
+// `pool workers: Worker count: 3` declares a `simple_one_for_one` pool of 3
 // fungible members. The bootstrap spawns all 3 into the pool slot and the
 // Vec-like accessor reaches them:
 //   - `sup.workers.len()` → 3 (the fixed static-member count).
@@ -26,7 +26,7 @@ supervisor Pool {
     strategy: simple_one_for_one;
     intensity: 5 within 60s;
 
-    pool workers: Worker(count: 3, value: 7);
+    pool workers: Worker(value: 7) count: 3;
 }
 
 fn main() -> i64 {

--- a/tests/vertical-slice/accept/supervisor_static_pool_huge_index_traps.hew
+++ b/tests/vertical-slice/accept/supervisor_static_pool_huge_index_traps.hew
@@ -21,7 +21,7 @@ supervisor Pool {
     strategy: simple_one_for_one;
     intensity: 5 within 60s;
 
-    pool workers: Worker(count: 3, value: 42);
+    pool workers: Worker(value: 42) count: 3;
 }
 
 fn main() -> i64 {

--- a/tests/vertical-slice/accept/supervisor_static_pool_restart.hew
+++ b/tests/vertical-slice/accept/supervisor_static_pool_restart.hew
@@ -31,7 +31,7 @@ supervisor Pool {
     strategy: simple_one_for_one;
     intensity: 5 within 60s;
 
-    pool workers: Worker(count: 2, value: 7);
+    pool workers: Worker(value: 7) count: 2;
 }
 
 extern "C" {

--- a/tests/vertical-slice/reject/supervisor_count_clause_on_static_child.hew
+++ b/tests/vertical-slice/reject/supervisor_count_clause_on_static_child.hew
@@ -1,0 +1,25 @@
+// `count:` is a pool clause. A `child` declaration is one actor, so it has no
+// arity to declare and the clause is refused rather than ignored (#3253).
+
+actor Worker {
+    var value: i64;
+
+    receive fn id() -> i64 {
+        value
+    }
+}
+
+supervisor Farm {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+
+    child worker: Worker(value: 7) count: 2;
+}
+
+fn main() -> i64 {
+    let sup = spawn Farm;
+    match await sup.worker.id() {
+        Ok(value) => value,
+        Err(_) => 1,
+    }
+}

--- a/tests/vertical-slice/reject/supervisor_pool_count_clause_missing.hew
+++ b/tests/vertical-slice/reject/supervisor_pool_count_clause_missing.hew
@@ -1,0 +1,23 @@
+// A pool declares a fixed-size fleet, so the arity clause is required. Without
+// it the size is undefined, and the checker fails closed rather than guessing
+// a default (#3253, E_SUPERVISOR_POOL_COUNT_MISSING).
+
+actor Worker {
+    var value: i64;
+
+    receive fn id() -> i64 {
+        value
+    }
+}
+
+supervisor Farm {
+    strategy: simple_one_for_one;
+    intensity: 3 within 60s;
+
+    pool workers: Worker(value: 7);
+}
+
+fn main() -> i64 {
+    let sup = spawn Farm;
+    sup.workers.len()
+}

--- a/tests/vertical-slice/reject/supervisor_pool_count_init_arg.hew
+++ b/tests/vertical-slice/reject/supervisor_pool_count_init_arg.hew
@@ -1,0 +1,24 @@
+// The retired pool-arity spelling: `count:` inside the init-arg parentheses
+// on a pool child with no arity clause (#3253). The refusal names the clause
+// form rather than passing `count` on as an init field, which would surface as
+// a diagnostic about the actor's own fields.
+
+actor Worker {
+    var value: i64;
+
+    receive fn id() -> i64 {
+        value
+    }
+}
+
+supervisor Farm {
+    strategy: simple_one_for_one;
+    intensity: 3 within 60s;
+
+    pool workers: Worker(count: 2, value: 7);
+}
+
+fn main() -> i64 {
+    let sup = spawn Farm;
+    sup.workers.len()
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1935,7 +1935,7 @@ run_accept_expect_status "supervisor_owned_child_init_restart" 10
 # `leaks --atExit` on macOS.
 run_accept_expect_status "supervisor_literal_only_config_param" 0
 
-# v0.6 static supervisor pool (A209/A212): `pool workers: Worker(count: 3)`
+# v0.6 static supervisor pool (A209/A212): `pool workers: Worker count: 3`
 # spawns 3 fungible members into pool_slots[] at bootstrap and the Vec-like
 # accessor reaches them — `sup.workers.len()` is 3 and `sup.workers[i]` round-
 # trips to each Live member. Exit 24 = len(3) + three members × id(7); a wrong
@@ -1946,6 +1946,36 @@ run_accept_expect_status "supervisor_static_pool" 24
 # Safe pool lookup: in-range members produce Some live handles with exact
 # payload values, while the negative and end boundary indices produce None.
 run_accept_expect_stdout "supervisor_pool_get_option"
+
+# Pool arity is a child clause, not an init field (#3253). The pooled actor
+# declares its own field named `count`, set through the parenthesised list,
+# while the clause declares the arity. Exit 20 = len(2) + two members ×
+# count(9); a dropped clause changes the length and a clause read as the field
+# makes each member report 2.
+run_accept_expect_status "supervisor_pool_count_clause" 20
+
+# The retired spelling fails closed with the clause form as its fix-it, instead
+# of passing `count` on as an init field the checker then blames on the actor.
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/supervisor_pool_count_init_arg.hew" \
+    "pool arity is a child clause" \
+    "supervisor_pool_count_init_arg"
+echo "PASS supervisor_pool_count_init_arg (reject)"
+
+# The clause is refused on a static child: one actor has no arity.
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/supervisor_count_clause_on_static_child.hew" \
+    "\`count:\` is a pool clause" \
+    "supervisor_count_clause_on_static_child"
+echo "PASS supervisor_count_clause_on_static_child (reject)"
+
+# A pool without the clause has no declared size, so the checker fails closed
+# rather than guessing one.
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/supervisor_pool_count_clause_missing.hew" \
+    "E_SUPERVISOR_POOL_COUNT_MISSING" \
+    "supervisor_pool_count_clause_missing"
+echo "PASS supervisor_pool_count_clause_missing (reject)"
 
 # Whole-field pool access: bind `let workers = sup.workers`, then route len,
 # trapping index, and safe get through the first-class pool view.

--- a/tools/downstream/generate-tmgrammar.mjs
+++ b/tools/downstream/generate-tmgrammar.mjs
@@ -163,9 +163,18 @@ const typeGroups = {
 // entries as "only valid inside an attribute" so this becomes data-driven.
 const ATTRIBUTE_ONLY_CONTEXTUAL = ['resource', 'linear', 'opaque', 'wire'];
 
+// Contextual identifiers common enough as ordinary names that a broad
+// word-boundary match does more harm than the highlight is worth. `count` is
+// the supervisor pool-arity clause, and also a routine field name and the
+// `.count()` method, so a fallback match paints most of its real uses.
+// Same exclusion reason as ATTRIBUTE_ONLY_CONTEXTUAL, different cause: these
+// need the clause position, not an attribute, to be a keyword at all.
+const BROAD_MATCH_UNSAFE_CONTEXTUAL = ['count'];
+
 const contextualNames = Object.keys(syntaxData.contextual_identifiers)
   .filter(name => name !== 'self' && name !== 'description'
-    && !ATTRIBUTE_ONLY_CONTEXTUAL.includes(name));
+    && !ATTRIBUTE_ONLY_CONTEXTUAL.includes(name)
+    && !BROAD_MATCH_UNSAFE_CONTEXTUAL.includes(name));
 
 const contextualGroup = {
   'variable.language.contextual.hew': contextualNames,

--- a/tools/downstream/patch-vim-syntax.mjs
+++ b/tools/downstream/patch-vim-syntax.mjs
@@ -81,11 +81,18 @@ const overflowKinds = Object.entries(contextual)
     name !== 'overflow' && typeof desc === 'string' && /overflow/i.test(desc))
   .map(([name]) => name);
 
+// Contextual identifiers common enough as ordinary names that a keyword match
+// does more harm than the highlight is worth. `count` is the supervisor
+// pool-arity clause, and also a routine field name and the `.count()` method,
+// so highlighting it paints most of its real uses.
+const BROAD_MATCH_UNSAFE_CONTEXTUAL = ['count'];
+
 // Remaining contextual identifiers: soft keywords that are not reserved and
 // not overflow values (within, intensity, initial, repeated, infinity, ...).
 const contextualKeywords = Object.keys(contextual)
   .filter(name => name !== 'description' && name !== 'self'
-    && !overflowKinds.includes(name));
+    && !overflowKinds.includes(name)
+    && !BROAD_MATCH_UNSAFE_CONTEXTUAL.includes(name));
 
 // -- Category → { group, keywords[] } mapping -----------------------------
 // Each category produces one or more `syn keyword <group> <words...>` lines.


### PR DESCRIPTION
## Why

Pool arity was spelled as a named init arg, so `pool ws: Worker(count: 2, value: 7)`
put the arity in the same parenthesised list as the actor's own fields. The two
namespaces collided: an actor declaring a field named `count` could not be pooled,
and the diagnostic blamed the user's field. The clause form the spec makes
normative in §5.1 was refused outright with `unknown supervisor field`.

## What

- **parser**: `count:` is a per-child clause parsed in the suffix-clause loop beside
  `restart:`, `shutdown:`, and `wired_to:`, into the new `ChildSpec.count`. It is
  refused on a `child` declaration, since one actor has no arity. A pool child that
  carries `count:` in its parentheses and no arity clause is written in the retired
  spelling and fails closed with the clause form as its fix-it; with the clause
  present the parenthesised entry is the actor's own field and is left alone, which
  is the case the change exists to allow.
- **fmt**: the clause round-trips outside the parentheses, and `count` is no longer
  emitted from the init-arg list.
- **types**: `check_supervisor_pool_count` reads `child.count`. The presence check
  stays here rather than moving to the parser so pool-arity validation - presence,
  integer type, positive literal - has one authority, and
  `E_SUPERVISOR_POOL_COUNT_MISSING` keeps its wording and its span with the example
  updated to the clause form.
- **hir**: `pool_count` comes from `child.count`, and `init_args` carries the
  parenthesised list whole. No `HIR`, `MIR`, or codegen shape changed, so neither
  lowering nor emission needed edits.
- **docs**: the §5.1 implementation-status note and the matching note in
  `docs/language/supervision.hew` are gone; `count` joins `shutdown` and `wired_to`
  in `docs/syntax-data.json`'s contextual-identifier list.
- **downstream**: the TextMate and Vim generators exclude `count` from the broad
  contextual-keyword match, the way the attribute-only contextuals are excluded.
  `count` is a keyword only in the clause position, and a routine field name and
  `.count()` method everywhere else, so a word-boundary match paints most of its
  real uses. Re-running `generate-tmgrammar.mjs` reports the grammar already in
  sync, so no checked-in editor grammar changes. Nothing in `hew-lsp` or
  `hew-analysis` enumerates the per-child clauses (`wired_to` and `shutdown` appear
  in neither), so there was no completion or grammar list to extend.
- **sources**: every `std`, `examples`, and `tests` source using the retired
  spelling moves to the clause form. No code path reads arity by scanning
  `child.args` for the string `"count"` any more.

Nothing was added to `docs/diagnostics/README.md`: the two new refusals are parser
diagnostics with no code, matching their `restart:` and `shutdown:` siblings, and
`E_SUPERVISOR_POOL_COUNT_MISSING` is a pre-existing code that the README's tables
never listed. No `grammar-parity` make target exists, so that check was skipped.

## Test

- `tests/vertical-slice/accept/supervisor_pool_count_clause.hew` pools an actor with
  a field literally named `count`, setting the field to 9 through the parentheses and
  the arity to 2 through the clause. Exit 20 = len(2) + two members × count(9): a
  dropped clause changes the length, a clause read as the field makes each member
  report 2, and the program is unwritable under the retired spelling.
- `tests/vertical-slice/reject/supervisor_pool_count_init_arg.hew`,
  `supervisor_count_clause_on_static_child.hew`, and
  `supervisor_pool_count_clause_missing.hew` pin the migration fix-it, the non-pool
  refusal, and the still-required arity under its own diagnostic.
- `hew-parser` unit tests: `parse_pool_count_clause_lands_beside_the_init_args`,
  `parse_pool_child_sets_an_actor_field_named_count`,
  `parse_pool_count_as_init_arg_is_refused_with_the_clause_spelling`,
  `parse_count_clause_on_a_static_child_is_refused`, and
  `parse_static_child_count_init_arg_stays_a_field` as the negative control that the
  migration does not reach a static child's ordinary field.
- `fmt_supervisor_static_pool_count_roundtrip` now round-trips the clause form, and
  `pool_count_clause_lowers_into_pool_count` covers the HIR split.

Fixes #3253

