### PR TITLE
feat(pkg,cli): honour HEW_HOME/HEW_REGISTRY and fail closed on bad manifest fields

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -112,6 +112,10 @@ pub enum Command {
     Completions(CompletionsArgs),
     /// Print version info.
     Version,
+    /// Print resolved package-manager environment (`HEW_HOME`,
+    /// `HEW_REGISTRY`, `HEW_CC`), naming which are set and which fall back
+    /// to their default.
+    Env,
     /// Launch the TUI actor observer (`hew-observe`).
     ///
     /// Forwards all arguments to `hew-observe`. Requires the `hew-observe`

--- a/hew-cli/src/help.rs
+++ b/hew-cli/src/help.rs
@@ -69,7 +69,7 @@ const COMMAND_GROUPS: &[(&str, &[&str])] = &[
     ),
     (
         "Tooling",
-        &["tool", "lsp", "observe", "completions", "version"],
+        &["tool", "lsp", "observe", "completions", "version", "env"],
     ),
 ];
 

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -3016,6 +3016,34 @@ fn cmd_version() {
     println!("hew {}", env!("HEW_VERSION"));
 }
 
+/// `hew env`: print the resolved package-manager environment, one
+/// `NAME=value` line per variable, `(default)` appended when the variable
+/// itself is unset and a compiled-in default is in effect.
+fn cmd_env() {
+    let hew_home = hew_pkg::config::hew_home();
+    let hew_home_set = std::env::var("HEW_HOME").is_ok();
+    println!(
+        "HEW_HOME={}{}",
+        hew_home.display(),
+        if hew_home_set { "" } else { " (default)" }
+    );
+
+    let registry = hew_pkg::config::discover_registry();
+    let registry_set = std::env::var("HEW_REGISTRY").is_ok();
+    println!(
+        "HEW_REGISTRY={}{}",
+        registry.api,
+        if registry_set { "" } else { " (default)" }
+    );
+
+    // HEW_CC has no reader yet (V060-FD-3): report the raw env value, with
+    // no resolved default to fall back to.
+    match std::env::var("HEW_CC") {
+        Ok(value) => println!("HEW_CC={value}"),
+        Err(_) => println!("HEW_CC= (default)"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Observe / LSP — sibling binary delegation
 // ---------------------------------------------------------------------------

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -23,6 +23,7 @@ pub(crate) trait CommandDispatcher {
     fn sir_coverage(&mut self, args: &args::SirCoverageArgs);
     fn completions(&mut self, args: &args::CompletionsArgs);
     fn version(&mut self);
+    fn env(&mut self);
     fn help(&mut self);
     fn observe(&mut self, args: &args::ObserveArgs);
     fn lsp(&mut self, args: &args::LspArgs);
@@ -103,6 +104,10 @@ impl CommandDispatcher for MainCommandDispatcher {
         crate::cmd_version();
     }
 
+    fn env(&mut self) {
+        crate::cmd_env();
+    }
+
     fn help(&mut self) {
         // No subcommand — shouldn't normally happen since clap shows help,
         // but handle gracefully.
@@ -153,6 +158,7 @@ pub(crate) fn dispatch_command(command: Option<&Command>, dispatcher: &mut impl 
         },
         Some(Command::Completions(args)) => dispatcher.completions(args),
         Some(Command::Version) => dispatcher.version(),
+        Some(Command::Env) => dispatcher.env(),
         Some(Command::Observe(args)) => dispatcher.observe(args),
         Some(Command::Lsp(args)) => dispatcher.lsp(args),
         Some(Command::Pkg(cmd)) => dispatcher.pkg(cmd),
@@ -577,6 +583,10 @@ mod tests {
 
         fn version(&mut self) {
             self.calls.push("version".to_string());
+        }
+
+        fn env(&mut self) {
+            self.calls.push("env".to_string());
         }
 
         fn help(&mut self) {

--- a/hew-pkg/src/client.rs
+++ b/hew-pkg/src/client.rs
@@ -755,7 +755,14 @@ fn percent_encode(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    // Serialize env-var–mutating tests: `std::env::set_var` / `remove_var`
+    // are not thread-safe when multiple tests share the same process, and
+    // `client_default_url` below pins the env-free default.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn package_urls_preserve_dotted_names() {
@@ -768,9 +775,20 @@ mod tests {
 
     #[test]
     fn client_default_url() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("HEW_REGISTRY");
         let client = RegistryClient::new_with_config(&config::PkgConfig::default());
         assert_eq!(client.api_url, config::DEFAULT_REGISTRY_API);
         assert!(client.token.is_none());
+    }
+
+    #[test]
+    fn client_honours_hew_registry_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("HEW_REGISTRY", "https://registry.internal.example/api/v1");
+        let client = RegistryClient::new_with_config(&config::PkgConfig::default());
+        std::env::remove_var("HEW_REGISTRY");
+        assert_eq!(client.api_url, "https://registry.internal.example/api/v1");
     }
 
     #[test]

--- a/hew-pkg/src/config.rs
+++ b/hew-pkg/src/config.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-pub use crate::paths::home_dir;
+pub use crate::paths::{hew_home, home_dir};
 
 /// Top-level configuration loaded from `~/.hew/config.toml`.
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -162,11 +162,14 @@ pub struct RegistryEndpoints {
     pub fallback_api: Option<String>,
 }
 
-/// Return the compiled-in registry endpoints.
+/// Return the registry endpoints: `HEW_REGISTRY` overrides the compiled-in
+/// default API URL when set (the CDN and fallback stay compiled-in — a
+/// registry override has no way to name its own CDN or mirror).
 #[must_use]
 pub fn discover_registry() -> RegistryEndpoints {
+    let api = std::env::var("HEW_REGISTRY").unwrap_or_else(|_| DEFAULT_REGISTRY_API.to_string());
     RegistryEndpoints {
-        api: DEFAULT_REGISTRY_API.to_string(),
+        api,
         cdn: DEFAULT_REGISTRY_CDN.to_string(),
         fallback_api: DEFAULT_FALLBACK_API.map(std::string::ToString::to_string),
     }

--- a/hew-pkg/src/manifest.rs
+++ b/hew-pkg/src/manifest.rs
@@ -30,13 +30,36 @@ pub fn default_edition() -> String {
 
 /// A dependency can be specified as a bare version string or as a table with
 /// additional options.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum DepSpec {
     /// Shorthand: `"^1.0"`.
     Version(String),
     /// Table: `{ version = "^1.0", optional = true, features = ["tls"] }`.
     Table(DepTable),
+}
+
+impl<'de> Deserialize<'de> for DepSpec {
+    /// Hand-written rather than `#[serde(untagged)]`: an untagged enum
+    /// buffers the input and discards each variant's own error on failure,
+    /// so a malformed table (e.g. the unquoted dotted key
+    /// `hew.math.stats = "0.3"` nesting a bogus `math` field under
+    /// `[dev-dependencies]`) surfaces only "data did not match any variant
+    /// of untagged enum `DepSpec`" — it swallows `DepTable`'s
+    /// `deny_unknown_fields` message entirely. Trying the string form
+    /// first, then deserializing the table form directly, preserves that
+    /// message instead of discarding it.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match toml::Value::deserialize(deserializer)? {
+            toml::Value::String(s) => Ok(Self::Version(s)),
+            other => DepTable::deserialize(other)
+                .map(Self::Table)
+                .map_err(serde::de::Error::custom),
+        }
+    }
 }
 
 impl PartialEq<&str> for DepSpec {
@@ -67,6 +90,7 @@ impl fmt::Display for DepSpec {
 
 /// Table form of a dependency specification.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct DepTable {
     /// Semver version requirement (defaults to `"*"` for path dependencies).
     #[serde(default = "default_dependency_version")]
@@ -78,7 +102,11 @@ pub struct DepTable {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub features: Option<Vec<String>>,
     /// Whether to include the dependency's default features (default: `true`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "default-features",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub default_features: Option<bool>,
     /// Non-default registry name for this dependency.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -156,6 +184,7 @@ impl From<toml::ser::Error> for ManifestError {
 
 /// The `[package]` section of a `hew.toml` manifest.
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Package {
     /// Package name (required).
     pub name: String,
@@ -229,6 +258,7 @@ impl Package {
 /// the compiler links the produced `lib<lib>.a` (or `.dylib`) when the package is
 /// built or imported, so consumers never pass `--link-lib` manually.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct NativeLib {
     /// Path to the Cargo crate directory, relative to `hew.toml` (default `"."`).
     #[serde(rename = "crate", default = "default_native_crate")]
@@ -297,6 +327,7 @@ pub fn package_root_source(package_name: &str) -> String {
 
 /// A parsed `hew.toml` manifest.
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct HewManifest {
     /// `[package]` metadata.
     pub package: Package,
@@ -929,6 +960,92 @@ mod tests {
         assert_eq!(m.dependencies.len(), 1);
         assert_eq!(m.dev_dependencies.len(), 1);
         assert_eq!(m.dev_dependencies["testing::assert"].version_req(), "^1.0");
+    }
+
+    /// The unquoted dotted key `hew.math.stats = "0.3"` under
+    /// `[dev-dependencies]` parses as a nested TOML table
+    /// (`dev-dependencies.hew = { math = { stats = "0.3" } }`), which
+    /// silently produced a default-valued `DepTable` for `hew` before
+    /// `deny_unknown_fields` — the unrecognized `math` field was dropped
+    /// rather than rejected. `DepTable`'s `deny_unknown_fields` is what
+    /// catches this, since `dev_dependencies`'s own key (`hew`) is an
+    /// arbitrary map key, not a struct field.
+    #[test]
+    fn dev_dependencies_typo_rejected_by_dep_table() {
+        let f = write_temp(concat!(
+            "[package]\n",
+            "name = \"typo\"\n",
+            "version = \"0.1.0\"\n",
+            "\n[dev-dependencies]\n",
+            "hew.math.stats = \"0.3\"\n",
+        ));
+        let error = parse_manifest(f.path()).expect_err("unknown field must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("math"),
+            "error should name the unrecognized field: {message}"
+        );
+    }
+
+    #[test]
+    fn hew_manifest_rejects_unknown_top_level_field() {
+        let f = write_temp(concat!(
+            "[package]\n",
+            "name = \"unknownfield\"\n",
+            "version = \"0.1.0\"\n",
+            "\nunknown-section-value = true\n",
+        ));
+        let error = parse_manifest(f.path()).expect_err("unknown top-level field must be rejected");
+        assert!(
+            error.to_string().contains("unknown-section-value"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn package_rejects_unknown_field() {
+        let f = write_temp(concat!(
+            "[package]\n",
+            "name = \"unknownpkgfield\"\n",
+            "version = \"0.1.0\"\n",
+            "typo-field = \"oops\"\n",
+        ));
+        let error = parse_manifest(f.path()).expect_err("unknown package field must be rejected");
+        assert!(error.to_string().contains("typo-field"), "{error}");
+    }
+
+    #[test]
+    fn native_lib_rejects_unknown_field() {
+        let f = write_temp(concat!(
+            "[package]\n",
+            "name = \"unknownnativefield\"\n",
+            "version = \"0.1.0\"\n",
+            "edition = \"2026\"\n",
+            "\n[native]\n",
+            "lib = \"foo\"\n",
+            "typo = \"oops\"\n",
+        ));
+        let error = parse_manifest(f.path()).expect_err("unknown native field must be rejected");
+        assert!(error.to_string().contains("typo"), "{error}");
+    }
+
+    /// The cargo-conventional `default-features` spelling is the accepted
+    /// one (`DepTable::default_features` is `#[serde(rename =
+    /// "default-features")]`); the underscore spelling is now unknown.
+    #[test]
+    fn dep_table_accepts_hyphenated_default_features() {
+        let f = write_temp(concat!(
+            "[package]\n",
+            "name = \"defaultfeatures\"\n",
+            "version = \"0.1.0\"\n",
+            "\n[dependencies]\n",
+            "pkg = { version = \"^1.0\", default-features = false }\n",
+        ));
+        let m = parse_manifest(f.path()).unwrap();
+        let DepSpec::Table(dep) = &m.dependencies["pkg"] else {
+            panic!("expected table dependency");
+        };
+        assert_eq!(dep.default_features, Some(false));
     }
 
     #[test]

--- a/hew-pkg/src/paths.rs
+++ b/hew-pkg/src/paths.rs
@@ -10,8 +10,42 @@ pub fn home_dir() -> PathBuf {
         .map_or_else(|_| std::env::temp_dir(), PathBuf::from)
 }
 
-/// Return the Hew package-manager home directory (`~/.hew`).
+/// Return the Hew package-manager home directory.
+///
+/// `HEW_HOME` overrides the default `~/.hew` when set. This is the one
+/// choke point for package-manager state: config, the local registry cache,
+/// the index, signing keys, and credentials all resolve through this
+/// function rather than reading `HEW_HOME` themselves.
 #[must_use]
 pub fn hew_home() -> PathBuf {
-    home_dir().join(".hew")
+    std::env::var("HEW_HOME").map_or_else(|_| home_dir().join(".hew"), PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use super::hew_home;
+
+    // Serialize env-var–mutating tests: `std::env::set_var` / `remove_var`
+    // are not thread-safe when multiple tests share the same process.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn hew_home_honours_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("HEW_HOME", "/tmp/custom-hew-home");
+        let resolved = hew_home();
+        std::env::remove_var("HEW_HOME");
+        assert_eq!(resolved, PathBuf::from("/tmp/custom-hew-home"));
+    }
+
+    #[test]
+    fn hew_home_defaults_when_env_absent() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("HEW_HOME");
+        let resolved = hew_home();
+        assert!(resolved.ends_with(".hew"));
+    }
 }


### PR DESCRIPTION
## Why

`hew_home()` had no environment override, so nothing could redirect
package-manager state (config, the local registry cache, the index,
signing keys, credentials) for a hermetic test or an alternate machine
layout. `discover_registry()` likewise had no way to point the client at
anything but the compiled-in default, and `hew.toml` silently accepted
unknown fields in every table — an unquoted dotted key like
`hew.math.stats = "0.3"` under `[dev-dependencies]` parsed as a nested
TOML table and dropped the unrecognized field without a diagnostic.

## What

- `hew_home()` (`hew-pkg/src/paths.rs`) honours `HEW_HOME`, the one
  choke point every other package-manager path resolves through.
- `discover_registry()` (`hew-pkg/src/config.rs`) honours `HEW_REGISTRY`
  ahead of the compiled-in default for the primary registry endpoint.
- `hew env` (new `Command::Env`) prints the resolved `HEW_HOME`,
  `HEW_REGISTRY`, and `HEW_CC`, naming which fall back to their default.
- `HewManifest`, `Package`, `DepTable`, and `NativeLib` all gain
  `#[serde(deny_unknown_fields)]`. `DepSpec`'s `Deserialize` is hand-
  written rather than `#[serde(untagged)]`, because the derived untagged
  form buffers the input and discards each variant's own error on
  failure, which would otherwise mask `DepTable`'s new
  `deny_unknown_fields` message behind a generic "data did not match any
  variant" error.
- `DepTable::default_features` is now `#[serde(rename =
  "default-features")]`, the cargo-conventional spelling.

## Test

- `hew-pkg/src/paths.rs`: `hew_home_honours_env`,
  `hew_home_defaults_when_env_absent`.
- `hew-pkg/src/client.rs`: `client_honours_hew_registry_env` alongside
  the existing `client_default_url` pin.
- `hew-pkg/src/manifest.rs`: one negative-control parse test per struct
  gaining `deny_unknown_fields`
  (`dev_dependencies_typo_rejected_by_dep_table` reproduces the exact
  unquoted-dotted-key shape, `hew_manifest_rejects_unknown_top_level_field`,
  `package_rejects_unknown_field`, `native_lib_rejects_unknown_field`),
  plus `dep_table_accepts_hyphenated_default_features`.
- Swept all 32 `hew.toml` files under `ecosystem/`, `examples/`, and
  `hew/examples/` through the changed parser: only
  `examples/module_generic_boundaries/hew.toml` fails, and it was already
  broken before this change (missing the always-required `version`
  field, unrelated to `deny_unknown_fields`).
- `HEW_HOME=$PWD/.h hew env | grep -q "HEW_HOME=$PWD/.h"` verified
  against the built binary.
