### PR TITLE
fix(mir): preserve ownership through compiled value flow

### DIFF
--- a/hew-mir/src/lower/assign.rs
+++ b/hew-mir/src/lower/assign.rs
@@ -133,6 +133,13 @@ impl Builder {
             }
         }
         let copy_in = self.assign_target_stays_copy_in(target, value);
+        let binding_target_place = match &target.kind {
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(binding),
+                ..
+            } => self.binding_locals.get(binding).copied(),
+            _ => None,
+        };
         // A Vec index assignment that MOVES a bound local (`v[i] = h`, routed
         // to `hew_vec_set_owned_move` below) hands the value to the runtime
         // only on the call's normal edge, after the bounds check lowered in
@@ -421,11 +428,23 @@ impl Builder {
                 name,
                 ..
             } => {
-                if let Some(dest) = self.binding_locals.get(binding).copied() {
+                if let Some(dest) = binding_target_place {
+                    self.binding_locals.insert(*binding, dest);
                     let mut cursor_owner_handoff = false;
                     let cursor_flag = self.vec_iter_drop_flags.get(binding).copied();
+                    let affine_release_flag = self.affine_release_flags.get(binding).copied();
                     let cursor_value_flag =
                         self.vec_iter_value_drop_flags.get(&value.site).copied();
+                    let receiver_identity_already_adopted = self
+                        .param_ownership
+                        .produced_value_facts
+                        .get(&value.site)
+                        .is_some_and(|fact| {
+                            matches!(
+                                fact.ownership,
+                                hew_types::ProducedValueOwnership::ReceiverIdentity
+                            )
+                        });
                     // #2420 -- the overwrite release below is sound ONLY when
                     // the incoming value cannot alias the outgoing value's
                     // heap. An RHS that reads the reassigned binding (`s =
@@ -441,7 +460,8 @@ impl Builder {
                     // posture for this aliasing channel. WHEN-OBSOLETE: the
                     // COW retain-on-share
                     // spine (every share retained => release always sound).
-                    let rhs_may_alias_old = self.reassign_rhs_may_alias_binding(value, *binding);
+                    let rhs_may_alias_old = self.reassign_rhs_may_alias_binding(value, *binding)
+                        || receiver_identity_already_adopted;
                     // #53 / #2301: release the prior heap-owning value before
                     // the slot is overwritten.
                     if let Some(flag) = cursor_flag {
@@ -477,7 +497,7 @@ impl Builder {
                                 &target.ty,
                             );
                         }
-                    } else if let Some(flag) = self.affine_release_flags.get(binding).copied() {
+                    } else if let Some(flag) = affine_release_flag {
                         // A `var` reassignment is a GENERATION BOUNDARY for an
                         // affine refcounted handle (`Rc` / `Weak`) or a user
                         // `#[resource]`. Two obligations meet here, and the
@@ -610,18 +630,7 @@ impl Builder {
                     // adopted the RHS temp, retire that exact source-place owner
                     // now; the destination binding remains the sole authority
                     // whose drop plan fans out across exits.
-                    let receiver_identity_already_adopted = src == dest
-                        && self
-                            .param_ownership
-                            .produced_value_facts
-                            .get(&value.site)
-                            .is_some_and(|fact| {
-                                matches!(
-                                    fact.ownership,
-                                    hew_types::ProducedValueOwnership::ReceiverIdentity
-                                )
-                            });
-                    if !cursor_owner_handoff && !receiver_identity_already_adopted {
+                    if !cursor_owner_handoff {
                         self.retire_provisional_owner_after_assignment_move(
                             *binding, dest, &target.ty, src, &value.ty,
                         );

--- a/hew-mir/src/lower/assign.rs
+++ b/hew-mir/src/lower/assign.rs
@@ -610,7 +610,18 @@ impl Builder {
                     // adopted the RHS temp, retire that exact source-place owner
                     // now; the destination binding remains the sole authority
                     // whose drop plan fans out across exits.
-                    if !cursor_owner_handoff {
+                    let receiver_identity_already_adopted = src == dest
+                        && self
+                            .param_ownership
+                            .produced_value_facts
+                            .get(&value.site)
+                            .is_some_and(|fact| {
+                                matches!(
+                                    fact.ownership,
+                                    hew_types::ProducedValueOwnership::ReceiverIdentity
+                                )
+                            });
+                    if !cursor_owner_handoff && !receiver_identity_already_adopted {
                         self.retire_provisional_owner_after_assignment_move(
                             *binding, dest, &target.ty, src, &value.ty,
                         );

--- a/hew-mir/src/lower/mod.rs
+++ b/hew-mir/src/lower/mod.rs
@@ -7777,13 +7777,15 @@ fn splice_normal_call_ownership_commits(blocks: &mut [BasicBlock], builder: &mut
             DischargeSite::CallArgumentTransfer,
         );
     }
+}
 
-    // A consuming receiver is discharged only if its call returns normally.
-    // Lowering records the typed `Discharge` use but deliberately leaves the
-    // OwnerId and guard untouched before the invoke so the unwind plan can
-    // still destroy it. Resolve the exact live generation from MIR state at
-    // the call, then commit the close in its normal successor. This is the
-    // receiver sibling of the ProvenConsume argument protocol above.
+/// A consuming receiver is discharged only if its call returns normally.
+/// Lowering records the typed `Discharge` use but deliberately leaves the
+/// `OwnerId` and guard untouched before the invoke so the unwind plan can still
+/// destroy it. Resolve the exact live generation from MIR state at the call,
+/// then commit the close in its normal successor. This runs after the first
+/// ownership-phi seal so a loop-carried receiver resolves to its joined owner.
+fn splice_normal_receiver_discharge_commits(blocks: &mut [BasicBlock], builder: &mut Builder) {
     let exact_states = drop_plan::exact_owner_states(blocks);
     let owner_exits = &exact_states.1;
     let guards = blocks
@@ -8491,6 +8493,7 @@ fn prepare_body_transfers(blocks: &mut Vec<BasicBlock>, builder: &mut Builder) {
     // consume. The pass runs again after all late operations to seal any new
     // joins they introduce.
     materialize_exact_owner_join_transfers(&mut *blocks, builder);
+    splice_normal_receiver_discharge_commits(&mut *blocks, builder);
     let resolved_outbound =
         resolve_outbound_actor_modes(&mut *blocks, builder, &projection_tainted);
     prepare_outbound_actor_payloads(

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -2515,12 +2515,10 @@ impl Checker {
                         fact: ProducedValueFact {
                             ownership: if non_owning {
                                 crate::runtime_call::ProducedValueOwnership::NoOwner
-                            } else if matches!(&resolved_result_ty, Ty::String) {
+                            } else {
                                 crate::runtime_call::ProducedValueOwnership::owned(
                                     crate::runtime_call::ProducedValueAcquisition::Delivery,
                                 )
-                            } else {
-                                crate::runtime_call::ProducedValueOwnership::Unknown
                             },
                             receiver_span: None,
                             receiver_boundary: None,

--- a/tests/hew/call_scrutinee_indirect_ownership_test.hew
+++ b/tests/hew/call_scrutinee_indirect_ownership_test.hew
@@ -15,7 +15,24 @@ fn inspect() -> i64 {
     }
 }
 
+fn identity(value: i64) -> i64 {
+    value
+}
+
+fn inspect_nonowning() -> i64 {
+    let f = identity;
+    match f(7) {
+        7 => 1,
+        _ => 0,
+    }
+}
+
 #[test]
 fn indirect_owned_result_call_scrutinee_preserves_payload() {
     testing.assert_eq(inspect(), 7);
+}
+
+#[test]
+fn indirect_nonowning_result_call_scrutinee_preserves_scalar() {
+    testing.assert_eq(inspect_nonowning(), 1);
 }

--- a/tests/hew/json_value_loop_reassign_test.hew
+++ b/tests/hew/json_value_loop_reassign_test.hew
@@ -15,7 +15,19 @@ fn rendered_count() -> string {
     rendered
 }
 
+fn rendered_without_reassignment() -> string {
+    let values = json.array();
+    let rendered = values.stringify();
+    values.close();
+    rendered
+}
+
 #[test]
 fn reassigns_json_resource_builder_in_loop() {
     testing.assert_eq_str(rendered_count(), "[0,1,2]");
+}
+
+#[test]
+fn nonreassigned_json_resource_builder_preserves_payload() {
+    testing.assert_eq_str(rendered_without_reassignment(), "[]");
 }


### PR DESCRIPTION
## Why

Current main rejects two valid compiled Hew programs: reassigning a resource-backed JSON builder from its consuming receiver result loses loop-carried ownership, and matching an owned result returned through an indirect callable lacks produced-value ownership.

## What

- **types**: classify non-copy indirect callable results as delivered owners, replacing the string-only result special case.
- **MIR assignment**: preserve the destination place across RHS lowering, treat receiver identity as an alias of the consumed value, and use the existing assignment adoption path to publish the destination generation.
- **MIR discharge**: resolve consuming receiver commits after ownership phis are sealed so loop-carried resources close exactly once.
- **tests**: add non-reassigned resource and non-owning indirect-result controls beside the two regression cases.

## Test

- `hew test tests/hew/json_value_loop_reassign_test.hew --filter reassigns_json_resource_builder_in_loop`
- `hew test tests/hew/call_scrutinee_indirect_ownership_test.hew --filter indirect_owned_result_call_scrutinee_preserves_payload`
- `hew test tests/hew/json_value_loop_reassign_test.hew --filter nonreassigned_json_resource_builder_preserves_payload`
- `hew test tests/hew/call_scrutinee_indirect_ownership_test.hew --filter indirect_nonowning_result_call_scrutinee_preserves_scalar`
- `make test-ownership-balance-corpus`
- `cargo clippy -p hew-types -p hew-mir --tests --message-format=json -- -D warnings`