### PR TITLE
fix(cli): run selected tests instead of main

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -965,9 +965,44 @@ pub(crate) fn compile_native_from_program_with_paths(
         }
         channel.unwrap_or(DiagChannel::User)
     })?;
+    let state = hew_compile::FileFrontendState {
+        program: state.program,
+        diagnostics: state.diagnostics,
+        typecheck_result: state.typecheck_result,
+        source: state.source,
+        entry_selection: None,
+        companion: None,
+    };
+    compile_native_from_file_frontend_with_paths(
+        &state,
+        source_label,
+        output_path,
+        options,
+        paths,
+        extra_libs,
+    )
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "cohesive frontend->MIR->emit->link pipeline already at the line boundary; \\
+              splitting it would obscure the linear flow"
+)]
+pub(crate) fn compile_native_from_file_frontend_with_paths(
+    state: &hew_compile::FileFrontendState,
+    source_label: &str,
+    output_path: &Path,
+    options: &compile::CompileOptions,
+    paths: Option<&NativeBuildPaths>,
+    extra_libs: &[String],
+) -> Result<(), DiagChannel> {
+    let target = target::TargetSpec::from_requested(options.target.as_deref()).map_err(|e| {
+        eprintln!("Error: {e}");
+        DiagChannel::User
+    })?;
     compile::render_frontend_diagnostics(&state.diagnostics);
 
-    let tco = state.typecheck_result.tco.ok_or_else(|| {
+    let tco = state.typecheck_result.tco.as_ref().ok_or_else(|| {
         eprintln!(
             "Error: eval compilation requires a type-checked program; \
              this path should be unreachable (no_typecheck = false)"
@@ -977,7 +1012,7 @@ pub(crate) fn compile_native_from_program_with_paths(
 
     let lower_output = hew_hir::lower_program(
         &state.program,
-        &tco,
+        tco,
         &hew_hir::ResolutionCtx,
         hir_target_arch(&target),
     );
@@ -1002,7 +1037,7 @@ pub(crate) fn compile_native_from_program_with_paths(
     }
 
     let (pipeline, sir_report) =
-        lower_verified_hir_to_pipeline(&lower_output.module, &tco, &target, options.sir_mode)?;
+        lower_verified_hir_to_pipeline(&lower_output.module, tco, &target, options.sir_mode)?;
     if let Some(report) = sir_report.as_ref() {
         report_sir_lane(report);
     }

--- a/hew-cli/src/test_runner/discovery.rs
+++ b/hew-cli/src/test_runner/discovery.rs
@@ -4,6 +4,7 @@ use hew_parser::ast::{Item, Program};
 use hew_parser::ParseError;
 #[cfg(test)]
 use hew_parser::Severity;
+use hew_types::{DeclarationKind, DeclarationOccurrence};
 
 /// A discovered test case.
 #[derive(Debug, Clone)]
@@ -12,6 +13,10 @@ pub struct TestCase {
     pub name: String,
     /// Source file path.
     pub file: String,
+    /// Exact source declaration selected for process entry.
+    pub occurrence: DeclarationOccurrence,
+    /// Canonical production peer matched to this test root.
+    pub companion: Option<String>,
     /// Whether the test has `#[ignore]`.
     pub ignored: bool,
     /// Whether the test has `#[should_panic]`.
@@ -48,7 +53,8 @@ impl DiscoveredTestFile {
 #[must_use]
 pub fn discover_tests(program: &Program, file: &str) -> Vec<TestCase> {
     let mut tests = Vec::new();
-    for (item, _span) in &program.items {
+    let companion = matched_production_peer(std::path::Path::new(file));
+    for (item_ordinal, (item, span)) in program.items.iter().enumerate() {
         if let Item::Function(f) = item {
             let is_test = f.attributes.iter().any(|a| a.name == "test");
             if is_test {
@@ -58,6 +64,14 @@ pub fn discover_tests(program: &Program, file: &str) -> Vec<TestCase> {
                 tests.push(TestCase {
                     name: f.name.clone(),
                     file: file.to_string(),
+                    occurrence: DeclarationOccurrence::new_with_synthetic_ordinal(
+                        None,
+                        span,
+                        item_ordinal,
+                        DeclarationKind::Function,
+                        0,
+                    ),
+                    companion: companion.clone(),
                     ignored,
                     should_panic,
                     serial,
@@ -66,6 +80,15 @@ pub fn discover_tests(program: &Program, file: &str) -> Vec<TestCase> {
         }
     }
     tests
+}
+
+fn matched_production_peer(path: &std::path::Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?.strip_suffix("_test")?;
+    let peer = path.with_file_name(format!("{stem}.hew"));
+    peer.is_file()
+        .then_some(peer)
+        .and_then(|peer| peer.canonicalize().ok())
+        .map(|peer| peer.display().to_string())
 }
 
 /// Parse a source file and discover tests.

--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -356,6 +356,13 @@ mod partition_tests {
         let test = discovery::TestCase {
             name: "works".into(),
             file: "/repo/tests/hew/sample_test.hew".into(),
+            occurrence: hew_types::DeclarationOccurrence::new(
+                None,
+                &(0..0),
+                hew_types::DeclarationKind::Function,
+                0,
+            ),
+            companion: None,
             ignored: false,
             should_panic: false,
             serial: false,

--- a/hew-cli/src/test_runner/output.rs
+++ b/hew-cli/src/test_runner/output.rs
@@ -291,6 +291,13 @@ mod tests {
                 test: TestCase {
                     name: "test_ok".into(),
                     file: "f.hew".into(),
+                    occurrence: hew_types::DeclarationOccurrence::new(
+                        None,
+                        &(0..0),
+                        hew_types::DeclarationKind::Function,
+                        0,
+                    ),
+                    companion: None,
                     ignored: false,
                     should_panic: false,
                     serial: false,
@@ -316,6 +323,13 @@ mod tests {
                 test: TestCase {
                     name: "test_bad".into(),
                     file: "f.hew".into(),
+                    occurrence: hew_types::DeclarationOccurrence::new(
+                        None,
+                        &(0..0),
+                        hew_types::DeclarationKind::Function,
+                        0,
+                    ),
+                    companion: None,
                     ignored: false,
                     should_panic: false,
                     serial: false,
@@ -343,6 +357,13 @@ mod tests {
                     test: TestCase {
                         name: "test_pass".into(),
                         file: "math_test.hew".into(),
+                        occurrence: hew_types::DeclarationOccurrence::new(
+                            None,
+                            &(0..0),
+                            hew_types::DeclarationKind::Function,
+                            0,
+                        ),
+                        companion: None,
                         ignored: false,
                         should_panic: false,
                         serial: false,
@@ -355,6 +376,13 @@ mod tests {
                     test: TestCase {
                         name: "test_fail".into(),
                         file: "math_test.hew".into(),
+                        occurrence: hew_types::DeclarationOccurrence::new(
+                            None,
+                            &(0..0),
+                            hew_types::DeclarationKind::Function,
+                            0,
+                        ),
+                        companion: None,
                         ignored: false,
                         should_panic: false,
                         serial: false,
@@ -367,6 +395,13 @@ mod tests {
                     test: TestCase {
                         name: "test_skip".into(),
                         file: "other_test.hew".into(),
+                        occurrence: hew_types::DeclarationOccurrence::new(
+                            None,
+                            &(0..0),
+                            hew_types::DeclarationKind::Function,
+                            0,
+                        ),
+                        companion: None,
                         ignored: true,
                         should_panic: false,
                         serial: false,

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -5,7 +5,7 @@ use super::discovery::TestCase;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::Duration;
 
 const MAX_DEFAULT_JOBS: usize = 8;
@@ -273,26 +273,7 @@ fn run_tests_serial(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestSum
         }
     }
 
-    for (file, file_tests) in by_file {
-        let source = match std::fs::read_to_string(file) {
-            Ok(s) => s,
-            Err(e) => {
-                for test in &file_tests {
-                    failed += 1;
-                    results.push(TestResult {
-                        test: (*test).clone(),
-                        outcome: TestOutcome::failed(
-                            TestFailureKind::Compile,
-                            format!("cannot read {file}: {e}"),
-                        ),
-                        output: String::new(),
-                        duration: Duration::ZERO,
-                    });
-                }
-                continue;
-            }
-        };
-
+    for (_, file_tests) in by_file {
         for test in file_tests {
             if test.ignored && !options.include_ignored {
                 ignored += 1;
@@ -306,7 +287,6 @@ fn run_tests_serial(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestSum
             }
 
             let result = run_single_test(
-                &source,
                 test,
                 options.ffi_lib,
                 options.compile_paths,
@@ -332,7 +312,6 @@ fn run_tests_serial(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestSum
 
 struct TestTask {
     result_index: usize,
-    source: Arc<str>,
     test: TestCase,
 }
 
@@ -365,26 +344,7 @@ fn run_tests_parallel(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestS
     let mut tasks = Vec::new();
     let mut result_index = 0;
 
-    for (file, file_tests) in by_file {
-        let source = match std::fs::read_to_string(file) {
-            Ok(source) => Some(Arc::<str>::from(source)),
-            Err(error) => {
-                for test in file_tests {
-                    result_slots[result_index] = Some(TestResult {
-                        test: test.clone(),
-                        outcome: TestOutcome::failed(
-                            TestFailureKind::Compile,
-                            format!("cannot read {file}: {error}"),
-                        ),
-                        output: String::new(),
-                        duration: Duration::ZERO,
-                    });
-                    result_index += 1;
-                }
-                continue;
-            }
-        };
-
+    for (_, file_tests) in by_file {
         for test in file_tests {
             if test.ignored && !options.include_ignored {
                 result_slots[result_index] = Some(TestResult {
@@ -396,7 +356,6 @@ fn run_tests_parallel(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestS
             } else {
                 tasks.push(TestTask {
                     result_index,
-                    source: Arc::clone(source.as_ref().expect("source was read")),
                     test: test.clone(),
                 });
             }
@@ -424,7 +383,6 @@ fn run_tests_parallel(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestS
                             .lock()
                             .unwrap_or_else(std::sync::PoisonError::into_inner);
                         run_single_test(
-                            &task.source,
                             &task.test,
                             options.ffi_lib,
                             options.compile_paths,
@@ -433,7 +391,6 @@ fn run_tests_parallel(tests: &[TestCase], options: &TestRunOptions<'_>) -> TestS
                         )
                     } else {
                         run_single_test(
-                            &task.source,
                             &task.test,
                             options.ffi_lib,
                             options.compile_paths,
@@ -484,21 +441,12 @@ struct CompiledTestArtifact {
     binary_path: PathBuf,
 }
 
-/// Compile a synthetic test program to a native binary.
 fn compile_test(
-    source: &str,
     test: &TestCase,
     ffi_lib: Option<&str>,
     compile_paths: &TestCompilePaths,
     sir_mode: crate::compile::SirMode,
 ) -> Result<CompiledTestArtifact, String> {
-    let synthetic = format!(
-        "{source}\n\nfn main() {{\n    {name}();\n}}\n",
-        name = test.name,
-    );
-
-    let parsed = hew_parser::parse(&synthetic);
-
     let emit_dir = tempfile::Builder::new()
         .prefix("hew_test_emit_")
         .tempdir_in(std::env::temp_dir())
@@ -514,22 +462,39 @@ fn compile_test(
         .executable_path(emit_dir.path(), binary_name);
     let extra_libs = ffi_lib.into_iter().map(str::to_owned).collect::<Vec<_>>();
 
+    let options = crate::compile::CompileOptions {
+        project_dir: Some(compile_paths.paths.project_dir.clone()),
+        sir_mode,
+        ..crate::compile::CompileOptions::default()
+    };
+    let mut frontend_options = crate::compile::frontend_options(&compile_paths.target, &options);
+    frontend_options.module_search_paths = Some(compile_paths.paths.module_search_paths.clone());
+
     crate::diagnostic::start_diagnostic_capture();
-    // Compile the synthetic program in memory while retaining the real test
-    // path for file-relative imports and the invocation root for package imports.
-    let compile_result = crate::compile_native_from_program_with_paths(
-        parsed.program,
-        &synthetic,
-        &test.file,
-        &binary_path,
-        &crate::compile::CompileOptions {
-            project_dir: Some(compile_paths.paths.project_dir.clone()),
-            sir_mode,
-            ..crate::compile::CompileOptions::default()
-        },
-        Some(&compile_paths.paths),
-        &extra_libs,
-    );
+    let compile_result = (|| -> Result<(), String> {
+        let state = hew_compile::run_file_frontend_to_typecheck_with_selection(
+            &test.file,
+            &frontend_options,
+            Some(test.occurrence),
+            test.companion.as_deref().map(Path::new),
+        )
+        .map_err(|failure| {
+            crate::compile::render_frontend_diagnostics(&failure.diagnostics);
+            if failure.diagnostics.is_empty() {
+                eprintln!("Error: {}", failure.message);
+            }
+            failure.message
+        })?;
+        crate::compile_native_from_file_frontend_with_paths(
+            &state,
+            &test.file,
+            &binary_path,
+            &options,
+            Some(&compile_paths.paths),
+            &extra_libs,
+        )
+        .map_err(|_| "in-process compilation failed".to_string())
+    })();
     let diagnostics = crate::diagnostic::finish_diagnostic_capture();
     if compile_result.is_err() {
         return Err(if diagnostics.is_empty() {
@@ -545,10 +510,7 @@ fn compile_test(
     })
 }
 
-/// Build a synthetic program that calls the test function, compile it natively,
-/// and execute the resulting binary.
 fn run_single_test(
-    source: &str,
     test: &TestCase,
     ffi_lib: Option<&str>,
     compile_paths: &TestCompilePaths,
@@ -557,7 +519,7 @@ fn run_single_test(
 ) -> TestResult {
     let start = std::time::Instant::now();
 
-    let artifact = match compile_test(source, test, ffi_lib, compile_paths, sir_mode) {
+    let artifact = match compile_test(test, ffi_lib, compile_paths, sir_mode) {
         Ok(artifact) => artifact,
         Err(msg) => {
             let outcome = if test.should_panic {
@@ -873,7 +835,7 @@ fn selected_test() {
         let dir = tempfile::tempdir().expect("create peer fixture directory");
         std::fs::write(
             dir.path().join("peer.hew"),
-            "fn peer_value() -> bool { true }\n",
+            "pub fn peer_value() -> bool { true }\n",
         )
         .expect("write production peer");
         let test_path = dir.path().join("peer_test.hew");
@@ -882,6 +844,26 @@ fn selected_test() {
             "#[test]\nfn uses_peer() { assert(peer_value()); }\n",
         )
         .expect("write test peer");
+
+        let summary = run_discovered_file(&test_path);
+
+        assert_eq!(summary.passed, 1, "{}", describe(&summary));
+    }
+
+    #[test]
+    fn unrelated_sibling_is_not_loaded() {
+        if !require_codegen() {
+            return;
+        }
+        let dir = tempfile::tempdir().expect("create sibling fixture directory");
+        std::fs::write(
+            dir.path().join("unrelated.hew"),
+            "fn invalid_helper() { missing_symbol(); }\n",
+        )
+        .expect("write unrelated sibling");
+        let test_path = dir.path().join("isolated_test.hew");
+        std::fs::write(&test_path, "#[test]\nfn isolated() { assert(true); }\n")
+            .expect("write isolated test");
 
         let summary = run_discovered_file(&test_path);
 
@@ -1064,6 +1046,13 @@ fn test_timeout() {
             TestCase {
                 name: "alpha".into(),
                 file: "alpha_test.hew".into(),
+                occurrence: hew_types::DeclarationOccurrence::new(
+                    None,
+                    &(0..0),
+                    hew_types::DeclarationKind::Function,
+                    0,
+                ),
+                companion: None,
                 ignored: true,
                 should_panic: false,
                 serial: false,
@@ -1071,6 +1060,13 @@ fn test_timeout() {
             TestCase {
                 name: "beta".into(),
                 file: "nested/beta_test.hew".into(),
+                occurrence: hew_types::DeclarationOccurrence::new(
+                    None,
+                    &(0..0),
+                    hew_types::DeclarationKind::Function,
+                    0,
+                ),
+                companion: None,
                 ignored: true,
                 should_panic: false,
                 serial: false,
@@ -1078,6 +1074,13 @@ fn test_timeout() {
             TestCase {
                 name: "gamma".into(),
                 file: "tests/gamma.hew".into(),
+                occurrence: hew_types::DeclarationOccurrence::new(
+                    None,
+                    &(0..0),
+                    hew_types::DeclarationKind::Function,
+                    0,
+                ),
+                companion: None,
                 ignored: true,
                 should_panic: false,
                 serial: false,

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -810,6 +810,24 @@ mod tests {
         summary
     }
 
+    fn run_discovered_file(path: &Path) -> TestSummary {
+        let discovered =
+            discovery::discover_tests_in_file(path.to_str().expect("test fixture path is utf-8"))
+                .expect("discover test fixture");
+        run_tests(
+            &discovered.tests,
+            TestRunOptions {
+                filter: None,
+                include_ignored: false,
+                ffi_lib: None,
+                compile_paths: cargo_test_compile_paths(),
+                timeout: DEFAULT_TEST_TIMEOUT,
+                jobs: 1,
+                sir_mode: crate::compile::SirMode::Disabled,
+            },
+        )
+    }
+
     #[test]
     fn passing_test() {
         if !require_codegen() {
@@ -825,6 +843,49 @@ fn test_pass() {
         );
         assert_eq!(summary.passed, 1, "{}", describe(&summary));
         assert_eq!(summary.failed, 0, "{}", describe(&summary));
+    }
+
+    #[test]
+    fn selected_test_runs_instead_of_authored_main() {
+        if !require_codegen() {
+            return;
+        }
+        let summary = run_inline(
+            r"
+fn main() {
+    assert(false);
+}
+
+#[test]
+fn selected_test() {
+    assert(true);
+}
+",
+        );
+        assert_eq!(summary.passed, 1, "{}", describe(&summary));
+    }
+
+    #[test]
+    fn matched_production_peer_supplies_test_symbols() {
+        if !require_codegen() {
+            return;
+        }
+        let dir = tempfile::tempdir().expect("create peer fixture directory");
+        std::fs::write(
+            dir.path().join("peer.hew"),
+            "fn peer_value() -> bool { true }\n",
+        )
+        .expect("write production peer");
+        let test_path = dir.path().join("peer_test.hew");
+        std::fs::write(
+            &test_path,
+            "#[test]\nfn uses_peer() { assert(peer_value()); }\n",
+        )
+        .expect("write test peer");
+
+        let summary = run_discovered_file(&test_path);
+
+        assert_eq!(summary.passed, 1, "{}", describe(&summary));
     }
 
     #[test]

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -33997,9 +33997,10 @@ fn param_is_aliasable_representation_loan(func: &RawMirFunction, param_idx: usiz
 // ---------------------------------------------------------------------------
 
 #[derive(Clone, Copy)]
-enum ProcessEntryTarget {
+enum ProcessEntrySymbolRole {
     Native,
     Wasm,
+    Displaced,
 }
 
 fn declare_function<'ctx>(
@@ -34009,9 +34010,9 @@ fn declare_function<'ctx>(
     func: &RawMirFunction,
     record_layouts: &RecordLayoutMap<'ctx>,
     enum_layouts: &[EnumLayout],
-    process_entry_target: Option<ProcessEntryTarget>,
+    process_entry_role: Option<ProcessEntrySymbolRole>,
 ) -> CodegenResult<FnSymbol<'ctx>> {
-    let linkage = if process_entry_target.is_some() {
+    let linkage = if process_entry_role.is_some() {
         Some(Linkage::External)
     } else {
         Some(Linkage::Internal)
@@ -34142,14 +34143,15 @@ fn declare_function<'ctx>(
         BasicTypeEnum::VectorType(v) => v.fn_type(&param_tys, false),
         BasicTypeEnum::ScalableVectorType(v) => v.fn_type(&param_tys, false),
     };
-    let symbol_name = match process_entry_target {
-        Some(ProcessEntryTarget::Wasm) => WASM_MAIN_BODY_SYMBOL,
-        Some(ProcessEntryTarget::Native) => NATIVE_MAIN_BODY_SYMBOL,
+    let symbol_name = match process_entry_role {
+        Some(ProcessEntrySymbolRole::Wasm) => WASM_MAIN_BODY_SYMBOL,
+        Some(ProcessEntrySymbolRole::Native) => NATIVE_MAIN_BODY_SYMBOL,
+        Some(ProcessEntrySymbolRole::Displaced) => DISPLACED_ENTRY_BODY_SYMBOL,
         None => &func.name,
     };
     // The native entry body is reached only through the runtime's catch
     // boundary, so it is not part of the module's external surface.
-    let linkage = if process_entry_target.is_some() {
+    let linkage = if process_entry_role.is_some() {
         Some(Linkage::Internal)
     } else {
         linkage
@@ -34211,6 +34213,11 @@ const NATIVE_MAIN_BODY_SYMBOL: &str = "__hew_main_body";
 /// The exported `main` there is the export wrapper emitted by
 /// [`emit_direct_process_entry_adapter`].
 const WASM_MAIN_BODY_SYMBOL: &str = "__original_main";
+
+/// Private body symbol for an authored entry displaced by a frontend-selected
+/// process entry. The checker identifies the displaced declaration; codegen
+/// never rediscovers it from the source or emitted name.
+const DISPLACED_ENTRY_BODY_SYMBOL: &str = "__hew_displaced_entry_body";
 
 /// The symbol carrying the program entry's own body on a given target.
 ///
@@ -38281,14 +38288,18 @@ fn build_module_for_target<'ctx>(
                 func.name
             )));
         }
-        let is_process_entry = pipeline
-            .entry_exit_plan
-            .as_ref()
-            .is_some_and(|plan| plan.entry == func.key.declaration);
-        let process_entry_target = is_process_entry.then_some(if emit_wasm_entry_alias {
-            ProcessEntryTarget::Wasm
-        } else {
-            ProcessEntryTarget::Native
+        let process_entry_role = pipeline.entry_exit_plan.as_ref().and_then(|plan| {
+            if plan.entry == func.key.declaration {
+                Some(if emit_wasm_entry_alias {
+                    ProcessEntrySymbolRole::Wasm
+                } else {
+                    ProcessEntrySymbolRole::Native
+                })
+            } else if plan.displaced_entry.as_ref() == Some(&func.key.declaration) {
+                Some(ProcessEntrySymbolRole::Displaced)
+            } else {
+                None
+            }
         });
         let sym = declare_function(
             ctx,
@@ -38297,7 +38308,7 @@ fn build_module_for_target<'ctx>(
             func,
             &record_layouts,
             &pipeline.enum_layouts,
-            process_entry_target,
+            process_entry_role,
         )
         // Attach the function's own source span to a fail-closed declaration
         // error ONLY when the function's body provably indexes the root

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -773,22 +773,23 @@ fn import_directory_module_entry_for_peer(
     let Some(entry_name) = directory_module_entry_for_peer(program, input, mode) else {
         return;
     };
-    program.items.insert(
-        0,
-        (
-            Item::Import(ImportDecl {
-                path: Vec::new(),
-                spec: None,
-                selection_trailing_comma: false,
-                module_alias: None,
-                file_path: Some(entry_name),
-                resolved_items: None,
-                resolved_item_source_paths: Vec::new(),
-                resolved_source_paths: Vec::new(),
-            }),
-            0..0,
-        ),
-    );
+    program.items.insert(0, file_import(entry_name));
+}
+
+fn file_import(file_path: String) -> Spanned<Item> {
+    (
+        Item::Import(ImportDecl {
+            path: Vec::new(),
+            spec: None,
+            selection_trailing_comma: false,
+            module_alias: None,
+            file_path: Some(file_path),
+            resolved_items: None,
+            resolved_item_source_paths: Vec::new(),
+            resolved_source_paths: Vec::new(),
+        }),
+        0..0,
+    )
 }
 
 fn project_context_for_program(
@@ -1029,6 +1030,7 @@ fn typecheck_program_with_diagnostics(
     input: &str,
     options: &FrontendOptions,
     mode: FrontendParseMode,
+    entry_selection: Option<hew_types::DeclarationOccurrence>,
 ) -> Result<(TypeCheckResult, Vec<FrontendDiagnostic>), FrontendFailure> {
     let search_paths = checker_search_paths(options, input);
     let module_registry = hew_types::module_registry::ModuleRegistry::new(search_paths);
@@ -1052,6 +1054,9 @@ fn typecheck_program_with_diagnostics(
     }
     if mode == FrontendParseMode::Migration {
         checker.set_migration_mode();
+    }
+    if let Some(entry_selection) = entry_selection {
+        checker.set_entry_selection(entry_selection);
     }
     checker.set_lint_levels(options.lint_levels.clone());
     // Install source text so the lint sweep can resolve in-source
@@ -1108,8 +1113,15 @@ pub fn typecheck_program(
     input: &str,
     options: &FrontendOptions,
 ) -> Result<TypeCheckResult, FrontendFailure> {
-    typecheck_program_with_diagnostics(program, source, input, options, FrontendParseMode::Strict)
-        .map(|(result, _)| result)
+    typecheck_program_with_diagnostics(
+        program,
+        source,
+        input,
+        options,
+        FrontendParseMode::Strict,
+        None,
+    )
+    .map(|(result, _)| result)
 }
 
 /// Resolve imports and type-check an already-parsed in-memory program.
@@ -1153,6 +1165,7 @@ pub fn check_program(
         source_label,
         options,
         FrontendParseMode::Strict,
+        None,
     ) {
         Ok((tcr, type_diagnostics)) => {
             diagnostics.extend(type_diagnostics);
@@ -2138,6 +2151,8 @@ pub struct FileFrontendState {
     pub diagnostics: Vec<FrontendDiagnostic>,
     pub typecheck_result: TypeCheckResult,
     pub source: String,
+    pub entry_selection: Option<hew_types::DeclarationOccurrence>,
+    pub companion: Option<PathBuf>,
 }
 
 #[allow(
@@ -2170,7 +2185,29 @@ pub fn run_file_frontend_to_typecheck(
     input: &str,
     options: &FrontendOptions,
 ) -> Result<FileFrontendState, FrontendFailure> {
-    run_file_frontend_to_typecheck_with_mode(input, options, FrontendParseMode::Strict)
+    run_file_frontend_to_typecheck_with_selection(input, options, None, None)
+}
+
+/// Run the shared file frontend with an exact process-entry selection and one
+/// canonical file companion.
+///
+/// # Errors
+///
+/// Returns [`FrontendFailure`] when project loading, parsing, import
+/// resolution, or type-checking fails.
+pub fn run_file_frontend_to_typecheck_with_selection(
+    input: &str,
+    options: &FrontendOptions,
+    entry_selection: Option<hew_types::DeclarationOccurrence>,
+    companion: Option<&Path>,
+) -> Result<FileFrontendState, FrontendFailure> {
+    run_file_frontend_to_typecheck_with_mode(
+        input,
+        options,
+        FrontendParseMode::Strict,
+        entry_selection,
+        companion,
+    )
 }
 
 /// Run the shared file frontend for the checker-backed syntax migrator.
@@ -2188,18 +2225,31 @@ pub fn run_file_frontend_to_typecheck_for_migration(
     input: &str,
     options: &FrontendOptions,
 ) -> Result<FileFrontendState, FrontendFailure> {
-    run_file_frontend_to_typecheck_with_mode(input, options, FrontendParseMode::Migration)
+    run_file_frontend_to_typecheck_with_mode(
+        input,
+        options,
+        FrontendParseMode::Migration,
+        None,
+        None,
+    )
 }
 
 fn run_file_frontend_to_typecheck_with_mode(
     input: &str,
     options: &FrontendOptions,
     mode: FrontendParseMode,
+    entry_selection: Option<hew_types::DeclarationOccurrence>,
+    companion: Option<&Path>,
 ) -> Result<FileFrontendState, FrontendFailure> {
     let project = load_project_context(input, Some(options))?;
     let (mut program, parse_diagnostics) =
         parse_source_with_diagnostics(&project.source, input, mode)?;
     import_directory_module_entry_for_peer(&mut program, Path::new(input), mode);
+    if let Some(companion) = companion {
+        program
+            .items
+            .push(file_import(companion.display().to_string()));
+    }
     let mut diagnostics = parse_diagnostics;
 
     if let Err(failure) = resolve_imports_internal(
@@ -2214,14 +2264,20 @@ fn run_file_frontend_to_typecheck_with_mode(
         return Err(merge_prior_diagnostics(diagnostics, failure));
     }
 
-    let typecheck_result =
-        match typecheck_program_with_diagnostics(&program, &project.source, input, options, mode) {
-            Ok((result, type_diagnostics)) => {
-                diagnostics.extend(type_diagnostics);
-                result
-            }
-            Err(failure) => return Err(merge_prior_diagnostics(diagnostics, failure)),
-        };
+    let typecheck_result = match typecheck_program_with_diagnostics(
+        &program,
+        &project.source,
+        input,
+        options,
+        mode,
+        entry_selection,
+    ) {
+        Ok((result, type_diagnostics)) => {
+            diagnostics.extend(type_diagnostics);
+            result
+        }
+        Err(failure) => return Err(merge_prior_diagnostics(diagnostics, failure)),
+    };
 
     flatten_file_import_items(&mut program);
     let stdlib_roots = configured_stdlib_roots(options);
@@ -2232,6 +2288,8 @@ fn run_file_frontend_to_typecheck_with_mode(
         diagnostics,
         typecheck_result,
         source: project.source,
+        entry_selection,
+        companion: companion.map(Path::to_path_buf),
     })
 }
 
@@ -2272,6 +2330,7 @@ pub fn run_program_frontend_to_typecheck(
         source_label,
         options,
         FrontendParseMode::Strict,
+        None,
     ) {
         Ok((result, type_diagnostics)) => {
             diagnostics.extend(type_diagnostics);
@@ -2517,7 +2576,8 @@ mod tests {
         check_file, check_file_with_state, check_program, checker_search_paths,
         hir_diagnostics_to_frontend, load_dependencies, load_lockfile, load_package_name,
         parse_source, retain_user_facing_diagnostics, run_file_frontend_to_typecheck,
-        run_file_frontend_to_typecheck_for_migration, FrontendDiagnostic, FrontendDiagnosticKind,
+        run_file_frontend_to_typecheck_for_migration,
+        run_file_frontend_to_typecheck_with_selection, FrontendDiagnostic, FrontendDiagnosticKind,
         FrontendOptions,
     };
     use hew_parser::ast::Item;
@@ -2541,6 +2601,59 @@ mod tests {
         file.write_all(content.as_bytes())
             .expect("write source file");
         path.display().to_string()
+    }
+
+    #[test]
+    fn selected_occurrence_never_falls_back_to_authored_main() {
+        let dir = tempfile::tempdir().expect("create selected-entry fixture");
+        let source = "fn main() {}\n\n#[test]\nfn selected_test() {}\n";
+        let input = write_source(dir.path(), "entry_test.hew", source);
+        let program = parse_source(source, &input).expect("parse selected-entry fixture");
+        let selection = program
+            .items
+            .iter()
+            .enumerate()
+            .find_map(|(item_ordinal, (item, span))| match item {
+                Item::Function(function)
+                    if function
+                        .attributes
+                        .iter()
+                        .any(|attribute| attribute.name == "test") =>
+                {
+                    Some(
+                        hew_types::DeclarationOccurrence::new_with_synthetic_ordinal(
+                            None,
+                            span,
+                            item_ordinal,
+                            hew_types::DeclarationKind::Function,
+                            0,
+                        ),
+                    )
+                }
+                _ => None,
+            })
+            .expect("selected test occurrence");
+
+        let state = run_file_frontend_to_typecheck_with_selection(
+            &input,
+            &FrontendOptions::default(),
+            Some(selection),
+            None,
+        )
+        .expect("selected-entry fixture must type-check");
+
+        assert_eq!(
+            state
+                .typecheck_result
+                .tco
+                .expect("typecheck output")
+                .entry_exit_plan
+                .expect("selected entry plan")
+                .entry
+                .display_name(),
+            "selected_test",
+            "a present selection must not fall back to authored main"
+        );
     }
 
     /// The checker's module search paths must anchor Tier 2 in-worktree

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -45,9 +45,9 @@ pub struct HirModule {
     /// producer missing from `diagnostic_source_modules` cannot leak a false
     /// root caret — it simply is not in this set.
     pub root_item_ids: HashSet<ItemId>,
-    /// Checker-selected process entry and its complete typed exit contract.
-    /// Downstream layers join on the plan's declaration identity and execute
-    /// its action without rediscovering either fact.
+    /// Checker-selected process entry, any displaced authored entry, and the
+    /// complete typed exit contract. Downstream layers join on declaration
+    /// identity and execute the action without rediscovering any fact.
     pub entry_exit_plan: Option<hew_types::EntryExitPlan>,
     /// Parameters whose resolved type has a checker-proven projection into
     /// caller-visible storage, keyed by stable function item id and parameter

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -101,7 +101,8 @@ impl PointerWidth {
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct IrPipeline {
-    /// Checker-selected process entry and its complete typed exit contract.
+    /// Checker-selected process entry, any displaced authored entry, and its
+    /// complete typed exit contract.
     pub entry_exit_plan: Option<hew_types::EntryExitPlan>,
     pub raw_mir: Vec<RawMirFunction>,
     pub checked_mir: Vec<CheckedMirFunction>,

--- a/hew-sir/src/model.rs
+++ b/hew-sir/src/model.rs
@@ -369,7 +369,8 @@ pub struct SemModule {
     /// from [`Self::entry_callable`], so unrelated root bodies do not block a
     /// selected program.
     pub root_unit_callables: Vec<CallableId>,
-    /// Checker-selected process entry and its complete typed exit contract.
+    /// Checker-selected process entry, any displaced authored entry, and its
+    /// complete typed exit contract.
     pub entry_exit_plan: Option<hew_types::EntryExitPlan>,
     /// Resolved entry callable, projected by joining the entry plan's `DefId`.
     /// Neither lowering nor the verifier rediscovers an entry from a

--- a/hew-sir/tests/entry.rs
+++ b/hew-sir/tests/entry.rs
@@ -45,6 +45,7 @@ fn declaration_of(module: &HirModule, name: &str) -> DefId {
 fn integer_entry(entry: DefId) -> EntryExitPlan {
     EntryExitPlan {
         entry,
+        displaced_entry: None,
         action: EntryExitAction::Integer(EntryIntegerType::I64),
     }
 }

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -734,6 +734,11 @@ fn declaration_walk_terminates(
 }
 
 impl Checker {
+    /// Select one exact root declaration for the process entry plan.
+    pub fn set_entry_selection(&mut self, selection: crate::DeclarationOccurrence) {
+        self.entry_selection = Some(selection);
+    }
+
     /// Build the §6.3 fact table over every concrete accepted expression type.
     ///
     /// The walk is closed under a type's own components so a `Vec<Conn>` row is
@@ -1242,54 +1247,36 @@ impl Checker {
         None
     }
 
-    fn classify_entry_exit_plan(
-        &mut self,
-        program: &Program,
-        resolved_fn_sigs: &HashMap<String, FnSig>,
-    ) -> Option<EntryExitPlan> {
-        let (item_index, span) =
-            program
-                .items
-                .iter()
-                .enumerate()
-                .find_map(|(item_index, (item, span))| match item {
-                    Item::Function(declaration)
-                        if declaration.name == "main"
-                            && declaration.type_params.as_ref().is_none_or(Vec::is_empty) =>
-                    {
-                        Some((item_index, span))
-                    }
-                    _ => None,
-                })?;
-        let occurrence = crate::DeclarationOccurrence::new_with_synthetic_ordinal(
-            self.identity.root_module(),
-            span,
-            item_index,
-            crate::DeclarationKind::Function,
-            0,
-        );
-        let entry = self.identity.declaration(occurrence)?.clone();
-        let Some(return_type) = resolved_fn_sigs
-            .get(entry.full_path())
-            .map(|signature| signature.return_type.clone())
-        else {
-            self.errors.push(TypeError::new(
-                TypeErrorKind::InvalidOperation,
-                span.clone(),
-                format!(
-                    "checker has no resolved signature for process entry `{}`",
-                    entry.display_name()
-                ),
-            ));
-            return None;
-        };
+    fn selected_entry_item<'a>(
+        &self,
+        program: &'a Program,
+    ) -> Option<(usize, &'a std::ops::Range<usize>)> {
+        let selected_entry = self.entry_selection?;
+        program
+            .items
+            .iter()
+            .enumerate()
+            .find_map(|(item_index, (item, span))| {
+                let Item::Function(_) = item else {
+                    return None;
+                };
+                (selected_entry.kind() == crate::DeclarationKind::Function
+                    && selected_entry.span() == *span)
+                    .then_some((item_index, span))
+            })
+    }
 
+    fn classify_entry_exit_action(
+        &mut self,
+        return_type: Ty,
+        span: &std::ops::Range<usize>,
+    ) -> Option<EntryExitAction> {
         let resolved_return_type = ResolvedTy::from_ty(&return_type).ok();
-        let action = match return_type {
-            Ty::Unit => EntryExitAction::Unit,
-            integer if EntryIntegerType::from_ty(&integer).is_some() => {
-                EntryExitAction::Integer(EntryIntegerType::from_ty(&integer)?)
-            }
+        match return_type {
+            Ty::Unit => Some(EntryExitAction::Unit),
+            integer if EntryIntegerType::from_ty(&integer).is_some() => Some(
+                EntryExitAction::Integer(EntryIntegerType::from_ty(&integer)?),
+            ),
             Ty::Named {
                 builtin: Some(crate::BuiltinType::Result),
                 args,
@@ -1325,14 +1312,14 @@ impl Checker {
                     ResolvedTy::Named { args, .. } => args.clone(),
                     _ => Vec::new(),
                 };
-                EntryExitAction::Result {
+                Some(EntryExitAction::Result {
                     result_ty: resolved_return_type?,
                     error_ty: resolved_error_ty,
                     display: EntryDisplayTarget {
                         declaration: display_declaration,
                         type_args,
                     },
-                }
+                })
             }
             unsupported => {
                 self.errors.push(TypeError::new(
@@ -1343,9 +1330,55 @@ impl Checker {
                         unsupported.user_facing()
                     ),
                 ));
-                return None;
+                None
             }
+        }
+    }
+
+    fn classify_entry_exit_plan(
+        &mut self,
+        program: &Program,
+        resolved_fn_sigs: &HashMap<String, FnSig>,
+    ) -> Option<EntryExitPlan> {
+        let (item_index, span) =
+            if self.entry_selection.is_some() {
+                self.selected_entry_item(program)?
+            } else {
+                program.items.iter().enumerate().find_map(
+                    |(item_index, (item, span))| match item {
+                        Item::Function(declaration)
+                            if declaration.name == "main"
+                                && declaration.type_params.as_ref().is_none_or(Vec::is_empty) =>
+                        {
+                            Some((item_index, span))
+                        }
+                        _ => None,
+                    },
+                )?
+            };
+        let occurrence = crate::DeclarationOccurrence::new_with_synthetic_ordinal(
+            self.identity.root_module(),
+            span,
+            item_index,
+            crate::DeclarationKind::Function,
+            0,
+        );
+        let entry = self.identity.declaration(occurrence)?.clone();
+        let Some(return_type) = resolved_fn_sigs
+            .get(entry.full_path())
+            .map(|signature| signature.return_type.clone())
+        else {
+            self.errors.push(TypeError::new(
+                TypeErrorKind::InvalidOperation,
+                span.clone(),
+                format!(
+                    "checker has no resolved signature for process entry `{}`",
+                    entry.display_name()
+                ),
+            ));
+            return None;
         };
+        let action = self.classify_entry_exit_action(return_type, span)?;
 
         Some(EntryExitPlan { entry, action })
     }
@@ -2693,6 +2726,7 @@ impl Checker {
         let consume_receiver_methods = std::mem::take(&mut self.consume_receiver_methods);
         let lint_levels = self.lint_levels.clone();
         let lint_sources = self.lint_sources.clone();
+        let entry_selection = self.entry_selection;
 
         *self = Self::new(module_registry);
         self.wasm_target = wasm_target;
@@ -2703,6 +2737,7 @@ impl Checker {
         self.consume_receiver_methods = consume_receiver_methods;
         self.lint_levels = lint_levels;
         self.lint_sources = lint_sources;
+        self.entry_selection = entry_selection;
     }
 
     /// The canonical prelude is an import-only authority manifest: its imports

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -1266,6 +1266,37 @@ impl Checker {
             })
     }
 
+    fn authored_entry_item(program: &Program) -> Option<(usize, &std::ops::Range<usize>)> {
+        program
+            .items
+            .iter()
+            .enumerate()
+            .find_map(|(item_index, (item, span))| match item {
+                Item::Function(declaration)
+                    if declaration.name == "main"
+                        && declaration.type_params.as_ref().is_none_or(Vec::is_empty) =>
+                {
+                    Some((item_index, span))
+                }
+                _ => None,
+            })
+    }
+
+    fn entry_declaration(
+        &self,
+        item_index: usize,
+        span: &std::ops::Range<usize>,
+    ) -> Option<crate::DefId> {
+        let occurrence = crate::DeclarationOccurrence::new_with_synthetic_ordinal(
+            self.identity.root_module(),
+            span,
+            item_index,
+            crate::DeclarationKind::Function,
+            0,
+        );
+        self.identity.declaration(occurrence).cloned()
+    }
+
     fn classify_entry_exit_action(
         &mut self,
         return_type: Ty,
@@ -1340,30 +1371,18 @@ impl Checker {
         program: &Program,
         resolved_fn_sigs: &HashMap<String, FnSig>,
     ) -> Option<EntryExitPlan> {
-        let (item_index, span) =
-            if self.entry_selection.is_some() {
-                self.selected_entry_item(program)?
-            } else {
-                program.items.iter().enumerate().find_map(
-                    |(item_index, (item, span))| match item {
-                        Item::Function(declaration)
-                            if declaration.name == "main"
-                                && declaration.type_params.as_ref().is_none_or(Vec::is_empty) =>
-                        {
-                            Some((item_index, span))
-                        }
-                        _ => None,
-                    },
-                )?
-            };
-        let occurrence = crate::DeclarationOccurrence::new_with_synthetic_ordinal(
-            self.identity.root_module(),
-            span,
-            item_index,
-            crate::DeclarationKind::Function,
-            0,
-        );
-        let entry = self.identity.declaration(occurrence)?.clone();
+        let authored_entry_item = Self::authored_entry_item(program);
+        let (item_index, span) = if self.entry_selection.is_some() {
+            self.selected_entry_item(program)?
+        } else {
+            authored_entry_item?
+        };
+        let entry = self.entry_declaration(item_index, span)?;
+        let displaced_entry = self
+            .entry_selection
+            .and(authored_entry_item)
+            .and_then(|(item_index, span)| self.entry_declaration(item_index, span))
+            .filter(|authored_entry| authored_entry != &entry);
         let Some(return_type) = resolved_fn_sigs
             .get(entry.full_path())
             .map(|signature| signature.return_type.clone())
@@ -1380,7 +1399,11 @@ impl Checker {
         };
         let action = self.classify_entry_exit_action(return_type, span)?;
 
-        Some(EntryExitPlan { entry, action })
+        Some(EntryExitPlan {
+            entry,
+            displaced_entry,
+            action,
+        })
     }
 
     #[expect(

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -260,6 +260,10 @@ pub enum EntryExitAction {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EntryExitPlan {
     pub entry: crate::DefId,
+    /// Authored process entry displaced by an explicit frontend selection.
+    /// This keeps the process ABI symbol available for the selected adapter
+    /// without downstream name-based rediscovery.
+    pub displaced_entry: Option<crate::DefId>,
     pub action: EntryExitAction,
 }
 

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2797,6 +2797,8 @@ pub struct Checker {
     /// Source-order discriminator used only for source-less AST inventories
     /// whose top-level declarations all carry the synthetic `0..0` span.
     pub(super) current_item_ordinal: usize,
+    /// Exact source occurrence selected as process entry by a file frontend.
+    pub(super) entry_selection: Option<crate::DeclarationOccurrence>,
     /// Type names declared per source FILE (populated during type
     /// collection from per-item attribution). This is the lexical authority
     /// behind extern-signature nominal identity: a bare name in an extern
@@ -3932,6 +3934,7 @@ impl Checker {
             source_file_span_indices: HashMap::new(),
             current_item_source: None,
             current_item_ordinal: 0,
+            entry_selection: None,
             file_type_decls: HashMap::new(),
             canonical_std_root_sources: HashSet::new(),
             protected_prelude_declaration_collisions: HashSet::new(),


### PR DESCRIPTION
## Why

Selecting a test from a file that also defined `main` built a binary whose entry point still ran `main`.

## What

- Record which `main` declaration is displaced by test selection.
- Emit that function under a private symbol.
- Reserve the process entry point for the selected test adapter.

## Test

- `test_runner::runner::tests::passing_test`
- `test_runner::runner::tests::selected_test_runs_instead_of_authored_main`
- `test_runner::runner::tests::matched_production_peer_supplies_test_symbols`
- `test_runner::runner::tests::unrelated_sibling_is_not_loaded`