### PR TITLE
fix(runtime): detach a blocked-sender registration by id, not slot address

### DIFF
--- a/hew-cabi/include/hew_cabi_surface.h
+++ b/hew-cabi/include/hew_cabi_surface.h
@@ -58,7 +58,7 @@ static const struct hew_cabi_manifest_row hew_cabi_manifest_functions[1488] = {
      HEW_CABI_OWNERSHIP_UNMEASURED},
     {"hew_actor_await_send_by_id",
      "{\"native\": \"fn hew_actor_await_send_by_id( u64, i32, *mut c_void, "
-     "usize, *mut HewActor, *mut HewReadSlot, ) -> c_int\"}",
+     "usize, *mut HewActor, *mut HewReadSlot, *mut u64, ) -> c_int\"}",
      "native", "codegen-stable", "not-applicable", "length-or-count",
      HEW_CABI_OWNERSHIP_UNMEASURED},
     {"hew_actor_cancel_periodic",
@@ -85,9 +85,9 @@ static const struct hew_cabi_manifest_row hew_cabi_manifest_functions[1488] = {
      "native", "stable", "not-applicable", "not-applicable",
      HEW_CABI_OWNERSHIP_UNMEASURED},
     {"hew_actor_detach_await_send_by_id",
-     "{\"native\": \"fn hew_actor_detach_await_send_by_id( u64, *mut "
-     "HewReadSlot, )\"}",
-     "native", "codegen-stable", "not-applicable", "no-in-signature-extent",
+     "{\"native\": \"fn hew_actor_detach_await_send_by_id( u64, "
+     "mailbox::BlockedSenderId, )\"}",
+     "native", "codegen-stable", "not-applicable", "not-applicable",
      HEW_CABI_OWNERSHIP_UNMEASURED},
     {"hew_actor_drain_outcome_free",
      "{\"native\": \"fn hew_actor_drain_outcome_free( *mut "
@@ -5420,8 +5420,8 @@ static const struct hew_cabi_manifest_row hew_cabi_manifest_functions[1488] = {
      HEW_CABI_OWNERSHIP_UNMEASURED},
     {"hew_supervisor_role_await_send",
      "{\"native\": \"fn hew_supervisor_role_await_send( HewLocalPidId, u32, "
-     "i32, *mut c_void, usize, *mut HewActor, *mut HewReadSlot, *mut u64, ) -> "
-     "c_int\"}",
+     "i32, *mut c_void, usize, *mut HewActor, *mut HewReadSlot, *mut u64, *mut "
+     "u64, ) -> c_int\"}",
      "native", "codegen-stable", "not-applicable", "length-or-count",
      HEW_CABI_OWNERSHIP_UNMEASURED},
     {"hew_supervisor_role_send",

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -4787,6 +4787,8 @@ pub(crate) fn intern_runtime_decl<'ctx>(
         ),
         // Cooperative bounded Block send. `0` registers a parked producer;
         // `1` means immediate admission; negative values retain caller ownership.
+        // The final pointer receives the minted `BlockedSenderId` for detach
+        // (`0` when admitted immediately) — issue #3147.
         "hew_actor_await_send_by_id" => i32_ty.fn_type(
             &[
                 i64_ty.into(),
@@ -4795,11 +4797,13 @@ pub(crate) fn intern_runtime_decl<'ctx>(
                 size_ty.into(),
                 ptr_ty.into(),
                 ptr_ty.into(),
+                ptr_ty.into(),
             ],
             false,
         ),
-        // Stable-role sibling of `hew_actor_await_send_by_id`. The final
-        // pointer receives the exact accepted incarnation id for detach.
+        // Stable-role sibling of `hew_actor_await_send_by_id`. The penultimate
+        // pointer receives the exact accepted incarnation id for detach; the
+        // final pointer receives the minted `BlockedSenderId` (#3147).
         "hew_supervisor_role_await_send" => i32_ty.fn_type(
             &[
                 i64_ty.into(),
@@ -4810,12 +4814,17 @@ pub(crate) fn intern_runtime_decl<'ctx>(
                 ptr_ty.into(),
                 ptr_ty.into(),
                 ptr_ty.into(),
+                ptr_ty.into(),
             ],
             false,
         ),
+        // `registration_id` is the opaque `BlockedSenderId` scalar minted by
+        // `hew_actor_await_send_by_id` / `hew_supervisor_role_await_send`, not
+        // a pointer — matching by slot address let a recycled allocation
+        // detach the wrong registration (#3147).
         "hew_actor_detach_await_send_by_id" => ctx
             .void_type()
-            .fn_type(&[i64_ty.into(), ptr_ty.into()], false),
+            .fn_type(&[i64_ty.into(), i64_ty.into()], false),
         // hew_tcp_attach_local(conn: c_int, actor: *mut HewActor,
         //                      on_data_type: i32, on_close_type: i32) -> c_int
         // (`hew-runtime/src/transport.rs`). The active-mode `conn.attach(handler)`

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -4712,7 +4712,19 @@ pub(crate) fn emit_suspending_actor_send_terminator<'ctx>(
         .ok_or_else(|| CodegenError::FailClosed("hew_read_slot_new returned void".into()))?
         .into_pointer_value();
     let msg_type = fn_ctx.ctx.i32_type().const_int(term.msg_type as u64, false);
-    let (actor_id, rc) = if let Some(role) = term.stable_role {
+    // The registration id `mailbox_await_send` mints for a parked waiter
+    // (`0` when admitted immediately). Detach must name this id rather than
+    // the read-slot address: slot allocations are recycled, so a detach
+    // keyed on the slot pointer could remove a different registration that
+    // reused the freed address after this one parked (#3147).
+    let reg_id_out = fn_ctx
+        .builder
+        .build_alloca(
+            fn_ctx.ctx.i64_type(),
+            "suspending_actor_send_registration_id",
+        )
+        .llvm_ctx("suspending actor-send registration-id alloca")?;
+    let (actor_id, reg_id, rc) = if let Some(role) = term.stable_role {
         let i64_ty = fn_ctx.ctx.i64_type();
         let supervisor_token = load_int_arg(
             fn_ctx,
@@ -4757,6 +4769,7 @@ pub(crate) fn emit_suspending_actor_send_terminator<'ctx>(
                     sender.into(),
                     slot.into(),
                     actor_id_out.into(),
+                    reg_id_out.into(),
                 ],
                 "suspending_actor_send_role_register",
             )
@@ -4776,7 +4789,16 @@ pub(crate) fn emit_suspending_actor_send_terminator<'ctx>(
             )
             .llvm_ctx("suspending actor-send role actor-id load")?
             .into_int_value();
-        (actor_id, rc)
+        let reg_id = fn_ctx
+            .builder
+            .build_load(
+                i64_ty,
+                reg_id_out,
+                "suspending_actor_send_role_registration_id_load",
+            )
+            .llvm_ctx("suspending actor-send role registration-id load")?
+            .into_int_value();
+        (actor_id, reg_id, rc)
     } else {
         let actor_ptr = load_duplex_handle(fn_ctx, term.actor, "suspending_actor_send receiver")?;
         let actor_id = load_actor_id(fn_ctx, actor_ptr)?;
@@ -4797,6 +4819,7 @@ pub(crate) fn emit_suspending_actor_send_terminator<'ctx>(
                     payload_size.into(),
                     sender.into(),
                     slot.into(),
+                    reg_id_out.into(),
                 ],
                 "suspending_actor_send_register",
             )
