### PR TITLE
feat(cli): write build output under target/<profile>, honour -o in both modes

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -490,9 +490,10 @@ pub struct BuildArgs {
     /// Input .hew file, or a package directory. Omit it to build the package
     /// enclosing the current directory.
     pub input: Option<PathBuf>,
-    /// Output binary path. Default: `<package-root>/<package-name>` for a
-    /// package, `./<stem>` for an explicit file (no extension on Unix targets,
-    /// `.exe` on Windows targets). Ignored with `--emit-obj`.
+    /// Output path, for the linked binary or (with `--emit-obj`) the object
+    /// file. Default: `<package-root>/target/<debug|release>/<package-name>`
+    /// for a package, `./<stem>` for an explicit file (no extension on Unix
+    /// targets, `.exe` on Windows targets; `.o`/`.obj` with `--emit-obj`).
     #[arg(long, short = 'o', value_name = "PATH")]
     pub output: Option<PathBuf>,
     /// Target triple. Omit for host native; e.g. `arm64-apple-darwin`,
@@ -500,9 +501,9 @@ pub struct BuildArgs {
     /// `wasm32-unknown-unknown`.
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,
-    /// Emit a relocatable object file instead of a linked binary, written to
-    /// `<cwd>/<stem><.o|.obj>`. Required for foreign-OS targets that cannot be
-    /// linked on this host.
+    /// Emit a relocatable object file instead of a linked binary, named the
+    /// same way the linked binary would be (or `-o` verbatim). Required for
+    /// foreign-OS targets that cannot be linked on this host.
     #[arg(long = "emit-obj")]
     pub emit_obj: bool,
     /// Retain the pre-optimization textual LLVM IR beside the output.

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -1076,31 +1076,61 @@ pub(crate) fn compile_native_from_program_with_paths(
     }
 }
 
-/// Resolve the output binary path for `hew build` using go-build naming.
+/// Which build artefact [`resolve_output`] is naming.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Artifact {
+    /// The linked, runnable binary `hew build` produces by default.
+    Binary,
+    /// The standalone relocatable object `hew build --emit-obj` produces.
+    Object,
+}
+
+/// Resolve the output path for a build artefact using go-build/cargo naming.
 ///
