### PR TITLE
fix(parser): close the attribute set to HEW-SPEC-2026 §12.6

### DIFF
--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -60,12 +60,13 @@ them.
 | `E_VISIBILITY_PRIVATE`, `E_VISIBILITY_PACKAGE` | A cross-module reference to a private or package item.                                                                        |
 | `E_MODULE_NOT_FOUND`                           | An `import` no search path resolves.                                                                                          |
 | `E_GEN_RETURN_SPELLING`                        | A `gen fn` return type spelling the generator handle (`Generator<Y, R>`) instead of the yield type `Y` (HEW-SPEC-2026 §4.12). |
+| `E_UNKNOWN_ATTRIBUTE`                          | An attribute whose name is not in the closed table of HEW-SPEC-2026 §12.6, or that appears in a position the table does not list for it — on a type declaration, function, parameter, field, actor member, or `impl` block alike. Supersedes the retired `E_UNKNOWN_TYPE_MARKER`. |
 
 The remaining v0.6.0 surface codes are named by the decision that introduces
 them, and their rule lives in the spec section that decision writes — not
 here. Each row is added by the lane that lands the refusal:
 `E_IS_VALUE_TYPE`, `E_OPAQUE_MESSAGE_PAYLOAD`, `E_CALLABLE_MESSAGE_PAYLOAD`,
-`E_USE_AFTER_SEND`, `E_UNKNOWN_ATTRIBUTE`, `E_RESERVED_HANDLER_NAME`,
+`E_USE_AFTER_SEND`, `E_RESERVED_HANDLER_NAME`,
 `E_ACTOR_CONTEXT_REQUIRED`, `E_BREAK_VALUE`, `E_SCOPE_IS_STATEMENT`,
 `E_NO_ASYNC_FN`, `E_NO_ASYNC_GEN`,
 `E_FOR_STREAM_NEEDS_AWAIT`, `E_AWAIT_NOT_STREAM`.

--- a/hew-cli/src/eval/classify.rs
+++ b/hew-cli/src/eval/classify.rs
@@ -93,22 +93,70 @@ pub fn input_completeness(input: &str) -> InputCompleteness {
     InputCompleteness::Invalid
 }
 
-/// True if `input` is a syntactically complete attribute list (`#[wire]`,
-/// stacked `#[a]\n#[b]`, …) with no item yet attached to it.
+/// True if `input` is nothing but one or more syntactically complete
+/// `#[name]` / `#[name(args)]` attribute groups (`#[wire]`, stacked
+/// `#[a]\n#[b]`, …) with no item yet attached to them.
 ///
 /// An attribute alone has balanced delimiters (so `has_unclosed_delimiters`
 /// says "complete") and does not parse in any standalone context (so
 /// `parses_in_any_context` says "no"), which without this check falls
 /// through to `Invalid` — surfacing a parse error on the attribute line
 /// instead of buffering for the item it decorates.
+///
+/// This is a token-level check, deliberately independent of
+/// HEW-SPEC-2026 §12.6's closed attribute table: whether `name` turns out to
+/// be a recognised attribute (and legal in whatever position the item the
+/// user is about to type would put it in) is the parser's job once the item
+/// arrives. The REPL only needs to know "is this shape still waiting for an
+/// item", and a misspelled or invented attribute name is exactly the input a
+/// user is mid-way through typing — not evidence the buffer is unrecoverable.
 fn ends_with_bare_attribute(input: &str) -> bool {
-    if parses_as_item(input) {
-        // Already a complete item (with or without its own attributes) —
-        // nothing left to wait for.
-        return false;
+    let tokens = hew_lexer::lex(input);
+    let mut pos = 0usize;
+    let mut saw_group = false;
+    while pos < tokens.len() {
+        if !matches!(tokens[pos].0, hew_lexer::Token::HashBracket) {
+            return false;
+        }
+        pos += 1;
+        // Attribute name: any identifier-like token (including contextual
+        // keywords used as attribute names, e.g. `#[on(..)]`).
+        let Some((name_tok, _)) = tokens.get(pos) else {
+            return false;
+        };
+        if !matches!(
+            name_tok,
+            hew_lexer::Token::Identifier(_) | hew_lexer::Token::On
+        ) {
+            return false;
+        }
+        pos += 1;
+        if matches!(
+            tokens.get(pos).map(|(t, _)| t),
+            Some(hew_lexer::Token::LeftParen)
+        ) {
+            pos += 1;
+            let mut depth = 1usize;
+            while depth > 0 {
+                match tokens.get(pos).map(|(t, _)| t) {
+                    Some(hew_lexer::Token::LeftParen) => depth += 1,
+                    Some(hew_lexer::Token::RightParen) => depth -= 1,
+                    Some(_) => {}
+                    None => return false,
+                }
+                pos += 1;
+            }
+        }
+        if !matches!(
+            tokens.get(pos).map(|(t, _)| t),
+            Some(hew_lexer::Token::RightBracket)
+        ) {
+            return false;
+        }
+        pos += 1;
+        saw_group = true;
     }
-    let probe = format!("{input}\nfn __hew_repl_attr_probe__() {{}}\n");
-    parses_as_item(&probe)
+    saw_group
 }
 
 /// Parse a REPL command string (after the leading `:`).
@@ -229,8 +277,11 @@ mod tests {
         );
         assert_eq!(classify("pub fn bar() {}"), InputKind::Item);
         assert_eq!(classify("/// Adds numbers.\nfn add() {}"), InputKind::Item);
+        // `#[export(..)]` (not `#[memo]`, which HEW-SPEC-2026 §12.6's closed
+        // attribute table does not recognise) exercises classification of an
+        // attribute-decorated item.
         assert_eq!(
-            classify("#[memo]\nfn cached() -> i64 { 42 }"),
+            classify("#[export(\"cached\")]\nfn cached() -> i64 { 42 }"),
             InputKind::Item
         );
     }

--- a/hew-cli/tests/resource_marker_applicability_reject.rs
+++ b/hew-cli/tests/resource_marker_applicability_reject.rs
@@ -36,9 +36,13 @@ fn main() {}
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+    // `#[resource]` is only legal at type/enum declaration position
+    // (HEW-SPEC-2026 §12.6); a type alias never carries a `ResourceMarker`,
+    // so this is `E_UNKNOWN_ATTRIBUTE`, superseding the retired
+    // `E_RESOURCE_MARKER_TARGET`.
     let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
     assert!(
-        stderr.contains("E_RESOURCE_MARKER_TARGET")
+        stderr.contains("E_UNKNOWN_ATTRIBUTE")
             && stderr.contains("#[resource]")
             && stderr.contains("resource_alias_marker.hew:1:1")
             && stderr.contains("^^^^^^^^^^^"),

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -15651,7 +15651,6 @@ impl LowerCtx {
                     "crash" => Some(HirLifecycleHookKind::Crash),
                     "exit" => Some(HirLifecycleHookKind::Exit),
                     "down" => Some(HirLifecycleHookKind::Down),
-                    "upgrade" => Some(HirLifecycleHookKind::Upgrade),
                     _ => None,
                 });
             match hook_kind {

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -654,9 +654,6 @@ pub enum HirLifecycleHookKind {
     Exit,
     /// `#[on(down)]` — receives a typed monitor terminal notification.
     Down,
-    /// `#[on(upgrade)]` — reserved marker for hot-upgrade flows. No
-    /// runtime invocation in v0.5.
-    Upgrade,
 }
 
 // ── Machine declarations ─────────────────────────────────────────────────────

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -2532,7 +2532,6 @@ machine Traffic {
             TypeErrorKind::Shadowing,
             TypeErrorKind::OrphanImpl,
             TypeErrorKind::PlatformLimitation,
-            TypeErrorKind::OnUpgradeNotYetWired,
             TypeErrorKind::MachineExhaustivenessError,
             TypeErrorKind::BlockingCallInReceiveFn,
         ];

--- a/hew-lsp/tests/fixtures/v05_attributes.hew
+++ b/hew-lsp/tests/fixtures/v05_attributes.hew
@@ -5,12 +5,14 @@ actor AttributeActor {
     }
 }
 
-#[on(crash)]
+// `#[on(..)]` is only legal on a plain `fn` inside an actor body
+// (HEW-SPEC-2026 §12.6); these two probes are free functions, so they carry
+// no attribute — the fixture only needs their names for the LSP hover/
+// goto-definition/find-references smoke checks below.
 fn attribute_crash_probe() -> i32 {
     7
 }
 
-#[on(upgrade)]
 fn attribute_upgrade_probe() -> i32 {
     attribute_crash_probe()
 }

--- a/hew-mir/src/lower/machine_synth.rs
+++ b/hew-mir/src/lower/machine_synth.rs
@@ -485,7 +485,7 @@ fn lower_actor_init_handler(
 )]
 #[allow(
     clippy::too_many_lines,
-    reason = "each lifecycle hook kind (Start, Stop, Crash, Upgrade) needs its own arm; extracting would not reduce conceptual complexity"
+    reason = "each lifecycle hook kind (Start, Stop, Crash, Exit, Down) needs its own arm; extracting would not reduce conceptual complexity"
 )]
 fn lower_actor_lifecycle_handlers(
     actor: &HirActorDecl,
@@ -1168,34 +1168,9 @@ fn lower_actor_lifecycle_handlers(
                     ActorHandlerKind::Down,
                 ));
             }
-            HirLifecycleHookKind::Upgrade => push_lifecycle_not_wired_diagnostic(
-                diagnostics,
-                &actor.name,
-                &hook.name,
-                "OnUpgradeNotYetWired",
-                "upgrade",
-                "hot-upgrade lifecycle invocation is pending explicit ratification",
-            ),
         }
     }
     lowered
-}
-fn push_lifecycle_not_wired_diagnostic(
-    diagnostics: &mut Vec<MirDiagnostic>,
-    actor_name: &str,
-    hook_name: &str,
-    diagnostic_name: &str,
-    hook_kind: &str,
-    reason: &str,
-) {
-    diagnostics.push(MirDiagnostic {
-        kind: MirDiagnosticKind::UnsupportedNode {
-            reason: format!("{diagnostic_name}: #[on({hook_kind})] is not wired"),
-        },
-        note: format!(
-            "`#[on({hook_kind})]` hook `{actor_name}.{hook_name}` would silently never run; {reason}"
-        ),
-    });
 }
 /// The `$`-mangled symbol base for an actor's native symbols.
 ///

