### PR TITLE
feat(runtime): add supervisor.restarts_by_child and dot the handler label

### DIFF
--- a/docs/observe.md
+++ b/docs/observe.md
@@ -50,7 +50,8 @@ visible in `scrape()` output, not by a labelled `read` call.
 ### `observe.series() -> string`
 
 Returns the canonical metric names, one per line. It lists the 28 scalar names
-accepted by `observe.read` plus the two labelled actor-attribution series names.
+accepted by `observe.read` plus the labelled series names (per-handler actor
+attribution and per-child supervisor restarts).
 
 ```hew
 import std.observe;
@@ -82,7 +83,9 @@ Example excerpt:
 # TYPE heap_live_bytes gauge
 heap_live_bytes 32
 # TYPE actors_attributed_turns_by_handler_total counter
-actors_attributed_turns_by_handler_total{dispatch="0x...",msg_type="...",handler="Counter::increment"} 2
+actors_attributed_turns_by_handler_total{dispatch="0x...",msg_type="...",handler="Counter.increment"} 2
+# TYPE supervisor_restarts_by_child_total counter
+supervisor_restarts_by_child_total{supervisor="supervisor:1",child="store"} 1
 ```
 
 ## Getting started: read and scrape a small workload
@@ -127,8 +130,8 @@ Expected useful output includes:
 - `3` from the actor's `total` handler.
 - A non-zero `actors.turns_total` scalar.
 - `actors.attributed_turns_by_handler_total` in the series list.
-- Scrape samples labelled with handlers such as `Counter::increment` and
-  `Counter::total`.
+- Scrape samples labelled with handlers such as `Counter.increment` and
+  `Counter.total`.
 
 `observe.barrier()` is a current synchronization helper, not a metric API. It
 waits until actor dispatches that started before the call have reached their
@@ -173,22 +176,26 @@ value only increments when `HEW_OBSERVE` enables the hot tier.
 | `reactor.ready_events_total` | counter | no | Reactor ready-event count. |
 | `arena.resets_total` | counter | no | Arena reset count. |
 
-The two labelled series are emitted by `observe.scrape()` when attribution data
+The labelled series are emitted by `observe.scrape()` when attribution data
 exists:
 
 | Scrape series | Kind | Labels | What it measures |
 | --- | --- | --- | --- |
 | `actors_attributed_turns_by_handler_total` | counter | `dispatch`, `msg_type`, `handler` | Actor turn count grouped by dispatch pointer, message type id, and resolved handler name. |
 | `actors_attributed_turn_duration_ns_by_handler_total` | counter | `dispatch`, `msg_type`, `handler` | Total actor turn duration in nanoseconds for the same label set. |
+| `supervisor_restarts_by_child_total` | counter | `supervisor`, `child` | Each supervised child's lifetime restart count, one row per child across every registered supervisor tree. |
 
 How to read the labelled series:
 
 - `handler` is the most useful label. With profiler support enabled, it resolves
-  to names such as `Counter::increment`.
+  to names such as `Counter.increment`.
 - `msg_type` is an integer message type id. It is useful for joining samples but
   is not meant to be hand-decoded.
 - `dispatch` is the dispatch function pointer rendered as hex. Treat it as a
   process-local grouping key, not a stable cross-run identifier.
+- `child` is the declared child slot name (e.g. `store`), not the actor type.
+  `supervisor` identifies the owning supervisor by its actor id and is a
+  process-local grouping key like `dispatch`, not a stable cross-run identifier.
 - The labelled series are scrape-only. Use the aggregate scalar metrics when you
   need `observe.read`.
 

--- a/examples/observe-restarts-fixture.hew
+++ b/examples/observe-restarts-fixture.hew
@@ -1,0 +1,38 @@
+import std.observe;
+
+actor Fragile {
+    let id: i32;
+    receive fn break_it() {
+        panic("fragile crash");
+    }
+}
+
+supervisor Pair {
+    strategy: one_for_one;
+    intensity: 10 within 60s;
+
+    child a: Fragile(id: 1);
+    child b: Fragile(id: 2);
+}
+
+fn main() {
+    let sup = spawn Pair;
+    sleep(30ms);
+
+    let a = sup.a;
+    a.break_it();
+    sleep(300ms);
+
+    var b = sup.b;
+    var i = 0;
+    while i < 3 {
+        b.break_it();
+        sleep(300ms);
+        b = sup.b;
+        i = i + 1;
+    }
+
+    let _barrier = observe.barrier();
+    println("restarts fixture ready");
+    sleep(15s);
+}