@@ -4807,7 +4830,16 @@ pub(crate) fn emit_suspending_actor_send_terminator<'ctx>(
                 CodegenError::FailClosed("hew_actor_await_send_by_id returned void".into())
             })?
             .into_int_value();
-        (actor_id, rc)
+        let reg_id = fn_ctx
+            .builder
+            .build_load(
+                fn_ctx.ctx.i64_type(),
+                reg_id_out,
+                "suspending_actor_send_registration_id_load",
+            )
+            .llvm_ctx("suspending actor-send registration-id load")?
+            .into_int_value();
+        (actor_id, reg_id, rc)
     };
 
     let parent = fn_ctx
@@ -4939,7 +4971,7 @@ pub(crate) fn emit_suspending_actor_send_terminator<'ctx>(
                 .builder
                 .build_call(
                     detach,
-                    &[actor_id.into(), slot.into()],
+                    &[actor_id.into(), reg_id.into()],
                     "suspending_actor_send_abandon_detach",
                 )
                 .llvm_ctx("hew_actor_detach_await_send_by_id call")?;

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -4079,10 +4079,17 @@ pub unsafe extern "C" fn hew_actor_send_by_id(
 /// no ownership transfer occurred. A registered producer is resumed by the
 /// target mailbox after dequeue creates capacity.
 ///
+/// `out_id` receives the [`mailbox::BlockedSenderId`] minted for a parked
+/// registration (`0` when the send was admitted immediately, since there is
+/// then no registration to detach). The caller passes it back to
+/// [`hew_actor_detach_await_send_by_id`] to withdraw the registration by
+/// identity rather than by the read-slot address, which is recycled (#3147).
+///
 /// # Safety
 ///
 /// `data` must cover `size` readable bytes; `sender` is the current live actor
 /// and `slot` is a live read slot whose creator ref remains with the caller.
+/// `out_id` must be a writable `*mut u64`, or null to discard the id.
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_await_send_by_id(
@@ -4092,17 +4099,26 @@ pub unsafe extern "C" fn hew_actor_await_send_by_id(
     size: usize,
     sender: *mut HewActor,
     slot: *mut crate::read_slot::HewReadSlot,
+    out_id: *mut u64,
 ) -> c_int {
     let result = live_actors::with_actor_send_by_id(actor_id, |actor| {
         // SAFETY: the live registry pin keeps the actor valid for this closure;
         // the remaining arguments retain the public ABI's contract.
         unsafe { actor_await_send_pinned(actor, msg_type, data, size, sender, slot) }
     });
-    result.unwrap_or(HewError::ErrActorStopped as i32)
+    let (rc, id) = result.unwrap_or((HewError::ErrActorStopped as i32, 0));
+    if !out_id.is_null() {
+        // SAFETY: caller-provided non-null output, per this function's contract.
+        unsafe { out_id.write(id) };
+    }
+    rc
 }
 
 /// Register a cooperative send while an identity-verified live-actor pin is
 /// held. Shared by direct-PID and stable-supervisor-role submission.
+///
+/// Returns the status code and the [`mailbox::BlockedSenderId`] minted for a
+/// parked registration (`0` when admitted immediately or refused).
 ///
 /// # Safety
 ///
@@ -4116,42 +4132,44 @@ pub(crate) unsafe fn actor_await_send_pinned(
     size: usize,
     sender: *mut HewActor,
     slot: *mut crate::read_slot::HewReadSlot,
-) -> c_int {
+) -> (c_int, mailbox::BlockedSenderId) {
     // SAFETY: the caller holds an identity-verified live-actor pin.
     let target = unsafe { &*actor };
     if !actor_runtime_matches(target) {
-        return HewError::ErrForeignRuntime as i32;
+        return (HewError::ErrForeignRuntime as i32, 0);
     }
     if actor_send_is_terminal(target) {
-        return HewError::ErrActorStopped as i32;
+        return (HewError::ErrActorStopped as i32, 0);
     }
     // SAFETY: the pin keeps the mailbox live and the caller supplies the
     // payload, sender, and read-slot contracts.
-    let rc = unsafe {
+    let (rc, id) = unsafe {
         mailbox::mailbox_await_send(target.mailbox.cast(), msg_type, data, size, sender, slot)
     };
     if rc == mailbox::MAILBOX_AWAIT_SEND_READY {
         // SAFETY: immediate readiness means a node reached the target queue.
         unsafe { schedule_actor_after_enqueue(actor, target, msg_type) };
     }
-    rc
+    (rc, id)
 }
 
-/// Detach an abandoned cooperative block-send registration. Idempotent when
-/// admission or target close already resolved the waiter.
+/// Detach an abandoned cooperative block-send registration, named by the
+/// [`mailbox::BlockedSenderId`] [`hew_actor_await_send_by_id`] minted for it.
+/// Idempotent when admission or target close already resolved the waiter.
 ///
 /// # Safety
 ///
-/// `slot` must be the live slot passed to [`hew_actor_await_send_by_id`].
+/// No pointer safety obligations beyond the ordinary ABI call convention;
+/// `registration_id` is an opaque scalar identity, not a pointer.
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_detach_await_send_by_id(
     actor_id: u64,
-    slot: *mut crate::read_slot::HewReadSlot,
+    registration_id: mailbox::BlockedSenderId,
 ) {
     let _ = live_actors::with_actor_send_by_id(actor_id, |actor| {
         // SAFETY: the registry pin keeps the actor and mailbox live.
-        unsafe { mailbox::mailbox_detach_await_send((*actor).mailbox.cast(), slot) };
+        unsafe { mailbox::mailbox_detach_await_send((*actor).mailbox.cast(), registration_id) };
     });
 }
 

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -26,7 +26,7 @@ use std::cell::UnsafeCell;
 use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
 
 use crate::internal::types::{HewError, HewOverflowPolicy};
@@ -1405,11 +1405,34 @@ struct SlowPathQueue {
     user_queue: VecDeque<*mut HewMsgNode>,
 }
 
+/// Identity of one [`BlockedSender`] registration, minted at
+/// [`mailbox_await_send`] and handed back to the caller so a later detach
+/// names the registration rather than the read-slot address that carried it.
+///
+/// Slot allocations are recycled ([`crate::read_slot`]), so a detach keyed on
+/// `waiter.slot == slot` can match a different registration that reused the
+/// freed address (#3147). The registration id is minted from a monotonic
+/// counter scoped to the whole process and never reused, so it identifies
+/// exactly the registration that minted it.
+pub(crate) type BlockedSenderId = u64;
+
+/// Monotonic counter for [`BlockedSenderId`]; never reuses an id within a
+/// process. `0` is reserved as "no registration" (an admitted-immediately
+/// send never parks a waiter and so never needs to be detached).
+static NEXT_BLOCKED_SENDER_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Mint the next [`BlockedSenderId`].
+fn next_blocked_sender_id() -> BlockedSenderId {
+    // 1 is the first valid id; in practice u64 will never wrap during a process.
+    NEXT_BLOCKED_SENDER_ID.fetch_add(1, Ordering::Relaxed)
+}
+
 /// One producer continuation parked by a full `overflow block` mailbox. The
 /// mailbox owns the copied node and one retained read-slot ref until admission,
 /// cancellation, or close wins the registration race.
 #[derive(Debug)]
 struct BlockedSender {
+    id: BlockedSenderId,
     sender: ActorIncarnation,
     slot: *mut HewReadSlot,
     node: *mut HewMsgNode,
@@ -2771,9 +2794,11 @@ pub(crate) const MAILBOX_AWAIT_SEND_READY: i32 = 1;
 /// Register a cooperative producer wait for a bounded `Block` mailbox.
 ///
 /// On a full mailbox this copies the message into a FIFO waiter, retains
-/// `slot`, and returns [`MAILBOX_AWAIT_SEND_SUSPEND`]. The consumer admits and
-/// wakes one waiter whenever it frees a queue slot. An immediately available
-/// slot admits the copied node and returns [`MAILBOX_AWAIT_SEND_READY`].
+/// `slot`, mints a [`BlockedSenderId`] for the registration, and returns
+/// [`MAILBOX_AWAIT_SEND_SUSPEND`] with the id. The consumer admits and wakes
+/// one waiter whenever it frees a queue slot. An immediately available slot
+/// admits the copied node and returns [`MAILBOX_AWAIT_SEND_READY`] with `0`
+/// (no registration to detach).
 ///
 /// # Safety
 ///
@@ -2786,34 +2811,34 @@ pub(crate) unsafe fn mailbox_await_send(
     size: usize,
     actor: *mut crate::actor::HewActor,
     slot: *mut HewReadSlot,
-) -> i32 {
+) -> (i32, BlockedSenderId) {
     if mb.is_null() || slot.is_null() {
-        return HewError::ErrClosed as i32;
+        return (HewError::ErrClosed as i32, 0);
     }
     // SAFETY: caller guarantees a live mailbox.
     let mailbox = unsafe { &*mb };
     if mailbox.closed.load(Ordering::Acquire) {
-        return HewError::ErrActorStopped as i32;
+        return (HewError::ErrActorStopped as i32, 0);
     }
     if mailbox.capacity <= 0 || mailbox.overflow != HewOverflowPolicy::Block {
-        return HewError::ErrMailboxFull as i32;
+        return (HewError::ErrMailboxFull as i32, 0);
     }
 
     let mut queue = mailbox.slow_path.lock_or_recover();
     if mailbox.closed.load(Ordering::Acquire) {
-        return HewError::ErrActorStopped as i32;
+        return (HewError::ErrActorStopped as i32, 0);
     }
     // SAFETY: the caller guarantees the readable payload range.
     let node = unsafe { msg_node_alloc(msg_type, data, size, ptr::null_mut()) };
     if node.is_null() {
-        return HewError::ErrOom as i32;
+        return (HewError::ErrOom as i32, 0);
     }
     if i64::try_from(queue.user_queue.len()).unwrap_or(i64::MAX) < mailbox.capacity {
         enqueue_bounded_slow_path_node(mailbox, &mut queue, node);
         drop(queue);
         update_high_water_mark(mailbox);
         MESSAGES_SENT.fetch_add(1, Ordering::Relaxed);
-        return MAILBOX_AWAIT_SEND_READY;
+        return (MAILBOX_AWAIT_SEND_READY, 0);
     }
 
     // Join the independent waiter lock while the queue is still held so a
@@ -2826,7 +2851,7 @@ pub(crate) unsafe fn mailbox_await_send(
         drop(queue);
         // SAFETY: the node was never published and remains exclusively owned.
         unsafe { hew_msg_node_free_with_message_drop(node, mailbox.message_drop_fn) };
-        return HewError::ErrActorStopped as i32;
+        return (HewError::ErrActorStopped as i32, 0);
     }
     // SAFETY: the caller owns the creator ref, so the slot is live to retain.
     unsafe { read_slot_retain(slot) };
@@ -2835,8 +2860,14 @@ pub(crate) unsafe fn mailbox_await_send(
     // than the pointer is what makes the later wake refuse a replacement actor
     // that reused this allocation.
     let sender = unsafe { ActorIncarnation::of(actor) };
-    waiters.push_back(BlockedSender { sender, slot, node });
-    MAILBOX_AWAIT_SEND_SUSPEND
+    let id = next_blocked_sender_id();
+    waiters.push_back(BlockedSender {
+        id,
+        sender,
+        slot,
+        node,
+    });
+    (MAILBOX_AWAIT_SEND_SUSPEND, id)
 }
 
 /// Submit an ask without parking the scheduler worker when a bounded `Block`
@@ -2900,6 +2931,10 @@ pub(crate) unsafe fn mailbox_send_with_reply_cooperative(
         return HewError::ErrActorStopped as i32;
     }
     waiters.push_back(BlockedSender {
+        // An ask waiter has no capacity-wait read slot and is never detached
+        // by id (its caller is suspended on the reply channel instead); mint
+        // one anyway so every waiter carries a unique, non-zero identity.
+        id: next_blocked_sender_id(),
         sender: ActorIncarnation::NONE,
         slot: ptr::null_mut(),
         node,
@@ -2907,14 +2942,20 @@ pub(crate) unsafe fn mailbox_send_with_reply_cooperative(
     HewError::Ok as i32
 }
 
-/// Remove an abandoned cooperative block-send registration. Idempotent when
-/// admission or close already consumed the waiter.
+/// Remove an abandoned cooperative block-send registration, named by the
+/// [`BlockedSenderId`] [`mailbox_await_send`] minted for it. Idempotent when
+/// admission or close already consumed the waiter, and safe against slot
+/// address reuse: read-slot allocations are recycled, so matching by
+/// `waiter.slot == slot` could remove a different registration that reused
+/// the freed address after this caller's slot was freed (#3147). The id is
+/// minted from a monotonic counter that never repeats within a process, so it
+/// names exactly the registration that minted it and nothing else.
 ///
 /// # Safety
 ///
-/// `mb` and `slot` must be live pointers supplied to [`mailbox_await_send`].
-pub(crate) unsafe fn mailbox_detach_await_send(mb: *mut HewMailbox, slot: *mut HewReadSlot) {
-    if mb.is_null() || slot.is_null() {
+/// `mb` must be a live pointer supplied to [`mailbox_await_send`].
+pub(crate) unsafe fn mailbox_detach_await_send(mb: *mut HewMailbox, id: BlockedSenderId) {
+    if mb.is_null() || id == 0 {
         return;
     }
     // SAFETY: caller guarantees a live mailbox.
@@ -2923,7 +2964,7 @@ pub(crate) unsafe fn mailbox_detach_await_send(mb: *mut HewMailbox, slot: *mut H
         let mut waiters = mailbox.blocked_senders.lock_or_recover();
         waiters
             .iter()
-            .position(|waiter| waiter.slot == slot)
+            .position(|waiter| waiter.id == id)
             .and_then(|position| waiters.remove(position))
     };
     if let Some(waiter) = removed {
@@ -3695,11 +3736,11 @@ mod tests {
         // SAFETY: mailbox and zero-sized payload are valid.
         assert_eq!(unsafe { hew_mailbox_send(mb, 1, ptr::null_mut(), 0) }, 0);
         let slot = crate::read_slot::hew_read_slot_new();
-        assert_eq!(
+        let (rc, id) =
             // SAFETY: mailbox and slot remain live through waiter resolution.
-            unsafe { mailbox_await_send(mb, 2, ptr::null_mut(), 0, ptr::null_mut(), slot) },
-            MAILBOX_AWAIT_SEND_SUSPEND
-        );
+            unsafe { mailbox_await_send(mb, 2, ptr::null_mut(), 0, ptr::null_mut(), slot) };
+        assert_eq!(rc, MAILBOX_AWAIT_SEND_SUSPEND);
+        assert_ne!(id, 0, "a suspended registration must mint a non-zero id");
         // SAFETY: the creator reference keeps the slot live.
         assert_eq!(unsafe { crate::read_slot::hew_read_slot_status(slot) }, 0);
 
@@ -3738,11 +3779,10 @@ mod tests {
         // SAFETY: mailbox and zero-sized payload are valid.
         assert_eq!(unsafe { hew_mailbox_send(mb, 1, ptr::null_mut(), 0) }, 0);
         let slot = crate::read_slot::hew_read_slot_new();
-        assert_eq!(
+        let (rc, _id) =
             // SAFETY: mailbox and slot remain live through waiter resolution.
-            unsafe { mailbox_await_send(mb, 2, ptr::null_mut(), 0, ptr::null_mut(), slot) },
-            MAILBOX_AWAIT_SEND_SUSPEND
-        );
+            unsafe { mailbox_await_send(mb, 2, ptr::null_mut(), 0, ptr::null_mut(), slot) };
+        assert_eq!(rc, MAILBOX_AWAIT_SEND_SUSPEND);
         // SAFETY: this test owns the mailbox; close drains and deposits the waiter slot.
         unsafe { mailbox_close(mb) };
         assert_eq!(
@@ -3753,6 +3793,139 @@ mod tests {
         // SAFETY: this test retains the slot and mailbox creator ownership.
         unsafe {
             crate::read_slot::hew_read_slot_free(slot);
+            hew_mailbox_free(mb);
+        }
+    }
+
+    /// #3147's oracle: a stale detach must not remove a registration that
+    /// happens to reuse a freed read-slot address. The first registration's
+    /// owner detaches by id, releasing the mailbox's retained slot ref while
+    /// the test's own creator ref keeps the allocation (and its address)
+    /// alive — standing in for whatever legitimately kept the address live
+    /// for the next registration. A second registration then parks on the
+    /// exact same address. A late or duplicated detach carrying the first
+    /// registration's (now-stale) id must remove nothing, even though the
+    /// pre-fix `waiter.slot == slot` match would have found the second
+    /// registration at that address and wrongly removed it — the assertion
+    /// after the stale detach proves both halves in one place.
+    #[test]
+    fn detach_by_id_ignores_a_registration_that_reused_the_freed_slot_address() {
+        // SAFETY: this test exclusively owns the mailbox.
+        let mb = unsafe { hew_mailbox_new_with_policy(1, HewOverflowPolicy::Block) };
+        // SAFETY: mailbox and zero-sized payload are valid.
+        assert_eq!(unsafe { hew_mailbox_send(mb, 1, ptr::null_mut(), 0) }, 0);
+
+        let slot = crate::read_slot::hew_read_slot_new();
+        let (rc, first_id) =
+            // SAFETY: mailbox and slot remain live through waiter resolution.
+            unsafe { mailbox_await_send(mb, 2, ptr::null_mut(), 0, ptr::null_mut(), slot) };
+        assert_eq!(rc, MAILBOX_AWAIT_SEND_SUSPEND);
+        assert_ne!(
+            first_id, 0,
+            "a suspended registration must mint a non-zero id"
+        );
+
+        // The first registration's owner gives up and detaches by id. This
+        // releases the mailbox's retained slot ref; the test's own creator
+        // ref is what keeps `slot`'s address live for reuse below.
+        // SAFETY: `mb` is live and `first_id` names the just-created waiter.
+        unsafe { mailbox_detach_await_send(mb, first_id) };
+
+        // A second registration reuses the exact same slot address.
+        let (rc, second_id) =
+            // SAFETY: mailbox and slot remain live through waiter resolution.
+            unsafe { mailbox_await_send(mb, 3, ptr::null_mut(), 0, ptr::null_mut(), slot) };
+        assert_eq!(rc, MAILBOX_AWAIT_SEND_SUSPEND);
+        assert_ne!(
+            first_id, second_id,
+            "registration ids must never repeat within a process"
+        );
+
+        // The stale first-registration id arrives again (a late or duplicated
+        // detach). By id, it names nothing live and must remove nothing.
+        // SAFETY: `mb` is live; `first_id` is a stale (already-detached) id.
+        unsafe { mailbox_detach_await_send(mb, first_id) };
+
+        // SAFETY: this test exclusively owns the mailbox for inspection.
+        let mailbox = unsafe { &*mb };
+        let waiters = mailbox.blocked_senders.lock_or_recover();
+        assert_eq!(
+            waiters.len(),
+            1,
+            "the second registration must remain parked"
+        );
+        assert_eq!(
+            waiters[0].id, second_id,
+            "the surviving waiter must be the second registration, named by its own id"
+        );
+        assert!(
+            waiters.iter().any(|w| w.slot == slot),
+            "the surviving waiter's slot equals the first registration's freed \
+             address — matching on that address (the pre-fix behaviour) would \
+             have found and removed this waiter instead of leaving it alone"
+        );
+        drop(waiters);
+
+        // SAFETY: this test owns the mailbox; close drains and deposits the
+        // surviving waiter's slot before the creator ref is freed.
+        unsafe { mailbox_close(mb) };
+        // SAFETY: this test retains the slot and mailbox creator ownership.
+        unsafe {
+            crate::read_slot::hew_read_slot_free(slot);
+            hew_mailbox_free(mb);
+        }
+    }
+
+    /// Positive control for [`detach_by_id_ignores_a_registration_that_reused_the_freed_slot_address`]:
+    /// with two distinct live registrations at two distinct addresses,
+    /// detaching by one's id removes exactly that one and leaves the other
+    /// parked.
+    #[test]
+    fn detach_by_id_removes_exactly_the_registering_waiter() {
+        // SAFETY: this test exclusively owns the mailbox.
+        let mb = unsafe { hew_mailbox_new_with_policy(1, HewOverflowPolicy::Block) };
+        // SAFETY: mailbox and zero-sized payload are valid.
+        assert_eq!(unsafe { hew_mailbox_send(mb, 1, ptr::null_mut(), 0) }, 0);
+
+        let slot_a = crate::read_slot::hew_read_slot_new();
+        let (rc, id_a) =
+            // SAFETY: mailbox and slot remain live through waiter resolution.
+            unsafe { mailbox_await_send(mb, 2, ptr::null_mut(), 0, ptr::null_mut(), slot_a) };
+        assert_eq!(rc, MAILBOX_AWAIT_SEND_SUSPEND);
+
+        let slot_b = crate::read_slot::hew_read_slot_new();
+        let (rc, id_b) =
+            // SAFETY: mailbox and slot remain live through waiter resolution.
+            unsafe { mailbox_await_send(mb, 3, ptr::null_mut(), 0, ptr::null_mut(), slot_b) };
+        assert_eq!(rc, MAILBOX_AWAIT_SEND_SUSPEND);
+        assert_ne!(id_a, id_b);
+
+        // SAFETY: `mb` is live and `id_a` names the first waiter.
+        unsafe { mailbox_detach_await_send(mb, id_a) };
+
+        // SAFETY: this test exclusively owns the mailbox for inspection.
+        let mailbox = unsafe { &*mb };
+        let waiters = mailbox.blocked_senders.lock_or_recover();
+        assert_eq!(
+            waiters.len(),
+            1,
+            "exactly the named registration must be removed"
+        );
+        assert_eq!(
+            waiters[0].id, id_b,
+            "the untouched registration must remain parked"
+        );
+        drop(waiters);
+
+        // SAFETY: `slot_a`'s waiter was removed by detach and freed its own
+        // retained ref; this test's creator ref is the last owner.
+        unsafe { crate::read_slot::hew_read_slot_free(slot_a) };
+        // SAFETY: this test owns the mailbox; close drains and deposits the
+        // surviving waiter's slot before its creator ref is freed.
+        unsafe { mailbox_close(mb) };
+        // SAFETY: this test retains the slot and mailbox creator ownership.
+        unsafe {
+            crate::read_slot::hew_read_slot_free(slot_b);
             hew_mailbox_free(mb);
         }
     }

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -5138,7 +5138,7 @@ mod tests {
             0
         );
         let slot = crate::read_slot::hew_read_slot_new();
-        assert_eq!(
+        let (rc, _id) =
             // SAFETY: sender, mailbox, and slot remain live until the waiter is resolved.
             unsafe {
                 crate::mailbox::mailbox_await_send(
@@ -5149,7 +5149,9 @@ mod tests {
                     sender.ptr(),
                     slot,
                 )
-            },
+            };
+        assert_eq!(
+            rc,
             crate::mailbox::MAILBOX_AWAIT_SEND_SUSPEND,
             "a full bounded Block mailbox must park the producer"
         );
@@ -5210,13 +5212,12 @@ mod tests {
             0
         );
         let slot = crate::read_slot::hew_read_slot_new();
-        assert_eq!(
+        let (rc, _id) =
             // SAFETY: sender, mailbox, and slot remain live until the waiter is resolved.
             unsafe {
                 crate::mailbox::mailbox_await_send(mailbox, 2, ptr::null_mut(), 0, sender_ptr, slot)
-            },
-            crate::mailbox::MAILBOX_AWAIT_SEND_SUSPEND
-        );
+            };
+        assert_eq!(rc, crate::mailbox::MAILBOX_AWAIT_SEND_SUSPEND);
 
         assert!(
             BLOCKED_SENDER_REINCARNATION

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -9066,12 +9066,19 @@ pub extern "C" fn hew_supervisor_role_send(
 /// Cooperatively submit a bounded `overflow block` tell through a stable
 /// supervisor role. Resolution and mailbox registration occur under one
 /// identity pin; on acceptance, `out_actor_id` receives the exact incarnation
-/// whose mailbox owns the waiter so cancellation can detach from that mailbox.
+/// whose mailbox owns the waiter so cancellation can detach from that
+/// mailbox, and `out_registration_id` receives the
+/// [`crate::mailbox::BlockedSenderId`] minted for a parked waiter (`0` when
+/// admitted immediately). Detach must name the registration id rather than
+/// the read-slot address: slot allocations are recycled, so a detach keyed on
+/// the pointer could remove a different registration that reused the freed
+/// address (#3147).
 ///
 /// # Safety
 ///
 /// `data`, `sender`, and `slot` must satisfy
-/// [`crate::actor::actor_await_send_pinned`]. `out_actor_id` must be writable.
+/// [`crate::actor::actor_await_send_pinned`]. `out_actor_id` and
+/// `out_registration_id` must be writable.
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub unsafe extern "C" fn hew_supervisor_role_await_send(
@@ -9083,20 +9090,24 @@ pub unsafe extern "C" fn hew_supervisor_role_await_send(
     sender: *mut HewActor,
     slot: *mut crate::read_slot::HewReadSlot,
     out_actor_id: *mut u64,
+    out_registration_id: *mut u64,
 ) -> c_int {
-    if out_actor_id.is_null() {
-        set_last_error("stable-role cooperative tell received a null actor-id output".to_string());
+    if out_actor_id.is_null() || out_registration_id.is_null() {
+        set_last_error("stable-role cooperative tell received a null output".to_string());
         return crate::internal::types::HewError::ErrActorStopped as i32;
     }
-    // SAFETY: the null check above establishes the caller-provided output is
-    // writable. Initialize it even on refusal because codegen loads before
-    // branching on status and only uses the value on the suspend edge.
-    unsafe { out_actor_id.write(0) };
+    // SAFETY: the null check above establishes the caller-provided outputs
+    // are writable. Initialize them even on refusal because codegen loads
+    // before branching on status and only uses the values on the suspend edge.
+    unsafe {
+        out_actor_id.write(0);
+        out_registration_id.write(0);
+    }
     let (child_id, child_serial) = match role_resolve_current_child_id(token, key, false) {
         Ok(ids) => ids,
         Err(code) => return code,
     };
-    let rc = crate::lifetime::live_actors::with_actor_send_by_identity(
+    let (rc, registration_id) = crate::lifetime::live_actors::with_actor_send_by_identity(
         child_id,
         child_serial,
         |pin| {
@@ -9118,11 +9129,14 @@ pub unsafe extern "C" fn hew_supervisor_role_await_send(
         set_last_error(format!(
             "stable-role cooperative tell refused: child slot {key} incarnation retired during submission"
         ));
-        crate::internal::types::HewError::ErrActorStopped as i32
+        (crate::internal::types::HewError::ErrActorStopped as i32, 0)
     });
     if rc >= 0 {
-        // SAFETY: non-null writable output is part of this ABI's contract.
-        unsafe { out_actor_id.write(child_id) };
+        // SAFETY: non-null writable outputs are part of this ABI's contract.
+        unsafe {
+            out_actor_id.write(child_id);
+            out_registration_id.write(registration_id);
+        }
     }
     rc
 }
@@ -9138,6 +9152,7 @@ pub extern "C" fn hew_supervisor_role_await_send(
     _sender: *mut HewActor,
     _slot: *mut crate::read_slot::HewReadSlot,
     _out_actor_id: *mut u64,
+    _out_registration_id: *mut u64,
 ) -> c_int {
     crate::internal::types::HewError::ErrActorStopped as i32
 }

--- a/scripts/cabi-surface.json
+++ b/scripts/cabi-surface.json
@@ -99,7 +99,7 @@
       "nul": "not-applicable",
       "ownership": "unmeasured",
       "signature": {
-        "native": "fn hew_actor_await_send_by_id( u64, i32, *mut c_void, usize, *mut HewActor, *mut HewReadSlot, ) -> c_int"
+        "native": "fn hew_actor_await_send_by_id( u64, i32, *mut c_void, usize, *mut HewActor, *mut HewReadSlot, *mut u64, ) -> c_int"
       },
       "symbol": "hew_actor_await_send_by_id"
     },
@@ -181,11 +181,11 @@
         "native"
       ],
       "classification": "codegen-stable",
-      "extent": "no-in-signature-extent",
+      "extent": "not-applicable",
       "nul": "not-applicable",
       "ownership": "unmeasured",
       "signature": {
-        "native": "fn hew_actor_detach_await_send_by_id( u64, *mut HewReadSlot, )"
+        "native": "fn hew_actor_detach_await_send_by_id( u64, mailbox::BlockedSenderId, )"
       },
       "symbol": "hew_actor_detach_await_send_by_id"
     },
@@ -15208,7 +15208,7 @@
       "nul": "not-applicable",
       "ownership": "unmeasured",
       "signature": {
-        "native": "fn hew_supervisor_role_await_send( HewLocalPidId, u32, i32, *mut c_void, usize, *mut HewActor, *mut HewReadSlot, *mut u64, ) -> c_int"
+        "native": "fn hew_supervisor_role_await_send( HewLocalPidId, u32, i32, *mut c_void, usize, *mut HewActor, *mut HewReadSlot, *mut u64, *mut u64, ) -> c_int"
       },
       "symbol": "hew_supervisor_role_await_send"
     },


### PR DESCRIPTION
## Why

`mailbox_detach_await_send` (`hew-runtime/src/mailbox.rs`) found the blocked-sender waiter to remove by comparing raw slot addresses (`waiter.slot == slot`). Read-slot allocations are recycled, and nothing at the entry point itself proves the address it was handed still names the registration that made it — what kept this correct was the detaching caller holding the slot's creator reference for the whole call, correctness by convention rather than by lookup. A detach arriving late, or duplicated, could match a different registration that reused the freed address and remove somebody else's waiter.

## What

- **runtime (mailbox)**: `mailbox_await_send` mints a `BlockedSenderId` (a monotonic counter, never reused within a process, `0` reserved for "no registration") for each parked waiter and returns it alongside the status code. `mailbox_detach_await_send` takes the id instead of the slot pointer and matches on it.
- **runtime (C ABI)**: `hew_actor_await_send_by_id` and `hew_supervisor_role_await_send` gained an out-pointer that receives the minted id; `hew_actor_detach_await_send_by_id` takes the id (a `u64` scalar) instead of a slot pointer.
- **codegen**: `suspend.rs` allocates a slot for the registration id alongside the existing actor-id out-param, loads it on both the direct-PID and stable-role paths, and passes it to the detach call on abandonment instead of the slot pointer.
- **cabi surface**: regenerated `hew_cabi_surface.h` / `scripts/cabi-surface.json` via `make cabi-surface`.

## Test

- `mailbox::tests::detach_by_id_ignores_a_registration_that_reused_the_freed_slot_address`: frees a registration's slot address (by detaching it) and parks a second registration on the identical address, then shows a stale detach by the first registration's id removes nothing — while the surviving waiter's slot still equals the freed address, the exact ambiguity the pre-fix address match would have resolved wrongly.
- `mailbox::tests::detach_by_id_removes_exactly_the_registering_waiter`: positive control with two live registrations at two distinct addresses; detaching by one's id removes exactly that one.

Fixes #3147
