### PR TITLE
fix(ci): resolve LLVM assets on Linux runners

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -57,16 +57,19 @@ runs:
       run: |
         set -euo pipefail
         version="${{ inputs.version }}"
-        case "${{ runner.os }}-${{ runner.arch }}" in
-          Linux-X64)
+        runner_os="${{ runner.os }}"
+        runner_arch="${{ runner.arch }}"
+        target="${runner_os}-${runner_arch}"
+        case "${target,,}" in
+          linux-x64)
             asset="LLVM-${version}-Linux-X64.tar.xz"
             subdir="LLVM-${version}-Linux-X64"
             ;;
-          Linux-ARM64)
+          linux-arm64)
             asset="LLVM-${version}-Linux-ARM64.tar.xz"
             subdir="LLVM-${version}-Linux-ARM64"
             ;;
-          Windows-X64)
+          windows-x64)
             # The official upstream Windows tarball statically embeds rpmalloc
             # (defines malloc/free/calloc -> duplicate symbols against ucrt at
             # lld-link time) and omits xml2s.lib. Use hew-lang/llvm-toolchain's
@@ -84,7 +87,7 @@ runs:
             subdir="llvm-22"
             ;;
           *)
-            echo "::error::No upstream LLVM binary asset known for ${{ runner.os }}-${{ runner.arch }}"
+            echo "::error::No upstream LLVM binary asset known for ${target}"
             exit 1
             ;;
         esac
@@ -131,7 +134,7 @@ runs:
     - name: Cache extracted LLVM
       id: cache
       if: runner.os != 'macOS'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.layout.outputs.prefix }}
         key: llvm-${{ runner.os }}-${{ runner.arch }}-${{ steps.layout.outputs.version }}-${{ steps.layout.outputs.sha256 }}

--- a/scripts/tests/test_setup_llvm_contract.sh
+++ b/scripts/tests/test_setup_llvm_contract.sh
@@ -10,7 +10,8 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 
 RESOLVER="$TMP_ROOT/resolver.sh"
 awk '
-  /^        set -euo pipefail$/ { in_run=1 }
+  /^    - name: Resolve LLVM asset metadata$/ { in_layout=1 }
+  in_layout && /^        set -euo pipefail$/ { in_run=1 }
   in_run {
     line = $0
     sub(/^        /, "", line)

--- a/scripts/tests/test_setup_llvm_contract.sh
+++ b/scripts/tests/test_setup_llvm_contract.sh
@@ -20,7 +20,8 @@ awk '
   }
 ' "$ACTION" |
     sed -e 's|\${{ runner\.os }}|$TEST_RUNNER_OS|g' \
-        -e 's|\${{ runner\.arch }}|$TEST_RUNNER_ARCH|g' >"$RESOLVER"
+        -e 's|\${{ runner\.arch }}|$TEST_RUNNER_ARCH|g' \
+        -e 's|\${{ inputs\.version }}|22.1.5|g' >"$RESOLVER"
 
 RUNNER_TEMP="$TMP_ROOT/runner-temp"
 GITHUB_OUTPUT="$TMP_ROOT/linux.output"

--- a/scripts/tests/test_setup_llvm_contract.sh
+++ b/scripts/tests/test_setup_llvm_contract.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Execute the setup-llvm metadata resolver for supported and unsupported hosts.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ACTION="$ROOT/.github/actions/setup-llvm/action.yml"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hew-setup-llvm-contract.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+RESOLVER="$TMP_ROOT/resolver.sh"
+awk '
+  /^        set -euo pipefail$/ { in_run=1 }
+  in_run {
+    line = $0
+    sub(/^        /, "", line)
+    print line
+    if (line == "echo \"prefix=${prefix}\" >> \"$GITHUB_OUTPUT\"") exit
+  }
+' "$ACTION" |
+    sed -e 's|\${{ runner\.os }}|$TEST_RUNNER_OS|g' \
+        -e 's|\${{ runner\.arch }}|$TEST_RUNNER_ARCH|g' >"$RESOLVER"
+
+RUNNER_TEMP="$TMP_ROOT/runner-temp"
+GITHUB_OUTPUT="$TMP_ROOT/linux.output"
+TEST_RUNNER_OS=Linux TEST_RUNNER_ARCH=X64 \
+    RUNNER_TEMP="$RUNNER_TEMP" GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+    bash "$RESOLVER"
+
+grep -Fx 'asset=LLVM-22.1.5-Linux-X64.tar.xz' "$GITHUB_OUTPUT"
+grep -Fx 'sha256=04dfa3ab6f1c332dd73a057daeb8f48cdaacdef24178f8eccddf2cbfa8944aa4' "$GITHUB_OUTPUT"
+
+if TEST_RUNNER_OS=FreeBSD TEST_RUNNER_ARCH=X64 \
+    RUNNER_TEMP="$RUNNER_TEMP" GITHUB_OUTPUT="$TMP_ROOT/unknown.output" \
+    bash "$RESOLVER" >"$TMP_ROOT/unknown.log" 2>&1; then
+    echo "unsupported LLVM target unexpectedly resolved" >&2
+    exit 1
+fi
+grep -Fqx '::error::No upstream LLVM binary asset known for FreeBSD-X64' "$TMP_ROOT/unknown.log"
+
+echo "setup-llvm metadata contract: PASS"


### PR DESCRIPTION
## Why

GitHub reports the Linux runner architecture as `X64`, while the LLVM asset table uses a normalized platform key. Setup failed before it could select the Linux archive.

## What

- Normalize the runner platform before looking up the LLVM archive.
- Keep the archive names and checksums unchanged.
- Reject unsupported platforms.

## Test

- `scripts/tests/test_setup_llvm_contract.sh` covers Linux-X64 lookup and an unsupported platform