### PR TITLE
chore: ignore local agent/env artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ tests/hew/hew_test_emit_*/
 # compiler substrate is `hew-codegen-rs`; keep any machine-local `hew-codegen/`
 # directory untracked without deleting it.
 /hew-codegen/
+.[Cc]odex/
+.env
+.env.*
+/AGENTS.md


### PR DESCRIPTION
**Why**: Local agent/env artifacts (Codex directories, `.env` files, machine-local `AGENTS.md`) were untracked but not ignored, risking accidental commits.

**What**: Adds `.[Cc]odex/`, `.env`, `.env.*`, and `/AGENTS.md` to `.gitignore`.