--- a/examples/observe-restarts-fixture.hew
+++ b/examples/observe-restarts-fixture.hew
@@ -21,13 +21,16 @@ fn main() {
 
     let a = sup.a;
     a.break_it();
-    sleep(300ms);
+    sleep(1s);
 
+    // Child B's restart backoff doubles each crash (100ms, 200ms, 400ms);
+    // 1s per iteration keeps a >2x margin over the widest window so a slow
+    // CI runner cannot observe a still-restarting slot before the next crash.
     var b = sup.b;
     var i = 0;
     while i < 3 {
         b.break_it();
-        sleep(300ms);
+        sleep(1s);
         b = sup.b;
         i = i + 1;
     }

--- a/hew-cli/tests/distributed_two_process_e2e.rs
+++ b/hew-cli/tests/distributed_two_process_e2e.rs
@@ -1264,7 +1264,7 @@ fn linker_local_crash_reports_once() {
     let stdout = run_link_cascade_scenario(
         "linker_local_crash",
         1,
-        StderrExpectation::ExactOneCrashIn("Linker::crash_local"),
+        StderrExpectation::ExactOneCrashIn("Linker.crash_local"),
     );
     assert!(
         !stdout.contains("FAIL "),

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -492,7 +492,7 @@ run_counter();
         stdout.contains("actors_attributed_turn_duration_ns_by_handler_total"),
         "stdout: {stdout}"
     );
-    assert!(stdout.contains("Counter::total"), "stdout: {stdout}");
+    assert!(stdout.contains("Counter.total"), "stdout: {stdout}");
     assert!(
         stdout.lines().any(
             |line| line.starts_with("actors_attributed_turns_by_handler_total{")
@@ -505,6 +505,54 @@ run_counter();
             .starts_with("actors_attributed_turn_duration_ns_by_handler_total{")
             && !line.ends_with(" 0")),
         "stdout: {stdout}"
+    );
+}
+
+/// An unsupervised actor crash reports the dotted `Actor.handler` label on
+/// stderr — the same registration the observe series above reads, exercised
+/// here through the crash-reporter funnel (`hew-runtime/src/crash.rs`)
+/// instead of the scrape.
+#[test]
+fn eval_unsupervised_actor_crash_reports_dotted_handler_label() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let path = dir.path().join("crash_label_eval.hew");
+    std::fs::write(
+        &path,
+        r#"actor Boom {
+    receive fn detonate() -> i64 {
+        panic("boom");
+    }
+}
+
+fn crash_boom() {
+    let b = spawn Boom;
+    let _ = await b.detonate();
+}
+crash_boom();
+"#,
+    )
+    .unwrap();
+
+    let mut command = Command::new(hew_binary());
+    command
+        .args(["eval", "--timeout", "30", "-f"])
+        .arg(&path)
+        .current_dir(repo_root());
+
+    let output = support::run_bounded_command(command, format!("hew eval {}", path.display()));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "an unsupervised actor crash must fail the process: stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("hew: actor crash in Boom.detonate ("),
+        "expected the dotted `Boom.detonate` handler label in the crash \
+         diagnostic; stderr: {stderr}"
     );
 }
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -5073,7 +5073,7 @@ pub(crate) fn emit_native_actor_metadata_registration<'ctx>(
                 "actor `{actor_name}` handler index exceeds u32::MAX"
             ))
         })?;
