### PR TITLE
fix(parser,compile): one error for let mut, located module-not-found

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -173,17 +173,23 @@ pub(crate) fn render_frontend_diagnostics(
     }
     for diagnostic in diagnostics {
         match &diagnostic.kind {
-            FrontendDiagnosticKind::Message(diagnostic) => {
-                match (&diagnostic.span, diagnostic.source.as_deref()) {
-                    (Some(span), Some(source)) => crate::diagnostic::render_diagnostic(
-                        source,
-                        "",
-                        span,
-                        &diagnostic.message,
-                        &[],
-                        &[],
-                    ),
-                    _ => crate::diagnostic::emit_plain_diagnostic_line(&diagnostic.message),
+            FrontendDiagnosticKind::Message(inner) => {
+                match (
+                    &inner.span,
+                    inner.source.as_deref(),
+                    diagnostic.filename.as_deref(),
+                ) {
+                    (Some(span), Some(source), Some(filename)) => {
+                        crate::diagnostic::render_diagnostic(
+                            source,
+                            filename,
+                            span,
+                            &inner.message,
+                            &[],
+                            &[],
+                        );
+                    }
+                    _ => crate::diagnostic::emit_plain_diagnostic_line(&inner.message),
                 }
             }
             FrontendDiagnosticKind::Parse(error) => {
@@ -248,8 +254,8 @@ fn push_frontend_diagnostics_json(diagnostics: &[FrontendDiagnostic]) {
         let source = diagnostic.source.as_deref();
         let filename = diagnostic.filename.as_deref();
         let json = match &diagnostic.kind {
-            FrontendDiagnosticKind::Message(diagnostic) => {
-                from_coded_message_diagnostic(diagnostic)
+            FrontendDiagnosticKind::Message(inner) => {
+                from_coded_message_diagnostic(inner, filename)
             }
             FrontendDiagnosticKind::Parse(error) => match (source, filename) {
                 (Some(source), Some(filename)) => from_parse_error(source, filename, error),

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -174,7 +174,17 @@ pub(crate) fn render_frontend_diagnostics(
     for diagnostic in diagnostics {
         match &diagnostic.kind {
             FrontendDiagnosticKind::Message(diagnostic) => {
-                crate::diagnostic::emit_plain_diagnostic_line(&diagnostic.message);
+                match (&diagnostic.span, diagnostic.source.as_deref()) {
+                    (Some(span), Some(source)) => crate::diagnostic::render_diagnostic(
+                        source,
+                        "",
+                        span,
+                        &diagnostic.message,
+                        &[],
+                        &[],
+                    ),
+                    _ => crate::diagnostic::emit_plain_diagnostic_line(&diagnostic.message),
+                }
             }
             FrontendDiagnosticKind::Parse(error) => {
                 let suggestions: Vec<String> = error.hint.iter().cloned().collect();
@@ -231,18 +241,16 @@ pub(crate) fn render_frontend_diagnostics(
 /// was attached) are emitted with a zero span and the best available code.
 fn push_frontend_diagnostics_json(diagnostics: &[FrontendDiagnostic]) {
     use crate::diagnostic_json::{
-        coded_message_diagnostic, from_hir_diagnostic, from_parse_error, from_type_error,
+        from_coded_message_diagnostic, from_hir_diagnostic, from_parse_error, from_type_error,
         message_diagnostic, push_json_diagnostic,
     };
     for diagnostic in diagnostics {
         let source = diagnostic.source.as_deref();
         let filename = diagnostic.filename.as_deref();
         let json = match &diagnostic.kind {
-            FrontendDiagnosticKind::Message(diagnostic) => coded_message_diagnostic(
-                &diagnostic.code,
-                &diagnostic.message,
-                hew_types::error::DiagChannel::User,
-            ),
+            FrontendDiagnosticKind::Message(diagnostic) => {
+                from_coded_message_diagnostic(diagnostic)
+            }
             FrontendDiagnosticKind::Parse(error) => match (source, filename) {
                 (Some(source), Some(filename)) => from_parse_error(source, filename, error),
                 _ => message_diagnostic(&error.message),

--- a/hew-cli/src/diagnostic_json.rs
+++ b/hew-cli/src/diagnostic_json.rs
@@ -268,6 +268,23 @@ pub(crate) fn coded_message_diagnostic(
     }
 }
 
+/// Build a [`JsonDiagnostic`] from a coded frontend message that carries its
+/// own span and source text (today, only `E_MODULE_NOT_FOUND`, which locates
+/// the offending `import`). Falls back to [`coded_message_diagnostic`]'s zero
+/// span when either half is missing, matching every other coded-message site
+/// that never attached one.
+pub(crate) fn from_coded_message_diagnostic(
+    diagnostic: &hew_compile::FrontendMessageDiagnostic,
+) -> JsonDiagnostic {
+    match (&diagnostic.span, diagnostic.source.as_deref()) {
+        (Some(span), Some(source)) => JsonDiagnostic {
+            span: JsonSpan::from_range(source, span),
+            ..coded_message_diagnostic(&diagnostic.code, &diagnostic.message, DiagChannel::User)
+        },
+        _ => coded_message_diagnostic(&diagnostic.code, &diagnostic.message, DiagChannel::User),
+    }
+}
+
 /// Build a [`JsonDiagnostic`] from a parser diagnostic.
 pub(crate) fn from_parse_error(
     source: &str,

--- a/hew-cli/src/diagnostic_json.rs
+++ b/hew-cli/src/diagnostic_json.rs
@@ -272,13 +272,16 @@ pub(crate) fn coded_message_diagnostic(
 /// own span and source text (today, only `E_MODULE_NOT_FOUND`, which locates
 /// the offending `import`). Falls back to [`coded_message_diagnostic`]'s zero
 /// span when either half is missing, matching every other coded-message site
-/// that never attached one.
+/// that never attached one. `filename` is the enclosing `FrontendDiagnostic`'s
+/// (the same field `Parse`/`Type` diagnostics use), not a new one.
 pub(crate) fn from_coded_message_diagnostic(
     diagnostic: &hew_compile::FrontendMessageDiagnostic,
+    filename: Option<&str>,
 ) -> JsonDiagnostic {
     match (&diagnostic.span, diagnostic.source.as_deref()) {
         (Some(span), Some(source)) => JsonDiagnostic {
             span: JsonSpan::from_range(source, span),
+            file: filename.unwrap_or_default().to_string(),
             ..coded_message_diagnostic(&diagnostic.code, &diagnostic.message, DiagChannel::User)
         },
         _ => coded_message_diagnostic(&diagnostic.code, &diagnostic.message, DiagChannel::User),

--- a/hew-cli/tests/json_diagnostics_e2e.rs
+++ b/hew-cli/tests/json_diagnostics_e2e.rs
@@ -305,3 +305,41 @@ fn compile_mir_gate_failure_text_has_no_debug_payload() {
         "compile MIR diagnostic should be source-attributed; got:\n{stderr}",
     );
 }
+
+/// `E_MODULE_NOT_FOUND` locates itself at the offending `import` (not a zero
+/// span) and, for a std-module typo close to a real module, names the fix.
+#[test]
+fn module_not_found_has_span_and_suggestion() {
+    let (_dir, path) = write_fixture("import std.htp;\nfn main() { }\n");
+    let output = run(&["check", "--format", "json", path.to_str().unwrap()]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "module-not-found must exit 1\n{}",
+        describe_output(&output),
+    );
+
+    let diagnostics = parse_json_array(&output);
+    let not_found = diagnostics
+        .iter()
+        .find(|d| d["code"] == "E_MODULE_NOT_FOUND")
+        .unwrap_or_else(|| panic!("expected an E_MODULE_NOT_FOUND diagnostic: {diagnostics:?}"));
+
+    let span = &not_found["span"];
+    assert!(
+        span["start_line"].as_u64().unwrap_or(0) > 0,
+        "module-not-found must carry the import's own span, not a zero span: {span}",
+    );
+    assert_eq!(
+        span["start_line"], 1,
+        "the bad `import` is on line 1 of the fixture: {span}",
+    );
+    assert!(
+        not_found["message"]
+            .as_str()
+            .unwrap()
+            .contains("std.net.http"),
+        "a std-module typo close to `std.net.http` must suggest it: {not_found}",
+    );
+}

--- a/hew-cli/tests/json_diagnostics_e2e.rs
+++ b/hew-cli/tests/json_diagnostics_e2e.rs
@@ -342,4 +342,31 @@ fn module_not_found_has_span_and_suggestion() {
             .contains("std.net.http"),
         "a std-module typo close to `std.net.http` must suggest it: {not_found}",
     );
+    assert!(
+        not_found["file"].as_str().unwrap().ends_with("main.hew"),
+        "file field must name the source: {not_found}",
+    );
+}
+
+/// The right module name at the wrong nesting (`std.http` for `std.net.http`)
+/// is the single likeliest real mistake — not a typo `find_similar` would
+/// catch (the leaf spelling is exactly right), so it needs its own exact-leaf
+/// match ahead of the fuzzy fallback.
+#[test]
+fn module_not_found_suggests_an_exact_leaf_match_at_the_wrong_nesting() {
+    let (_dir, path) = write_fixture("import std.http;\nfn main() { }\n");
+    let output = run(&["check", "--format", "json", path.to_str().unwrap()]);
+
+    let diagnostics = parse_json_array(&output);
+    let not_found = diagnostics
+        .iter()
+        .find(|d| d["code"] == "E_MODULE_NOT_FOUND")
+        .unwrap_or_else(|| panic!("expected an E_MODULE_NOT_FOUND diagnostic: {diagnostics:?}"));
+    assert!(
+        not_found["message"]
+            .as_str()
+            .unwrap()
+            .contains("std.net.http"),
+        "the right leaf name at the wrong nesting must still suggest `std.net.http`: {not_found}",
+    );
 }

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -264,17 +264,21 @@ impl FrontendDiagnostic {
 
     /// A coded message that also locates itself in source — the one shape
     /// [`FrontendMessageDiagnostic`] needs to render like a `Parse`/`Type`
-    /// diagnostic instead of a zero-span message. See
-    /// [`FrontendFailure::coded_message_at`], its only caller.
+    /// diagnostic instead of a zero-span message. `filename` lands on the
+    /// existing outer field (the same one `parse`/`type_` already populate)
+    /// rather than a new one, so the renderers' `(source, filename)` pattern
+    /// keeps working unchanged. See [`FrontendFailure::coded_message_at`],
+    /// its only caller.
     fn coded_message_at(
         code: &str,
         message: impl Into<String>,
         span: Range<usize>,
         source: &str,
+        filename: &str,
     ) -> Self {
         Self {
             source: None,
-            filename: None,
+            filename: Some(filename.to_string()),
             note_sources: Vec::new(),
             kind: FrontendDiagnosticKind::Message(FrontendMessageDiagnostic {
                 code: code.to_string(),
@@ -367,12 +371,13 @@ impl FrontendFailure {
         message: impl Into<String>,
         span: Range<usize>,
         source: &str,
+        filename: &str,
     ) -> Self {
         let message = message.into();
         Self::new(
             message.clone(),
             vec![FrontendDiagnostic::coded_message_at(
-                code, message, span, source,
+                code, message, span, source, filename,
             )],
         )
     }
@@ -587,14 +592,19 @@ fn module_leaf(full: &str) -> &str {
 }
 
 /// The closest existing `std` module to a mistyped import's last path
-/// segment, e.g. `htp` -> `std.net.http`.
+/// segment: an exact leaf match (`std.http` -> `std.net.http`, a missed or
+/// mis-nested path segment) when one exists, else a near-miss typo
+/// (`std.htp` -> `std.net.http`).
 ///
-/// Compares leaf names (the last dotted segment), not full dotted paths:
-/// `std.htp` and `std.net.http` differ by far more than
+/// Near-miss matching compares leaf names (the last dotted segment), not
+/// full dotted paths: `std.htp` and `std.net.http` differ by far more than
 /// [`hew_types::error::find_similar`]'s length-scaled Levenshtein threshold
 /// allows, but `htp` and `http` — the part the user actually mistyped — are
-/// one edit apart. Returns `None` when nothing is close enough, matching
-/// `find_similar`'s own "no good match" case.
+/// one edit apart. An exact leaf match is checked first because
+/// `find_similar` filters exact matches out entirely (it exists to catch
+/// spelling, not path mistakes) — without this, the single most likely
+/// real-world slip (the right module name, wrong or missing nesting) would
+/// get no suggestion at all. Returns `None` when neither finds anything.
 fn nearest_std_module(leaf: &str, search_paths: &[PathBuf]) -> Option<String> {
     let mut modules = Vec::new();
     for root in search_paths {
@@ -602,6 +612,9 @@ fn nearest_std_module(leaf: &str, search_paths: &[PathBuf]) -> Option<String> {
         if std_dir.is_dir() {
             collect_std_module_names(&std_dir, &mut modules);
         }
+    }
+    if let Some(exact) = modules.iter().find(|full| module_leaf(full) == leaf) {
+        return Some(exact.clone());
     }
     let leaves: Vec<&str> = modules.iter().map(|full| module_leaf(full)).collect();
     let best_leaf = hew_types::error::find_similar(leaf, leaves.iter().copied())
@@ -1823,15 +1836,25 @@ fn resolve_file_imports_internal(
                     } else {
                         String::new()
                     };
-                    let module_source = std::fs::read_to_string(source_file).unwrap_or_default();
-                    return Err(FrontendFailure::coded_message_at(
-                        "E_MODULE_NOT_FOUND",
-                        format!(
-                            "Error: module `{source_module}` not found (tried: {tried}){hint}{suggestion}"
+                    // No leading "Error: " here (unlike the sibling messages
+                    // above): this one now renders with a real
+                    // `file:line:col: error:` header, and the plain-text
+                    // fallback below only fires if `source_file` cannot be
+                    // re-read, which never happens on the path that just
+                    // parsed it.
+                    let message = format!(
+                        "module `{source_module}` not found (tried: {tried}){hint}{suggestion}"
+                    );
+                    return Err(match std::fs::read_to_string(source_file) {
+                        Ok(module_source) => FrontendFailure::coded_message_at(
+                            "E_MODULE_NOT_FOUND",
+                            message,
+                            items[*idx].1.clone(),
+                            &module_source,
+                            &source_file.display().to_string(),
                         ),
-                        items[*idx].1.clone(),
-                        &module_source,
-                    ));
+                        Err(_) => FrontendFailure::coded_message("E_MODULE_NOT_FOUND", message),
+                    });
                 }
             }
             _ => continue,

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
+use std::ops::Range;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use hew_parser::ast::{ImportDecl, Item, Program, Spanned};
 use serde::{de::DeserializeOwned, Deserialize};
@@ -206,10 +208,19 @@ pub enum FrontendDiagnosticKind {
 
 /// A frontend failure that has no parser/type/HIR payload but still needs a
 /// stable machine-readable identity (for example package-module resolution).
+///
+/// `span`/`source` are `None` for the ordinary message-only sites (the code
+/// carries the identity, but there is nowhere in the source to point at —
+/// `E_IMPORT_AMBIGUOUS` spans two files, `E_PACKAGE_ROOT_MISSING` names a
+/// missing file on disk). A site that *does* have a location — today just
+/// `E_MODULE_NOT_FOUND`, pointing at the offending `import` — sets both so
+/// the renderers can locate it instead of falling back to a zero span.
 #[derive(Debug, Clone)]
 pub struct FrontendMessageDiagnostic {
     pub code: String,
     pub message: String,
+    pub span: Option<Range<usize>>,
+    pub source: Option<Arc<str>>,
 }
 
 #[derive(Debug, Clone)]
@@ -231,6 +242,8 @@ impl FrontendDiagnostic {
             kind: FrontendDiagnosticKind::Message(FrontendMessageDiagnostic {
                 code: "E_MESSAGE".to_string(),
                 message: message.into(),
+                span: None,
+                source: None,
             }),
         }
     }
@@ -243,6 +256,31 @@ impl FrontendDiagnostic {
             kind: FrontendDiagnosticKind::Message(FrontendMessageDiagnostic {
                 code: code.to_string(),
                 message: message.into(),
+                span: None,
+                source: None,
+            }),
+        }
+    }
+
+    /// A coded message that also locates itself in source — the one shape
+    /// [`FrontendMessageDiagnostic`] needs to render like a `Parse`/`Type`
+    /// diagnostic instead of a zero-span message. See
+    /// [`FrontendFailure::coded_message_at`], its only caller.
+    fn coded_message_at(
+        code: &str,
+        message: impl Into<String>,
+        span: Range<usize>,
+        source: &str,
+    ) -> Self {
+        Self {
+            source: None,
+            filename: None,
+            note_sources: Vec::new(),
+            kind: FrontendDiagnosticKind::Message(FrontendMessageDiagnostic {
+                code: code.to_string(),
+                message: message.into(),
+                span: Some(span),
+                source: Some(Arc::from(source)),
             }),
         }
     }
@@ -317,6 +355,25 @@ impl FrontendFailure {
         Self::new(
             message.clone(),
             vec![FrontendDiagnostic::coded_message(code, message)],
+        )
+    }
+
+    /// [`FrontendFailure::coded_message`], but the diagnostic also carries a
+    /// span and the source it indexes into, so a renderer can point at it
+    /// instead of showing a bare message. Used only by `E_MODULE_NOT_FOUND`,
+    /// which can locate the offending `import` statement.
+    fn coded_message_at(
+        code: &str,
+        message: impl Into<String>,
+        span: Range<usize>,
+        source: &str,
+    ) -> Self {
+        let message = message.into();
+        Self::new(
+            message.clone(),
+            vec![FrontendDiagnostic::coded_message_at(
+                code, message, span, source,
+            )],
         )
     }
 }
@@ -522,6 +579,83 @@ fn is_builtin_module(module_path: &str) -> bool {
     module_path.starts_with("std::")
         || module_path.starts_with("hew::")
         || module_path.starts_with("ecosystem::")
+}
+
+/// The last dotted segment of a full module path (`std.net.http` -> `http`).
+fn module_leaf(full: &str) -> &str {
+    full.rsplit('.').next().unwrap_or(full)
+}
+
+/// The closest existing `std` module to a mistyped import's last path
+/// segment, e.g. `htp` -> `std.net.http`.
+///
+/// Compares leaf names (the last dotted segment), not full dotted paths:
+/// `std.htp` and `std.net.http` differ by far more than
+/// [`hew_types::error::find_similar`]'s length-scaled Levenshtein threshold
+/// allows, but `htp` and `http` — the part the user actually mistyped — are
+/// one edit apart. Returns `None` when nothing is close enough, matching
+/// `find_similar`'s own "no good match" case.
+fn nearest_std_module(leaf: &str, search_paths: &[PathBuf]) -> Option<String> {
+    let mut modules = Vec::new();
+    for root in search_paths {
+        let std_dir = root.join("std");
+        if std_dir.is_dir() {
+            collect_std_module_names(&std_dir, &mut modules);
+        }
+    }
+    let leaves: Vec<&str> = modules.iter().map(|full| module_leaf(full)).collect();
+    let best_leaf = hew_types::error::find_similar(leaf, leaves.iter().copied())
+        .into_iter()
+        .next()?;
+    modules
+        .into_iter()
+        .find(|full| module_leaf(full) == best_leaf)
+}
+
+/// Recursively collect every dotted `std.…` module name reachable under
+/// `std_dir` into `out`.
+///
+/// Mirrors the two entry-file shapes the import resolver's own per-import
+/// candidate list already assumes (`dir_path`/`rel_path` above: a directory
+/// names its module through a same-named `<dir>/<dir-name>.hew`, or a flat
+/// `<name>.hew` file sits directly at that path) — this walks the whole
+/// tree once instead of probing one path, so "did you mean" has a full
+/// candidate list to compare a typo against. Cold path (only runs once
+/// import resolution has already failed), so no caching: the stdlib tree is
+/// a few hundred files, and this only walks it on a diagnostic.
+fn collect_std_module_names(std_dir: &Path, out: &mut Vec<String>) {
+    let mut segments = vec!["std".to_string()];
+    collect_module_names_at(std_dir, &mut segments, out);
+}
+
+fn collect_module_names_at(dir: &Path, segments: &mut Vec<String>, out: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let Some(name) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
+                continue;
+            };
+            segments.push(name.to_string());
+            collect_module_names_at(&path, segments, out);
+            segments.pop();
+        } else if path.extension().is_some_and(|ext| ext == "hew") {
+            let Some(stem) = path.file_stem().and_then(std::ffi::OsStr::to_str) else {
+                continue;
+            };
+            if segments.last().map(String::as_str) == Some(stem) {
+                // `<dir>/<dir-name>.hew` — the directory's own canonical entry.
+                out.push(segments.join("."));
+            } else {
+                // A flat file: its own name is the trailing path segment.
+                segments.push(stem.to_string());
+                out.push(segments.join("."));
+                segments.pop();
+            }
+        }
+    }
 }
 
 fn load_project_context(
@@ -1682,9 +1816,21 @@ fn resolve_file_imports_internal(
                     } else {
                         ""
                     };
-                    return Err(FrontendFailure::coded_message(
+                    let suggestion = if is_std_import {
+                        nearest_std_module(last, search_paths)
+                            .map(|nearest| format!("\n  did you mean `{nearest}`?"))
+                            .unwrap_or_default()
+                    } else {
+                        String::new()
+                    };
+                    let module_source = std::fs::read_to_string(source_file).unwrap_or_default();
+                    return Err(FrontendFailure::coded_message_at(
                         "E_MODULE_NOT_FOUND",
-                        format!("Error: module `{source_module}` not found (tried: {tried}){hint}"),
+                        format!(
+                            "Error: module `{source_module}` not found (tried: {tried}){hint}{suggestion}"
+                        ),
+                        items[*idx].1.clone(),
+                        &module_source,
                     ));
                 }
             }

--- a/hew-parser/src/parser/statements.rs
+++ b/hew-parser/src/parser/statements.rs
@@ -307,6 +307,54 @@ impl Parser<'_> {
         let stmt = match self.peek() {
             Some(Token::Let) => {
                 self.advance();
+
+                // `let mut x = …` is the single most common Rust-shaped typo:
+                // Hew spells mutability `var`, not `mut`. Recognizing it here,
+                // before the pattern parse, lets the whole statement recover
+                // as `var name = …` behind one diagnostic. Left to fall
+                // through to `parse_pattern`, `mut` matches none of the
+                // pattern-start arms — it lands in `error_invalid_pattern`'s
+                // reserved-word branch (which tells the user to rename `mut`
+                // itself, nonsensically), aborts the `let` parse without
+                // consuming `mut`, and the block-statement loop then cascades
+                // two more errors resyncing token-by-token.
+                if self.peek() == Some(&Token::Mut) {
+                    let mut_span = self.peek_span();
+                    self.advance();
+                    let hint = match self.peek() {
+                        Some(Token::Identifier(name)) => {
+                            format!(
+                                "delete `mut` and change `let` to `var`: write `var {name} = …`"
+                            )
+                        }
+                        _ => "delete `mut` and change `let` to `var`".to_string(),
+                    };
+                    self.error_at_with_hint(
+                        "Hew spells mutability `var`, not `let mut`".to_string(),
+                        mut_span,
+                        hint,
+                    );
+
+                    let name = self.expect_ident()?;
+
+                    let ty = if self.eat(&Token::Colon) {
+                        Some(self.parse_type()?)
+                    } else {
+                        None
+                    };
+
+                    let value = if self.eat(&Token::Equal) {
+                        Some(self.parse_expr()?)
+                    } else {
+                        None
+                    };
+
+                    self.expect(&Token::Semicolon)?;
+
+                    let end = self.peek_span().start;
+                    return Some((Stmt::Var { name, ty, value }, start..end));
+                }
+
                 let pattern = self.parse_pattern()?;
 
                 // `let r? = expr;` is syntactic sugar for `let r = expr?;`.

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -318,6 +318,60 @@ fn let_binding_reserved_keyword_names_it_as_reserved() {
     );
 }
 
+/// `let mut x = …` recovers as `var x = …` behind exactly one diagnostic: the
+/// message names Hew's `var` spelling, the hint spells out the fix-it, and
+/// parsing resumes cleanly — the following statement still parses, which
+/// would not hold if `mut` were left unconsumed (the three-error cascade this
+/// replaces: `mut` fails as a pattern, then as an expression, then triggers
+/// block-level token recovery).
+#[test]
+fn let_mut_reports_one_error_and_recovers() {
+    let result = parse("fn f() { let mut x = 1; x = 2; }");
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected exactly one diagnostic, got: {:?}",
+        result.errors
+    );
+    let diagnostic = &result.errors[0];
+    assert!(
+        diagnostic.message.contains("var") && diagnostic.message.contains("let mut"),
+        "message must name Hew's `var` spelling; got: {}",
+        diagnostic.message
+    );
+    assert!(
+        diagnostic
+            .hint
+            .as_ref()
+            .is_some_and(|hint| hint.contains("var x")),
+        "a `let mut` diagnostic must carry a fix-it naming the corrected spelling; got: {:?}",
+        diagnostic.hint
+    );
+
+    let func = match &result.program.items[0].0 {
+        Item::Function(f) => f,
+        other => panic!("expected a function item, got {other:?}"),
+    };
+    assert_eq!(
+        func.body.stmts.len(),
+        2,
+        "expected the `let mut` statement plus the following assignment to both parse; got: {:?}",
+        func.body.stmts
+    );
+    assert!(
+        matches!(func.body.stmts[0].0, Stmt::Var { .. }),
+        "let mut recovers as a mutable (`var`) binding so a later reassignment does not raise a \
+         second, unrelated immutability error downstream; got: {:?}",
+        func.body.stmts[0].0
+    );
+    assert!(
+        matches!(func.body.stmts[1].0, Stmt::Assign { .. }),
+        "the statement after the recovered `let mut` must parse normally, proving `mut` was \
+         consumed rather than left for block-level recovery to eat; got: {:?}",
+        func.body.stmts[1].0
+    );
+}
+
 /// The same fact through the other pattern position.
 #[test]
 fn match_arm_reserved_keyword_names_it_as_reserved() {

--- a/scripts/journeys-expected.tsv
+++ b/scripts/journeys-expected.tsv
@@ -33,10 +33,6 @@ day-one.11	V060-FD-5	hew new --actor: unrecognized subcommand
 day-one.12	V060-FD-5	hew new --actor does not exist; actor scaffold never created
 day-one.13	V060-FD-5	hew new --lib: unrecognized subcommand
 day-one.14	V060-FD-5	hew new --lib does not exist; lib scaffold never created
-day-one.16	V060-FD-4	let mut error text says "rename this binding", not "var x"
-day-one.17	V060-FD-4	let mut is a three-error cascade, not one error
-day-one.20	V060-FD-4	module-not-found JSON carries a zero span (start_line: 0)
-day-one.21	V060-FD-4	module-not-found JSON carries no nearest-module suggestion
 day-one.22	V060-FD-3	HEW_CC has no reader in the compiler (grep -rn HEW_CC --include=*.rs is empty); the env var is silently ignored and build falls through to system cc, exit 0
 day-one.23	V060-FD-3	HEW_CC unimplemented (see day-one.22): no error output naming the bad path
 day-one.24	V060-FD-3	HEW_CC unimplemented (see day-one.22): no error output naming a package to install


### PR DESCRIPTION
## Why

`let mut x = 1;` produced three parse errors, the first of which told
the user to rename the binding `mut` itself instead of naming Hew's
`var` spelling. `import std.htp;` reported `E_MODULE_NOT_FOUND` at a
zero span with no suggestion, even though the import node's own span
was sitting unused right beside the failed resolution. V060-FD-4
(ground map `V060-FRONTDOOR.md` items 5 and 6).

## What

- **parser**: the `let` arm recognizes `Token::Mut` immediately after
  `let`, consumes it, emits one diagnostic naming Hew's `var` spelling
  with a fix-it, and finishes parsing the statement as a `var` binding
  — so a later reassignment in the same program sees a genuinely
  mutable name instead of a second, unrelated immutability error.
- **hew-compile**: `FrontendMessageDiagnostic` gains an optional span
  and source text; the one raise site (`E_MODULE_NOT_FOUND`) threads
  the import's own span and re-reads its module's source, and the
  outer `FrontendDiagnostic.filename` field (already used by
  `Parse`/`Type` diagnostics) carries the file name through. Every
  other `coded_message` site is unchanged (still spanless). A
  std-import miss also gets a "did you mean" suggestion: an exact
  leaf-name match first (the right module at the wrong nesting, e.g.
  `std.http` for `std.net.http` — not a typo `find_similar` would
  catch, since it filters exact matches), then a fuzzy match on the
  mistyped leaf segment against every module the resolver's own std/
  search roots can reach (matching on the full dotted path fails
  `find_similar`'s length-scaled threshold; the leaf is what the user
  actually mistyped).
- **hew-cli**: both renderers (JSON and text) render the new span,
  source, and filename when present, falling back to today's
  zero-span/plain-message shape otherwise.
- **journeys**: deletes the four `day-one` ratchet rows this fixes.

## Test

- `hew-parser`: `let_mut_reports_one_error_and_recovers` — one
  diagnostic, the fix-it text, and that `let mut x = 1; x = 2;` still
  parses both statements (proving `mut` was consumed, not left for
  block-level recovery).
- `hew-cli`: `module_not_found_has_span_and_suggestion` (non-zero
  span, the `std.net.http` suggestion, exit 1, the `file` field) and
  `module_not_found_suggests_an_exact_leaf_match_at_the_wrong_nesting`
  (`std.http` -> `std.net.http`, the exact-leaf path).

Acceptance, run against this branch:

```
$ cargo nextest run -p hew-parser -p hew-compile -p hew-cli -E 'test(let_mut) | test(module_not_found)'
3 tests run: 3 passed, 3308 skipped

$ printf 'fn main() { let mut x = 1; x = 2; }\n' > lm.hew; hew check lm.hew 2>&1 | grep -c 'error:'
1

$ hew check --format json bad_import.hew | jq '.[0].span.start_line'
1
```

Note: the brief's acceptance line reads `jq '.diagnostics[0]...'`, but
`hew check --format json` has always emitted a bare top-level array
(unchanged by this PR — see `parse_json_array` in
`hew-cli/tests/json_diagnostics_e2e.rs`, pre-existing); run verbatim,
that command errors with `Cannot index array with string "diagnostics"`.
`.[0].span.start_line` is the correct path against the real schema and
returns `1`.

`make test-journeys JOURNEY=day-one`: this worktree's `CARGO_TARGET_DIR`
is out-of-tree (the scratch-pool build convention this machine's lanes
use), and `hew`'s stdlib discovery falls back to a heuristic relative
to the binary's own path when running from outside the checkout — a
heuristic that only resolves for an in-tree `target/`, which CI's
build is. With `HEWPATH` pointed at this worktree (equivalent to what
tier-3 discovery gets for free in-tree), the gate passes cleanly for
every row this PR touches (`day-one.16`, `.17`, `.20`, `.21`); the raw
out-of-tree run is identical except for those four rows, which is
consistent with an environment gap rather than a defect in the change.

Also surfaced, out of this PR's scope: `day-one.26`/`.27`/`.28`/`.30`
(tag `V060-DIAG-1`) are stale on current `main` — that lane's own PR
(`5ed485cd9`) landed after the ground map's baseline and never deleted
its rows. Left alone here per this PR's fences; needs a one-line
follow-up `chore: tidy` PR.
