### PR TITLE
build(ci): add the grammar-parity and downstream-check gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,6 +571,10 @@ jobs:
 
       - name: Setup Node.js for browser checks
         if: matrix.shard == 3
+        # Also the node/npm this shard's `make ci-shard-3` needs for
+        # grammar-parity (npm install in the cloned tree-sitter-hew) and
+        # downstream-check (tools/downstream/generate-nano.mjs), alongside
+        # sandbox-parity's existing hew-sandbox-vm dependency.
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,15 +81,35 @@ directly and does not define a competing build graph. See the
 
 ### Test suite overview
 
-| Suite             | Command                       | Scope                                                                                        | Speed  |
-| ----------------- | ----------------------------- | -------------------------------------------------------------------------------------------- | ------ |
-| Full (default)    | `make test`                   | Rust workspace (via nextest)                                                                 | medium |
-| Stdlib type-check | `make test-stdlib-ratchet`    | `std/` type-check sweep, ratcheted against `scripts/stdlib-expected-failures.txt`            | medium |
-| Compiler pipeline | `make test-compiler-pipeline` | Lexer through CLI and package consumers                                                      | medium |
-| Runtime (no-net)  | `make test-runtime-unit`      | `hew-runtime` unit + integration tests, without QUIC/TLS/profiler stack (~3× faster compile) | fast   |
-| Hew test files    | `make test-hew-ratchet`       | `tests/hew/` via `hew test`, ratcheted against `scripts/hew-suite-expected-failures.txt`     | medium |
+| Suite             | Command                       | Scope                                                                                                                             | Speed  |
+| ----------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| Full (default)    | `make test`                   | Rust workspace (via nextest)                                                                                                      | medium |
+| Stdlib type-check | `make test-stdlib-ratchet`    | `std/` type-check sweep, ratcheted against `scripts/stdlib-expected-failures.txt`                                                 | medium |
+| Compiler pipeline | `make test-compiler-pipeline` | Lexer through CLI and package consumers                                                                                           | medium |
+| Runtime (no-net)  | `make test-runtime-unit`      | `hew-runtime` unit + integration tests, without QUIC/TLS/profiler stack (~3× faster compile)                                      | fast   |
+| Hew test files    | `make test-hew-ratchet`       | `tests/hew/` via `hew test`, ratcheted against `scripts/hew-suite-expected-failures.txt`                                          | medium |
+| Grammar parity    | `make grammar-parity`         | Vertical-slice accept fixtures, `std/**`, `examples/**` parsed with the pinned tree-sitter-hew grammar; fails on any `ERROR` node | fast   |
 
 Use `test-runtime-unit` for no-network runtime iteration and `test-compiler-pipeline` for compiler iteration. Run `make test` before opening a PR.
