### PR TITLE
test(hir): pin the dotted struct-variant machine transition body

### DIFF
--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -3084,13 +3084,13 @@ machine Name {
 
     // Transitions: on Event: Source => Target { body }
     on EventZ: StateB => StateA { .StateA } // explicit body returns target value
-    on EventY: StateA => StateB { StateB { field: event.payload } }
+    on EventY: StateA => StateB { .StateB { field: event.payload } }
 
     // Head binding: name payload fields at the rule site
     on EventY(payload): StateB => StateA { Name.StateA }
 
     // Self-transition with reenter (runs exit/entry even when state is unchanged)
-    on EventX: StateB => StateB reenter { StateB { field: self.field } }
+    on EventX: StateB => StateB reenter { .StateB { field: self.field } }
 
     // Wildcard — applies in all unhandled source states for this event
     on EventX: _ => _ { state }           // _ => _ means "stay in current state"

--- a/hew-hir/tests/lowering_core/machine_hir.rs
+++ b/hew-hir/tests/lowering_core/machine_hir.rs
@@ -1,6 +1,9 @@
 //! Tests for HIR machine lowering and static checks.
 
-use hew_hir::{HirDiagnosticKind, HirExpr, HirExprKind, HirItem, HirLiteral, HirStmtKind};
+use hew_hir::{
+    HirDiagnosticKind, HirExpr, HirExprKind, HirItem, HirLiteral, HirProducedValueSourceAnchor,
+    HirStmtKind,
+};
 
 use crate::support;
 
@@ -1330,5 +1333,136 @@ fn machine_event_undeclared_field_emits_field_not_found_not_nyi() {
             );
         }
         other => panic!("unexpected diagnostic kind: {other:?}"),
