### PR TITLE
fix(mir): keep a record projection write into actor state

### DIFF
--- a/hew-mir/src/lower/assign.rs
+++ b/hew-mir/src/lower/assign.rs
@@ -763,6 +763,47 @@ impl Builder {
                 if !copy_in {
                     self.transfer_typed_produced_value_owner(value.site, src, record_place);
                 }
+                // #3266 — a projection whose object IS an actor state field
+                // (`origin.y = v`, or the `self.origin.y = v` spelling) named
+                // the actor's own storage in the source, but `lower_value`
+                // above materialised that field through `ActorStateFieldLoad`,
+                // which byte-copies the field out of the state record into a
+                // frame local. The `RecordFieldStore` therefore landed on a
+                // copy and the handler's write was discarded at return, while
+                // whole-field replacement (`origin = …`, the depth-0
+                // `actor_state_field_for_target` hit at the top of `assign`)
+                // was unaffected. Publish the mutated value back through the
+                // same store authority the depth-0 path uses, so the one place
+                // that writes actor state stays the one place that writes
+                // actor state.
+                //
+                // The load's own/borrow classifier
+                // (`classify_actor_state_load_modes`) sees `record_place`
+                // escape as a whole value into this store and so leaves the
+                // load `Owned`: codegen clones the field on load, the field
+                // store mutates the clone, and the store-back releases the
+                // original. No aliasing of the released payload.
+                //
+                // SHORTCUT. WHY: actor state is an owning sink outside the MIR
+                // `Place` domain, so no place addresses `state.origin.y` and
+                // the write cannot be a GEP chain today; load-modify-store is
+                // the faithful write analog of the load-copy-then-project read
+                // path. WHEN: obsolete once a store carries a projection path
+                // into state (or a `Place` form resolves actor-state
+                // interiors), or once the COW spine makes the `Owned` load a
+                // refcount bump rather than a deep clone — the same horizon
+                // `ActorStateLoadMode`'s doc names. WHAT: one GEP-chain store
+                // that overwrites the leaf and releases only the leaf's old
+                // owner, with no whole-field clone.
+                if let Some((state_field_offset, _)) =
+                    self.actor_state_field_for_target(object.as_ref())
+                {
+                    self.push_instr(Instr::ActorStateFieldStore {
+                        field_offset: state_field_offset,
+                        src: record_place,
+                        handoff: ActorStateStoreHandoff::ConsumeSource,
+                    });
+                }
             }
             // `xs[i] = v` over a `Vec<T>` lowers to the same runtime call that
             // `xs.set(i, v)` emits.

--- a/hew-mir/tests/actor.rs
+++ b/hew-mir/tests/actor.rs
@@ -10,6 +10,8 @@ mod actor_handler_lowering;
 mod actor_send_ask;
 #[path = "actor/actor_state_lock_lowering.rs"]
 mod actor_state_lock_lowering;
+#[path = "actor/actor_state_record_projection_store.rs"]
+mod actor_state_record_projection_store;
 #[path = "actor/cancellation_scope.rs"]
 mod cancellation_scope;
 #[path = "actor/cancellation_token_lower.rs"]

