### PR TITLE
feat(runtime): make node setup and registry typed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -686,8 +686,13 @@ ci-preflight-smoke:
 	$(TEST_RUN_ENV) cargo nextest run --workspace --profile smoke
 
 NODE_API_TEST ?= node_api
+NODE_API_EXAMPLE_INVENTORY = --label "node API" \
+	  --source examples/distributed/kv_server.hew \
+	  --source examples/distributed/kv_client.hew
 test-node-api: hew-native
 	$(TEST_RUN_ENV) cargo test -p hew-cli --test distributed_two_process_e2e $(NODE_API_TEST) -- --test-threads=1
+	@$(PYTHON) scripts/example-expectations.py \
+	  --hew-bin "$(DEBUG_DIR)/hew" $(NODE_API_EXAMPLE_INVENTORY)
 
 # ── Local Linux CI-parity harness ────────────────────────────────────────────
 # Runs the GitHub Actions `Build & test (Linux)` job on a NATIVE x86_64 Linux
@@ -1392,6 +1397,7 @@ ux-examples-expect: hew-native
 #
 SURFACE_EXAMPLE_INVENTORY = --label "surface" \
 	  --source-root examples/v05/surfaces \
+	  --source-root examples/distributed \
 	  --source examples/net/http_await_service.hew
 
 test-surface-examples: hew-native test-example-expectations-selftest

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks help shell-script-lint test-install-version-resolution actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check playground-verify preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
-.PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-node-api test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
+.PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-node-api test-node-api-runtime test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
 .PHONY: test-ownership-balance-corpus test-ownership-balance-runner-selftest
 .PHONY: stdlib-user-build-clean
 .PHONY: clean install uninstall verify-ffi ffi-ownership-ratchet-record test-verify-ffi test-cabi-surface cabi-surface cabi-surface-check
@@ -693,6 +693,10 @@ test-node-api: hew-native
 	$(TEST_RUN_ENV) cargo test -p hew-cli --test distributed_two_process_e2e $(NODE_API_TEST) -- --test-threads=1
 	@$(PYTHON) scripts/example-expectations.py \
 	  --hew-bin "$(DEBUG_DIR)/hew" $(NODE_API_EXAMPLE_INVENTORY)
+
+test-node-api-runtime:
+	$(TEST_RUN_ENV) cargo test -p hew-runtime registry_gossip --lib -- --test-threads=1
+	$(TEST_RUN_ENV) cargo test -p hew-runtime --test envelope_round_trip registry_gossip -- --test-threads=1
 
 # ── Local Linux CI-parity harness ────────────────────────────────────────────
 # Runs the GitHub Actions `Build & test (Linux)` job on a NATIVE x86_64 Linux

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks help shell-script-lint test-install-version-resolution actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check playground-verify preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
-.PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
+.PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-node-api test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
 .PHONY: test-ownership-balance-corpus test-ownership-balance-runner-selftest
 .PHONY: stdlib-user-build-clean
 .PHONY: clean install uninstall verify-ffi ffi-ownership-ratchet-record test-verify-ffi test-cabi-surface cabi-surface cabi-surface-check
@@ -684,6 +684,10 @@ ci-shard-3: grammar-parity downstream-check mqtt-broker-e2e sandbox-parity \
 ci-preflight-smoke:
 	cargo fmt --all -- --check
 	$(TEST_RUN_ENV) cargo nextest run --workspace --profile smoke
+
+NODE_API_TEST ?= node_api
+test-node-api: hew-native
+	$(TEST_RUN_ENV) cargo test -p hew-cli --test distributed_two_process_e2e $(NODE_API_TEST) -- --test-threads=1
 
 # ── Local Linux CI-parity harness ────────────────────────────────────────────
 # Runs the GitHub Actions `Build & test (Linux)` job on a NATIVE x86_64 Linux

--- a/examples/distributed/kv_client.expected
+++ b/examples/distributed/kv_client.expected
@@ -1,0 +1,1 @@
+[kv-client] set HEW_NODE_KEY and HEW_NODE_PEER before starting

