### PR TITLE
fix(types): name the gen fn return-type handle mis-spelling

### DIFF
--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -51,14 +51,15 @@ same change that lands the mechanism.
 These refuse a program the language does not accept, so no release removes
 them.
 
-| Code                                           | Refuses                                                                                                                     |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `E_RANGE_VALUE`                                | A range in value position. Ranges are `for` iterables, by design.                                                           |
-| `E_DYN_SUPERTRAIT`                             | A supertrait method reached through a trait object in a shape the checker cannot resolve (HEW-SPEC-2026 §2.2.1).            |
-| `E_BARE_VARIANT_PATTERN`                       | A bare variant in pattern position (`Ok(v)`). Write `.Ok(v)` when the scrutinee selects the enum, `Result.Ok(v)` otherwise. |
-| `E_BARE_VARIANT_EXPR`                          | A bare variant in expression position, under the same rule.                                                                 |
-| `E_VISIBILITY_PRIVATE`, `E_VISIBILITY_PACKAGE` | A cross-module reference to a private or package item.                                                                      |
-| `E_MODULE_NOT_FOUND`                           | An `import` no search path resolves.                                                                                        |
+| Code                                           | Refuses                                                                                                                       |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `E_RANGE_VALUE`                                | A range in value position. Ranges are `for` iterables, by design.                                                             |
+| `E_DYN_SUPERTRAIT`                             | A supertrait method reached through a trait object in a shape the checker cannot resolve (HEW-SPEC-2026 §2.2.1).              |
+| `E_BARE_VARIANT_PATTERN`                       | A bare variant in pattern position (`Ok(v)`). Write `.Ok(v)` when the scrutinee selects the enum, `Result.Ok(v)` otherwise.   |
+| `E_BARE_VARIANT_EXPR`                          | A bare variant in expression position, under the same rule.                                                                   |
+| `E_VISIBILITY_PRIVATE`, `E_VISIBILITY_PACKAGE` | A cross-module reference to a private or package item.                                                                        |
+| `E_MODULE_NOT_FOUND`                           | An `import` no search path resolves.                                                                                          |
+| `E_GEN_RETURN_SPELLING`                        | A `gen fn` return type spelling the generator handle (`Generator<Y, R>`) instead of the yield type `Y` (HEW-SPEC-2026 §4.12). |
 
 The remaining v0.6.0 surface codes are named by the decision that introduces
 them, and their rule lives in the spec section that decision writes — not
@@ -66,7 +67,7 @@ here. Each row is added by the lane that lands the refusal:
 `E_IS_VALUE_TYPE`, `E_OPAQUE_MESSAGE_PAYLOAD`, `E_CALLABLE_MESSAGE_PAYLOAD`,
 `E_USE_AFTER_SEND`, `E_UNKNOWN_ATTRIBUTE`, `E_RESERVED_HANDLER_NAME`,
 `E_ACTOR_CONTEXT_REQUIRED`, `E_BREAK_VALUE`, `E_SCOPE_IS_STATEMENT`,
-`E_GEN_RETURN_SPELLING`, `E_NO_ASYNC_FN`, `E_NO_ASYNC_GEN`,
+`E_NO_ASYNC_FN`, `E_NO_ASYNC_GEN`,
 `E_FOR_STREAM_NEEDS_AWAIT`, `E_AWAIT_NOT_STREAM`.
 
 ## Refusals with no code yet

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -72,6 +72,83 @@ impl Checker {
         }
     }
 