--- a/hew-mir/tests/actor/actor_state_record_projection_store.rs
+++ b/hew-mir/tests/actor/actor_state_record_projection_store.rs
@@ -1,0 +1,143 @@
+// #3266 — a projection into a record-typed actor state field must publish the
+// mutated value back into state. Lowering materialises the state field into a
+// frame local (`ActorStateFieldLoad`) before it can project into it, so without
+// a trailing `ActorStateFieldStore` the `RecordFieldStore` lands on a copy and
+// the handler's write is discarded when the frame goes away.
+use hew_hir::{lower_program, ResolutionCtx};
+use hew_mir::{FieldOffset, Instr};
+use hew_types::{module_registry::ModuleRegistry, Checker};
+
+fn lower_source(source: &str) -> hew_mir::IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(tc_output.errors.is_empty(), "{:?}", tc_output.errors);
+    let hir = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(hir.diagnostics.is_empty(), "{:?}", hir.diagnostics);
+    hew_mir::lower_hir_module(&hir.module)
+}
+
+fn instructions_of<'a>(pipeline: &'a hew_mir::IrPipeline, name: &str) -> Vec<&'a Instr> {
+    pipeline
+        .raw_mir
+        .iter()
+        .find(|func| func.name == name)
+        .unwrap_or_else(|| panic!("no MIR function named `{name}`"))
+        .blocks
+        .iter()
+        .flat_map(|block| &block.instructions)
+        .collect()
+}
+
+/// The write-back exists, targets the same state field the load read, and
+/// republishes the very local the field store mutated.
+#[test]
+fn record_projection_into_actor_state_field_stores_back_to_the_same_field() {
+    let pipeline = lower_source(
+        r"
+type Point {
+    x: i64,
+    y: i64,
+}
+
+actor Holder {
+    var origin: Point;
+    receive fn bump() {
+        origin.y = 1;
+    }
+}
+
+fn main() {
+    let h = spawn Holder(origin: Point { x: 1, y: 4 });
+    h.bump();
+}
+",
+    );
+
+    let instrs = instructions_of(&pipeline, "Holder__recv__bump");
+    let found = instrs.windows(3).any(|window| {
+        matches!(
+            window,
+            [
+                Instr::ActorStateFieldLoad {
+                    field_offset: load_field,
+                    dest,
+                    ..
+                },
+                Instr::RecordFieldStore {
+                    record,
+                    field_offset: leaf,
+                    ..
+                },
+                Instr::ActorStateFieldStore {
+                    field_offset: store_field,
+                    src,
+                    ..
+                },
+            ] if record == dest
+                && src == dest
+                && load_field == store_field
+                // `origin` is the actor's only state field, `y` the record's
+                // second — pinning both proves the offsets are not crossed.
+                && *load_field == FieldOffset(0)
+                && *leaf == FieldOffset(1)
+        )
+    });
+    assert!(
+        found,
+        "expected load/field-store/store-back on state field 0 leaf 1, got: {instrs:#?}"
+    );
+}
+
+/// Negative control for the arm's guard: the same projection shape on a local
+/// record is already in-place, so lowering it must not reach into actor state.
+/// Without the `actor_state_field_for_target` guard on the write-back this
+/// handler would publish an unrelated local into state field 0.
+#[test]
+fn record_projection_into_a_local_emits_no_actor_state_store() {
+    let pipeline = lower_source(
+        r"
+type Point {
+    x: i64,
+    y: i64,
+}
+
+actor Holder {
+    var origin: Point;
+    receive fn touch_local() {
+        var scratch = Point { x: 0, y: 0 };
+        scratch.y = 1;
+    }
+}
+
+fn main() {
+    let h = spawn Holder(origin: Point { x: 1, y: 4 });
+    h.touch_local();
+}
+",
+    );
+
+    let instrs = instructions_of(&pipeline, "Holder__recv__touch_local");
+    assert!(
+        instrs
+            .iter()
+            .any(|instr| matches!(instr, Instr::RecordFieldStore { .. })),
+        "the local projection should still lower to a record field store: {instrs:#?}"
+    );
+    assert!(
+        !instrs
+            .iter()
+            .any(|instr| matches!(instr, Instr::ActorStateFieldStore { .. })),
+        "a local record write must not publish into actor state: {instrs:#?}"
+    );
+}

--- a/tests/vertical-slice/accept/actor_state_record_projection_write.expected
+++ b/tests/vertical-slice/accept/actor_state_record_projection_write.expected
@@ -1,0 +1,6 @@
+n=3
+label=relabelled
+churned_n=19
+churned_label=churned
+replaced_n=100
+replaced_label=replaced