--- a/hew-mir/tests/actor/actor_handler_lowering.rs
+++ b/hew-mir/tests/actor/actor_handler_lowering.rs
@@ -1671,11 +1671,10 @@ fn generator_handler_call_lowers_to_stream_dispatch() {
 }
 
 #[test]
-fn actor_lifecycle_start_lowers_and_unwired_hooks_fail_closed() {
+fn actor_lifecycle_start_and_crash_hooks_lower_to_actor_handler_functions() {
     let mut ids = IdGen::default();
     let start_return = return_none_stmt(&mut ids);
     let crash_return = return_none_stmt(&mut ids);
-    let upgrade_return = return_none_stmt(&mut ids);
     let actor = {
         let mut actor = actor(&mut ids, "Counter", vec![]);
         actor.lifecycle_hooks = vec![
@@ -1695,15 +1694,6 @@ fn actor_lifecycle_start_lowers_and_unwired_hooks_fail_closed() {
                 params: vec![],
                 return_ty: ResolvedTy::Unit,
                 body: block(&mut ids, vec![crash_return], None, ResolvedTy::Unit),
-                span: 0..0,
-            },
-            HirLifecycleHook {
-                kind: HirLifecycleHookKind::Upgrade,
-                name: "upgrade".to_string(),
-                declaration: hew_types::DefId::for_test("upgrade"),
-                params: vec![],
-                return_ty: ResolvedTy::Unit,
-                body: block(&mut ids, vec![upgrade_return], None, ResolvedTy::Unit),
                 span: 0..0,
             },
         ];
@@ -1741,16 +1731,6 @@ fn actor_lifecycle_start_lowers_and_unwired_hooks_fail_closed() {
         .find(|func| func.name == "Counter__on_crash")
         .expect("on(crash) hook must produce a MIR function");
     assert_eq!(crash_fn.call_conv, FunctionCallConv::ActorHandler);
-    // on(upgrade) remains fail-closed — no MIR function, a diagnostic.
-    assert!(
-        pipeline.diagnostics.iter().any(|diag| {
-            matches!(
-                &diag.kind,
-                MirDiagnosticKind::UnsupportedNode { reason } if reason.contains("OnUpgradeNotYetWired")
-            )
-        }),
-        "OnUpgradeNotYetWired must still be fail-closed"
-    );
     // on(stop) is wired — no fail-closed diagnostic for it.
     assert!(
         !pipeline.diagnostics.iter().any(|diag| {

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -575,9 +575,9 @@ impl<'a> Formatter<'a> {
                 TypeBodyItem::Field {
                     name,
                     ty,
+                    attributes,
                     doc_comment,
                     span,
-                    ..
                 } => {
                     // flush inline comments that appear before this field
                     self.flush_comments_before(span.start);
@@ -586,6 +586,7 @@ impl<'a> Formatter<'a> {
                     // between the field name and any trailing comment
                     self.prev_source_pos = span.start;
                     self.write_outer_doc(doc_comment.as_ref());
+                    self.format_attributes(attributes);
                     self.write_indent();
                     self.write(name);
                     self.write(": ");

--- a/hew-parser/src/parser/actor_machine_supervisor.rs
+++ b/hew-parser/src/parser/actor_machine_supervisor.rs
@@ -63,27 +63,10 @@ impl Parser<'_> {
             if doc_comment.is_none() {
                 doc_comment = self.collect_doc_comments();
             }
-            self.reject_resource_marker_attributes(&attrs);
-
-            // `#[extern_symbol]` belongs on `extern "C"` fns and `impl`
-            // methods — not on actor body members (init, receive fn,
-            // receive gen fn, or inherent methods).
-            for attr in &attrs {
-                if attr.name == "extern_symbol" {
-                    self.error_at(
-                        "`#[extern_symbol]` is only valid on `fn` declarations inside an \
-                         `extern \"C\"` block or an `impl` block; actor members cannot \
-                         bind to a runtime C-ABI symbol"
-                            .to_string(),
-                        attr.span.clone(),
-                    );
-                }
-            }
 
             if self.peek() == Some(&Token::Init) {
-                if !attrs.is_empty() {
-                    self.error("attributes are not supported on init blocks".to_string());
-                }
+                // No attribute is legal on an `init` block.
+                self.validate_attributes_for(&attrs, AttrPosition::Unsupported);
                 self.advance();
                 self.expect(&Token::LeftParen)?;
                 let params = self.parse_params();
@@ -91,6 +74,7 @@ impl Parser<'_> {
                 let body = self.parse_block()?;
                 init = Some(ActorInit { params, body });
             } else if self.peek() == Some(&Token::Receive) {
+                self.validate_attributes_for(&attrs, AttrPosition::ActorReceiveFn);
                 let recv_start = self.peek_span().start;
                 self.advance();
                 let is_generator = if self.eat(&Token::Gen) {
@@ -140,18 +124,11 @@ impl Parser<'_> {
                 // permitted on plain `fn` declarations inside an actor body.
                 // All other attributes on actor methods are rejected: they
                 // belong on `receive fn` declarations.
-                let mut hook_attrs = Vec::new();
-                let mut other_attrs = Vec::new();
-                for attr in attrs {
-                    if is_lifecycle_hook_attr(&attr.name) {
-                        hook_attrs.push(attr);
-                    } else {
-                        other_attrs.push(attr);
-                    }
-                }
-                if !other_attrs.is_empty() {
-                    self.error("attributes are not supported on actor methods; use them on receive fn declarations".to_string());
-                }
+                self.validate_attributes_for(&attrs, AttrPosition::ActorMemberFn);
+                let hook_attrs: Vec<_> = attrs
+                    .into_iter()
+                    .filter(|attr| is_lifecycle_hook_attr(&attr.name))
+                    .collect();
                 let fn_start = self.peek_span().start;
                 self.advance();
                 if let Some(mut method) =
@@ -165,9 +142,7 @@ impl Parser<'_> {
                     self.skip_to_actor_item_boundary();
                 }
             } else if self.peek() == Some(&Token::Let) {
-                if !attrs.is_empty() {
-                    self.error("attributes are not supported on field declarations".to_string());
-                }
+                self.validate_attributes_for(&attrs, AttrPosition::Unsupported);
                 self.advance();
                 let field_name = self.expect_ident()?;
                 self.expect(&Token::Colon)?;
@@ -189,6 +164,7 @@ impl Parser<'_> {
                     doc_comment,
                 });
             } else if self.peek() == Some(&Token::Var) {
+                self.validate_attributes_for(&attrs, AttrPosition::Unsupported);
                 self.advance();
                 let field_name = self.expect_ident()?;
                 self.expect(&Token::Colon)?;
@@ -210,6 +186,7 @@ impl Parser<'_> {
                     doc_comment,
                 });
             } else if matches!(self.peek(), Some(Token::Identifier(s)) if *s == "mailbox") {
+                self.validate_attributes_for(&attrs, AttrPosition::Unsupported);
                 self.advance();
                 if let Some(Token::Integer(n)) = self.peek() {
                     if let Some(cap) = parse_int_literal(n)
@@ -227,6 +204,7 @@ impl Parser<'_> {
                 }
                 self.eat(&Token::Semicolon);
             } else if self.peek_is_field_decl() {
+                self.validate_attributes_for(&attrs, AttrPosition::Unsupported);
                 let field_name = self.expect_ident()?;
                 self.expect(&Token::Colon)?;
                 let ty = self.parse_type()?;

--- a/hew-parser/src/parser/attributes.rs
+++ b/hew-parser/src/parser/attributes.rs
@@ -1,0 +1,129 @@
+//! The closed attribute table (HEW-SPEC-2026 §12.6).
+//!
+//! The attribute set is closed: every `#[name]` the parser accepts, and every
+//! position it is legal in, is listed in [`legal_positions`]. An attribute
+//! whose name is not in the table, or that appears in a position the table
+//! does not list for it, is `E_UNKNOWN_ATTRIBUTE` (User channel) — this is
+//! the one diagnostic path every attribute-consuming call site in the parser
+//! routes through via [`Parser::validate_attributes_for`].
+//!
+//! Substrate attributes (`lang_item`, `intrinsic`, `diagnostic_item`,
+//! `overload`, `runtime_capability`, `abi`) are recognised here at the
+//! positions they occupy in `std/`; restricting them to `std/` itself is a
+//! separate, existing authority (`RESERVED_SUBSTRATE_ATTRIBUTES` in
+//! `hew-types::stdlib_authority`) that runs after parsing. The two checks
+//! compose: this table says a name+position pair is *known*, the authority
+//! check says a substrate name is only *usable* inside `std/`.
+
+#[allow(
+    clippy::wildcard_imports,
+    reason = "grammar-area submodules share the parent parser namespace via the split"
+)]
+use super::*;
+
+/// A syntactic position an attribute can appear in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttrPosition {
+    /// `type Name { .. }`, `enum Name { .. }`, `indirect enum Name { .. }`.
+    TypeDecl,
+    /// A field inside a `type { .. }` body.
+    Field,
+    /// A free function (top-level `fn`, including `pub`/`package`).
+    FreeFn,
+    /// A `trait Name { .. }` declaration itself.
+    TraitDecl,
+    /// A method signature inside a `trait { .. }` body.
+    TraitMethod,
+    /// An `actor Name { .. }` declaration itself.
+    ActorDecl,
+    /// A plain `fn` inside an actor body (lifecycle hooks).
+    ActorMemberFn,
+    /// A `receive fn` inside an actor body.
+    ActorReceiveFn,
+    /// A method inside an `impl { .. }` block.
+    ImplMethod,
+    /// A `fn` inside an `extern "C" { .. }` block.
+    ExternFn,
+    /// A position no attribute is legal in (`const`, `import`, `supervisor`,
+    /// `machine`, a type alias, a tuple-form record, an `impl`/`extern`
+    /// block's own header, an inline method inside a `type { .. }` body, an
+    /// actor `init`/`let`/`var` field). No table entry ever names this
+    /// variant, so every attribute found here is unconditionally
+    /// `E_UNKNOWN_ATTRIBUTE`.
+    Unsupported,
+}
+
+/// Returns the positions `name` is legal in, or `None` if `name` is not a
+/// recognised attribute at all.
+fn legal_positions(name: &str) -> Option<&'static [AttrPosition]> {
+    use AttrPosition::{
+        ActorDecl, ActorMemberFn, ActorReceiveFn, ExternFn, Field, FreeFn, ImplMethod, TraitDecl,
+        TraitMethod, TypeDecl,
+    };
+
+    // Substrate attributes share one broad position set: every declaration
+    // shape `hew-types::stdlib_authority::AuthorityDeclarationKind` tracks
+    // (Type, Trait, TraitMethod, Function, Method, ExternFunction). Whether a
+    // given use is inside `std/` is validated separately after parsing.
+    const SUBSTRATE_POSITIONS: &[AttrPosition] = &[
+        TypeDecl,
+        TraitDecl,
+        TraitMethod,
+        FreeFn,
+        ImplMethod,
+        ExternFn,
+    ];
+
+    Some(match name {
+        "resource" | "linear" | "opaque" | "json" | "yaml" | "deprecated" => &[TypeDecl],
+        "wire" => &[TypeDecl, Field],
+        // `#[ignore]`/`#[should_panic]`/`#[serial]` structurally sit at
+        // `FreeFn` like `#[test]` and `#[export]`; the co-occurrence half of
+        // their `#[test]`-only rule is enforced by
+        // `Parser::validate_attributes_for`, not by this table.
+        "test" | "export" | "ignore" | "should_panic" | "serial" => &[FreeFn],
+        "on" => &[ActorMemberFn],
+        "every" => &[ActorReceiveFn],
+        "max_heap" => &[ActorDecl],
+        "extern_symbol" => &[ImplMethod, ExternFn],
+        // Not gated to `std/` by `RESERVED_SUBSTRATE_ATTRIBUTES` today (it is
+        // used by non-stdlib code, e.g.
+        // `tests/vertical-slice/accept/returns_receiver_consuming_result.hew`),
+        // so it is listed as an ordinary attribute rather than folded into
+        // `SUBSTRATE_POSITIONS`.
+        "returns_receiver" => &[TraitMethod, ImplMethod],
+        "lang_item" | "intrinsic" | "diagnostic_item" | "overload" | "runtime_capability"
+        | "abi" => SUBSTRATE_POSITIONS,
+        _ => return None,
+    })
+}
+
+impl Parser<'_> {
+    /// Validate every attribute in `attrs` against the closed table for
+    /// `position`, emitting `E_UNKNOWN_ATTRIBUTE` for any name the table does
+    /// not know, or that is not legal in `position`.
+    ///
+    /// This is the one diagnostic path every attribute-consuming call site
+    /// routes through — no call site keeps its own bespoke allowlist.
+    pub(crate) fn validate_attributes_for(&mut self, attrs: &[Attribute], position: AttrPosition) {
+        let has_test = attrs.iter().any(|a| a.name == "test");
+        for attr in attrs {
+            let in_table = legal_positions(&attr.name).is_some_and(|p| p.contains(&position));
+            // `#[ignore]`, `#[should_panic]`, and `#[serial]` structurally sit
+            // at `FreeFn` like `#[test]` itself, but §12.6 only legalises them
+            // on a function that also carries `#[test]` — a misspelled
+            // `#[test]` must not leave them silently accepted either.
+            let requires_test = matches!(attr.name.as_str(), "ignore" | "should_panic" | "serial");
+            let legal = in_table && (!requires_test || has_test);
+            if !legal {
+                self.error_at(
+                    format!(
+                        "unrecognised attribute `#[{}]` in this position [E_UNKNOWN_ATTRIBUTE]",
+                        attr.name
+                    ),
+                    attr.span.clone(),
+                );
+            }
+        }
+    }
+}

--- a/hew-parser/src/parser/items.rs
+++ b/hew-parser/src/parser/items.rs
@@ -7,6 +7,27 @@
 )]
 use super::*;
 