+
+### Changing Hew syntax
+
+`hew-lexer`/`hew-parser` are the grammar authority; `tree-sitter-hew` (a
+sibling repo used by editor tooling) is a mirror kept honest by `make
+grammar-parity`, which parses the accepted corpus with the commit pinned in
+`tools/downstream/tree-sitter.lock`. A PR that adds or changes syntax:
+
+1. Updates `tree-sitter-hew/grammar.js` to match (a separate repo; see
+   ["Downstream grammar sync"](docs/release-runbook.md#downstream-grammar-sync)
+   for the full sibling chain: tree-sitter-hew, vscode-hew, vim-hew, hew.sh,
+   hew.run), pushes that change, and bumps `tools/downstream/tree-sitter.lock`'s
+   `commit` (and `npm` once a new package version is published) to match —
+   in the same PR, not a follow-up.
+2. Runs `make grammar-parity` locally to confirm the pinned commit parses
+   the new syntax cleanly.
+3. Runs `make downstream-check` (`scripts/sync-downstream.sh --check`),
+   which reports drift against `docs/syntax-data.json` for whichever
+   sibling repos are checked out next to this one.
 
 `make test-runtime-unit` is the recommended target when iterating on `hew-runtime` logic that does not touch QUIC, TLS, or the profiler. It runs the full `hew-runtime` test suite (lib unit tests + all integration tests) with `--no-default-features`, cutting compile time roughly 3× (measured: ~32 s vs ~85 s per integration test binary on a warm build cache). The two profiler allocator tests in `transport.rs` are excluded under this target because they require active allocation counters to be meaningful; they still run under `cargo test -p hew-runtime` (default features).
 

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@
 .PHONY: compile-determinism-verify compile-determinism-verify-build compile-determinism-selftest compile-determinism-selftest-build
 .PHONY: checked-mir-verify checked-mir-golden checked-mir-run checked-mir-expect
 .PHONY: hew-check-all
+.PHONY: grammar-parity downstream-check
 .PHONY: sir-coverage sir-parity
 .PHONY: test-journeys check-time-ratchet check-time-ratchet-record
 
@@ -661,7 +662,7 @@ ci-shard-2: hew-profile-check libhew-link-race-test test \
 	test-asan-fixture-selftest hew-fmt-property stdlib-lint \
 	sir-coverage sir-parity
 
-ci-shard-3: mqtt-broker-e2e sandbox-parity \
+ci-shard-3: grammar-parity downstream-check mqtt-broker-e2e sandbox-parity \
 	fuzz-oracle fuzz-oracle-selftest test-package-install \
 	checked-mir-verify checked-mir-run \
 	test-core-matrix test-stdlib-ratchet \
@@ -1665,6 +1666,23 @@ hew-fmt-property: hew
 hew-check-all: hew-native
 	@echo "==> hew-check-all: compiling full .hew corpus"
 	HEW_BIN="$(DEBUG_HEW)" scripts/corpus-ratchet.sh hew-corpus
+
+# Parse the vertical-slice accept fixtures, std/, and examples/ with the
+# tree-sitter-hew grammar pinned in tools/downstream/tree-sitter.lock and
+# fail on any ERROR node (D19). The parser (hew-lexer/hew-parser) stays the
+# grammar authority; this only checks that the tree-sitter mirror used by
+# editor tooling has not drifted from it. See scripts/grammar-parity.sh.
+grammar-parity:
+	@echo "==> grammar-parity: parsing the accepted corpus with tree-sitter-hew"
+	scripts/grammar-parity.sh
+
+# Report drift between docs/syntax-data.json and every downstream sibling
+# repo checkout found next to this one (vscode-hew, hew.sh, hew.run,
+# tree-sitter-hew, vim-hew, hew-studio). A sibling repo not present locally
+# is skipped, not failed — see scripts/sync-downstream.sh.
+downstream-check:
+	@echo "==> downstream-check: comparing docs/syntax-data.json against sibling repos"
+	scripts/sync-downstream.sh --check
 
 # Runs one journey script under repros/journeys/ (day-one, day-two, or
 # week-one-local) against HEW_BIN and ratchets its `step <id>: pass|fail`

--- a/scripts/grammar-parity.sh
+++ b/scripts/grammar-parity.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# grammar-parity.sh — parse every accepted .hew program with the pinned
+# tree-sitter-hew grammar and fail on any ERROR node.
+#
+# The tree-sitter grammar (tree-sitter-hew, a sibling repo) is a syntax
+# highlighting/editor-tooling mirror of the real authority, hew-parser
+# (D19). This gate is the leash that keeps the mirror honest: it never
+# type-checks or runs anything, it only asks whether the pinned grammar
+# commit can produce a parse tree with zero ERROR nodes for every file the
+# compiler itself accepts. A red run here means the mirror has drifted,
+# either because a compiler-side syntax change landed without a matching
+# tree-sitter-hew update (fix tree-sitter-hew, push it, bump the lock), or
+# because a parsed file is not actually acceptable Hew (fix the file).
+#
+# Usage:
+#   scripts/grammar-parity.sh
+#
+# Environment variables:
+#   HEW_SYNC_TREE_SITTER   Path to an existing tree-sitter-hew checkout to
+#                           parse with instead of cloning into .tmp/. Used
+#                           as-is: never fetched or checked out by this
+#                           script (same env scheme as sync-downstream.sh).
+#                           A HEAD that does not match the pinned commit is
+#                           a warning, not an error — local iteration on an
+#                           unpushed tree-sitter-hew change is the point.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOCK_FILE="$REPO_ROOT/tools/downstream/tree-sitter.lock"
+CLONE_DIR="$REPO_ROOT/.tmp/tree-sitter-hew"
+GIT_URL="https://github.com/hew-lang/tree-sitter-hew.git"
+
+# shellcheck source=scripts/lib/corpus-nonempty.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/corpus-nonempty.sh"
+
+if [[ ! -f "$LOCK_FILE" ]]; then
+    echo "grammar-parity: $LOCK_FILE not found" >&2
+    exit 1
+fi
+
+LOCK_COMMIT="$(sed -n 's/^commit *= *"\([^"]*\)".*/\1/p' "$LOCK_FILE" | head -1)"
+if [[ ! "$LOCK_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "grammar-parity: tools/downstream/tree-sitter.lock's commit is not a 40-character hex sha (got '$LOCK_COMMIT')" >&2
+    exit 1
+fi
+
+# ── Resolve the tree-sitter-hew checkout ────────────────────────────────
+if [[ -n "${HEW_SYNC_TREE_SITTER:-}" ]]; then
+    TS_DIR="$HEW_SYNC_TREE_SITTER"
+    if [[ ! -d "$TS_DIR/.git" ]]; then
+        echo "grammar-parity: HEW_SYNC_TREE_SITTER=$TS_DIR is not a git checkout" >&2
+        exit 1
+    fi
+    TS_HEAD="$(cd "$TS_DIR" && git rev-parse HEAD)"
+    if [[ "$TS_HEAD" != "$LOCK_COMMIT" ]]; then
+        echo "grammar-parity: warning: HEW_SYNC_TREE_SITTER's HEAD ($TS_HEAD) does not match the pinned commit ($LOCK_COMMIT); parsing with HEAD as-is" >&2
+    fi
+else
+    TS_DIR="$CLONE_DIR"
+    if [[ ! -d "$TS_DIR/.git" ]]; then
+        mkdir -p "$(dirname "$TS_DIR")"
+        git clone --quiet "$GIT_URL" "$TS_DIR"
+    fi
+    (cd "$TS_DIR" && git fetch --quiet origin)
+    if ! (cd "$TS_DIR" && git checkout --quiet "$LOCK_COMMIT"); then
+        echo "grammar-parity: commit $LOCK_COMMIT (from tools/downstream/tree-sitter.lock) was not found in $GIT_URL after fetching" >&2
+        exit 1
+    fi
+fi
+
+# ── Ensure the tree-sitter CLI is available in that checkout ───────────
+if [[ ! -x "$TS_DIR/node_modules/.bin/tree-sitter" ]]; then
+    (cd "$TS_DIR" && npm install --no-audit --no-fund >/dev/null)
+fi
+
+# ── Enumerate the accepted corpus: vertical-slice accept fixtures, all of
+# std/, all of examples/. `find` (not `git ls-files`) so an untracked
+# scratch file placed under one of these roots is still parsed — the
+# negative control this gate names relies on that.
+FILE_LIST="$(mktemp)"
+trap 'rm -f "$FILE_LIST"' EXIT
+{
+    find "$REPO_ROOT/tests/vertical-slice/accept" -name '*.hew' -type f
+    find "$REPO_ROOT/std" -name '*.hew' -type f
+    find "$REPO_ROOT/examples" -name '*.hew' -type f
+} | LC_ALL=C sort >"$FILE_LIST"
+
+TOTAL=$(wc -l <"$FILE_LIST")
+corpus_nonempty_assert "grammar-parity-files" "$TOTAL" || exit 1
+
+# ── Parse the whole set in one CLI invocation and read the JSON summary.
+# The CLI also prints one plain-text diagnostic line per failing file to
+# stdout ahead of the JSON blob (undocumented, version-specific); the
+# Python reader below skips to the first line that is exactly "{" rather
+# than relying on that text, so it does not depend on CLI-version
+# formatting quirks.
+PARSE_OUT="$(mktemp)"
+PARSE_ERR="$(mktemp)"
+trap 'rm -f "$FILE_LIST" "$PARSE_OUT" "$PARSE_ERR"' EXIT
+(cd "$TS_DIR" && node_modules/.bin/tree-sitter parse --json-summary --paths "$FILE_LIST") \
+    >"$PARSE_OUT" 2>"$PARSE_ERR" || true
+
+FAILURES="$(
+    python3 - "$PARSE_OUT" "$PARSE_ERR" "$REPO_ROOT" <<'PYEOF'
+import json
+import sys
+
+out_path, err_path, repo_root = sys.argv[1], sys.argv[2], sys.argv[3].rstrip("/") + "/"
+lines = open(out_path, encoding="utf-8").read().splitlines()
+start = next((i for i, line in enumerate(lines) if line == "{"), None)
+if start is None:
+    print("grammar-parity: tree-sitter parse produced no JSON summary; stderr was:", file=sys.stderr)
+    print(open(err_path, encoding="utf-8").read(), file=sys.stderr)
+    sys.exit(1)
+data = json.loads("\n".join(lines[start:]))
+for summary in data["parse_summaries"]:
+    if not summary["successful"]:
+        path = summary["file"]
+        if path.startswith(repo_root):
+            path = path[len(repo_root):]
+        print(path)
+PYEOF
+)"
+
+if [[ -n "$FAILURES" ]]; then
+    FAIL_COUNT=$(printf '%s\n' "$FAILURES" | wc -l)
+    echo "grammar-parity: $FAIL_COUNT of $TOTAL file(s) parsed with an ERROR node (tree-sitter-hew @ $LOCK_COMMIT):" >&2
+    printf '%s\n' "$FAILURES" | sed 's/^/  /' >&2
+    exit 1
+fi
+
+echo "grammar-parity: $TOTAL files parsed cleanly with tree-sitter-hew @ $LOCK_COMMIT"

--- a/tools/downstream/tree-sitter.lock
+++ b/tools/downstream/tree-sitter.lock
@@ -1,0 +1,2 @@
+commit = "f5c78ce3f0e4d8c918db404372ed056e043a857b"
+npm = "1.0.2"


### PR DESCRIPTION
## Why

D19 makes hew-parser the grammar authority and retires the EBNF/ANTLR
specs, but nothing proved tree-sitter-hew (the sibling repo editor
tooling consumes) stays in sync with it. Every later V060-S syntax
lane needs this gate green before it can bump the lock.

## What

- **`scripts/grammar-parity.sh`**: resolves the tree-sitter-hew commit
  pinned in `tools/downstream/tree-sitter.lock` (clone/update into
  `.tmp/`, or use an existing checkout via `HEW_SYNC_TREE_SITTER`),
  parses the vertical-slice accept fixtures, `std/**`, and
  `examples/**` with it, and fails listing every file that produces an
  `ERROR` node.
- **`tools/downstream/tree-sitter.lock`**: new two-line pin
  (`commit`, `npm`).
- **`Makefile`**: `grammar-parity` and `downstream-check` (a thin
  wrapper over the existing `scripts/sync-downstream.sh --check`, no
  new drift logic) join `ci-shard-3` ahead of its slower gates.
- **`.github/workflows/ci.yml`**: a comment documenting that shard 3's
  existing node/npm setup now also serves these two targets.
  The brief placed both targets in `playground-wasm-build`; that job has
  no node setup, while `ci-shard-3` already provisions node for its
  browser checks, so shard 3 is where the Decision's own rationale
  lands them.
- **`CONTRIBUTING.md`**: documents the syntax-change workflow — update
  `tree-sitter-hew`, push it, bump the lock, in the same PR.
- **tree-sitter-hew** (sibling repo, pushed directly to its `main` per
  the ecosystem convention, `hew-lang/tree-sitter-hew@f5c78ce`, outside
  this repo's Sites but required to make the gate pass — see below):
  standing the gate up surfaced real drift — the `on`-rule grammar
  never accepted the contextual `.Target` spelling the checker steers
  authors towards (or a qualified `Composite.Leaf` source), so
  `examples/machine/run_connection_lifecycle.hew` failed to parse.
  Fixed `machine_transition`'s source/target productions in
  `grammar.js` to match `hew-parser`'s `parse_state_pattern`, added a
  corpus case, and replaced `tools/check-drift.sh`'s hand-maintained
  keyword regex with a comparison against `docs/syntax-data.json`'s
  own `all_keywords` (dropping `reserved_unused` words the same way
  `generate-tmgrammar.mjs` already does).

Not changed: `tools/downstream/generate-tmgrammar.mjs`'s keyword
cross-check — the false positive MEMORY.md recorded against it
(`machine`/`state`/`event`/`on`/`when` reported as "not in
all_keywords") does not reproduce on current `docs/syntax-data.json`;
those keywords are already in `all_keywords`, and there is no
`contextual_keywords` field for the described exclusion to have ever
targeted. Running the generator today prints no drift.

## Test

```
make grammar-parity          # 1444 files parsed cleanly with tree-sitter-hew @ f5c78ce
make downstream-check         # exit 0
```

In this worktree, `downstream-check` only exercises the
`syntax-data.json`-vs-lexer test and `editors/nano/hew.nanorc`; the
other six sibling-repo comparisons skip with "not found" because no
sibling checkout sits next to this one here. CI is in the same
position (a single checked-out repo), so the same subset runs there.

Negative control: an untracked `.hew` file with a syntax error placed
under `examples/` or `std/` makes `make grammar-parity` exit non-zero
and name the file (verified on both roots; removed before commit).

`tree-sitter-hew`'s own corpus test suite
(`npx tree-sitter test`, 90/90) covers the grammar fix, including a
new case for the dot-target/qualified-source forms.

Fixes #3287