-        let handler_name = format!("{actor_name}::{}", handler.name);
+        let handler_name = format!("{actor_name}.{}", handler.name);
         let handler_name_fragment = llvm_global_name_fragment(&handler.name);
         let handler_name_ptr = intern_global_string_ptr(
             fn_ctx,

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -8051,7 +8051,7 @@ fn emit_nested_supervisor_register<'ctx>(
 
 /// Register a supervised child actor's type name and per-handler names into the
 /// runtime profiler registry so a crash inside one of its handlers is reported
-/// by name (`Worker::run`) rather than the bare `msg_type` discriminant.
+/// by name (`Worker.run`) rather than the bare `msg_type` discriminant.
 ///
 /// The direct-`spawn` path emits the equivalent registration via
 /// `emit_native_actor_metadata_registration`. A supervised child, however, is
@@ -8126,7 +8126,7 @@ fn emit_supervised_child_handler_name_registration<'ctx>(
         void_ty.fn_type(&[ptr_ty.into(), i32_ty.into(), ptr_ty.into()], false),
     );
     for (h_idx, handler) in layout.handlers.iter().enumerate() {
-        let handler_name = format!("{actor_name}::{}", handler.name);
+        let handler_name = format!("{actor_name}.{}", handler.name);
         let handler_fragment = llvm_global_name_fragment(&handler.name);
         let handler_name_global = builder
             .build_global_string_ptr(
@@ -8212,7 +8212,7 @@ fn emit_supervisor_child_spec_and_register<'ctx>(
     // (where `emit_native_actor_metadata_registration` would do this), so
     // without this its handler-name registry stays empty and a crash inside one
     // of its handlers is reported by the bare `msg_type` discriminant instead of
-    // the handler name (e.g. `Worker::run`).
+    // the handler name (e.g. `Worker.run`).
     emit_supervised_child_handler_name_registration(
         ctx,
         llvm_mod,

--- a/hew-codegen-rs/tests/structural/supervised_handler_name_registration.rs
+++ b/hew-codegen-rs/tests/structural/supervised_handler_name_registration.rs
@@ -1,6 +1,6 @@
 //! Codegen test: a SUPERVISED actor's handler names are registered into the
 //! runtime profiler registry so a crash inside a supervised handler is reported
-//! by name (`Worker::run`) instead of the bare `msg_type` discriminant.
+//! by name (`Worker.run`) instead of the bare `msg_type` discriminant.
 //!
 //! Background: the direct-`spawn` path emits the handler-name registration via
 //! `emit_native_actor_metadata_registration`. A supervised child, however, is
@@ -11,9 +11,9 @@
 //! integer.
 //!
 //! The source below supervises `Worker` but NEVER directly `spawn`s it, so the
-//! only path that can register `Worker::run` is the supervisor child-spec
+//! only path that can register `Worker.run` is the supervisor child-spec
 //! emission. The IR assertions therefore pin that path specifically: drop the
-//! registration and `Worker::run` disappears from the emitted module.
+//! registration and `Worker.run` disappears from the emitted module.
 
 use std::path::Path;
 
@@ -109,7 +109,7 @@ fn emit_supervised_ir() -> String {
 }
 
 /// The supervised child's per-handler name is registered: the emitted IR both
-/// references `hew_register_handler_name` and embeds the `Worker::run` name
+/// references `hew_register_handler_name` and embeds the `Worker.run` name
 /// string. Because `Worker` is never directly `spawn`ed, this proves the
 /// registration came from the supervisor child-spec path.
 #[test]
@@ -120,8 +120,8 @@ fn supervised_child_registers_handler_name() {
         "expected a `hew_register_handler_name` reference in the emitted IR;\ngot:\n{ir}"
     );
     assert!(
-        ir.contains("Worker::run"),
-        "expected the `Worker::run` handler-name string in the emitted IR \
+        ir.contains("Worker.run"),
+        "expected the `Worker.run` handler-name string in the emitted IR \
          (registered via the supervisor child-spec path);\ngot:\n{ir}"
     );
     // A `call void @hew_register_handler_name(` must actually be emitted, not

--- a/hew-observe/tests/functional.rs
+++ b/hew-observe/tests/functional.rs
@@ -136,6 +136,57 @@ fn profiler_endpoint_captures_fixture_observability_data() {
     }
 }
 
+/// `supervisor.restarts_by_child` reports each child's lifetime restart total
+/// separately: a supervisor with two children restarted a different number of
+/// times must emit two distinct series values, not a shared or collapsed one.
+#[test]
+#[ignore = "run by `make observe-functional-test` with built compiler artifacts"]
+fn restarts_by_child_counts_each_child_separately() {
+    let fixture = build_restarts_fixture_binary();
+    let port = reserve_local_port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let child = ChildGuard::new(
+        Command::new(&fixture.binary)
+            .env("HEW_PPROF", format!("127.0.0.1:{port}"))
+            .env("HEW_OBSERVE", "hot")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|error| {
+                panic!("failed to start {}: {error}", fixture.binary.display())
+            }),
+    );
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_millis(750))
+        .build()
+        .expect("build HTTP client");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut last_error = "restarts-by-child fixture was not contacted".to_owned();
+    let mut scrape = String::new();
+    while Instant::now() < deadline {
+        match fetch_text(&client, &base_url, "/api/observe/scrape") {
+            Ok(text) => {
+                let a = restart_count(&text, "a");
+                let b = restart_count(&text, "b");
+                scrape = text;
+                if a == Some(1) && b == Some(3) {
+                    return;
+                }
+                last_error = format!("observed restarts a={a:?} b={b:?}");
+            }
+            Err(error) => last_error = error,
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    panic!(
+        "timed out waiting for the expected restart counts: {last_error}\n\
+         last scrape:\n{scrape}\n{}",
+        child.output_after_kill()
+    );
+}
+
 #[test]
 #[ignore = "run by `make observe-functional-test` with the positive endpoint test"]
 fn observe_snapshot_validation_rejects_no_data() {
@@ -170,6 +221,38 @@ fn build_fixture_binary() -> BuiltFixture {
     assert!(
         output.status.success(),
         "failed to build observe fixture with {}\nstdout:\n{}\nstderr:\n{}",
+        hew.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    BuiltFixture {
+        _dir: out_dir,
+        binary,
+    }
+}
+
+fn build_restarts_fixture_binary() -> BuiltFixture {
+    ensure_compiler_artifacts();
+
+    let out_dir = tempfile::tempdir().expect("create restarts fixture output directory");
+    let binary = out_dir.path().join(format!(
+        "observe-restarts-fixture{}",
+        std::env::consts::EXE_SUFFIX
+    ));
+    let fixture = repo_root().join("examples/observe-restarts-fixture.hew");
+    let hew = hew_binary_path();
+    let output = Command::new(&hew)
+        .args(["build"])
+        .arg(&fixture)
+        .args(["-o"])
+        .arg(&binary)
+        .current_dir(repo_root())
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {} build: {error}", hew.display()));
+
+    assert!(
+        output.status.success(),
+        "failed to build observe-restarts fixture with {}\nstdout:\n{}\nstderr:\n{}",
         hew.display(),
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
@@ -394,9 +477,9 @@ fn validate_scrape_metrics(scrape: &str) -> Result<(), String> {
         "actors_attributed_turns_total",
         EXPECTED_ACTOR_TURNS,
     )?;
-    expect_handler_turns(scrape, "Counter::increment", FIXTURE_COUNTER_INCREMENTS)?;
-    expect_handler_turns(scrape, "Counter::total", 1)?;
-    expect_handler_turns(scrape, "Pinger::ping", 1)?;
+    expect_handler_turns(scrape, "Counter.increment", FIXTURE_COUNTER_INCREMENTS)?;
+    expect_handler_turns(scrape, "Counter.total", 1)?;
+    expect_handler_turns(scrape, "Pinger.ping", 1)?;
     Ok(())
 }
 
@@ -455,6 +538,20 @@ fn expect_handler_turns(scrape: &str, handler: &str, expected: u64) -> Result<()
             many.len()
         )),
     }
+}
+
+/// Read the `supervisor_restarts_by_child{...,child="<child>"}` value off a
+/// scrape, regardless of which `supervisor="..."` label carries it — the
+/// restarts-fixture registers exactly one supervisor, so the child label
+/// alone disambiguates the row.
+fn restart_count(scrape: &str, child: &str) -> Option<u64> {
+    let prefix = "supervisor_restarts_by_child{";
+    let needle = format!("child=\"{child}\"");
+    scrape
+        .lines()
+        .find(|line| line.starts_with(prefix) && line.contains(&needle))
+        .and_then(|line| line.rsplit_once(' '))
+        .and_then(|(_, value)| value.parse::<u64>().ok())
 }
 
 fn assert_snapshot_has_expected_data(snapshot: &Snapshot) {

--- a/hew-observe/tests/functional.rs
+++ b/hew-observe/tests/functional.rs
@@ -136,7 +136,7 @@ fn profiler_endpoint_captures_fixture_observability_data() {
     }
 }
 
-/// `supervisor.restarts_by_child` reports each child's lifetime restart total
+/// `supervisor.restarts_by_child_total` reports each child's lifetime restart total
 /// separately: a supervisor with two children restarted a different number of
 /// times must emit two distinct series values, not a shared or collapsed one.
 #[test]
@@ -540,12 +540,12 @@ fn expect_handler_turns(scrape: &str, handler: &str, expected: u64) -> Result<()
     }
 }
 