--- a/tests/vertical-slice/accept/actor_state_record_projection_write.hew
+++ b/tests/vertical-slice/accept/actor_state_record_projection_write.hew
@@ -1,0 +1,92 @@
+// #3266 — a write through a record-typed actor state field names the actor's
+// own storage, so it must survive the handler. Lowering materialises the state
+// field into a frame local before projecting into it, so the mutated value has
+// to be published back through the actor-state store; before that write-back
+// the handler mutated a copy and the assignment was silently discarded.
+//
+// Covers the three spellings that reach the same projection: the bare field
+// name, the `self.` receiver form (#3075), and compound assignment. The heap
+// leaf (`label`) is the counterweight to the scalar one: the store-back
+// releases the field's previous owner, so a mishandled write-back shows up as a
+// corrupted or freed string rather than a stale integer.
+type Named {
+    label: string,
+    n: i64,
+}
+
+actor Holder {
+    var cur: Named;
+
+    receive fn bump_bare() {
+        cur.n = cur.n + 1;
+    }
+
+    receive fn bump_self() {
+        self.cur.n = self.cur.n + 1;
+    }
+
+    receive fn bump_compound() {
+        cur.n += 1;
+    }
+
+    receive fn relabel(v: string) {
+        self.cur.label = v;
+    }
+
+    // Whole-field replacement never went through the projection path; it is
+    // here as the control that the write-back did not disturb it.
+    receive fn replace() {
+        cur = Named { label: "replaced", n: 100 };
+    }
+
+    receive fn get_n() -> i64 {
+        cur.n
+    }
+
+    receive fn get_label() -> string {
+        cur.label
+    }
+}
+
+fn main() {
+    let h = spawn Holder(cur: Named { label: "initial", n: 0 });
+
+    h.bump_bare();
+    h.bump_self();
+    h.bump_compound();
+    match await h.get_n() {
+        .Ok(v) => println(f"n={v}"),
+        .Err(_) => println("ask failed"),
+    }
+
+    h.relabel("relabelled");
+    match await h.get_label() {
+        .Ok(v) => println(f"label={v}"),
+        .Err(_) => println("ask failed"),
+    }
+
+    // Repeat the heap-leaf write so a leaked or double-released owner has more
+    // than one chance to surface.
+    for i in 0..16 {
+        h.relabel("churned");
+        h.bump_bare();
+    }
+    match await h.get_n() {
+        .Ok(v) => println(f"churned_n={v}"),
+        .Err(_) => println("ask failed"),
+    }
+    match await h.get_label() {
+        .Ok(v) => println(f"churned_label={v}"),
+        .Err(_) => println("ask failed"),
+    }
+
+    h.replace();
+    match await h.get_n() {
+        .Ok(v) => println(f"replaced_n={v}"),
+        .Err(_) => println("ask failed"),
+    }
+    match await h.get_label() {
+        .Ok(v) => println(f"replaced_label={v}"),
+        .Err(_) => println("ask failed"),
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -6142,6 +6142,13 @@ run_accept_expect_stdout "actor_arg_field_projection_sibling_use"
 run_accept_expect_stdout "actor_arg_value_field_projection"
 run_accept_expect_stdout "actor_state_field_reinit"
 
+# #3266: a write through a record-typed state field lands in the actor's own
+# storage rather than in the frame copy lowering makes to project into it, for
+# the bare, `self.`-receiver, and compound-assignment spellings alike, with a
+# heap leaf proving the store-back releases the field's previous owner exactly
+# once and whole-field replacement still behaving as before.
+run_accept_expect_stdout "actor_state_record_projection_write"
+
 # Ownership seams: a `var` record reassigned from a match inside a loop, a
 # payload binder reused after a callee-owned call (a call never consumes a
 # non-resource argument), a `#[returns_receiver]` consuming receiver whose


### PR DESCRIPTION
## Why

A write through a record-typed actor state field was accepted and then
discarded. Inside a handler, `origin.y = origin.y + 1` on a `var origin: Point`
left the actor's state untouched, with no diagnostic and no crash, so the issue
program printed the stale `4` where the same write on a local record printed
`5`. Whole-field replacement (`origin = Point { ... }`) was unaffected, which is
what made the loss look arbitrary from the outside.

## What

- **mir**: the `FieldAccess` arm of `assign` lowers the target's object with
  `lower_value`, and for an actor state field that is an `ActorStateFieldLoad`
   - a byte copy of the field into a frame local. The `RecordFieldStore`
  therefore landed on that copy and died with the frame. The arm now publishes
  the mutated local back through `ActorStateFieldStore` when the projection's
  object is itself an actor state field, which is the same store authority the
  depth-0 replacement path already used, so one place still owns writing actor
  state. The store-back keeps the load classified `Owned`, so codegen clones on
  load and releases the previous field owner exactly once.

The write-back is marked as a shortcut in place: actor state is an owning sink
outside the MIR `Place` domain, so no place addresses `state.origin.y` and the
write cannot yet be a GEP chain. Load-modify-store is the faithful write analog
of the load-copy-then-project read path, and the comment names the projection
carrying store that replaces it.

## Test

- `tests/vertical-slice/accept/actor_state_record_projection_write.hew`, run
  from `run.sh` alongside the other actor-state fixtures: covers the bare,
  `self.`-receiver (#3075) and compound-assignment spellings, a heap leaf whose
  repeated rewriting proves the store-back releases the previous owner exactly
  once, and whole-field replacement as the control that the unchanged path
  still behaves. Reverting the lowering change turns every projected read-back
  stale while the replacement control stays correct.
- `hew-mir/tests/actor/actor_state_record_projection_store.rs`: pins the emitted
  load/field-store/store-back sequence with the state field and record leaf
  offsets tied together, and a counterpart asserting the same projection on a
  local record emits no actor-state store.

Depth-2 projection (`outer.inner.y = v`) still drops, on plain locals as well as
on actor state, so it is general to the assignment arm rather than specific to
actors. Filed as #3316.

Fixes #3266
