### PR TITLE
build: emit Clippy JSON diagnostics from make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1567,7 +1567,7 @@ miri:
 .SECONDEXPANSION:
 lint: $$(LINT_GATES) ## Check: run the complete local lint graph and Clippy
 	cargo fmt --all -- --check
-	cargo clippy --workspace --tests -- -D warnings
+	cargo clippy --workspace --tests --message-format=json -- -D warnings
 
 LINT_GATES += legacy-path-syntax-lint
 legacy-path-syntax-lint:


### PR DESCRIPTION
## Why

`make lint` emits human-readable Clippy diagnostics while the CI reporting path consumes JSON. Using the same diagnostic format makes local output consistent with CI tooling.

## Test

Verified the lint recipe with `make -n lint LINT_GATES=` and exercised its argument and exit-status propagation with an isolated Cargo stub. Successful Clippy execution succeeds, and a Clippy failure makes Make fail. The full compiler lint suite was not run for this output-format change.