-/// Read the `supervisor_restarts_by_child{...,child="<child>"}` value off a
-/// scrape, regardless of which `supervisor="..."` label carries it — the
-/// restarts-fixture registers exactly one supervisor, so the child label
+/// Read the `supervisor_restarts_by_child_total{...,child="<child>"}` value
+/// off a scrape, regardless of which `supervisor="..."` label carries it —
+/// the restarts-fixture registers exactly one supervisor, so the child label
 /// alone disambiguates the row.
 fn restart_count(scrape: &str, child: &str) -> Option<u64> {
-    let prefix = "supervisor_restarts_by_child{";
+    let prefix = "supervisor_restarts_by_child_total{";
     let needle = format!("child=\"{child}\"");
     scrape
         .lines()

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -5270,7 +5270,7 @@ pub unsafe extern "C" fn hew_actor_register_type(
 /// multiple actor types use overlapping `msg_type` integers (unlike the WASM
 /// bridge's flat `msg_type → name` map).
 ///
-/// `name` must be a NUL-terminated `"ActorName::handler_name"` string with
+/// `name` must be a NUL-terminated `"ActorName.handler_name"` string with
 /// static lifetime (a string literal baked into the binary).
 ///
 /// # Safety

--- a/hew-runtime/src/bridge.rs
+++ b/hew-runtime/src/bridge.rs
@@ -144,7 +144,7 @@ impl std::fmt::Debug for HewActorMeta {
 struct MetaState {
     registry: HashMap<String, ActorMetaEntry>,
     trace_attribution: HashMap<i32, ActorTraceAttribution>,
-    /// `msg_type → "ActorName::handler_name"` side table for trace attribution.
+    /// `msg_type → "ActorName.handler_name"` side table for trace attribution.
     ///
     /// Populated at registration time by [`hew_wasm_register_actor_meta`].
     ///
@@ -244,7 +244,7 @@ pub(crate) fn register_bridge_reset_hook() {
 
 /// Resolve a `msg_type` integer to its fully-qualified handler name.
 ///
-/// Returns `Some("ActorName::handler_name")` when the `msg_type` was
+/// Returns `Some("ActorName.handler_name")` when the `msg_type` was
 /// previously registered via [`hew_wasm_register_actor_meta`], or `None`
 /// if registration has not yet occurred for this `msg_type` (e.g. a trace
 /// event arrived before registration completed).
@@ -642,11 +642,11 @@ pub unsafe extern "C" fn hew_wasm_register_actor_meta(meta: *const HewActorMeta)
     }
 
     let mut state = meta_state();
-    // Populate the msg_type → "ActorName::handler_name" side table used by
+    // Populate the msg_type → "ActorName.handler_name" side table used by
     // drain_events_json for span-level trace attribution.
     let actor_type_id = wasm_actor_type_id(&name);
     for h in &handlers {
-        let handler_name = format!("{}::{}", name, h.name);
+        let handler_name = format!("{}.{}", name, h.name);
         state.handler_names.insert(h.msg_type, handler_name.clone());
         state.trace_attribution.insert(
             h.msg_type,
@@ -1417,7 +1417,7 @@ mod tests {
             hew_wasm_register_actor_meta(&raw const actor_meta);
         }
 
-        assert_eq!(resolve_handler_name(42), Some("Foo::handle_bar".to_owned()));
+        assert_eq!(resolve_handler_name(42), Some("Foo.handle_bar".to_owned()));
         // Unknown msg_type still returns None.
         assert_eq!(resolve_handler_name(99), None);
     }
@@ -1452,7 +1452,7 @@ mod tests {
         assert_ne!(actor_type_id, 0);
         assert_eq!(actor_type_id, wasm_actor_type_id("TraceActor"));
         assert_eq!(actor_type, "TraceActor");
-        assert_eq!(handler_name, Some("TraceActor::handle_ping".to_owned()));
+        assert_eq!(handler_name, Some("TraceActor.handle_ping".to_owned()));
         assert_eq!(resolve_actor_trace_attribution(99), None);
     }
 
@@ -1482,7 +1482,7 @@ mod tests {
         // SAFETY: actor_meta is a valid stack-allocated struct with valid C strings.
         unsafe { hew_wasm_register_actor_meta(&raw const actor_meta) };
 
-        assert_eq!(resolve_handler_name(7), Some("ResetActor::ping".to_owned()));
+        assert_eq!(resolve_handler_name(7), Some("ResetActor.ping".to_owned()));
         assert!(
             resolve_actor_trace_attribution(7).is_some(),
             "trace attribution must be populated before reset"
@@ -1491,7 +1491,7 @@ mod tests {
         bridge_shutdown();
         assert_eq!(
             resolve_handler_name(7),
-            Some("ResetActor::ping".to_owned()),
+            Some("ResetActor.ping".to_owned()),
             "bridge_shutdown keeps handler_names until session_reset runs"
         );
         assert!(

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -776,10 +776,10 @@ const ATTRIBUTED_TURN_SERIES_CANONICAL: [&str; 2] = [
 /// `{supervisor,child}` series. A user metric whose rendered name equals this
 /// would emit a duplicate `# TYPE` block and shadow the runtime's per-child
 /// restart telemetry, so the registry rejects it.
-const SUPERVISOR_RESTART_SERIES_NAMES: [&str; 1] = ["supervisor_restarts_by_child"];
+const SUPERVISOR_RESTART_SERIES_NAMES: [&str; 1] = ["supervisor_restarts_by_child_total"];
 
 /// Canonical (dotted) name of the supervisor restart series, for `series_text`.
-const SUPERVISOR_RESTART_SERIES_CANONICAL: [&str; 1] = ["supervisor.restarts_by_child"];
+const SUPERVISOR_RESTART_SERIES_CANONICAL: [&str; 1] = ["supervisor.restarts_by_child_total"];
 
 /// Rendered Prometheus series names of the user-metric registry self-metrics
 /// the scrape emits from [`push_user_metric_self_series`]. Already in rendered

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -770,6 +770,17 @@ const ATTRIBUTED_TURN_SERIES_CANONICAL: [&str; 2] = [
     "actors.attributed_turn_duration_ns_by_handler_total",
 ];
 
+/// Rendered Prometheus series name of the per-child supervisor restart series
+/// the scrape emits from [`push_restarts_by_child_series`]. Already in
+/// rendered form (`_`, never `.`); the base name of the labelled
+/// `{supervisor,child}` series. A user metric whose rendered name equals this
+/// would emit a duplicate `# TYPE` block and shadow the runtime's per-child
+/// restart telemetry, so the registry rejects it.
+const SUPERVISOR_RESTART_SERIES_NAMES: [&str; 1] = ["supervisor_restarts_by_child"];
+
+/// Canonical (dotted) name of the supervisor restart series, for `series_text`.
+const SUPERVISOR_RESTART_SERIES_CANONICAL: [&str; 1] = ["supervisor.restarts_by_child"];
+
 /// Rendered Prometheus series names of the user-metric registry self-metrics
 /// the scrape emits from [`push_user_metric_self_series`]. Already in rendered
 /// form. A user metric that shadowed one of these would mask the very
@@ -796,8 +807,8 @@ pub fn render_prometheus_name(name: &str) -> String {
 /// Every rendered Prometheus series name the scrape owns. This is the single
 /// authoritative set the registry's collision check consults so that *no*
 /// scrape-owned name can be shadowed by a user metric — the `observe_series()`
-/// built-ins (rendered), the per-handler attributed-turn series, and the
-/// user-metric registry self-metrics.
+/// built-ins (rendered), the per-handler attributed-turn series, the per-child
+/// supervisor restart series, and the user-metric registry self-metrics.
 ///
 /// Returning rendered names keeps the collision check on the rendered form (see
 /// [`rendered_name_collides_with_builtin`]): the scrape render is non-injective,
@@ -809,6 +820,11 @@ fn reserved_rendered_names() -> impl Iterator<Item = String> {
         .map(|(builtin, _)| render_prometheus_name(builtin))
         .chain(
             ATTRIBUTED_TURN_SERIES_NAMES
+                .iter()
+                .map(|s| (*s).to_string()),
+        )
+        .chain(
+            SUPERVISOR_RESTART_SERIES_NAMES
                 .iter()
                 .map(|s| (*s).to_string()),
         )
@@ -894,6 +910,42 @@ fn push_attributed_turn_series(out: &mut String) {
         out.push_str(&prometheus_label_value(&handler));
         out.push_str("\"} ");
         out.push_str(&turn.duration_ns_total.to_string());
+        out.push('\n');
+    }
+}
+
+/// `(supervisor_label, child_label, restarts)` rows for every child across
+/// every registered supervisor tree, read from the same
+/// `CrashStats::total_crashes` lifetime counter the supervisor debug tree
+/// formats — not the bounded restart-budget ring. Empty on wasm32 and on a
+/// build without the `profiler` feature, same as [`handler_name`] above.
+#[cfg(all(not(target_arch = "wasm32"), feature = "profiler"))]
+fn restarts_by_child_snapshot() -> Vec<(String, String, u64)> {
+    crate::supervisor::restarts_by_child_snapshot()
+}
+
+#[cfg(any(target_arch = "wasm32", not(feature = "profiler")))]
+fn restarts_by_child_snapshot() -> Vec<(String, String, u64)> {
+    Vec::new()
+}
+
+fn push_restarts_by_child_series(out: &mut String) {
+    let rows = restarts_by_child_snapshot();
+    if rows.is_empty() {
+        return;
+    }
+
+    out.push_str("# TYPE ");
+    out.push_str(SUPERVISOR_RESTART_SERIES_NAMES[0]);
+    out.push_str(" counter\n");
+    for (supervisor, child, restarts) in &rows {
+        out.push_str(SUPERVISOR_RESTART_SERIES_NAMES[0]);
+        out.push_str("{supervisor=\"");
+        out.push_str(&prometheus_label_value(supervisor));
+        out.push_str("\",child=\"");
+        out.push_str(&prometheus_label_value(child));
+        out.push_str("\"} ");
+        out.push_str(&restarts.to_string());
         out.push('\n');
     }
 }
@@ -996,6 +1048,7 @@ pub fn scrape_text() -> String {
         }
     }
     push_attributed_turn_series(&mut out);
+    push_restarts_by_child_series(&mut out);
     push_user_metric_series(&mut out);
     out
 }
@@ -1008,6 +1061,10 @@ pub fn series_text() -> String {
         out.push('\n');
     }
     for name in ATTRIBUTED_TURN_SERIES_CANONICAL {
+        out.push_str(name);
+        out.push('\n');
+    }
+    for name in SUPERVISOR_RESTART_SERIES_CANONICAL {
         out.push_str(name);
         out.push('\n');
     }

--- a/hew-runtime/src/profiler/actor_registry.rs
+++ b/hew-runtime/src/profiler/actor_registry.rs
@@ -47,7 +47,7 @@ static DISPATCH_TYPE_REGISTRY: PoisonSafe<Option<HashMap<usize, &'static str>>> 
     PoisonSafe::new(None);
 
 /// Side table mapping `(dispatch_fn_ptr_as_usize, msg_type)` to the fully-qualified
-/// handler name `"ActorName::handler_name"`.
+/// handler name `"ActorName.handler_name"`.
 ///
 /// Populated by `hew_register_handler_name` (called at program startup by codegen).
 /// Used at `drain_events_json` time on native profiler builds to resolve handler names
@@ -179,7 +179,7 @@ pub fn lookup_dispatch_type_by_ptr(dispatch_ptr: usize) -> String {
 
 /// Look up the fully-qualified handler name by raw dispatch pointer and `msg_type`.
 ///
-/// Returns `Some("ActorName::handler_name")` when registered, `None` otherwise.
+/// Returns `Some("ActorName.handler_name")` when registered, `None` otherwise.
 /// This variant avoids a `transmute` by operating on the raw `usize` pointer.
 pub fn handler_name_by_ptr(dispatch_ptr: usize, msg_type: i32) -> Option<String> {
     if dispatch_ptr == 0 {
@@ -198,7 +198,7 @@ pub fn handler_name_by_ptr(dispatch_ptr: usize, msg_type: i32) -> Option<String>
 /// any instances of that actor type are spawned.  Subsequent registrations for the
 /// same key are silently ignored (first-registered wins, matching `register_dispatch_type`).
 ///
-/// `handler_name` must be a `"ActorName::handler_name"` string.
+/// `handler_name` must be a `"ActorName.handler_name"` string.
 pub fn register_handler_name(
     dispatch_fn: Option<HewDispatchFn>,
     msg_type: i32,

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 use crate::reactor;
-use crate::runtime::{rt_current, rt_default};
+use crate::runtime::{rt_current, rt_current_opt, rt_default};
 use crate::scheduler;
 
 // ---------------------------------------------------------------------------
@@ -205,6 +205,24 @@ pub(crate) unsafe fn free_registered_supervisors() -> bool {
 #[cfg(feature = "profiler")]
 pub(crate) fn registered_supervisors_snapshot() -> Vec<*mut crate::supervisor::HewSupervisor> {
     with_supervisor_roots(|sups| sups.iter().map(|sup| sup.0).collect())
+}
+
+/// Like [`registered_supervisors_snapshot`] but reports an empty tree instead
+/// of panicking when no runtime is installed.
+///
+/// The observability scrape surface (`observe::scrape_text`) may run before
+/// `hew_sched_init` installs a runtime or after teardown drops it — there is
+/// simply no supervisor tree to read, the same case [`rt_current_opt`]'s docs
+/// describe for `metrics::render_snapshot`. `registered_supervisors_snapshot`
+/// keeps its fail-closed `rt_current` panic for its other callers (the
+/// profiler tree dump, shutdown's own drain), where running with no runtime
+/// installed is the caller's lifecycle bug, not a legitimate scrape.
+#[cfg(feature = "profiler")]
+pub(crate) fn registered_supervisors_snapshot_opt() -> Vec<*mut crate::supervisor::HewSupervisor> {
+    rt_current_opt().map_or_else(Vec::new, |rt| {
+        rt.supervisor_roots
+            .access(|sups| sups.iter().map(|sup| sup.0).collect())
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -264,7 +264,7 @@ fn append_restart_rows(rows: &mut Vec<(String, String, u64)>, sup: *mut HewSuper
 /// Snapshot the lifetime restart total of every child across every registered
 /// supervisor tree, as `(supervisor_label, child_label, restarts)` rows.
 ///
-/// Backs the `supervisor.restarts_by_child` observe series
+/// Backs the `supervisor.restarts_by_child_total` observe series
 /// ([`crate::observe::scrape_text`]); mirrors [`snapshot_tree_json`]'s walk,
 /// but reads through the non-panicking
 /// [`crate::shutdown::registered_supervisors_snapshot_opt`] rather than

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -193,6 +193,95 @@ pub fn snapshot_tree_json() -> String {
     json
 }
 
+/// Append `(supervisor_label, child_label, restarts)` rows for one supervisor
+/// and, recursively, every nested child supervisor beneath it.
+///
+/// `restarts` reads the same `CrashStats::total_crashes` lifetime counter
+/// `append_supervisor_rows` formats into its debug tree row above (under the
+/// same `roster.lock_or_recover()` discipline), not the bounded
+/// `roster.restart_count` ring used only for the restart-budget window.
+#[cfg(feature = "profiler")]
+fn append_restart_rows(rows: &mut Vec<(String, String, u64)>, sup: *mut HewSupervisor) {
+    if sup.is_null() {
+        return;
+    }
+
+    // SAFETY: copy the self-actor pointer from the live allocation.
+    let self_actor = unsafe { (*sup).self_actor };
+    let self_actor_id = if self_actor.is_null() {
+        0
+    } else {
+        // SAFETY: self_actor belongs to the live supervisor.
+        unsafe { (*self_actor).id }
+    };
+    let supervisor_label = format!("supervisor:{self_actor_id}");
+
+    // Snapshot restart counts and nested pins under this node's roster, then
+    // release it before recursive descent — same discipline as
+    // `append_supervisor_rows` above.
+    let (child_rows, nested) = {
+        // SAFETY: top-level supervisor pointers remain valid while registered;
+        // nested calls carry a stable pin acquired by their parent snapshot.
+        let roster = unsafe { &(*sup).roster }.lock_or_recover();
+        let child_rows = roster
+            .children
+            .iter()
+            .take(roster.child_count)
+            .enumerate()
+            .map(|(index, _child)| {
+                let spec = &roster.child_specs[index];
+                let name = child_name(spec.name, &format!("child[{index}]"));
+                let restarts: u64 = if spec.circuit_breaker.crash_stats.is_null() {
+                    0
+                } else {
+                    // SAFETY: crash stats pointer belongs to the child spec.
+                    u64::from(unsafe { (*spec.circuit_breaker.crash_stats).total_crashes })
+                };
+                (name, restarts)
+            })
+            .collect::<Vec<_>>();
+        let nested = roster
+            .child_supervisors
+            .iter()
+            .copied()
+            .zip(roster.child_supervisor_tokens.iter().copied())
+            .filter_map(|(child, token)| {
+                let pin = crate::lifetime::local_handles::pin_current_supervisor(token)?;
+                (pin.supervisor() == child).then_some((child, pin))
+            })
+            .collect::<Vec<_>>();
+        (child_rows, nested)
+    };
+
+    for (child, restarts) in child_rows {
+        rows.push((supervisor_label.clone(), child, restarts));
+    }
+    for (child_sup, _pin) in nested {
+        append_restart_rows(rows, child_sup);
+    }
+}
+
+/// Snapshot the lifetime restart total of every child across every registered
+/// supervisor tree, as `(supervisor_label, child_label, restarts)` rows.
+///
+/// Backs the `supervisor.restarts_by_child` observe series
+/// ([`crate::observe::scrape_text`]); mirrors [`snapshot_tree_json`]'s walk,
+/// but reads through the non-panicking
+/// [`crate::shutdown::registered_supervisors_snapshot_opt`] rather than
+/// [`crate::shutdown::registered_supervisors_snapshot`] — a scrape may run
+/// before `hew_sched_init` installs a runtime or after teardown drops it,
+/// where there is legitimately no supervisor tree yet, not a caller bug.
+#[cfg(feature = "profiler")]
+#[must_use]
+pub fn restarts_by_child_snapshot() -> Vec<(String, String, u64)> {
+    let roots = crate::shutdown::registered_supervisors_snapshot_opt();
+    let mut rows = Vec::new();
+    for root in roots {
+        append_restart_rows(&mut rows, root);
+    }
+    rows
+}
+
 // ---------------------------------------------------------------------------
 // Child lookup result types (shared by static and pool ABI)
 // ---------------------------------------------------------------------------

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -969,7 +969,7 @@ pub extern "C" fn hew_trace_reset() {
 ///                 "lambda_spawned"|"lambda_released"|"unknown",
 ///   "msg_type": N,
 ///   "timestamp_ns": N,
-///   "handler_name": "ActorType::handler_name"|null
+///   "handler_name": "ActorType.handler_name"|null
 /// }
 /// ```
 ///
@@ -1593,7 +1593,7 @@ mod tests {
         hew_trace_reset();
     }
 
-    /// Verify that `drain_events_json` emits `"handler_name":"ActorType::handler"`
+    /// Verify that `drain_events_json` emits `"handler_name":"ActorType.handler"`
     /// for a registered `msg_type` and `"handler_name":null` for an unknown one.
     ///
     /// This test exercises the bridge registration path together with the tracing
@@ -1647,9 +1647,9 @@ mod tests {
 
         let json = crate::tracing::drain_events_json();
 
-        // The known msg_type must carry "handler_name":"TestActor::on_ping".
+        // The known msg_type must carry "handler_name":"TestActor.on_ping".
         assert!(
-            json.contains(r#""handler_name":"TestActor::on_ping""#),
+            json.contains(r#""handler_name":"TestActor.on_ping""#),
             "expected handler_name for known msg_type in: {json}"
         );
         // The unknown msg_type must carry "handler_name":null.
@@ -1711,7 +1711,7 @@ mod tests {
             "registered actor_type_id must be non-zero: {json}"
         );
         assert!(
-            json.contains(r#""handler_name":"TypedActor::on_tick""#),
+            json.contains(r#""handler_name":"TypedActor.on_tick""#),
             "{json}"
         );
         assert!(

--- a/hew-runtime/src/wasm_parity_tests.rs
+++ b/hew-runtime/src/wasm_parity_tests.rs
@@ -1225,7 +1225,7 @@ fn wasm_trace_json_uses_registered_actor_type_attribution() {
         "registered actor type should render in WASM/test trace JSON: {json}"
     );
     assert!(
-        json.contains(r#""handler_name":"WasmActor::on_ping""#),
+        json.contains(r#""handler_name":"WasmActor.on_ping""#),
         "registered handler name should render in WASM/test trace JSON: {json}"
     );
     assert!(

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -118,7 +118,7 @@ string-method-identity	qualified-format-macro	hew-analysis/src/hover.rs	5	stage-
 string-method-identity	qualified-format-macro	hew-analysis/src/inlay_hints.rs	5	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-analysis/src/signature_help.rs	1	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/layout.rs	20	stage-5	reviewed qualified string identity construction
-string-method-identity	qualified-format-macro	hew-codegen-rs/src/llvm.rs	114	stage-5	reviewed qualified string identity construction; Raw virtual-value semantic admission belongs to the canonical hew-mir verifier, leaving LLVM realization diagnostics only
+string-method-identity	qualified-format-macro	hew-codegen-rs/src/llvm.rs	113	stage-5	reviewed qualified string identity construction; Raw virtual-value semantic admission belongs to the canonical hew-mir verifier, leaving LLVM realization diagnostics only
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/llvm/identity.rs	6	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/runtime_abi.rs	64	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/suspend.rs	10	stage-5	reviewed qualified string identity construction

--- a/scripts/structural-authority-inventory.tsv
+++ b/scripts/structural-authority-inventory.tsv
@@ -121,7 +121,7 @@ string-method-identity	qualified-format-macro	hew-codegen-rs/src/layout.rs	20	st
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/llvm.rs	114	stage-5	reviewed qualified string identity construction; Raw virtual-value semantic admission belongs to the canonical hew-mir verifier, leaving LLVM realization diagnostics only
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/llvm/identity.rs	6	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/runtime_abi.rs	64	stage-5	reviewed qualified string identity construction
-string-method-identity	qualified-format-macro	hew-codegen-rs/src/suspend.rs	11	stage-5	reviewed qualified string identity construction
+string-method-identity	qualified-format-macro	hew-codegen-rs/src/suspend.rs	10	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-codegen-rs/src/thunks.rs	3	stage-5	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-hir/src/dump.rs	2	stage-1	reviewed qualified string identity construction
 string-method-identity	qualified-format-macro	hew-hir/src/lower.rs	32	stage-1	reviewed compatibility-key factory for unique imported tagged-union constructors and `?` checker payload mismatch diagnostics; exact source owner remains the authority


### PR DESCRIPTION
## Why

I need observer scrapes to identify which supervised child restarted and to keep handler labels consistent with dotted identities.

## What

I expose `supervisor_restarts_by_child_total` with `supervisor` and `child` labels, and update handler labels, documentation, fixture assertions, and the WASM-facing mirror to use dotted names.

## Test

I ran `make structural-lint`.