### PR TITLE
feat: name HEW_CC failures and refuse a mismatched native rustc

### DIFF
--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -493,7 +493,7 @@ fn find_darwin_sdk() -> Option<String> {
 }
 
 fn select_native_compiler(target: &TargetSpec) -> Result<NativeCompiler, String> {
-    select_native_compiler_with(target, has_tool)
+    select_native_compiler_with(target, driver_version)
 }
 
 #[cfg_attr(
@@ -527,6 +527,14 @@ fn coverage_instrument_enabled(compiler_program: &str, hew_coverage_env_set: boo
     hew_coverage_env_set && compiler_program == "clang"
 }
 
+/// Whether a C driver's `--version` banner identifies a clang-family driver.
+fn driver_version_is_clang(version: &str) -> bool {
+    version
+        .lines()
+        .next()
+        .is_some_and(|first| first.to_lowercase().contains("clang"))
+}
+
 /// Build the "no C driver found" message: names what was tried and the
 /// packages that provide one, mirroring `windows_missing_clang_error`'s shape
 /// (what was tried, what to install) for the non-Windows probe order.
@@ -541,29 +549,27 @@ fn native_compiler_not_found_error(tried: &str) -> String {
 
 fn select_native_compiler_with<F>(
     target: &TargetSpec,
-    has_tool: F,
+    driver_version: F,
 ) -> Result<NativeCompiler, String>
 where
-    F: Fn(&str) -> bool,
+    F: Fn(&str) -> Option<String>,
 {
-    // `HEW_CC` overrides the probe entirely: when set, it is the one driver
-    // tried, named literally in the error so a bad path never degrades into
-    // an unnamed spawn failure later at actual link time.
+    // `HEW_CC` overrides probing. Its version banner determines whether the
+    // clang-only `-target` flag is valid.
     if let Some(hew_cc) = std::env::var_os("HEW_CC") {
         let hew_cc = hew_cc.to_string_lossy().into_owned();
-        return if has_tool(&hew_cc) {
-            Ok(NativeCompiler {
+        return match driver_version(&hew_cc) {
+            Some(version) => Ok(NativeCompiler {
+                accepts_target_flag: driver_version_is_clang(&version),
                 program: hew_cc,
-                accepts_target_flag: true,
-            })
-        } else {
-            Err(native_compiler_not_found_error(&format!(
+            }),
+            None => Err(native_compiler_not_found_error(&format!(
                 "HEW_CC={hew_cc} not found"
-            )))
+            ))),
         };
     }
 
-    if has_tool("clang") {
+    if driver_version("clang").is_some() {
         return Ok(NativeCompiler {
             program: "clang".to_string(),
             accepts_target_flag: true,
@@ -589,7 +595,7 @@ where
         // branch returned `Ok("cc")` unconditionally, so a host with neither
         // clang nor a working `cc` failed later at raw process spawn instead
         // of with a named diagnostic.
-        if has_tool("cc") {
+        if driver_version("cc").is_some() {
             return Ok(NativeCompiler {
                 program: "cc".to_string(),
                 accepts_target_flag: false,
@@ -1411,6 +1417,19 @@ fn has_tool(name: &str) -> bool {
         .is_ok_and(|s| s.success())
 }
 
+/// Probe a C driver and return its version banner.
+fn driver_version(name: &str) -> Option<String> {
+    let output = std::process::Command::new(name)
+        .arg("--version")
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1918,8 +1937,10 @@ mod tests {
         // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
         unsafe { std::env::remove_var("HEW_CC") };
         let target = TargetSpec::from_requested(None).expect("host target");
-        let compiler =
-            select_native_compiler_with(&target, |tool| tool != "clang").expect("cc fallback");
+        let compiler = select_native_compiler_with(&target, |tool| {
+            (tool != "clang").then(|| "cc (Ubuntu 15.2.0-16ubuntu1) 15.2.0".to_string())
+        })
+        .expect("cc fallback");
 
         assert_eq!(
             compiler,
@@ -1936,8 +1957,10 @@ mod tests {
         // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
         unsafe { std::env::remove_var("HEW_CC") };
         let target = TargetSpec::from_requested(None).expect("host target");
-        let compiler =
-            select_native_compiler_with(&target, |tool| tool == "clang").expect("clang selected");
+        let compiler = select_native_compiler_with(&target, |tool| {
+            (tool == "clang").then(|| CLANG_BANNER.to_string())
+        })
+        .expect("clang selected");
 
         assert_eq!(
             compiler,
@@ -1947,6 +1970,12 @@ mod tests {
             }
         );
     }
+
+    /// A clang `--version` first line, vendor-prefixed the way distributions
+    /// ship it, for the injected driver probe.
+    const CLANG_BANNER: &str = "Ubuntu clang version 20.1.8 (++20250918)";
+    /// A GCC-family `--version` first line — the shape Debian's `cc` prints.
+    const GCC_BANNER: &str = "cc (Ubuntu 15.2.0-16ubuntu1) 15.2.0";
 
     // ── HEW_CC env-var contract ───────────────────────────────────────
     // Mirrors the HEW_COVERAGE/HEW_SANITIZE_ADDRESS tests above; uses the
@@ -1958,8 +1987,10 @@ mod tests {
         // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
         unsafe { std::env::set_var("HEW_CC", "/opt/my-cc") };
         let target = TargetSpec::from_requested(None).expect("host target");
-        let compiler = select_native_compiler_with(&target, |tool| tool == "/opt/my-cc")
-            .expect("HEW_CC driver selected");
+        let compiler = select_native_compiler_with(&target, |tool| {
+            (tool == "/opt/my-cc").then(|| CLANG_BANNER.to_string())
+        })
+        .expect("HEW_CC driver selected");
         // SAFETY: same guard as above.
         unsafe { std::env::remove_var("HEW_CC") };
 
@@ -1978,7 +2009,7 @@ mod tests {
         // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
         unsafe { std::env::set_var("HEW_CC", "/nonexistent/cc") };
         let target = TargetSpec::from_requested(None).expect("host target");
-        let error = select_native_compiler_with(&target, |_| false).unwrap_err();
+        let error = select_native_compiler_with(&target, |_| None).unwrap_err();
         // SAFETY: same guard as above.
         unsafe { std::env::remove_var("HEW_CC") };
 
@@ -2000,10 +2031,60 @@ mod tests {
         // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
         unsafe { std::env::remove_var("HEW_CC") };
         let target = TargetSpec::from_requested(None).expect("host target");
-        let compiler =
-            select_native_compiler_with(&target, |tool| tool == "clang").expect("clang selected");
+        let compiler = select_native_compiler_with(&target, |tool| {
+            (tool == "clang").then(|| CLANG_BANNER.to_string())
+        })
+        .expect("clang selected");
 
         assert_eq!(compiler.program, "clang");
+    }
+
+    #[test]
+    fn hew_cc_naming_a_gcc_driver_withholds_the_target_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::set_var("HEW_CC", "/usr/bin/cc") };
+        let target = TargetSpec::from_requested(None).expect("host target");
+        let compiler = select_native_compiler_with(&target, |tool| {
+            (tool == "/usr/bin/cc").then(|| GCC_BANNER.to_string())
+        })
+        .expect("HEW_CC driver selected");
+        // SAFETY: same guard as above.
+        unsafe { std::env::remove_var("HEW_CC") };
+
+        assert_eq!(
+            compiler,
+            NativeCompiler {
+                program: "/usr/bin/cc".to_string(),
+                // GCC rejects clang's `-target`; passing it makes the link
+                // fail with "unrecognized command-line option '-target'".
+                accepts_target_flag: false
+            }
+        );
+    }
+
+    #[test]
+    fn driver_version_banner_identifies_the_clang_family() {
+        for clang in [
+            CLANG_BANNER,
+            "clang version 22.1.6",
+            "Apple clang version 17.0.0 (clang-1700.0.13.3)",
+        ] {
+            assert!(
+                driver_version_is_clang(clang),
+                "must read as clang: {clang}"
+            );
+        }
+        for gcc in [
+            GCC_BANNER,
+            "gcc (GCC) 15.2.0",
+            "x86_64-linux-gnu-gcc-15 (Ubuntu 15.2.0-16ubuntu1) 15.2.0",
+        ] {
+            assert!(
+                !driver_version_is_clang(gcc),
+                "must not read as clang: {gcc}"
+            );
+        }
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -2013,7 +2094,7 @@ mod tests {
         // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
         unsafe { std::env::remove_var("HEW_CC") };
         let target = TargetSpec::from_requested(None).expect("host target");
-        let error = select_native_compiler_with(&target, |_| false).unwrap_err();
+        let error = select_native_compiler_with(&target, |_| None).unwrap_err();
 
         assert!(error.contains("clang"), "must name clang: {error}");
         assert!(error.contains("cc"), "must name cc: {error}");
@@ -2080,7 +2161,7 @@ mod tests {
             "aarch64-unknown-linux-gnu"
         };
         let target = TargetSpec::from_requested(Some(target_triple)).expect("cross target");
-        let error = select_native_compiler_with(&target, |_| false).unwrap_err();
+        let error = select_native_compiler_with(&target, |_| None).unwrap_err();
 
         assert!(error.contains("clang not found"));
         assert!(error.contains(target_triple));

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -5,9 +5,9 @@
 use crate::diagnostic::emit_plain_diagnostic_line;
 use crate::target::TargetSpec;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct NativeCompiler {
-    program: &'static str,
+    program: String,
     accepts_target_flag: bool,
 }
 
@@ -185,7 +185,7 @@ pub(crate) fn link_executable_with_hew_lib(
     // real CLI surface. WHAT real looks like: a typed build option that also
     // drives the libhew instrumentation, not an out-of-band env contract.
     let coverage_instrument = coverage_instrument_enabled(
-        compiler.program,
+        &compiler.program,
         std::env::var_os("HEW_COVERAGE").as_deref() == Some(std::ffi::OsStr::new("1")),
     );
 
@@ -233,7 +233,7 @@ pub(crate) fn link_executable_with_hew_lib(
         )?,
     };
 
-    let mut cmd = std::process::Command::new(compiler.program);
+    let mut cmd = std::process::Command::new(&compiler.program);
 
     // ── lld selection (host-driven) ────────────────────────────────────
     // Use lld when available — ~20x faster than GNU ld for large static libs.
@@ -527,6 +527,18 @@ fn coverage_instrument_enabled(compiler_program: &str, hew_coverage_env_set: boo
     hew_coverage_env_set && compiler_program == "clang"
 }
 
+/// Build the "no C driver found" message: names what was tried and the
+/// packages that provide one, mirroring `windows_missing_clang_error`'s shape
+/// (what was tried, what to install) for the non-Windows probe order.
+fn native_compiler_not_found_error(tried: &str) -> String {
+    format!(
+        "Error: {tried}. Install a C compiler driver: `clang` (https://clang.llvm.org), \
+         `gcc`/`build-essential` on Debian/Ubuntu (`apt install build-essential`) or \
+         Fedora/RHEL (`dnf install gcc`), or the Xcode Command Line Tools on macOS \
+         (`xcode-select --install`)."
+    )
+}
+
 fn select_native_compiler_with<F>(
     target: &TargetSpec,
     has_tool: F,
@@ -534,9 +546,26 @@ fn select_native_compiler_with<F>(
 where
     F: Fn(&str) -> bool,
 {
+    // `HEW_CC` overrides the probe entirely: when set, it is the one driver
+    // tried, named literally in the error so a bad path never degrades into
+    // an unnamed spawn failure later at actual link time.
+    if let Some(hew_cc) = std::env::var_os("HEW_CC") {
+        let hew_cc = hew_cc.to_string_lossy().into_owned();
+        return if has_tool(&hew_cc) {
+            Ok(NativeCompiler {
+                program: hew_cc,
+                accepts_target_flag: true,
+            })
+        } else {
+            Err(native_compiler_not_found_error(&format!(
+                "HEW_CC={hew_cc} not found"
+            )))
+        };
+    }
+
     if has_tool("clang") {
         return Ok(NativeCompiler {
-            program: "clang",
+            program: "clang".to_string(),
             accepts_target_flag: true,
         });
     }
@@ -549,16 +578,26 @@ where
 
     #[cfg(not(target_os = "windows"))]
     {
-        if target.can_run_on_host() {
+        if !target.can_run_on_host() {
+            return Err(format!(
+                "Error: clang not found. Install LLVM/Clang to link target {} from this host.",
+                target.normalized_triple()
+            ));
+        }
+
+        // The `cc` fallback must itself be verified to exist — previously this
+        // branch returned `Ok("cc")` unconditionally, so a host with neither
+        // clang nor a working `cc` failed later at raw process spawn instead
+        // of with a named diagnostic.
+        if has_tool("cc") {
             return Ok(NativeCompiler {
-                program: "cc",
+                program: "cc".to_string(),
                 accepts_target_flag: false,
             });
         }
 
-        Err(format!(
-            "Error: clang not found. Install LLVM/Clang to link target {} from this host.",
-            target.normalized_triple()
+        Err(native_compiler_not_found_error(
+            "no C compiler found (tried clang, cc)",
         ))
     }
 }
@@ -1875,6 +1914,9 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn native_unix_without_clang_falls_back_to_cc_without_target_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::remove_var("HEW_CC") };
         let target = TargetSpec::from_requested(None).expect("host target");
         let compiler =
             select_native_compiler_with(&target, |tool| tool != "clang").expect("cc fallback");
@@ -1882,7 +1924,7 @@ mod tests {
         assert_eq!(
             compiler,
             NativeCompiler {
-                program: "cc",
+                program: "cc".to_string(),
                 accepts_target_flag: false
             }
         );
@@ -1890,6 +1932,9 @@ mod tests {
 
     #[test]
     fn native_compiler_prefers_clang_with_target_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::remove_var("HEW_CC") };
         let target = TargetSpec::from_requested(None).expect("host target");
         let compiler =
             select_native_compiler_with(&target, |tool| tool == "clang").expect("clang selected");
@@ -1897,10 +1942,81 @@ mod tests {
         assert_eq!(
             compiler,
             NativeCompiler {
-                program: "clang",
+                program: "clang".to_string(),
                 accepts_target_flag: true
             }
         );
+    }
+
+    // ── HEW_CC env-var contract ───────────────────────────────────────
+    // Mirrors the HEW_COVERAGE/HEW_SANITIZE_ADDRESS tests above; uses the
+    // same ENV_LOCK for safety, since these mutate the process environment.
+
+    #[test]
+    fn hew_cc_selects_named_driver_when_present() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::set_var("HEW_CC", "/opt/my-cc") };
+        let target = TargetSpec::from_requested(None).expect("host target");
+        let compiler = select_native_compiler_with(&target, |tool| tool == "/opt/my-cc")
+            .expect("HEW_CC driver selected");
+        // SAFETY: same guard as above.
+        unsafe { std::env::remove_var("HEW_CC") };
+
+        assert_eq!(
+            compiler,
+            NativeCompiler {
+                program: "/opt/my-cc".to_string(),
+                accepts_target_flag: true
+            }
+        );
+    }
+
+    #[test]
+    fn hew_cc_missing_tool_names_value_and_package() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::set_var("HEW_CC", "/nonexistent/cc") };
+        let target = TargetSpec::from_requested(None).expect("host target");
+        let error = select_native_compiler_with(&target, |_| false).unwrap_err();
+        // SAFETY: same guard as above.
+        unsafe { std::env::remove_var("HEW_CC") };
+
+        assert!(
+            error.contains("/nonexistent/cc"),
+            "must name the literal HEW_CC value: {error}"
+        );
+        assert!(
+            ["clang", "gcc", "build-essential", "xcode"]
+                .iter()
+                .any(|pkg| error.to_lowercase().contains(pkg)),
+            "must name a package that provides a driver: {error}"
+        );
+    }
+
+    #[test]
+    fn hew_cc_unset_leaves_the_existing_probe_order_untouched() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::remove_var("HEW_CC") };
+        let target = TargetSpec::from_requested(None).expect("host target");
+        let compiler =
+            select_native_compiler_with(&target, |tool| tool == "clang").expect("clang selected");
+
+        assert_eq!(compiler.program, "clang");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn native_unix_neither_clang_nor_cc_names_both_in_error() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::remove_var("HEW_CC") };
+        let target = TargetSpec::from_requested(None).expect("host target");
+        let error = select_native_compiler_with(&target, |_| false).unwrap_err();
+
+        assert!(error.contains("clang"), "must name clang: {error}");
+        assert!(error.contains("cc"), "must name cc: {error}");
     }
 
     #[test]
@@ -1955,6 +2071,9 @@ mod tests {
     ))]
     #[test]
     fn linux_cross_target_without_clang_errors() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::remove_var("HEW_CC") };
         let target_triple = if cfg!(target_arch = "aarch64") {
             "x86_64-unknown-linux-gnu"
         } else {

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -1971,15 +1971,8 @@ mod tests {
         );
     }
 
-    /// A clang `--version` first line, vendor-prefixed the way distributions
-    /// ship it, for the injected driver probe.
     const CLANG_BANNER: &str = "Ubuntu clang version 20.1.8 (++20250918)";
-    /// A GCC-family `--version` first line — the shape Debian's `cc` prints.
     const GCC_BANNER: &str = "cc (Ubuntu 15.2.0-16ubuntu1) 15.2.0";
-
-    // ── HEW_CC env-var contract ───────────────────────────────────────
-    // Mirrors the HEW_COVERAGE/HEW_SANITIZE_ADDRESS tests above; uses the
-    // same ENV_LOCK for safety, since these mutate the process environment.
 
     #[test]
     fn hew_cc_selects_named_driver_when_present() {
@@ -2056,8 +2049,6 @@ mod tests {
             compiler,
             NativeCompiler {
                 program: "/usr/bin/cc".to_string(),
-                // GCC rejects clang's `-target`; passing it makes the link
-                // fail with "unrecognized command-line option '-target'".
                 accepts_target_flag: false
             }
         );

--- a/hew-cli/src/native_link.rs
+++ b/hew-cli/src/native_link.rs
@@ -49,9 +49,10 @@ fn collect_items(items: &[Spanned<Item>], dirs: &mut BTreeSet<PathBuf>) {
 /// that declares a `[native]` library. Directories without a `[native]` section
 /// yield nothing. Returns an error string if a native crate fails to build.
 pub fn build_native_link_libs(dirs: &[PathBuf]) -> Result<Vec<String>, String> {
+    let expected = hew_pkg::native::embedded_rustc_identity();
     let mut libs = Vec::new();
     for dir in dirs {
-        if let Some(artifact) = hew_pkg::native::build_native(dir)? {
+        if let Some(artifact) = hew_pkg::native::build_native(dir, &expected)? {
             let path = artifact.path.to_str().ok_or_else(|| {
                 format!(
                     "native library path is not valid UTF-8: {}",

--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -294,7 +294,8 @@ fn detect_and_build_ffi_lib(start_dir: &std::path::Path) -> Result<Option<String
     if !start_dir.join("hew.toml").is_file() {
         return Ok(None);
     }
-    let Some(artifact) = hew_pkg::native::build_native(start_dir)? else {
+    let expected = hew_pkg::native::embedded_rustc_identity();
+    let Some(artifact) = hew_pkg::native::build_native(start_dir, &expected)? else {
         return Ok(None);
     };
     let canonical = artifact

--- a/hew-cli/tests/package_mode_e2e.rs
+++ b/hew-cli/tests/package_mode_e2e.rs
@@ -279,6 +279,53 @@ fn native_prerequisite_failure_stops_the_build() {
     );
 }
 
+/// The `[native]` prerequisite's toolchain check (`E_NATIVE_TOOLCHAIN`) is
+/// the positive case: this test's own `cargo test` run builds both `libhew.a`
+/// and this fixture's `[native]` crate with the identical rustc, so the check
+/// passes and the package builds and links exactly as it did before the
+/// check existed. The mismatch case is `hew-pkg::native::
+/// build_native_refuses_mismatched_rustc`, which injects a deliberately wrong
+/// `expected` identity directly — this repo's own build never disagrees with
+/// itself, so there is no way to force a real mismatch from an e2e test.
+#[test]
+fn native_prerequisite_with_matching_toolchain_builds_and_links() {
+    require_codegen();
+    let dir = workspace();
+    write_package(
+        dir.path(),
+        "withnativeok",
+        "main.hew",
+        "\n[native]\nlib = \"withnativeok_native\"\ncrate = \"native\"\n",
+    );
+    let native_dir = dir.path().join("native");
+    std::fs::create_dir_all(native_dir.join("src")).expect("create native crate dir");
+    // `[workspace]` with no `members` makes this crate the root of its own
+    // single-package workspace — otherwise cargo would refuse to build it,
+    // since it sits inside the hew repo's own workspace directory tree
+    // without being one of that workspace's listed `members`.
+    std::fs::write(
+        native_dir.join("Cargo.toml"),
+        "[workspace]\n\n\
+         [package]\nname = \"withnativeok_native\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+         [lib]\ncrate-type = [\"staticlib\"]\n",
+    )
+    .expect("write native Cargo.toml");
+    std::fs::write(native_dir.join("src/lib.rs"), "").expect("write native lib.rs");
+
+    let output = Command::new(hew_binary())
+        .arg("build")
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew build");
+
+    assert!(
+        output.status.success(),
+        "a package whose [native] crate matches the runtime's rustc must build\n{}",
+        describe_output(&output),
+    );
+    assert_prints_greeting(&binary_in(dir.path(), "withnativeok"));
+}
+
 /// Outside any package, the file-less form is a usage error naming the search
 /// origin and the way out.
 #[test]

--- a/hew-cli/tests/package_mode_e2e.rs
+++ b/hew-cli/tests/package_mode_e2e.rs
@@ -279,14 +279,6 @@ fn native_prerequisite_failure_stops_the_build() {
     );
 }
 
-/// The `[native]` prerequisite's toolchain check (`E_NATIVE_TOOLCHAIN`) is
-/// the positive case: this test's own `cargo test` run builds both `libhew.a`
-/// and this fixture's `[native]` crate with the identical rustc, so the check
-/// passes and the package builds and links exactly as it did before the
-/// check existed. The mismatch case is `hew-pkg::native::
-/// build_native_refuses_mismatched_rustc`, which injects a deliberately wrong
-/// `expected` identity directly — this repo's own build never disagrees with
-/// itself, so there is no way to force a real mismatch from an e2e test.
 #[test]
 fn native_prerequisite_with_matching_toolchain_builds_and_links() {
     require_codegen();
@@ -299,10 +291,7 @@ fn native_prerequisite_with_matching_toolchain_builds_and_links() {
     );
     let native_dir = dir.path().join("native");
     std::fs::create_dir_all(native_dir.join("src")).expect("create native crate dir");
-    // `[workspace]` with no `members` makes this crate the root of its own
-    // single-package workspace — otherwise cargo would refuse to build it,
-    // since it sits inside the hew repo's own workspace directory tree
-    // without being one of that workspace's listed `members`.
+    // Make the fixture its own Cargo workspace.
     std::fs::write(
         native_dir.join("Cargo.toml"),
         "[workspace]\n\n\

--- a/hew-pkg/build.rs
+++ b/hew-pkg/build.rs
@@ -1,0 +1,48 @@
+//! Stamps the rustc identity that built this crate (and, in the same
+//! workspace build, `libhew.a`) so `native::build_native` can refuse to
+//! build a `[native]` crate with a *different* rustc: a mismatched toolchain
+//! produces a staticlib whose embedded `libstd` is not byte-identical to
+//! `libhew.a`'s, and the final link fails on a duplicate
+//! `rust_eh_personality` symbol (see the comment at native.rs's `build_native`).
+
+use std::env;
+use std::process::Command;
+
+fn main() {
+    // Cargo sets `RUSTC` to the compiler it is actually invoking, which can
+    // differ from a bare `rustc` on PATH (rustup proxies, explicit `RUSTC=`
+    // builds); querying that exact binary is what makes the embedded identity
+    // trustworthy.
+    let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    println!("cargo:rerun-if-env-changed=RUSTC");
+
+    let output = Command::new(&rustc)
+        .arg("-vV")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `{rustc} -vV`: {e}"));
+    assert!(
+        output.status.success(),
+        "`{rustc} -vV` failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = String::from_utf8(output.stdout)
+        .unwrap_or_else(|e| panic!("`{rustc} -vV` produced non-UTF-8 output: {e}"));
+
+    let release = field(&text, "release").unwrap_or_else(|| {
+        panic!("`{rustc} -vV` output has no `release:` line:\n{text}");
+    });
+    let host = field(&text, "host").unwrap_or_else(|| {
+        panic!("`{rustc} -vV` output has no `host:` line:\n{text}");
+    });
+
+    println!("cargo:rustc-env=HEW_RUNTIME_RUSTC={release} {host}");
+}
+
+/// Extract the value of a `<name>: <value>` line from `rustc -vV` output.
+fn field(text: &str, name: &str) -> Option<String> {
+    let prefix = format!("{name}: ");
+    text.lines()
+        .find_map(|line| line.strip_prefix(&prefix))
+        .map(str::trim)
+        .map(str::to_string)
+}

--- a/hew-pkg/build.rs
+++ b/hew-pkg/build.rs
@@ -1,18 +1,10 @@
-//! Stamps the rustc identity that built this crate (and, in the same
-//! workspace build, `libhew.a`) so `native::build_native` can refuse to
-//! build a `[native]` crate with a *different* rustc: a mismatched toolchain
-//! produces a staticlib whose embedded `libstd` is not byte-identical to
-//! `libhew.a`'s, and the final link fails on a duplicate
-//! `rust_eh_personality` symbol (see the comment at native.rs's `build_native`).
+//! Stamps the rustc identity used to build the Hew runtime.
 
 use std::env;
 use std::process::Command;
 
 fn main() {
-    // Cargo sets `RUSTC` to the compiler it is actually invoking, which can
-    // differ from a bare `rustc` on PATH (rustup proxies, explicit `RUSTC=`
-    // builds); querying that exact binary is what makes the embedded identity
-    // trustworthy.
+    // Cargo may use a rustc other than the one on PATH.
     let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
     println!("cargo:rerun-if-env-changed=RUSTC");
 

--- a/hew-pkg/src/native.rs
+++ b/hew-pkg/src/native.rs
@@ -19,12 +19,7 @@ pub struct NativeArtifact {
     pub path: PathBuf,
 }
 
-/// The `<release> <host>` identity of the rustc that built something.
-///
-/// A `[native]` crate's staticlib must be built with the identical rustc that
-/// built `libhew.a`, or its embedded `libstd` is not byte-identical and the
-/// final link fails on a duplicate `rust_eh_personality` symbol (see
-/// [`build_native`]'s toolchain check below).
+/// The release and host identity of a rustc toolchain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustcIdentity {
     pub release: String,
@@ -64,14 +59,11 @@ impl RustcIdentity {
     }
 }
 
-/// The rustc identity that built this compiler — and, in the same workspace
-/// build, `libhew.a` — embedded at compile time by `hew-pkg/build.rs`.
+/// The rustc identity embedded while building the Hew runtime.
 ///
 /// # Panics
 ///
-/// Panics if `HEW_RUNTIME_RUSTC` is malformed, which cannot happen from a
-/// normal build: `hew-pkg/build.rs` is the only writer of this env var and
-/// always emits the `<release> <host>` shape this parses.
+/// Panics if the build stamp is malformed.
 #[must_use]
 pub fn embedded_rustc_identity() -> RustcIdentity {
     RustcIdentity::parse_stamp(env!("HEW_RUNTIME_RUSTC")).unwrap_or_else(|| {
@@ -82,11 +74,7 @@ pub fn embedded_rustc_identity() -> RustcIdentity {
     })
 }
 
-/// Query the rustc identity `cargo build` will use for the crate at
-/// `crate_dir`. Spawned **from** `crate_dir`, exactly like the `cargo build`
-/// call in [`build_native`], so rustup resolves the same
-/// `rust-toolchain.toml` cargo is about to honour — probing from a different
-/// directory could report a different (wrong) toolchain.
+/// Query the rustc selected for a native crate directory.
 fn crate_rustc_identity(crate_dir: &Path) -> Result<RustcIdentity, String> {
     let output = Command::new("rustc")
         .arg("-vV")
@@ -157,11 +145,7 @@ pub fn build_native(
         ));
     }
 
-    // Fail closed before invoking cargo: cargo build "succeeds" under a
-    // mismatched rustc, but the resulting staticlib embeds a libstd that
-    // isn't byte-identical to libhew.a's, and the *final* link fails much
-    // later on a duplicate `rust_eh_personality` symbol — a confusing
-    // failure far from its cause.
+    // Refuse before cargo builds a static library with an incompatible libstd.
     let actual = crate_rustc_identity(&crate_dir)?;
     if actual != *expected {
         return Err(format!(
@@ -313,11 +297,6 @@ mod tests {
         assert!(RustcIdentity::parse_verbose("binary: rustc\n").is_none());
     }
 
-    /// `build_native` must refuse a `[native]` crate before ever invoking
-    /// cargo when the caller's `expected` identity doesn't match the host's
-    /// actual rustc — the negative control for the toolchain check: with a
-    /// matching `expected` (any real build) this same fixture would proceed
-    /// past this point.
     #[test]
     fn build_native_refuses_mismatched_rustc() {
         let dir = tempfile::tempdir().unwrap();

--- a/hew-pkg/src/native.rs
+++ b/hew-pkg/src/native.rs
@@ -19,6 +19,92 @@ pub struct NativeArtifact {
     pub path: PathBuf,
 }
 
+/// The `<release> <host>` identity of the rustc that built something.
+///
+/// A `[native]` crate's staticlib must be built with the identical rustc that
+/// built `libhew.a`, or its embedded `libstd` is not byte-identical and the
+/// final link fails on a duplicate `rust_eh_personality` symbol (see
+/// [`build_native`]'s toolchain check below).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RustcIdentity {
+    pub release: String,
+    pub host: String,
+}
+
+impl std::fmt::Display for RustcIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "rustc {} ({})", self.release, self.host)
+    }
+}
+
+impl RustcIdentity {
+    /// Parse the `<release> <host>` stamp `hew-pkg/build.rs` embeds via
+    /// `cargo:rustc-env=HEW_RUNTIME_RUSTC`.
+    fn parse_stamp(text: &str) -> Option<Self> {
+        let (release, host) = text.trim().split_once(' ')?;
+        Some(Self {
+            release: release.to_string(),
+            host: host.to_string(),
+        })
+    }
+
+    /// Parse the `release:`/`host:` lines out of full `rustc -vV` output.
+    fn parse_verbose(text: &str) -> Option<Self> {
+        let field = |name: &str| -> Option<String> {
+            let prefix = format!("{name}: ");
+            text.lines()
+                .find_map(|line| line.strip_prefix(prefix.as_str()))
+                .map(str::trim)
+                .map(str::to_string)
+        };
+        Some(Self {
+            release: field("release")?,
+            host: field("host")?,
+        })
+    }
+}
+
+/// The rustc identity that built this compiler — and, in the same workspace
+/// build, `libhew.a` — embedded at compile time by `hew-pkg/build.rs`.
+///
+/// # Panics
+///
+/// Panics if `HEW_RUNTIME_RUSTC` is malformed, which cannot happen from a
+/// normal build: `hew-pkg/build.rs` is the only writer of this env var and
+/// always emits the `<release> <host>` shape this parses.
+#[must_use]
+pub fn embedded_rustc_identity() -> RustcIdentity {
+    RustcIdentity::parse_stamp(env!("HEW_RUNTIME_RUSTC")).unwrap_or_else(|| {
+        panic!(
+            "HEW_RUNTIME_RUSTC={:?} embedded by hew-pkg/build.rs is malformed",
+            env!("HEW_RUNTIME_RUSTC")
+        )
+    })
+}
+
+/// Query the rustc identity `cargo build` will use for the crate at
+/// `crate_dir`. Spawned **from** `crate_dir`, exactly like the `cargo build`
+/// call in [`build_native`], so rustup resolves the same
+/// `rust-toolchain.toml` cargo is about to honour — probing from a different
+/// directory could report a different (wrong) toolchain.
+fn crate_rustc_identity(crate_dir: &Path) -> Result<RustcIdentity, String> {
+    let output = Command::new("rustc")
+        .arg("-vV")
+        .current_dir(crate_dir)
+        .output()
+        .map_err(|e| format!("failed to run `rustc -vV`: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "`rustc -vV` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let text = String::from_utf8(output.stdout)
+        .map_err(|e| format!("`rustc -vV` produced non-UTF-8 output: {e}"))?;
+    RustcIdentity::parse_verbose(&text)
+        .ok_or_else(|| format!("could not parse `rustc -vV` output:\n{text}"))
+}
+
 /// Platform-specific file name for a built library of the given `kind`.
 fn artifact_file_name(lib: &str, kind: &str) -> String {
     if kind == "cdylib" {
@@ -43,11 +129,19 @@ fn artifact_file_name(lib: &str, kind: &str) -> String {
 /// static libraries and locates the produced artifact.
 /// Returns `Ok(None)` when the manifest has no `[native]` section.
 ///
+/// `expected` is the rustc identity `libhew.a` was built with — callers pass
+/// [`embedded_rustc_identity`] in production; tests pass a deliberately
+/// mismatching value directly, with no env var involved.
+///
 /// # Errors
 ///
-/// Returns an error when the manifest can't be read, the crate fails to build,
+/// Returns an error when the manifest can't be read, the crate's rustc
+/// doesn't match `expected` (`E_NATIVE_TOOLCHAIN`), the crate fails to build,
 /// or the built artifact can't be located.
-pub fn build_native(manifest_dir: &Path) -> Result<Option<NativeArtifact>, String> {
+pub fn build_native(
+    manifest_dir: &Path,
+    expected: &RustcIdentity,
+) -> Result<Option<NativeArtifact>, String> {
     let manifest_path = manifest_dir.join("hew.toml");
     let m = manifest::parse_manifest(&manifest_path).map_err(|e| e.to_string())?;
     let Some(native) = m.native else {
@@ -60,6 +154,24 @@ pub fn build_native(manifest_dir: &Path) -> Result<Option<NativeArtifact>, Strin
         return Err(format!(
             "[native] crate at {} has no Cargo.toml",
             crate_dir.display()
+        ));
+    }
+
+    // Fail closed before invoking cargo: cargo build "succeeds" under a
+    // mismatched rustc, but the resulting staticlib embeds a libstd that
+    // isn't byte-identical to libhew.a's, and the *final* link fails much
+    // later on a duplicate `rust_eh_personality` symbol — a confusing
+    // failure far from its cause.
+    let actual = crate_rustc_identity(&crate_dir)?;
+    if actual != *expected {
+        return Err(format!(
+            "error[E_NATIVE_TOOLCHAIN]: [native] crate at {} would build with {actual}, \
+             but the Hew runtime (libhew.a) was built with {expected}. A mismatched rustc \
+             embeds an incompatible libstd, and the final link would fail on a duplicate \
+             `rust_eh_personality` symbol. Fix: pin {}/rust-toolchain.toml to release {}.",
+            crate_dir.display(),
+            crate_dir.display(),
+            expected.release,
         ));
     }
 
@@ -168,6 +280,79 @@ mod tests {
             "[package]\nname = \"p\"\nversion = \"0.1.0\"\nedition = \"2026\"\n",
         )
         .unwrap();
-        assert!(build_native(dir.path()).unwrap().is_none());
+        assert!(build_native(dir.path(), &embedded_rustc_identity())
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn rustc_identity_display_names_release_and_host() {
+        let id = RustcIdentity {
+            release: "1.82.0".to_string(),
+            host: "x86_64-unknown-linux-gnu".to_string(),
+        };
+        assert_eq!(id.to_string(), "rustc 1.82.0 (x86_64-unknown-linux-gnu)");
+    }
+
+    #[test]
+    fn rustc_identity_parses_verbose_output() {
+        let text = "rustc 1.82.0 (f6e511eec 2024-10-15)\n\
+                     binary: rustc\n\
+                     commit-hash: f6e511eec5f43ba5e5e2b60eb1a35d4f1a35e97a\n\
+                     commit-date: 2024-10-15\n\
+                     host: x86_64-unknown-linux-gnu\n\
+                     release: 1.82.0\n\
+                     LLVM version: 19.1.1\n";
+        let id = RustcIdentity::parse_verbose(text).expect("parses");
+        assert_eq!(id.release, "1.82.0");
+        assert_eq!(id.host, "x86_64-unknown-linux-gnu");
+    }
+
+    #[test]
+    fn rustc_identity_parse_verbose_rejects_output_missing_fields() {
+        assert!(RustcIdentity::parse_verbose("binary: rustc\n").is_none());
+    }
+
+    /// `build_native` must refuse a `[native]` crate before ever invoking
+    /// cargo when the caller's `expected` identity doesn't match the host's
+    /// actual rustc — the negative control for the toolchain check: with a
+    /// matching `expected` (any real build) this same fixture would proceed
+    /// past this point.
+    #[test]
+    fn build_native_refuses_mismatched_rustc() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("hew.toml"),
+            "[package]\nname = \"p\"\nversion = \"0.1.0\"\nedition = \"2026\"\n\
+             [native]\nlib = \"p_native\"\ncrate = \"native\"\n",
+        )
+        .unwrap();
+        let native_dir = dir.path().join("native");
+        std::fs::create_dir_all(&native_dir).unwrap();
+        std::fs::write(
+            native_dir.join("Cargo.toml"),
+            "[package]\nname = \"p_native\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\
+             [lib]\ncrate-type = [\"staticlib\"]\n",
+        )
+        .unwrap();
+
+        let mismatching = RustcIdentity {
+            release: "0.0.0-does-not-exist".to_string(),
+            host: "nowhere".to_string(),
+        };
+        let error = build_native(dir.path(), &mismatching).unwrap_err();
+
+        assert!(
+            error.contains("E_NATIVE_TOOLCHAIN"),
+            "must carry the toolchain-mismatch code: {error}"
+        );
+        assert!(
+            error.contains("0.0.0-does-not-exist"),
+            "must name the expected (libhew.a) rustc: {error}"
+        );
+        assert!(
+            !error.contains("cargo build failed"),
+            "must fail before ever invoking cargo: {error}"
+        );
     }
 }

--- a/hew-pkg/src/project.rs
+++ b/hew-pkg/src/project.rs
@@ -210,7 +210,8 @@ fn absolute_normalized_path(path: &Path) -> Result<PathBuf, ResolveError> {
 ///
 /// Returns the underlying cargo build failure message.
 pub fn build_native_lib(root: &Path) -> Result<Option<PathBuf>, String> {
-    let Some(artifact) = crate::native::build_native(root)? else {
+    let expected = crate::native::embedded_rustc_identity();
+    let Some(artifact) = crate::native::build_native(root, &expected)? else {
         return Ok(None);
     };
     Ok(Some(artifact.path))


### PR DESCRIPTION
## Why

I need `HEW_CC` to select the requested native linker, and native package builds must reject a rustc mismatch before it becomes a linker failure.

## What

- I honour `HEW_CC`, report a missing selected driver clearly, and pass clang-only target flags only to clang-family drivers.
- I record the runtime rustc identity and compare it with the rustc selected for each `[native]` crate before building.

## Test

- `make test-pkg-import`
- Native compiler and rustc-identity unit coverage
- Package native-prerequisite integration coverage