+    }
+}
+
+/// A struct-variant transition body written with the contextual dotted
+/// spelling (hew-lang/hew#3241). The dotted form is the language (A363), so
+/// this body must lower like any other expression position: the target-state
+/// construction survives into the transition's HIR body carrying its payload,
+/// and each payload expression keeps the checker's consumed child as a source
+/// anchor instead of dropping the occurrence.
+const DOTTED_STRUCT_VARIANT_BODY_SRC: &str = r"
+machine Name {
+    events { EventY { payload: i64; } }
+
+    state StateA;
+    state StateB { field: i64; }
+
+    on EventY: StateA => StateB { .StateB { field: event.payload } }
+    on EventY: StateB => StateB reenter { .StateB { field: self.field } }
+}
+";
+
+/// The state index and payload of a lowered machine state constructor.
+type MachineCtor<'e> = (usize, &'e Option<Vec<(String, HirExpr)>>);
+
+/// Finds the machine state constructor a transition body evaluates to.
+fn machine_variant_ctor(expr: &HirExpr) -> Option<MachineCtor<'_>> {
+    match &expr.kind {
+        HirExprKind::MachineVariantCtor {
+            state_idx, payload, ..
+        } => Some((*state_idx, payload)),
+        HirExprKind::Block(block) => block
+            .statements
+            .iter()
+            .find_map(|stmt| match &stmt.kind {
+                HirStmtKind::Expr(expr)
+                | HirStmtKind::Let(_, Some(expr))
+                | HirStmtKind::Return(Some(expr)) => machine_variant_ctor(expr),
+                HirStmtKind::Assign { value, .. } => machine_variant_ctor(value),
+                _ => None,
+            })
+            .or_else(|| block.tail.as_deref().and_then(machine_variant_ctor)),
+        _ => None,
+    }
+}
+
+/// The source anchor a machine field or event-field read carries, if it is one.
+fn machine_read_anchor(expr: &HirExpr) -> Option<&Option<HirProducedValueSourceAnchor>> {
+    match &expr.kind {
+        HirExprKind::MachineFieldAccess { source_anchor, .. }
+        | HirExprKind::MachineEventFieldAccess { source_anchor, .. } => Some(source_anchor),
+        _ => None,
+    }
+}
+
+#[test]
+fn dotted_struct_variant_transition_body_keeps_its_checker_anchors() {
+    let output = lower(DOTTED_STRUCT_VARIANT_BODY_SRC);
+
+    // The lowerer's produced-value carrier resolution reports a dropped
+    // occurrence as a `CheckerBoundaryViolation` in `LowerOutput::diagnostics`,
+    // not through the verifier, so both surfaces have to be clean.
+    let boundary: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| matches!(d.kind, HirDiagnosticKind::CheckerBoundaryViolation { .. }))
+        .collect();
+    assert!(
+        boundary.is_empty(),
+        "dotted struct-variant transition body must not violate the checker boundary; got: {boundary:?}"
+    );
+    let verify = hew_hir::verify_hir(&output.module);
+    assert!(
+        verify.is_empty(),
+        "verifier must accept the lowered machine; got: {verify:?}"
+    );
+
+    let machine = output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            HirItem::Machine(m) if m.name == "Name" => Some(m),
+            _ => None,
+        })
+        .expect("machine `Name` is lowered");
+    assert_eq!(
+        machine.transitions.len(),
+        2,
+        "both transitions are lowered; got: {:?}",
+        machine.transitions
+    );
+
+    // Positive control: the anchor is recorded, not merely un-diagnosed. Each
+    // body builds `StateB` with its payload, and the payload expression — the
+    // checker child a rewrite could drop — still names its source anchor.
+    for transition in &machine.transitions {
+        let (state_idx, payload) = machine_variant_ctor(&transition.body).unwrap_or_else(|| {
+            panic!(
+                "transition {} => {} must lower its `.StateB {{ .. }}` body to a state constructor; got: {:?}",
+                transition.source_state, transition.target_state, transition.body.kind
+            )
+        });
+        assert_eq!(
+            state_idx, 1,
+            "the constructor names `StateB`, the second declared state"
+        );
+        let payload = payload.as_ref().unwrap_or_else(|| {
+            panic!(
+                "transition {} => {} constructs a struct variant, so it carries a payload",
+                transition.source_state, transition.target_state
+            )
+        });
+        let names: Vec<&str> = payload.iter().map(|(name, _)| name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["field"],
+            "the state payload field survives lowering"
+        );
+        let (_, value) = &payload[0];
+        let anchor = machine_read_anchor(value).unwrap_or_else(|| {
+            panic!(
+                "transition {} => {} reads a machine field or event field for `field`; got: {:?}",
+                transition.source_state, transition.target_state, value.kind
+            )
+        });
+        assert!(
+            anchor.is_some(),
+            "transition {} => {} must preserve the consumed checker child as a source anchor",
+            transition.source_state,
+            transition.target_state
+        );
     }
 }

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -138,7 +138,7 @@ spec-0077   3711765580   # SNIPPET: bare `let`/`var` — machine state illustrat
 spec-0078   1632573552   # SNIPPET: bare `let`/`import` — stdlib module tour (re-verified after `testing.assert_true` became the generic `testing.assert`, D22)
 spec-0079   3943447574   # SNIPPET: bare `let m = ...` — machine instantiation illustration
 spec-0080   70193944   # SNIPPET: bare identifier list — prelude illustration (re-verified after the `Error` trait joined the prelude, D21)
-spec-0081   356096974   # FRAGMENT: placeholder type name `Type` — declaration-syntax skeleton
+spec-0081   3800685072  # FRAGMENT: placeholder type name `Type` — declaration-syntax skeleton
 spec-0082   3707425012   # SPEC-BUG: interleaved `event` declarations — old machine syntax pre-`events {}`
 spec-0083   813722226   # SNIPPET: bare `on event { ... }` — machine transition illustration
 spec-0084   2693414511   # SNIPPET: bare `on event ...` — machine state illustration

--- a/tests/vertical-slice/accept/machine_dotted_struct_variant_body.expected
+++ b/tests/vertical-slice/accept/machine_dotted_struct_variant_body.expected
@@ -1,0 +1,2 @@
+StateB
+StateB