--- a/examples/distributed/kv_client.hew
+++ b/examples/distributed/kv_client.hew
@@ -42,21 +42,44 @@ impl ActorMsg for KeyValue {
 }
 
 fn main() -> i64 {
-    var port: string = "9100";
-    var server_addr: string = "127.0.0.1";
-    if os.args().len() > 1 {
-        server_addr = os.args().get(1);
+    let key = os.env("HEW_NODE_KEY").unwrap_or("");
+    let peer = os.env("HEW_NODE_PEER").unwrap_or("");
+    if key.is_empty() || peer.is_empty() {
+        println("[kv-client] set HEW_NODE_KEY and HEW_NODE_PEER before starting");
+        return 0;
     }
-    if os.args().len() > 2 {
-        port = os.args().get(2);
-    }
+
+    let args = os.args();
+    let server_addr = match args.get(1) {
+        .Some(value) => value,
+        .None => "127.0.0.1",
+    };
+    let port = match args.get(2) {
+        .Some(value) => value,
+        .None => "9100",
+    };
     let remote_addr = f"{server_addr}:{port}";
     println(f"[kv-client] starting node, will connect to {remote_addr}");
-    Node.set_transport("tcp");
-    Node.start("0.0.0.0:0");
+    let peers: Vec<string> = Vec.new();
+    peers.push(f"1@{peer}");
+    let config = NodeConfig { bind: "0.0.0.0:0", transport: "tcp", key: key, trust: "pinned", peers: peers, seeds: Vec.new() };
+    match Node.start(config) {
+        .Err(err) => {
+            println(f"[kv-client] start failed: {err}");
+            return 1;
+        },
+        .Ok(_) => {},
+    }
     println("[kv-client] local node started");
     sleep(500ms);
-    Node.connect(remote_addr);
+    match Node.connect(f"1@{remote_addr}") {
+        .Err(err) => {
+            println(f"[kv-client] connect failed: {err}");
+            Node.shutdown();
+            return 1;
+        },
+        .Ok(_) => {},
+    }
     println(f"[kv-client] connected to {remote_addr}");
     // Wait for the connection handshake to complete and registry gossip to arrive.
     // hew_node_connect is non-blocking; gossip propagates asynchronously.

--- a/examples/distributed/kv_server.expected
+++ b/examples/distributed/kv_server.expected
@@ -1,0 +1,1 @@
+[kv-server] set HEW_NODE_KEY and HEW_NODE_PEER before starting

--- a/examples/distributed/kv_server.hew
+++ b/examples/distributed/kv_server.hew
@@ -55,19 +55,42 @@ impl ActorMsg for KeyValue {
     type Reply = KvResp;
 }
 
-fn main() {
-    var port: string = "9100";
-    if os.args().len() > 1 {
-        port = os.args().get(1);
+fn main() -> i64 {
+    let key = os.env("HEW_NODE_KEY").unwrap_or("");
+    let peer = os.env("HEW_NODE_PEER").unwrap_or("");
+    if key.is_empty() || peer.is_empty() {
+        println("[kv-server] set HEW_NODE_KEY and HEW_NODE_PEER before starting");
+        return 0;
     }
+
+    let args = os.args();
+    let port = match args.get(1) {
+        .Some(value) => value,
+        .None => "9100",
+    };
     let addr = f"0.0.0.0:{port}";
     println(f"[kv-server] starting on {addr}");
-    Node.set_transport("tcp");
-    Node.start(addr);
+    let peers: Vec<string> = Vec.new();
+    peers.push(f"2@{peer}");
+    let config = NodeConfig { bind: addr, transport: "tcp", key: key, trust: "pinned", peers: peers, seeds: Vec.new() };
+    match Node.start(config) {
+        .Err(err) => {
+            println(f"[kv-server] start failed: {err}");
+            return 1;
+        },
+        .Ok(_) => {},
+    }
     println("[kv-server] node started");
     let s: HashMap<string, string> = HashMap.new();
     let kv = spawn KeyValue(store: s);
-    Node.register("kv", kv);
+    match Node.register("kv", kv) {
+        .Err(err) => {
+            println(f"[kv-server] registration failed: {err}");
+            Node.shutdown();
+            return 2;
+        },
+        .Ok(_) => {},
+    }
     println("[kv-server] 'kv' actor registered; waiting for client...");
 
     // Wait for client to connect and run assertions.
@@ -82,4 +105,5 @@ fn main() {
     }
     Node.shutdown();
     println("[kv-server] shutdown complete");
+    0
 }

--- a/hew-cli/tests/distributed_two_process_e2e.rs
+++ b/hew-cli/tests/distributed_two_process_e2e.rs
@@ -202,13 +202,28 @@ impl Drop for ManagedChild {
 struct SecureScenario {
     kx_dir: tempfile::TempDir,
     port: u16,
+    server_key: PathBuf,
+    client_key: PathBuf,
+    server_public: String,
+    client_public: String,
 }
 
 impl SecureScenario {
     fn new() -> Self {
+        let kx_dir = tempfile::tempdir().expect("create key-exchange dir for scenario");
+        let server_key = kx_dir.path().join("server.key");
+        let client_key = kx_dir.path().join("client.key");
+        let server_identity = hew_runtime::encryption::noise_identity_load_or_create(&server_key)
+            .expect("create server Noise identity");
+        let client_identity = hew_runtime::encryption::noise_identity_load_or_create(&client_key)
+            .expect("create client Noise identity");
         Self {
-            kx_dir: tempfile::tempdir().expect("create key-exchange dir for scenario"),
+            kx_dir,
             port: allocate_loopback_port(),
+            server_key,
+            client_key,
+            server_public: hew_runtime::peer_binding::hex_lower(&server_identity.public()),
+            client_public: hew_runtime::peer_binding::hex_lower(&client_identity.public()),
         }
     }
 
@@ -216,6 +231,11 @@ impl SecureScenario {
     /// key-exchange directory, and fixture role/port/scenario.
     fn spawn(&self, role: &str, scenario: &str, extra_env: &[(&str, &str)]) -> ManagedChild {
         let binary = compiled_node_binary();
+        let (key_path, peer_key) = match role {
+            "server" => (&self.server_key, &self.client_public),
+            "client" => (&self.client_key, &self.server_public),
+            other => panic!("unknown distributed fixture role {other}"),
+        };
         let mut command = Command::new(binary);
         command
             .env("HEW_TRANSPORT", "tcp")
@@ -223,6 +243,8 @@ impl SecureScenario {
             .env("HEW_DIST_PORT", self.port.to_string())
             .env("HEW_DIST_SCENARIO", scenario)
             .env("HEW_DIST_KX_DIR", self.kx_dir.path())
+            .env("HEW_DIST_KEY_PATH", key_path)
+            .env("HEW_DIST_PEER_KEY", peer_key)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         for (key, value) in extra_env {

--- a/hew-cli/tests/distributed_two_process_e2e.rs
+++ b/hew-cli/tests/distributed_two_process_e2e.rs
@@ -1012,6 +1012,63 @@ fn authenticated_v2_handshake_rejects_wrong_credential_pin() {
     );
 }
 
+#[test]
+fn node_api_two_process_wrong_actor_type_returns_type_mismatch() {
+    let stdout = run_two_process_scenario("type_mismatch_lookup");
+    assert!(
+        stdout.contains("PASS type_mismatch_lookup error=TypeMismatch"),
+        "a registry lookup under the wrong actor type must return TypeMismatch; client stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("FAIL "),
+        "client reported a FAIL on typed registry lookup; client stdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn node_api_results_cover_prestart_registry_and_start_outcomes() {
+    require_codegen();
+
+    let source = repo_root()
+        .join("hew-cli")
+        .join("tests")
+        .join("fixtures")
+        .join("distributed")
+        .join("node_api_results.hew");
+    let key_dir = tempfile::tempdir().expect("create Node API key directory");
+    let key_path = key_dir.path().join("node.key");
+    let mut command = Command::new(hew_binary());
+    command
+        .arg("run")
+        .arg(&source)
+        .current_dir(repo_root())
+        .env("HEW_NODE_TEST_KEY", key_path);
+    let output = support::run_bounded_command(command, "run node_api_results.hew");
+    assert!(
+        output.status.success(),
+        "Node API result fixture failed\n{}",
+        support::describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "PASS prestart-register",
+        "PASS prestart-lookup",
+        "PASS prestart-type-mismatch",
+        "PASS start-refusal-result",
+        "PASS start-success-result",
+        "PASS poststart-lookup",
+    ] {
+        assert!(
+            stdout.lines().any(|line| line == expected),
+            "missing `{expected}` in Node API fixture stdout:\n{stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("FAIL "),
+        "Node API fixture reported a behavioural failure:\n{stdout}"
+    );
+}
+
 /// Node identity/location proof across two OS processes. The remote actor's
 /// key-backed node id, slot, and session incarnation must match the registry
 /// lookup exactly, and its node id must differ from the client's.

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -34,13 +34,9 @@ import std.link_monitor.{DownNotification, DownReason, DownTarget, MonitorError,
 // the Stopped terminal state from within its own handler. `stop(self)` is not a
 // working surface yet, so the actor calls the runtime self-stop directly.
 //
-// hew_node_api_unregister: the repoint_preserves_ref scenario re-points a
-// registered name to a DIFFERENT actor. `Node::unregister` is not yet a Hew
-// surface, so the server calls the runtime api directly.
 extern "C" {
     fn hew_actor_self_stop();
     fn hew_actor_self_id() -> i64;
-    fn hew_node_api_unregister(name: string) -> i32;
     fn hew_dist_setup_race_kind() -> i64;
 }
 
@@ -875,9 +871,13 @@ fn wait_for_file(path: string) -> string {
     var attempts: i64 = 0;
     loop {
         if fs.exists(path) {
-            let contents = fs.read(path);
-            if !contents.is_empty() {
-                return contents;
+            match fs.read(path) {
+                .Ok(contents) => {
+                    if !contents.is_empty() {
+                        return contents;
+                    }
+                },
+                .Err(_) => {},
             }
         }
         attempts = attempts + 1;
@@ -888,17 +888,14 @@ fn wait_for_file(path: string) -> string {
     }
 }
 
-fn stage_peer_credentials(kx: string, my_role: string, peer_role: string, peer_route_slot: u16) {
-    Node.load_keys(f"{kx}/{my_role}.key");
-    let me = Node.identity_key();
-    publish_atomic(kx, f"{my_role}.pub", me);
-    let peer_key = wait_for_file(f"{kx}/{peer_role}.pub");
+fn configured_peer(peer_route_slot: u16) -> string {
+    let peer_key = os.env("HEW_DIST_PEER_KEY").unwrap_or("");
     let configured_peer_key = if os.env("HEW_DIST_BAD_PEER_PIN").unwrap_or("") == "1" {
         "0000000000000000000000000000000000000000000000000000000000000000"
     } else {
         peer_key
     };
-    Node.allow_peer(peer_route_slot, configured_peer_key);
+    f"{peer_route_slot}@{configured_peer_key}"
 }
 
 fn signal_server_listening(kx: string) {
@@ -975,9 +972,16 @@ fn lookup_identity_with_retry(name: string) -> Result<RemotePid<IdentityProbe>, 
 fn run_server(port: string, scenario: string) {
     let addr = f"127.0.0.1:{port}";
     let kx = os.env("HEW_DIST_KX_DIR").unwrap_or("");
-    Node.set_transport("tcp");
-    stage_peer_credentials(kx, "server", "client", 2);
-    Node.start(addr);
+    let peers: Vec<string> = Vec.new();
+    peers.push(configured_peer(2));
+    let config = NodeConfig { bind: addr, transport: "tcp", key: os.env("HEW_DIST_KEY_PATH").unwrap_or(""), trust: "pinned", peers: peers, seeds: Vec.new() };
+    match Node.start(config) {
+        .Err(err) => {
+            println(f"FAIL {scenario} server-start={err}");
+            return;
+        },
+        .Ok(_) => {},
+    }
     let s: HashMap<string, string> = HashMap.new();
     let kv = spawn KeyValue(store: s);
     Node.register("kv", kv);
@@ -1012,9 +1016,7 @@ fn run_server(port: string, scenario: string) {
         } else {
             if scenario == "repoint_preserves_ref" {
                 sleep(1s);
-                let _ = unsafe {
-                    hew_node_api_unregister("kv")
-                };
+                let _ = Node.unregister("kv");
                 let s2: HashMap<string, string> = HashMap.new();
                 let kv2 = spawn KeyValue(store: s2);
                 Node.register("kv", kv2);
@@ -2071,12 +2073,26 @@ fn scenario_type_mismatch_lookup() -> i64 {
 
 fn run_client(port: string, scenario: string) -> i64 {
     let kx = os.env("HEW_DIST_KX_DIR").unwrap_or("");
-    Node.set_transport("tcp");
-    stage_peer_credentials(kx, "client", "server", 1);
-    Node.start("127.0.0.1:0");
+    let peers: Vec<string> = Vec.new();
+    peers.push(configured_peer(1));
+    let config = NodeConfig { bind: "127.0.0.1:0", transport: "tcp", key: os.env("HEW_DIST_KEY_PATH").unwrap_or(""), trust: "pinned", peers: peers, seeds: Vec.new() };
+    match Node.start(config) {
+        .Err(err) => {
+            println(f"FAIL {scenario} client-start={err}");
+            return 1;
+        },
+        .Ok(_) => {},
+    }
     wait_for_server_listening(kx);
     let remote_addr = f"1@127.0.0.1:{port}";
-    Node.connect(remote_addr);
+    match Node.connect(remote_addr) {
+        .Err(err) => {
+            println(f"FAIL {scenario} client-connect={err}");
+            Node.shutdown();
+            return 1;
+        },
+        .Ok(_) => {},
+    }
     let status = if scenario == "handshake_reject" {
         scenario_handshake_reject()
     } else if scenario == "type_mismatch_lookup" {

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -2040,6 +2040,35 @@ fn scenario_stale_incarnation_restart(old: RemotePid<KeyValue>, kx: string, port
     }
 }
 
+fn scenario_type_mismatch_lookup() -> i64 {
+    var attempts: i64 = 0;
+    loop {
+        let found: Result<RemotePid<WireProbe>, LookupError> = Node.lookup("kv");
+        match found {
+            .Err(err) => {
+                match err {
+                    LookupError.TypeMismatch => {
+                        println("PASS type_mismatch_lookup error=TypeMismatch");
+                        return 0;
+                    },
+                    _ => {
+                        attempts = attempts + 1;
+                        if attempts >= 50 {
+                            println("FAIL type_mismatch_lookup unresolved");
+                            return 1;
+                        }
+                        sleep(100ms);
+                    },
+                }
+            },
+            .Ok(_) => {
+                println("FAIL type_mismatch_lookup unchecked-cast");
+                return 2;
+            },
+        }
+    }
+}
+
 fn run_client(port: string, scenario: string) -> i64 {
     let kx = os.env("HEW_DIST_KX_DIR").unwrap_or("");
     Node.set_transport("tcp");
@@ -2050,6 +2079,8 @@ fn run_client(port: string, scenario: string) -> i64 {
     Node.connect(remote_addr);
     let status = if scenario == "handshake_reject" {
         scenario_handshake_reject()
+    } else if scenario == "type_mismatch_lookup" {
+        scenario_type_mismatch_lookup()
     } else if scenario == "quarantine_rejoin" {
         scenario_quarantine_rejoin()
     } else if scenario == "identity_location" || scenario == "identity_display_low" || scenario == "identity_display_high" {

--- a/hew-cli/tests/fixtures/distributed/node_api_results.hew
+++ b/hew-cli/tests/fixtures/distributed/node_api_results.hew
@@ -1,0 +1,92 @@
+import std.os;
+
+actor Alpha {
+    receive fn ping() -> i64 {
+        1
+    }
+}
+
+actor Beta {
+    receive fn ping() -> i64 {
+        2
+    }
+}
+
+fn main() -> i64 {
+    let alpha = spawn Alpha;
+
+    match Node.register("local-alpha", alpha) {
+        .Err(err) => {
+            println(f"FAIL prestart-register {err}");
+            return 1;
+        },
+        .Ok(_) => println("PASS prestart-register"),
+    }
+
+    let found: Result<RemotePid<Alpha>, LookupError> = Node.lookup("local-alpha");
+    match found {
+        .Err(err) => {
+            println(f"FAIL prestart-lookup {err}");
+            return 2;
+        },
+        .Ok(_) => println("PASS prestart-lookup"),
+    }
+
+    let wrong: Result<RemotePid<Beta>, LookupError> = Node.lookup("local-alpha");
+    match wrong {
+        .Err(err) => {
+            match err {
+                LookupError.TypeMismatch => println("PASS prestart-type-mismatch"),
+                _ => {
+                    println(f"FAIL prestart-type-mismatch {err}");
+                    return 3;
+                },
+            }
+        },
+        .Ok(_) => {
+            println("FAIL prestart-type-mismatch unchecked-cast");
+            return 3;
+        },
+    }
+
+    var refused = NodeConfig { bind: "127.0.0.1:0", transport: "tcp", key: "", trust: "pinned", peers: Vec.new(), seeds: Vec.new() };
+    refused.trust = "open";
+    match Node.start(refused) {
+        .Err(err) => {
+            match err {
+                NodeError.Config => println("PASS start-refusal-result"),
+                _ => {
+                    println(f"FAIL start-refusal-result {err}");
+                    return 4;
+                },
+            }
+        },
+        .Ok(_) => {
+            println("FAIL start-refusal-result accepted-invalid-trust");
+            return 4;
+        },
+    }
+
+    var config = NodeConfig { bind: "127.0.0.1:0", transport: "tcp", key: "", trust: "pinned", peers: Vec.new(), seeds: Vec.new() };
+    config.key = os.env("HEW_NODE_TEST_KEY").unwrap_or("");
+    match Node.start(config) {
+        .Err(err) => {
+            println(f"FAIL start-success-result {err}");
+            return 5;
+        },
+        .Ok(_) => println("PASS start-success-result"),
+    }
+
+    let promoted: Result<RemotePid<Alpha>, LookupError> = Node.lookup("local-alpha");
+    match promoted {
+        .Err(err) => {
+            println(f"FAIL poststart-lookup {err}");
+            Node.shutdown();
+            return 6;
+        },
+        .Ok(_) => println("PASS poststart-lookup"),
+    }
+
+    Node.shutdown();
+    0
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -72,7 +72,7 @@ use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
 use hew_hir::stdlib_catalog::PrintKind;
-use hew_hir::{mangle_dotted_name, ItemId};
+use hew_hir::{mangle_dotted_name, mangle_resolved_ty, ItemId};
 use hew_mir::{
     instr_source_places, is_string_const_ty, terminator_source_places, validate_context_markers,
     verify_raw_virtual_value_ladder, ActorHandlerKind, ActorLayout, ActorStateLoadMode,
@@ -1513,17 +1513,15 @@ fn wasm_excluded_call_family(
         | F::MetricHistogramRecord
         | F::MetricVecRegister
         | F::MetricVecWith
-        | F::NodeAllowPeer
         | F::NodeConnect
         | F::NodeId
         | F::NodeIdentityKey
-        | F::NodeLoadKeys
         | F::NodeLookup
         | F::NodeMonitor
         | F::NodeRegister
-        | F::NodeSetTransport
         | F::NodeShutdown
         | F::NodeStart
+        | F::NodeUnregister
         | F::ObserveReadU64
         | F::ObserveScrape
         | F::ObserveSeries
@@ -29439,6 +29437,39 @@ pub(crate) fn emit_node_lookup_call<'ctx>(
         }
     };
 
+    let actor_ty = match place_resolved_ty(fn_ctx, *dest_place)? {
+        ResolvedTy::Named {
+            builtin: Some(BuiltinType::Result),
+            args,
+            ..
+        } if args.len() == 2 => match &args[0] {
+            ResolvedTy::Named {
+                builtin: Some(BuiltinType::RemotePid),
+                args,
+                ..
+            } if args.len() == 1 => &args[0],
+            other => {
+                return Err(CodegenError::FailClosed(format!(
+                    "Node::lookup Ok type must be RemotePid<T>, got {other:?}"
+                )));
+            }
+        },
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "Node::lookup destination must be Result<RemotePid<T>, LookupError>, got {other:?}"
+            )));
+        }
+    };
+    let actor_identity = mangle_resolved_ty(actor_ty);
+    let actor_identity_ptr = intern_global_string_ptr(
+        fn_ctx,
+        &actor_identity,
+        &format!(
+            "str_node_lookup_type_{}",
+            llvm_global_name_fragment(&actor_identity)
+        ),
+    )?;
+
     // Load the name string (a `ptr` value stored in the arg's alloca).
     let (name_ptr_slot, name_slot_ty) = place_pointer(fn_ctx, *name_arg)?;
     let name_val = fn_ctx
@@ -29480,7 +29511,11 @@ pub(crate) fn emit_node_lookup_call<'ctx>(
         .builder
         .build_call(
             lookup_fn,
-            &[metadata_value_from_basic(name_val), ok_field_ptr.into()],
+            &[
+                metadata_value_from_basic(name_val),
+                actor_identity_ptr.into(),
+                ok_field_ptr.into(),
+            ],
             "lookup_rc",
         )
         .llvm_ctx("hew_node_api_lookup_location call")?;
@@ -29540,13 +29575,21 @@ pub(crate) fn emit_node_lookup_call<'ctx>(
             field_idx: 0,
         },
     )?;
-    // `LookupError::NotFound` is variant 0 of a single-variant enum with no
-    // payload — the entire `LookupError` outer struct is zero-initialised.
-    let zero_lookup_err = err_field_ty.const_zero();
-    fn_ctx
+    let error_discriminant = fn_ctx
         .builder
-        .build_store(err_field_ptr, zero_lookup_err)
-        .llvm_ctx("store LookupError::NotFound")?;
+        .build_int_sub(
+            rc,
+            rc.get_type().const_int(1, false),
+            "lookup_error_discriminant",
+        )
+        .llvm_ctx("lookup error discriminant")?;
+    store_error_discriminant(
+        fn_ctx,
+        err_field_ptr,
+        err_field_ty,
+        error_discriminant,
+        "Node::lookup",
+    )?;
     fn_ctx
         .builder
         .build_unconditional_branch(next_bb)
@@ -29573,6 +29616,236 @@ pub(crate) fn emit_node_lookup_call<'ctx>(
         .build_unconditional_branch(next_bb)
         .llvm_ctx("lookup ok br next")?;
 
+    Ok(())
+}
+
+fn store_error_discriminant(
+    fn_ctx: &FnCtx<'_, '_>,
+    error_ptr: PointerValue<'_>,
+    error_ty: BasicTypeEnum<'_>,
+    discriminant: IntValue<'_>,
+    helper: &str,
+) -> CodegenResult<()> {
+    let (tag_ptr, tag_ty) = match error_ty {
+        BasicTypeEnum::IntType(int_ty) => (error_ptr, int_ty),
+        BasicTypeEnum::StructType(struct_ty) => {
+            fn_ctx
+                .builder
+                .build_store(error_ptr, struct_ty.const_zero())
+                .llvm_ctx_with(|| format!("{helper} zero error enum"))?;
+            let tag_ptr = fn_ctx
+                .builder
+                .build_struct_gep(struct_ty, error_ptr, 0, "error_tag_ptr")
+                .llvm_ctx_with(|| format!("{helper} error tag GEP"))?;
+            let Some(BasicTypeEnum::IntType(tag_ty)) = struct_ty.get_field_type_at_index(0) else {
+                return Err(CodegenError::FailClosed(format!(
+                    "{helper} error enum has no integer discriminant"
+                )));
+            };
+            (tag_ptr, tag_ty)
+        }
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "{helper} error payload must be an integer or struct, got {other:?}"
+            )));
+        }
+    };
+    let tag = fn_ctx
+        .builder
+        .build_int_cast(discriminant, tag_ty, "error_tag")
+        .llvm_ctx_with(|| format!("{helper} error tag cast"))?;
+    fn_ctx
+        .builder
+        .build_store(tag_ptr, tag)
+        .llvm_ctx_with(|| format!("{helper} store error tag"))?;
+    Ok(())
+}
+
+fn emit_unit_result_status(
+    fn_ctx: &FnCtx<'_, '_>,
+    status: IntValue<'_>,
+    dest: Place,
+    helper: &str,
+) -> CodegenResult<()> {
+    let dest_local = match dest {
+        Place::Local(local) => local,
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "{helper} Result destination must be local, got {other:?}"
+            )));
+        }
+    };
+    let parent = fn_ctx
+        .builder
+        .get_insert_block()
+        .and_then(|block| block.get_parent())
+        .ok_or_else(|| CodegenError::FailClosed(format!("{helper} has no parent function")))?;
+    let ok_bb = fn_ctx.ctx.append_basic_block(parent, "node_result_ok");
+    let err_bb = fn_ctx.ctx.append_basic_block(parent, "node_result_err");
+    let merge_bb = fn_ctx.ctx.append_basic_block(parent, "node_result_merge");
+    let success = fn_ctx
+        .builder
+        .build_int_compare(
+            IntPredicate::EQ,
+            status,
+            status.get_type().const_zero(),
+            "node_result_success",
+        )
+        .llvm_ctx_with(|| format!("{helper} status compare"))?;
+    fn_ctx
+        .builder
+        .build_conditional_branch(success, ok_bb, err_bb)
+        .llvm_ctx_with(|| format!("{helper} status branch"))?;
+
+    fn_ctx.builder.position_at_end(ok_bb);
+    store_composite_tag(fn_ctx, dest_local, 0, helper)?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(merge_bb)
+        .llvm_ctx_with(|| format!("{helper} ok merge"))?;
+
+    fn_ctx.builder.position_at_end(err_bb);
+    store_composite_tag(fn_ctx, dest_local, 1, helper)?;
+    let (error_ptr, error_ty) = place_pointer(
+        fn_ctx,
+        Place::MachineVariant {
+            local: dest_local,
+            variant_idx: 1,
+            field_idx: 0,
+        },
+    )?;
+    let discriminant = fn_ctx
+        .builder
+        .build_int_sub(
+            status,
+            status.get_type().const_int(1, false),
+            "node_error_discriminant",
+        )
+        .llvm_ctx_with(|| format!("{helper} error discriminant"))?;
+    store_error_discriminant(fn_ctx, error_ptr, error_ty, discriminant, helper)?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(merge_bb)
+        .llvm_ctx_with(|| format!("{helper} error merge"))?;
+    fn_ctx.builder.position_at_end(merge_bb);
+    Ok(())
+}
+
+fn emit_node_start_call(
+    fn_ctx: &FnCtx<'_, '_>,
+    args: &[Place],
+    dest: Option<&Place>,
+    next: u32,
+) -> CodegenResult<()> {
+    let [config] = args else {
+        return Err(CodegenError::FailClosed(format!(
+            "Node::start expects one NodeConfig, got {} arguments",
+            args.len()
+        )));
+    };
+    let dest = dest.copied().ok_or_else(|| {
+        CodegenError::FailClosed("Node::start must carry a Result destination".into())
+    })?;
+    let (config_ptr, config_ty) = place_pointer(fn_ctx, *config)?;
+    let BasicTypeEnum::StructType(config_ty) = config_ty else {
+        return Err(CodegenError::FailClosed(
+            "Node::start argument is not a NodeConfig record".into(),
+        ));
+    };
+    if config_ty.count_fields() != 6 {
+        return Err(CodegenError::FailClosed(format!(
+            "NodeConfig must have six fields, got {}",
+            config_ty.count_fields()
+        )));
+    }
+    let mut call_args = Vec::with_capacity(6);
+    for index in 0..6 {
+        let field_ptr = fn_ctx
+            .builder
+            .build_struct_gep(config_ty, config_ptr, index, "node_config_field_ptr")
+            .llvm_ctx("NodeConfig field GEP")?;
+        let field_ty = config_ty.get_field_type_at_index(index).ok_or_else(|| {
+            CodegenError::FailClosed(format!("NodeConfig field {index} is missing"))
+        })?;
+        let field = fn_ctx
+            .builder
+            .build_load(field_ty, field_ptr, "node_config_field")
+            .llvm_ctx("load NodeConfig field")?;
+        call_args.push(metadata_value_from_basic(field));
+    }
+    let start_fn = intern_runtime_decl(
+        fn_ctx.ctx,
+        fn_ctx.llvm_mod,
+        &mut fn_ctx.runtime_decls.borrow_mut(),
+        "hew_node_api_start",
+    )?;
+    let call = fn_ctx
+        .builder
+        .build_call(start_fn, &call_args, "node_start_status")
+        .llvm_ctx("hew_node_api_start call")?;
+    let status = call
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed("hew_node_api_start returned void".into()))?
+        .into_int_value();
+    emit_unit_result_status(fn_ctx, status, dest, "Node::start")?;
+    let next_bb = *fn_ctx
+        .blocks
+        .get(&next)
+        .ok_or_else(|| CodegenError::FailClosed(format!("Node::start next bb{next} missing")))?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(next_bb)
+        .llvm_ctx("Node::start next branch")?;
+    Ok(())
+}
+
+fn emit_node_string_result_call(
+    fn_ctx: &FnCtx<'_, '_>,
+    args: &[Place],
+    dest: Option<&Place>,
+    next: u32,
+    symbol: &str,
+    helper: &str,
+) -> CodegenResult<()> {
+    let [arg] = args else {
+        return Err(CodegenError::FailClosed(format!(
+            "{helper} expects one string, got {} arguments",
+            args.len()
+        )));
+    };
+    let dest = dest.copied().ok_or_else(|| {
+        CodegenError::FailClosed(format!("{helper} must carry a Result destination"))
+    })?;
+    let (arg_ptr, arg_ty) = place_pointer(fn_ctx, *arg)?;
+    let value = fn_ctx
+        .builder
+        .build_load(arg_ty, arg_ptr, "node_string_arg")
+        .llvm_ctx_with(|| format!("{helper} load argument"))?;
+    let function = intern_runtime_decl(
+        fn_ctx.ctx,
+        fn_ctx.llvm_mod,
+        &mut fn_ctx.runtime_decls.borrow_mut(),
+        symbol,
+    )?;
+    let call = fn_ctx
+        .builder
+        .build_call(function, &[metadata_value_from_basic(value)], "node_status")
+        .llvm_ctx_with(|| format!("{helper} runtime call"))?;
+    let status = call
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| CodegenError::FailClosed(format!("{helper} returned void")))?
+        .into_int_value();
+    emit_unit_result_status(fn_ctx, status, dest, helper)?;
+    let next_bb = *fn_ctx
+        .blocks
+        .get(&next)
+        .ok_or_else(|| CodegenError::FailClosed(format!("{helper} next bb{next} missing")))?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(next_bb)
+        .llvm_ctx_with(|| format!("{helper} next branch"))?;
     Ok(())
 }
 
@@ -31321,6 +31594,32 @@ fn lower_terminator<'ctx>(
                 emit_node_lookup_call(fn_ctx, args, dest.as_ref(), *next)?;
                 return Ok(());
             }
+            if builtin == Some(RtFamily::NodeStart) {
+                emit_node_start_call(fn_ctx, args, dest.as_ref(), *next)?;
+                return Ok(());
+            }
+            if builtin == Some(RtFamily::NodeConnect) {
+                emit_node_string_result_call(
+                    fn_ctx,
+                    args,
+                    dest.as_ref(),
+                    *next,
+                    "hew_node_api_connect",
+                    "Node::connect",
+                )?;
+                return Ok(());
+            }
+            if builtin == Some(RtFamily::NodeUnregister) {
+                emit_node_string_result_call(
+                    fn_ctx,
+                    args,
+                    dest.as_ref(),
+                    *next,
+                    "hew_node_api_unregister",
+                    "Node::unregister",
+                )?;
+                return Ok(());
+            }
             // `hew_remote_pid_send` is the checker's MethodCallRewrite target
             // for `pid.send(msg)` on a `RemotePid<T>` receiver.  The catalog
             // entry uses `BuiltinLinkage::CalleeNameDispatchOnly` (a fieldless
@@ -31974,10 +32273,31 @@ fn lower_terminator<'ctx>(
                     };
                     let dest_place = dest.as_ref().ok_or_else(|| {
                         CodegenError::FailClosed(
-                            "Node::register (i32-returning) must carry a Terminator::Call dest"
-                                .into(),
+                            "Node::register must carry a Result destination".into(),
                         )
                     })?;
+
+                    let actor_ty = match place_resolved_ty(fn_ctx, *pid_arg)? {
+                        ResolvedTy::Named {
+                            builtin: Some(BuiltinType::LocalPid),
+                            args,
+                            ..
+                        } if args.len() == 1 => &args[0],
+                        other => {
+                            return Err(CodegenError::FailClosed(format!(
+                                "Node::register pid must be LocalPid<T>, got {other:?}"
+                            )));
+                        }
+                    };
+                    let actor_identity = mangle_resolved_ty(actor_ty);
+                    let actor_identity_ptr = intern_global_string_ptr(
+                        fn_ctx,
+                        &actor_identity,
+                        &format!(
+                            "str_node_register_type_{}",
+                            llvm_global_name_fragment(&actor_identity)
+                        ),
+                    )?;
 
                     // Load the name string pointer (ptr-typed alloca).
                     let (name_ptr, name_ty) = place_pointer(fn_ctx, *name_arg)?;
@@ -32012,6 +32332,7 @@ fn lower_terminator<'ctx>(
                             &[
                                 metadata_value_from_basic(name_val),
                                 metadata_value_from_basic(pid_u64),
+                                actor_identity_ptr.into(),
                             ],
                             "reg_result",
                         )
@@ -32021,19 +32342,12 @@ fn lower_terminator<'ctx>(
                             "hew_node_api_register_by_pid returned void — expected i32".into(),
                         )
                     })?;
-
-                    // Store the i32 return value into the destination.
-                    let (dest_ptr, dest_ty) = place_pointer(fn_ctx, *dest_place)?;
-                    let i32_ty = fn_ctx.ctx.i32_type();
-                    if dest_ty != BasicTypeEnum::IntType(i32_ty) {
-                        return Err(CodegenError::FailClosed(format!(
-                            "Node::register dest type {dest_ty:?} does not match i32"
-                        )));
-                    }
-                    fn_ctx
-                        .builder
-                        .build_store(dest_ptr, reg_i32)
-                        .llvm_ctx("store reg result")?;
+                    emit_unit_result_status(
+                        fn_ctx,
+                        reg_i32.into_int_value(),
+                        *dest_place,
+                        "Node::register",
+                    )?;
                 }
             }
             if let Some(dest) = dest {

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -4001,16 +4001,14 @@ pub(crate) fn lower_call_runtime_abi(
         | F::MetricHistogramRegister
         | F::MetricVecRegister
         | F::MetricVecWith
-        | F::NodeAllowPeer
         | F::NodeConnect
         | F::NodeId
         | F::NodeIdentityKey
-        | F::NodeLoadKeys
         | F::NodeLookup
         | F::NodeRegister
-        | F::NodeSetTransport
         | F::NodeShutdown
         | F::NodeStart
+        | F::NodeUnregister
         | F::RcClone
         | F::RcDowngrade
         | F::RcDrop
@@ -4802,7 +4800,21 @@ pub(crate) fn intern_runtime_decl<'ctx>(
             false,
         ),
         "hew_node_api_lookup_location" => {
-            i32_ty.fn_type(&[ptr_ty.into(), ptr_ty.into()], false)
+            i32_ty.fn_type(&[ptr_ty.into(), ptr_ty.into(), ptr_ty.into()], false)
+        }
+        "hew_node_api_start" => i32_ty.fn_type(
+            &[
+                ptr_ty.into(),
+                ptr_ty.into(),
+                ptr_ty.into(),
+                ptr_ty.into(),
+                ptr_ty.into(),
+                ptr_ty.into(),
+            ],
+            false,
+        ),
+        "hew_node_api_connect" | "hew_node_api_unregister" => {
+            i32_ty.fn_type(&[ptr_ty.into()], false)
         }
         "hew_node_api_id" => i32_ty.fn_type(&[ptr_ty.into()], false),
         "hew_node_id_format" | "hew_location_format" => {
@@ -6434,8 +6446,9 @@ pub(crate) fn predeclare_stdlib_catalog<'ctx>(
                     llvm_mod.add_function(pid_accessor, pid_fn_ty, Some(Linkage::External))
                 });
 
