### PR TITLE
refactor(stdlib): adopt Result-only core APIs

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -826,11 +826,12 @@ import std.os;
 
 // Pattern 2: check args, exit non-zero on error
 fn main() -> i32 {
-    if os.args_count() < 2 {
+    let arguments = os.args();
+    if arguments.len() < 2 {
         println("usage: prog <arg>");
         return 1;
     }
-    println(f"arg: {os.args(1)}");
+    println(f"arg: {arguments.get(1)}");
     0
 }
 ```

--- a/docs/observe.md
+++ b/docs/observe.md
@@ -14,7 +14,7 @@ There are three primary metric APIs in `std::observe`:
 ```hew
 import std.observe;
 
-observe.read("heap.live_bytes"); // i64
+observe.read("heap.live_bytes"); // Option<i64>
 observe.series();                 // string
 observe.scrape();                 // string
 ```
@@ -28,20 +28,20 @@ HEW_OBSERVE=hot hew eval --timeout 30 -f observe_demo.hew
 
 ## Hew API
 
-### `observe.read(name: string) -> i64`
+### `observe.read(name: string) -> Option<i64>`
 
 Reads one scalar metric by its canonical dotted name and returns its current
-value as an `i64`.
+value as `Option<i64>`.
 
 ```hew
 import std.observe;
 
-println(observe.read("heap.live_bytes"));
-println(observe.read("actors.turns_total"));
-println(observe.read("does.not.exist")); // -1
+println(observe.read("heap.live_bytes").unwrap_or(0));
+println(observe.read("actors.turns_total").unwrap_or(0));
+println(observe.read("does.not.exist")); // None
 ```
 
-Unknown names return `-1`. Runtime `u64` values are converted to `i64`; values
+Unknown names return `None`. Runtime `u64` values are converted to `i64`; values
 larger than `i64::MAX` saturate at `i64::MAX`.
 
 `read` only addresses scalar metrics. Labelled actor-attribution series are
@@ -114,7 +114,7 @@ let total = await counter.total();
 let _barrier = observe.barrier();
 
 println(total);
-println(observe.read("actors.turns_total"));
+println(observe.read("actors.turns_total").unwrap_or(0));
 println(observe.series());
 observe.scrape()
 ```
@@ -135,10 +135,11 @@ Expected useful output includes:
 
 `observe.barrier()` is a current synchronization helper, not a metric API. It
 waits until actor dispatches that started before the call have reached their
-observe-attribution point. It returns `0` on success, `-1` when called from
-inside an actor dispatch, and `-2` if the native runtime's bounded 30-second wait
-expires. In WASM it is currently a no-op success because the WASM scheduler does
-not have the native attribution probe path.
+observe-attribution point and returns `Result<(), ObserveError>`. It returns
+`ObserveError.ActorTurn` inside an actor dispatch and `ObserveError.TimedOut`
+when the native runtime's bounded 30-second wait expires. In WASM it is
+currently a no-op success because the WASM scheduler does not have the native
+attribution probe path.
 
 ## Metrics surface
 

--- a/examples/chat_client.hew
+++ b/examples/chat_client.hew
@@ -54,12 +54,12 @@ actor ChatReader {
 fn main() {
     var port: string = "9000";
     var name: string = "guest";
-    let argc = os.args_count();
+    let argc = os.args().len();
     if argc > 1 {
-        port = os.args(1);
+        port = os.args().get(1);
     }
     if argc > 2 {
-        name = os.args(2);
+        name = os.args().get(2);
     }
     let addr = f"127.0.0.1:{port}";
     let connect_timeout_sec: i64 = 5;

--- a/examples/chat_server.hew
+++ b/examples/chat_server.hew
@@ -97,9 +97,9 @@ actor ClientHandler {
 
 fn main() {
     var port: string = "9000";
-    let argc = os.args_count();
+    let argc = os.args().len();
     if argc > 1 {
-        port = os.args(1);
+        port = os.args().get(1);
     }
     let addr = f"0.0.0.0:{port}";
     let listener = match net.try_listen(addr) {

--- a/examples/cli_argparse.hew
+++ b/examples/cli_argparse.hew
@@ -49,7 +49,7 @@ fn print_positional(positional: Vec<string>) {
 }
 
 fn main() {
-    let argc = os.args_count();
+    let argc = os.args().len();
     // No arguments: print usage
     if argc <= 1 {
         println("No arguments provided.");
@@ -63,7 +63,7 @@ fn main() {
     var show_help = 0;
     // Parse arguments (skip argv[0] which is the program name)
     for i in 1 .. argc {
-        let arg = os.args(i);
+        let arg = os.args().get(i);
         if arg.starts_with("--") {
             // Long option: check for "=" to distinguish flag from key=value
             let eq_pos = arg.find("=");

--- a/examples/curl_client.hew
+++ b/examples/curl_client.hew
@@ -79,12 +79,12 @@ fn main() {
     // Parse arguments
     var url = "http://example.com";
     var outfile = "";
-    let argc = os.args_count();
+    let argc = os.args().len();
     if argc > 1 {
-        url = os.args(1);
+        url = os.args().get(1);
     }
     if argc > 2 {
-        outfile = os.args(2);
+        outfile = os.args().get(2);
     }
     let host = parse_host(url);
     let port = parse_port(url);

--- a/examples/distributed/kv_client.hew
+++ b/examples/distributed/kv_client.hew
@@ -44,11 +44,11 @@ impl ActorMsg for KeyValue {
 fn main() -> i64 {
     var port: string = "9100";
     var server_addr: string = "127.0.0.1";
-    if os.args_count() > 1 {
-        server_addr = os.args(1);
+    if os.args().len() > 1 {
+        server_addr = os.args().get(1);
     }
-    if os.args_count() > 2 {
-        port = os.args(2);
+    if os.args().len() > 2 {
+        port = os.args().get(2);
     }
     let remote_addr = f"{server_addr}:{port}";
     println(f"[kv-client] starting node, will connect to {remote_addr}");

--- a/examples/distributed/kv_server.hew
+++ b/examples/distributed/kv_server.hew
@@ -57,8 +57,8 @@ impl ActorMsg for KeyValue {
 
 fn main() {
     var port: string = "9100";
-    if os.args_count() > 1 {
-        port = os.args(1);
+    if os.args().len() > 1 {
+        port = os.args().get(1);
     }
     let addr = f"0.0.0.0:{port}";
     println(f"[kv-server] starting on {addr}");

--- a/examples/grep/grep.hew
+++ b/examples/grep/grep.hew
@@ -49,7 +49,7 @@ type MatchState {
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
 fn parse_args() -> Result<Config, string> {
-    let argc = os.args_count();
+    let argc = os.args().len();
     if argc < 2 {
         return Result.Err("usage: grep [FLAGS] PATTERN [FILE...]");
     }
@@ -63,7 +63,7 @@ fn parse_args() -> Result<Config, string> {
     let files: Vec<string> = Vec.new();
     var i = 1;
     while i < argc {
-        let arg = os.args(i);
+        let arg = os.args().get(i);
         if !pattern_set && arg.starts_with("-") && arg.len() > 1 {
             // Treat each character after '-' as an individual flag.
             // "--" ends flag parsing (next arg is the pattern).
@@ -72,7 +72,7 @@ fn parse_args() -> Result<Config, string> {
                 if i >= argc {
                     return Result.Err("grep: missing pattern after --");
                 }
-                pattern = os.args(i);
+                pattern = os.args().get(i);
                 pattern_set = true;
                 i = i + 1;
                 continue;

--- a/examples/grep/grep.hew
+++ b/examples/grep/grep.hew
@@ -166,7 +166,7 @@ fn grep_file(file_path: string, pat: regex.Pattern, cfg: Config, show_label: boo
     } else {
         ""
     };
-    let result = fs.try_read(file_path);
+    let result = fs.read(file_path);
     match result {
         .Err(e) => {
             let msg = to_string(e);
@@ -193,7 +193,7 @@ fn grep_file(file_path: string, pat: regex.Pattern, cfg: Config, show_label: boo
 // GAP: no fs.walk_dir; we implement recursive descent via fs.list_dir + fs.is_dir.
 // Returns updated MatchState (structs are value-semantic; callers must reassign).
 fn grep_dir(dir_path: string, pat: regex.Pattern, cfg: Config, state: MatchState) -> MatchState {
-    let entries_result = fs.try_list_dir(dir_path);
+    let entries_result = fs.list_dir(dir_path);
     match entries_result {
         .Err(e) => {
             let msg = to_string(e);

--- a/examples/hew-orch/main.hew
+++ b/examples/hew-orch/main.hew
@@ -128,8 +128,8 @@ fn ingest_file(path: string, index: HashMap<string, i32>) {
 // main
 //
 // CLI surface: `hew run examples/hew-orch/main.hew -- <dir>`.
-// `os.args(i)` returns `string` (dialect authority §1 stdlib survey),
-// `os.args_count() -> i64`. A247 #11's preferred `os.args() -> Vec<string>`
+// `os.args().get(i)` returns `string` (dialect authority §1 stdlib survey),
+// `os.args().len() -> i64`. A247 #11's preferred `os.args() -> Vec<string>`
 // surface does not exist today; rather than fabricate it, we accept the
 // current surface and default to `.tmp/orchestration` when no arg is given.
 fn main() {

--- a/examples/hew_grep.hew
+++ b/examples/hew_grep.hew
@@ -46,16 +46,16 @@ fn search_file(filename: string, pattern: string, nl: string) -> i32 {
 }
 
 fn main() -> i32 {
-    let argc = os.args_count();
+    let argc = os.args().len();
     if argc < 3 {
         println("Usage: hew_grep <pattern> <file1> [file2...]");
         return 1;
     }
     let nl = string.from_char(10);
-    let pattern = os.args(1);
+    let pattern = os.args().get(1);
     var total_matches = 0;
     for fi in 2 .. argc {
-        let filename = os.args(fi);
+        let filename = os.args().get(fi);
         let count = search_file(filename, pattern, nl);
         total_matches = total_matches + count;
     }

--- a/examples/http_server.hew
+++ b/examples/http_server.hew
@@ -54,12 +54,12 @@ fn serve_request(root: string, req: Request) {
 fn main() {
     var port: string = "8080";
     var root: string = ".";
-    let argc = os.args_count();
+    let argc = os.args().len();
     if argc > 1 {
-        port = os.args(1);
+        port = os.args().get(1);
     }
     if argc > 2 {
-        root = os.args(2);
+        root = os.args().get(2);
     }
     let addr = f"0.0.0.0:{port}";
     println("=== Hew HTTP Static File Server ===");

--- a/examples/mqtt_broker.hew
+++ b/examples/mqtt_broker.hew
@@ -652,8 +652,8 @@ actor Acceptor {
 
 fn main() {
     var port = "1883";
-    if os.args_count() > 1 {
-        port = os.args(1);
+    if os.args().len() > 1 {
+        port = os.args().get(1);
     }
     let addr = f"127.0.0.1:{port}";
     let empty_sessions: Vec<string> = Vec.new();

--- a/examples/network_file_reader.hew
+++ b/examples/network_file_reader.hew
@@ -31,7 +31,7 @@ fn main() {
     // `try_read` keeps an input-path failure in the program's control flow.
     // The successful contents are printed unchanged, preserving the simple
     // stdout stream used by this example.
-    match fs.try_read(path) {
+    match fs.read(path) {
         .Ok(contents) => print(contents),
         .Err(error) => println(f"Could not read `{path}`: {error}"),
     }

--- a/examples/network_file_reader.hew
+++ b/examples/network_file_reader.hew
@@ -23,8 +23,8 @@ import std.os;
 
 fn main() {
     println("=== File Reader + Actor Pipeline ===");
-    let path = if os.args_count() > 1 {
-        os.args(1)
+    let path = if os.args().len() > 1 {
+        os.args().get(1)
     } else {
         "examples/test_input.txt"
     };

--- a/examples/quic_service/client.hew
+++ b/examples/quic_service/client.hew
@@ -28,7 +28,7 @@ fn assert_ok(result: Result<(), net.NetError>) {
 fn service_port() -> string {
     var port = "4433";
     if os.has_env("HEW_QUIC_SERVICE_PORT") {
-        port = os.env("HEW_QUIC_SERVICE_PORT");
+        port = os.env("HEW_QUIC_SERVICE_PORT").unwrap_or("");
     }
     port
 }

--- a/examples/quic_service/server.hew
+++ b/examples/quic_service/server.hew
@@ -31,7 +31,7 @@ fn assert_ok(result: Result<(), net.NetError>) {
 fn service_port() -> string {
     var port = "4433";
     if os.has_env("HEW_QUIC_SERVICE_PORT") {
-        port = os.env("HEW_QUIC_SERVICE_PORT");
+        port = os.env("HEW_QUIC_SERVICE_PORT").unwrap_or("");
     }
     port
 }

--- a/examples/static_server.hew
+++ b/examples/static_server.hew
@@ -61,12 +61,12 @@ fn serve_request(root: string, req: Request) {
 fn main() {
     var port = "8080";
     var root = ".";
-    let argc = os.args_count();
+    let argc = os.args().len();
     if argc > 1 {
-        port = os.args(1);
+        port = os.args().get(1);
     }
     if argc > 2 {
-        root = os.args(2);
+        root = os.args().get(2);
     }
     let addr = f"0.0.0.0:{port}";
     println(f"Serving {root} on http://{addr}");

--- a/hew-cli/tests/actor_resource_opaque_state.rs
+++ b/hew-cli/tests/actor_resource_opaque_state.rs
@@ -34,7 +34,7 @@ type Dq {{}}
 impl Dq {{
     fn close(self) {{
         unsafe {{ hew_deque_free(self) }};
-        match fs.try_append("{marker_literal}", "closed\n") {{
+        match fs.append("{marker_literal}", "closed\n") {{
             .Ok(_) => {{}},
             .Err(_) => panic("append close marker"),
         }}
@@ -111,7 +111,7 @@ type {type_name} {{}}
 impl {type_name} {{
     fn close(self) {{
         unsafe {{ hew_deque_free(self) }};
-        match fs.try_append("{marker_literal}", "closed\n") {{
+        match fs.append("{marker_literal}", "closed\n") {{
             .Ok(_) => {{}},
             .Err(_) => panic("append close marker"),
         }}
@@ -186,7 +186,7 @@ pub type UserReceiver {{}}
 impl UserReceiver {{
     fn close(self) {{
         unsafe {{ hew_deque_free(self) }};
-        match fs.try_append("{marker_literal}", "closed\n") {{
+        match fs.append("{marker_literal}", "closed\n") {{
             .Ok(_) => {{}},
             .Err(_) => panic("append close marker"),
         }}

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -893,7 +893,7 @@ fn stage_peer_credentials(kx: string, my_role: string, peer_role: string, peer_r
     let me = Node.identity_key();
     publish_atomic(kx, f"{my_role}.pub", me);
     let peer_key = wait_for_file(f"{kx}/{peer_role}.pub");
-    let configured_peer_key = if os.env("HEW_DIST_BAD_PEER_PIN") == "1" {
+    let configured_peer_key = if os.env("HEW_DIST_BAD_PEER_PIN").unwrap_or("") == "1" {
         "0000000000000000000000000000000000000000000000000000000000000000"
     } else {
         peer_key
@@ -910,7 +910,7 @@ fn wait_for_server_listening(kx: string) {
 }
 
 fn lookup_with_retry(name: string) -> Result<RemotePid<KeyValue>, LookupError> {
-    let selected_scenario = os.env("HEW_DIST_SCENARIO");
+    let selected_scenario = os.env("HEW_DIST_SCENARIO").unwrap_or("");
     let max_attempts: i64 = if selected_scenario == "monitor_leak_low" || selected_scenario == "monitor_leak_high" {
         300
     } else {
@@ -974,7 +974,7 @@ fn lookup_identity_with_retry(name: string) -> Result<RemotePid<IdentityProbe>, 
 
 fn run_server(port: string, scenario: string) {
     let addr = f"127.0.0.1:{port}";
-    let kx = os.env("HEW_DIST_KX_DIR");
+    let kx = os.env("HEW_DIST_KX_DIR").unwrap_or("");
     Node.set_transport("tcp");
     stage_peer_credentials(kx, "server", "client", 2);
     Node.start(addr);
@@ -996,7 +996,7 @@ fn run_server(port: string, scenario: string) {
         stopper.run();
     }
     signal_server_listening(kx);
-    if os.env("HEW_DIST_RESTARTED") == "1" {
+    if os.env("HEW_DIST_RESTARTED").unwrap_or("") == "1" {
         publish_atomic(kx, "server.restarted", "1");
     }
     println(f"READY {port}");
@@ -2041,7 +2041,7 @@ fn scenario_stale_incarnation_restart(old: RemotePid<KeyValue>, kx: string, port
 }
 
 fn run_client(port: string, scenario: string) -> i64 {
-    let kx = os.env("HEW_DIST_KX_DIR");
+    let kx = os.env("HEW_DIST_KX_DIR").unwrap_or("");
     Node.set_transport("tcp");
     stage_peer_credentials(kx, "client", "server", 1);
     Node.start("127.0.0.1:0");
@@ -2184,9 +2184,9 @@ fn run_client(port: string, scenario: string) -> i64 {
 }
 
 fn main() -> i64 {
-    let role = os.env("HEW_DIST_ROLE");
-    let port = os.env("HEW_DIST_PORT");
-    var scenario = os.env("HEW_DIST_SCENARIO");
+    let role = os.env("HEW_DIST_ROLE").unwrap_or("");
+    let port = os.env("HEW_DIST_PORT").unwrap_or("");
+    var scenario = os.env("HEW_DIST_SCENARIO").unwrap_or("");
     if scenario == "" {
         scenario = "remote_ask";
     }

--- a/hew-cli/tests/http_ws_string_result_retention_leak_oracle.rs
+++ b/hew-cli/tests/http_ws_string_result_retention_leak_oracle.rs
@@ -55,7 +55,7 @@ fn main() {{
                     + request.body("utf-8").len();
                 println(checksum);
             }}
-            match request.try_respond_text(200, "ok") {{
+            match request.respond_text(200, "ok") {{
                 Ok(_) => {{}},
                 Err(_) => panic("HTTP retention response failed"),
             }}
@@ -117,7 +117,7 @@ fn main() {{
             );
             client.fetch(0);
             let request = server.accept();
-            match request.try_respond(
+            match request.respond(
                 200,
                 "application/retention",
                 "response-owner",

--- a/hew-cli/tests/measured_os_io_string_retention_canary.rs
+++ b/hew-cli/tests/measured_os_io_string_retention_canary.rs
@@ -23,8 +23,8 @@ import std.path;
 import std.process;
 
 fn all_measured_wrappers() -> i64 {
-    let arg = os.args(0);
-    let env = os.env("PATH");
+    let arg = os.args().get(0);
+    let env = os.env("PATH").unwrap_or("");
     let cwd = os.cwd();
     let home = os.home_dir();
     let host = os.hostname();
@@ -32,12 +32,12 @@ fn all_measured_wrappers() -> i64 {
     let line = io.read_line();
     let all = io.read_all();
     let direct_file = fs.read("/tmp/hew-os-io-retention-input.txt");
-    let streamed_file = match fs.try_read("/tmp/hew-os-io-retention-input.txt") {
+    let streamed_file = match fs.read("/tmp/hew-os-io-retention-input.txt") {
         .Ok(text) => text,
         .Err(error) => to_string(error),
     };
     let absolute = path.absolute(".");
-    let glob_len = match path.try_glob("/tmp/hew-os-io-retention-*.txt") {
+    let glob_len = match path.glob("/tmp/hew-os-io-retention-*.txt") {
         .Ok(matches) => {
             let entry = matches.try_get(0);
             matches.close();
@@ -90,12 +90,12 @@ const SYMBOLS: &[&str] = &[
 /// later calls. The CFG oracle below proves that every path from each mint to
 /// a terminating block passes through its matching `hew_string_drop`.
 ///
-/// The `fs.try_read` result binds through the owned-carrier release funnel,
+/// The `fs.read` result binds through the owned-carrier release funnel,
 /// which moves the selected `Ok(text)` / `Err(...)` payload into a fresh local
 /// and neutralizes the carrier slot before releasing it on every exit.
 const STRING_OWNER_SLOTS: &[&str] = &[
     // os.args, os.env, cwd, home_dir, hostname, temp_dir, stdin line/all,
-    // fs.read, fs.try_read, path.absolute, the path-error Display dispatch,
+    // fs.read, fs.read, path.absolute, the path-error Display dispatch,
     // dns direct / timed, and the two process-output field clones. These are
     // every slot the witness releases through `hew_string_drop` — the compress `Err(reason)`
     // and process `output.stdout`/`stderr` ORIGINALS are freed by their

--- a/hew-cli/tests/measured_os_io_string_retention_leak_oracle.rs
+++ b/hew-cli/tests/measured_os_io_string_retention_leak_oracle.rs
@@ -18,8 +18,8 @@ import std.os;
 import std.process;
 
 fn one_frame() -> i64 {
-    let arg = os.args(0);
-    let env = os.env("PATH");
+    let arg = os.args().get(0);
+    let env = os.env("PATH").unwrap_or("");
     let cwd = os.cwd();
     let home = os.home_dir();
     let host = os.hostname();

--- a/hew-cli/tests/std_path_glob_ownership_ir.rs
+++ b/hew-cli/tests/std_path_glob_ownership_ir.rs
@@ -19,7 +19,7 @@ const SOURCE: &str = r#"
 import std.path;
 
 fn main() {
-    match path.try_glob("std/*.hew") {
+    match path.glob("std/*.hew") {
         .Ok(matches) => matches.close(),
         .Err(_) => (),
     }

--- a/hew-cli/tests/string_result_retention_leak_oracle.rs
+++ b/hew-cli/tests/string_result_retention_leak_oracle.rs
@@ -177,7 +177,7 @@ actor Reader {
 }
 
 fn main() {
-    let frame_baseline = observe.read("coroutines.frame_bytes_live");
+    let frame_baseline = observe.read("coroutines.frame_bytes_live").unwrap_or(0);
     let listener = net.listen("127.0.0.1:0");
     let port = listener.local_port();
     let reader = spawn Reader(addr: f"127.0.0.1:{port}");
@@ -190,7 +190,7 @@ fn main() {
         .Err(_) => println("crash-fallback"),
     }
     println("main-done");
-    println(observe.read("coroutines.frame_bytes_live") - frame_baseline);
+    println(observe.read("coroutines.frame_bytes_live").unwrap_or(0) - frame_baseline);
 }
 "#;
 
@@ -493,7 +493,7 @@ actor Runner {
 }
 
 fn main() {
-    let frame_baseline = observe.read("coroutines.frame_bytes_live");
+    let frame_baseline = observe.read("coroutines.frame_bytes_live").unwrap_or(0);
     let gate = spawn Gate;
     let runner = spawn Runner(gate: gate);
     let r = await runner.go(0);
@@ -502,7 +502,7 @@ fn main() {
         .Err(_) => println("crash-fallback"),
     }
     println("main-done");
-    println(observe.read("coroutines.frame_bytes_live") - frame_baseline);
+    println(observe.read("coroutines.frame_bytes_live").unwrap_or(0) - frame_baseline);
 }
 "#;
 
@@ -732,12 +732,12 @@ actor Crasher {
 }
 
 fn main() {
-    let frame_baseline = observe.read("coroutines.frame_bytes_live");
+    let frame_baseline = observe.read("coroutines.frame_bytes_live").unwrap_or(0);
     let gate = spawn Gate;
     for _ in 0..__FRAMES__ {
         let crasher = spawn Crasher(gate: gate);
         let result = await crasher.run();
-        if observe.read("coroutines.frame_bytes_live") != frame_baseline {
+        if observe.read("coroutines.frame_bytes_live").unwrap_or(0) != frame_baseline {
             panic("nested crash left coroutine-frame bytes live");
         }
         match result {

--- a/hew-codegen-rs/tests/exec/wasm_generator_exec.rs
+++ b/hew-codegen-rs/tests/exec/wasm_generator_exec.rs
@@ -146,8 +146,8 @@ fn main() {
     complete(Capture { label: "complete", values: [1, 2] });
     suspended(Capture { label: "suspended", values: [3, 4] });
     never_resumed(Capture { label: "never", values: [5, 6] });
-    println(observe.read("coroutines.frame_bytes_live"));
-    println(observe.read("heap.live_bytes"));
+    println(observe.read("coroutines.frame_bytes_live").unwrap_or(0));
+    println(observe.read("heap.live_bytes").unwrap_or(0));
 }
 "#,
     )

--- a/std/encoding/csv/csv.hew
+++ b/std/encoding/csv/csv.hew
@@ -111,7 +111,7 @@ pub fn try_parse_no_headers(data: string) -> Result<Table, string> {
 /// Returns `Err(string)` if the file cannot be read or the input is not
 /// well-formed CSV.
 pub fn try_parse_file(path: string) -> Result<Table, string> {
-    match fs.try_read(path) {
+    match fs.read(path) {
         .Ok(content) => parse_impl(content, true),
         .Err(reason) => Err(to_string(reason)),
     }

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -9,15 +9,15 @@
 //! # Error Handling
 //!
 //! `IoError` is the stable user-facing error enum for file-system failures.
-//! Use the `try_*` wrappers in this module—such as `try_read`,
-//! `try_write`, `try_rename`, and `try_copy`—with `Result<T, IoError>`
+//! Use the Result-returning operations in this module—such as `read`,
+//! `write`, `rename`, and `copy`—with `Result<T, IoError>`
 //! and the `?` operator for clean error propagation:
 //!
 //! ```
 //! import std.fs;
 //!
 //! fn load_config(path: string) -> Result<string, fs.IoError> {
-//!     fs.try_read(path)
+//!     fs.read(path)
 //! }
 //!
 //! fn main() {
@@ -69,8 +69,8 @@ pub enum IoError {
 /// Windows Win32 codes that do not collide with a POSIX errno (only
 /// `ERROR_ALREADY_EXISTS` = 183 today). Codes that mean *different* things on
 /// each platform — for example 5 (`EIO` on POSIX, `ERROR_ACCESS_DENIED` on
-/// Windows) — cannot be disambiguated from the integer alone; the `try_*`
-/// wrappers classify those correctly through the runtime's canonical error-kind
+/// Windows) — cannot be disambiguated from the integer alone; the
+/// Result-returning operations classify those correctly through the runtime's canonical error-kind
 /// channel (`hew_stream_last_error_kind`) and only fall back to this function
 /// for kinds without a canonical tag.
 ///
@@ -109,8 +109,8 @@ pub fn io_error_from_errno(errno: i64) -> IoError {
 /// (e.g. `EISDIR`/`ENOTDIR` -> `Other(raw)`). Keep the tag values in sync with
 /// the `IO_ERROR_KIND_*` constants in `hew-runtime/src/stream_error.rs`.
 ///
-/// Public so sibling wrappers that read the same runtime error channel — e.g.
-/// `std.stream`'s `try_from_file` / `try_to_file` — classify failures through
+/// Public so sibling operations that read the same runtime error channel
+/// classify failures through
 /// this one authority rather than re-deriving it from the raw errno.
 pub fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
     if kind == 1 {
@@ -134,7 +134,7 @@ pub fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
 /// import std.fs;
 ///
 /// fn main() {
-///     let result: Result<i64, fs.IoError> = fs.try_delete("/tmp/scratch-file");
+///     let result: Result<(), fs.IoError> = fs.delete("/tmp/scratch-file");
 ///     match result {
 ///         .Err(e) => panic(f"operation failed: {e}"),
 ///         .Ok(_) => {},
@@ -186,8 +186,7 @@ fn last_io_error() -> IoError {
 
 /// Read the entire contents of a file as a UTF-8 string.
 ///
-/// Panics if the file does not exist or cannot be read.
-/// Use `try_read` for a structured `Result<string, IoError>` surface.
+/// Returns a structured error if the file does not exist or cannot be read.
 ///
 /// # Examples
 ///
@@ -198,26 +197,7 @@ fn last_io_error() -> IoError {
 ///     let src = fs.read("main.hew");
 /// }
 /// ```
-pub fn read(path: string) -> string {
-    unsafe {
-        let contents = hew_file_read(path);
-        let errno = hew_stream_last_errno();
-        if errno != 0 {
-            let detail = hew_stream_last_error();
-            if detail.len() == 0 {
-                panic(f"fs.read failed for `{path}`: {io_error_from_errno(errno as i64)}");
-            } else {
-                panic(f"fs.read failed for `{path}`: {detail}");
-            }
-        }
-        contents
-    }
-}
-
-/// Read the entire contents of a file as a UTF-8 string.
-///
-/// Returns `Err(IoError)` instead of panicking on open failures.
-pub fn try_read(file_path: string) -> Result<string, IoError> {
+pub fn read(file_path: string) -> Result<string, IoError> {
     unsafe {
         let file = hew_file_read_stream_open(file_path);
         if hew_file_read_stream_is_valid(file) {
@@ -238,44 +218,24 @@ pub fn try_read(file_path: string) -> Result<string, IoError> {
 
 /// Write a string to a file, creating or overwriting it.
 ///
-/// Returns 0 on success, non-zero on error.
-/// Use `try_write` for a structured `Result<i64, IoError>` surface.
-pub fn write(path: string, content: string) -> i64 {
-    unsafe {
-        hew_file_write(path, content) as i64
-    }
-}
-
-/// Write a string to a file, creating or overwriting it.
-///
-/// Lifts the native status code into `Result<i64, IoError>`.
-pub fn try_write(file_path: string, content: string) -> Result<i64, IoError> {
+/// Returns `Ok(())` on success.
+pub fn write(file_path: string, content: string) -> Result<(), IoError> {
     match unsafe {
         hew_file_write(file_path, content)
     } {
-        0 => Ok(0),
+        0 => Ok(()),
         _ => Err(last_io_error()),
     }
 }
 
 /// Append a string to the end of a file.
 ///
-/// Creates the file if it does not exist. Returns 0 on success.
-/// Use `try_append` for a structured `Result<i64, IoError>` surface.
-pub fn append(path: string, content: string) -> i64 {
-    unsafe {
-        hew_file_append(path, content) as i64
-    }
-}
-
-/// Append a string to the end of a file.
-///
-/// Lifts the native status code into `Result<i64, IoError>`.
-pub fn try_append(file_path: string, content: string) -> Result<i64, IoError> {
+/// Creates the file if it does not exist.
+pub fn append(file_path: string, content: string) -> Result<(), IoError> {
     match unsafe {
         hew_file_append(file_path, content)
     } {
-        0 => Ok(0),
+        0 => Ok(()),
         _ => Err(last_io_error()),
     }
 }
@@ -298,21 +258,14 @@ pub fn exists(path: string) -> bool {
     }
 }
 
-/// Delete a file. Returns 0 on success.
-pub fn delete(path: string) -> i64 {
-    unsafe {
-        hew_file_delete(path) as i64
-    }
-}
-
 /// Delete a file.
 ///
 /// Returns `Err(IoError.NotFound(_))` when the path is missing.
-pub fn try_delete(file_path: string) -> Result<i64, IoError> {
+pub fn delete(file_path: string) -> Result<(), IoError> {
     match unsafe {
         hew_file_delete(file_path)
     } {
-        0 => Ok(0),
+        0 => Ok(()),
         _ => Err(last_io_error()),
     }
 }
@@ -326,8 +279,7 @@ pub fn size(path: string) -> i64 {
 
 /// Read the raw bytes of a file into a `bytes` value.
 ///
-/// Returns an empty `bytes` buffer on error.
-/// Use `try_read_bytes` for a structured `Result<bytes, IoError>` surface.
+/// Returns a structured error on failure.
 ///
 /// # Examples
 ///
@@ -339,23 +291,14 @@ pub fn size(path: string) -> i64 {
 ///     println(data.len());
 /// }
 /// ```
-pub fn read_bytes(path: string) -> bytes {
-    unsafe {
-        hew_file_read_bytes(path)
-    }
-}
-
-/// Read the raw bytes of a file into a `bytes` value.
-///
-/// Returns `Err(IoError)` instead of an ambiguous empty buffer on failure.
-pub fn try_read_bytes(file_path: string) -> Result<bytes, IoError> {
+pub fn read_bytes(file_path: string) -> Result<bytes, IoError> {
     unsafe {
         let data = hew_file_read_bytes(file_path);
         let kind = hew_stream_last_error_kind() as i64;
         let errno = hew_stream_last_errno();
         if errno != 0 {
             // Drain the thread-local error message on the failure path,
-            // mirroring `try_read` above, so a stale
+            // mirroring `read` above, so a stale
             // `hew_file_read_bytes: ...` message can't leak into a later,
             // unrelated `hew_last_error()` / `hew_stream_last_error()` read.
             let _ = hew_stream_last_error();
@@ -371,72 +314,45 @@ pub fn try_read_bytes(file_path: string) -> Result<bytes, IoError> {
 
 /// Write a `bytes` value to a file, creating or overwriting it.
 ///
-/// Returns 0 on success, non-zero on error.
-/// Use `try_write_bytes` for a structured `Result<i64, IoError>` surface.
-pub fn write_bytes(path: string, data: bytes) -> i64 {
-    unsafe {
-        hew_file_write_bytes(path, data) as i64
-    }
-}
-
 /// Write a `bytes` value to a file, creating or overwriting it.
-///
-/// Lifts the native status code into `Result<i64, IoError>`.
-pub fn try_write_bytes(file_path: string, data: bytes) -> Result<i64, IoError> {
+pub fn write_bytes(file_path: string, data: bytes) -> Result<(), IoError> {
     match unsafe {
         hew_file_write_bytes(file_path, data)
     } {
-        0 => Ok(0),
+        0 => Ok(()),
         _ => Err(last_io_error()),
     }
 }
 
 // ── Directory operations ──────────────────────────────────────────────
-/// Create a directory. Returns 0 on success, -1 on error.
+/// Create a directory.
 ///
 /// Fails if any parent directory does not exist. Use `mkdir_all` to create
 /// parent directories automatically.
-pub fn mkdir(path: string) -> i64 {
-    unsafe {
-        hew_fs_mkdir(path) as i64
-    }
-}
-
-/// Create a directory with structured `IoError` results.
-pub fn try_mkdir(dir_path: string) -> Result<i64, IoError> {
+pub fn mkdir(dir_path: string) -> Result<(), IoError> {
     match unsafe {
         hew_fs_mkdir(dir_path)
     } {
-        0 => Ok(0),
+        0 => Ok(()),
         _ => Err(last_io_error()),
     }
 }
 
 /// Create a directory and all its parent components.
 ///
-/// Returns 0 on success, -1 on error.
-pub fn mkdir_all(path: string) -> i64 {
-    unsafe {
-        hew_fs_mkdir_all(path) as i64
-    }
-}
-
 /// Create a directory and all its parent components.
-///
-/// Lifts the native status code into `Result<i64, IoError>`.
-pub fn try_mkdir_all(dir_path: string) -> Result<i64, IoError> {
+pub fn mkdir_all(dir_path: string) -> Result<(), IoError> {
     match unsafe {
         hew_fs_mkdir_all(dir_path)
     } {
-        0 => Ok(0),
+        0 => Ok(()),
         _ => Err(last_io_error()),
     }
 }
 
 /// List the entries in a directory.
 ///
-/// Returns a list of entry names (not full paths). Returns an empty list on
-/// error. Use `try_list_dir` when missing-path handling matters.
+/// Returns a list of entry names (not full paths).
 ///
 /// # Examples
 ///
@@ -450,16 +366,7 @@ pub fn try_mkdir_all(dir_path: string) -> Result<i64, IoError> {
 ///     }
 /// }
 /// ```
-pub fn list_dir(path: string) -> Vec<string> {
-    unsafe {
-        hew_fs_list_dir(path)
-    }
-}
-
-/// List the entries in a directory.
-///
-/// Returns an error for every directory-read failure.
-pub fn try_list_dir(dir_path: string) -> Result<Vec<string>, IoError> {
+pub fn list_dir(dir_path: string) -> Result<Vec<string>, IoError> {
     unsafe {
         let entries = hew_fs_list_dir(dir_path);
         let kind = hew_stream_last_error_kind() as i64;
@@ -475,42 +382,22 @@ pub fn try_list_dir(dir_path: string) -> Result<Vec<string>, IoError> {
 
 /// Rename or move a file or directory.
 ///
-/// Returns 0 on success, -1 on error.
-pub fn rename(from: string, to: string) -> i64 {
-    unsafe {
-        hew_fs_rename(from, to) as i64
-    }
-}
-
-/// Rename or move a file or directory.
-///
-/// Lifts the native status code into `Result<i64, IoError>`.
-pub fn try_rename(from: string, to: string) -> Result<i64, IoError> {
+pub fn rename(from: string, to: string) -> Result<(), IoError> {
     match unsafe {
         hew_fs_rename(from, to)
     } {
-        0 => Ok(0),
+        0 => Ok(()),
         _ => Err(last_io_error()),
     }
 }
 
 /// Copy a file.
 ///
-/// Returns 0 on success, -1 on error.
-pub fn copy(from: string, to: string) -> i64 {
-    unsafe {
-        hew_fs_copy(from, to) as i64
-    }
-}
-
-/// Copy a file.
-///
-/// Lifts the native status code into `Result<i64, IoError>`.
-pub fn try_copy(from: string, to: string) -> Result<i64, IoError> {
+pub fn copy(from: string, to: string) -> Result<(), IoError> {
     match unsafe {
         hew_fs_copy(from, to)
     } {
-        0 => Ok(0),
+        0 => Ok(()),
         _ => Err(last_io_error()),
     }
 }

--- a/std/io/scanner.hew
+++ b/std/io/scanner.hew
@@ -138,7 +138,7 @@ pub fn from_stdin() -> Scanner {
 ///
 /// Returns `Err(fs.IoError)` if the file cannot be opened or read.
 pub fn from_file(path: string) -> Result<Scanner, fs.IoError> {
-    match fs.try_read(path) {
+    match fs.read(path) {
         .Ok(contents) => Ok(Scanner { source: contents, pos: 0, current: "", valid: false, done: false, mode: .SplitLines }),
         .Err(e) => Err(e),
     }

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -124,7 +124,7 @@ trait RequestMethods {
     /// Send a full HTTP response with status, content-type, and body.
     ///
     /// The `Content-Length` header is derived from `body` automatically.
-    fn respond(self, status: i64, content_type: string, body: string) -> i64;
+    fn respond(self, status: i64, content_type: string, body: string) -> Result<(), net.NetError>;
 
     /// Send a plain-text HTTP response.
     ///
@@ -145,10 +145,10 @@ trait RequestMethods {
     ///     }
     /// }
     /// ```
-    fn respond_text(self, status: i64, body: string) -> i64;
+    fn respond_text(self, status: i64, body: string) -> Result<(), net.NetError>;
 
     /// Send a JSON HTTP response with `Content-Type: application/json`.
-    fn respond_json(self, status: i64, json: string) -> i64;
+    fn respond_json(self, status: i64, json: string) -> Result<(), net.NetError>;
 
     /// Begin a streaming response and return a `Sink` for chunked output.
     ///
@@ -174,19 +174,7 @@ trait RequestMethods {
     ///     }
     /// }
     /// ```
-    fn respond_stream(self, status: i64, content_type: string) -> Sink<string>;
-
-    /// Send a full HTTP response, returning `Err(net.NetError)` on failure.
-    fn try_respond(self, status: i64, content_type: string, body: string) -> Result<i64, net.NetError>;
-
-    /// Send a plain-text HTTP response, returning `Err(net.NetError)` on failure.
-    fn try_respond_text(self, status: i64, body: string) -> Result<i64, net.NetError>;
-
-    /// Send a JSON HTTP response, returning `Err(net.NetError)` on failure.
-    fn try_respond_json(self, status: i64, json: string) -> Result<i64, net.NetError>;
-
-    /// Begin a streaming response, returning `Err(net.NetError)` on failure.
-    fn try_respond_stream(self, status: i64, content_type: string) -> Result<Sink<string>, net.NetError>;
+    fn respond_stream(self, status: i64, content_type: string) -> Result<Sink<string>, net.NetError>;
 }
 
 impl RequestMethods for Request {
@@ -221,47 +209,7 @@ impl RequestMethods for Request {
         }
     }
     /// Send a full HTTP response with status, content-type, and body.
-    fn respond(req: Request, status: i64, content_type: string, body: string) -> i64 {
-        if !valid_response_status(status) {
-            return -1;
-        }
-        unsafe {
-            hew_http_respond_bridge(req.handle, status as i32, content_type, body) as i64
-        } // INTERNAL-ABI: C ABI status is i32
-    }
-    /// Send a plain-text HTTP response.
-    fn respond_text(req: Request, status: i64, body: string) -> i64 {
-        if !valid_response_status(status) {
-            return -1;
-        }
-        unsafe {
-            hew_http_respond_text(req.handle, status as i32, body) as i64
-        } // INTERNAL-ABI: C ABI status is i32
-    }
-    /// Send a JSON HTTP response with `Content-Type: application/json`.
-    fn respond_json(req: Request, status: i64, json: string) -> i64 {
-        if !valid_response_status(status) {
-            return -1;
-        }
-        unsafe {
-            hew_http_respond_json(req.handle, status as i32, json) as i64
-        } // INTERNAL-ABI: C ABI status is i32
-    }
-    /// Begin a streaming response and return a `Sink` for chunked output.
-    fn respond_stream(req: Request, status: i64, content_type: string) -> Sink<string> {
-        if !valid_response_status(status) {
-            panic(f"http.respond_stream: invalid status {status} (must be 100..=599)");
-        }
-        unsafe {
-            hew_http_respond_stream(req.handle, status as i32, content_type)
-        } // INTERNAL-ABI: C ABI status is i32
-    }
-    /// Send a full HTTP response; returns Err(NetError.Other(0)) on failure.
-    fn try_respond(req: Request, status: i64, content_type: string, body: string) -> Result<i64, net.NetError> {
-        // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond(); call FFI
-        //   directly to preserve the i32 truncation the FFI signature requires.
-        // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
-        // WHAT — restore to: let n = req.respond(status, content_type, body);
+    fn respond(req: Request, status: i64, content_type: string, body: string) -> Result<(), net.NetError> {
         let n = if valid_response_status(status) {
             unsafe {
                 hew_http_respond_bridge(req.handle, status as i32, content_type, body)
@@ -272,15 +220,11 @@ impl RequestMethods for Request {
         if n < 0 {
             Err(net.net_error_from_errno(0))
         } else {
-            Ok(n)
+            Ok(())
         } // HTTP has no OS errno channel
     }
-    /// Send a plain-text HTTP response; returns Err(NetError.Other(0)) on failure.
-    fn try_respond_text(req: Request, status: i64, body: string) -> Result<i64, net.NetError> {
-        // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond_text(); call FFI
-        //   directly to preserve the i32 truncation the FFI signature requires.
-        // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
-        // WHAT — restore to: let n = req.respond_text(status, body);
+    /// Send a plain-text HTTP response.
+    fn respond_text(req: Request, status: i64, body: string) -> Result<(), net.NetError> {
         let n = if valid_response_status(status) {
             unsafe {
                 hew_http_respond_text(req.handle, status as i32, body)
@@ -291,15 +235,11 @@ impl RequestMethods for Request {
         if n < 0 {
             Err(net.net_error_from_errno(0))
         } else {
-            Ok(n)
+            Ok(())
         } // HTTP has no OS errno channel
     }
-    /// Send a JSON HTTP response; returns Err(NetError.Other(0)) on failure.
-    fn try_respond_json(req: Request, status: i64, json: string) -> Result<i64, net.NetError> {
-        // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond_json(); call FFI
-        //   directly to preserve the i32 truncation the FFI signature requires.
-        // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
-        // WHAT — restore to: let n = req.respond_json(status, json);
+    /// Send a JSON HTTP response with `Content-Type: application/json`.
+    fn respond_json(req: Request, status: i64, json: string) -> Result<(), net.NetError> {
         let n = if valid_response_status(status) {
             unsafe {
                 hew_http_respond_json(req.handle, status as i32, json)
@@ -310,11 +250,11 @@ impl RequestMethods for Request {
         if n < 0 {
             Err(net.net_error_from_errno(0))
         } else {
-            Ok(n)
+            Ok(())
         } // HTTP has no OS errno channel
     }
-    /// Begin a streaming response; returns Err(NetError.Other(0)) on failure.
-    fn try_respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, net.NetError> {
+    /// Begin a streaming response.
+    fn respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, net.NetError> {
         if valid_response_status(status) {
             let sink = unsafe {
                 hew_http_respond_stream(req.handle, status as i32, content_type)
@@ -409,24 +349,24 @@ pub fn listen(addr: string) -> Result<Server, net.NetError> {
     Err(net.net_error_from_errno(errno))
 }
 
-/// Send a full HTTP response, returning `Err(net.NetError)` on failure.
-pub fn try_respond(req: Request, status: i64, content_type: string, body: string) -> Result<i64, net.NetError> {
-    req.try_respond(status, content_type, body)
+/// Send a full HTTP response.
+pub fn respond(req: Request, status: i64, content_type: string, body: string) -> Result<(), net.NetError> {
+    req.respond(status, content_type, body)
 }
 
-/// Send a plain-text HTTP response, returning `Err(net.NetError)` on failure.
-pub fn try_respond_text(req: Request, status: i64, body: string) -> Result<i64, net.NetError> {
-    req.try_respond_text(status, body)
+/// Send a plain-text HTTP response.
+pub fn respond_text(req: Request, status: i64, body: string) -> Result<(), net.NetError> {
+    req.respond_text(status, body)
 }
 
-/// Send a JSON HTTP response, returning `Err(net.NetError)` on failure.
-pub fn try_respond_json(req: Request, status: i64, json: string) -> Result<i64, net.NetError> {
-    req.try_respond_json(status, json)
+/// Send a JSON HTTP response.
+pub fn respond_json(req: Request, status: i64, json: string) -> Result<(), net.NetError> {
+    req.respond_json(status, json)
 }
 
-/// Begin a streaming HTTP response, returning `Err(net.NetError)` on failure.
-pub fn try_respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, net.NetError> {
-    req.try_respond_stream(status, content_type)
+/// Begin a streaming HTTP response.
+pub fn respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, net.NetError> {
+    req.respond_stream(status, content_type)
 }
 
 // ── FFI bindings (implementation detail) ──────────────────────────────

--- a/std/observe.hew
+++ b/std/observe.hew
@@ -2,10 +2,15 @@
 
 /// Read one canonical metric by name.
 ///
-/// Returns -1 when the metric name is unknown.
-pub fn read(name: string) -> i64 {
-    unsafe {
+/// Returns `None` when the metric name is unknown.
+pub fn read(name: string) -> Option<i64> {
+    let value = unsafe {
         hew_observe_read_u64(name)
+    };
+    if value == -1 {
+        None
+    } else {
+        Some(value)
     }
 }
 
@@ -25,11 +30,32 @@ pub fn series() -> string {
 
 /// Wait for actor-turn observe attribution visible to `series`/`scrape`.
 ///
-/// Returns 0 on success, -1 when called from inside an actor turn, and -2 if
-/// the native runtime's bounded 30-second internal wait expires.
-pub fn barrier() -> i64 {
-    unsafe {
+pub enum ObserveError {
+    ActorTurn;
+    TimedOut;
+}
+
+impl Display for ObserveError {
+    fn fmt(error: ObserveError) -> string {
+        match error {
+            ObserveError.ActorTurn => "observe.barrier cannot wait from an actor turn",
+            ObserveError.TimedOut => "observe.barrier timed out",
+        }
+    }
+}
+
+/// Returns an error when called from an actor turn or when the native runtime's
+/// bounded 30-second internal wait expires.
+pub fn barrier() -> Result<(), ObserveError> {
+    let status = unsafe {
         hew_observe_barrier()
+    };
+    if status == 0 {
+        Ok(())
+    } else if status == -1 {
+        Err(ObserveError.ActorTurn)
+    } else {
+        Err(ObserveError.TimedOut)
     }
 }
 

--- a/std/os.hew
+++ b/std/os.hew
@@ -9,23 +9,14 @@
 //! import std.os;
 //!
 //! fn main() {
-//!     let n = os.args_count();
-//!     let first = os.args(0);
+//!     let arguments = os.args();
+//!     let first = arguments.get(0);
 //!     let home = os.home_dir();
 //!     println(home);
 //! }
 //! ```
 
-/// Returns the number of command-line arguments.
-pub fn args_count() -> i64 {
-    unsafe {
-        hew_args_count() as i64
-    }
-}
-
-/// Returns the command-line argument at the given index.
-///
-/// Index 0 is the program name. Panics if `index` is out of range.
+/// Return all command-line arguments, including the program name.
 ///
 /// # Examples
 ///
@@ -33,23 +24,27 @@ pub fn args_count() -> i64 {
 /// import std.os;
 ///
 /// fn main() {
-///     let program = os.args(0);
-///     let first_arg = os.args(1);
+///     let arguments = os.args();
+///     let program = arguments.get(0);
 /// }
 /// ```
-pub fn args(index: i64) -> string {
-    let count = args_count();
-    if index < 0 || index >= count {
-        panic(f"os.args: index {index} out of range for {count} argument(s)");
+pub fn args() -> Vec<string> {
+    let count = unsafe {
+        hew_args_count() as i64
+    };
+    var values: Vec<string> = Vec::new();
+    for index in 0..count {
+        let value = unsafe {
+            hew_args_get(index as i32)
+        };
+        values.push(value);
     }
-    unsafe {
-        hew_args_get(index as i32)
-    }
+    values
 }
 
 /// Get the value of an environment variable.
 ///
-/// Returns an empty string if the variable is not set.
+/// Returns `None` if the variable is not set.
 ///
 /// # Examples
 ///
@@ -60,9 +55,13 @@ pub fn args(index: i64) -> string {
 ///     let path = os.env("PATH");
 /// }
 /// ```
-pub fn env(name: string) -> string {
+pub fn env(name: string) -> Option<string> {
     unsafe {
-        hew_env_get(name)
+        if hew_env_has(name) {
+            Some(hew_env_get(name))
+        } else {
+            None
+        }
     }
 }
 
@@ -82,13 +81,13 @@ impl Display for EnvError {
 /// Set an environment variable for the current process.
 ///
 /// Environment names must be non-empty and cannot contain `=`.
-pub fn set_env(name: string, value: string) -> Result<i64, EnvError> {
+pub fn set_env(name: string, value: string) -> Result<(), EnvError> {
     if name == "" || name.contains("=") {
         return Err(EnvError.InvalidName(name));
     }
     unsafe {
         if hew_env_set(name, value) == 0 {
-            Ok(0)
+            Ok(())
         } else {
             Err(EnvError.InvalidName(name))
         }
@@ -98,13 +97,13 @@ pub fn set_env(name: string, value: string) -> Result<i64, EnvError> {
 /// Remove an environment variable.
 ///
 /// Environment names must be non-empty and cannot contain `=`.
-pub fn remove_env(name: string) -> Result<i64, EnvError> {
+pub fn remove_env(name: string) -> Result<(), EnvError> {
     if name == "" || name.contains("=") {
         return Err(EnvError.InvalidName(name));
     }
     unsafe {
         if hew_env_remove(name) == 0 {
-            Ok(0)
+            Ok(())
         } else {
             Err(EnvError.InvalidName(name))
         }

--- a/std/path.hew
+++ b/std/path.hew
@@ -111,8 +111,8 @@ impl GlobResult {
 // ── Module-level functions ────────────────────────────────────────────
 /// Expand a glob pattern and return all matching paths.
 ///
-/// Panics when the expansion cannot complete (for example a matching directory
-/// that cannot be read). Use `try_glob` to handle that without terminating.
+/// Returns an error when the expansion cannot complete (for example a matching
+/// directory that cannot be read).
 ///
 /// # Examples
 ///
@@ -123,22 +123,6 @@ impl GlobResult {
 ///     let files = path.glob("src/**/*.hew");
 /// }
 /// ```
-pub fn glob(pattern: string) -> GlobResult {
-    unsafe {
-        let handle = hew_glob(pattern);
-        if !hew_glob_is_valid(handle) {
-            // `hew_glob` always transfers one heap-owned result handle, even
-            // when expansion fails.  Copy its error before releasing that
-            // handle: `hew_glob_error` borrows the result while constructing
-            // the Hew-owned string it returns.
-            let detail = hew_glob_error(handle);
-            hew_glob_free(handle);
-            panic(f"path.glob: {detail}");
-        }
-        GlobResult { handle: handle }
-    }
-}
-
 /// Expand a glob pattern, reporting expansion failure separately from a
 /// completed walk that matched nothing.
 ///
@@ -148,13 +132,13 @@ pub fn glob(pattern: string) -> GlobResult {
 /// import std.path;
 ///
 /// fn main() {
-///     match path.try_glob("src/**/*.hew") {
+///     match path.glob("src/**/*.hew") {
 ///         .Ok(files) => println(f"{files.len()} match(es)"),
 ///         .Err(err) => println(f"{err}"),
 ///     }
 /// }
 /// ```
-pub fn try_glob(pattern: string) -> Result<GlobResult, PathError> {
+pub fn glob(pattern: string) -> Result<GlobResult, PathError> {
     unsafe {
         let handle = hew_glob(pattern);
         if hew_glob_is_valid(handle) {

--- a/tests/hew/csv_test.hew
+++ b/tests/hew/csv_test.hew
@@ -66,7 +66,7 @@ fn test_parse_get_by_name_missing_column_returns_empty() {
 #[serial]
 fn test_try_parse_file_missing_path_returns_err() {
     let path = "tests/hew/_csv_try_parse_missing.csv";
-    let _ = fs.try_delete(path);
+    let _ = fs.delete(path);
     match csv.try_parse_file(path) {
         .Ok(tbl) => {
             tbl.free();

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -30,7 +30,7 @@ fn cleanup_file(file_path: string) {
 fn test_try_read_missing_returns_not_found() {
     let file_path = "tests/hew/_fs_stream_missing.txt";
     cleanup_file(file_path);
-    match fs.try_read(file_path) {
+    match fs.read(file_path) {
         .Ok(_) => panic("expected missing file error"),
         .Err(err) => match err {
             IoError.NotFound(_) => {},
@@ -41,7 +41,7 @@ fn test_try_read_missing_returns_not_found() {
 
 #[test]
 fn test_try_read_directory_returns_eisdir() {
-    match fs.try_read("/") {
+    match fs.read("/") {
         .Ok(_) => panic("expected directory read error"),
         .Err(err) => match err {
             IoError.Other(errno) => testing.assert_eq(errno, 21),
@@ -55,7 +55,7 @@ fn test_try_read_directory_returns_eisdir() {
 fn test_try_read_bytes_missing_returns_not_found() {
     let file_path = "tests/hew/_fs_stream_bytes_missing.bin";
     cleanup_file(file_path);
-    match fs.try_read_bytes(file_path) {
+    match fs.read_bytes(file_path) {
         .Ok(_) => panic("expected missing file error"),
         .Err(err) => match err {
             IoError.NotFound(_) => {},
@@ -76,7 +76,7 @@ fn test_try_read_bytes_failure_drains_stale_error_message() {
     // where it can leak into a later, unrelated hew_stream_last_error() read.
     let file_path = "tests/hew/_fs_stream_drain_missing.bin";
     cleanup_file(file_path);
-    match fs.try_read_bytes(file_path) {
+    match fs.read_bytes(file_path) {
         .Ok(_) => panic("expected missing file error"),
         .Err(err) => match err {
             IoError.NotFound(_) => {},
@@ -112,16 +112,16 @@ fn test_try_read_bytes_failure_drains_stale_error_message() {
 fn test_try_write_read_size_and_delete_roundtrip() {
     let file_path = "tests/hew/_fs_stream_roundtrip.txt";
     cleanup_file(file_path);
-    match fs.try_write(file_path, "hello") {
+    match fs.write(file_path, "hello") {
         .Ok(_) => {},
         .Err(_) => panic("expected try_write to succeed"),
     }
-    match fs.try_read(file_path) {
+    match fs.read(file_path) {
         .Ok(data) => testing.assert_eq_str(data, "hello"),
         .Err(_) => panic("expected try_read to succeed"),
     }
     testing.assert_true(fs.size(file_path) == 5);
-    match fs.try_delete(file_path) {
+    match fs.delete(file_path) {
         .Ok(_) => {},
         .Err(_) => panic("expected try_delete to succeed"),
     }
@@ -134,7 +134,7 @@ fn test_try_rename_missing_source_returns_not_found() {
     let target_path = "tests/hew/_fs_stream_rename_missing_target.txt";
     cleanup_file(source_path);
     cleanup_file(target_path);
-    match fs.try_rename(source_path, target_path) {
+    match fs.rename(source_path, target_path) {
         .Ok(_) => panic("expected missing source error"),
         .Err(err) => match err {
             IoError.NotFound(_) => {},
@@ -150,16 +150,16 @@ fn test_try_rename_success() {
     let target_path = "tests/hew/_fs_stream_rename_dst.txt";
     cleanup_file(source_path);
     cleanup_file(target_path);
-    match fs.try_write(source_path, "renamed") {
+    match fs.write(source_path, "renamed") {
         .Ok(_) => {},
         .Err(_) => panic("expected source write to succeed"),
     }
-    match fs.try_rename(source_path, target_path) {
+    match fs.rename(source_path, target_path) {
         .Ok(_) => {},
         .Err(_) => panic("expected try_rename to succeed"),
     }
     testing.assert_true(fs.exists(source_path) == false);
-    match fs.try_read(target_path) {
+    match fs.read(target_path) {
         .Ok(data) => testing.assert_eq_str(data, "renamed"),
         .Err(_) => panic("expected renamed file to be readable"),
     }
@@ -173,7 +173,7 @@ fn test_try_copy_missing_source_returns_not_found() {
     let target_path = "tests/hew/_fs_stream_copy_missing_target.txt";
     cleanup_file(source_path);
     cleanup_file(target_path);
-    match fs.try_copy(source_path, target_path) {
+    match fs.copy(source_path, target_path) {
         .Ok(_) => panic("expected missing source error"),
         .Err(err) => match err {
             IoError.NotFound(_) => {},
@@ -189,16 +189,16 @@ fn test_try_copy_success() {
     let target_path = "tests/hew/_fs_stream_copy_dst.txt";
     cleanup_file(source_path);
     cleanup_file(target_path);
-    match fs.try_write(source_path, "copied") {
+    match fs.write(source_path, "copied") {
         .Ok(_) => {},
         .Err(_) => panic("expected source write to succeed"),
     }
-    match fs.try_copy(source_path, target_path) {
+    match fs.copy(source_path, target_path) {
         .Ok(_) => {},
         .Err(_) => panic("expected try_copy to succeed"),
     }
     testing.assert_true(fs.exists(source_path));
-    match fs.try_read(target_path) {
+    match fs.read(target_path) {
         .Ok(data) => testing.assert_eq_str(data, "copied"),
         .Err(_) => panic("expected copied file to be readable"),
     }
@@ -211,15 +211,15 @@ fn test_try_copy_success() {
 fn test_try_append_and_try_read_bytes() {
     let file_path = "tests/hew/_fs_stream_bytes.txt";
     cleanup_file(file_path);
-    match fs.try_write(file_path, "hello") {
+    match fs.write(file_path, "hello") {
         .Ok(_) => {},
         .Err(_) => panic("expected initial write to succeed"),
     }
-    match fs.try_append(file_path, " world") {
+    match fs.append(file_path, " world") {
         .Ok(_) => {},
         .Err(_) => panic("expected try_append to succeed"),
     }
-    match fs.try_read_bytes(file_path) {
+    match fs.read_bytes(file_path) {
         .Ok(data) => testing.assert_true(data.len() == 11),
         .Err(_) => panic("expected try_read_bytes to succeed"),
     }
@@ -244,11 +244,11 @@ fn test_try_write_and_try_read_bytes_binary_roundtrip() {
     let b2: u8 = 108;
     let b3: u8 = 108;
     let b4: u8 = 111;
-    match fs.try_write_bytes(file_path, "hello".to_bytes()) {
+    match fs.write_bytes(file_path, "hello".to_bytes()) {
         .Ok(_) => {},
         .Err(_) => panic("expected try_write_bytes to succeed"),
     }
-    match fs.try_read_bytes(file_path) {
+    match fs.read_bytes(file_path) {
         .Ok(data) => {
             testing.assert_eq(data.len(), expected_len);
             testing.assert_eq_u8(data[0], b0);
@@ -264,11 +264,11 @@ fn test_try_write_and_try_read_bytes_binary_roundtrip() {
 
 #[test]
 fn test_try_list_dir_handles_success_and_missing_paths() {
-    match fs.try_list_dir("tests/hew") {
+    match fs.list_dir("tests/hew") {
         .Ok(entries) => testing.assert_true(entries.len() > 0),
         .Err(_) => panic("expected tests/hew listing to succeed"),
     }
-    match fs.try_list_dir("tests/hew/_fs_stream_missing_dir") {
+    match fs.list_dir("tests/hew/_fs_stream_missing_dir") {
         .Ok(_) => panic("expected missing directory error"),
         .Err(err) => match err {
             IoError.NotFound(_) => {},
@@ -283,7 +283,7 @@ fn test_try_list_dir_regular_file_returns_enotdir() {
     let file_path = "tests/hew/_fs_stream_not_directory.txt";
     cleanup_file(file_path);
     let _ = fs.write(file_path, "not a directory");
-    match fs.try_list_dir(file_path) {
+    match fs.list_dir(file_path) {
         .Ok(_) => panic("expected regular-file listing error"),
         .Err(err) => match err {
             IoError.Other(errno) => testing.assert_eq(errno, 20),
@@ -299,7 +299,7 @@ fn test_try_write_reports_enotdir_errno() {
     let file_path = "tests/hew/_fs_stream_write_parent.txt";
     cleanup_file(file_path);
     let _ = fs.write(file_path, "not a directory");
-    match fs.try_write(file_path + "/child", "content") {
+    match fs.write(file_path + "/child", "content") {
         .Ok(_) => panic("expected write through regular file to fail"),
         .Err(err) => match err {
             IoError.Other(errno) => testing.assert_eq(errno, 20),
@@ -482,7 +482,7 @@ fn test_try_mkdir_existing_returns_already_exists() {
     // "tests/hew" always exists (it holds this test), so no fixture/cleanup is
     // needed and the test cannot leak state. The payload is the platform errno,
     // which we do not pin here.
-    let result = fs.try_mkdir("tests/hew");
+    let result = fs.mkdir("tests/hew");
     match result {
         .Ok(_) => panic("expected mkdir on an existing directory to fail"),
         .Err(err) => match err {

--- a/tests/hew/http_response_body_non_2xx_test.hew
+++ b/tests/hew/http_response_body_non_2xx_test.hew
@@ -48,7 +48,7 @@ fn test_non_2xx_response_body_round_trips() {
             let client = spawn Client(url: f"http://127.0.0.1:{port}/missing", status: 0, body: "");
             client.fetch(0);
             let req = server.accept();
-            let _ = req.try_respond_text(404, "not found: the resource does not exist");
+            let _ = req.respond_text(404, "not found: the resource does not exist");
             req.close();
             server.close();
             match await client.status_result() {

--- a/tests/hew/http_server_client_roundtrip_test.hew
+++ b/tests/hew/http_server_client_roundtrip_test.hew
@@ -63,7 +63,7 @@ fn test_server_client_roundtrip_returns_200_and_echoes_path() {
             client.fetch(0);
             let req = server.accept();
             let path = req.path();
-            let _ = req.try_respond_text(200, "pong:" + path);
+            let _ = req.respond_text(200, "pong:" + path);
             req.close();
             server.close();
             match await client.status_result() {

--- a/tests/hew/os_test.hew
+++ b/tests/hew/os_test.hew
@@ -2,6 +2,8 @@
 
 import std.os;
 
+import std.observe;
+
 import std.testing;
 
 #[test]
@@ -28,4 +30,26 @@ fn test_remove_env_rejects_equals_in_name() {
 fn test_env_error_display_names_the_rejected_name() {
     let err = EnvError.InvalidName("HEW=INVALID");
     testing.assert_eq_str(to_string(err), "invalid environment variable name: `HEW=INVALID`");
+}
+
+#[test]
+#[serial]
+fn test_env_distinguishes_unset_from_empty_values() {
+    let name = "HEW_RESULT_ONLY_ST2A";
+    let _ = os.remove_env(name);
+    testing.assert_true(os.env(name).is_none());
+    match os.set_env(name, "") {
+        .Ok(()) => {},
+        .Err(_) => panic("expected environment variable to be set"),
+    }
+    match os.env(name) {
+        .Some(value) => testing.assert_eq_str(value, ""),
+        .None => panic("expected an explicitly empty environment value"),
+    }
+    let _ = os.remove_env(name);
+}
+
+#[test]
+fn test_observe_read_reports_unknown_metrics_as_none() {
+    testing.assert_true(observe.read("hew.result_only_st2a.unknown").is_none());
 }

--- a/tests/hew/path_test.hew
+++ b/tests/hew/path_test.hew
@@ -249,7 +249,7 @@ fn chmod_dir(mode: string, dir: string) -> i64 {
 
 #[test]
 fn test_try_glob_reports_matches_for_a_completed_walk() {
-    match path.try_glob("std/*.hew") {
+    match path.glob("std/*.hew") {
         .Ok(matches) => {
             testing.assert_true(matches.len() > 0);
             match matches.try_get(0) {
@@ -263,7 +263,7 @@ fn test_try_glob_reports_matches_for_a_completed_walk() {
 
 #[test]
 fn test_try_glob_reports_no_match_as_an_empty_success() {
-    match path.try_glob("std/hew-no-such-glob-subject-*.hew") {
+    match path.glob("std/hew-no-such-glob-subject-*.hew") {
         .Ok(matches) => testing.assert_true(matches.len() == 0),
         .Err(_) => panic("a completed walk that matched nothing is not a failure"),
     }
@@ -277,7 +277,7 @@ fn test_try_glob_reports_an_unreadable_directory_as_a_failure() {
     fs.mkdir_all(inner);
     fs.write(f"{inner}/present.txt", "x");
     testing.assert_true(chmod_dir("000", inner) == 0);
-    let observed = match path.try_glob(f"{inner}/*") {
+    let observed = match path.glob(f"{inner}/*") {
         .Ok(_) => "fabricated-empty-success",
         .Err(err) => to_string(err),
     };

--- a/tests/vertical-slice/accept/await_accept_shutdown_repark_loop.hew
+++ b/tests/vertical-slice/accept/await_accept_shutdown_repark_loop.hew
@@ -39,7 +39,7 @@ actor Server {
 fn main() {
     let server = spawn Server;
     server.go();
-    while observe.read("reactor.registrations_live") == 0 {}
+    while observe.read("reactor.registrations_live").unwrap_or(0) == 0 {}
     while unsafe {
         hew_sched_metrics_active_workers()
     } != 0 {}

--- a/tests/vertical-slice/accept/await_read_shutdown_cancelled.hew
+++ b/tests/vertical-slice/accept/await_read_shutdown_cancelled.hew
@@ -37,7 +37,7 @@ fn main() {
     let reader = spawn Reader(port: port);
     reader.go();
     let _peer = listener.accept();
-    while observe.read("reactor.registrations_live") == 0 {}
+    while observe.read("reactor.registrations_live").unwrap_or(0) == 0 {}
     while unsafe {
         hew_sched_metrics_active_workers()
     } != 0 {}

--- a/tests/vertical-slice/accept/std_panic_wrappers_success.hew
+++ b/tests/vertical-slice/accept/std_panic_wrappers_success.hew
@@ -18,7 +18,7 @@ fn main() -> i64 {
     if contents.len() == 0 {
         return 2;
     }
-    let arg0 = os.args(0);
+    let arg0 = os.args().get(0);
     if arg0.len() == 0 {
         return 3;
     }

--- a/tests/vertical-slice/reject/result_only_core_try_names_removed.hew
+++ b/tests/vertical-slice/reject/result_only_core_try_names_removed.hew
@@ -1,0 +1,13 @@
+// Removed core Result-only names must fail at the public API boundary.
+import std.fs;
+import std.net.http;
+import std.os;
+import std.path;
+
+fn main() {
+    let _ = fs.try_read;
+    let _ = fs.try_write;
+    let _ = path.try_glob;
+    let _ = http.try_respond;
+    let _ = os.args_count;
+}


### PR DESCRIPTION
Why

The core standard-library modules exposed paired fallible and sentinel APIs, leaving callers to choose incompatible error paths.

What

- Replace fs, path, os, observe, and HTTP response APIs with their decided Result or Option contracts.
- Migrate current callers, documentation fences, and behavioural rejection coverage without aliases.

Test

- make test-stdlib-ratchet
- make stdlib-lint
- make test-doc-examples