+    /// Reject a `gen fn` return-type annotation that spells the generator
+    /// handle (`Generator<Y, R>`) instead of the yield type `Y`
+    /// (HEW-SPEC-2026 §4.12). `gen fn f() -> Y` names the type of each
+    /// `yield` operand; the compiler synthesizes the `Generator<Y, R>`
+    /// handle wrapper itself, so a source annotation that spells the handle
+    /// double-wraps it and every `yield` in the body then fails to unify
+    /// against the (wrong) expected type — surfacing as a confusing type
+    /// mismatch pointed at the first `yield` instead of the actual mistake
+    /// at the annotation. This diagnostic fires at the annotation's span and
+    /// recovers using the intended `Y`, so the body still checks sensibly.
+    pub(super) fn report_gen_return_spelling(&mut self, declared: &Ty, yields: &Ty, span: &Span) {
+        self.errors.push(TypeError {
+            severity: crate::error::Severity::Error,
+            kind: TypeErrorKind::GenReturnSpelling,
+            span: span.clone(),
+            message: format!(
+                "E_GEN_RETURN_SPELLING: `gen fn` return type names the yield type, not the generator handle it produces; write `-> {yields}` instead of the `Generator<Y, R>` handle spelling"
+            ),
+            notes: Vec::new(),
+            suggestions: vec![format!("replace `{declared}` with `{yields}`")],
+            source_module: self.current_module.clone(),
+        });
+    }
+
+    /// If `declared` (the raw, unwrapped return-type annotation of a `gen
+    /// fn`) already spells `Generator<Y, R>`, report
+    /// [`Self::report_gen_return_spelling`] (once per span — a function's
+    /// signature is rebuilt by more than one registration pass, e.g. its own
+    /// module's registration and an importer's, and both visit the same
+    /// annotation) and return the recovered yield type `Y` in its place;
+    /// otherwise return `declared` unchanged. Callers use the recovered type
+    /// to continue building the function signature on every call, so the
+    /// mis-spelling produces exactly one diagnostic but a correct signature
+    /// on every registration pass.
+    fn recover_gen_return_spelling(
+        &mut self,
+        is_generator: bool,
+        declared: Ty,
+        span: Option<&Span>,
+    ) -> Ty {
+        if !is_generator {
+            return declared;
+        }
+        let Some((yields, _returns)) = declared.as_generator() else {
+            return declared;
+        };
+        let yields = yields.clone();
+        if let Some(span) = span {
+            let span_key = SpanKey::in_module(span, self.current_module_idx);
+            if self.reported_gen_return_spellings.insert(span_key) {
+                self.report_gen_return_spelling(&declared, &yields, span);
+            }
+        }
+        yields
+    }
+
+    /// A function declaration's final return type: `E_GEN_RETURN_SPELLING`
+    /// recovery (see [`Self::recover_gen_return_spelling`]) followed by the
+    /// generator/async-generator wrap (`Generator<Y, R>` / `AsyncGenerator<Y>`).
+    /// `span` is the return-type annotation's span, if any.
+    pub(super) fn wrap_fn_return_type(
+        &mut self,
+        fd: &FnDecl,
+        declared_return: Ty,
+        span: Option<&Span>,
+    ) -> Ty {
+        let declared_return =
+            self.recover_gen_return_spelling(fd.is_generator, declared_return, span);
+        if fd.is_generator && fd.is_async {
+            Ty::async_generator(declared_return)
+        } else if fd.is_generator {
+            Ty::generator(declared_return, Ty::Unit)
+        } else {
+            declared_return
+        }
+    }
+
     /// Emit warnings for functions that are never called (dead code).
     /// Uses BFS reachability from entry points: main, actor handlers, and
     /// underscore-prefixed functions.

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -7412,14 +7412,9 @@ impl Checker {
         if pushed_bounds {
             self.current_type_param_bounds.pop();
         }
-        // Wrap return type for generator functions
-        let return_type = if fd.is_generator && fd.is_async {
-            Ty::async_generator(declared_return)
-        } else if fd.is_generator {
-            Ty::generator(declared_return, Ty::Unit)
-        } else {
-            declared_return
-        };
+        // E_GEN_RETURN_SPELLING recovery + generator/async-generator wrap.
+        let return_type =
+            self.wrap_fn_return_type(fd, declared_return, fd.return_type.as_ref().map(|(_, s)| s));
 
         let fn_assoc_bindings = fn_scope.assoc_bindings;
         let sig = FnSig {
@@ -13417,13 +13412,9 @@ impl Checker {
         let type_params = fd.type_params.as_ref().map_or(vec![], |params| {
             params.iter().map(|p| p.name.clone()).collect()
         });
-        let return_type = if fd.is_generator && fd.is_async {
-            Ty::async_generator(declared_return)
-        } else if fd.is_generator {
-            Ty::generator(declared_return, Ty::Unit)
-        } else {
-            declared_return
-        };
+        // E_GEN_RETURN_SPELLING recovery + generator/async-generator wrap.
+        let return_type =
+            self.wrap_fn_return_type(fd, declared_return, fd.return_type.as_ref().map(|(_, s)| s));
         let assoc_bindings = scope.assoc_bindings;
         let sig = FnSig {
             type_params,

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -3194,6 +3194,12 @@ pub struct Checker {
     pub(super) reported_undefined_named_types: HashSet<(String, SpanKey)>,
     /// Borrow-type spans already rejected during ordinary annotation resolution.
     pub(super) reported_borrow_types_outside_extern: HashSet<SpanKey>,
+    /// `gen fn` return-type spans already rejected as
+    /// `E_GEN_RETURN_SPELLING`, so the mis-spelling is reported exactly once
+    /// even though a function's signature is rebuilt by more than one
+    /// registration pass (own-module registration and import registration
+    /// both visit the same return-type annotation).
+    pub(super) reported_gen_return_spellings: HashSet<SpanKey>,
     /// `false` until `collect_types` has registered every type declaration.
     /// The undefined-named-type guard in `resolve_type_expr_tracking_holes`
     /// only fires once this is `true`: type-declaration member resolution runs
@@ -3930,6 +3936,7 @@ impl Checker {
             reported_type_visibility_violations: HashSet::new(),
             reported_undefined_named_types: HashSet::new(),
             reported_borrow_types_outside_extern: HashSet::new(),
+            reported_gen_return_spellings: HashSet::new(),
             type_decls_registered: false,
             suppress_undefined_type_report: false,
             declared_type_param_names: HashSet::new(),

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -806,6 +806,11 @@ pub enum TypeErrorKind {
     UseAfterConsume,
     /// Yield used outside a generator function
     YieldOutsideGenerator,
+    /// A `gen fn` return-type annotation spells the generator handle
+    /// (`Generator<Y, R>`) instead of the yield type `Y` (HEW-SPEC-2026
+    /// §4.12). The compiler synthesizes the handle wrapper itself; naming it
+    /// in the annotation says the body yields handles, not `Y` values.
+    GenReturnSpelling,
     /// Actor types form a reference cycle via `LocalPid` fields
     ActorRefCycle,
     /// A value-typed enum/record/struct contains itself by value, directly or
@@ -1506,6 +1511,7 @@ impl TypeErrorKind {
             Self::UseAfterMove => "UseAfterMove",
             Self::UseAfterConsume => "UseAfterConsume",
             Self::YieldOutsideGenerator => "YieldOutsideGenerator",
+            Self::GenReturnSpelling => "E_GEN_RETURN_SPELLING",
             Self::ActorRefCycle => "ActorRefCycle",
             Self::RecursiveValueType { .. } => "RecursiveValueType",
             Self::UnusedVariable => "UnusedVariable",

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -1499,6 +1499,67 @@ fn for_await_receive_generator_int_stream_typechecks() {
     );
 }
 
+/// A `gen fn` return type that spells the generator handle
+/// `Generator<Y, R>` instead of the yield type `Y` is `E_GEN_RETURN_SPELLING`
+/// (HEW-SPEC-2026 §4.12), not a fallthrough type mismatch on the first
+/// `yield`. #3265.
+#[test]
+fn gen_fn_return_type_spelling_generator_handle_rejected() {
+    let output = typecheck_inline(
+        r"
+        gen fn counter() -> Generator<i64, ()> {
+            yield 1;
+        }
+
+        fn main() {
+            let _g = counter();
+        }
+        ",
+    );
+    // Pinned at exactly 1: the checker recovers using the intended yield
+    // type, so no downstream `yield` mismatch cascades alongside the new
+    // diagnostic.
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "expected exactly one error (no mismatch cascade), got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == hew_types::error::TypeErrorKind::GenReturnSpelling
+                && e.message.contains("E_GEN_RETURN_SPELLING")
+        }),
+        "expected E_GEN_RETURN_SPELLING for a gen fn spelling its own Generator<Y, R> handle, got: {:#?}",
+        output.errors
+    );
+}
+
+/// Negative control: naming the yield type directly (the accepted spelling)
+/// must not trip `E_GEN_RETURN_SPELLING`.
+#[test]
+fn gen_fn_return_type_spelling_yield_type_accepted() {
+    let output = typecheck_inline(
+        r"
+        gen fn counter() -> i64 {
+            yield 1;
+        }
+
+        fn main() {
+            let _g = counter();
+        }
+        ",
+    );
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.kind == hew_types::error::TypeErrorKind::GenReturnSpelling),
+        "expected no E_GEN_RETURN_SPELLING for the accepted `-> Y` spelling, got: {:#?}",
+        output.errors
+    );
+}
+
 /// Actor method calls in `for await` must target `receive gen fn`, even if the
 /// method's return type is `Stream<T>`.
 #[test]

--- a/tests/vertical-slice/accept/gen_fn_return_type_yield_spelling.hew
+++ b/tests/vertical-slice/accept/gen_fn_return_type_yield_spelling.hew
@@ -1,0 +1,11 @@
+// Accept fixture: negative control for E_GEN_RETURN_SPELLING. A `gen fn`
+// return type naming the yield type `Y` directly (not the `Generator<Y, R>`
+// handle) is the accepted spelling (HEW-SPEC-2026 §4.12) and must type-check
+// cleanly.
+gen fn counter() -> i64 {
+    yield 1;
+}
+
+fn main() {
+    let _g = counter();
+}

--- a/tests/vertical-slice/reject/gen_fn_return_type_spells_handle.hew
+++ b/tests/vertical-slice/reject/gen_fn_return_type_spells_handle.hew
@@ -1,0 +1,12 @@
+// Reject fixture: a `gen fn` return type that spells the generator handle
+// `Generator<Y, R>` instead of the yield type `Y` — HEW-SPEC-2026 §4.12.
+// `-> Y` is the accepted spelling; the compiler synthesizes the handle
+// wrapper itself, so naming it explicitly is E_GEN_RETURN_SPELLING, not a
+// generic type mismatch on the first `yield`.
+gen fn counter() -> Generator<i64, ()> {
+    yield 1;
+}
+
+fn main() {
+    let _g = counter();
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3416,6 +3416,26 @@ if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/yield_outside_gen.hew" >"
 fi
 grep -q 'outside of generator' "${reject_output}"
 
+# Reject: a `gen fn` return type that spells the generator handle
+# `Generator<Y, R>` instead of the yield type `Y` (HEW-SPEC-2026 §4.12).
+# #3265 — this used to fall through to a generic type mismatch on the first
+# `yield`; it must now surface as a dedicated, annotation-sited diagnostic.
+# Error count pinned at exactly 1: the recovered `Y` must let the body check
+# cleanly, so no downstream `yield` mismatch cascades alongside the new code.
+expect_check_fail_error_count \
+    "${ROOT}/tests/vertical-slice/reject/gen_fn_return_type_spells_handle.hew" \
+    1 \
+    "gen_fn_return_type_spells_handle"
+grep -q 'E_GEN_RETURN_SPELLING' "${reject_output}"
+
+# Accept: negative control — naming the yield type directly is the accepted
+# spelling and must not trip E_GEN_RETURN_SPELLING.
+if ! "${HEW}" check "${ROOT}/tests/vertical-slice/accept/gen_fn_return_type_yield_spelling.hew" >"${reject_output}" 2>&1; then
+    echo "expected gen-fn-return-type-yield-spelling fixture to pass; got:" >&2
+    cat "${reject_output}" >&2
+    exit 1
+fi
+
 # Accept + run: generator bodies that read FREE VARIABLES — a `gen fn`'s formal
 # parameter and a `gen { }` block's captured outer locals. Both travel through
 # the runtime env channel (`hew_gen_ctx_create` deep-copies the env into the


### PR DESCRIPTION
**Why**

A `gen fn` whose declared return type spells the generator handle (`Generator<Y, R>`) instead of the yield type `Y` fell through to a generic type-mismatch diagnostic pointed at the first `yield`, instead of at the annotation that caused it. HEW-SPEC-2026 §4.12 names this mistake `E_GEN_RETURN_SPELLING` with a fix-it that replaces the handle spelling with the yield type.

**What**

- **types**: detect the handle shape (`declared.as_generator()`) at return-type registration, report `E_GEN_RETURN_SPELLING` at the annotation span with a fix-it, and recover using the intended yield type so the body still checks cleanly. A function signature is rebuilt by more than one registration pass (its own module and, separately, an importer), so the report is guarded per annotation span (`reported_gen_return_spellings`) to avoid a duplicate diagnostic.
- **docs**: list the new code in `docs/diagnostics/README.md`.

**Test**

- hew-types: `gen_fn_return_type_spelling_generator_handle_rejected`, `gen_fn_return_type_spelling_yield_type_accepted` (negative control) in `hew-types/tests/e2e_typecheck.rs`.
- vertical-slice: `reject/gen_fn_return_type_spells_handle.hew` (error count pinned at 1, no cascade), `accept/gen_fn_return_type_yield_spelling.hew` (negative control).

Fixes #3265