-                // hew_node_api_register_by_pid(name: *const c_char, pid: u64) -> c_int
-                let reg_fn_ty = i32_ty.fn_type(&[ptr_ty.into(), i64_ty.into()], false);
+                // hew_node_api_register_by_pid(name, pid, actor_type) -> c_int
+                let reg_fn_ty =
+                    i32_ty.fn_type(&[ptr_ty.into(), i64_ty.into(), ptr_ty.into()], false);
                 let register_fn = llvm_mod.get_function(register_symbol).unwrap_or_else(|| {
                     llvm_mod.add_function(register_symbol, reg_fn_ty, Some(Linkage::External))
                 });

--- a/hew-hir/src/builtin_type_classes.rs
+++ b/hew-hir/src/builtin_type_classes.rs
@@ -39,6 +39,8 @@ pub enum BuiltinFieldTy {
     /// `BitCopy` aggregate — it routes through the owned-aggregate record
     /// clone/drop synthesis (`__hew_record_{clone,drop}_inplace_<R>`).
     String,
+    /// An owned `Vec<string>` field.
+    VecString,
 }
 
 impl BuiltinFieldTy {
@@ -54,6 +56,9 @@ impl BuiltinFieldTy {
                 Vec::new(),
             ),
             Self::String => ResolvedTy::String,
+            Self::VecString => {
+                ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![ResolvedTy::String])
+            }
         }
     }
 }
@@ -162,6 +167,33 @@ const LOCATION_FIELDS: &[BuiltinTypeField] = &[
     },
 ];
 