-/// With `-o`, the path is used verbatim. A package builds
-/// `<package-root>/<package-name><suffix>`; an explicit file builds
-/// `./<input-stem><suffix>` in the current directory. The suffix is
-/// target-driven, not host-driven — `""` on Unix targets, `.exe` on Windows
-/// targets, `.wasm` on wasm targets — so a Windows cross-build names `foo.exe`
-/// even on a Unix host.
-fn resolve_build_output_path(
-    a: &args::BuildArgs,
-    resolved: &package::Input,
+/// `-o` (`explicit`) wins over every default, in both file mode and package
+/// mode, for both `kind`s. Absent `-o`: a package writes into
+/// `<root>/target/<profile>/`, named `<package-name><suffix>` — `profile` is
+/// `"debug"` or `"release"`, `suffix` is the target's executable suffix for
+/// [`Artifact::Binary`] (`""` on Unix targets, `.exe` on Windows targets,
+/// `.wasm` on wasm targets) or its object suffix for [`Artifact::Object`]
+/// (`.o`/`.obj`). An explicit file writes `<stem><suffix>` in the current
+/// directory — a single-file program has no package root to own a `target/`.
+fn resolve_output(
+    kind: Artifact,
+    input: &Path,
+    package: Option<&hew_pkg::project::ResolvedPackage>,
+    profile: &str,
     target: &target::TargetSpec,
+    explicit: Option<&Path>,
 ) -> std::path::PathBuf {
-    if let Some(output) = &a.output {
-        return output.clone();
+    if let Some(output) = explicit {
+        return output.to_path_buf();
     }
-    if let Some(pkg) = resolved.package() {
-        return pkg.default_binary_path(target.executable_suffix());
+    let suffix = match kind {
+        Artifact::Binary => target.executable_suffix(),
+        Artifact::Object => target.object_suffix(),
+    };
+    if let Some(pkg) = package {
+        return pkg.default_binary_path(profile, suffix);
     }
-    let source = resolved.source();
-    let stem = source
+    let stem = input
         .file_stem()
         .and_then(|s| s.to_str())
-        .unwrap_or("a.out");
-    target.executable_path(Path::new(""), stem)
+        .unwrap_or(match kind {
+            Artifact::Binary => "a.out",
+            Artifact::Object => "module",
+        });
+    Path::new(".").join(format!("{stem}{suffix}"))
+}
+
+/// `"release"` when `--release` is given, else `"debug"` — the `target/`
+/// profile directory `hew build` writes into.
+fn build_profile(a: &args::BuildArgs) -> &'static str {
+    if a.release {
+        "release"
+    } else {
+        "debug"
+    }
 }
 
 /// Link a native object into a binary for an explicit target.
@@ -1280,10 +1310,16 @@ fn remove_intermediate_object(path: &Path) -> Result<(), DiagChannel> {
 }
 
 /// Emit a single relocatable object for `hew build --emit-obj`, skipping the
-/// link step entirely. Writes `<cwd>/<stem><.o|.obj>` and exits 0 — even for
-/// foreign-OS targets that cannot be linked on this host (the whole point of
-/// object-only emission). The object format/arch are driven by the target
-/// triple, threaded into codegen.
+/// link step entirely — even for foreign-OS targets that cannot be linked on
+/// this host (the whole point of object-only emission). The object format/arch
+/// are driven by the target triple, threaded into codegen. `output` is `-o`
+/// when given; otherwise [`resolve_output`] names the object the same way it
+/// names the linked binary (package → `target/<profile>/`, file mode → the
+/// current directory).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the emit-obj path threads each naming/emit knob explicitly; grouping obscures the flow"
+)]
 fn emit_obj_only(
     input: &Path,
     target: &target::TargetSpec,
@@ -1291,13 +1327,20 @@ fn emit_obj_only(
     opt_level: hew_codegen_rs::OptLevel,
     emit_llvm: bool,
     options: &compile::CompileOptions,
+    package: Option<&hew_pkg::project::ResolvedPackage>,
+    profile: &str,
+    output: Option<&Path>,
 ) -> Result<(), DiagChannel> {
     let (pipeline, _native_pkg_dirs) = lower_file_to_mir_for_target(input, target, options)?;
-    let stem = input
+    let final_path = resolve_output(Artifact::Object, input, package, profile, target, output);
+    let out_dir = match final_path.parent() {
+        Some(dir) if !dir.as_os_str().is_empty() => dir,
+        _ => Path::new("."),
+    };
+    let stem = final_path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("module");
-    let out_dir = Path::new(".");
     let emit_target = if target.is_wasm() {
         CompileEmitTarget::Wasm
     } else {
@@ -1327,9 +1370,8 @@ fn emit_obj_only(
         DiagChannel::User
     })?;
 
-    // Codegen writes `<dir>/<stem>.o` (or `.wasm.o`); rename to the
-    // target-driven object extension (`.o`/`.obj`) when it differs.
-    let final_path = out_dir.join(format!("{stem}{}", target.object_suffix()));
+    // Codegen writes `<out_dir>/<stem>.o` (or `.wasm.o`); rename to the
+    // requested/target-driven object path when it differs.
     if produced != final_path {
         std::fs::rename(&produced, &final_path).map_err(|e| {
             eprintln!("Error: cannot move object to {}: {e}", final_path.display());
@@ -1424,8 +1466,20 @@ fn cmd_build_run(a: &args::BuildArgs) -> i32 {
         return 2;
     };
 
+    let profile = build_profile(a);
+
     if a.emit_obj {
-        return match emit_obj_only(input, &target, a.debug, opt_level, a.emit_llvm, &options) {
+        return match emit_obj_only(
+            input,
+            &target,
+            a.debug,
+            opt_level,
+            a.emit_llvm,
+            &options,
+            resolved.package(),
+            profile,
+            a.output.as_deref(),
+        ) {
             Ok(()) => 0,
             Err(channel) => channel.exit_code(),
         };
@@ -1438,7 +1492,14 @@ fn cmd_build_run(a: &args::BuildArgs) -> i32 {
         return 1;
     }
 
-    let output_path = resolve_build_output_path(a, &resolved, &target);
+    let output_path = resolve_output(
+        Artifact::Binary,
+        input,
+        resolved.package(),
+        profile,
+        &target,
+        a.output.as_deref(),
+    );
     match compile_build_binary(
         input,
         &output_path,
@@ -1449,9 +1510,27 @@ fn cmd_build_run(a: &args::BuildArgs) -> i32 {
         &link_libs,
         &options,
     ) {
-        Ok(()) => 0,
+        Ok(()) => {
+            eprintln!(
+                "   Built {}",
+                display_relative_to_cwd(&output_path).display()
+            );
+            0
+        }
         Err(channel) => channel.exit_code(),
     }
+}
+
+/// Render `path` relative to the current directory when it falls under it
+/// (the common case: a package root is an absolute path, but invocation
+/// happens from inside — or above — it), so the status line reads
+/// `target/release/<name>` rather than a full absolute path. Falls back to
+/// `path` unchanged when it is not.
+fn display_relative_to_cwd(path: &Path) -> std::path::PathBuf {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| path.strip_prefix(&cwd).ok())
+        .map_or_else(|| path.to_path_buf(), std::path::Path::to_path_buf)
 }
 
 fn cmd_compile(a: &args::CompileArgs) {
@@ -1587,7 +1666,7 @@ fn cmd_compile_run(a: &args::CompileArgs) -> i32 {
     // linker behaviour as release builds.
     if let Some(obj) = &artefacts.native_obj_path {
         // Name the executable through the same authority `hew build` uses
-        // (`resolve_build_output_path` → `TargetSpec::executable_suffix`).
+        // (`resolve_output` → `TargetSpec::executable_suffix`).
         // `hew compile` links for the host, and on Windows the linker writes
         // `<stem>.exe` whatever stem it is given — so a suffixless name made
         // the reported `native:` path name a file that does not exist.

--- a/hew-cli/tests/package_mode_e2e.rs
+++ b/hew-cli/tests/package_mode_e2e.rs
@@ -3,9 +3,10 @@
 //! With no argument, or with a directory argument, all three resolve the
 //! enclosing package through `hew.toml`: `[package] main` names the entry
 //! point, `[native]` is built first as a prerequisite, and the binary is named
-//! after the package and written to the package root. The explicit-file form is
-//! unchanged. A directory is resolved before any path reaches the compiler, so
-//! no raw OS error can escape.
+//! after the package and written to `<root>/target/<profile>/`, cargo-style.
+//! The explicit-file form is unchanged: no package root means no `target/` to
+//! own, so the binary lands beside the source. A directory is resolved before
+//! any path reaches the compiler, so no raw OS error can escape.
 
 mod support;
 
@@ -47,6 +48,13 @@ fn binary_in(dir: &Path, name: &str) -> PathBuf {
     dir.join(format!("{name}{}", std::env::consts::EXE_SUFFIX))
 }
 
+/// Where a package build writes its binary by default: `<root>/target/<profile>/<name>`.
+fn package_binary_in(root: &Path, profile: &str, name: &str) -> PathBuf {
+    root.join("target")
+        .join(profile)
+        .join(format!("{name}{}", std::env::consts::EXE_SUFFIX))
+}
+
 fn assert_prints_greeting(binary: &Path) {
     let run = run_bounded_command(Command::new(binary), format!("run {}", binary.display()));
     assert!(
@@ -81,7 +89,7 @@ fn build_no_argument_produces_the_package_named_binary() {
         "package build failed\n{}",
         describe_output(&output),
     );
-    assert_prints_greeting(&binary_in(dir.path(), "greeter"));
+    assert_prints_greeting(&package_binary_in(dir.path(), "debug", "greeter"));
 }
 
 /// `hew build .` names the current directory's package explicitly and behaves
@@ -103,7 +111,7 @@ fn build_dot_builds_the_current_package() {
         "`hew build .` failed\n{}",
         describe_output(&output),
     );
-    assert_prints_greeting(&binary_in(dir.path(), "dotpkg"));
+    assert_prints_greeting(&package_binary_in(dir.path(), "debug", "dotpkg"));
 }
 
 /// `hew build <dir>` builds that package and writes its binary into the package
@@ -131,7 +139,7 @@ fn build_directory_argument_writes_into_that_package_root() {
         !binary_in(dir.path(), "nested").is_file(),
         "binary should live in the package root, not the invoking directory",
     );
-    assert_prints_greeting(&binary_in(&pkg, "nested"));
+    assert_prints_greeting(&package_binary_in(&pkg, "debug", "nested"));
 }
 
 /// `hew run` with no argument compiles and runs the package's entry point.
@@ -181,7 +189,7 @@ fn package_main_field_selects_the_entry_point() {
         "build with a declared entry point failed\n{}",
         describe_output(&output),
     );
-    assert_prints_greeting(&binary_in(dir.path(), "custom"));
+    assert_prints_greeting(&package_binary_in(dir.path(), "debug", "custom"));
 }
 
 /// Resolution walks up from the working directory, so a subdirectory of a
@@ -205,7 +213,7 @@ fn build_from_a_subdirectory_resolves_the_enclosing_package() {
         "build from a subdirectory failed\n{}",
         describe_output(&output),
     );
-    assert_prints_greeting(&binary_in(dir.path(), "walkup"));
+    assert_prints_greeting(&package_binary_in(dir.path(), "debug", "walkup"));
 }
 
 /// A relative directory argument resolves from the invocation directory, then
@@ -230,7 +238,7 @@ fn build_relative_directory_from_a_subdirectory_resolves_the_enclosing_package()
         "relative directory build failed\n{}",
         describe_output(&output),
     );
-    assert_prints_greeting(&binary_in(dir.path(), "relativewalkup"));
+    assert_prints_greeting(&package_binary_in(dir.path(), "debug", "relativewalkup"));
 }
 
 /// The package's `[native]` crate is a prerequisite: when it cannot build, the
@@ -266,7 +274,7 @@ fn native_prerequisite_failure_stops_the_build() {
         describe_output(&output),
     );
     assert!(
-        !binary_in(dir.path(), "withnative").exists(),
+        !package_binary_in(dir.path(), "debug", "withnative").exists(),
         "no binary may be produced when the native prerequisite fails",
     );
 }
@@ -351,6 +359,150 @@ fn explicit_file_form_still_builds_to_the_stem() {
         describe_output(&output),
     );
     assert_prints_greeting(&binary_in(dir.path(), "main"));
+}
+
+/// `hew build` with no `--release` writes into `target/debug/` by default, and
+/// the status line names the artefact path.
+#[test]
+fn build_writes_target_debug_by_default() {
+    require_codegen();
+    let dir = workspace();
+    write_package(dir.path(), "debugpkg", "main.hew", "");
+
+    let output = Command::new(hew_binary())
+        .arg("build")
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew build");
+
+    assert!(
+        output.status.success(),
+        "debug build failed\n{}",
+        describe_output(&output),
+    );
+    assert_prints_greeting(&package_binary_in(dir.path(), "debug", "debugpkg"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Built target/debug/debugpkg"),
+        "status line should name the debug artefact path:\n{}",
+        describe_output(&output),
+    );
+}
+
+/// `hew build --release` writes into `target/release/`, not `target/debug/`,
+/// and the status line names the release artefact path.
+#[test]
+fn build_release_writes_target_release() {
+    require_codegen();
+    let dir = workspace();
+    write_package(dir.path(), "relpkg", "main.hew", "");
+
+    let output = Command::new(hew_binary())
+        .args(["build", "--release"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew build --release");
+
+    assert!(
+        output.status.success(),
+        "release build failed\n{}",
+        describe_output(&output),
+    );
+    assert_prints_greeting(&package_binary_in(dir.path(), "release", "relpkg"));
+    assert!(
+        !package_binary_in(dir.path(), "debug", "relpkg").exists(),
+        "a --release build must not also write target/debug/",
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Built target/release/relpkg"),
+        "status line should name the release artefact path:\n{}",
+        describe_output(&output),
+    );
+}
+
+/// `-o` names the linked binary explicitly and wins over the
+/// `target/<profile>/` default, even inside a package.
+#[test]
+fn dash_o_wins_in_package_mode() {
+    require_codegen();
+    let dir = workspace();
+    write_package(dir.path(), "customout", "main.hew", "");
+
+    let output = Command::new(hew_binary())
+        .args(["build", "-o", "bin/renamed"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew build -o bin/renamed");
+
+    assert!(
+        output.status.success(),
+        "-o build failed\n{}",
+        describe_output(&output),
+    );
+    assert_prints_greeting(&dir.path().join("bin/renamed"));
+    assert!(
+        !dir.path().join("target").exists(),
+        "-o must skip the target/ default entirely",
+    );
+}
+
+/// `--emit-obj -o` names the object explicitly in file mode, replacing the
+/// default stem-named object entirely.
+#[test]
+fn emit_obj_honours_dash_o_in_file_mode() {
+    require_codegen();
+    let dir = support::tempdir();
+    std::fs::write(dir.path().join("obj.hew"), "fn main() {}\n").expect("write obj.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["build", "obj.hew", "--emit-obj", "-o", "custom.o"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew build obj.hew --emit-obj -o custom.o");
+
+    assert!(
+        output.status.success(),
+        "--emit-obj -o (file mode) failed\n{}",
+        describe_output(&output),
+    );
+    assert!(
+        dir.path().join("custom.o").is_file(),
+        "named object not written"
+    );
+    assert!(
+        !dir.path().join("obj.o").exists(),
+        "the default stem-named object must not also be written",
+    );
+}
+
+/// `--emit-obj -o` names the object explicitly in package mode too, winning
+/// over the `target/<profile>/` default.
+#[test]
+fn emit_obj_honours_dash_o_in_package_mode() {
+    require_codegen();
+    let dir = workspace();
+    write_package(dir.path(), "objpkg", "main.hew", "");
+
+    let output = Command::new(hew_binary())
+        .args(["build", "--emit-obj", "-o", "custom.o"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew build --emit-obj -o custom.o");
+
+    assert!(
+        output.status.success(),
+        "--emit-obj -o (package mode) failed\n{}",
+        describe_output(&output),
+    );
+    assert!(
+        dir.path().join("custom.o").is_file(),
+        "named object not written"
+    );
+    assert!(
+        !dir.path().join("target").exists(),
+        "-o must skip the target/ default entirely",
+    );
 }
 
 /// `hew check` with no argument type-checks the package's entry point.

--- a/hew-pkg/src/project.rs
+++ b/hew-pkg/src/project.rs
@@ -32,12 +32,16 @@ impl ResolvedPackage {
         self.root.join(self.manifest.package.main_source())
     }
 
-    /// Path of the binary `hew build` writes by default: the package's binary
-    /// name, in the package root. `suffix` is the target's executable suffix
-    /// (`""`, `.exe`, `.wasm`).
+    /// Path of the build artefact `hew build` writes by default, cargo-style:
+    /// `<root>/target/<profile>/<name><suffix>`. `profile` is `"debug"` or
+    /// `"release"`; `suffix` is the target's executable suffix (`""`, `.exe`,
+    /// `.wasm`) for a linked binary, or its object suffix (`.o`, `.obj`) for
+    /// `--emit-obj`.
     #[must_use]
-    pub fn default_binary_path(&self, suffix: &str) -> PathBuf {
+    pub fn default_binary_path(&self, profile: &str, suffix: &str) -> PathBuf {
         self.root
+            .join("target")
+            .join(profile)
             .join(format!("{}{suffix}", self.manifest.package.binary_name()))
     }
 
@@ -237,7 +241,27 @@ mod tests {
         let pkg = resolve_package(dir.path()).expect("resolve");
 
         assert_eq!(pkg.entry_path(), dir.path().join("main.hew"));
-        assert_eq!(pkg.default_binary_path(""), dir.path().join("myproj"));
+        assert_eq!(
+            pkg.default_binary_path("debug", ""),
+            dir.path().join("target/debug/myproj")
+        );
+    }
+
+    #[test]
+    fn default_binary_path_separates_debug_and_release_profiles() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_package(dir.path(), BASIC, Some("main.hew"));
+
+        let pkg = resolve_package(dir.path()).expect("resolve");
+
+        assert_eq!(
+            pkg.default_binary_path("release", ""),
+            dir.path().join("target/release/myproj")
+        );
+        assert_ne!(
+            pkg.default_binary_path("debug", ""),
+            pkg.default_binary_path("release", "")
+        );
     }
 
     #[test]
@@ -278,8 +302,8 @@ mod tests {
         let pkg = resolve_package(dir.path()).expect("resolve");
 
         assert_eq!(
-            pkg.default_binary_path(".exe"),
-            dir.path().join("sqlite.exe")
+            pkg.default_binary_path("debug", ".exe"),
+            dir.path().join("target/debug/sqlite.exe")
         );
     }
 

--- a/scripts/journeys-expected.tsv
+++ b/scripts/journeys-expected.tsv
@@ -47,7 +47,7 @@ day-one.30	V060-DIAG-1	refusal text does not name join {} as the fan-out that wo
 #
 # day-two: trap symbolization (V060-FD-7) is unimplemented; hew new
 # (V060-FD-5) cascades through the whole dependency/build/deploy chain
-# once app/ is never created; two -o-in-file-mode bugs are V060-FD-2.
+# once app/ is never created.
 day-two.3	V060-FD-7	trap message has no crash.hew:2 file:line
 day-two.4	V060-FD-7	trap message does not name the function (boom)
 day-two.5	V060-FD-7	HEW_BACKTRACE=1 output has no caller frame line
@@ -68,8 +68,6 @@ day-two.23	V060-FD-5	cascades from day-two.8: build has no [package] table
 day-two.25	V060-FD-5	cascades from day-two.8: cross-object emission has no [package] table
 day-two.26	V060-FD-5	cascades from day-two.8: app-aarch64.o never written
 day-two.28	V060-FD-5	cascades from day-two.8: app-aarch64.o never written
-day-two.30	V060-FD-2	file-mode --emit-obj -o obj-aarch64.o did not write the named file
-day-two.31	V060-FD-2	file-mode --emit-obj wrote obj.o instead of honouring -o
 #
 # week-one-local: the decided-dialect program does not run today by design
 # (hew-platform-program.md §0.1: it is fable4/probes/local_svc.hew rewritten

--- a/scripts/journeys-expected.tsv
+++ b/scripts/journeys-expected.tsv
@@ -40,10 +40,6 @@ day-one.21	V060-FD-4	module-not-found JSON carries no nearest-module suggestion
 day-one.22	V060-FD-3	HEW_CC has no reader in the compiler (grep -rn HEW_CC --include=*.rs is empty); the env var is silently ignored and build falls through to system cc, exit 0
 day-one.23	V060-FD-3	HEW_CC unimplemented (see day-one.22): no error output naming the bad path
 day-one.24	V060-FD-3	HEW_CC unimplemented (see day-one.22): no error output naming a package to install
-day-one.26	V060-DIAG-1	scope { fork {..} } in main exits 1 (E_NOT_YET_IMPLEMENTED), not 3
-day-one.27	V060-DIAG-1	limitation output has no "compiler limitation:" prefix
-day-one.28	V060-DIAG-1	refusal carries no E_LIMIT_MAIN_CONTEXT code
-day-one.30	V060-DIAG-1	refusal text does not name join {} as the fan-out that works from main
 #
 # day-two: trap symbolization (V060-FD-7) is unimplemented; hew new
 # (V060-FD-5) cascades through the whole dependency/build/deploy chain


### PR DESCRIPTION
## Why

`hew build` inside a package wrote its binary at the package root with no
status line naming what it built, and `hew build --emit-obj -o <path>`
silently dropped `-o` in file mode — it wrote `<stem>.o` beside the source
instead of the requested name (V060-FD-2, `plans/briefs/v060/V060-FD-2-build-output.md`).

## What

- **hew-cli**: one helper, `resolve_output`, now decides every build output
  path (linked binary and `--emit-obj` object, package mode and file mode).
  `-o` wins over every default. A package build without `-o` writes
  `<root>/target/<debug|release>/<name>`, cargo-style; a linked binary in a
  package additionally prints `   Built <path>` to stderr on success. File
  mode without `-o` is unchanged: `<stem><suffix>` in the current directory
  (a single-file program has no package root to own a `target/`).
- **hew-pkg**: `ResolvedPackage::default_binary_path` gains a `profile`
  parameter (`"debug"`/`"release"`) to place the artefact under
  `target/<profile>/`.
- **hew-cli/args**: `--output`/`--emit-obj` help text updated — it described
  the old package-root/cwd convention and the exact "ignored with
  `--emit-obj`" bug this PR fixes.
- **journeys ratchet**: `day-two.30`/`.31` (this lane's own rows, the
  file-mode `-o` bugs) are deleted — they now pass. A second, unrelated
  commit deletes `day-one.26`/`.27`/`.28`/`.30`: those already pass on
  `main` since an earlier diagnostic-channel PR landed and the ratchet was
  never updated; `make test-journeys JOURNEY=day-one` reported them stale,
  and the ratchet rule is that whoever sees a stale row deletes it.
  `day-one.8`/`.9` (also mentioning `target/release/svc` in their reason
  text) stay: they're gated on `hew new` not existing yet (V060-FD-5), not
  on this lane, confirmed by running the journey.

## Test

- `hew-cli/tests/package_mode_e2e.rs`: every package-mode binary-path
  assertion moves to `target/<profile>/`. New tests
  `build_writes_target_debug_by_default`, `build_release_writes_target_release`,
  `dash_o_wins_in_package_mode`, `emit_obj_honours_dash_o_in_file_mode`,
  `emit_obj_honours_dash_o_in_package_mode`.
- `hew-pkg/src/project.rs`: `default_binary_path_separates_debug_and_release_profiles`.
- Negative control (manual, not committed): reverting `resolve_output`'s
  `Object` arm to ignore `-o` turns both new emit-obj tests red while every
  binary test stays green.