+/// Identifiers [`Parser::foreign_keyword_redirect`] recognises as
+/// foreign-language keywords at item position (`struct`, `class`, bare
+/// `wire`, and friends). [`Parser::top_level_attr_position`] skips
+/// closed-table validation ahead of these — the redirect emits its own
+/// targeted diagnostic and never constructs an item.
+const FOREIGN_KEYWORD_IDENTS: &[&str] = &[
+    "record",
+    "struct",
+    "class",
+    "object",
+    "func",
+    "function",
+    "def",
+    "sub",
+    "proc",
+    "method",
+    "interface",
+    "protocol",
+    "wire",
+];
+
 impl Parser<'_> {
     // ── Program and Items ──
     pub fn parse_program(&mut self) -> Program {
@@ -310,52 +331,49 @@ impl Parser<'_> {
         }
     }
 
-    /// Reject ownership markers on a top-level item that cannot store a
-    /// [`ResourceMarker`].
+    /// Determine which [`AttrPosition`] the leading attributes just parsed by
+    /// [`Self::parse_item`] belong to, without consuming any tokens.
     ///
-    /// `type Name { ... }`, `enum Name { ... }`, and `indirect enum Name {
-    /// ... }` are the only item forms that lower through `TypeDecl` and may
-    /// therefore carry `#[resource]` or `#[linear]`. Type aliases deliberately
-    /// do not qualify: they have no independent ownership contract.
-    fn reject_resource_markers_on_unsupported_item(&mut self, attrs: &[Attribute]) {
+    /// This is a lookahead over the same token shapes [`Self::parse_item`]'s
+    /// own dispatch match reads: an optional `pub`/`package` visibility
+    /// modifier, then the keyword (or lookahead-disambiguated `type` form)
+    /// that decides what item this becomes. Item forms with no legal
+    /// top-level attribute position (`const`, `import`, `supervisor`,
+    /// `machine`, type aliases, tuple-form records, `impl` blocks, `extern`
+    /// blocks) resolve to [`AttrPosition::Unsupported`], which the closed
+    /// table lists no attribute for.
+    ///
+    /// Returns `None` when the upcoming token is one [`Self::foreign_keyword_redirect`]
+    /// recognises (`struct`, `class`, `func`, bare `wire`, and friends) or the
+    /// reserved `foreign` keyword: these paths never construct an item — they
+    /// emit their own targeted diagnostic (e.g. "write `#[wire] type Name {
+    /// .. }` instead") and return `None` from [`Self::parse_item`] — so the
+    /// closed table stays silent rather than layering `E_UNKNOWN_ATTRIBUTE`
+    /// on top of that guidance.
+    fn top_level_attr_position(&self) -> Option<AttrPosition> {
         let target_pos = if matches!(self.peek(), Some(Token::Pub | Token::Package)) {
             self.pos + 1
         } else {
             self.pos
         };
 
-        let supports_resource_marker = match self.peek_at(target_pos) {
-            Some(Token::Enum | Token::Indirect) => true,
-            Some(Token::Type) => {
-                !self.is_type_alias_lookahead_at(target_pos)
-                    && !self.is_tuple_type_lookahead_at(target_pos)
+        match self.peek_at(target_pos) {
+            Some(Token::Fn | Token::Async | Token::Gen) => Some(AttrPosition::FreeFn),
+            Some(Token::Enum | Token::Indirect) => Some(AttrPosition::TypeDecl),
+            Some(Token::Type)
+                if !self.is_type_alias_lookahead_at(target_pos)
+                    && !self.is_tuple_type_lookahead_at(target_pos) =>
+            {
+                Some(AttrPosition::TypeDecl)
             }
-            _ => false,
-        };
-
-        if !supports_resource_marker {
-            self.reject_resource_marker_attributes(attrs);
-        }
-    }
-
-    /// Emit a source-spanned error for ownership markers in a context that
-    /// cannot carry [`ResourceMarker`].
-    ///
-    /// Attribute-bearing nested declarations (trait items, impl methods,
-    /// extern functions, and actor members) call this directly because they do
-    /// not pass through [`Self::parse_item`].
-    pub(crate) fn reject_resource_marker_attributes(&mut self, attrs: &[Attribute]) {
-        for attr in attrs {
-            if matches!(attr.name.as_str(), "resource" | "linear") {
-                self.error_at(
-                    format!(
-                        "#[{}] is only valid on `type` or `enum` declarations \
-                         [E_RESOURCE_MARKER_TARGET]",
-                        attr.name
-                    ),
-                    attr.span.clone(),
-                );
-            }
+            Some(Token::Trait) => Some(AttrPosition::TraitDecl),
+            Some(Token::Actor) => Some(AttrPosition::ActorDecl),
+            Some(Token::Foreign) => None,
+            Some(Token::Identifier(id)) if FOREIGN_KEYWORD_IDENTS.contains(id) => None,
+            // `type` alias/tuple-record forms, `const`, `import`,
+            // `supervisor`, `machine`, `impl`, `extern`, and anything else:
+            // no attribute is legal on these item forms.
+            _ => Some(AttrPosition::Unsupported),
         }
     }
 
@@ -368,45 +386,23 @@ impl Parser<'_> {
         if doc_comment.is_none() {
             doc_comment = self.collect_doc_comments();
         }
-        // `#[extern_symbol("…")]` attaches to a `fn` declaration nested inside
-        // either an `extern "C" { … }` block or an `impl Ty { … }` / `impl Trait
-        // for Ty { … }` block (parsed via `parse_extern_block` and
-        // `parse_impl_decl`'s body loop respectively). At item level it is
-        // never valid — reject it here with a clear diagnostic rather than
-        // silently dropping it onto whatever item follows.
-        for attr in &attrs {
-            if attr.name == "extern_symbol" {
-                self.error_at(
-                    "`#[extern_symbol]` is only valid on `fn` declarations inside an \
-                     `extern \"C\"` block or an `impl` block"
-                        .to_string(),
-                    attr.span.clone(),
-                );
-            }
-        }
         let start = self.peek_span().start;
         // Pre-compute attribute span before attrs is moved into the item.
         let attr_start = attrs.first().map(|a| a.span.start);
-
-        // Extract `#[max_heap]` before dispatch so we can set it on the actor
-        // and reject it on any non-actor item.  We pull both the result and the
-        // diagnostic span out as owned values so `attrs` can be moved freely
-        // into the match arms below.
-        let (max_heap_result, max_heap_attr_span): (Option<Result<u64, String>>, Option<Span>) =
-            if let Some(a) = attrs.iter().find(|a| a.name == "max_heap") {
-                (Some(resolve_max_heap_args(&a.args)), Some(a.span.clone()))
-            } else {
-                (None, None)
-            };
         let has_wire_attr = attrs.iter().any(|a| a.name == "wire");
 
-        // `#[resource]` and `#[linear]` are ownership declarations, not
-        // general-purpose item attributes. Only `type` / `enum` declarations
-        // carry `ResourceMarker` in the AST; accepting either marker on another
-        // item would parse successfully and then silently discard ownership.
-        // Validate before dispatch so every visibility form receives the same
-        // source-spanned, fail-closed diagnostic.
-        self.reject_resource_markers_on_unsupported_item(&attrs);
+        // Validate every leading attribute against the closed table for the
+        // item kind about to be dispatched, before dispatch, so every
+        // visibility form (`pub`, `package`, private) receives the same
+        // source-spanned, fail-closed `E_UNKNOWN_ATTRIBUTE` diagnostic. This
+        // is a lookahead only — no tokens are consumed.
+        if let Some(item_attr_position) = self.top_level_attr_position() {
+            self.validate_attributes_for(&attrs, item_attr_position);
+        }
+        // `attrs` is moved into the fn/type dispatch arms below; `#[max_heap]`
+        // is wired onto the resulting `Item::Actor` post-dispatch, so its
+        // value (if present) is captured here as an owned clone.
+        let max_heap_attr = attrs.iter().find(|a| a.name == "max_heap").cloned();
 
         let item = match self.peek() {
             Some(Token::Import) => {
@@ -584,28 +580,22 @@ impl Parser<'_> {
             }
         };
 
-        // Wire `#[max_heap]` into the actor, or emit a diagnostic if it appears
-        // on a non-actor item.
-        let item = match (item, max_heap_result) {
-            (Item::Actor(mut actor), Some(Ok(bytes))) => {
-                actor.max_heap_bytes = Some(bytes);
+        // Wire `#[max_heap]` into the actor. `attrs` was already validated
+        // against the closed table above, so `#[max_heap]` on a non-actor
+        // item was already reported there as `E_UNKNOWN_ATTRIBUTE`; only a
+        // malformed value on an actor itself (`#[max_heap(huge)]`) needs a
+        // diagnostic here.
+        let item = match item {
+            Item::Actor(mut actor) => {
+                if let Some(attr) = max_heap_attr {
+                    match resolve_max_heap_args(&attr.args) {
+                        Ok(bytes) => actor.max_heap_bytes = Some(bytes),
+                        Err(msg) => self.error_at(msg, attr.span),
+                    }
+                }
                 Item::Actor(actor)
             }
-            (Item::Actor(actor), Some(Err(msg))) => {
-                let span = max_heap_attr_span.unwrap_or(start..start);
-                self.error_at(msg, span);
-                Item::Actor(actor)
-            }
-            (Item::Actor(actor), None) => Item::Actor(actor),
-            (other_item, Some(_)) => {
-                let span = max_heap_attr_span.unwrap_or(start..start);
-                self.error_at(
-                    "#[max_heap] is only allowed on actor declarations".to_string(),
-                    span,
-                );
-                other_item
-            }
-            (other_item, None) => other_item,
+            other_item => other_item,
         };
 
         let end = self.peek_span().start;
@@ -1059,34 +1049,23 @@ impl Parser<'_> {
     /// `#[linear]`   → `ResourceMarker::Linear`
     ///
     /// Emits a diagnostic if both `#[resource]` and `#[linear]` appear on the
-    /// same type (they declare incompatible ownership disciplines).  Emits a
-    /// diagnostic for any attribute that is not a recognised type-decl attribute;
-    /// unrecognised names could be ownership-marker typos and are rejected
-    /// fail-closed rather than silently ignored.
+    /// same type (they declare incompatible ownership disciplines) via
+    /// `E_TYPE_MARKER_CONFLICT`. Attribute name/position validity itself is
+    /// the closed table's job (`validate_attributes_for`, called by
+    /// `parse_item` before dispatch reaches here) — `E_UNKNOWN_ATTRIBUTE`
+    /// supersedes the old `E_UNKNOWN_TYPE_MARKER` for this position.
     ///
     /// The attribute is not consumed from the slice; callers that render
     /// attributes should filter `resource` / `linear` out themselves if they
     /// want to suppress them in output. The checker is the only consumer, so
     /// we leave the slice untouched.
-    ///
-    /// Valid type-decl attributes: `resource`, `linear`, `wire`, `json`,
-    /// `yaml`, `deprecated`, `opaque`.  Anything else triggers `E_UNKNOWN_TYPE_MARKER`.
     pub(crate) fn extract_resource_marker(&mut self, attrs: &[Attribute]) -> ResourceMarker {
-        // Known-valid attributes for type declarations.  These are consumed by
-        // other parser paths (wire metadata, deprecation, naming-case, opaque
-        // representation); only `resource` and `linear` belong to the
-        // ownership-discipline surface this helper returns.
-        const KNOWN_TYPE_ATTRS: &[&str] = &[
-            "resource",
-            "linear",
-            "wire",
-            "json",
-            "yaml",
-            "deprecated",
-            "opaque",
-            "lang_item",
-        ];
-
+        // Attribute names and positions are validated by the closed table
+        // (`validate_attributes_for`) in `parse_item` before any of the
+        // `type`/`enum` dispatch functions run, so this only needs to decide
+        // the ownership-discipline surface `resource`/`linear` carry and
+        // catch the one combination the table can't express: the two
+        // markers conflicting on the same declaration.
         let mut resource_span: Option<std::ops::Range<usize>> = None;
         let mut linear_span: Option<std::ops::Range<usize>> = None;
         let mut marker = ResourceMarker::None;
@@ -1122,15 +1101,6 @@ impl Parser<'_> {
                     }
                     linear_span = Some(attr.span.clone());
                     marker = ResourceMarker::Linear;
-                }
-                name if !KNOWN_TYPE_ATTRS.contains(&name) => {
-                    self.error_at(
-                        format!(
-                            "unrecognised type attribute '#[{name}]' \
-                             [E_UNKNOWN_TYPE_MARKER]"
-                        ),
-                        attr.span.clone(),
-                    );
                 }
                 _ => {}
             }
@@ -1175,23 +1145,13 @@ impl Parser<'_> {
                 if doc_comment.is_none() {
                     doc_comment = self.collect_doc_comments();
                 }
-                self.reject_resource_marker_attributes(&attributes);
-
-                // `#[extern_symbol]` belongs on `extern "C"` fns and `impl`
-                // methods — not on methods declared inline in a type body.
-                for attr in &attributes {
-                    if attr.name == "extern_symbol" {
-                        self.error_at(
-                            "`#[extern_symbol]` is only valid on `fn` declarations inside an \
-                             `extern \"C\"` block or an `impl` block; declare the method in an \
-                             `impl` block instead"
-                                .to_string(),
-                            attr.span.clone(),
-                        );
-                    }
-                }
 
                 if self.peek() == Some(&Token::Fn) {
+                    // No attribute is legal on a method declared inline in a
+                    // `type { .. }` body (`#[extern_symbol]` belongs on an
+                    // `impl` method instead, `#[resource]`/`#[linear]` only
+                    // on the type declaration itself, and so on).
+                    self.validate_attributes_for(&attributes, AttrPosition::Unsupported);
                     let fn_start = self.peek_span().start;
                     self.advance();
                     // Use parse_type_method so `consuming self` receivers are accepted.
@@ -1200,6 +1160,7 @@ impl Parser<'_> {
                     method.doc_comment = doc_comment;
                     Some((TypeBodyItem::Method(method), has_consuming_self))
                 } else {
+                    self.validate_attributes_for(&attributes, AttrPosition::Field);
                     // Field with optional attributes (e.g. #[encode(rename = "x")])
                     let name = self.expect_ident()?;
                     self.expect(&Token::Colon)?;
@@ -1320,8 +1281,15 @@ impl Parser<'_> {
     pub(crate) fn parse_trait_item(&mut self) -> Option<TraitItem> {
         let doc_comment = self.collect_doc_comments();
         let attrs = self.parse_attributes();
-        self.reject_resource_marker_attributes(&attrs);
-        self.reject_extern_symbol_on_trait_item(&attrs);
+        // Only a method signature carries a legal attribute (the substrate
+        // set and `#[returns_receiver]`); an associated `type` declaration
+        // carries none.
+        let trait_item_attr_position = if self.peek() == Some(&Token::Fn) {
+            AttrPosition::TraitMethod
+        } else {
+            AttrPosition::Unsupported
+        };
+        self.validate_attributes_for(&attrs, trait_item_attr_position);
 
         match self.peek() {
             Some(Token::Fn) => {
@@ -1422,22 +1390,6 @@ impl Parser<'_> {
         }
     }
 
-    fn reject_extern_symbol_on_trait_item(&mut self, attrs: &[Attribute]) {
-        // Trait items describe an abstract surface; bind the C ABI symbol on
-        // the concrete implementation method instead.
-        for attr in attrs {
-            if attr.name == "extern_symbol" {
-                self.error_at(
-                    "`#[extern_symbol]` is only valid on `fn` declarations inside an \
-                     `extern \"C\"` block or an `impl` block; bind the symbol on the \
-                     concrete `impl` method instead"
-                        .to_string(),
-                    attr.span.clone(),
-                );
-            }
-        }
-    }
-
     pub(crate) fn parse_impl_decl(&mut self) -> Option<ImplDecl> {
         let type_params = self.parse_opt_type_params()?;
 
@@ -1465,7 +1417,21 @@ impl Parser<'_> {
         while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
             let doc_comment = self.collect_doc_comments();
             let method_attrs = self.parse_attributes();
-            self.reject_resource_marker_attributes(&method_attrs);
+            // `fn` methods carry the impl-method attribute set
+            // (`#[extern_symbol]`, the substrate set, `#[returns_receiver]`);
+            // a `type` alias inside an impl block carries none. Look past an
+            // optional `pub`/`package` modifier without consuming it.
+            let impl_item_probe = if matches!(self.peek(), Some(Token::Pub | Token::Package)) {
+                self.pos + 1
+            } else {
+                self.pos
+            };
+            let impl_item_attr_position = if self.peek_at(impl_item_probe) == Some(&Token::Fn) {
+                AttrPosition::ImplMethod
+            } else {
+                AttrPosition::Unsupported
+            };
+            self.validate_attributes_for(&method_attrs, impl_item_attr_position);
             let vis = if matches!(self.peek(), Some(Token::Pub | Token::Package)) {
                 self.parse_visibility()
             } else {
@@ -1473,13 +1439,6 @@ impl Parser<'_> {
             };
             match self.peek() {
                 Some(Token::Type) => {
-                    if !method_attrs.is_empty() {
-                        let span = method_attrs.first().map_or(0..0, |a| a.span.clone());
-                        self.error_at(
-                            "attributes are not supported on impl-block type aliases".to_string(),
-                            span,
-                        );
-                    }
                     if vis != Visibility::Private {
                         self.error(
                             "type aliases in impl bodies cannot have visibility modifiers"
@@ -1511,15 +1470,6 @@ impl Parser<'_> {
                 other => {
                     let other_msg =
                         format!("expected 'fn' or 'type' in impl body, found {other:?}");
-                    if !method_attrs.is_empty() {
-                        let span = method_attrs.first().map_or(0..0, |a| a.span.clone());
-                        self.error_at(
-                            "attributes inside an impl block must be followed by a `fn` \
-                             declaration"
-                                .to_string(),
-                            span,
-                        );
-                    }
                     self.error(other_msg);
                     self.advance(); // error recovery: skip the bad token
                 }
@@ -1568,7 +1518,7 @@ impl Parser<'_> {
             // Doc comments are not supported inside extern blocks today; only
             // attributes between the opening `{` and the next `fn` are parsed.
             let attributes = self.parse_attributes();
-            self.reject_resource_marker_attributes(&attributes);
+            self.validate_attributes_for(&attributes, AttrPosition::ExternFn);
             if self.peek() == Some(&Token::Fn) {
                 let item_start = attributes
                     .first()

--- a/hew-parser/src/parser/mod.rs
+++ b/hew-parser/src/parser/mod.rs
@@ -25,6 +25,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 mod actor_machine_supervisor;
+mod attributes;
 mod core;
 mod expressions;
 mod items;
@@ -46,6 +47,11 @@ pub(crate) use precedence::{
 // `expressions`'s `Token::Break` desugar too, so it is re-exported here like
 // the `precedence` free fns above.
 pub(crate) use statements::BreakValuePosition;
+
+// The closed attribute table (HEW-SPEC-2026 §12.6) — `AttrPosition` and
+// `Parser::validate_attributes_for` are used from every area submodule that
+// consumes `#[...]` attributes.
+pub(crate) use attributes::AttrPosition;
 
 #[cfg(test)]
 mod tests;
@@ -207,9 +213,10 @@ pub(crate) fn unquote_str(s: &str) -> &str {
 ///
 /// The parameterized form `#[on(<event>)]` uses a single attribute name
 /// `on` with the hook kind as a positional argument. Recognised events
-/// are `start`, `stop`, `crash`, `exit`, `down`, and `upgrade`. Validation of
-/// the event identifier and per-event signature shape lives in the
-/// type-checker (`hew-types::check::items`).
+/// are `start`, `stop`, `crash`, `exit`, and `down` (`upgrade` left this
+/// list at HEW-SPEC-2026 §12.6). Validation of the event identifier and
+/// per-event signature shape lives in the type-checker
+/// (`hew-types::check::items`).
 pub(crate) fn is_lifecycle_hook_attr(name: &str) -> bool {
     name == "on"
 }

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -1556,8 +1556,10 @@ fn parse_actor_on_crash_hook_attaches_to_method() {
 
 #[test]
 fn parse_actor_on_upgrade_hook_attaches_to_method() {
-    // E1: `#[on(upgrade)]` parses on an actor method. The parser accepts
-    // it; the type-checker rejects it as a reserved, unsupported attribute.
+    // E1: `#[on(upgrade)]` parses on an actor method — the parser is
+    // hook-kind-agnostic, only checking the attribute name is `on`. `upgrade`
+    // left the hook-kind list at the type-checker (HEW-SPEC-2026 §12.6);
+    // it rejects this as an unrecognised lifecycle hook.
     let source = r"actor Worker {
     #[on(upgrade)]
     fn on_upgrade() { }
@@ -1581,7 +1583,10 @@ fn parse_attribute_key_value_missing_value_emits_error_without_empty_fallback() 
 fn demo() {}
 ";
     let result = parse(source);
-    assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+    // `meta` is not a recognised attribute name, so the closed table also
+    // reports `E_UNKNOWN_ATTRIBUTE` in addition to the key-value shape error
+    // this test targets — both diagnostics are expected.
+    assert_eq!(result.errors.len(), 2, "errors: {:?}", result.errors);
     assert_eq!(
         result.errors[0].message,
         "invalid value for attribute `rename`: missing value"
@@ -1589,6 +1594,11 @@ fn demo() {}
     assert_eq!(
         result.errors[0].hint.as_deref(),
         Some("expected identifier, string literal, or integer literal")
+    );
+    assert!(
+        result.errors[1].message.contains("E_UNKNOWN_ATTRIBUTE"),
+        "errors: {:?}",
+        result.errors
     );
 
     let Item::Function(func) = &result.program.items[0].0 else {
@@ -3866,6 +3876,10 @@ fn unmarked_type_has_no_resource_marker() {
 
 #[test]
 fn resource_marker_rejects_tuple_type_without_affecting_supported_targets() {
+    // `#[resource]` is only legal at `type`/`enum` declaration position
+    // (HEW-SPEC-2026 §12.6); a tuple-form `type` never carries `ResourceMarker`,
+    // so this is `E_UNKNOWN_ATTRIBUTE`, superseding the old
+    // `E_RESOURCE_MARKER_TARGET` code.
     let unsupported_source = "#[resource]\ntype Pair(i64);";
     let unsupported = parse(unsupported_source);
     assert_eq!(
@@ -3877,8 +3891,8 @@ fn resource_marker_rejects_tuple_type_without_affecting_supported_targets() {
     assert!(
         unsupported.errors[0]
             .message
-            .contains("E_RESOURCE_MARKER_TARGET"),
-        "tuple-form ownership marker must use the target diagnostic: {:?}",
+            .contains("E_UNKNOWN_ATTRIBUTE"),
+        "tuple-form ownership marker must use the closed-table diagnostic: {:?}",
         unsupported.errors
     );
     assert_eq!(
@@ -3935,7 +3949,7 @@ fn resource_markers_reject_unsupported_top_level_items_in_every_visibility_form(
     let marker_errors: Vec<_> = result
         .errors
         .iter()
-        .filter(|error| error.message.contains("E_RESOURCE_MARKER_TARGET"))
+        .filter(|error| error.message.contains("E_UNKNOWN_ATTRIBUTE"))
         .collect();
 
     assert_eq!(
@@ -4006,7 +4020,7 @@ actor Worker {
     let marker_errors: Vec<_> = result
         .errors
         .iter()
-        .filter(|error| error.message.contains("E_RESOURCE_MARKER_TARGET"))
+        .filter(|error| error.message.contains("E_UNKNOWN_ATTRIBUTE"))
         .collect();
 
     assert_eq!(
@@ -4062,6 +4076,8 @@ fn linear_then_resource_combined_emits_conflict_diagnostic() {
 
 #[test]
 fn unknown_type_marker_emits_diagnostic() {
+    // `E_UNKNOWN_ATTRIBUTE` (the closed-table diagnostic) supersedes the
+    // retired `E_UNKNOWN_TYPE_MARKER` for this position.
     let source = r"
             #[both]
             type Bad { x: int }
@@ -4069,11 +4085,11 @@ fn unknown_type_marker_emits_diagnostic() {
     let result = parse(source);
     assert!(
         !result.errors.is_empty(),
-        "expected E_UNKNOWN_TYPE_MARKER diagnostic but got none"
+        "expected E_UNKNOWN_ATTRIBUTE diagnostic but got none"
     );
     assert!(
-        result.errors[0].message.contains("E_UNKNOWN_TYPE_MARKER"),
-        "expected E_UNKNOWN_TYPE_MARKER in message, got: {:?}",
+        result.errors[0].message.contains("E_UNKNOWN_ATTRIBUTE"),
+        "expected E_UNKNOWN_ATTRIBUTE in message, got: {:?}",
         result.errors[0].message
     );
 }
@@ -4194,36 +4210,41 @@ fn max_heap_attribute_gb_suffix_rejected() {
 
 #[test]
 fn max_heap_attribute_on_fn_rejected() {
+    // `#[max_heap]` is only legal on an actor declaration (HEW-SPEC-2026
+    // §12.6); on a free fn it is `E_UNKNOWN_ATTRIBUTE`, superseding the old
+    // bespoke "only allowed on actor declarations" message.
     let source = "#[max_heap(1024)] fn foo() {}";
     let result = parse(source);
     assert!(
         !result.errors.is_empty(),
-        "expected error: #[max_heap] only allowed on actor declarations"
+        "expected E_UNKNOWN_ATTRIBUTE for #[max_heap] on a free fn"
     );
     assert!(
         result
             .errors
             .iter()
-            .any(|e| e.message.contains("max_heap") && e.message.contains("actor")),
-        "expected error mentioning max_heap and actor, got: {:?}",
+            .any(|e| e.message.contains("max_heap") && e.message.contains("E_UNKNOWN_ATTRIBUTE")),
+        "expected error mentioning max_heap and E_UNKNOWN_ATTRIBUTE, got: {:?}",
         result.errors
     );
 }
 
 #[test]
 fn max_heap_attribute_on_type_rejected() {
+    // Same closed-table refusal as `max_heap_attribute_on_fn_rejected`, on a
+    // `type` declaration instead of a free fn.
     let source = "#[max_heap(1 kb)] type Bar { x: i32; }";
     let result = parse(source);
     assert!(
         !result.errors.is_empty(),
-        "expected error: #[max_heap] only allowed on actor declarations"
+        "expected E_UNKNOWN_ATTRIBUTE for #[max_heap] on a type declaration"
     );
     assert!(
         result
             .errors
             .iter()
-            .any(|e| e.message.contains("max_heap") && e.message.contains("actor")),
-        "expected error mentioning max_heap and actor, got: {:?}",
+            .any(|e| e.message.contains("max_heap") && e.message.contains("E_UNKNOWN_ATTRIBUTE")),
+        "expected error mentioning max_heap and E_UNKNOWN_ATTRIBUTE, got: {:?}",
         result.errors
     );
 }
@@ -5240,5 +5261,130 @@ fn record_rest_patterns_round_trip_through_formatter() {
         reparsed.errors.is_empty(),
         "formatted source failed to parse: {:?}\n{formatted}",
         reparsed.errors
+    );
+}
+
+// ── Closed attribute table (HEW-SPEC-2026 §12.6, issue #3261) ─────────
+//
+// These exercise `Parser::validate_attributes_for` directly through `parse`,
+// independent of the vertical-slice harness: an invented attribute name is
+// refused everywhere, a real name in the wrong position is refused too, and
+// the `#[test]`-only trio (`ignore`/`should_panic`/`serial`) is refused
+// without a co-occurring `#[test]`.
+
+#[test]
+fn unrecognised_attribute_name_rejected_on_free_fn() {
+    // The issue's own repro: an invented attribute name on a free function
+    // must fail closed, not disappear silently.
+    let source = "#[bogus]\nfn helper() -> i64 { 1 }\nfn main() { helper(); }";
+    let result = parse(source);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("unrecognised attribute `#[bogus]`")
+                && e.message.contains("E_UNKNOWN_ATTRIBUTE")),
+        "expected E_UNKNOWN_ATTRIBUTE for #[bogus], got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn recognised_attribute_name_rejected_in_wrong_position() {
+    // `#[every(..)]` is only legal on an actor `receive fn`; here it targets
+    // a plain actor method, so the name is known but the position is not.
+    let source = r"
+        actor Worker {
+            #[every(1s)]
+            fn tick() {}
+        }
+        fn main() {}
+    ";
+    let result = parse(source);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("unrecognised attribute `#[every]`")
+                && e.message.contains("E_UNKNOWN_ATTRIBUTE")),
+        "expected E_UNKNOWN_ATTRIBUTE for #[every] on a plain actor fn, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn test_trio_attrs_rejected_without_co_occurring_test_attr() {
+    // `#[ignore]`, `#[should_panic]`, and `#[serial]` are only legal on a
+    // function that also carries `#[test]` (§12.6). Without it, each is
+    // E_UNKNOWN_ATTRIBUTE — a misspelled `#[test]` must not leave these
+    // siblings silently accepted either.
+    for attr in ["ignore", "should_panic", "serial"] {
+        let source = format!("#[{attr}]\nfn probe() {{}}\nfn main() {{ probe(); }}");
+        let result = parse(&source);
+        assert!(
+            result.errors.iter().any(|e| e
+                .message
+                .contains(&format!("unrecognised attribute `#[{attr}]`"))
+                && e.message.contains("E_UNKNOWN_ATTRIBUTE")),
+            "expected E_UNKNOWN_ATTRIBUTE for #[{attr}] without #[test], got: {:?}",
+            result.errors
+        );
+    }
+}
+
+#[test]
+fn test_trio_attrs_accepted_with_co_occurring_test_attr() {
+    // The positive control for `test_trio_attrs_rejected_without_co_occurring_test_attr`:
+    // the same three attributes are legal once `#[test]` is present.
+    for attr in ["ignore", "should_panic", "serial"] {
+        let source = format!("#[test]\n#[{attr}]\nfn probe() {{}}\nfn main() {{}}");
+        let result = parse(&source);
+        assert!(
+            result.errors.is_empty(),
+            "expected #[test] + #[{attr}] to parse cleanly, got: {:?}",
+            result.errors
+        );
+    }
+}
+
+#[test]
+fn noncancellable_attribute_no_longer_recognised() {
+    // `#[noncancellable]` is removed in edition 2026 (§12.6): it is now an
+    // ordinary unrecognised name, not a special-cased parse.
+    let source = "#[noncancellable]\nfn helper() {}\nfn main() { helper(); }";
+    let result = parse(source);
+    assert!(
+        result.errors.iter().any(|e| e
+            .message
+            .contains("unrecognised attribute `#[noncancellable]`")
+            && e.message.contains("E_UNKNOWN_ATTRIBUTE")),
+        "expected E_UNKNOWN_ATTRIBUTE for #[noncancellable], got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn wire_attribute_legal_on_type_decl_and_field_only() {
+    // `#[wire]` is legal on a type declaration and, separately, on a field
+    // inside a plain (non-`#[wire]`) type declaration (§12.6) — not on a
+    // free function, which has no field/type-decl position for it to attach
+    // to. (The `@N` field-tag syntax used inside a `#[wire] type` body is a
+    // distinct grammar from the `#[wire]` attribute exercised here.)
+    let legal = parse("#[wire]\ntype Contract { x: i64; }\ntype Point { #[wire] x: i64; }");
+    assert!(
+        legal.errors.is_empty(),
+        "expected #[wire] on type decl and field to parse cleanly, got: {:?}",
+        legal.errors
+    );
+
+    let illegal = parse("#[wire]\nfn helper() {}\nfn main() { helper(); }");
+    assert!(
+        illegal
+            .errors
+            .iter()
+            .any(|e| e.message.contains("unrecognised attribute `#[wire]`")
+                && e.message.contains("E_UNKNOWN_ATTRIBUTE")),
+        "expected E_UNKNOWN_ATTRIBUTE for #[wire] on a free fn, got: {:?}",
+        illegal.errors
     );
 }

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -1557,12 +1557,15 @@ fn fmt_mutable_parameter() {
 
 #[test]
 fn fmt_function_attribute() {
-    let src = r"#[inline]
+    // `#[test]` (not `#[inline]`, which HEW-SPEC-2026 §12.6's closed
+    // attribute table does not recognise) exercises the formatter's
+    // attribute-printing path on a free function.
+    let src = r"#[test]
 fn fast() -> i32 {
     42
 }";
     let out = roundtrip(src);
-    assert!(out.contains("#[inline]"), "output: {out}");
+    assert!(out.contains("#[test]"), "output: {out}");
 }
 
 // -----------------------------------------------------------------------

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -1375,10 +1375,6 @@ impl Checker {
                     self.check_down_hook(&ad.name, method, &ad.fields);
                     continue;
                 }
-                "upgrade" => {
-                    self.reject_upgrade_hook(&ad.name, &method.name, hook_attr.span.clone());
-                    continue;
-                }
                 _ => {}
             }
 
@@ -1406,19 +1402,19 @@ impl Checker {
                     hook_attr.span.clone(),
                     format!(
                         "`#[on]` on `{actor_name}.{method_name}` requires a hook kind argument; \
-                         valid hook kinds are: start, stop, crash, exit, down, upgrade"
+                         valid hook kinds are: start, stop, crash, exit, down"
                     ),
                 ));
                 return None;
             }
-            Some("start" | "stop" | "crash" | "exit" | "down" | "upgrade") => {}
+            Some("start" | "stop" | "crash" | "exit" | "down") => {}
             Some(unknown) => {
                 self.errors.push(TypeError::new(
                     TypeErrorKind::InvalidOperation,
                     hook_attr.span.clone(),
                     format!(
                         "`#[on({unknown})]` on `{actor_name}.{method_name}` is not a recognised \
-                         lifecycle hook; valid hook kinds are: start, stop, crash, exit, down, upgrade"
+                         lifecycle hook; valid hook kinds are: start, stop, crash, exit, down"
                     ),
                 ));
                 return None;
@@ -1443,21 +1439,6 @@ impl Checker {
         }
 
         Some(hook_kind_str)
-    }
-
-    fn reject_upgrade_hook(&mut self, actor_name: &str, method_name: &str, attr_span: Span) {
-        // `#[on(upgrade)]` is a reserved attribute with no runtime behaviour:
-        // the runtime never invokes it, so accepting it would create a hook
-        // that silently never runs. Reject it fail-closed.
-        self.errors.push(TypeError::new(
-            TypeErrorKind::OnUpgradeNotYetWired,
-            attr_span,
-            format!(
-                "`#[on(upgrade)]` on `{actor_name}.{method_name}` is reserved and not supported: \
-                 the runtime never invokes this hook, so it would silently never run; \
-                 remove the attribute"
-            ),
-        ));
     }
 
     /// Bind actor fields as bare names with their *declared* mutability:

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -838,8 +838,6 @@ pub enum TypeErrorKind {
     OrphanImpl,
     /// Feature is not available on the selected compilation target
     PlatformLimitation,
-    /// `#[on(upgrade)]` is parsed but rejected: it is reserved and not supported.
-    OnUpgradeNotYetWired,
     /// Machine state × event exhaustiveness violation
     MachineExhaustivenessError,
     /// Import cannot be resolved: module not found or failed to parse
@@ -1519,7 +1517,6 @@ impl TypeErrorKind {
             Self::Shadowing => "Shadowing",
             Self::OrphanImpl => "OrphanImpl",
             Self::PlatformLimitation => "PlatformLimitation",
-            Self::OnUpgradeNotYetWired => "OnUpgradeNotYetWired",
             Self::MachineExhaustivenessError => "MachineExhaustivenessError",
             Self::UnresolvedImport => "UnresolvedImport",
             Self::BlockingCallInReceiveFn => "BlockingCallInReceiveFn",

--- a/hew-types/tests/actor/actor_lifecycle_hooks.rs
+++ b/hew-types/tests/actor/actor_lifecycle_hooks.rs
@@ -1,5 +1,7 @@
 //! Type-checker fixtures for actor lifecycle hooks
-//! (`#[on(start)]` / `#[on(stop)]` / `#[on(crash)]` / `#[on(upgrade)]`).
+//! (`#[on(start)]` / `#[on(stop)]` / `#[on(crash)]` / `#[on(exit)]` /
+//! `#[on(down)]`). `upgrade` is no longer a hook kind (HEW-SPEC-2026 §12.6);
+//! `#[on(upgrade)]` is exercised here only as an unrecognised-kind case.
 //!
 //! These exercise the §9.1.2 surface defined in
 //! `docs/specs/HEW-SPEC-2026.md`. The accept fixtures pin the
@@ -1188,18 +1190,18 @@ fn reject_unknown_hook_kind() {
                 && e.message.contains("start")
                 && e.message.contains("stop")
                 && e.message.contains("crash")
-                && e.message.contains("upgrade")),
+                && !e.message.contains("upgrade")),
         "`#[on(restart)]` should be rejected with valid-kinds list \
-         (start, stop, crash, upgrade): {:?}",
+         (start, stop, crash, exit, down) and no longer name `upgrade`: {:?}",
         output.errors
     );
 }
 
-// ── E1: `#[on(crash)]` recognition / `#[on(upgrade)]` fail-closed ─────
+// ── E1: `#[on(crash)]` recognition / `#[on(upgrade)]` removed ─────────
 //
-// `#[on(crash)]` remains a live lifecycle hook. `#[on(upgrade)]` remains
-// parser-recognised but must fail closed: it is reserved and not supported,
-// because accepting it would create code that never runs.
+// `#[on(crash)]` remains a live lifecycle hook. `upgrade` left the hook-kind
+// list (HEW-SPEC-2026 §12.6): `#[on(upgrade)]` is now an ordinary unrecognised
+// hook kind, the same as any other misspelling.
 
 #[test]
 fn on_crash_still_works() {
@@ -1230,6 +1232,9 @@ fn on_crash_still_works() {
 
 #[test]
 fn on_upgrade_attribute_compile_errors() {
+    // `upgrade` left the `#[on(..)]` hook-kind list (HEW-SPEC-2026 §12.6):
+    // `#[on(upgrade)]` is rejected the same way as any other unrecognised
+    // hook kind, not through a bespoke reserved-attribute diagnostic.
     let source = r"
         actor Worker {
             let count: i32;
@@ -1246,8 +1251,10 @@ fn on_upgrade_attribute_compile_errors() {
     let error = output
         .errors
         .iter()
-        .find(|e| matches!(&e.kind, TypeErrorKind::OnUpgradeNotYetWired))
-        .expect("`#[on(upgrade)]` should produce OnUpgradeNotYetWired");
+        .find(|e| {
+            matches!(&e.kind, TypeErrorKind::InvalidOperation) && e.message.contains("on(upgrade)")
+        })
+        .expect("`#[on(upgrade)]` should be rejected as an unrecognised lifecycle hook");
     let attr_start = source
         .find("#[on(upgrade)]")
         .expect("fixture should contain upgrade attribute");
@@ -1257,10 +1264,10 @@ fn on_upgrade_attribute_compile_errors() {
         "diagnostic should point at the `#[on(upgrade)]` attribute"
     );
     assert!(
-        error.message.contains("reserved")
-            && error.message.contains("not supported")
-            && error.message.contains("remove the attribute"),
-        "diagnostic should explain that the hook is reserved/unsupported and advise removal: {:?}",
+        error.message.contains("not a recognised")
+            && error.message.contains("start")
+            && error.message.contains("stop"),
+        "diagnostic should explain the hook kind is unrecognised and list the valid kinds: {:?}",
         output.errors
     );
 }
@@ -1292,6 +1299,9 @@ fn reject_on_crash_with_extra_args() {
 
 #[test]
 fn reject_on_upgrade_with_extra_args() {
+    // `upgrade` is no longer a recognised hook kind at all (HEW-SPEC-2026
+    // §12.6), so `#[on(upgrade, v2)]` fails the same way `#[on(upgrade)]`
+    // does — the unrecognised-kind check runs before any extra-args check.
     let output = typecheck(
         r"
         actor Worker {
@@ -1307,8 +1317,10 @@ fn reject_on_upgrade_with_extra_args() {
         output
             .errors
             .iter()
-            .any(|e| matches!(&e.kind, TypeErrorKind::OnUpgradeNotYetWired)),
-        "`#[on(upgrade, …)]` should fail closed before runtime wiring lands: {:?}",
+            .any(|e| matches!(&e.kind, TypeErrorKind::InvalidOperation)
+                && e.message.contains("on(upgrade)")
+                && e.message.contains("not a recognised")),
+        "`#[on(upgrade, …)]` should be rejected as an unrecognised hook kind: {:?}",
         output.errors
     );
 }

--- a/std/sort/sort.hew
+++ b/std/sort/sort.hew
@@ -261,7 +261,6 @@ pub fn sort_ints(v: Vec<i64>) -> Vec<i64> {
 /// Sort integers and return the production merge core's comparison count.
 ///
 /// This diagnostic form exists for deterministic complexity regression tests.
-#[doc(hidden)]
 pub fn sort_ints_counted(v: Vec<i64>) -> (Vec<i64>, i64) {
     let out = copy_ints(v);
     let comparisons = sort_ints_in_place(out);
@@ -280,7 +279,6 @@ pub fn sort_strings(v: Vec<string>) -> Vec<string> {
 /// Sort strings and return the production merge core's comparison count.
 ///
 /// This diagnostic form exists for deterministic complexity regression tests.
-#[doc(hidden)]
 pub fn sort_strings_counted(v: Vec<string>) -> (Vec<string>, i64) {
     let out = copy_strings(v);
     let comparisons = sort_strings_in_place(out);

--- a/tests/vertical-slice/accept/attribute_closed_table_positions.hew
+++ b/tests/vertical-slice/accept/attribute_closed_table_positions.hew
@@ -1,0 +1,88 @@
+// Accept twin for the closed-table reject fixtures: every attribute
+// HEW-SPEC-2026 §12.6 legalises, used in each position the spec lists for
+// it, must still type-check cleanly. Proves the closed table doesn't
+// over-refuse legitimate uses.
+
+#[resource]
+type Handle {
+    #[wire]
+    id: i64;
+}
+
+impl Handle {
+    fn close(self) {
+    }
+}
+
+#[linear]
+type Ticket {
+    id: i64;
+}
+
+impl Ticket {
+    fn consume(consuming self) {
+    }
+}
+
+#[opaque]
+type Blob {
+}
+
+#[deprecated]
+type OldShape {
+    value: i64;
+}
+
+#[max_heap(4096)]
+actor Worker {
+    let count: i64;
+
+    #[on(start)]
+    fn setup() {
+    }
+
+    #[every(1s)]
+    receive fn tick() {
+    }
+}
+
+trait Ordered {
+    #[returns_receiver]
+    fn bump(consuming self) -> Self;
+}
+
+impl Ordered for Ticket {
+    #[returns_receiver]
+    fn bump(consuming self) -> Ticket {
+        self
+    }
+}
+
+#[test]
+fn covered_by_test() {
+}
+
+#[test]
+#[ignore]
+fn skipped_test() {
+}
+
+#[test]
+#[should_panic]
+fn panicking_test() {
+    panic("boom");
+}
+
+#[test]
+#[serial]
+fn serial_test() {
+}
+
+#[export("helper")]
+fn helper() -> i64 {
+    1
+}
+
+fn main() {
+    println(f"{helper()}");
+}

--- a/tests/vertical-slice/reject/noncancellable_attribute_removed_reject.hew
+++ b/tests/vertical-slice/reject/noncancellable_attribute_removed_reject.hew
@@ -1,0 +1,10 @@
+// `#[noncancellable]` no longer parses (HEW-SPEC-2026 §12.6): cancellation
+// in edition 2026 is scope-structural, and the attribute has no surface to
+// be held for. It is now an ordinary unrecognised attribute name.
+#[noncancellable]
+fn helper() {
+}
+
+fn main() {
+    helper();
+}

--- a/tests/vertical-slice/reject/on_upgrade_hook_kind_removed_reject.hew
+++ b/tests/vertical-slice/reject/on_upgrade_hook_kind_removed_reject.hew
@@ -1,0 +1,13 @@
+// `upgrade` left the `#[on(..)]` hook-kind list (HEW-SPEC-2026 §12.6): hot
+// code upgrade is refused permanently, so the hook list stops holding a
+// place for it. `#[on(upgrade)]` is now an ordinary unrecognised hook kind.
+actor Worker {
+    let count: i64;
+
+    #[on(upgrade)]
+    fn on_upgrade() {
+    }
+}
+
+fn main() {
+}

--- a/tests/vertical-slice/reject/unknown_attribute_on_actor_member_reject.hew
+++ b/tests/vertical-slice/reject/unknown_attribute_on_actor_member_reject.hew
@@ -1,0 +1,14 @@
+// A plain `fn` inside an actor body only carries `#[on(kind)]` (HEW-SPEC-2026
+// §12.6). An unrecognised attribute there must fail closed rather than
+// disappear silently — the same closed-table refusal the free-fn, field, and
+// impl-method reject fixtures pin.
+actor Worker {
+    let count: i64;
+
+    #[bogus]
+    fn helper() {
+    }
+}
+
+fn main() {
+}

--- a/tests/vertical-slice/reject/unknown_attribute_on_field_reject.hew
+++ b/tests/vertical-slice/reject/unknown_attribute_on_field_reject.hew
@@ -1,0 +1,14 @@
+// A field inside a `type { .. }` body only carries `#[wire]` (HEW-SPEC-2026
+// §12.6). An unrecognised attribute on a field must fail closed the same
+// way it does on a type declaration or a free function — it is not a
+// special-cased position with its own silent-accept path.
+type Point {
+    #[bogus]
+    x: i64;
+    y: i64;
+}
+
+fn main() {
+    let p = Point { x: 1, y: 2 };
+    println(f"{p.x}");
+}

--- a/tests/vertical-slice/reject/unknown_attribute_on_fn_reject.hew
+++ b/tests/vertical-slice/reject/unknown_attribute_on_fn_reject.hew
@@ -1,0 +1,13 @@
+// The attribute set is closed (HEW-SPEC-2026 §12.6): an attribute whose name
+// is not in the table is `E_UNKNOWN_ATTRIBUTE` on a free function, the same
+// as any other position. This is the exact repro from the issue this
+// fixture guards against a regression of: a misspelled `#[test]` (or any
+// other invented attribute name) must fail closed, not disappear silently.
+#[bogus]
+fn helper() -> i64 {
+    1
+}
+
+fn main() {
+    println(f"{helper()}");
+}

--- a/tests/vertical-slice/reject/unknown_attribute_on_impl_method_reject.hew
+++ b/tests/vertical-slice/reject/unknown_attribute_on_impl_method_reject.hew
@@ -1,0 +1,19 @@
+// A method inside an `impl { .. }` block carries `#[extern_symbol]`, the
+// substrate set, and `#[returns_receiver]` (HEW-SPEC-2026 §12.6). An
+// unrecognised attribute there is `E_UNKNOWN_ATTRIBUTE`, matching the
+// closed-table refusal at every other attribute-consuming position.
+type Counter {
+    value: i64;
+}
+
+impl Counter {
+    #[bogus]
+    fn get(self) -> i64 {
+        self.value
+    }
+}
+
+fn main() {
+    let c = Counter { value: 5 };
+    println(f"{c.get()}");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -901,16 +901,50 @@ run_accept_expect_status "hashmap_iter_user_shadow" 43
 # Ownership markers (#[resource], #[linear]) remain valid on nominal `type`
 # declarations and preserve their affine/linear behaviour. Positive control on
 # `type`, plus both reject boundaries: an alias, which carries no resource
-# semantics, and a callable, which has no ResourceMarker slot at all.
+# semantics, and a callable, which has no ResourceMarker slot at all. Both
+# reject with E_UNKNOWN_ATTRIBUTE (HEW-SPEC-2026 §12.6's closed attribute
+# table) rather than the retired E_RESOURCE_MARKER_TARGET.
 run_accept_expect_status "resource_marker_nominal_type" 0
 expect_check_fail_contains \
     "${ROOT}/tests/vertical-slice/reject/resource_marker_on_fn_reject.hew" \
-    "#[resource] is only valid on \`type\` or \`enum\` declarations" \
+    "unrecognised attribute \`#[resource]\` in this position [E_UNKNOWN_ATTRIBUTE]" \
     "resource_marker_on_fn_reject"
 expect_check_fail_contains \
     "${ROOT}/tests/vertical-slice/reject/resource_marker_on_record_reject.hew" \
-    "#[resource] is only valid on \`type\` or \`enum\` declarations" \
+    "unrecognised attribute \`#[resource]\` in this position [E_UNKNOWN_ATTRIBUTE]" \
     "resource_marker_on_type_alias_reject"
+
+# The closed attribute table (HEW-SPEC-2026 §12.6, issue #3261): an
+# unrecognised attribute name, or a recognised name used in a position the
+# table does not list for it, is E_UNKNOWN_ATTRIBUTE everywhere — not just on
+# type declarations. Accept twin exercises every legal attribute in every
+# position the table lists it for; the reject fixtures pin the fn, field,
+# impl-method, and actor-member positions plus the two removed surfaces.
+run_accept_expect_status "attribute_closed_table_positions" 0
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/unknown_attribute_on_fn_reject.hew" \
+    "unrecognised attribute \`#[bogus]\` in this position [E_UNKNOWN_ATTRIBUTE]" \
+    "unknown_attribute_on_fn_reject"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/unknown_attribute_on_field_reject.hew" \
+    "unrecognised attribute \`#[bogus]\` in this position [E_UNKNOWN_ATTRIBUTE]" \
+    "unknown_attribute_on_field_reject"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/unknown_attribute_on_impl_method_reject.hew" \
+    "unrecognised attribute \`#[bogus]\` in this position [E_UNKNOWN_ATTRIBUTE]" \
+    "unknown_attribute_on_impl_method_reject"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/unknown_attribute_on_actor_member_reject.hew" \
+    "unrecognised attribute \`#[bogus]\` in this position [E_UNKNOWN_ATTRIBUTE]" \
+    "unknown_attribute_on_actor_member_reject"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/noncancellable_attribute_removed_reject.hew" \
+    "unrecognised attribute \`#[noncancellable]\` in this position [E_UNKNOWN_ATTRIBUTE]" \
+    "noncancellable_attribute_removed_reject"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/on_upgrade_hook_kind_removed_reject.hew" \
+    "on(upgrade)" \
+    "on_upgrade_hook_kind_removed_reject"
 
 # Reject: spawned closures must not capture non-Send values. This fixture uses
 # a real Checker-produced `Rc<i64>` capture fact and asserts the targeted HIR


### PR DESCRIPTION
## Why

An attribute the compiler did not recognise was accepted silently on
functions, parameters, fields, actor members, and impl blocks; only type
declarations failed closed, through `E_UNKNOWN_TYPE_MARKER`. A misspelled
`#[test]` dropped a test from discovery with `hew test` reporting a green
run over whatever tests remained.

## What

- **hew-parser**: one closed table (`hew-parser/src/parser/attributes.rs`)
  maps every known attribute name to the AST positions it is legal in
  (HEW-SPEC-2026 §12.6), and `Parser::validate_attributes_for` is the one
  diagnostic path every attribute-consuming call site routes through. An
  unknown name, or a known name in a position the table doesn't list for it,
  is `E_UNKNOWN_ATTRIBUTE` (User channel) — superseding the retired
  `E_UNKNOWN_TYPE_MARKER` **and** `E_RESOURCE_MARKER_TARGET` codes, and
  folding several bespoke "attributes are not supported on ..." messages
  (init blocks, actor methods, impl-block type aliases, trait items) into
  one path. `extract_resource_marker`'s own closed-table check is deleted;
  it now only resolves the resource/linear marker and the conflict case.
- **hew-parser/src/fmt.rs**: fixed a formatter bug the new accept fixture
  surfaced — `TypeBodyItem::Field`'s attributes were parsed but never
  printed (a `..` destructure dropped them), so `#[wire]` on a field
  silently vanished on `hew fmt`.
- **hew-types**: `upgrade` leaves the `#[on(..)]` hook-kind list
  (`check::items::resolve_on_hook_kind`); `#[on(upgrade)]` is now rejected
  the same way any other unrecognised hook kind is, and the
  `OnUpgradeNotYetWired` error kind it used is retired.
  `#[noncancellable]` needed no code change here — it was already fully
  absent from the compiler before this change.
- **hew-lsp**: dropped `OnUpgradeNotYetWired` from the diagnostic-kind
  enumeration test; fixed a fixture (`v05_attributes.hew`) that put
  `#[on(crash)]`/`#[on(upgrade)]` on free functions instead of inside an
  actor body.
- **hew-cli**: the REPL's bare-attribute buffering heuristic
  (`eval::classify::ends_with_bare_attribute`) relied on an attribute probe
  reparsing cleanly, which now fails closed for any name the table doesn't
  recognise — replaced with a token-level check independent of attribute-name
  validity, so a user mid-way through typing `#[foo]` still gets "waiting for
  more input" rather than a premature parse error. Migrated a pinned
  `E_RESOURCE_MARKER_TARGET` string in `resource_marker_applicability_reject.rs`.
- **std/sort/sort.hew**: removed `#[doc(hidden)]` — not in §12.6's table and
  nothing downstream consumed it.
- `docs/diagnostics/README.md`: registered `E_UNKNOWN_ATTRIBUTE` in the
  User-channel table.

## Test

- `cargo nextest run -p hew-lexer -p hew-parser -p hew-types -p hew-hir` —
  clean except two pre-existing failures
  (`canonical_builtin_source_owns_intrinsic_impls_for_coherence`,
  `project_local_std_builtins_source_cannot_claim_intrinsic_coherence`)
  that reproduce identically on a clean stash of this branch: they resolve
  `compiler_stdlib_root()` from the test binary's own path, which the
  worktree wrapper's out-of-tree `CARGO_TARGET_DIR` breaks — an environment
  artefact, not this change.
- `make test-vertical-slice` — new fixtures:
  `tests/vertical-slice/accept/attribute_closed_table_positions.hew` (every
  attribute the table allows, in every position it lists), and reject
  fixtures at fn, field, impl-method, and actor-member position plus the two
  retired surfaces (`unknown_attribute_on_{fn,field,impl_method,actor_member}_reject.hew`,
  `noncancellable_attribute_removed_reject.hew`,
  `on_upgrade_hook_kind_removed_reject.hew`). Also migrated the two existing
  `resource_marker_on_*_reject` expectations in `run.sh` to the new
  diagnostic text. One unrelated pre-existing flake observed once
  (`actor_ask_block_wrapped_await` duplicated a stdout line) and not
  reproduced on two subsequent clean reruns.
- `make hew-check-all`, `make test-doc-examples` — pass.
- `cargo clippy --workspace --tests --message-format=json -- -D warnings` —
  clean. `cargo fmt --all` — clean.
- New parser unit tests in `hew-parser/src/parser/tests.rs` exercise the
  closed table directly: an invented name on a free fn, a known name in the
  wrong position, the `#[test]`-only trio's co-occurrence rule (both
  directions), `#[noncancellable]`'s removal, and `#[wire]`'s
  type-decl/field-only legality.
- `hew-cli`'s broader e2e suite (`test_runner_e2e`, `machine_transition_watch_e2e`,
  `dwarf_debugger_locals_e2e`, several ownership oracles) has a large
  pre-existing failure set in this sandbox unrelated to this change (an
  `E_MIR_ICE` ownership-generation class, `gdb`-based tests exceeding a 30s
  wall-clock budget, and prerequisites `make test-artifacts` doesn't fully
  cover) — verified by manually reproducing the `#[test]`-failure scenario
  one of them exercises directly against the built `hew` binary, which
  behaves correctly.

## Skipped

- `grammar-parity`: no such make target exists on this main
  (`grep -nE '^grammar-parity:' Makefile` is empty).
- Named follow-up, not required by this issue's scope fence:
  `HirLifecycleHookKind::Upgrade` and the
  `push_lifecycle_not_wired_diagnostic(..., "OnUpgradeNotYetWired", ...)`
  arm in `hew-mir/src/lower/machine_synth.rs` are now unreachable dead code
  (the checker rejects `#[on(upgrade)]` before HIR/MIR lowering ever sees
  it), noted in `.tmp/TODO.md`.

Fixes #3261