--- a/tests/vertical-slice/accept/machine_dotted_struct_variant_body.hew
+++ b/tests/vertical-slice/accept/machine_dotted_struct_variant_body.hew
@@ -1,0 +1,21 @@
+// A transition body may name its target state contextually. The dotted
+// spelling is the language (A363), so a struct-variant state body takes it
+// exactly as a unit-state body does, and the lowered body keeps the checker's
+// consumed children as source anchors (hew-lang/hew#3241).
+machine Name {
+    events { EventY { payload: i64; } }
+
+    state StateA;
+    state StateB { field: i64; }
+
+    on EventY: StateA => StateB { .StateB { field: event.payload } }
+    on EventY: StateB => StateB reenter { .StateB { field: self.field } }
+}
+
+fn main() {
+    var m: Name = .StateA;
+    m.step(.EventY { payload: 3 });
+    println(m.state_name());
+    m.step(.EventY { payload: 7 });
+    println(m.state_name());
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -510,6 +510,12 @@ compile_accept "machine_fork_args_spawn"
 # type is normalised before the enum-layout probe so the bare-name view is found.
 run_accept_expect_status "machine_generic_record_field" 0
 
+# A struct-variant transition body written with the contextual dotted spelling
+# (#3241). Both the entry transition and the `reenter` self-transition build
+# `.StateB { ... }`, so the lowered bodies must keep the checker's consumed
+# children as source anchors rather than dropping the occurrence.
+run_accept_expect_stdout "machine_dotted_struct_variant_body"
+
 # Reject: negative control for #3149. A machine's own transition body resolves
 # the contextual `.Variant` spelling against the machine while the declaring
 # file is an imported dependency; a variant the machine never declared is still


### PR DESCRIPTION
## Why

#3241 reports that a machine transition body building its target state with the
contextual `.StateB { field: ... }` spelling is refused by the HIR checker-boundary
verifier. It does not reproduce. The program checks and runs clean at `a525f5f38`
(main when the issue was filed) and at current main, for `i64`, `string` and
`Vec<i64>` payloads, in both the dotted and the bare spelling. The defect was
branch-local to the in-progress A363 work; the landed A363 (`7582f68e7`) does not
carry it.

That leaves the shape with no oracle, which is why it could go unnoticed either
way. This pins it.

## What

- **hew-hir**: a lowering test for the dotted struct-variant transition body. It
  asserts no `CheckerBoundaryViolation` on either surface that can report one -
  `LowerOutput::diagnostics`, where the produced-value carrier resolution in
  `lower.rs` raises it, and `verify_hir` - and then asserts the anchor is
  positively recorded: each body lowers to a `MachineVariantCtor` carrying its
  payload, and the payload read names a `source_anchor`.
- **vertical-slice**: an accept fixture running the issue's own program, with its
  `.expected` stdout.
- **spec**: the machine declaration fence spelled a struct-variant body bare
  beside a unit body that took the dot, which is the inconsistency the issue's
  Notes call out. Both spellings check and the dotted one is the language, so the
  fence now uses it throughout. Its doc-fence checksum is re-recorded; the fence
  still fails only for its recorded placeholder-type reason.

No compiler change: the verifier is right and the lowering already threads the
anchor. The only `source_anchor: None` constructions in `hew-hir/src/lower.rs` are
`ActorAsk`, never a machine read.

## Test

`dotted_struct_variant_transition_body_keeps_its_checker_anchors` (hew-hir
`lowering_core::machine_hir`) and the `machine_dotted_struct_variant_body`
vertical-slice fixture. Both have a real negative control: setting the machine
event-field read's `source_anchor` to `None` in `hew-hir/src/lower.rs` turns the
unit test red with the issue's diagnostic verbatim - "specialised HIR rewrites
must preserve consumed checker children as source anchors" - which is the
mechanism the test now holds closed.

Fixes #3241