+const NODE_CONFIG_FIELDS: &[BuiltinTypeField] = &[
+    BuiltinTypeField {
+        name: "bind",
+        ty: BuiltinFieldTy::String,
+    },
+    BuiltinTypeField {
+        name: "transport",
+        ty: BuiltinFieldTy::String,
+    },
+    BuiltinTypeField {
+        name: "key",
+        ty: BuiltinFieldTy::String,
+    },
+    BuiltinTypeField {
+        name: "trust",
+        ty: BuiltinFieldTy::String,
+    },
+    BuiltinTypeField {
+        name: "peers",
+        ty: BuiltinFieldTy::VecString,
+    },
+    BuiltinTypeField {
+        name: "seeds",
+        ty: BuiltinFieldTy::VecString,
+    },
+];
+
 const CRASH_ACTION_VARIANTS: &[&str] = &["Restart", "Escalate", "Kill"];
 
 const fn marker(marker: BuiltinTypeMarker) -> ResourceMarker {
@@ -211,6 +243,7 @@ const BUILTIN_TYPE_REGISTRATIONS: &[BuiltinTypeRegistration] = &[
     registration!(NodeId, BuiltinTypeShape::Struct(NODE_ID_FIELDS)),
     registration!(Location, BuiltinTypeShape::Struct(LOCATION_FIELDS)),
     registration!(RemotePid, BuiltinTypeShape::Struct(LOCATION_FIELDS)),
+    registration!(NodeConfig, BuiltinTypeShape::Struct(NODE_CONFIG_FIELDS)),
     registration!(HewActor, BuiltinTypeShape::Opaque),
     registration!(HewDuplex, BuiltinTypeShape::Opaque),
     registration!(HewSendHalf, BuiltinTypeShape::Opaque),

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -533,6 +533,8 @@ const SYNTHETIC_RESULT_ITEM: ItemId = ItemId(u32::MAX - 2);
 /// path as `Option` / `Result` so `Err(LookupError::NotFound)` match arms
 /// resolve via `machine_ctor_registry`.
 const SYNTHETIC_LOOKUP_ERROR_ITEM: ItemId = ItemId(u32::MAX - 1000);
+const SYNTHETIC_NODE_ERROR_ITEM: ItemId = ItemId(u32::MAX - 1010);
+const SYNTHETIC_REGISTER_ERROR_ITEM: ItemId = ItemId(u32::MAX - 1011);
 /// `SendError` is also declared in `std/builtins.hew` and likewise invisible
 /// to the user-enum walk. Surface it so `match e { SendError::NodeRoutingNotWired
 /// => ... }` arms inside `Result<(), SendError>` matches resolve via
@@ -826,6 +828,8 @@ const EMPTY_BUILTIN_ENUM_SPEC: BuiltinEnumSpec = BuiltinEnumSpec {
 /// later specs replace earlier entries in `machine_ctor_registry`.
 const MONOMORPHIC_BUILTIN_ENUM_HIR_ORDER: &[(&str, ItemId)] = &[
     ("std.builtins.LookupError", SYNTHETIC_LOOKUP_ERROR_ITEM),
+    ("std.builtins.NodeError", SYNTHETIC_NODE_ERROR_ITEM),
+    ("std.builtins.RegisterError", SYNTHETIC_REGISTER_ERROR_ITEM),
     ("std.builtins.SendError", SYNTHETIC_SEND_ERROR_ITEM),
     ("std.builtins.TimeoutError", SYNTHETIC_TIMEOUT_ERROR_ITEM),
     ("std.builtins.LinkError", SYNTHETIC_LINK_ERROR_ITEM),
@@ -19394,19 +19398,47 @@ impl LowerCtx {
                         })
                         .unwrap_or_else(|| name.clone());
                     let result_name = self.canonical_current_module_record_name(&result_name);
+                    let compiler_record =
+                        crate::builtin_type_classes::builtin_type_registration(&result_name)
+                            .filter(|registration| {
+                                matches!(
+                                    registration.shape,
+                                    crate::builtin_type_classes::BuiltinTypeShape::Struct(_)
+                                )
+                            });
+                    let (layout_name, result_ty) = if let Some(registration) = compiler_record {
+                        let layout_name = crate::compiler_record_layout_key(
+                            registration.builtin,
+                            &resolved_type_args,
+                        )
+                        .expect("registered compiler Struct record must have a layout key");
+                        (
+                            layout_name,
+                            ResolvedTy::named_builtin(
+                                registration.name(),
+                                registration.builtin,
+                                resolved_type_args.clone(),
+                            ),
+                        )
+                    } else {
+                        (
+                            result_name.clone(),
+                            ResolvedTy::Named {
+                                name: result_name,
+                                args: resolved_type_args.clone(),
+                                builtin: None,
+                                is_opaque: false,
+                            },
+                        )
+                    };
                     (
                         HirExprKind::StructInit {
-                            name: result_name.clone(),
+                            name: layout_name,
                             type_args: resolved_type_args.clone(),
                             fields: hir_fields,
                             base: hir_base,
                         },
-                        ResolvedTy::Named {
-                            name: result_name,
-                            args: resolved_type_args,
-                            builtin: None,
-                            is_opaque: false,
-                        },
+                        result_ty,
                     )
                 }
             }

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -418,7 +418,6 @@ const I64_I64: &[BuiltinTy] = &[BuiltinTy::I64, BuiltinTy::I64];
 const F64_F64: &[BuiltinTy] = &[BuiltinTy::F64, BuiltinTy::F64];
 const BOOL_BOOL: &[BuiltinTy] = &[BuiltinTy::Bool, BuiltinTy::Bool];
 const STRING_STRING: &[BuiltinTy] = &[BuiltinTy::String, BuiltinTy::String];
-const U16_STRING: &[BuiltinTy] = &[BuiltinTy::U16, BuiltinTy::String];
 const STRING_I64: &[BuiltinTy] = &[BuiltinTy::String, BuiltinTy::I64];
 const STRING_I64_I64: &[BuiltinTy] = &[BuiltinTy::String, BuiltinTy::I64, BuiltinTy::I64];
 const STRING_STRING_STRING: &[BuiltinTy] =
@@ -2443,44 +2442,21 @@ pub const CATALOG: &[BuiltinEntry] = &[
     ),
     // Class B: Node namespace — distributed-node lifecycle builtins (A7 S1).
     //
-    // Each entry maps the Hew `Node::X` call form to its `hew_node_api_X` C
-    // extern in `hew-runtime/src/hew_node.rs`.  The C functions return `c_int`
-    // (0 = success, -1 = error) but are declared `Unit` here so HIR/MIR treat
-    // them as void-returning and the call is emitted without a destination slot.
-    // On x86-64 and arm64 the callee's return value sits in rax/x0 and is
-    // harmlessly discarded by the caller — this is the standard C idiom for
-    // ignoring a return value.  The runtime still surfaces a peer-auth setup
-    // failure even though the `-1` is discarded: `Node::load_keys` /
-    // `Node::allow_peer` set `hew_last_error`, print a `hew:` stderr diagnostic,
-    // and record a sticky failure so a later `Node::start` refuses to bind a
-    // listener (fail-closed) rather than silently presenting an ephemeral
-    // identity. See `node_peer_auth_setup_failed` in `hew_node.rs`.
-    direct(
-        "Node::set_transport",
-        BuiltinClass::ClassB,
-        STRING,
-        BuiltinTy::Unit,
-        BuiltinLinkage::RuntimeFfiShim {
-            symbol: "hew_node_api_set_transport",
-        },
-    ),
+    // Aggregate arguments and Result values are lowered by the codegen family
+    // intercepts; scalar catalogue types are dispatch placeholders only.
     direct(
         "Node::start",
         BuiltinClass::ClassB,
         STRING,
-        BuiltinTy::Unit,
-        BuiltinLinkage::RuntimeFfiShim {
-            symbol: "hew_node_api_start",
-        },
+        BuiltinTy::U64,
+        BuiltinLinkage::CalleeNameDispatchOnly,
     ),
     direct(
         "Node::connect",
         BuiltinClass::ClassB,
         STRING,
-        BuiltinTy::Unit,
-        BuiltinLinkage::RuntimeFfiShim {
-            symbol: "hew_node_api_connect",
-        },
+        BuiltinTy::U64,
+        BuiltinLinkage::CalleeNameDispatchOnly,
     ),
     direct(
         "Node::shutdown",
@@ -2489,32 +2465,6 @@ pub const CATALOG: &[BuiltinEntry] = &[
         BuiltinTy::Unit,
         BuiltinLinkage::RuntimeFfiShim {
             symbol: "hew_node_api_shutdown",
-        },
-    ),
-    // `Node::load_keys(path: String)` — load/persist this node's stable mesh
-    // TLS identity from a keyfile. Same FFI shim shape as set_transport: one
-    // String in, c_int discarded as Unit. Native quic-mesh only.
-    direct(
-        "Node::load_keys",
-        BuiltinClass::ClassB,
-        STRING,
-        BuiltinTy::Unit,
-        BuiltinLinkage::RuntimeFfiShim {
-            symbol: "hew_node_api_load_keys",
-        },
-    ),
-    // `Node::allow_peer(node_id: U16, credential_hex: String)` — bind a peer's
-    // authenticated credential to the NodeId it is permitted to claim (issue
-    // #2652). The credential is interpreted by the node's pinned transport: TCP
-    // ⇒ 32-byte Noise pubkey (`PeerCredential::NoiseKey`); quic-mesh ⇒ cert SPKI
-    // (`PeerCredential::Spki`). U16 + String in, c_int discarded as Unit.
-    direct(
-        "Node::allow_peer",
-        BuiltinClass::ClassB,
-        U16_STRING,
-        BuiltinTy::Unit,
-        BuiltinLinkage::RuntimeFfiShim {
-            symbol: "hew_node_api_allow_peer",
         },
     ),
     // `Node::identity_key() -> String` — this node's stable public credential
@@ -2538,7 +2488,7 @@ pub const CATALOG: &[BuiltinEntry] = &[
         BuiltinTy::U64,
         BuiltinLinkage::CalleeNameDispatchOnly,
     ),
-    // `Node::register<T>(name: String, pid: LocalPid<T>) -> i32`
+    // `Node::register<T>(name: String, pid: LocalPid<T>) -> Result<(), RegisterError>`
     //
     // Per R81, `LocalPid<T>` lowers to a bare `u64` PID at the C-ABI
     // boundary.  The catalog param list `[String, U64]` is a placeholder
@@ -2549,7 +2499,7 @@ pub const CATALOG: &[BuiltinEntry] = &[
         "Node::register",
         BuiltinClass::ClassB,
         &[BuiltinTy::String, BuiltinTy::U64],
-        BuiltinTy::I32,
+        BuiltinTy::U64,
         BuiltinLinkage::NodeRegisterByPid {
             register_symbol: "hew_node_api_register_by_pid",
             pid_accessor: "hew_actor_pid",
@@ -2564,6 +2514,13 @@ pub const CATALOG: &[BuiltinEntry] = &[
     // the C ABI for this CalleeNameDispatchOnly entry.
     direct(
         "Node::lookup",
+        BuiltinClass::ClassB,
+        STRING,
+        BuiltinTy::U64,
+        BuiltinLinkage::CalleeNameDispatchOnly,
+    ),
+    direct(
+        "Node::unregister",
         BuiltinClass::ClassB,
         STRING,
         BuiltinTy::U64,

--- a/hew-runtime/schemas/envelope.cddl
+++ b/hew-runtime/schemas/envelope.cddl
@@ -57,6 +57,7 @@ registry-gossip-payload = {
     op:       1 => registry-gossip-op,
     name:     2 => text,           ; bounded by runtime to 1024 UTF-8 bytes
     location: 3 => location,       ; exact identity for both add and remove
+    actor-type: 4 => text,         ; canonical compiler-minted actor identity
 }
 
 registry-gossip-op = 5 / 6         ; add / remove

--- a/hew-runtime/src/cluster.rs
+++ b/hew-runtime/src/cluster.rs
@@ -133,6 +133,8 @@ pub struct RegistryEvent {
     pub name: String,
     /// Exact owner-issued actor location for this add or remove.
     pub location: Location,
+    /// Canonical compiler-minted actor declaration identity.
+    pub actor_type: String,
     /// Whether this is an add (`true`) or remove (`false`) event.
     pub is_add: bool,
     /// How many times this event has been piggybacked.
@@ -272,9 +274,9 @@ struct PendingMemberTransitions {
 
 /// Callback for registry gossip notifications.
 ///
-/// Signature: `fn(name, location, is_add, user_data)`.
+/// Signature: `fn(name, location, actor_type, is_add, user_data)`.
 pub type HewRegistryGossipCallback =
-    extern "C" fn(*const c_char, *const HewLocation, bool, *mut c_void);
+    extern "C" fn(*const c_char, *const HewLocation, *const c_char, bool, *mut c_void);
 
 /// Cluster configuration.
 #[repr(C)]
@@ -2082,7 +2084,7 @@ impl HewCluster {
     // ── Registry gossip ────────────────────────────────────────────────
 
     /// Queue a registry add event for gossip dissemination.
-    pub fn emit_registry_add(&self, name: &str, location: Location) {
+    pub fn emit_registry_add(&self, name: &str, location: Location, actor_type: &str) {
         let mut events = self.registry_events.lock_or_recover();
         // Deduplicate: remove prior event for the same name.
         events.retain(|e| e.name != name);
@@ -2092,13 +2094,14 @@ impl HewCluster {
         events.push_back(RegistryEvent {
             name: name.to_owned(),
             location,
+            actor_type: actor_type.to_owned(),
             is_add: true,
             dissemination_count: 0,
         });
     }
 
     /// Queue a registry remove event for gossip dissemination.
-    pub fn emit_registry_remove(&self, name: &str, location: Location) {
+    pub fn emit_registry_remove(&self, name: &str, location: Location, actor_type: &str) {
         let mut events = self.registry_events.lock_or_recover();
         events.retain(|e| e.name != name);
         if events.len() >= MAX_GOSSIP_EVENTS {
@@ -2107,6 +2110,7 @@ impl HewCluster {
         events.push_back(RegistryEvent {
             name: name.to_owned(),
             location,
+            actor_type: actor_type.to_owned(),
             is_add: false,
             dissemination_count: 0,
         });
@@ -2135,17 +2139,27 @@ impl HewCluster {
     }
 
     /// Process an inbound registry gossip event received from a peer.
-    pub fn apply_registry_event(&self, name: &str, location: Location, is_add: bool) {
+    pub fn apply_registry_event(
+        &self,
+        name: &str,
+        location: Location,
+        actor_type: &str,
+        is_add: bool,
+    ) {
         let Some(cb) = self.registry_callback else {
             return;
         };
         let Ok(c_name) = std::ffi::CString::new(name) else {
             return;
         };
+        let Ok(c_actor_type) = std::ffi::CString::new(actor_type) else {
+            return;
+        };
         let location = HewLocation::from(location);
         cb(
             c_name.as_ptr(),
             &raw const location,
+            c_actor_type.as_ptr(),
             is_add,
             self.registry_callback_user_data,
         );
@@ -2659,8 +2673,9 @@ pub unsafe extern "C" fn hew_cluster_registry_add(
     cluster: *mut HewCluster,
     name: *const c_char,
     location: *const HewLocation,
+    actor_type: *const c_char,
 ) {
-    if cluster.is_null() || name.is_null() || location.is_null() {
+    if cluster.is_null() || name.is_null() || location.is_null() || actor_type.is_null() {
         return;
     }
     // SAFETY: caller guarantees `cluster` is valid.
@@ -2671,7 +2686,9 @@ pub unsafe extern "C" fn hew_cluster_registry_add(
     };
     // SAFETY: caller guarantees `name` is a valid null-terminated C string.
     let name_str = unsafe { CStr::from_ptr(name) }.to_string_lossy();
-    cluster.emit_registry_add(&name_str, location);
+    // SAFETY: caller guarantees `actor_type` is a valid null-terminated C string.
+    let actor_type = unsafe { CStr::from_ptr(actor_type) }.to_string_lossy();
+    cluster.emit_registry_add(&name_str, location, &actor_type);
 }
 
 /// Queue a registry-remove gossip event for dissemination.
@@ -2685,8 +2702,9 @@ pub unsafe extern "C" fn hew_cluster_registry_remove(
     cluster: *mut HewCluster,
     name: *const c_char,
     location: *const HewLocation,
+    actor_type: *const c_char,
 ) {
-    if cluster.is_null() || name.is_null() || location.is_null() {
+    if cluster.is_null() || name.is_null() || location.is_null() || actor_type.is_null() {
         return;
     }
     // SAFETY: caller guarantees `cluster` is valid.
@@ -2697,7 +2715,9 @@ pub unsafe extern "C" fn hew_cluster_registry_remove(
     };
     // SAFETY: caller guarantees `name` is a valid null-terminated C string.
     let name_str = unsafe { CStr::from_ptr(name) }.to_string_lossy();
-    cluster.emit_registry_remove(&name_str, location);
+    // SAFETY: caller guarantees `actor_type` is a valid null-terminated C string.
+    let actor_type = unsafe { CStr::from_ptr(actor_type) }.to_string_lossy();
+    cluster.emit_registry_remove(&name_str, location, &actor_type);
 }
 
 /// Get the number of pending registry gossip events.

--- a/hew-runtime/src/cluster.rs
+++ b/hew-runtime/src/cluster.rs
@@ -4298,13 +4298,14 @@ mod tests {
         assert_eq!(cluster.registry_gossip_count(), 0);
 
         let location = test_location(0x1234);
-        cluster.emit_registry_add("counter", location);
+        cluster.emit_registry_add("counter", location, "test.Counter");
         assert_eq!(cluster.registry_gossip_count(), 1);
 
         let events = cluster.take_registry_gossip(10);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].name, "counter");
         assert_eq!(events[0].location, location);
+        assert_eq!(events[0].actor_type, "test.Counter");
         assert!(events[0].is_add);
     }
 
@@ -4312,7 +4313,7 @@ mod tests {
     fn registry_remove_event_queued() {
         let cluster = HewCluster::new(make_config(1));
         let location = test_location(0x1234);
-        cluster.emit_registry_remove("counter", location);
+        cluster.emit_registry_remove("counter", location, "test.Counter");
         assert_eq!(cluster.registry_gossip_count(), 1);
 
         let events = cluster.take_registry_gossip(10);
@@ -4325,8 +4326,8 @@ mod tests {
     #[test]
     fn registry_events_deduplicate_by_name() {
         let cluster = HewCluster::new(make_config(1));
-        cluster.emit_registry_add("counter", test_location(0x1111));
-        cluster.emit_registry_add("counter", test_location(0x2222));
+        cluster.emit_registry_add("counter", test_location(0x1111), "test.Counter");
+        cluster.emit_registry_add("counter", test_location(0x2222), "test.Counter");
         assert_eq!(cluster.registry_gossip_count(), 1);
 
         let events = cluster.take_registry_gossip(10);
@@ -4337,7 +4338,7 @@ mod tests {
     #[test]
     fn registry_events_pruned_after_dissemination() {
         let cluster = HewCluster::new(make_config(1));
-        cluster.emit_registry_add("alpha", test_location(1));
+        cluster.emit_registry_add("alpha", test_location(1), "test.Alpha");
         // Disseminate 8 times to reach the prune threshold.
         for _ in 0..8 {
             let _ = cluster.take_registry_gossip(10);
@@ -4352,36 +4353,51 @@ mod tests {
         extern "C" fn collect_registry(
             name: *const c_char,
             location: *const HewLocation,
+            actor_type: *const c_char,
             is_add: bool,
             user_data: *mut c_void,
         ) {
             // SAFETY: test passes a valid Vec pointer.
-            let vec = unsafe { &mut *user_data.cast::<Vec<(String, Location, bool)>>() };
+            let vec = unsafe { &mut *user_data.cast::<Vec<(String, Location, String, bool)>>() };
             // SAFETY: name is a valid NUL-terminated C string from the cluster callback.
             let s = unsafe { CStr::from_ptr(name) }
                 .to_string_lossy()
                 .into_owned();
+            // SAFETY: actor_type is a valid C string from the cluster callback.
+            let actor_type = unsafe { CStr::from_ptr(actor_type) }
+                .to_string_lossy()
+                .into_owned();
             // SAFETY: location points to the callback's readable stack value.
             let location = Location::try_from(unsafe { *location }).unwrap();
-            vec.push((s, location, is_add));
+            vec.push((s, location, actor_type, is_add));
         }
 
         let mut cluster = HewCluster::new(make_config(1));
-        let mut collected: Vec<(String, Location, bool)> = Vec::new();
+        let mut collected: Vec<(String, Location, String, bool)> = Vec::new();
         cluster.registry_callback = Some(collect_registry);
         cluster.registry_callback_user_data = (&raw mut collected).cast();
 
-        cluster.apply_registry_event("counter", test_location(0x42), true);
-        cluster.apply_registry_event("timer", test_location(0x99), false);
+        cluster.apply_registry_event("counter", test_location(0x42), "test.Counter", true);
+        cluster.apply_registry_event("timer", test_location(0x99), "test.Timer", false);
 
         assert_eq!(collected.len(), 2);
         assert_eq!(
             collected[0],
-            ("counter".to_owned(), test_location(0x42), true)
+            (
+                "counter".to_owned(),
+                test_location(0x42),
+                "test.Counter".to_owned(),
+                true,
+            )
         );
         assert_eq!(
             collected[1],
-            ("timer".to_owned(), test_location(0x99), false)
+            (
+                "timer".to_owned(),
+                test_location(0x99),
+                "test.Timer".to_owned(),
+                false,
+            )
         );
     }
 
@@ -4394,11 +4410,22 @@ mod tests {
             assert_eq!(hew_cluster_registry_gossip_count(cluster), 0);
 
             let name = c"my_actor";
+            let actor_type = c"test.MyActor";
             let location = HewLocation::from(test_location(0xABCD));
-            hew_cluster_registry_add(cluster, name.as_ptr(), &raw const location);
+            hew_cluster_registry_add(
+                cluster,
+                name.as_ptr(),
+                &raw const location,
+                actor_type.as_ptr(),
+            );
             assert_eq!(hew_cluster_registry_gossip_count(cluster), 1);
 
-            hew_cluster_registry_remove(cluster, name.as_ptr(), &raw const location);
+            hew_cluster_registry_remove(
+                cluster,
+                name.as_ptr(),
+                &raw const location,
+                actor_type.as_ptr(),
+            );
             // Dedup replaces the add with a remove.
             assert_eq!(hew_cluster_registry_gossip_count(cluster), 1);
 
@@ -4609,7 +4636,7 @@ mod tests {
     fn apply_registry_event_without_callback_is_noop() {
         let cluster = HewCluster::new(make_config(1));
         // No callback registered — should not panic.
-        cluster.apply_registry_event("counter", test_location(42), true);
+        cluster.apply_registry_event("counter", test_location(42), "test.Counter", true);
     }
 
     #[test]
@@ -4617,6 +4644,7 @@ mod tests {
         extern "C" fn should_not_be_called(
             _: *const c_char,
             _: *const HewLocation,
+            _: *const c_char,
             _: bool,
             _: *mut c_void,
         ) {
@@ -4627,7 +4655,7 @@ mod tests {
         cluster.registry_callback_user_data = std::ptr::null_mut();
 
         // Name with interior null byte — CString::new fails, early return.
-        cluster.apply_registry_event("bad\0name", test_location(42), true);
+        cluster.apply_registry_event("bad\0name", test_location(42), "test.Bad", true);
     }
 
     // ── membership callback edge cases ─────────────────────────────────
@@ -4717,12 +4745,12 @@ mod tests {
     fn registry_gossip_overflow_evicts_oldest() {
         let cluster = HewCluster::new(make_config(1));
         for i in 0..MAX_GOSSIP_EVENTS {
-            cluster.emit_registry_add(&format!("actor_{i}"), test_location(i as u64));
+            cluster.emit_registry_add(&format!("actor_{i}"), test_location(i as u64), "test.Actor");
         }
         assert_eq!(cluster.registry_gossip_count(), MAX_GOSSIP_EVENTS);
 
         // One more should evict the oldest.
-        cluster.emit_registry_add("overflow", test_location(999));
+        cluster.emit_registry_add("overflow", test_location(999), "test.Actor");
         assert_eq!(cluster.registry_gossip_count(), MAX_GOSSIP_EVENTS);
 
         let events = cluster.take_registry_gossip(MAX_GOSSIP_EVENTS + 1);
@@ -4740,6 +4768,7 @@ mod tests {
         extern "C" fn noop_registry_cb(
             _: *const c_char,
             _: *const HewLocation,
+            _: *const c_char,
             _: bool,
             _: *mut c_void,
         ) {
@@ -4773,8 +4802,8 @@ mod tests {
             hew_cluster_set_registry_callback(null, noop_registry_cb, std::ptr::null_mut());
 
             // Null name pointers.
-            hew_cluster_registry_add(null, std::ptr::null(), std::ptr::null());
-            hew_cluster_registry_remove(null, std::ptr::null(), std::ptr::null());
+            hew_cluster_registry_add(null, std::ptr::null(), std::ptr::null(), std::ptr::null());
+            hew_cluster_registry_remove(null, std::ptr::null(), std::ptr::null(), std::ptr::null());
         }
     }
 

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -6211,7 +6211,7 @@ mod tests {
 
             let location = test_location(2, 0x42);
             assert_eq!(
-                hew_connmgr_broadcast_registry_gossip(mgr, "worker", location, true),
+                hew_connmgr_broadcast_registry_gossip(mgr, "worker", location, "test.Worker", true,),
                 1
             );
 
@@ -7153,7 +7153,7 @@ mod tests {
             (&*mgr).connections.access(|conns| conns.push(peer));
             let token = test_publish_claim(&*mgr, 2, 10);
 
-            (&*cluster).emit_registry_add("svc", test_location(1, 0x77));
+            (&*cluster).emit_registry_add("svc", test_location(1, 0x77), "test.Service");
 
             // Initial flush: the send fails; the frame must be parked, not lost.
             flush_registry_gossip_to_connection(&*mgr, 10, token, HEW_FEATURE_SUPPORTS_GOSSIP);
@@ -7481,7 +7481,7 @@ mod tests {
             let token = test_publish_claim(&*mgr, 2, 10);
 
             let location = test_location(1, 0x88);
-            (&*cluster).emit_registry_add("svc", location);
+            (&*cluster).emit_registry_add("svc", location, "test.Service");
             // The ADD flush fails and parks.
             flush_registry_gossip_to_connection(&*mgr, 10, token, HEW_FEATURE_SUPPORTS_GOSSIP);
             assert_eq!(
@@ -7492,7 +7492,7 @@ mod tests {
 
             // A later REMOVE broadcast must park BEHIND it, not overtake it.
             assert_eq!(
-                hew_connmgr_broadcast_registry_gossip(mgr, "svc", location, false),
+                hew_connmgr_broadcast_registry_gossip(mgr, "svc", location, "test.Service", false,),
                 0,
                 "the REMOVE must not report a direct send while the ADD is parked"
             );
@@ -7588,7 +7588,7 @@ mod tests {
             (&*mgr).connections.access(|conns| conns.push(peer));
             let token = test_publish_claim(&*mgr, 2, 10);
 
-            (&*cluster).emit_registry_add("svc", test_location(1, 0x99));
+            (&*cluster).emit_registry_add("svc", test_location(1, 0x99), "test.Service");
             flush_registry_gossip_to_connection(&*mgr, 10, token, HEW_FEATURE_SUPPORTS_GOSSIP);
             assert_eq!(
                 (*mgr).pending_registry_flush_count.load(Ordering::Acquire),
@@ -7638,13 +7638,19 @@ mod tests {
     extern "C" fn record_registry_apply(
         name: *const std::ffi::c_char,
         location: *const HewLocation,
+        actor_type: *const std::ffi::c_char,
         is_add: bool,
         user_data: *mut std::ffi::c_void,
     ) {
         // SAFETY: test installs a Mutex<Vec<_>> as the callback user data.
-        let applied = unsafe { &*(user_data.cast::<Mutex<Vec<(String, Location, bool)>>>()) };
+        let applied =
+            unsafe { &*(user_data.cast::<Mutex<Vec<(String, Location, String, bool)>>>()) };
         // SAFETY: the cluster passes a valid NUL-terminated name.
         let name = unsafe { std::ffi::CStr::from_ptr(name) }
+            .to_string_lossy()
+            .into_owned();
+        // SAFETY: the cluster passes a valid NUL-terminated actor type.
+        let actor_type = unsafe { std::ffi::CStr::from_ptr(actor_type) }
             .to_string_lossy()
             .into_owned();
         // SAFETY: cluster callback supplies a valid location pointer.
@@ -7652,7 +7658,7 @@ mod tests {
         applied
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .push((name, location, is_add));
+            .push((name, location, actor_type, is_add));
     }
 
     /// Real admission ordering through the production pieces (the full
@@ -7671,7 +7677,9 @@ mod tests {
     /// deny loses the peer's one-shot flush and the name never resolves.
     #[test]
     fn control_frame_before_install_applies_registry_event_after_real_publish() {
-        let applied = Box::into_raw(Box::new(Mutex::new(Vec::<(String, Location, bool)>::new())));
+        let applied = Box::into_raw(Box::new(Mutex::new(
+            Vec::<(String, Location, String, bool)>::new(),
+        )));
         let ops = Box::new(crate::transport::HewTransportOps {
             connect: None,
             listen: None,
@@ -7724,6 +7732,7 @@ mod tests {
                 op: crate::cluster::GOSSIP_REGISTRY_ADD,
                 name: "svc".to_owned(),
                 location: test_location(5, 0x99),
+                actor_type: "test.Service".to_owned(),
             };
             let frame_bytes = encode_control_frame(&ControlFrame {
                 version: WIRE_VERSION,
@@ -7780,7 +7789,12 @@ mod tests {
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
                 assert_eq!(
                     applied.as_slice(),
-                    &[("svc".to_owned(), location, true)],
+                    &[(
+                        "svc".to_owned(),
+                        location,
+                        "test.Service".to_owned(),
+                        true,
+                    )],
                     "the pre-install frame must apply exactly once after publication: {reader_error:?}",
                 );
             }
@@ -8116,8 +8130,13 @@ mod tests {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clear();
-            let count =
-                hew_connmgr_broadcast_registry_gossip(mgr, "svc", test_location(1, 0xdef0), true);
+            let count = hew_connmgr_broadcast_registry_gossip(
+                mgr,
+                "svc",
+                test_location(1, 0xdef0),
+                "test.Service",
+                true,
+            );
             assert_eq!(
                 count, 1,
                 "registry gossip broadcast reaches exactly the one authenticated peer"
@@ -8974,6 +8993,7 @@ mod tests {
                 "counter",
                 crate::node_identity::Location::new(NodeId::from_bytes([7; 16]), 9, 3)
                     .expect("test location should be valid"),
+                "test.Counter",
             );
             assert_eq!((&*cluster).registry_gossip_count(), 1);
 
@@ -9197,6 +9217,7 @@ mod tests {
                 "counter",
                 crate::node_identity::Location::new(NodeId::from_bytes([7; 16]), 9, 3)
                     .expect("test location should be valid"),
+                "test.Counter",
             );
             assert_eq!((&*cluster).registry_gossip_count(), 1);
 

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -1951,7 +1951,12 @@ unsafe fn encode_envelope(
     }
 }
 
-fn encode_registry_gossip_control(name: &str, location: Location, is_add: bool) -> Option<Vec<u8>> {
+fn encode_registry_gossip_control(
+    name: &str,
+    location: Location,
+    actor_type: &str,
+    is_add: bool,
+) -> Option<Vec<u8>> {
     let op = if is_add {
         crate::cluster::GOSSIP_REGISTRY_ADD
     } else {
@@ -1961,6 +1966,7 @@ fn encode_registry_gossip_control(name: &str, location: Location, is_add: bool) 
         op,
         name: name.to_owned(),
         location,
+        actor_type: actor_type.to_owned(),
     };
     let payload = match encode_registry_gossip_payload(&payload) {
         Ok(payload) => payload,
@@ -1995,22 +2001,20 @@ fn handle_control_frame(
     control: &ControlFrame,
 ) {
     match control.ctrl_kind {
-        CTRL_REGISTRY_GOSSIP => {}
+        CTRL_REGISTRY_GOSSIP => {
+            handle_registry_gossip_frame(mgr, peer_feature_flags, conn_id, claim_token, control);
+        }
         CTRL_SWIM => {
             handle_swim_control_frame(mgr, peer_feature_flags, conn_id, claim_token, control);
-            return;
         }
         CTRL_MONITOR_REQ => {
             handle_monitor_req_frame(mgr, conn_id, claim_token, control);
-            return;
         }
         CTRL_DEMONITOR => {
             handle_demonitor_frame(mgr, conn_id, claim_token, control);
-            return;
         }
         CTRL_MONITOR_DOWN => {
             handle_monitor_down_frame(mgr, conn_id, claim_token, control);
-            return;
         }
         CTRL_MONITOR_SETUP_RESULT => {
             handle_setup_result_frame(
@@ -2020,19 +2024,15 @@ fn handle_control_frame(
                 control,
                 crate::hew_node::RemoteSetupKind::Monitor,
             );
-            return;
         }
         CTRL_LINK_REQ => {
             handle_link_req_frame(mgr, conn_id, claim_token, control);
-            return;
         }
         CTRL_UNLINK => {
             handle_unlink_frame(mgr, conn_id, claim_token, control);
-            return;
         }
         CTRL_LINK_DOWN => {
             handle_link_down_frame(mgr, conn_id, claim_token, control);
-            return;
         }
         CTRL_LINK_SETUP_RESULT => {
             handle_setup_result_frame(
@@ -2042,15 +2042,22 @@ fn handle_control_frame(
                 control,
                 crate::hew_node::RemoteSetupKind::Link,
             );
-            return;
         }
         other => {
             set_last_error(format!(
                 "connection reader unknown control frame kind {other}"
             ));
-            return;
         }
     }
+}
+
+fn handle_registry_gossip_frame(
+    mgr: *mut HewConnMgr,
+    peer_feature_flags: u32,
+    conn_id: c_int,
+    claim_token: u64,
+    control: &ControlFrame,
+) {
     if !supports_gossip(peer_feature_flags) {
         set_last_error("connection reader rejected registry gossip from non-gossip peer");
         return;
@@ -2099,7 +2106,12 @@ fn handle_control_frame(
     // SAFETY: cluster pointer is owned by the live node/manager and remains
     // valid while the reader thread is running.
     unsafe {
-        (&*mgr_ref.cluster).apply_registry_event(&payload.name, payload.location, is_add);
+        (&*mgr_ref.cluster).apply_registry_event(
+            &payload.name,
+            payload.location,
+            &payload.actor_type,
+            is_add,
+        );
     }
 }
 
@@ -2621,7 +2633,12 @@ fn flush_registry_gossip_to_connection(
     let frames: Vec<Vec<u8>> = events
         .into_iter()
         .filter_map(|event| {
-            encode_registry_gossip_control(&event.name, event.location, event.is_add)
+            encode_registry_gossip_control(
+                &event.name,
+                event.location,
+                &event.actor_type,
+                event.is_add,
+            )
         })
         .collect();
     send_registry_flush_frames(mgr, conn_id, publication_token, frames, 0);
@@ -5200,6 +5217,7 @@ pub(crate) unsafe fn hew_connmgr_broadcast_registry_gossip(
     mgr: *mut HewConnMgr,
     name: &str,
     location: Location,
+    actor_type: &str,
     is_add: bool,
 ) -> c_int {
     if mgr.is_null() {
@@ -5207,7 +5225,7 @@ pub(crate) unsafe fn hew_connmgr_broadcast_registry_gossip(
     }
     // SAFETY: caller guarantees manager pointer validity.
     let mgr_ref = unsafe { &*mgr };
-    let Some(bytes) = encode_registry_gossip_control(name, location, is_add) else {
+    let Some(bytes) = encode_registry_gossip_control(name, location, actor_type, is_add) else {
         return 0;
     };
 

--- a/hew-runtime/src/envelope.rs
+++ b/hew-runtime/src/envelope.rs
@@ -28,7 +28,7 @@ use crate::node_identity::{Location, NodeId};
 /// Current wire protocol version.
 ///
 /// Frames carrying any other version value MUST be rejected by the decoder.
-pub const WIRE_VERSION: u8 = 2;
+pub const WIRE_VERSION: u8 = 3;
 
 /// Discriminant for a control frame (`frame_type` field value 0).
 pub const FRAME_TYPE_CONTROL: u8 = 0;
@@ -154,6 +154,9 @@ pub const MAX_REGISTRY_GOSSIP_PAYLOAD_BYTES: usize = 4096;
 /// Maximum accepted registry name length on the gossip wire, in UTF-8 bytes.
 pub const MAX_REGISTRY_GOSSIP_NAME_BYTES: usize = 1024;
 
+/// Maximum accepted compiler-minted actor identity length on the gossip wire.
+pub const MAX_REGISTRY_GOSSIP_ACTOR_TYPE_BYTES: usize = 1024;
+
 /// A control frame: node-level signalling with an opaque byte payload.
 ///
 /// CDDL: `control-frame` rule in `schemas/envelope.cddl`.
@@ -233,7 +236,7 @@ pub enum WireFrame {
 
 /// Bounded registry-gossip control payload.
 ///
-/// Encoded as a definite CBOR map `{1: op, 2: name, 3: location}`.
+/// Encoded as a definite CBOR map `{1: op, 2: name, 3: location, 4: actor_type}`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegistryGossipPayload {
     /// Registry operation (`REGISTRY_GOSSIP_OP_ADD` or `_REMOVE`).
@@ -242,6 +245,8 @@ pub struct RegistryGossipPayload {
     pub name: String,
     /// Exact actor identity being added or retracted.
     pub location: Location,
+    /// Canonical compiler-minted actor declaration identity.
+    pub actor_type: String,
 }
 
 /// Key-derived node identity paired with its durable session incarnation.
@@ -889,6 +894,10 @@ pub fn encode_registry_gossip_payload(
             Value::Integer(Integer::from(3u64)),
             location_to_value(payload.location),
         ),
+        (
+            Value::Integer(Integer::from(4u64)),
+            Value::Text(payload.actor_type.clone()),
+        ),
     ]);
     let mut bytes = Vec::new();
     ciborium::ser::into_writer(&value, &mut bytes)
@@ -1064,7 +1073,7 @@ pub fn decode_registry_gossip_payload(
     let value: Value =
         ciborium::de::from_reader(bytes).map_err(RegistryGossipPayloadError::CborDecode)?;
     let map = collect_map(&value).map_err(RegistryGossipPayloadError::from)?;
-    ensure_exact_keys(&map, &[1, 2, 3]).map_err(RegistryGossipPayloadError::from)?;
+    ensure_exact_keys(&map, &[1, 2, 3, 4]).map_err(RegistryGossipPayloadError::from)?;
     let payload = RegistryGossipPayload {
         op: value_to_u8(
             required(&map, 1).map_err(RegistryGossipPayloadError::from)?,
@@ -1079,6 +1088,11 @@ pub fn decode_registry_gossip_payload(
         location: value_to_location(
             required(&map, 3).map_err(RegistryGossipPayloadError::from)?,
             3,
+        )
+        .map_err(RegistryGossipPayloadError::from)?,
+        actor_type: value_to_text(
+            required(&map, 4).map_err(RegistryGossipPayloadError::from)?,
+            4,
         )
         .map_err(RegistryGossipPayloadError::from)?,
     };
@@ -1831,6 +1845,15 @@ fn validate_registry_gossip_payload(
         return Err(RegistryGossipPayloadError::MalformedField {
             key: 2,
             expected: "a registry name without NUL bytes",
+        });
+    }
+    if payload.actor_type.is_empty()
+        || payload.actor_type.len() > MAX_REGISTRY_GOSSIP_ACTOR_TYPE_BYTES
+        || payload.actor_type.as_bytes().contains(&0)
+    {
+        return Err(RegistryGossipPayloadError::MalformedField {
+            key: 4,
+            expected: "a non-empty canonical actor identity within the length bound",
         });
     }
     Ok(())

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -1206,6 +1206,7 @@ fn remote_reply_data_to_ptr(reply_data: &[u8], reply_size: usize) -> *mut c_void
 #[derive(Debug, Default)]
 pub struct HewRegistry {
     remote_names: Mutex<HashMap<String, Location>>,
+    actor_types: Mutex<HashMap<String, String>>,
 }
 
 #[derive(Clone, Copy)]
@@ -1314,6 +1315,7 @@ unsafe fn unregister_names_from_node(
                     node.cluster,
                     c_name.as_ptr(),
                     &raw const location,
+                    c"legacy".as_ptr(),
                 );
             };
         }
@@ -1336,6 +1338,7 @@ unsafe fn unregister_local_names_for_node(node: &HewNode) {
     unsafe { unregister_names_from_node(node, names, false) };
 
     registry.remote_names.lock_or_recover().clear();
+    registry.actor_types.lock_or_recover().clear();
 }
 
 /// Remove all registered names that still point at `actor_id`.
@@ -1957,10 +1960,11 @@ fn send_reply_envelope(
 extern "C" fn node_registry_gossip_callback(
     name: *const c_char,
     location: *const HewLocation,
+    actor_type: *const c_char,
     is_add: bool,
     user_data: *mut c_void,
 ) {
-    if name.is_null() || location.is_null() || user_data.is_null() {
+    if name.is_null() || location.is_null() || actor_type.is_null() || user_data.is_null() {
         return;
     }
     // SAFETY: user_data is a *mut HewRegistry pointer set during hew_node_start,
@@ -1970,6 +1974,10 @@ extern "C" fn node_registry_gossip_callback(
     let key = unsafe { CStr::from_ptr(name) }
         .to_string_lossy()
         .into_owned();
+    // SAFETY: caller guarantees `actor_type` is a valid C string.
+    let actor_type = unsafe { CStr::from_ptr(actor_type) }
+        .to_string_lossy()
+        .into_owned();
     // SAFETY: caller guarantees `location` is readable for the callback.
     let Ok(location) = Location::try_from(unsafe { *location }) else {
         set_last_error("registry gossip callback received an invalid Location");
@@ -1977,9 +1985,14 @@ extern "C" fn node_registry_gossip_callback(
     };
     let mut map = registry.remote_names.lock_or_recover();
     if is_add {
-        map.insert(key, location);
+        map.insert(key.clone(), location);
+        registry
+            .actor_types
+            .lock_or_recover()
+            .insert(key, actor_type);
     } else if map.get(&key) == Some(&location) {
         map.remove(&key);
+        registry.actor_types.lock_or_recover().remove(&key);
     }
 }
 
@@ -2660,7 +2673,17 @@ pub unsafe extern "C" fn hew_node_register(
     name: *const c_char,
     actor: u64,
 ) -> c_int {
-    cabi_guard!(node.is_null() || name.is_null(), -1);
+    // SAFETY: forwards the caller contract with a stable legacy type identity.
+    unsafe { hew_node_register_typed(node, name, actor, c"legacy".as_ptr()) }
+}
+
+unsafe fn hew_node_register_typed(
+    node: *mut HewNode,
+    name: *const c_char,
+    actor: u64,
+    actor_type: *const c_char,
+) -> c_int {
+    cabi_guard!(node.is_null() || name.is_null() || actor_type.is_null(), -1);
     // SAFETY: caller guarantees node pointer validity.
     let node = unsafe { &mut *node };
     if node.registry.is_null() {
@@ -2671,6 +2694,10 @@ pub unsafe extern "C" fn hew_node_register(
     let key = unsafe { CStr::from_ptr(name) }
         .to_string_lossy()
         .into_owned();
+    // SAFETY: caller guarantees `actor_type` is a valid C string.
+    let actor_type = unsafe { CStr::from_ptr(actor_type) }
+        .to_string_lossy()
+        .into_owned();
     let Some(location) = local_actor_location(node, actor) else {
         set_last_error("hew_node_register: node has no authenticated Location authority");
         return -1;
@@ -2678,7 +2705,8 @@ pub unsafe extern "C" fn hew_node_register(
     // SAFETY: registry pointer was allocated in hew_node_new and freed in hew_node_free.
     let reg = unsafe { &*node.registry };
     let previous = reg.remote_names.lock_or_recover().get(&key).copied();
-    if previous == Some(location) {
+    let previous_type = reg.actor_types.lock_or_recover().get(&key).cloned();
+    if previous == Some(location) && previous_type.as_deref() == Some(actor_type.as_str()) {
         return 0;
     }
     if previous.is_some() {
@@ -2686,24 +2714,41 @@ pub unsafe extern "C" fn hew_node_register(
         unsafe { crate::registry::hew_registry_unregister(name) };
     }
     // SAFETY: registry API expects a stable C string pointer.
-    if unsafe { crate::registry::hew_registry_register(name, actor_id_to_registry_ptr(actor)) } != 0
-    {
-        return -1;
-    }
+    crate::registry::register_typed(&key, actor_id_to_registry_ptr(actor), &actor_type);
     reg.remote_names
         .lock_or_recover()
         .insert(key.clone(), location);
+    reg.actor_types
+        .lock_or_recover()
+        .insert(key.clone(), actor_type.clone());
 
     // Propagate to cluster gossip so remote nodes learn about this actor.
     if !node.cluster.is_null() {
         let abi_location = HewLocation::from(location);
         // SAFETY: cluster pointer is valid while the node is alive.
-        unsafe { cluster::hew_cluster_registry_add(node.cluster, name, &raw const abi_location) };
+        let Ok(c_actor_type) = CString::new(actor_type.as_bytes()) else {
+            return -1;
+        };
+        // SAFETY: the cluster and all borrowed C values remain valid for this call.
+        unsafe {
+            cluster::hew_cluster_registry_add(
+                node.cluster,
+                name,
+                &raw const abi_location,
+                c_actor_type.as_ptr(),
+            );
+        };
     }
     if !node.conn_mgr.is_null() {
         // SAFETY: connection manager pointer is valid while the node is alive.
         unsafe {
-            connection::hew_connmgr_broadcast_registry_gossip(node.conn_mgr, &key, location, true);
+            connection::hew_connmgr_broadcast_registry_gossip(
+                node.conn_mgr,
+                &key,
+                location,
+                &actor_type,
+                true,
+            );
         }
     }
 
@@ -2744,13 +2789,26 @@ pub unsafe extern "C" fn hew_node_unregister(node: *mut HewNode, name: *const c_
     let Some(removed_location) = removed_location else {
         return 0;
     };
+    let removed_type = reg
+        .actor_types
+        .lock_or_recover()
+        .remove(&key)
+        .unwrap_or_else(|| "legacy".to_string());
+    let Ok(c_actor_type) = CString::new(removed_type.as_bytes()) else {
+        return -1;
+    };
 
     // Propagate removal to cluster gossip.
     if !node.cluster.is_null() {
         let abi_location = HewLocation::from(removed_location);
         // SAFETY: cluster pointer is valid while the node is alive.
         unsafe {
-            cluster::hew_cluster_registry_remove(node.cluster, name, &raw const abi_location);
+            cluster::hew_cluster_registry_remove(
+                node.cluster,
+                name,
+                &raw const abi_location,
+                c_actor_type.as_ptr(),
+            );
         };
     }
     if !node.conn_mgr.is_null() {
@@ -2760,6 +2818,7 @@ pub unsafe extern "C" fn hew_node_unregister(node: *mut HewNode, name: *const c_
                 node.conn_mgr,
                 &key,
                 removed_location,
+                &removed_type,
                 false,
             );
         }
@@ -2781,7 +2840,25 @@ pub unsafe extern "C" fn hew_node_lookup_location(
     name: *const c_char,
     out: *mut HewRemotePid,
 ) -> c_int {
-    cabi_guard!(node.is_null() || name.is_null() || out.is_null(), -1);
+    // SAFETY: forwards the caller contract with the legacy identity.
+    let status = unsafe { hew_node_lookup_location_typed(node, name, c"legacy".as_ptr(), out) };
+    if status == 0 {
+        0
+    } else {
+        -1
+    }
+}
+
+unsafe fn hew_node_lookup_location_typed(
+    node: *mut HewNode,
+    name: *const c_char,
+    actor_type: *const c_char,
+    out: *mut HewRemotePid,
+) -> c_int {
+    cabi_guard!(
+        node.is_null() || name.is_null() || actor_type.is_null() || out.is_null(),
+        1
+    );
     // SAFETY: caller guarantees node pointer validity.
     let node = unsafe { &*node };
     if node.registry.is_null() {
@@ -2791,12 +2868,22 @@ pub unsafe extern "C" fn hew_node_lookup_location(
     let key = unsafe { CStr::from_ptr(name) }
         .to_string_lossy()
         .into_owned();
+    // SAFETY: caller guarantees `actor_type` is a valid C string.
+    let actor_type = unsafe { CStr::from_ptr(actor_type) }.to_string_lossy();
     // SAFETY: registry pointer was allocated in hew_node_new and freed in hew_node_free.
     let reg = unsafe { &*node.registry };
     let map = reg.remote_names.lock_or_recover();
     let Some(location) = map.get(&key).copied() else {
-        return -1;
+        return 1;
     };
+    if reg
+        .actor_types
+        .lock_or_recover()
+        .get(&key)
+        .is_none_or(|registered| registered != actor_type.as_ref())
+    {
+        return 2;
+    }
     // SAFETY: caller guarantees `out` is writable.
     unsafe { out.write(HewRemotePid::from(location)) };
     0
@@ -4903,6 +4990,177 @@ fn select_local_route_slot(
     None
 }
 
+unsafe fn node_config_strings(values: *mut hew_cabi::vec::HewVec) -> Result<Vec<String>, String> {
+    if values.is_null() {
+        return Ok(Vec::new());
+    }
+    // SAFETY: the caller provides a readable HewVec for the duration of this call.
+    let values = unsafe { &*values };
+    if values.elem_size != std::mem::size_of::<*const c_char>() {
+        return Err("NodeConfig string vector has an invalid element layout".to_string());
+    }
+    let mut result = Vec::with_capacity(values.len);
+    for index in 0..values.len {
+        let mut string_ptr: *const c_char = std::ptr::null();
+        // SAFETY: the vector layout and index bounds were validated above. Copying
+        // bytes avoids imposing pointer alignment on HewVec's byte buffer.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                values
+                    .data
+                    .add(index * std::mem::size_of::<*const c_char>()),
+                (&raw mut string_ptr).cast::<u8>(),
+                std::mem::size_of::<*const c_char>(),
+            );
+        }
+        if string_ptr.is_null() {
+            return Err("NodeConfig string vector contains a null value".to_string());
+        }
+        // SAFETY: NodeConfig string vectors contain valid C string pointers.
+        result.push(
+            unsafe { CStr::from_ptr(string_ptr) }
+                .to_string_lossy()
+                .into_owned(),
+        );
+    }
+    Ok(result)
+}
+
+unsafe fn promote_local_registry(node: *mut HewNode) -> c_int {
+    for (name, entry) in crate::registry::typed_entries() {
+        let Ok(name) = CString::new(name) else {
+            return -1;
+        };
+        let Ok(actor_type) = CString::new(entry.actor_type) else {
+            return -1;
+        };
+        let actor = entry.actor.addr() as u64;
+        // SAFETY: the node is live and each CString remains valid for this call.
+        if unsafe { hew_node_register_typed(node, name.as_ptr(), actor, actor_type.as_ptr()) } != 0
+        {
+            return -1;
+        }
+    }
+    0
+}
+
+/// `Node::start(config)` — validate and atomically start a configured node.
+///
+/// Returns zero on success or one plus the `NodeError` discriminant.
+///
+/// # Safety
+///
+/// String pointers must be valid C strings and vector pointers must be valid
+/// `Vec<string>` runtime values for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn hew_node_api_start(
+    bind: *const c_char,
+    transport: *const c_char,
+    key: *const c_char,
+    trust: *const c_char,
+    peers: *mut hew_cabi::vec::HewVec,
+    seeds: *mut hew_cabi::vec::HewVec,
+) -> c_int {
+    if bind.is_null() || transport.is_null() || key.is_null() || trust.is_null() {
+        set_last_error("Node::start: NodeConfig contains a null string");
+        return 1;
+    }
+    // SAFETY: the pointer was checked non-null and is a valid C string by contract.
+    let bind_text = unsafe { CStr::from_ptr(bind) }.to_string_lossy();
+    // SAFETY: the pointer was checked non-null and is a valid C string by contract.
+    let key_text = unsafe { CStr::from_ptr(key) }.to_string_lossy();
+    // SAFETY: the pointer was checked non-null and is a valid C string by contract.
+    let trust_text = unsafe { CStr::from_ptr(trust) }.to_string_lossy();
+    if bind_text.is_empty() || key_text.is_empty() || trust_text != "pinned" {
+        set_last_error("Node::start: bind and key must be non-empty and trust must be `pinned`");
+        return 1;
+    }
+    // SAFETY: NodeConfig owns a valid HewVec for the duration of this call.
+    let peer_credentials = match unsafe { node_config_strings(peers) } {
+        Ok(values) => values,
+        Err(message) => {
+            set_last_error(message);
+            return 1;
+        }
+    };
+    // SAFETY: NodeConfig owns a valid HewVec for the duration of this call.
+    let seed_addresses = match unsafe { node_config_strings(seeds) } {
+        Ok(values) => values,
+        Err(message) => {
+            set_last_error(message);
+            return 1;
+        }
+    };
+
+    {
+        let mut guard = PEER_AUTH_STATE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !matches!(guard.state, ConfigState::Building(_)) {
+            set_last_error("Node::start: a public node lifecycle is already active");
+            return 1;
+        }
+        guard.state = ConfigState::default();
+    }
+    // SAFETY: NodeConfig strings remain valid C strings for these synchronous calls.
+    let transport_status = unsafe { configure_transport(transport) };
+    // SAFETY: NodeConfig strings remain valid C strings for these synchronous calls.
+    let key_status = unsafe { configure_keys(key) };
+    if transport_status != 0 || key_status != 0 {
+        return 1;
+    }
+    for (index, credential) in peer_credentials.iter().enumerate() {
+        let Ok(route_slot) = u16::try_from(index + 1) else {
+            set_last_error("Node::start: too many peer credentials");
+            return 1;
+        };
+        let Ok(credential) = CString::new(credential.as_bytes()) else {
+            set_last_error("Node::start: a peer credential contains a NUL byte");
+            return 1;
+        };
+        // SAFETY: the CString remains valid for this synchronous configuration call.
+        if unsafe { configure_peer(route_slot, credential.as_ptr()) } != 0 {
+            return 1;
+        }
+    }
+
+    // SAFETY: the NodeConfig bind string remains valid for this synchronous call.
+    if unsafe { start_address(bind) } != 0 {
+        return 2;
+    }
+    let promote_status = with_current_node_read(|guard| {
+        let node = *guard as *mut HewNode;
+        if node.is_null() {
+            -1
+        } else {
+            // SAFETY: the guarded current-node pointer is live for the closure.
+            unsafe { promote_local_registry(node) }
+        }
+    });
+    if promote_status != 0 {
+        // SAFETY: shutdown consumes only the guarded process-global node state.
+        let _ = unsafe { hew_node_api_shutdown() };
+        return 2;
+    }
+    for seed in seed_addresses {
+        if seed == bind_text {
+            continue;
+        }
+        let Ok(seed) = CString::new(seed) else {
+            // SAFETY: shutdown consumes only the guarded process-global node state.
+            let _ = unsafe { hew_node_api_shutdown() };
+            return 3;
+        };
+        // SAFETY: the seed CString remains valid for this synchronous call.
+        if unsafe { hew_node_api_connect(seed.as_ptr()) } != 0 {
+            // SAFETY: shutdown consumes only the guarded process-global node state.
+            let _ = unsafe { hew_node_api_shutdown() };
+            return 3;
+        }
+    }
+    0
+}
+
 /// Merge the start-time transport selection into staged pre-start config.
 ///
 /// # Errors
@@ -4911,11 +5169,9 @@ fn select_local_route_slot(
 fn merge_start_env_into_config(
     cfg: &mut crate::peer_binding::PeerAuthConfig,
 ) -> Result<(), String> {
-    // Transport (issue #2652): a selection pinned by an earlier transport-
-    // sensitive op (`Node::set_transport` / `Node::load_keys` /
-    // `Node::allow_peer`) is authoritative and wins over any later env change —
-    // start uses the STORED selection. Only when unpinned do we adopt the
-    // start-time env selection.
+    // A transport selected by NodeConfig is authoritative and wins over any
+    // later environment change. Only an unpinned internal configuration adopts
+    // the start-time environment selection.
     let effective = if let Some(pinned) = cfg.transport {
         pinned
     } else {
@@ -4933,13 +5189,12 @@ fn merge_start_env_into_config(
     Ok(())
 }
 
-/// `Node::start(addr)` — Create and start a node, binding to `addr`.
+/// Start a node from the already-staged peer-auth configuration.
 ///
 /// # Safety
 ///
 /// `addr` must be a valid null-terminated C string.
-#[no_mangle]
-pub unsafe extern "C" fn hew_node_api_start(addr: *const c_char) -> c_int {
+unsafe fn start_address(addr: *const c_char) -> c_int {
     if addr.is_null() {
         set_last_error("Node::start: address is null");
         return -1;
@@ -4979,18 +5234,15 @@ pub unsafe extern "C" fn hew_node_api_start(addr: *const c_char) -> c_int {
             let msg = format!(
                 "Node::start: refusing to bind listener — peer-auth setup failed (fail-closed): {reason}"
             );
-            eprintln!("hew: {msg}");
             set_last_error(msg);
             return -1;
         }
         if let Err(msg) = merge_start_env_into_config(&mut cfg) {
-            eprintln!("hew: {msg}");
             set_last_error(msg);
             return -1;
         }
         // Pre-listen public validation (fail-closed before allocation).
         if let Err(msg) = cfg.validate_public() {
-            eprintln!("hew: {msg}");
             set_last_error(msg);
             return -1;
         }
@@ -5000,7 +5252,6 @@ pub unsafe extern "C" fn hew_node_api_start(addr: *const c_char) -> c_int {
             select_local_route_slot(process_route_slot_base(), offset, cfg.bindings())
         else {
             let msg = "Node::start: no free local route slot remains after peer bindings";
-            eprintln!("hew: {msg}");
             set_last_error(msg);
             return -1;
         };
@@ -5008,7 +5259,6 @@ pub unsafe extern "C" fn hew_node_api_start(addr: *const c_char) -> c_int {
         let snapshot = match cfg.snapshot_for_start() {
             Ok(snapshot) => snapshot,
             Err(msg) => {
-                eprintln!("hew: {msg}");
                 set_last_error(msg);
                 return -1;
             }
@@ -5195,14 +5445,18 @@ pub unsafe extern "C" fn hew_node_api_register(
 /// `name` must be a valid null-terminated C string that remains live for
 /// the duration of this call.
 #[no_mangle]
-pub unsafe extern "C" fn hew_node_api_register_by_pid(name: *const c_char, pid: u64) -> c_int {
-    if name.is_null() {
+pub unsafe extern "C" fn hew_node_api_register_by_pid(
+    name: *const c_char,
+    pid: u64,
+    actor_type: *const c_char,
+) -> c_int {
+    if name.is_null() || actor_type.is_null() {
         set_last_error("Node::register: name pointer is null");
-        return -1;
+        return 1;
     }
     if pid == 0 {
         set_last_error("Node::register: pid is zero (invalid actor)");
-        return -1;
+        return 2;
     }
     // Verify the actor is currently live in the actor table before attempting
     // to register it.  This prevents dangling registrations after an actor
@@ -5212,17 +5466,24 @@ pub unsafe extern "C" fn hew_node_api_register_by_pid(name: *const c_char, pid: 
         set_last_error(format!(
             "Node::register: actor with pid {pid} not found in live-actor table"
         ));
-        return -1;
+        return 2;
     }
+    // SAFETY: both pointers were checked non-null and are valid C strings by contract.
+    let key = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+    // SAFETY: both pointers were checked non-null and are valid C strings by contract.
+    let actor_type_text = unsafe { CStr::from_ptr(actor_type) }.to_string_lossy();
+    if key.is_empty() || key.as_bytes().contains(&0) || actor_type_text.is_empty() {
+        set_last_error("Node::register: name and actor type must be non-empty");
+        return 1;
+    }
+    crate::registry::register_typed(&key, actor_id_to_registry_ptr(pid), &actor_type_text);
     with_current_node_read(|guard| {
         let node = *guard as *mut HewNode;
         if node.is_null() {
-            set_last_error("Node::register: no active node (call Node::start first)");
-            return -1;
+            return 0;
         }
-        // SAFETY: node is non-null; name is non-null and caller guarantees a
-        // valid C string; pid was validated above.
-        unsafe { hew_node_register(node, name, pid) }
+        // SAFETY: node and all arguments were validated above.
+        unsafe { hew_node_register_typed(node, name, pid, actor_type) }
     })
 }
 
@@ -5241,13 +5502,14 @@ pub unsafe extern "C" fn hew_node_api_register_by_pid(name: *const c_char, pid: 
 pub unsafe extern "C" fn hew_node_api_unregister(name: *const c_char) -> c_int {
     if name.is_null() {
         set_last_error("Node::unregister: name pointer is null");
-        return -1;
+        return 1;
     }
+    // SAFETY: name was checked non-null and is valid by the caller contract.
+    let local_status = unsafe { crate::registry::hew_registry_unregister(name) };
     with_current_node_read(|guard| {
         let node = *guard as *mut HewNode;
         if node.is_null() {
-            set_last_error("Node::unregister: no active node (call Node::start first)");
-            return -1;
+            return i32::from(local_status != 0);
         }
         // SAFETY: node is non-null; name is non-null and caller guarantees a
         // valid C string.
@@ -5265,18 +5527,34 @@ pub unsafe extern "C" fn hew_node_api_unregister(name: *const c_char) -> c_int {
 #[no_mangle]
 pub unsafe extern "C" fn hew_node_api_lookup_location(
     name: *const c_char,
+    actor_type: *const c_char,
     out: *mut HewRemotePid,
 ) -> c_int {
-    if name.is_null() || out.is_null() {
-        return -1;
+    if name.is_null() || actor_type.is_null() || out.is_null() {
+        return 1;
+    }
+    // SAFETY: both pointers were checked non-null and are valid C strings by contract.
+    let key = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+    // SAFETY: both pointers were checked non-null and are valid C strings by contract.
+    let expected = unsafe { CStr::from_ptr(actor_type) }.to_string_lossy();
+    if let Some(entry) = crate::registry::lookup_typed(&key) {
+        if entry.actor_type != expected {
+            return 2;
+        }
+        let has_node = with_current_node_read(|guard| *guard != 0);
+        if !has_node {
+            // SAFETY: out was checked non-null and writable by the caller contract.
+            unsafe { out.write(HewRemotePid::default()) };
+            return 0;
+        }
     }
     with_current_node_read(|guard| {
         let node = *guard as *mut HewNode;
         if node.is_null() {
-            return -1;
+            return 1;
         }
         // SAFETY: node is pinned by the read lock; caller guarantees name/output.
-        unsafe { hew_node_lookup_location(node, name, out) }
+        unsafe { hew_node_lookup_location_typed(node, name, actor_type, out) }
     })
 }
 
@@ -5295,8 +5573,7 @@ pub unsafe extern "C" fn hew_node_api_lookup_location(
 /// # Safety
 ///
 /// `name` must be a valid null-terminated C string.
-#[no_mangle]
-pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_int {
+unsafe fn configure_transport(name: *const c_char) -> c_int {
     // SAFETY: caller guarantees name is a valid C string (or null).
     let Some(s) = (unsafe { crate::util::cstr_to_str(&name, "hew_node_set_transport") }) else {
         return -1;
@@ -5376,7 +5653,6 @@ pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_in
 ///   allowlist after the operator's setup failed.
 fn node_peer_auth_setup_failed(msg: impl Into<String>) {
     let msg = msg.into();
-    eprintln!("hew: {msg} (fail-closed)");
     // Poison the staged config. If a public node lifecycle already owns the
     // state (Starting/Running) the poison is moot: that node already froze and
     // installed its snapshot. First poison wins (a later generic failure must
@@ -5411,8 +5687,7 @@ fn node_peer_auth_setup_failed(msg: impl Into<String>) {
 /// # Safety
 ///
 /// `path` must be a valid null-terminated C string.
-#[no_mangle]
-pub unsafe extern "C" fn hew_node_api_load_keys(path: *const c_char) -> c_int {
+unsafe fn configure_keys(path: *const c_char) -> c_int {
     // SAFETY: caller guarantees path is a valid C string (or null).
     let Some(p) = (unsafe { crate::util::cstr_to_str(&path, "Node::load_keys") }) else {
         node_peer_auth_setup_failed("Node::load_keys: invalid path argument");
@@ -5561,11 +5836,7 @@ fn stage_loaded_identity(
 /// # Safety
 ///
 /// `credential_hex` must be a valid null-terminated C string.
-#[no_mangle]
-pub unsafe extern "C" fn hew_node_api_allow_peer(
-    route_slot: u16,
-    credential_hex: *const c_char,
-) -> c_int {
+unsafe fn configure_peer(route_slot: u16, credential_hex: *const c_char) -> c_int {
     // SAFETY: caller guarantees credential_hex is a valid C string (or null).
     let Some(s) = (unsafe { crate::util::cstr_to_str(&credential_hex, "Node::allow_peer") }) else {
         node_peer_auth_setup_failed("Node::allow_peer: invalid credential argument");

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -7197,13 +7197,13 @@ mod tests {
         };
         let tcp = CString::new("tcp").expect("valid transport name");
         // SAFETY: tcp is a valid C string for this call.
-        assert_eq!(unsafe { hew_node_api_set_transport(tcp.as_ptr()) }, 0);
+        assert_eq!(unsafe { configure_transport(tcp.as_ptr()) }, 0);
 
         let key_path = identity.dir.path().join("node.key");
         let key_path = CString::new(key_path.to_str().expect("UTF-8 tempfile key path"))
             .expect("valid tempfile key path");
         // SAFETY: key_path is a valid C string and the directory remains live in the guard.
-        assert_eq!(unsafe { hew_node_api_load_keys(key_path.as_ptr()) }, 0);
+        assert_eq!(unsafe { configure_keys(key_path.as_ptr()) }, 0);
 
         identity
     }
@@ -8464,7 +8464,7 @@ mod tests {
         let _identity = stage_public_api_test_identity();
         let bind = CString::new("127.0.0.1:0").expect("valid bind addr");
         // SAFETY: bind is a valid C string for this call.
-        let rc = unsafe { hew_node_api_start(bind.as_ptr()) };
+        let rc = unsafe { start_address(bind.as_ptr()) };
         assert_eq!(rc, 0, "identity-backed public start should succeed");
         {
             let g = PEER_AUTH_STATE
@@ -8515,9 +8515,9 @@ mod tests {
         let _identity = stage_public_api_test_identity();
         let bind = CString::new("127.0.0.1:0").expect("valid bind addr");
         // SAFETY: bind valid.
-        assert_eq!(unsafe { hew_node_api_start(bind.as_ptr()) }, 0);
+        assert_eq!(unsafe { start_address(bind.as_ptr()) }, 0);
         // SAFETY: bind valid; second start must be rejected.
-        let second_rc = unsafe { hew_node_api_start(bind.as_ptr()) };
+        let second_rc = unsafe { start_address(bind.as_ptr()) };
         assert_eq!(
             second_rc, -1,
             "a second concurrent public start must be refused"
@@ -8579,9 +8579,9 @@ mod tests {
         std::fs::write(&key, b"not-a-keyfile-frame").unwrap();
         let c_key = CString::new(key.to_str().unwrap()).unwrap();
         // SAFETY: c_key is a valid NUL-terminated C string for this call.
-        let rc_load = unsafe { hew_node_api_load_keys(c_key.as_ptr()) };
+        let rc_load = unsafe { configure_keys(c_key.as_ptr()) };
         // SAFETY: bind is a valid NUL-terminated C string for this call.
-        let rc_start_after_load = unsafe { hew_node_api_start(bind.as_ptr()) };
+        let rc_start_after_load = unsafe { start_address(bind.as_ptr()) };
         // A fail-closed start never created a node; clean up if the gate regressed.
         if rc_start_after_load == 0 {
             // SAFETY: shutdown reclaims the current node, if any; takes no arguments.
@@ -8593,9 +8593,9 @@ mod tests {
         reset_staging();
         let bad_hex = CString::new("nothex!!").expect("valid C string");
         // SAFETY: bad_hex is a valid NUL-terminated C string for this call.
-        let rc_allow = unsafe { hew_node_api_allow_peer(2, bad_hex.as_ptr()) };
+        let rc_allow = unsafe { configure_peer(2, bad_hex.as_ptr()) };
         // SAFETY: bind is a valid NUL-terminated C string for this call.
-        let rc_start_after_allow = unsafe { hew_node_api_start(bind.as_ptr()) };
+        let rc_start_after_allow = unsafe { start_address(bind.as_ptr()) };
         if rc_start_after_allow == 0 {
             // SAFETY: shutdown reclaims the current node, if any; takes no arguments.
             unsafe { hew_node_api_shutdown() };
@@ -8634,7 +8634,7 @@ mod tests {
         let _identity = stage_public_api_test_identity();
         let bind_addr = CString::new("127.0.0.1:0").expect("valid bind addr");
         // SAFETY: bind_addr is a valid C string for the duration of this test.
-        unsafe { assert_eq!(hew_node_api_start(bind_addr.as_ptr()), 0) };
+        unsafe { assert_eq!(start_address(bind_addr.as_ptr()), 0) };
 
         let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
         let handles: Vec<_> = (0..2)
@@ -8785,12 +8785,12 @@ mod tests {
         // Pin TCP explicitly, then stage a peer credential under it.
         let tcp = CString::new("tcp").unwrap();
         // SAFETY: tcp is a valid C string for the call.
-        assert_eq!(unsafe { hew_node_api_set_transport(tcp.as_ptr()) }, 0);
+        assert_eq!(unsafe { configure_transport(tcp.as_ptr()) }, 0);
         assert_eq!(pinned_transport(), Some(PT::Tcp));
 
         let noise_hex = CString::new("11".repeat(32)).unwrap();
         // SAFETY: noise_hex is a valid 32-byte (64-hex) C string.
-        assert_eq!(unsafe { hew_node_api_allow_peer(2, noise_hex.as_ptr()) }, 0);
+        assert_eq!(unsafe { configure_peer(2, noise_hex.as_ptr()) }, 0);
         assert_eq!(
             pinned_transport(),
             Some(PT::Tcp),
@@ -8802,7 +8802,7 @@ mod tests {
         let mesh = CString::new("quic-mesh").unwrap();
         crate::hew_clear_error();
         // SAFETY: mesh is a valid C string for the call.
-        let flip_rc = unsafe { hew_node_api_set_transport(mesh.as_ptr()) };
+        let flip_rc = unsafe { configure_transport(mesh.as_ptr()) };
         assert_eq!(
             flip_rc, -1,
             "set_transport after credential staging must be rejected"
@@ -8820,7 +8820,7 @@ mod tests {
 
         // Re-selecting the same transport is idempotent and allowed.
         // SAFETY: tcp is a valid C string for the call.
-        let reselect_rc = unsafe { hew_node_api_set_transport(tcp.as_ptr()) };
+        let reselect_rc = unsafe { configure_transport(tcp.as_ptr()) };
         assert_eq!(
             reselect_rc, 0,
             "re-selecting the same transport after staging stays allowed"
@@ -8881,7 +8881,7 @@ mod tests {
                 let name = CString::new("quic-mesh").expect("valid transport name");
                 set_barrier.wait();
                 // SAFETY: name is a valid C string for this call.
-                unsafe { hew_node_api_set_transport(name.as_ptr()) }
+                unsafe { configure_transport(name.as_ptr()) }
             });
 
             let allow_hex = cred_hex.clone();
@@ -8889,7 +8889,7 @@ mod tests {
                 let hex = CString::new(allow_hex).expect("valid hex credential");
                 barrier.wait();
                 // SAFETY: hex is a valid C string for this call.
-                unsafe { hew_node_api_allow_peer(2, hex.as_ptr()) }
+                unsafe { configure_peer(2, hex.as_ptr()) }
             });
 
             let _ = set_thread.join().expect("set_transport thread panicked");
@@ -8982,7 +8982,7 @@ mod tests {
         let keyfile = dir.path().join("node.key");
         let keyfile_c = CString::new(keyfile.to_str().unwrap()).unwrap();
         // SAFETY: keyfile_c is a valid C string for the call.
-        assert_eq!(unsafe { hew_node_api_load_keys(keyfile_c.as_ptr()) }, 0);
+        assert_eq!(unsafe { configure_keys(keyfile_c.as_ptr()) }, 0);
         assert_eq!(pinned_transport(), Some(PT::Tcp));
 
         let key_before = read_identity();
@@ -8995,7 +8995,7 @@ mod tests {
         let mesh = CString::new("quic-mesh").unwrap();
         crate::hew_clear_error();
         // SAFETY: mesh is a valid C string for the call.
-        assert_eq!(unsafe { hew_node_api_set_transport(mesh.as_ptr()) }, -1);
+        assert_eq!(unsafe { configure_transport(mesh.as_ptr()) }, -1);
 
         let key_after = read_identity();
         assert_eq!(
@@ -9385,8 +9385,15 @@ mod tests {
             .insert("l18_gossip".to_owned(), Location::try_from(old).unwrap());
         let user_data = (&raw const registry).cast_mut().cast::<c_void>();
         let name = c"l18_gossip";
+        let actor_type = c"test.Counter";
 
-        node_registry_gossip_callback(name.as_ptr(), &raw const new, true, user_data);
+        node_registry_gossip_callback(
+            name.as_ptr(),
+            &raw const new,
+            actor_type.as_ptr(),
+            true,
+            user_data,
+        );
         let map = registry.remote_names.lock_or_recover();
         assert_eq!(
             map.get("l18_gossip").copied(),
@@ -9394,7 +9401,13 @@ mod tests {
             "new registration must re-point future lookup"
         );
         drop(map);
-        node_registry_gossip_callback(name.as_ptr(), &raw const old, false, user_data);
+        node_registry_gossip_callback(
+            name.as_ptr(),
+            &raw const old,
+            actor_type.as_ptr(),
+            false,
+            user_data,
+        );
         assert_eq!(
             registry
                 .remote_names
@@ -10302,12 +10315,14 @@ mod tests {
             // Simulate a remote registry gossip event arriving.
             let n = &*node.as_ptr();
             let remote_name = c"remote_counter";
+            let remote_actor_type = c"test.Counter";
             let remote_location = HewLocation::from(test_location(200, 0x99));
 
             // Invoke the callback directly (as the cluster would).
             node_registry_gossip_callback(
                 remote_name.as_ptr(),
                 &raw const remote_location,
+                remote_actor_type.as_ptr(),
                 true,
                 n.registry.cast::<c_void>(),
             );
@@ -10318,7 +10333,12 @@ mod tests {
             // Node lookup should find it via remote_names.
             let mut found = HewRemotePid::default();
             assert_eq!(
-                hew_node_lookup_location(node.as_ptr(), remote_name.as_ptr(), &raw mut found,),
+                hew_node_lookup_location_typed(
+                    node.as_ptr(),
+                    remote_name.as_ptr(),
+                    remote_actor_type.as_ptr(),
+                    &raw mut found,
+                ),
                 0
             );
             assert_eq!(
@@ -10330,6 +10350,7 @@ mod tests {
             node_registry_gossip_callback(
                 remote_name.as_ptr(),
                 &raw const remote_location,
+                remote_actor_type.as_ptr(),
                 false,
                 n.registry.cast::<c_void>(),
             );

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -5110,9 +5110,22 @@ pub unsafe extern "C" fn hew_node_api_start(
         return 1;
     }
     for (index, credential) in peer_credentials.iter().enumerate() {
-        let Ok(route_slot) = u16::try_from(index + 1) else {
-            set_last_error("Node::start: too many peer credentials");
-            return 1;
+        let (route_slot, credential) = if let Some((slot, value)) = credential.split_once('@') {
+            let Ok(slot) = slot.parse::<u16>() else {
+                set_last_error("Node::start: peer route slot must be a non-zero u16");
+                return 1;
+            };
+            if slot == 0 {
+                set_last_error("Node::start: peer route slot must be a non-zero u16");
+                return 1;
+            }
+            (slot, value)
+        } else {
+            let Ok(slot) = u16::try_from(index + 1) else {
+                set_last_error("Node::start: too many peer credentials");
+                return 1;
+            };
+            (slot, credential.as_str())
         };
         let Ok(credential) = CString::new(credential.as_bytes()) else {
             set_last_error("Node::start: a peer credential contains a NUL byte");

--- a/hew-runtime/src/registry.rs
+++ b/hew-runtime/src/registry.rs
@@ -22,9 +22,16 @@ mod native {
 
     const N_SHARDS: usize = 256;
 
+    /// One local registry entry, including the compiler-minted actor identity.
+    #[derive(Clone, Debug)]
+    pub(crate) struct RegistryEntry {
+        pub(crate) actor: *mut c_void,
+        pub(crate) actor_type: String,
+    }
+
     /// Wrapper around the raw-pointer map so we can mark it `Send + Sync`.
     #[derive(Debug)]
-    struct RegistryShard(HashMap<String, *mut c_void>);
+    struct RegistryShard(HashMap<String, RegistryEntry>);
 
     // SAFETY: The registry stores raw pointers that may be sent/shared between
     // threads. Callers are responsible for ensuring the pointed-to actors remain
@@ -101,8 +108,52 @@ mod native {
         if reg.0.contains_key(&key) {
             return -1;
         }
-        reg.0.insert(key, actor);
+        reg.0.insert(
+            key,
+            RegistryEntry {
+                actor,
+                actor_type: String::new(),
+            },
+        );
         0
+    }
+
+    /// Register or re-point a typed local actor entry.
+    pub(crate) fn register_typed(name: &str, actor: *mut c_void, actor_type: &str) {
+        let shard = rt_current().registry.shard_for(name);
+        shard.write_or_recover().0.insert(
+            name.to_owned(),
+            RegistryEntry {
+                actor,
+                actor_type: actor_type.to_owned(),
+            },
+        );
+    }
+
+    /// Resolve a complete typed local entry.
+    pub(crate) fn lookup_typed(name: &str) -> Option<RegistryEntry> {
+        let registry = registry_opt()?;
+        let shard = registry.shard_for(name);
+        shard.read_or_recover().0.get(name).cloned()
+    }
+
+    /// Snapshot typed entries for promotion when a node starts.
+    pub(crate) fn typed_entries() -> Vec<(String, RegistryEntry)> {
+        let Some(registry) = registry_opt() else {
+            return Vec::new();
+        };
+        let mut entries = Vec::new();
+        for shard in &registry.shards {
+            entries.extend(
+                shard
+                    .read_or_recover()
+                    .0
+                    .iter()
+                    .filter(|(_, entry)| !entry.actor_type.is_empty())
+                    .map(|(name, entry)| (name.clone(), entry.clone())),
+            );
+        }
+        entries
     }
 
     /// Look up an actor by name.
@@ -123,7 +174,9 @@ mod native {
         };
         let shard = registry.shard_for(key);
         let reg = shard.read_or_recover();
-        reg.0.get(key).copied().unwrap_or(std::ptr::null_mut())
+        reg.0
+            .get(key)
+            .map_or(std::ptr::null_mut(), |entry| entry.actor)
     }
 
     /// Remove an actor registration by name.

--- a/hew-runtime/tests/envelope_round_trip.rs
+++ b/hew-runtime/tests/envelope_round_trip.rs
@@ -261,6 +261,7 @@ fn registry_payload(op: u8, name: &str, location: Location) -> RegistryGossipPay
         op,
         name: name.to_owned(),
         location,
+        actor_type: "test.Worker".to_owned(),
     }
 }
 
@@ -446,11 +447,12 @@ fn registry_gossip_payload_round_trips_and_matches_cluster_ops() {
 
     let value = decode_value(&bytes);
     let entries = map_entries(&value);
-    assert_eq!(entries.len(), 3);
-    assert_integer_keys_and_order(entries, &[1, 2, 3]);
+    assert_eq!(entries.len(), 4);
+    assert_integer_keys_and_order(entries, &[1, 2, 3, 4]);
     assert_integer_value(find_field(entries, 1), i128::from(REGISTRY_GOSSIP_OP_ADD));
     assert_text_value(find_field(entries, 2), "worker");
     assert_location_value(find_field(entries, 3), original.location);
+    assert_text_value(find_field(entries, 4), "test.Worker");
 
     let remove = registry_payload(
         REGISTRY_GOSSIP_OP_REMOVE,
@@ -470,6 +472,7 @@ fn registry_gossip_payload_codec_rejects_malformed_payloads() {
         (int(1u64), int(99u8)),
         (int(2u64), Value::Text("worker".to_owned())),
         (int(3u64), location_value(location(11, 42, 37))),
+        (int(4u64), Value::Text("test.Worker".to_owned())),
     ]);
     assert!(matches!(
         decode_registry_gossip_payload(&value_to_cbor(&unknown_op)),
@@ -487,6 +490,7 @@ fn registry_gossip_payload_codec_rejects_malformed_payloads() {
         (int(2u64), Value::Text("worker".to_owned())),
         (int(2u64), Value::Text("other".to_owned())),
         (int(3u64), location_value(location(11, 42, 37))),
+        (int(4u64), Value::Text("test.Worker".to_owned())),
     ]);
     assert!(matches!(
         decode_registry_gossip_payload(&value_to_cbor(&duplicate_name)),
@@ -497,17 +501,19 @@ fn registry_gossip_payload_codec_rejects_malformed_payloads() {
         (int(1u64), int(REGISTRY_GOSSIP_OP_ADD)),
         (int(2u64), Value::Text("worker".to_owned())),
         (int(3u64), location_value(location(11, 42, 37))),
-        (int(4u64), int(0u64)),
+        (int(4u64), Value::Text("test.Worker".to_owned())),
+        (int(5u64), int(0u64)),
     ]);
     assert!(matches!(
         decode_registry_gossip_payload(&value_to_cbor(&unknown_key)),
-        Err(RegistryGossipPayloadError::UnknownKey { key: 4 })
+        Err(RegistryGossipPayloadError::UnknownKey { key: 5 })
     ));
 
     let add_zero_node = Value::Map(vec![
         (int(1u64), int(REGISTRY_GOSSIP_OP_ADD)),
         (int(2u64), Value::Text("worker".to_owned())),
         (int(3u64), raw_location_value([0; 16], 42, 37)),
+        (int(4u64), Value::Text("test.Worker".to_owned())),
     ]);
     assert!(matches!(
         decode_registry_gossip_payload(&value_to_cbor(&add_zero_node)),
@@ -518,6 +524,7 @@ fn registry_gossip_payload_codec_rejects_malformed_payloads() {
         (int(1u64), int(REGISTRY_GOSSIP_OP_ADD)),
         (int(2u64), Value::Text("bad\0name".to_owned())),
         (int(3u64), location_value(location(11, 42, 37))),
+        (int(4u64), Value::Text("test.Worker".to_owned())),
     ]);
     assert!(matches!(
         decode_registry_gossip_payload(&value_to_cbor(&nul_name)),

--- a/hew-types/src/builtin_names.rs
+++ b/hew-types/src/builtin_names.rs
@@ -415,7 +415,8 @@ pub fn builtin_named_type(name: &str) -> Option<BuiltinNamedType> {
             | BuiltinType::Duration
             | BuiltinType::Instant
             | BuiltinType::Trap
-            | BuiltinType::TimeoutError,
+            | BuiltinType::TimeoutError
+            | BuiltinType::NodeConfig,
         )
         | None => None,
     }

--- a/hew-types/src/builtin_type.rs
+++ b/hew-types/src/builtin_type.rs
@@ -40,6 +40,7 @@ pub enum BuiltinType {
     NodeId,
     Location,
     RemotePid,
+    NodeConfig,
     HewActor,
     HewDuplex,
     HewSendHalf,
@@ -223,6 +224,7 @@ builtin_types! {
     NodeId => "NodeId",
     Location => "Location",
     RemotePid => "RemotePid",
+    NodeConfig => "NodeConfig",
     HewActor => "HewActor",
     HewDuplex => "HewDuplex",
     HewSendHalf => "HewSendHalf",
@@ -544,7 +546,8 @@ impl BuiltinType {
             | Self::Instant
             | Self::Trap
             | Self::CancellationToken
-            | Self::TimeoutError => 0,
+            | Self::TimeoutError
+            | Self::NodeConfig => 0,
         }
     }
 
@@ -686,6 +689,9 @@ pub const fn builtin_types() -> &'static [BuiltinTypeInfo] {
 #[must_use]
 pub fn lookup_builtin_type(name: &str) -> Option<BuiltinType> {
     match name {
+        "NodeConfig" | "std.builtins.NodeConfig" => {
+            return Some(BuiltinType::NodeConfig);
+        }
         "channel.Sender" | "std.channel.Sender" => {
             return Some(BuiltinType::Sender);
         }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -14017,16 +14017,14 @@ mod node_builtin_catalog_tests {
         assert_eq!(
             emitted,
             [
-                "Node::allow_peer",
                 "Node::connect",
                 "Node::id",
                 "Node::identity_key",
-                "Node::load_keys",
                 "Node::lookup",
                 "Node::register",
-                "Node::set_transport",
                 "Node::shutdown",
                 "Node::start",
+                "Node::unregister",
             ]
         );
 

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -1347,18 +1347,32 @@ impl Checker {
         self.register_builtin_fn("bool_to_string", vec![Ty::Bool], Ty::String);
 
         // Node/distributed builtins
-        self.register_builtin_fn("Node::start", vec![Ty::String], Ty::Unit);
+        let node_config_ty = Ty::Named {
+            builtin: None,
+            name: "NodeConfig".to_string(),
+            args: vec![],
+        };
+        let node_error_ty = Ty::Named {
+            name: "NodeError".to_string(),
+            args: vec![],
+            builtin: None,
+        };
+        let register_error_ty = Ty::Named {
+            name: "RegisterError".to_string(),
+            args: vec![],
+            builtin: None,
+        };
+        self.register_builtin_fn(
+            "Node::start",
+            vec![node_config_ty],
+            Ty::result(Ty::Unit, node_error_ty.clone()),
+        );
         self.register_builtin_fn("Node::shutdown", vec![], Ty::Unit);
-        self.register_builtin_fn("Node::connect", vec![Ty::String], Ty::Unit);
-        self.register_builtin_fn("Node::set_transport", vec![Ty::String], Ty::Unit);
-        // `Node::load_keys(path: String)` — load/persist this node's mesh
-        // identity. `Node::allow_peer(node_id: U16, credential_hex: String)` —
-        // bind a peer's authenticated credential to the NodeId it may claim
-        // (issue #2652; Noise pubkey on TCP, cert SPKI on quic-mesh). Both are
-        // pre-start peer-auth setup; codegen routes them through the shared
-        // RuntimeFfiShim path (catalog), like start/connect.
-        self.register_builtin_fn("Node::load_keys", vec![Ty::String], Ty::Unit);
-        self.register_builtin_fn("Node::allow_peer", vec![Ty::U16, Ty::String], Ty::Unit);
+        self.register_builtin_fn(
+            "Node::connect",
+            vec![Ty::String],
+            Ty::result(Ty::Unit, node_error_ty),
+        );
         // `Node::identity_key() -> String` — this node's stable public
         // credential for the pinned transport as lowercase hex (issue #2652);
         // `""` when no stable identity has been loaded.
@@ -1368,7 +1382,7 @@ impl Checker {
             vec![],
             Ty::option(Ty::builtin_named(BuiltinType::NodeId, vec![])),
         );
-        // `Node::register<T>(name: String, pid: LocalPid<T>) -> i32`
+        // `Node::register<T>(name: String, pid: LocalPid<T>) -> Result<(), RegisterError>`
         // The second argument is tightened to `LocalPid<T>` so that passing a
         // `RemotePid<T>` or bare `u64` is caught at the checker rather than
         // failing with a cryptic codegen error. Codegen already assumes a
@@ -1379,9 +1393,14 @@ impl Checker {
             self.register_builtin_fn(
                 "Node::register",
                 vec![Ty::String, Ty::local_pid(Ty::Var(t))],
-                Ty::I32,
+                Ty::result(Ty::Unit, register_error_ty.clone()),
             );
         }
+        self.register_builtin_fn(
+            "Node::unregister",
+            vec![Ty::String],
+            Ty::result(Ty::Unit, register_error_ty),
+        );
         // `Node::lookup<T>(name: String) -> Result<RemotePid<T>, LookupError>`.
         // The runtime extern returns a packed `u64` pid (0 == not found); the
         // codegen branch lowers this into a `Result` construction inline.

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -552,11 +552,9 @@ pub enum RuntimeCallFamily {
     // Their runtime FFI symbols are carried separately by the stdlib catalog;
     // the family records the source-level builtin identity used by checker,
     // MIR, and codegen dispatch.
-    NodeAllowPeer,
     NodeConnect,
     NodeId,
     NodeIdentityKey,
-    NodeLoadKeys,
     NodeLookup,
     /// `monitor(RemotePid<T>)` →
     /// `hew_node_monitor_location(target, out_monitor_id) -> i32`.
@@ -567,9 +565,9 @@ pub enum RuntimeCallFamily {
     /// full `Location`; non-consuming.
     NodeMonitor,
     NodeRegister,
-    NodeSetTransport,
     NodeShutdown,
     NodeStart,
+    NodeUnregister,
 
     // --- User metrics (#1862) -----------------------------------------------
     // `std::metrics` emit path: register-or-get + mutate developer-defined
@@ -1223,17 +1221,15 @@ impl RuntimeCallFamily {
             Self::MathIntrinsic(MathIntrinsic::Ceil) => "ceil",
             Self::MathIntrinsic(MathIntrinsic::Round) => "round",
             // Node (pre-staged)
-            Self::NodeAllowPeer => "Node::allow_peer",
             Self::NodeConnect => "Node::connect",
             Self::NodeId => "Node::id",
             Self::NodeIdentityKey => "Node::identity_key",
-            Self::NodeLoadKeys => "Node::load_keys",
             Self::NodeLookup => "Node::lookup",
             Self::NodeMonitor => "hew_node_monitor_location",
             Self::NodeRegister => "Node::register",
-            Self::NodeSetTransport => "Node::set_transport",
             Self::NodeShutdown => "Node::shutdown",
             Self::NodeStart => "Node::start",
+            Self::NodeUnregister => "Node::unregister",
             // User metrics (#1862)
             Self::MetricCounterRegister => "hew_metric_counter_register",
             Self::MetricCounterInc => "hew_metric_counter_inc",
@@ -1551,17 +1547,15 @@ impl RuntimeCallFamily {
             "ceil" => Self::MathIntrinsic(MathIntrinsic::Ceil),
             "round" => Self::MathIntrinsic(MathIntrinsic::Round),
             // Node
-            "Node::allow_peer" => Self::NodeAllowPeer,
             "Node::connect" => Self::NodeConnect,
             "Node::id" => Self::NodeId,
             "Node::identity_key" => Self::NodeIdentityKey,
-            "Node::load_keys" => Self::NodeLoadKeys,
             "Node::lookup" => Self::NodeLookup,
             "hew_node_monitor_location" => Self::NodeMonitor,
             "Node::register" => Self::NodeRegister,
-            "Node::set_transport" => Self::NodeSetTransport,
             "Node::shutdown" => Self::NodeShutdown,
             "Node::start" => Self::NodeStart,
+            "Node::unregister" => Self::NodeUnregister,
             // User metrics (#1862)
             "hew_metric_counter_register" => Self::MetricCounterRegister,
             "hew_metric_counter_inc" => Self::MetricCounterInc,
@@ -1887,16 +1881,14 @@ impl RuntimeCallFamily {
     pub const fn is_node_builtin(self) -> bool {
         matches!(
             self,
-            Self::NodeAllowPeer
-                | Self::NodeConnect
+            Self::NodeConnect
                 | Self::NodeId
                 | Self::NodeIdentityKey
-                | Self::NodeLoadKeys
                 | Self::NodeLookup
                 | Self::NodeRegister
-                | Self::NodeSetTransport
                 | Self::NodeShutdown
                 | Self::NodeStart
+                | Self::NodeUnregister
         )
     }
 
@@ -2384,17 +2376,15 @@ impl RuntimeCallFamily {
             | F::MetricHistogramRecord
             | F::MetricVecRegister
             | F::MetricVecWith
-            | F::NodeAllowPeer
             | F::NodeConnect
             | F::NodeId
             | F::NodeIdentityKey
-            | F::NodeLoadKeys
             | F::NodeLookup
             | F::NodeMonitor
             | F::NodeRegister
-            | F::NodeSetTransport
             | F::NodeShutdown
             | F::NodeStart
+            | F::NodeUnregister
             | F::ObserveReadU64
             | F::ObserveScrape
             | F::ObserveSeries
@@ -3118,16 +3108,14 @@ pub const fn is_pre_staged_family(family: RuntimeCallFamily) -> bool {
             | F::HashSetClearLayout
             | F::HashSetCloneLayout
             | F::HashSetToVecLayout
-            | F::NodeAllowPeer
             | F::NodeConnect
             | F::NodeId
             | F::NodeIdentityKey
-            | F::NodeLoadKeys
             | F::NodeLookup
             | F::NodeRegister
-            | F::NodeSetTransport
             | F::NodeShutdown
             | F::NodeStart
+            | F::NodeUnregister
             | F::RemotePidSend
             | F::SinkClose
             | F::SinkPeerClosed

--- a/hew-types/src/stdlib_authority/codegen.rs
+++ b/hew-types/src/stdlib_authority/codegen.rs
@@ -35,9 +35,23 @@ const BUILTIN_ENUM_ABI: &[BuiltinEnumAbi] = &[
     BuiltinEnumAbi {
         module: "std.builtins",
         name: "LookupError",
-        variant_count: 8,
-        order_fingerprint: 0x7ab9_6324_a0dd_7d1f,
+        variant_count: 9,
+        order_fingerprint: 0xafd5_b234_3d03_6548,
         suppress_from_sandbox_emit: true,
+    },
+    BuiltinEnumAbi {
+        module: "std.builtins",
+        name: "NodeError",
+        variant_count: 3,
+        order_fingerprint: 0x1399_304b_ba53_42ae,
+        suppress_from_sandbox_emit: false,
+    },
+    BuiltinEnumAbi {
+        module: "std.builtins",
+        name: "RegisterError",
+        variant_count: 2,
+        order_fingerprint: 0xb7cc_2d0d_82d9_ffbd,
+        suppress_from_sandbox_emit: false,
     },
     BuiltinEnumAbi {
         module: "std.builtins",

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -78,7 +78,8 @@ fn builtin_named_type_from_builtin(builtin: Option<BuiltinType>) -> Option<Built
             | BuiltinType::Duration
             | BuiltinType::Instant
             | BuiltinType::Trap
-            | BuiltinType::TimeoutError,
+            | BuiltinType::TimeoutError
+            | BuiltinType::NodeConfig,
         )
         | None => None,
     }

--- a/hew-types/src/type_facts.rs
+++ b/hew-types/src/type_facts.rs
@@ -475,7 +475,9 @@ mod tests {
                 BuiltinType::HashMap | BuiltinType::HashMapIter => {
                     Some((ValueClass::CowValue, CloneKind::FieldWise))
                 }
-                BuiltinType::CrashInfo => Some((ValueClass::CowValue, CloneKind::FieldWise)),
+                BuiltinType::CrashInfo | BuiltinType::NodeConfig => {
+                    Some((ValueClass::CowValue, CloneKind::FieldWise))
+                }
                 BuiltinType::CrashNotification => Some((ValueClass::BitCopy, CloneKind::Bits)),
                 BuiltinType::Rc | BuiltinType::Weak | BuiltinType::LambdaPid => {
                     Some((ValueClass::AffineResource, CloneKind::Retain))

--- a/hew-types/src/value_class.rs
+++ b/hew-types/src/value_class.rs
@@ -703,7 +703,9 @@ fn classify(
                 collection_facts(&classify_all(args, decls, walk)?)
             }
             // Aggregate rule over the std declaration's fields.
-            BuiltinType::CrashInfo | BuiltinType::CrashNotification => {
+            BuiltinType::CrashInfo
+            | BuiltinType::CrashNotification
+            | BuiltinType::NodeConfig => {
                 classify_declaration(name, args, decls, walk)?
             }
             BuiltinType::Rc | BuiltinType::Weak | BuiltinType::LambdaPid => affine_retain,

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -45,6 +45,48 @@ pub type Location {
 pub type RemotePid<T> {
 }
 
+/// Complete configuration for starting a distributed node.
+pub type NodeConfig {
+    bind: string;
+    transport: string;
+    key: string;
+    trust: string;
+    peers: Vec<string>;
+    seeds: Vec<string>;
+}
+
+/// Error returned when a node cannot be started or connected.
+pub enum NodeError {
+    Config;
+    Start;
+    Connect;
+}
+
+impl Display for NodeError {
+    fn fmt(err: NodeError) -> string {
+        match err {
+            NodeError.Config => "the node configuration is invalid",
+            NodeError.Start => "the node could not be started",
+            NodeError.Connect => "a configured seed could not be connected",
+        }
+    }
+}
+
+/// Error returned when a registry mutation is rejected.
+pub enum RegisterError {
+    InvalidName;
+    InvalidPid;
+}
+
+impl Display for RegisterError {
+    fn fmt(err: RegisterError) -> string {
+        match err {
+            RegisterError.InvalidName => "the registry name is invalid",
+            RegisterError.InvalidPid => "the actor pid is invalid or no longer live",
+        }
+    }
+}
+
 /// Error returned when a pid send cannot be completed.
 pub enum SendError {
     /// The destination mailbox is full.
@@ -101,6 +143,8 @@ impl Display for SendError {
 pub enum LookupError {
     /// No actor is registered under the requested name.
     NotFound;
+    /// The registered actor declaration does not match the requested type.
+    TypeMismatch;
     /// The lookup route is unavailable or the peer is suspected dead.
     Partition;
     /// The caller's lookup deadline elapsed before a result arrived.
@@ -121,6 +165,7 @@ impl Display for LookupError {
     fn fmt(err: LookupError) -> string {
         match err {
             LookupError.NotFound => "no actor is registered under the requested name",
+            LookupError.TypeMismatch => "the registered actor type does not match the requested type",
             LookupError.Partition => "the lookup route is unavailable or the peer is suspected dead",
             LookupError.Timeout => "the caller's lookup deadline elapsed before a result arrived",
             LookupError.StaleRef => "the name resolved to an old session or actor incarnation",


### PR DESCRIPTION
## Why

Node setup failures were reported outside the type system, configuration was split across mutable setters, and registry lookup could return an actor under the wrong type.

## What

- Replace staged setters with `Node.start(NodeConfig)` and typed configuration, startup, connection, and registration errors.
- Keep registration available before startup and preserve compiler-minted actor identity through local registry entries and distributed gossip.
- Reject wrong-type lookups with `LookupError.TypeMismatch` and migrate the distributed examples to the new surface.
- Retain `RemotePid<A>` as the current return spelling; the final public `RemotePid<A>` to `Pid<A>` unification follows in S-4. This PR does not complete #3256.

## Test

- `make test-node-api`
- `make test-node-api-runtime`
- `make test-node-api NODE_API_TEST=remote_ask_round_trip_returns_exact_values`
- `emitted_node_builtins_are_catalogued_for_wasm_rejection`
