### PR TITLE
feat(cli,pkg): scaffold hew new, fail closed on unknown packages, add --dry-run

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -100,6 +100,14 @@ pub enum Command {
     Fmt(FmtArgs),
     /// Scaffold a manifest-first project (`hew.toml` + starter source + merged `.gitignore`).
     Init(InitArgs),
+    /// Create a new manifest-first project directory and initialize it as a
+    /// git repository.
+    ///
+    /// Like `cargo new`: creates `<name>/`, scaffolds it exactly as `hew
+    /// init` would, and runs `git init` unless the new directory already
+    /// sits inside a repository. Use `hew init` to scaffold the current
+    /// directory in place without touching git.
+    New(NewArgs),
     /// Curated playground example tools.
     ///
     /// Superseded by `hew tool playground-verify`. Kept as a hidden alias so
@@ -890,6 +898,22 @@ pub struct FmtArgs {
 pub struct InitArgs {
     /// Project name (creates the directory if needed; omit to init the current directory).
     pub name: Option<String>,
+    /// Scaffold a library project (`<final-package-segment>.hew`).
+    #[arg(long, conflicts_with = "actor")]
+    pub lib: bool,
+    /// Scaffold an actor project.
+    #[arg(long)]
+    pub actor: bool,
+}
+
+// ---------------------------------------------------------------------------
+// New
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct NewArgs {
+    /// Project name; the new directory is created with this name.
+    pub name: String,
     /// Scaffold a library project (`<final-package-segment>.hew`).
     #[arg(long, conflicts_with = "actor")]
     pub lib: bool,

--- a/hew-cli/src/help.rs
+++ b/hew-cli/src/help.rs
@@ -42,7 +42,7 @@ const UNFILED_HEADING: &str = "Other";
 const COMMAND_GROUPS: &[(&str, &[&str])] = &[
     (
         "Build and run",
-        &["run", "build", "debug", "watch", "eval", "init"],
+        &["run", "build", "debug", "watch", "eval", "init", "new"],
     ),
     (
         "Code quality",

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -3077,6 +3077,53 @@ fn cmd_init(a: &args::InitArgs) {
     hew_pkg::cli::run_init(&project_dir, template);
 }
 
+/// `hew new <name>`: create `<name>/`, scaffold it exactly as `hew init`
+/// would (sharing `hew_pkg::cli::run_init`'s template table — no second
+/// scaffold writer), then `git init -q` unless the new directory already
+/// sits inside a repository. `hew init` never touches git; this is the only
+/// site that runs `git init`.
+fn cmd_new(a: &args::NewArgs) {
+    let project_dir = std::path::PathBuf::from(&a.name);
+    if let Err(e) = std::fs::create_dir_all(&project_dir) {
+        eprintln!(
+            "Error: cannot create directory '{}': {e}",
+            project_dir.display()
+        );
+        std::process::exit(1);
+    }
+
+    let template = if a.lib {
+        hew_pkg::manifest::ManifestTemplate::Lib
+    } else if a.actor {
+        hew_pkg::manifest::ManifestTemplate::Actor
+    } else {
+        hew_pkg::manifest::ManifestTemplate::Bin
+    };
+
+    hew_pkg::cli::run_init(&project_dir, template);
+
+    let already_in_repo = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(&project_dir)
+        .output()
+        .is_ok_and(|output| output.status.success());
+    if already_in_repo {
+        return;
+    }
+    match std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&project_dir)
+        .status()
+    {
+        Ok(status) if status.success() => {}
+        Ok(status) => eprintln!(
+            "hew new: warning: git init exited {} (skipping)",
+            status.code().unwrap_or(-1)
+        ),
+        Err(e) => eprintln!("hew new: warning: could not run git init: {e}"),
+    }
+}
+
 fn cmd_completions(a: &args::CompletionsArgs) {
     use clap::CommandFactory;
     use clap_complete::{generate, Shell};

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -19,6 +19,7 @@ pub(crate) trait CommandDispatcher {
     fn machine(&mut self, args: &args::MachineCommand);
     fn fmt(&mut self, args: &args::FmtArgs);
     fn init(&mut self, args: &args::InitArgs);
+    fn new_project(&mut self, args: &args::NewArgs);
     fn playground_verify(&mut self, args: &args::PlaygroundVerifyArgs);
     fn sir_coverage(&mut self, args: &args::SirCoverageArgs);
     fn completions(&mut self, args: &args::CompletionsArgs);
@@ -85,6 +86,10 @@ impl CommandDispatcher for MainCommandDispatcher {
         crate::cmd_init(args);
     }
 
+    fn new_project(&mut self, args: &args::NewArgs) {
+        crate::cmd_new(args);
+    }
+
     fn playground_verify(&mut self, args: &args::PlaygroundVerifyArgs) {
         crate::playground::cmd_playground_verify(args);
     }
@@ -148,6 +153,7 @@ pub(crate) fn dispatch_command(command: Option<&Command>, dispatcher: &mut impl 
         Some(Command::Machine(args)) => dispatcher.machine(args),
         Some(Command::Fmt(args)) => dispatcher.fmt(args),
         Some(Command::Init(args)) => dispatcher.init(args),
+        Some(Command::New(args)) => dispatcher.new_project(args),
         Some(Command::Playground(args)) => match &args.command {
             args::PlaygroundSubcommand::Verify(verify) => dispatcher.playground_verify(verify),
         },
@@ -559,6 +565,10 @@ mod tests {
 
         fn init(&mut self, _args: &crate::args::InitArgs) {
             self.calls.push("init".to_string());
+        }
+
+        fn new_project(&mut self, _args: &crate::args::NewArgs) {
+            self.calls.push("new".to_string());
         }
 
         fn playground_verify(&mut self, _args: &crate::args::PlaygroundVerifyArgs) {

--- a/hew-cli/tests/package_mode_e2e.rs
+++ b/hew-cli/tests/package_mode_e2e.rs
@@ -596,3 +596,139 @@ fn directory_reaching_the_compiler_gets_a_diagnostic() {
         describe_output(&output),
     );
 }
+
+/// `hew new <name>` creates the directory, scaffolds it like `hew init`,
+/// and — like `cargo new` — initializes a git repository of its own, since
+/// this fixture (a bare `tempfile::tempdir()`, unlike `workspace()`) sits
+/// outside any existing repository.
+#[test]
+fn hew_new_scaffolds_and_inits_git() {
+    let outside_any_repo = tempfile::tempdir().expect("temp dir outside the checkout");
+
+    let output = Command::new(hew_binary())
+        .args(["new", "svc"])
+        .current_dir(outside_any_repo.path())
+        .output()
+        .expect("run hew new");
+
+    assert!(
+        output.status.success(),
+        "hew new failed\n{}",
+        describe_output(&output),
+    );
+
+    let project_dir = outside_any_repo.path().join("svc");
+    assert!(
+        project_dir.join("hew.toml").exists(),
+        "hew new should scaffold hew.toml"
+    );
+    assert!(
+        project_dir.join("main.hew").exists(),
+        "hew new should scaffold main.hew"
+    );
+    assert!(
+        project_dir.join(".git").is_dir(),
+        "hew new should initialize a git repository of its own"
+    );
+    let gitignore = std::fs::read_to_string(project_dir.join(".gitignore")).unwrap();
+    assert!(
+        gitignore.lines().any(|l| l.trim() == "target/"),
+        "scaffold .gitignore should ignore target/:\n{gitignore}"
+    );
+}
+
+/// Negative control for the test above: `hew new` inside an existing
+/// repository must not nest a second `.git` (matching `cargo new`).
+#[test]
+fn hew_new_inside_a_repo_does_not_nest_git() {
+    let dir = workspace();
+
+    let output = Command::new(hew_binary())
+        .args(["new", "svc"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew new");
+
+    assert!(
+        output.status.success(),
+        "hew new failed\n{}",
+        describe_output(&output),
+    );
+    assert!(
+        !dir.path().join("svc").join(".git").exists(),
+        "hew new must not nest a repository inside an existing one"
+    );
+}
+
+/// `hew add` refuses an unknown package with exit 1 before writing the
+/// manifest — proven against a hermetic canned registry (a 404 for every
+/// package name), never the real default registry.
+#[test]
+fn hew_add_unknown_package_exits_1() {
+    let dir = workspace();
+    write_package(dir.path(), "consumer", "main.hew", "");
+
+    let port = support::http_canned::spawn_canned_response_server(
+        "404 Not Found",
+        r#"{"message":"package not found"}"#,
+    );
+    let manifest_before = std::fs::read_to_string(dir.path().join("hew.toml")).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["add", "hew.does.not.exist"])
+        .current_dir(dir.path())
+        // A fresh HEW_HOME keeps a developer's real ~/.hew/config.toml (a
+        // configured fallback-api, stored credentials) from leaking in.
+        .env("HEW_HOME", dir.path().join(".fresh-hew-home"))
+        .env("HEW_REGISTRY", format!("http://127.0.0.1:{port}"))
+        .output()
+        .expect("run hew add");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "an unknown package must exit 1\n{}",
+        describe_output(&output),
+    );
+    let manifest_after = std::fs::read_to_string(dir.path().join("hew.toml")).unwrap();
+    assert_eq!(
+        manifest_before, manifest_after,
+        "hew.toml must be unchanged when the package is refused"
+    );
+}
+
+/// `hew add --dry-run` prints the manifest change and writes nothing. Uses
+/// a local path dependency so the test doubles as proof of the invariant
+/// that local-path dependencies never contact a registry.
+#[test]
+fn hew_add_dry_run_writes_nothing() {
+    let dir = workspace();
+    write_package(dir.path(), "consumer", "main.hew", "");
+    let dep_dir = dir.path().join("localdep");
+    std::fs::create_dir_all(&dep_dir).expect("create dependency dir");
+    write_package(&dep_dir, "localdep", "localdep.hew", "");
+
+    let manifest_before = std::fs::read_to_string(dir.path().join("hew.toml")).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["add", "localdep", "--path", "localdep", "--dry-run"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew add --dry-run");
+
+    assert!(
+        output.status.success(),
+        "hew add --dry-run failed\n{}",
+        describe_output(&output),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Would add"),
+        "dry-run should report the change it would make:\n{stdout}"
+    );
+    let manifest_after = std::fs::read_to_string(dir.path().join("hew.toml")).unwrap();
+    assert_eq!(
+        manifest_before, manifest_after,
+        "hew add --dry-run must not write hew.toml"
+    );
+}

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -35,6 +35,9 @@ pub enum PkgCommand {
         /// Add a dependency from a local directory
         #[arg(long, value_name = "DIR", conflicts_with = "registry")]
         path: Option<PathBuf>,
+        /// Print the manifest change without writing hew.toml
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Install dependencies into .hew/packages/
     Install {
@@ -57,6 +60,9 @@ pub enum PkgCommand {
         /// remote registry
         #[arg(long, conflicts_with = "registry")]
         local: bool,
+        /// Build and validate the archive without uploading it
+        #[arg(long)]
+        dry_run: bool,
     },
     /// List packages in the local registry
     List,
@@ -226,7 +232,8 @@ pub fn dispatch(cmd: &PkgCommand) {
             version,
             registry: reg,
             path,
-        } => cmd_add(package, version, reg.as_deref(), path.as_deref()),
+            dry_run,
+        } => cmd_add(package, version, reg.as_deref(), path.as_deref(), *dry_run),
         PkgCommand::Install {
             locked,
             registry: reg,
@@ -235,7 +242,8 @@ pub fn dispatch(cmd: &PkgCommand) {
         PkgCommand::Publish {
             registry: reg,
             local,
-        } => cmd_publish(&registry, reg.as_deref(), *local),
+            dry_run,
+        } => cmd_publish(&registry, reg.as_deref(), *local, *dry_run),
         PkgCommand::List => cmd_list(&registry),
         PkgCommand::Search {
             query,
@@ -506,6 +514,34 @@ fn write_template_source(dir: &Path, name: &str, template: manifest::ManifestTem
             eprintln!("warning: could not create {filename}: {e}");
         }
     }
+    write_template_test(dir, &filename);
+}
+
+/// Write a starter `<stem>_test.hew` beside the scaffolded source file so
+/// `hew test` is green immediately after `hew new`/`hew init`, skip-if-exists
+/// like every other scaffold file.
+///
+/// Self-contained (asserts an arithmetic fact rather than calling into the
+/// sibling source file): the discovered test file is compiled as its own
+/// isolated program (`compile_test`, `hew-cli/src/test_runner/runner.rs`),
+/// and peer compilation — a test file calling functions declared in
+/// `main.hew` — is D17, tracked separately (V060-FD-6).
+fn write_template_test(dir: &Path, source_filename: &str) {
+    let Some(stem) = Path::new(source_filename)
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+    else {
+        return;
+    };
+    let test_filename = format!("{stem}_test.hew");
+    let test_path = dir.join(&test_filename);
+    if test_path.exists() {
+        return;
+    }
+    let content = "#[test]\nfn scaffold_test() {\n    assert(1 + 1 == 2);\n}\n";
+    if let Err(e) = std::fs::write(&test_path, content) {
+        eprintln!("warning: could not create {test_filename}: {e}");
+    }
 }
 
 /// Write a `.gitignore` with `target/` and `.hew/` entries.
@@ -548,16 +584,18 @@ fn ensure_gitignore_entry(dir: &Path, entry: &str) {
     }
 }
 
-fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>, dependency_path: Option<&Path>) {
+fn cmd_add(
+    pkg: &str,
+    version: &str,
+    registry_name: Option<&str>,
+    dependency_path: Option<&Path>,
+    dry_run: bool,
+) {
     if !is_valid_package_name(pkg) {
         eprintln!("hew add: {}", invalid_package_name_message(pkg));
         std::process::exit(1);
     }
 
-    // Validate the named registry exists (if specified) early.
-    if registry_name.is_some() {
-        let _ = make_client(registry_name);
-    }
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let manifest_path = cwd.join("hew.toml");
     if !manifest_path.exists() {
@@ -565,12 +603,25 @@ fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>, dependency_pat
         eprintln!("Run `hew init` to create one.");
         std::process::exit(1);
     }
-    let result = if let Some(path) = dependency_path {
+
+    // Local-path dependencies never contact a registry: the target's own
+    // hew.toml is the only source of truth for its package name.
+    if let Some(path) = dependency_path {
         let resolved = cwd.join(path);
         let dependency_manifest = resolved.join("hew.toml");
         match manifest::parse_manifest(&dependency_manifest) {
             Ok(dependency) if dependency.package.name == pkg => {
-                manifest::add_path_dependency(&manifest_path, pkg, version, path)
+                if dry_run {
+                    println!("Would add {pkg} from {} to hew.toml", resolved.display());
+                    return;
+                }
+                match manifest::add_path_dependency(&manifest_path, pkg, version, path) {
+                    Ok(()) => println!("Added {pkg} from {} to hew.toml", resolved.display()),
+                    Err(e) => {
+                        eprintln!("hew add: {e}");
+                        std::process::exit(1);
+                    }
+                }
             }
             Ok(dependency) => {
                 eprintln!(
@@ -588,14 +639,31 @@ fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>, dependency_pat
                 std::process::exit(1);
             }
         }
-    } else {
-        manifest::add_dependency(&manifest_path, pkg, version, registry_name)
-    };
-    match result {
-        Ok(()) if dependency_path.is_some() => println!(
-            "Added {pkg} from {} to hew.toml",
-            dependency_path.expect("checked path dependency").display()
-        ),
+        return;
+    }
+
+    // Registry dependency: refuse an unknown package (or an unreachable
+    // registry — fail closed rather than write a dependency nothing can
+    // ever resolve) before touching hew.toml.
+    let api_client = make_client(registry_name);
+    match api_client.get_package(pkg) {
+        Ok(entries) if !entries.is_empty() => {}
+        Ok(_) => {
+            eprintln!("hew add: package `{pkg}` not found in registry");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("hew add: {e}");
+            std::process::exit(1);
+        }
+    }
+
+    if dry_run {
+        println!("Would add {pkg}@{version} to hew.toml");
+        return;
+    }
+
+    match manifest::add_dependency(&manifest_path, pkg, version, registry_name) {
         Ok(()) => println!("Added {pkg}@{version} to hew.toml"),
         Err(e) => {
             eprintln!("hew add: {e}");
@@ -1563,7 +1631,12 @@ fn verify_registry_signature(
     clippy::too_many_lines,
     reason = "CLI command handler requires many steps"
 )]
-fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>, local: bool) {
+fn cmd_publish(
+    registry: &registry::Registry,
+    registry_name: Option<&str>,
+    local: bool,
+    dry_run: bool,
+) {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let manifest_path = cwd.join("hew.toml");
     if !manifest_path.exists() {
@@ -1622,9 +1695,9 @@ fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>, local
     };
 
     // Resolve the remote token up front, before packing, so a logged-out
-    // publish never packs a tarball it cannot use. `--local` never reads
-    // credentials at all.
-    let token = if local {
+    // publish never packs a tarball it cannot use. `--local` and
+    // `--dry-run` never read credentials: neither ever uploads.
+    let token = if local || dry_run {
         None
     } else {
         // Validate a named registry before touching credentials at all, so
@@ -1670,6 +1743,21 @@ fn cmd_publish(registry: &registry::Registry, registry_name: Option<&str>, local
     // Sign the checksum.
     let signature = keypair.sign(pack_result.checksum.as_bytes());
     let fingerprint = keypair.fingerprint();
+
+    // `--dry-run`: the archive is built and validated above (manifest
+    // fields, name, version, packing, checksum, signature); stop before
+    // either the `--local` copy or the remote upload — nothing is written.
+    if dry_run {
+        println!(
+            "Would publish {}@{} ({} bytes)",
+            m.package.name,
+            m.package.version,
+            pack_result.data.len()
+        );
+        println!("Checksum: {}", pack_result.checksum);
+        println!("Signature: {signature}");
+        return;
+    }
 
     // Build deps list for the index entry.
     let deps: Vec<index::IndexDep> = m
@@ -1843,11 +1931,46 @@ fn cmd_search(
     }
 }
 
+/// Print info for `package` from a non-empty set of registry index entries,
+/// picking the highest semver version. Shared by `cmd_info`'s named- and
+/// default-registry branches so the two print identically apart from the
+/// `source:` line.
+fn print_remote_package_info(
+    package: &str,
+    entries: Vec<index::IndexEntry>,
+    registry_name: Option<&str>,
+) {
+    let Some(latest) = entries.into_iter().max_by(|left, right| {
+        let left_version =
+            semver::Version::parse(&left.vers).unwrap_or_else(|_| semver::Version::new(0, 0, 0));
+        let right_version =
+            semver::Version::parse(&right.vers).unwrap_or_else(|_| semver::Version::new(0, 0, 0));
+        left_version.cmp(&right_version)
+    }) else {
+        eprintln!("hew info: package `{package}` not found in registry");
+        std::process::exit(1);
+    };
+    println!("{}@{}", latest.name, latest.vers);
+    match registry_name {
+        Some(name) => println!("  source: registry `{name}`"),
+        None => println!("  source: default registry"),
+    }
+    println!("  checksum: {}", latest.cksum);
+    if !latest.deps.is_empty() {
+        println!("  dependencies:");
+        for dep in latest.deps {
+            println!("    {} {}", dep.name, dep.req);
+        }
+    }
+}
+
 fn cmd_info(package: &str, registry: &registry::Registry, registry_name: Option<&str>) {
     if let Some(registry_name) = registry_name {
         let api_client = make_client(Some(registry_name));
-        let entries = match api_client.get_package(package) {
-            Ok(entries) if !entries.is_empty() => entries,
+        match api_client.get_package(package) {
+            Ok(entries) if !entries.is_empty() => {
+                print_remote_package_info(package, entries, Some(registry_name));
+            }
             Ok(_) => {
                 eprintln!("hew info: package `{package}` not found in registry `{registry_name}`");
                 std::process::exit(1);
@@ -1856,27 +1979,28 @@ fn cmd_info(package: &str, registry: &registry::Registry, registry_name: Option<
                 eprintln!("hew info: {e}");
                 std::process::exit(1);
             }
-        };
-        let Some(latest) = entries.into_iter().max_by(|left, right| {
-            let left_version = semver::Version::parse(&left.vers)
-                .unwrap_or_else(|_| semver::Version::new(0, 0, 0));
-            let right_version = semver::Version::parse(&right.vers)
-                .unwrap_or_else(|_| semver::Version::new(0, 0, 0));
-            left_version.cmp(&right_version)
-        }) else {
-            eprintln!("hew info: package `{package}` not found in registry `{registry_name}`");
-            std::process::exit(1);
-        };
-        println!("{}@{}", latest.name, latest.vers);
-        println!("  source: registry `{registry_name}`");
-        println!("  checksum: {}", latest.cksum);
-        if !latest.deps.is_empty() {
-            println!("  dependencies:");
-            for dep in latest.deps {
-                println!("    {} {}", dep.name, dep.req);
-            }
         }
         return;
+    }
+
+    // No `-r`: ask the default registry first, mirroring cmd_search's
+    // client-first shape, and fall back to the local cache only when the
+    // remote lookup itself fails (network, timeout, …) rather than
+    // treating "not found remotely" and "registry unreachable" alike.
+    let api_client = make_client(None);
+    match api_client.get_package(package) {
+        Ok(entries) if !entries.is_empty() => {
+            print_remote_package_info(package, entries, None);
+            return;
+        }
+        Ok(_) => {
+            // Not found on the default registry: fall through to the
+            // local cache below before giving up.
+        }
+        Err(e) => {
+            eprintln!("warning: remote lookup failed: {e}");
+            eprintln!("Falling back to local cache.");
+        }
     }
 
     let packages = registry.list_packages();

--- a/hew-pkg/src/cli.rs
+++ b/hew-pkg/src/cli.rs
@@ -612,11 +612,11 @@ fn cmd_add(
         match manifest::parse_manifest(&dependency_manifest) {
             Ok(dependency) if dependency.package.name == pkg => {
                 if dry_run {
-                    println!("Would add {pkg} from {} to hew.toml", resolved.display());
+                    println!("Would add {pkg} from {} to hew.toml", path.display());
                     return;
                 }
                 match manifest::add_path_dependency(&manifest_path, pkg, version, path) {
-                    Ok(()) => println!("Added {pkg} from {} to hew.toml", resolved.display()),
+                    Ok(()) => println!("Added {pkg} from {} to hew.toml", path.display()),
                     Err(e) => {
                         eprintln!("hew add: {e}");
                         std::process::exit(1);

--- a/scripts/journeys-expected.tsv
+++ b/scripts/journeys-expected.tsv
@@ -18,48 +18,50 @@
 # two as stale rows even though nothing regressed. Tracked as #3297:
 # the gate should be green in its default configuration either way.
 #
-# day-one: hew new/--actor/--lib do not exist yet (V060-FD-5), so every
-# step downstream of scaffolding a package fails too.
-day-one.1	V060-FD-5	hew new: unrecognized subcommand
-day-one.2	V060-FD-5	hew new does not exist; scaffold ships no test file
-day-one.3	V060-FD-5	hew new does not exist; no repository to check
-day-one.4	V060-FD-5	hew new does not exist; no .gitignore to check
-day-one.5	V060-FD-5	hew new does not exist; hew run finds no hew.toml
-day-one.6	V060-FD-5	hew new does not exist; hew test finds no test files
-day-one.7	V060-FD-5	hew new does not exist; hew build finds no hew.toml
-day-one.8	V060-FD-5	hew new does not exist; no target/release/svc artefact
-day-one.9	V060-FD-5	hew new does not exist; no release binary to run
-day-one.11	V060-FD-5	hew new --actor: unrecognized subcommand
-day-one.12	V060-FD-5	hew new --actor does not exist; actor scaffold never created
-day-one.13	V060-FD-5	hew new --lib: unrecognized subcommand
-day-one.14	V060-FD-5	hew new --lib does not exist; lib scaffold never created
+# day-one: hew new/--actor/--lib scaffold and test green (V060-FD-5);
+# build's target/ layout (day-one.7-9, ground item 3) is a separate,
+# undispatched gap the day-one.1-6/11-14 fix did not touch.
+day-one.7	V060-FD-5	build does not write target/release/svc: default_binary_path has no target/ component (ground item 3, undispatched)
+day-one.8	V060-FD-5	no target/release/svc artefact (cascades from day-one.7)
+day-one.9	V060-FD-5	no release binary to run (cascades from day-one.7)
+day-one.16	V060-FD-4	let mut error text says "rename this binding", not "var x"
+day-one.17	V060-FD-4	let mut is a three-error cascade, not one error
+day-one.20	V060-FD-4	module-not-found JSON carries a zero span (start_line: 0)
+day-one.21	V060-FD-4	module-not-found JSON carries no nearest-module suggestion
 day-one.22	V060-FD-3	HEW_CC has no reader in the compiler (grep -rn HEW_CC --include=*.rs is empty); the env var is silently ignored and build falls through to system cc, exit 0
 day-one.23	V060-FD-3	HEW_CC unimplemented (see day-one.22): no error output naming the bad path
 day-one.24	V060-FD-3	HEW_CC unimplemented (see day-one.22): no error output naming a package to install
 #
 # day-two: trap symbolization (V060-FD-7) is unimplemented; hew new
-# (V060-FD-5) cascades through the whole dependency/build/deploy chain
-# once app/ is never created.
+# (V060-FD-5) itself is green (step 8) but the dependency chain past it
+# (search/add/install/info) still needs a reachable registry - day-two.12,
+# day-two.16, day-two.17, day-two.20 pass on a dev machine with a local
+# hew-registry checkout (empty seed data still resolves each step's own
+# check, e.g. install has nothing to fetch) but fail closed in CI, where
+# no registry is reachable; #3297 tracks making the gate agree either way,
+# do not delete those four rows from a dev-machine run. Two -o-in-file-mode
+# bugs are V060-FD-2.
 day-two.3	V060-FD-7	trap message has no crash.hew:2 file:line
 day-two.4	V060-FD-7	trap message does not name the function (boom)
 day-two.5	V060-FD-7	HEW_BACKTRACE=1 output has no caller frame line
 day-two.7	V060-FD-7	release-build trap has no file:line either
-day-two.8	V060-FD-5	hew new: unrecognized subcommand
-day-two.9	V060-FD-5	search prints hew::math::stats, not the dotted hew.math.stats that add accepts
-day-two.10	V060-FD-5	hew new never created app/; add runs with no hew.toml
-day-two.11	V060-FD-5	cascades from day-two.8/10: no hew.toml to write the dependency into
-day-two.12	V060-FD-5	no local registry (registry-harness.sh exit 75): unknown-package refusal never attempted
-day-two.15	V060-FD-5	cascades from day-two.8: hew.toml never had a [package] table to append to
-day-two.16	V060-FD-5	cascades from day-two.8/15: install has no valid manifest to read
-day-two.17	V060-FD-5	cascades: no hew.lock without a working install
+day-two.9	V060-FD-5	search prints hew::math::stats, not the dotted hew.math.stats that add accepts (or no registry reachable)
+day-two.10	V060-FD-5	add resolves against the registry: no registry reachable, or the package is not seeded there
+day-two.11	V060-FD-5	cascades from day-two.10: no hew.toml to write the dependency into
+day-two.12	V060-FD-5	no local registry (registry-harness.sh exit 75): unknown-package refusal never attempted (#3297: passes on a dev machine with an empty local registry)
+day-two.15	V060-FD-5	deny_unknown_fields rejects the unquoted dotted key (exit 1, day-two.14) but its generic "unknown field" message does not name the quoted `"hew.math.stats"` form the journey expects
+day-two.16	V060-FD-5	cascades from day-two.10: install has no dependency to fetch (#3297: passes on a dev machine with an empty local registry)
+day-two.17	V060-FD-5	cascades: no hew.lock without a working install (#3297: passes on a dev machine with an empty local registry)
 day-two.18	V060-FD-5	cascades: main.hew never compiles without the dependency installed
 day-two.19	V060-FD-5	cascades: tests never compile without the dependency installed
-day-two.20	V060-FD-5	no local registry (registry-harness.sh exit 75): info not-found never attempted
+day-two.20	V060-FD-5	no local registry (registry-harness.sh exit 75): info not-found never attempted (#3297: passes on a dev machine with an empty local registry)
 day-two.22	V060-SURFACE	.Err(AErr.Bad)/.Ok(()) construction refused: "no variant Err/Ok" on Result<(), AErr> (D3 bare-variant expression construction, unshipped; owning S-lane not yet assigned)
-day-two.23	V060-FD-5	cascades from day-two.8: build has no [package] table
-day-two.25	V060-FD-5	cascades from day-two.8: cross-object emission has no [package] table
-day-two.26	V060-FD-5	cascades from day-two.8: app-aarch64.o never written
-day-two.28	V060-FD-5	cascades from day-two.8: app-aarch64.o never written
+day-two.23	V060-FD-5	cascades from day-two.10: build has no dependency to compile against
+day-two.25	V060-FD-5	cascades from day-two.10: cross-object emission has no dependency to compile against
+day-two.26	V060-FD-5	cascades from day-two.10: app-aarch64.o never written
+day-two.28	V060-FD-5	cascades from day-two.10: app-aarch64.o never written
+day-two.30	V060-FD-2	file-mode --emit-obj -o obj-aarch64.o did not write the named file
+day-two.31	V060-FD-2	file-mode --emit-obj wrote obj.o instead of honouring -o
 #
 # week-one-local: the decided-dialect program does not run today by design
 # (hew-platform-program.md §0.1: it is fable4/probes/local_svc.hew rewritten


### PR DESCRIPTION
## Why

We need the FD-5 package front door to create projects, validate package additions before changing manifests, inspect package information, and preview package changes safely.

## What

- We add `hew new`, which scaffolds a project and initializes Git unless it is already inside a repository.
- We validate registry packages before `hew add` writes the manifest, while local paths remain registry-free and preserve their supplied spelling.
- We query the default registry for `hew info` and add `--dry-run` to `add` and `publish`.
- We keep generated scaffold tests self-contained and group every visible command in help.

## Test

- `hew_new_scaffolds_and_inits_git`, `hew_add_unknown_package_exits_1`, and `hew_add_dry_run_writes_nothing`.
- `help::tests::every_visible_command_is_filed_under_exactly_one_group`.
- `init_lib_path_dependency_first_run_and_locked_offline_reuse` and `dotted_init_lib_path_dependency_first_run_and_locked_offline_reuse`.
