### PR TITLE
fix(sandbox-vm): read page stdin at run time instead of per call site

### DIFF
--- a/docs/sandbox-vm-divergences.md
+++ b/docs/sandbox-vm-divergences.md
@@ -49,6 +49,8 @@ Actor and message identifiers are allocated deterministically by the sandbox run
 
 Sandbox standard input, output, and error are page-owned streams. They are provided by the embedding page or test harness, not by operating-system file descriptors. Output ordering is defined by VM execution order.
 
+Standard input arrives as a `stdin` replay input and is consumed one line per `read_line` call while the program runs, so a loop reads successive lines and sees `""` at end of input. It is not baked into the bytecode ahead of execution.
+
 ## In-memory streams only (no file/network backing)
 
 Sandbox streams are in-memory values. They do not open host files, sockets, pipes, terminals, or device handles. Programs that require file-backed or network-backed streams must run on a native target.

--- a/hew-sandbox-vm/src/interpreter/interpreter.ts
+++ b/hew-sandbox-vm/src/interpreter/interpreter.ts
@@ -8,7 +8,7 @@ import {
   type SchedulerPolicy,
   type SupervisorLayout,
   type SupervisorStrategy,
-  type ChildRestartClass
+  type ChildRestartClass,
 } from "../scheduler/scheduler.js";
 import type {
   BytecodeFunction,
@@ -21,9 +21,18 @@ import type {
   SandboxTrace,
   Terminator,
   JsonValue,
-  TrapKind
+  TrapKind,
 } from "./types.js";
-import { UNIT, canonicalJson, cloneValue, i64ComparableJson, renderStdout, toJsonValue, valueFromLiteral, type VmValue } from "./values.js";
+import {
+  UNIT,
+  canonicalJson,
+  cloneValue,
+  i64ComparableJson,
+  renderStdout,
+  toJsonValue,
+  valueFromLiteral,
+  type VmValue,
+} from "./values.js";
 import {
   SANDBOX_STDLIB_PROFILE,
   lookupStdlibProfile,
@@ -31,7 +40,7 @@ import {
   validateStdlibProfile,
   type StdlibProfileEntry,
   type StdlibShimHandler,
-  type UnsupportedStdlibDiagnostic
+  type UnsupportedStdlibDiagnostic,
 } from "./stdlib-profile.js";
 
 const DEFAULT_STEP_BUDGET = 1_000_000;
@@ -50,6 +59,7 @@ const IMPLEMENTED_STDLIB_HANDLERS: ReadonlySet<StdlibShimHandler> = new Set([
   "io.stderr.print",
   "io.stderr.println",
   "io.log",
+  "io.stdin.read_line",
   "process.exit",
   "time.now",
   "time.sleep",
@@ -68,7 +78,7 @@ const IMPLEMENTED_STDLIB_HANDLERS: ReadonlySet<StdlibShimHandler> = new Set([
   "regex.compile",
   "regex.is_match",
   "regex.find",
-  "regex.replace"
+  "regex.replace",
 ]);
 
 validateStdlibProfile(SANDBOX_STDLIB_PROFILE, IMPLEMENTED_STDLIB_HANDLERS);
@@ -139,34 +149,102 @@ type NumericCastType =
   | { kind: "bool" }
   | { kind: "char" };
 
+// Page stdin is the concatenation of the replay record's `stdin` inputs,
+// handed out one line per `read_line` call at run time. Reading at run time
+// (rather than baking a line into each call site when the bytecode is
+// prepared) is what lets a loop consume successive lines.
+class StdinReader {
+  private readonly bytes: Uint8Array;
+  private offset = 0;
+
+  constructor(stdin: string) {
+    this.bytes = new TextEncoder().encode(stdin);
+  }
+
+  static fromReplay(
+    inputs: ReadonlyArray<{ kind: string; data: JsonValue }>,
+  ): StdinReader {
+    return new StdinReader(
+      inputs
+        .filter((input) => input.kind === "stdin")
+        .map((input) => (typeof input.data === "string" ? input.data : ""))
+        .join(""),
+    );
+  }
+
+  // Byte-clean: splits on LF, drops a trailing CR, returns "" at end of input.
+  readLine(): string {
+    if (this.offset >= this.bytes.length) {
+      return "";
+    }
+    const start = this.offset;
+    while (
+      this.offset < this.bytes.length &&
+      this.bytes[this.offset] !== LINE_FEED
+    ) {
+      this.offset += 1;
+    }
+    let end = this.offset;
+    if (
+      this.offset < this.bytes.length &&
+      this.bytes[this.offset] === LINE_FEED
+    ) {
+      this.offset += 1;
+    }
+    if (end > start && this.bytes[end - 1] === CARRIAGE_RETURN) {
+      end -= 1;
+    }
+    return new TextDecoder().decode(this.bytes.slice(start, end));
+  }
+}
+
+const LINE_FEED = 0x0a;
+const CARRIAGE_RETURN = 0x0d;
+
 class VmHalt extends Error {
   constructor(readonly status: RuntimeStatus) {
     super(status);
   }
 }
 
-export function runBytecode(input: unknown, options: RunOptions = {}): SandboxTrace {
+export function runBytecode(
+  input: unknown,
+  options: RunOptions = {},
+): SandboxTrace {
   const bytecode = validateBytecodePackage(input);
   const fixtureId = options.fixtureId ?? fixtureIdFromPackage(bytecode);
   const replay: ReplayConfig = {
     seed: options.replay?.seed ?? 0,
-    step_budget: options.stepBudget ?? options.replay?.step_budget ?? DEFAULT_STEP_BUDGET,
-    virtual_clock: options.replay?.virtual_clock ? { ...options.replay.virtual_clock } : { epoch_ms: 0, tick_ms: 1, current_ms: 0 },
-    inputs: [...(options.replay?.inputs ?? [])]
+    step_budget:
+      options.stepBudget ?? options.replay?.step_budget ?? DEFAULT_STEP_BUDGET,
+    virtual_clock: options.replay?.virtual_clock
+      ? { ...options.replay.virtual_clock }
+      : { epoch_ms: 0, tick_ms: 1, current_ms: 0 },
+    inputs: [...(options.replay?.inputs ?? [])],
   };
   const trace = new TraceBuilder(
     bytecode,
     fixtureId,
     options.traceId ?? `trace:${fixtureId}`,
     replay,
-    options.sandboxVersion ?? "0.0.0-spec"
+    options.sandboxVersion ?? "0.0.0-spec",
   );
-  const vm = new Interpreter(bytecode, trace, options.schedulerPolicy ?? "round_robin");
+  const vm = new Interpreter(
+    bytecode,
+    trace,
+    options.schedulerPolicy ?? "round_robin",
+    StdinReader.fromReplay(replay.inputs),
+  );
   try {
     vm.run();
   } catch (error) {
     if (!(error instanceof VmHalt)) {
-      const failure = runtimeFailure("internal_error", "sandbox internal error", "internal_error", null);
+      const failure = runtimeFailure(
+        "internal_error",
+        "sandbox internal error",
+        "internal_error",
+        null,
+      );
       trace.fail("runtime_failure", "runtime.failure", failure);
     }
   }
@@ -175,10 +253,22 @@ export function runBytecode(input: unknown, options: RunOptions = {}): SandboxTr
 
 class Interpreter {
   private readonly functions = new Map<string, BytecodeFunction>();
-  private readonly stdlibSymbols: Map<string, SandboxBytecodePackage["stdlib_symbols"][number]>;
-  private readonly capabilities: Map<string, SandboxBytecodePackage["capabilities"][number]>;
-  private readonly records: Map<string, SandboxBytecodePackage["layouts"]["records"][number]>;
-  private readonly enums: Map<string, SandboxBytecodePackage["layouts"]["enums"][number]>;
+  private readonly stdlibSymbols: Map<
+    string,
+    SandboxBytecodePackage["stdlib_symbols"][number]
+  >;
+  private readonly capabilities: Map<
+    string,
+    SandboxBytecodePackage["capabilities"][number]
+  >;
+  private readonly records: Map<
+    string,
+    SandboxBytecodePackage["layouts"]["records"][number]
+  >;
+  private readonly enums: Map<
+    string,
+    SandboxBytecodePackage["layouts"]["enums"][number]
+  >;
   private readonly actors: Map<string, ActorLayout>;
   private readonly supervisors: Map<string, SupervisorLayout>;
   private readonly machines: Map<string, MachineLayout>;
@@ -194,31 +284,52 @@ class Interpreter {
   constructor(
     private readonly bytecode: SandboxBytecodePackage,
     private readonly trace: TraceBuilder,
-    schedulerPolicy: SchedulerPolicy
+    schedulerPolicy: SchedulerPolicy,
+    private readonly stdin: StdinReader = new StdinReader(""),
   ) {
     for (const fn of bytecode.functions) {
       this.functions.set(fn.id, fn);
     }
-    this.stdlibSymbols = new Map(bytecode.stdlib_symbols.map((symbol) => [symbol.id, symbol]));
-    this.capabilities = new Map(bytecode.capabilities.map((capability) => [capability.id, capability]));
-    this.records = new Map(bytecode.layouts.records.map((record) => [record.id, record]));
-    this.enums = new Map(bytecode.layouts.enums.map((enumLayout) => [enumLayout.id, enumLayout]));
-    this.actors = new Map(bytecode.layouts.actors.map((layout) => {
-      const actor = actorLayout(layout);
-      return [actor.id, actor];
-    }));
-    this.supervisors = new Map(bytecode.layouts.supervisors.map((layout) => {
-      const supervisor = supervisorLayout(layout);
-      return [supervisor.id, supervisor];
-    }));
-    this.machines = new Map(bytecode.layouts.machines.map((layout) => {
-      const machine = machineLayout(layout);
-      return [machine.id, machine];
-    }));
-    this.scheduler = new ActorScheduler(trace.replay.seed, schedulerPolicy, trace, {
-      invoke: (functionId, args) => this.invoke(this.functionFor(functionId, null), args),
-      consumeStep: () => this.commitOrExhaust()
-    });
+    this.stdlibSymbols = new Map(
+      bytecode.stdlib_symbols.map((symbol) => [symbol.id, symbol]),
+    );
+    this.capabilities = new Map(
+      bytecode.capabilities.map((capability) => [capability.id, capability]),
+    );
+    this.records = new Map(
+      bytecode.layouts.records.map((record) => [record.id, record]),
+    );
+    this.enums = new Map(
+      bytecode.layouts.enums.map((enumLayout) => [enumLayout.id, enumLayout]),
+    );
+    this.actors = new Map(
+      bytecode.layouts.actors.map((layout) => {
+        const actor = actorLayout(layout);
+        return [actor.id, actor];
+      }),
+    );
+    this.supervisors = new Map(
+      bytecode.layouts.supervisors.map((layout) => {
+        const supervisor = supervisorLayout(layout);
+        return [supervisor.id, supervisor];
+      }),
+    );
+    this.machines = new Map(
+      bytecode.layouts.machines.map((layout) => {
+        const machine = machineLayout(layout);
+        return [machine.id, machine];
+      }),
+    );
+    this.scheduler = new ActorScheduler(
+      trace.replay.seed,
+      schedulerPolicy,
+      trace,
+      {
+        invoke: (functionId, args) =>
+          this.invoke(this.functionFor(functionId, null), args),
+        consumeStep: () => this.commitOrExhaust(),
+      },
+    );
   }
 
   run(): void {
@@ -236,12 +347,18 @@ class Interpreter {
   }
 
   private entryFunction(): BytecodeFunction {
-    const entryModule = this.bytecode.module_graph.modules.find((module) => module.id === this.bytecode.module_graph.entry);
+    const entryModule = this.bytecode.module_graph.modules.find(
+      (module) => module.id === this.bytecode.module_graph.entry,
+    );
     const entryFunctionId =
-      entryModule?.functions.find((id) => this.functions.get(id)?.name === "main") ??
+      entryModule?.functions.find(
+        (id) => this.functions.get(id)?.name === "main",
+      ) ??
       entryModule?.functions[0] ??
       this.bytecode.functions[0]?.id;
-    const entry = entryFunctionId ? this.functions.get(entryFunctionId) : undefined;
+    const entry = entryFunctionId
+      ? this.functions.get(entryFunctionId)
+      : undefined;
     if (!entry) {
       this.trap("invalid_call", "entry function not found", null);
     }
@@ -286,16 +403,32 @@ class Interpreter {
   }
 
   private executeInstruction(frame: Frame, instruction: Instruction): void {
-    if (M6_DEFERRED_OP_PREFIXES.some((prefix) => instruction.op.startsWith(prefix))) {
-      this.unsupported(`Unsupported::M6_DEFERRED: ${instruction.op}`, instruction.span);
+    if (
+      M6_DEFERRED_OP_PREFIXES.some((prefix) =>
+        instruction.op.startsWith(prefix),
+      )
+    ) {
+      this.unsupported(
+        `Unsupported::M6_DEFERRED: ${instruction.op}`,
+        instruction.span,
+      );
     }
-    if (NATIVE_ONLY_OP_PREFIXES.some((prefix) => instruction.op.startsWith(prefix))) {
-      this.unsupported(`Unsupported::NATIVE_ONLY: ${instruction.op}`, instruction.span, {
-        kind: "Unsupported::NATIVE_ONLY",
-        symbol: instruction.op,
-        status: "unsupported_native_only",
-        reason: "File/network-backed streams are unavailable in the deterministic browser sandbox"
-      });
+    if (
+      NATIVE_ONLY_OP_PREFIXES.some((prefix) =>
+        instruction.op.startsWith(prefix),
+      )
+    ) {
+      this.unsupported(
+        `Unsupported::NATIVE_ONLY: ${instruction.op}`,
+        instruction.span,
+        {
+          kind: "Unsupported::NATIVE_ONLY",
+          symbol: instruction.op,
+          status: "unsupported_native_only",
+          reason:
+            "File/network-backed streams are unavailable in the deterministic browser sandbox",
+        },
+      );
     }
 
     switch (instruction.op) {
@@ -303,30 +436,65 @@ class Interpreter {
         this.writeDst(frame, instruction, UNIT);
         return;
       case "const.bool":
-        this.writeDst(frame, instruction, { kind: "bool", value: Boolean(instruction.args[0]?.value) });
+        this.writeDst(frame, instruction, {
+          kind: "bool",
+          value: Boolean(instruction.args[0]?.value),
+        });
         return;
       case "const.i64":
       case "const.u64":
-        this.writeDst(frame, instruction, this.i64(this.bigintArg(instruction.args[0], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(this.bigintArg(instruction.args[0], instruction.span)),
+        );
         return;
       case "const.f32":
-        this.writeDst(frame, instruction, this.f32(this.numberArg(instruction.args[0], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f32(this.numberArg(instruction.args[0], instruction.span)),
+        );
         return;
       case "const.f64":
-        this.writeDst(frame, instruction, { kind: "f64", value: this.numberArg(instruction.args[0], instruction.span) });
+        this.writeDst(frame, instruction, {
+          kind: "f64",
+          value: this.numberArg(instruction.args[0], instruction.span),
+        });
         return;
       case "const.string":
-        this.writeDst(frame, instruction, { kind: "string", value: this.stringArg(instruction.args[0], instruction.span) });
+        this.writeDst(frame, instruction, {
+          kind: "string",
+          value: this.stringArg(instruction.args[0], instruction.span),
+        });
         return;
       case "const.regex":
-        this.writeDst(frame, instruction, this.compileRegex(this.stringArg(instruction.args[0], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.compileRegex(
+            this.stringArg(instruction.args[0], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "bool.not": {
-        const value = this.resolve(frame, instruction.args[0], instruction.span);
+        const value = this.resolve(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
         if (value.kind !== "bool") {
-          this.trap("invalid_local", "bool.not requires a bool operand", instruction.span);
+          this.trap(
+            "invalid_local",
+            "bool.not requires a bool operand",
+            instruction.span,
+          );
         }
-        this.writeDst(frame, instruction, { kind: "bool", value: !value.value });
+        this.writeDst(frame, instruction, {
+          kind: "bool",
+          value: !value.value,
+        });
         return;
       }
       case "numeric.cast":
@@ -341,11 +509,24 @@ class Interpreter {
         // Aliasing safety: `local.set` clones on write, so an independent assignment
         // `local:b = local:a` produces a distinct copy — the clone happens at the
         // write site, not the read site.
-        this.writeDst(frame, instruction, this.readLocal(frame, this.localId(instruction.args[0], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.readLocal(
+            frame,
+            this.localId(instruction.args[0], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "local.set": {
         const target = this.localId(instruction.args[0], instruction.span);
-        frame.locals.set(target, cloneValue(this.resolve(frame, instruction.args[1], instruction.span)));
+        frame.locals.set(
+          target,
+          cloneValue(
+            this.resolve(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       }
       // Wrapping arithmetic (`&+`/`&-`/`&*`): truncate to two's-complement 64 bits
@@ -354,72 +535,239 @@ class Interpreter {
       // unbounded BigInt (e.g. `i64::MAX &+ 1` -> 2^63 instead of `i64::MIN`).
       // The shift opcode already applies the same truncation; see #2341.
       case "i64.add":
-        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) + this.i64Arg(frame, instruction.args[1], instruction.span))));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            BigInt.asIntN(
+              64,
+              this.i64Arg(frame, instruction.args[0], instruction.span) +
+                this.i64Arg(frame, instruction.args[1], instruction.span),
+            ),
+          ),
+        );
         return;
       case "i64.sub":
-        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) - this.i64Arg(frame, instruction.args[1], instruction.span))));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            BigInt.asIntN(
+              64,
+              this.i64Arg(frame, instruction.args[0], instruction.span) -
+                this.i64Arg(frame, instruction.args[1], instruction.span),
+            ),
+          ),
+        );
         return;
       case "i64.mul":
-        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) * this.i64Arg(frame, instruction.args[1], instruction.span))));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            BigInt.asIntN(
+              64,
+              this.i64Arg(frame, instruction.args[0], instruction.span) *
+                this.i64Arg(frame, instruction.args[1], instruction.span),
+            ),
+          ),
+        );
         return;
       case "i64.and":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) & this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            this.i64Arg(frame, instruction.args[0], instruction.span) &
+              this.i64Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "i64.or":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) | this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            this.i64Arg(frame, instruction.args[0], instruction.span) |
+              this.i64Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "i64.xor":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) ^ this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            this.i64Arg(frame, instruction.args[0], instruction.span) ^
+              this.i64Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "i64.shl": {
-        const count = this.shiftCount(frame, instruction.args[1], instruction.span);
-        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) << count)));
+        const count = this.shiftCount(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            BigInt.asIntN(
+              64,
+              this.i64Arg(frame, instruction.args[0], instruction.span) <<
+                count,
+            ),
+          ),
+        );
         return;
       }
       case "i64.shr": {
-        const count = this.shiftCount(frame, instruction.args[1], instruction.span);
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) >> count));
+        const count = this.shiftCount(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            this.i64Arg(frame, instruction.args[0], instruction.span) >> count,
+          ),
+        );
         return;
       }
       case "i64.div":
       case "i64.checked_div":
-        this.writeDst(frame, instruction, this.i64(this.checkedDiv(frame, instruction.args[0], instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            this.checkedDiv(
+              frame,
+              instruction.args[0],
+              instruction.args[1],
+              instruction.span,
+            ),
+          ),
+        );
         return;
       case "i64.rem":
       case "i64.checked_rem":
-        this.writeDst(frame, instruction, this.i64(this.checkedRem(frame, instruction.args[0], instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            this.checkedRem(
+              frame,
+              instruction.args[0],
+              instruction.args[1],
+              instruction.span,
+            ),
+          ),
+        );
         return;
       case "i64.neg":
-        this.writeDst(frame, instruction, this.checkedI64(-this.i64Arg(frame, instruction.args[0], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.checkedI64(
+            -this.i64Arg(frame, instruction.args[0], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "i64.checked_add":
-        this.writeDst(frame, instruction, this.checkedI64(this.i64Arg(frame, instruction.args[0], instruction.span) + this.i64Arg(frame, instruction.args[1], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.checkedI64(
+            this.i64Arg(frame, instruction.args[0], instruction.span) +
+              this.i64Arg(frame, instruction.args[1], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "i64.checked_sub":
-        this.writeDst(frame, instruction, this.checkedI64(this.i64Arg(frame, instruction.args[0], instruction.span) - this.i64Arg(frame, instruction.args[1], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.checkedI64(
+            this.i64Arg(frame, instruction.args[0], instruction.span) -
+              this.i64Arg(frame, instruction.args[1], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "i64.checked_mul":
-        this.writeDst(frame, instruction, this.checkedI64(this.i64Arg(frame, instruction.args[0], instruction.span) * this.i64Arg(frame, instruction.args[1], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.checkedI64(
+            this.i64Arg(frame, instruction.args[0], instruction.span) *
+              this.i64Arg(frame, instruction.args[1], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       // f32 values use the VM's numeric value representation, but every literal
       // and arithmetic result is rounded to IEEE-754 single precision.
       case "f32.add":
-        this.writeDst(frame, instruction, this.f32(this.f32Arg(frame, instruction.args[0], instruction.span) + this.f32Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f32(
+            this.f32Arg(frame, instruction.args[0], instruction.span) +
+              this.f32Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f32.sub":
-        this.writeDst(frame, instruction, this.f32(this.f32Arg(frame, instruction.args[0], instruction.span) - this.f32Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f32(
+            this.f32Arg(frame, instruction.args[0], instruction.span) -
+              this.f32Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f32.mul":
-        this.writeDst(frame, instruction, this.f32(this.f32Arg(frame, instruction.args[0], instruction.span) * this.f32Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f32(
+            this.f32Arg(frame, instruction.args[0], instruction.span) *
+              this.f32Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f32.div":
-        this.writeDst(frame, instruction, this.f32(this.f32Arg(frame, instruction.args[0], instruction.span) / this.f32Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f32(
+            this.f32Arg(frame, instruction.args[0], instruction.span) /
+              this.f32Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f32.rem":
-        this.writeDst(frame, instruction, this.f32(this.f32Arg(frame, instruction.args[0], instruction.span) % this.f32Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f32(
+            this.f32Arg(frame, instruction.args[0], instruction.span) %
+              this.f32Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f32.neg":
-        this.writeDst(frame, instruction, this.f32(-this.f32Arg(frame, instruction.args[0], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f32(-this.f32Arg(frame, instruction.args[0], instruction.span)),
+        );
         return;
       // f64 arithmetic follows IEEE-754 exactly (matching native LLVM
       // fadd/fsub/fmul/fdiv/frem/fneg). JS `number` is an IEEE-754 double, so
@@ -427,24 +775,63 @@ class Interpreter {
       // checked i64 ops these never trap: float divide-by-zero yields
       // ±Infinity/NaN, never `divide_by_zero`.
       case "f64.add":
-        this.writeDst(frame, instruction, this.f64(this.f64Arg(frame, instruction.args[0], instruction.span) + this.f64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f64(
+            this.f64Arg(frame, instruction.args[0], instruction.span) +
+              this.f64Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f64.sub":
-        this.writeDst(frame, instruction, this.f64(this.f64Arg(frame, instruction.args[0], instruction.span) - this.f64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f64(
+            this.f64Arg(frame, instruction.args[0], instruction.span) -
+              this.f64Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f64.mul":
-        this.writeDst(frame, instruction, this.f64(this.f64Arg(frame, instruction.args[0], instruction.span) * this.f64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f64(
+            this.f64Arg(frame, instruction.args[0], instruction.span) *
+              this.f64Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f64.div":
-        this.writeDst(frame, instruction, this.f64(this.f64Arg(frame, instruction.args[0], instruction.span) / this.f64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f64(
+            this.f64Arg(frame, instruction.args[0], instruction.span) /
+              this.f64Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f64.rem":
         // JS `%` on doubles is C `fmod` / LLVM `frem`: truncated remainder
         // carrying the sign of the dividend — identical to native.
-        this.writeDst(frame, instruction, this.f64(this.f64Arg(frame, instruction.args[0], instruction.span) % this.f64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f64(
+            this.f64Arg(frame, instruction.args[0], instruction.span) %
+              this.f64Arg(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       case "f64.neg":
-        this.writeDst(frame, instruction, this.f64(-this.f64Arg(frame, instruction.args[0], instruction.span)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.f64(-this.f64Arg(frame, instruction.args[0], instruction.span)),
+        );
         return;
       case "cmp.eq":
       case "cmp.ne":
@@ -452,11 +839,19 @@ class Interpreter {
       case "cmp.le":
       case "cmp.gt":
       case "cmp.ge":
-        this.writeDst(frame, instruction, { kind: "bool", value: this.compare(frame, instruction) });
+        this.writeDst(frame, instruction, {
+          kind: "bool",
+          value: this.compare(frame, instruction),
+        });
         return;
       case "call.direct": {
-        const fn = this.functionFor(this.stringOperand(instruction.args[0], instruction.span), instruction.span);
-        const args = instruction.args.slice(1).map((arg) => this.resolve(frame, arg, instruction.span));
+        const fn = this.functionFor(
+          this.stringOperand(instruction.args[0], instruction.span),
+          instruction.span,
+        );
+        const args = instruction.args
+          .slice(1)
+          .map((arg) => this.resolve(frame, arg, instruction.span));
         this.writeDst(frame, instruction, this.invoke(fn, args));
         return;
       }
@@ -464,12 +859,22 @@ class Interpreter {
         // Resolve the callee local, which must hold a `function`-kind value
         // materialised by `const.function`.  Look up the function by its id and
         // invoke it with the remaining operands as arguments.
-        const calleeValue = this.resolve(frame, instruction.args[0], instruction.span);
+        const calleeValue = this.resolve(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
         if (calleeValue.kind !== "function") {
-          this.trap("invalid_call", "call.indirect: callee is not a function value", instruction.span);
+          this.trap(
+            "invalid_call",
+            "call.indirect: callee is not a function value",
+            instruction.span,
+          );
         }
         const fn = this.functionFor(calleeValue.id, instruction.span);
-        const args = instruction.args.slice(1).map((arg) => this.resolve(frame, arg, instruction.span));
+        const args = instruction.args
+          .slice(1)
+          .map((arg) => this.resolve(frame, arg, instruction.span));
         this.writeDst(frame, instruction, this.invoke(fn, args));
         return;
       }
@@ -484,7 +889,10 @@ class Interpreter {
         this.callStdlib(frame, instruction);
         return;
       case "actor.spawn": {
-        const layoutId = this.stringOperand(instruction.args[0], instruction.span);
+        const layoutId = this.stringOperand(
+          instruction.args[0],
+          instruction.span,
+        );
         const layout = this.actors.get(layoutId);
         if (!layout) {
           this.trap("invalid_call", "actor layout not found", instruction.span);
@@ -492,23 +900,42 @@ class Interpreter {
         this.writeDst(
           frame,
           instruction,
-          this.scheduler.spawn(layout, instruction.args.slice(1).map((arg) => this.resolve(frame, arg, instruction.span)), this.scheduler.activeActor ?? "actor:root", this.trace.span(instruction.span))
+          this.scheduler.spawn(
+            layout,
+            instruction.args
+              .slice(1)
+              .map((arg) => this.resolve(frame, arg, instruction.span)),
+            this.scheduler.activeActor ?? "actor:root",
+            this.trace.span(instruction.span),
+          ),
         );
         return;
       }
       case "supervisor.spawn": {
         this.assertSupervisorOpAllowed(instruction);
-        const layoutId = this.stringOperand(instruction.args[0], instruction.span);
+        const layoutId = this.stringOperand(
+          instruction.args[0],
+          instruction.span,
+        );
         const layout = this.supervisors.get(layoutId);
         if (!layout) {
-          this.trap("invalid_call", "supervisor layout not found", instruction.span);
+          this.trap(
+            "invalid_call",
+            "supervisor layout not found",
+            instruction.span,
+          );
         }
         this.writeDst(
           frame,
           instruction,
           this.withSchedulerError(instruction, () =>
-            this.scheduler.spawnSupervisor(layout, this.actors, this.scheduler.activeActor ?? "actor:root", this.trace.span(instruction.span))
-          )
+            this.scheduler.spawnSupervisor(
+              layout,
+              this.actors,
+              this.scheduler.activeActor ?? "actor:root",
+              this.trace.span(instruction.span),
+            ),
+          ),
         );
         return;
       }
@@ -520,21 +947,28 @@ class Interpreter {
           this.withSchedulerError(instruction, () =>
             this.scheduler.child(
               this.resolve(frame, instruction.args[0], instruction.span),
-              this.stringOperand(instruction.args[1], instruction.span)
-            )
-          )
+              this.stringOperand(instruction.args[1], instruction.span),
+            ),
+          ),
         );
         return;
       case "supervisor.restart":
       case "supervisor.stop":
         this.assertSupervisorOpAllowed(instruction);
-        this.unsupported(`Unsupported::M6_DEFERRED: ${instruction.op} direct control`, instruction.span);
+        this.unsupported(
+          `Unsupported::M6_DEFERRED: ${instruction.op} direct control`,
+          instruction.span,
+        );
         return;
       case "machine.new":
         this.writeDst(frame, instruction, this.machineNew(instruction));
         return;
       case "machine.state":
-        this.writeDst(frame, instruction, this.machineState(frame, instruction));
+        this.writeDst(
+          frame,
+          instruction,
+          this.machineState(frame, instruction),
+        );
         return;
       case "machine.step":
         this.writeDst(frame, instruction, this.machineStep(frame, instruction));
@@ -544,8 +978,10 @@ class Interpreter {
           this.scheduler.send(
             this.resolve(frame, instruction.args[0], instruction.span),
             this.messageName(instruction.args[1], instruction.span),
-            instruction.args.slice(2).map((arg) => this.resolve(frame, arg, instruction.span)),
-            this.trace.span(instruction.span)
+            instruction.args
+              .slice(2)
+              .map((arg) => this.resolve(frame, arg, instruction.span)),
+            this.trace.span(instruction.span),
           );
         });
         return;
@@ -557,15 +993,20 @@ class Interpreter {
             this.scheduler.ask(
               this.resolve(frame, instruction.args[0], instruction.span),
               this.messageName(instruction.args[1], instruction.span),
-              instruction.args.slice(2).map((arg) => this.resolve(frame, arg, instruction.span)),
-              this.trace.span(instruction.span)
-            )
-          )
+              instruction.args
+                .slice(2)
+                .map((arg) => this.resolve(frame, arg, instruction.span)),
+              this.trace.span(instruction.span),
+            ),
+          ),
         );
         return;
       case "actor.reply":
         this.withSchedulerError(instruction, () => {
-          this.scheduler.reply(this.resolve(frame, instruction.args[0], instruction.span), this.resolve(frame, instruction.args[1], instruction.span));
+          this.scheduler.reply(
+            this.resolve(frame, instruction.args[0], instruction.span),
+            this.resolve(frame, instruction.args[1], instruction.span),
+          );
         });
         return;
       case "actor.link":
@@ -586,65 +1027,157 @@ class Interpreter {
           instruction,
           this.withSchedulerError(instruction, () => {
             const [owner, target] = this.actorPair(frame, instruction);
-            return this.scheduler.monitor(owner, target, this.trace.span(instruction.span));
-          })
+            return this.scheduler.monitor(
+              owner,
+              target,
+              this.trace.span(instruction.span),
+            );
+          }),
         );
         return;
       case "actor.demonitor":
         this.withSchedulerError(instruction, () => {
-          this.scheduler.demonitor(this.resolve(frame, instruction.args[0], instruction.span), this.trace.span(instruction.span));
+          this.scheduler.demonitor(
+            this.resolve(frame, instruction.args[0], instruction.span),
+            this.trace.span(instruction.span),
+          );
         });
         return;
       case "mailbox.dequeue":
-        this.writeDst(frame, instruction, this.withSchedulerError(instruction, () => this.scheduler.dequeueCurrentPayload()));
+        this.writeDst(
+          frame,
+          instruction,
+          this.withSchedulerError(instruction, () =>
+            this.scheduler.dequeueCurrentPayload(),
+          ),
+        );
         return;
       case "channel.new":
-        this.writeDst(frame, instruction, { kind: "channel", id: this.createChannel(this.capacityArg(frame, instruction.args[1], instruction.span), null, instruction.span).id });
+        this.writeDst(frame, instruction, {
+          kind: "channel",
+          id: this.createChannel(
+            this.capacityArg(frame, instruction.args[1], instruction.span),
+            null,
+            instruction.span,
+          ).id,
+        });
         return;
       case "channel.send":
         this.channelSend(
           this.channelArg(frame, instruction.args[0], instruction.span),
           this.resolve(frame, instruction.args[1], instruction.span),
-          instruction.span
+          instruction.span,
         );
         return;
       case "channel.recv":
-        this.writeDst(frame, instruction, this.channelRecv(this.channelArg(frame, instruction.args[0], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.channelRecv(
+            this.channelArg(frame, instruction.args[0], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "channel.close":
-        this.channelClose(this.channelArg(frame, instruction.args[0], instruction.span), instruction.span);
+        this.channelClose(
+          this.channelArg(frame, instruction.args[0], instruction.span),
+          instruction.span,
+        );
         return;
       case "stream.memory": {
-        const channel = this.createChannel(this.capacityArg(frame, instruction.args[0], instruction.span), "stream.memory", instruction.span);
-        this.writeDst(frame, instruction, { kind: "duplex", channelId: channel.id });
+        const channel = this.createChannel(
+          this.capacityArg(frame, instruction.args[0], instruction.span),
+          "stream.memory",
+          instruction.span,
+        );
+        this.writeDst(frame, instruction, {
+          kind: "duplex",
+          channelId: channel.id,
+        });
         return;
       }
       case "stream.write":
-        this.channelSend(this.streamWritableArg(frame, instruction.args[0], instruction.span), this.resolve(frame, instruction.args[1], instruction.span), instruction.span);
+        this.channelSend(
+          this.streamWritableArg(frame, instruction.args[0], instruction.span),
+          this.resolve(frame, instruction.args[1], instruction.span),
+          instruction.span,
+        );
         return;
       case "stream.read":
-        this.writeDst(frame, instruction, this.channelRecv(this.streamReadableArg(frame, instruction.args[0], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.channelRecv(
+            this.streamReadableArg(
+              frame,
+              instruction.args[0],
+              instruction.span,
+            ),
+            instruction.span,
+          ),
+        );
         return;
       case "stream.close":
-        this.channelClose(this.streamChannelArg(frame, instruction.args[0], instruction.span), instruction.span);
+        this.channelClose(
+          this.streamChannelArg(frame, instruction.args[0], instruction.span),
+          instruction.span,
+        );
         return;
       case "task.spawn":
-        this.writeDst(frame, instruction, this.spawnTask(this.functionOperand(instruction.args[0], instruction.span), instruction.args.slice(1).map((arg) => this.resolve(frame, arg, instruction.span)), null));
+        this.writeDst(
+          frame,
+          instruction,
+          this.spawnTask(
+            this.functionOperand(instruction.args[0], instruction.span),
+            instruction.args
+              .slice(1)
+              .map((arg) => this.resolve(frame, arg, instruction.span)),
+            null,
+          ),
+        );
         return;
       case "task.await":
-        this.writeDst(frame, instruction, this.awaitTask(this.taskArg(frame, instruction.args[0], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.awaitTask(
+            this.taskArg(frame, instruction.args[0], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "task.cancel":
-        this.cancelTask(this.taskArg(frame, instruction.args[0], instruction.span), "task.cancel");
+        this.cancelTask(
+          this.taskArg(frame, instruction.args[0], instruction.span),
+          "task.cancel",
+        );
         return;
       case "scope.enter":
         this.enterScope();
         return;
       case "scope.launch":
-        this.writeDst(frame, instruction, this.spawnTask(this.functionOperand(instruction.args[0], instruction.span), instruction.args.slice(1).map((arg) => this.resolve(frame, arg, instruction.span)), this.currentScope().id));
+        this.writeDst(
+          frame,
+          instruction,
+          this.spawnTask(
+            this.functionOperand(instruction.args[0], instruction.span),
+            instruction.args
+              .slice(1)
+              .map((arg) => this.resolve(frame, arg, instruction.span)),
+            this.currentScope().id,
+          ),
+        );
         return;
       case "scope.await":
-        this.writeDst(frame, instruction, this.awaitTask(this.taskArg(frame, instruction.args[0], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.awaitTask(
+            this.taskArg(frame, instruction.args[0], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "scope.cancel":
         this.cancelScope("scope.cancel");
@@ -656,31 +1189,45 @@ class Interpreter {
         this.writeDst(frame, instruction, this.selectPoll(frame, instruction));
         return;
       case "clock.sleep":
-        this.sleepVirtual(this.durationArg(frame, instruction.args[0], instruction.span), instruction.span);
+        this.sleepVirtual(
+          this.durationArg(frame, instruction.args[0], instruction.span),
+          instruction.span,
+        );
         return;
       case "record.new":
         this.writeDst(frame, instruction, {
           kind: "record",
           typeId: this.stringOperand(instruction.args[0], instruction.span),
-          fields: instruction.args.slice(1).map((arg) => this.resolve(frame, arg, instruction.span))
+          fields: instruction.args
+            .slice(1)
+            .map((arg) => this.resolve(frame, arg, instruction.span)),
         });
         return;
       case "record.get":
         this.writeDst(frame, instruction, this.recordGet(frame, instruction));
         return;
       case "record.set":
-        this.unsupported("Unsupported::M4_DEFERRED: record.set mutable projection", instruction.span);
+        this.unsupported(
+          "Unsupported::M4_DEFERRED: record.set mutable projection",
+          instruction.span,
+        );
         return;
       case "enum.new":
         this.writeDst(frame, instruction, {
           kind: "enum",
           typeId: this.stringOperand(instruction.args[0], instruction.span),
           tag: this.numberArg(instruction.args[1], instruction.span),
-          payload: instruction.args.slice(2).map((arg) => this.resolve(frame, arg, instruction.span))
+          payload: instruction.args
+            .slice(2)
+            .map((arg) => this.resolve(frame, arg, instruction.span)),
         });
         return;
       case "enum.tag": {
-        const value = this.resolve(frame, instruction.args[0], instruction.span);
+        const value = this.resolve(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
         if (value.kind !== "enum") {
           this.trap("invalid_enum_tag", "invalid enum tag", instruction.span);
         }
@@ -691,45 +1238,108 @@ class Interpreter {
         this.writeDst(frame, instruction, this.enumPayload(frame, instruction));
         return;
       case "vector.new":
-        this.writeDst(frame, instruction, { kind: "vector", elementType: this.stringOperand(instruction.args[0], instruction.span), items: [] });
+        this.writeDst(frame, instruction, {
+          kind: "vector",
+          elementType: this.stringOperand(
+            instruction.args[0],
+            instruction.span,
+          ),
+          items: [],
+        });
         return;
       case "vector.push": {
-        const vector = this.vectorArg(frame, instruction.args[0], instruction.span);
-        vector.items.push(cloneValue(this.resolve(frame, instruction.args[1], instruction.span)));
+        const vector = this.vectorArg(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
+        vector.items.push(
+          cloneValue(
+            this.resolve(frame, instruction.args[1], instruction.span),
+          ),
+        );
         return;
       }
       case "vector.get": {
         this.writeDst(
           frame,
           instruction,
-          this.vectorGetOption(frame, instruction, instruction.args[0], instruction.args[1])
+          this.vectorGetOption(
+            frame,
+            instruction,
+            instruction.args[0],
+            instruction.args[1],
+          ),
         );
         return;
       }
       case "vector.index": {
-        const vector = this.vectorArg(frame, instruction.args[0], instruction.span);
-        const index = this.indexArg(frame, instruction.args[1], instruction.span);
+        const vector = this.vectorArg(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
+        const index = this.indexArg(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
         if (index < 0 || index >= vector.items.length) {
-          this.trap("vector_bounds", "vector index out of bounds", instruction.span);
+          this.trap(
+            "vector_bounds",
+            "vector index out of bounds",
+            instruction.span,
+          );
         }
         this.writeDst(frame, instruction, cloneValue(vector.items[index]!));
         return;
       }
       case "vector.set": {
-        const vector = this.vectorArg(frame, instruction.args[0], instruction.span);
-        const index = this.indexArg(frame, instruction.args[1], instruction.span);
+        const vector = this.vectorArg(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
+        const index = this.indexArg(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
         if (index < 0 || index >= vector.items.length) {
-          this.trap("vector_bounds", "vector index out of bounds", instruction.span);
+          this.trap(
+            "vector_bounds",
+            "vector index out of bounds",
+            instruction.span,
+          );
         }
-        vector.items[index] = cloneValue(this.resolve(frame, instruction.args[2], instruction.span));
+        vector.items[index] = cloneValue(
+          this.resolve(frame, instruction.args[2], instruction.span),
+        );
         return;
       }
       case "vector.len":
-        this.writeDst(frame, instruction, this.i64(BigInt(this.vectorArg(frame, instruction.args[0], instruction.span).items.length)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            BigInt(
+              this.vectorArg(frame, instruction.args[0], instruction.span).items
+                .length,
+            ),
+          ),
+        );
         return;
       case "vector.contains": {
-        const vec = this.vectorArg(frame, instruction.args[0], instruction.span);
-        const needle = this.resolve(frame, instruction.args[1], instruction.span);
+        const vec = this.vectorArg(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
+        const needle = this.resolve(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
         // Use valuesEqual so f64 non-finite values (NaN, +/-Infinity) follow
         // native fcmp-OEQ semantics: [NaN].contains(NaN) == false.
         const found = vec.items.some((item) => valuesEqual(item, needle));
@@ -737,11 +1347,23 @@ class Interpreter {
         return;
       }
       case "vector.range_slice": {
-        const vec = this.vectorArg(frame, instruction.args[0], instruction.span);
-        const start = this.indexArg(frame, instruction.args[1], instruction.span);
+        const vec = this.vectorArg(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
+        const start = this.indexArg(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
         const end = this.indexArg(frame, instruction.args[2], instruction.span);
         if (start < 0 || end < start || end > vec.items.length) {
-          this.trap("vector_bounds", "vector slice out of bounds", instruction.span);
+          this.trap(
+            "vector_bounds",
+            "vector slice out of bounds",
+            instruction.span,
+          );
         }
         this.writeDst(frame, instruction, {
           kind: "vector",
@@ -753,67 +1375,167 @@ class Interpreter {
       case "string.concat":
         this.writeDst(frame, instruction, {
           kind: "string",
-          value: this.stringValue(frame, instruction.args[0], instruction.span) + this.stringValue(frame, instruction.args[1], instruction.span)
+          value:
+            this.stringValue(frame, instruction.args[0], instruction.span) +
+            this.stringValue(frame, instruction.args[1], instruction.span),
         });
         return;
       case "string.len":
-        this.writeDst(frame, instruction, this.i64(BigInt([...this.stringValue(frame, instruction.args[0], instruction.span)].length)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            BigInt(
+              [
+                ...this.stringValue(
+                  frame,
+                  instruction.args[0],
+                  instruction.span,
+                ),
+              ].length,
+            ),
+          ),
+        );
         return;
       case "string.slice": {
-        const value = this.stringValue(frame, instruction.args[0], instruction.span);
+        const value = this.stringValue(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        );
         const chars = [...value];
-        const start = this.indexArg(frame, instruction.args[1], instruction.span);
+        const start = this.indexArg(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
         const end = this.indexArg(frame, instruction.args[2], instruction.span);
         if (start < 0 || end < start || end > chars.length) {
-          this.trap("string_bounds", "string slice out of bounds", instruction.span);
+          this.trap(
+            "string_bounds",
+            "string slice out of bounds",
+            instruction.span,
+          );
         }
-        this.writeDst(frame, instruction, { kind: "string", value: chars.slice(start, end).join("") });
+        this.writeDst(frame, instruction, {
+          kind: "string",
+          value: chars.slice(start, end).join(""),
+        });
         return;
       }
       case "regex.compile":
-        this.writeDst(frame, instruction, this.compileRegex(this.stringValue(frame, instruction.args[0], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.compileRegex(
+            this.stringValue(frame, instruction.args[0], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "regex.is_match":
-        this.writeDst(frame, instruction, { kind: "bool", value: this.regexArg(frame, instruction.args[0], instruction.span).regex.test(this.stringValue(frame, instruction.args[1], instruction.span)) });
+        this.writeDst(frame, instruction, {
+          kind: "bool",
+          value: this.regexArg(
+            frame,
+            instruction.args[0],
+            instruction.span,
+          ).regex.test(
+            this.stringValue(frame, instruction.args[1], instruction.span),
+          ),
+        });
         return;
       case "regex.find": {
-        const regex = this.regexArg(frame, instruction.args[0], instruction.span).regex;
-        const found = regex.exec(this.stringValue(frame, instruction.args[1], instruction.span))?.[0] ?? "";
+        const regex = this.regexArg(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        ).regex;
+        const found =
+          regex.exec(
+            this.stringValue(frame, instruction.args[1], instruction.span),
+          )?.[0] ?? "";
         this.writeDst(frame, instruction, { kind: "string", value: found });
         return;
       }
       case "regex.replace": {
-        const regex = this.regexArg(frame, instruction.args[0], instruction.span).regex;
-        const input = this.stringValue(frame, instruction.args[1], instruction.span);
-        const replacement = this.stringValue(frame, instruction.args[2], instruction.span);
-        this.writeDst(frame, instruction, { kind: "string", value: input.replace(regex, replacement) });
+        const regex = this.regexArg(
+          frame,
+          instruction.args[0],
+          instruction.span,
+        ).regex;
+        const input = this.stringValue(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
+        const replacement = this.stringValue(
+          frame,
+          instruction.args[2],
+          instruction.span,
+        );
+        this.writeDst(frame, instruction, {
+          kind: "string",
+          value: input.replace(regex, replacement),
+        });
         return;
       }
       case "regex.free":
         return;
       case "panic":
-        this.fail("panic", "panic", this.stringValue(frame, instruction.args[0], instruction.span), instruction.span);
+        this.fail(
+          "panic",
+          "panic",
+          this.stringValue(frame, instruction.args[0], instruction.span),
+          instruction.span,
+        );
         return;
       case "trap":
-        this.trap(this.trapKind(instruction.args[0], instruction.span), trapMessage(this.trapKind(instruction.args[0], instruction.span)), instruction.span);
+        this.trap(
+          this.trapKind(instruction.args[0], instruction.span),
+          trapMessage(this.trapKind(instruction.args[0], instruction.span)),
+          instruction.span,
+        );
         return;
       default:
-        this.unsupported(`unsupported instruction ${instruction.op}`, instruction.span);
+        this.unsupported(
+          `unsupported instruction ${instruction.op}`,
+          instruction.span,
+        );
     }
   }
 
   private executeTerminator(
     frame: Frame,
     terminator: Terminator,
-    blocks: Map<string, Frame["fn"]["blocks"][number]>
-  ): { returned: true; value: VmValue } | { returned: false; block: Frame["fn"]["blocks"][number] } {
+    blocks: Map<string, Frame["fn"]["blocks"][number]>,
+  ):
+    | { returned: true; value: VmValue }
+    | { returned: false; block: Frame["fn"]["blocks"][number] } {
     switch (terminator.op) {
       case "br":
-        return { returned: false, block: this.branchTarget(frame, terminator.target, terminator.args, blocks, terminator.span) };
+        return {
+          returned: false,
+          block: this.branchTarget(
+            frame,
+            terminator.target,
+            terminator.args,
+            blocks,
+            terminator.span,
+          ),
+        };
       case "br_if": {
-        const condition = this.resolve(frame, terminator.condition, terminator.span);
+        const condition = this.resolve(
+          frame,
+          terminator.condition,
+          terminator.span,
+        );
         if (condition.kind !== "bool") {
-          this.trap("invalid_block", "branch condition is not bool", terminator.span);
+          this.trap(
+            "invalid_block",
+            "branch condition is not bool",
+            terminator.span,
+          );
         }
         return {
           returned: false,
@@ -822,26 +1544,49 @@ class Interpreter {
             condition.value ? terminator.target : terminator.else_target,
             terminator.args,
             blocks,
-            terminator.span
-          )
+            terminator.span,
+          ),
         };
       }
       case "return":
-        return { returned: true, value: terminator.args.length > 0 ? cloneValue(this.resolve(frame, terminator.args[0], terminator.span)) : UNIT };
+        return {
+          returned: true,
+          value:
+            terminator.args.length > 0
+              ? cloneValue(
+                  this.resolve(frame, terminator.args[0], terminator.span),
+                )
+              : UNIT,
+        };
       case "tail_call":
-        this.unsupported("Unsupported::M4_DEFERRED: tail_call", terminator.span);
+        this.unsupported(
+          "Unsupported::M4_DEFERRED: tail_call",
+          terminator.span,
+        );
         break;
       case "trap":
-        this.trap(terminator.trap_kind ?? "internal_error", trapMessage(terminator.trap_kind ?? "internal_error"), terminator.span);
+        this.trap(
+          terminator.trap_kind ?? "internal_error",
+          trapMessage(terminator.trap_kind ?? "internal_error"),
+          terminator.span,
+        );
         break;
       case "unreachable":
-        this.trap("internal_error", "unreachable bytecode executed", terminator.span);
+        this.trap(
+          "internal_error",
+          "unreachable bytecode executed",
+          terminator.span,
+        );
         break;
     }
     throw new VmHalt(this.trace.status);
   }
 
-  private createChannel(capacity: number, origin: string | null, spanRef: string | null): ChannelCell {
+  private createChannel(
+    capacity: number,
+    origin: string | null,
+    spanRef: string | null,
+  ): ChannelCell {
     if (capacity <= 0) {
       this.trap("invalid_call", "channel capacity must be positive", spanRef);
     }
@@ -849,11 +1594,19 @@ class Interpreter {
     const channel: ChannelCell = { id, capacity, queue: [], closed: false };
     this.channels.set(id, channel);
     this.trace.allocateId("channel", id, null);
-    this.trace.snapshot("channel-new", { channel_id: id, capacity, origin }, this.trace.span(spanRef));
+    this.trace.snapshot(
+      "channel-new",
+      { channel_id: id, capacity, origin },
+      this.trace.span(spanRef),
+    );
     return channel;
   }
 
-  private channelSend(channel: ChannelCell, value: VmValue, spanRef: string | null): void {
+  private channelSend(
+    channel: ChannelCell,
+    value: VmValue,
+    spanRef: string | null,
+  ): void {
     if (channel.closed) {
       this.trap("invalid_call", `channel ${channel.id} is closed`, spanRef);
     }
@@ -862,15 +1615,23 @@ class Interpreter {
       this.scheduler.drain();
     }
     if (channel.queue.length >= channel.capacity) {
-      this.trap("invalid_call", `M6_CHANNEL_SEND_WOULD_BLOCK: channel ${channel.id} send would block`, spanRef);
+      this.trap(
+        "invalid_call",
+        `M6_CHANNEL_SEND_WOULD_BLOCK: channel ${channel.id} send would block`,
+        spanRef,
+      );
     }
     channel.queue.push(cloneValue(value));
-    this.trace.snapshot("channel-send", {
-      channel_id: channel.id,
-      depth: channel.queue.length,
-      capacity: channel.capacity,
-      value: toTraceValue(value)
-    }, this.trace.span(spanRef));
+    this.trace.snapshot(
+      "channel-send",
+      {
+        channel_id: channel.id,
+        depth: channel.queue.length,
+        capacity: channel.capacity,
+        value: toTraceValue(value),
+      },
+      this.trace.span(spanRef),
+    );
   }
 
   private channelRecv(channel: ChannelCell, spanRef: string | null): VmValue {
@@ -879,30 +1640,52 @@ class Interpreter {
       this.scheduler.drain();
     }
     if (channel.queue.length === 0) {
-      this.trap("invalid_call", channel.closed ? `channel ${channel.id} is closed and drained` : `channel ${channel.id} recv would block`, spanRef);
+      this.trap(
+        "invalid_call",
+        channel.closed
+          ? `channel ${channel.id} is closed and drained`
+          : `channel ${channel.id} recv would block`,
+        spanRef,
+      );
     }
     const value = channel.queue.shift()!;
-    this.trace.snapshot("channel-recv", {
-      channel_id: channel.id,
-      depth: channel.queue.length,
-      closed: channel.closed,
-      value: toTraceValue(value)
-    }, this.trace.span(spanRef));
+    this.trace.snapshot(
+      "channel-recv",
+      {
+        channel_id: channel.id,
+        depth: channel.queue.length,
+        closed: channel.closed,
+        value: toTraceValue(value),
+      },
+      this.trace.span(spanRef),
+    );
     return cloneValue(value);
   }
 
   private channelClose(channel: ChannelCell, spanRef: string | null): void {
     if (channel.closed) {
-      this.trap("invalid_call", `channel ${channel.id} is already closed`, spanRef);
+      this.trap(
+        "invalid_call",
+        `channel ${channel.id} is already closed`,
+        spanRef,
+      );
     }
     channel.closed = true;
-    this.trace.snapshot("channel-close", {
-      channel_id: channel.id,
-      drained_after_close: channel.queue.length
-    }, this.trace.span(spanRef));
+    this.trace.snapshot(
+      "channel-close",
+      {
+        channel_id: channel.id,
+        drained_after_close: channel.queue.length,
+      },
+      this.trace.span(spanRef),
+    );
   }
 
-  private spawnTask(functionId: string, args: VmValue[], scopeId: string | null): VmValue {
+  private spawnTask(
+    functionId: string,
+    args: VmValue[],
+    scopeId: string | null,
+  ): VmValue {
     const id = this.scheduler.ids.task();
     const task: TaskCell = {
       id,
@@ -910,15 +1693,23 @@ class Interpreter {
       args: args.map(cloneValue),
       status: "pending",
       value: UNIT,
-      scopeId
+      scopeId,
     };
     this.tasks.set(id, task);
     this.readyTasks.push(id);
     if (scopeId) {
       this.scopes.find((scope) => scope.id === scopeId)?.children.add(id);
     }
-    this.trace.allocateId("task", id, this.scheduler.activeActor ?? "actor:root");
-    this.trace.snapshot("async-spawn", { task_id: id, function_id: functionId, scope_id: scopeId });
+    this.trace.allocateId(
+      "task",
+      id,
+      this.scheduler.activeActor ?? "actor:root",
+    );
+    this.trace.snapshot("async-spawn", {
+      task_id: id,
+      function_id: functionId,
+      scope_id: scopeId,
+    });
     return { kind: "task", id };
   }
 
@@ -928,7 +1719,11 @@ class Interpreter {
     }
     while (task.status !== "completed") {
       if (!this.runNextTask()) {
-        this.trap("invalid_call", `task ${task.id} cannot make progress`, spanRef);
+        this.trap(
+          "invalid_call",
+          `task ${task.id} cannot make progress`,
+          spanRef,
+        );
       }
     }
     return cloneValue(task.value);
@@ -944,11 +1739,15 @@ class Interpreter {
     if (this.taskDriverDepth > 0) {
       this.trace.snapshot("async-trampoline", {
         depth: this.taskDriverDepth,
-        ready_tasks: this.readyTasks.length
+        ready_tasks: this.readyTasks.length,
       });
     }
     if (this.taskDriverDepth >= 256) {
-      this.trap("budget_exhausted", "M6_TASK_DRIVER_TRAMPOLINE_DEPTH_EXCEEDED", null);
+      this.trap(
+        "budget_exhausted",
+        "M6_TASK_DRIVER_TRAMPOLINE_DEPTH_EXCEEDED",
+        null,
+      );
     }
     const taskId = this.readyTasks.shift();
     if (!taskId) {
@@ -963,11 +1762,21 @@ class Interpreter {
       this.commitOrExhaust();
       task.status = "running";
       this.trace.stepCommitted("task.scheduler-step");
-      this.trace.snapshot("async-resume", { task_id: task.id, function_id: task.functionId });
-      const returned = this.invoke(this.functionFor(task.functionId, null), task.args.map(cloneValue));
+      this.trace.snapshot("async-resume", {
+        task_id: task.id,
+        function_id: task.functionId,
+      });
+      const returned = this.invoke(
+        this.functionFor(task.functionId, null),
+        task.args.map(cloneValue),
+      );
       task.status = "completed";
       task.value = cloneValue(returned);
-      this.trace.snapshot("async-complete", { task_id: task.id, status: "completed", value: toTraceValue(returned) });
+      this.trace.snapshot("async-complete", {
+        task_id: task.id,
+        status: "completed",
+        value: toTraceValue(returned),
+      });
       return true;
     } finally {
       this.taskDriverDepth -= 1;
@@ -983,12 +1792,20 @@ class Interpreter {
     if (readyIndex >= 0) {
       this.readyTasks.splice(readyIndex, 1);
     }
-    this.trace.snapshot("async-complete", { task_id: task.id, status: "cancelled", reason });
+    this.trace.snapshot("async-complete", {
+      task_id: task.id,
+      status: "cancelled",
+      reason,
+    });
   }
 
   private enterScope(): void {
     this.scopeCounter += 1;
-    const scope: ScopeCell = { id: `scope:s${this.scopeCounter}`, children: new Set(), cancelled: false };
+    const scope: ScopeCell = {
+      id: `scope:s${this.scopeCounter}`,
+      children: new Set(),
+      cancelled: false,
+    };
     this.scopes.push(scope);
     this.trace.snapshot("scope-enter", { scope_id: scope.id });
   }
@@ -996,7 +1813,11 @@ class Interpreter {
   private currentScope(): ScopeCell {
     const scope = this.scopes[this.scopes.length - 1];
     if (!scope) {
-      this.trap("invalid_call", "scope operation requires an active scope", null);
+      this.trap(
+        "invalid_call",
+        "scope operation requires an active scope",
+        null,
+      );
     }
     return scope;
   }
@@ -1010,7 +1831,11 @@ class Interpreter {
         this.cancelTask(task, reason);
       }
     }
-    this.trace.snapshot("scope-cancel", { scope_id: scope.id, reason, children: [...scope.children] });
+    this.trace.snapshot("scope-cancel", {
+      scope_id: scope.id,
+      reason,
+      children: [...scope.children],
+    });
   }
 
   private exitScope(): void {
@@ -1025,33 +1850,54 @@ class Interpreter {
     this.trace.snapshot("scope-exit", {
       scope_id: scope.id,
       cancelled: scope.cancelled,
-      children: [...scope.children].map((taskId) => ({ task_id: taskId, status: this.tasks.get(taskId)?.status ?? "unknown" }))
+      children: [...scope.children].map((taskId) => ({
+        task_id: taskId,
+        status: this.tasks.get(taskId)?.status ?? "unknown",
+      })),
     });
     this.scopes.pop();
   }
 
   private selectPoll(frame: Frame, instruction: Instruction): VmValue {
     const arms = this.selectArms(frame, instruction);
-    const recvReady = arms.filter((arm) => arm.kind === "recv" && arm.channel && arm.channel.queue.length > 0);
+    const recvReady = arms.filter(
+      (arm) =>
+        arm.kind === "recv" && arm.channel && arm.channel.queue.length > 0,
+    );
     const timerArms = arms.filter((arm) => arm.kind === "timer");
     const ready = recvReady.length > 0 ? recvReady : timerArms;
     if (ready.length === 0) {
-      this.trap("invalid_call", "select has no ready arm and no timer", instruction.span);
+      this.trap(
+        "invalid_call",
+        "select has no ready arm and no timer",
+        instruction.span,
+      );
     }
     this.selectCounter += 1;
-    const selected = ready[selectTieIndex(this.trace.replay.seed, this.selectCounter, ready.length)]!;
-    this.trace.snapshot("select-resolve", {
-      select_id: `select:${this.selectCounter}`,
-      selected: selected.label,
-      ready: ready.map((arm) => arm.label)
-    }, this.trace.span(instruction.span));
+    const selected =
+      ready[
+        selectTieIndex(this.trace.replay.seed, this.selectCounter, ready.length)
+      ]!;
+    this.trace.snapshot(
+      "select-resolve",
+      {
+        select_id: `select:${this.selectCounter}`,
+        selected: selected.label,
+        ready: ready.map((arm) => arm.label),
+      },
+      this.trace.span(instruction.span),
+    );
     for (const arm of arms) {
       if (arm !== selected) {
-        this.trace.snapshot("select-loser-cleanup", {
-          select_id: `select:${this.selectCounter}`,
-          arm: arm.label,
-          kind: arm.kind
-        }, this.trace.span(instruction.span));
+        this.trace.snapshot(
+          "select-loser-cleanup",
+          {
+            select_id: `select:${this.selectCounter}`,
+            arm: arm.label,
+            kind: arm.kind,
+          },
+          this.trace.span(instruction.span),
+        );
       }
     }
     if (selected.kind === "timer") {
@@ -1065,14 +1911,27 @@ class Interpreter {
     const metadata = metadataRecord(instruction.metadata);
     const rawArms = Array.isArray(metadata.arms) ? metadata.arms : [];
     if (rawArms.length === 0) {
-      this.trap("invalid_call", "select requires at least one arm", instruction.span);
+      this.trap(
+        "invalid_call",
+        "select requires at least one arm",
+        instruction.span,
+      );
     }
     return rawArms.map((raw, index) => {
       const arm = metadataRecord(raw);
       const label = typeof arm.label === "string" ? arm.label : `arm:${index}`;
       if (arm.kind === "recv") {
         const argIndex = typeof arm.arg === "number" ? arm.arg : index;
-        return { kind: "recv", label, index, channel: this.channelArg(frame, instruction.args[argIndex], instruction.span) };
+        return {
+          kind: "recv",
+          label,
+          index,
+          channel: this.channelArg(
+            frame,
+            instruction.args[argIndex],
+            instruction.span,
+          ),
+        };
       }
       if (arm.kind === "timer") {
         const afterMs = typeof arm.after_ms === "number" ? arm.after_ms : 0;
@@ -1084,7 +1943,11 @@ class Interpreter {
 
   private sleepVirtual(amountMs: number, spanRef: string | null): void {
     if (!Number.isInteger(amountMs) || amountMs < 0) {
-      this.trap("invalid_call", "virtual sleep duration must be a non-negative integer", spanRef);
+      this.trap(
+        "invalid_call",
+        "virtual sleep duration must be a non-negative integer",
+        spanRef,
+      );
     }
     this.trace.advanceVirtualClock(amountMs, this.trace.span(spanRef));
   }
@@ -1094,21 +1957,29 @@ class Interpreter {
     target: string | undefined,
     args: Operand[],
     blocks: Map<string, Frame["fn"]["blocks"][number]>,
-    span: string | null
+    span: string | null,
   ): Frame["fn"]["blocks"][number] {
     const block = target ? blocks.get(target) : undefined;
     if (!block) {
       this.trap("invalid_block", "invalid branch target", span);
     }
     for (const [index, param] of block.params.entries()) {
-      frame.locals.set(param, cloneValue(this.resolve(frame, args[index], span)));
+      frame.locals.set(
+        param,
+        cloneValue(this.resolve(frame, args[index], span)),
+      );
     }
     return block;
   }
 
   private commitOrExhaust(): void {
     if (this.trace.budgetRemaining === 0) {
-      const failure = runtimeFailure("budget_exhausted", "step budget exhausted", "budget_exhausted", null);
+      const failure = runtimeFailure(
+        "budget_exhausted",
+        "step budget exhausted",
+        "budget_exhausted",
+        null,
+      );
       this.trace.fail("budget_exhausted", "budget.exhausted", failure);
       throw new VmHalt("budget_exhausted");
     }
@@ -1122,8 +1993,14 @@ class Interpreter {
       this.trap("invalid_call", "stdlib symbol not found", instruction.span);
     }
     const profile = lookupStdlibProfile(symbol);
-    const capability = symbol.capability ? this.capabilities.get(symbol.capability) : undefined;
-    if (symbol.admission !== "allowed" || capability?.disposition === "rejected" || capability?.disposition === "reserved") {
+    const capability = symbol.capability
+      ? this.capabilities.get(symbol.capability)
+      : undefined;
+    if (
+      symbol.admission !== "allowed" ||
+      capability?.disposition === "rejected" ||
+      capability?.disposition === "reserved"
+    ) {
       this.unsupportedStdlib(symbol, profile, instruction.span);
     }
     if (!profile || profile.status !== "shim" || !profile.handler) {
@@ -1132,114 +2009,274 @@ class Interpreter {
     this.applyStdlibShim(profile.handler, frame, instruction, profile);
   }
 
-  private applyStdlibShim(handler: StdlibShimHandler, frame: Frame, instruction: Instruction, profile: StdlibProfileEntry): void {
+  private applyStdlibShim(
+    handler: StdlibShimHandler,
+    frame: Frame,
+    instruction: Instruction,
+    profile: StdlibProfileEntry,
+  ): void {
     switch (handler) {
       case "io.stdout.print":
-        this.trace.writeStdout(this.renderStdlibArgs(frame, instruction), this.trace.span(instruction.span));
+        this.trace.writeStdout(
+          this.renderStdlibArgs(frame, instruction),
+          this.trace.span(instruction.span),
+        );
         return;
       case "io.stdout.println":
-        this.trace.writeStdout(`${this.renderStdlibArgs(frame, instruction)}\n`, this.trace.span(instruction.span));
+        this.trace.writeStdout(
+          `${this.renderStdlibArgs(frame, instruction)}\n`,
+          this.trace.span(instruction.span),
+        );
         return;
       case "io.stderr.print":
-        this.trace.writeStderr(this.renderStdlibArgs(frame, instruction), this.trace.span(instruction.span));
+        this.trace.writeStderr(
+          this.renderStdlibArgs(frame, instruction),
+          this.trace.span(instruction.span),
+        );
         return;
       case "io.stderr.println":
-        this.trace.writeStderr(`${this.renderStdlibArgs(frame, instruction)}\n`, this.trace.span(instruction.span));
+        this.trace.writeStderr(
+          `${this.renderStdlibArgs(frame, instruction)}\n`,
+          this.trace.span(instruction.span),
+        );
         return;
       case "io.log":
-        this.trace.snapshot("page.log", { text: this.renderStdlibArgs(frame, instruction) }, this.trace.span(instruction.span));
+        this.trace.snapshot(
+          "page.log",
+          { text: this.renderStdlibArgs(frame, instruction) },
+          this.trace.span(instruction.span),
+        );
         return;
+      case "io.stdin.read_line": {
+        const line = this.stdin.readLine();
+        this.trace.recordReplayInput({ kind: "stdin", data: line }, false);
+        this.writeDst(frame, instruction, { kind: "string", value: line });
+        return;
+      }
       case "process.exit": {
-        const code = instruction.args.length > 1 ? this.indexArg(frame, instruction.args[1], instruction.span) : 0;
+        const code =
+          instruction.args.length > 1
+            ? this.indexArg(frame, instruction.args[1], instruction.span)
+            : 0;
         this.trace.exit(code, this.trace.span(instruction.span));
         throw new VmHalt("ok");
       }
       case "time.now":
-        this.writeDst(frame, instruction, this.i64(BigInt(this.trace.clockSnapshot().current_ms)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(BigInt(this.trace.clockSnapshot().current_ms)),
+        );
         return;
       case "time.sleep":
-        this.sleepVirtual(this.durationArg(frame, instruction.args[1], instruction.span), instruction.span);
+        this.sleepVirtual(
+          this.durationArg(frame, instruction.args[1], instruction.span),
+          instruction.span,
+        );
         return;
       case "time.deadline": {
         const now = BigInt(this.trace.clockSnapshot().current_ms);
-        const duration = BigInt(this.durationArg(frame, instruction.args[1], instruction.span));
-        this.writeDst(frame, instruction, this.checkedI64(now + duration, instruction.span));
+        const duration = BigInt(
+          this.durationArg(frame, instruction.args[1], instruction.span),
+        );
+        this.writeDst(
+          frame,
+          instruction,
+          this.checkedI64(now + duration, instruction.span),
+        );
         return;
       }
       case "fmt.to_string":
-        this.writeDst(frame, instruction, { kind: "string", value: renderStdout(this.resolve(frame, instruction.args[1], instruction.span)) });
+        this.writeDst(frame, instruction, {
+          kind: "string",
+          value: renderStdout(
+            this.resolve(frame, instruction.args[1], instruction.span),
+          ),
+        });
         return;
       case "string.len":
-        this.writeDst(frame, instruction, this.i64(BigInt([...this.stringValue(frame, instruction.args[1], instruction.span)].length)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            BigInt(
+              [
+                ...this.stringValue(
+                  frame,
+                  instruction.args[1],
+                  instruction.span,
+                ),
+              ].length,
+            ),
+          ),
+        );
         return;
       case "string.concat":
         this.writeDst(frame, instruction, {
           kind: "string",
-          value: this.stringValue(frame, instruction.args[1], instruction.span) + this.stringValue(frame, instruction.args[2], instruction.span)
+          value:
+            this.stringValue(frame, instruction.args[1], instruction.span) +
+            this.stringValue(frame, instruction.args[2], instruction.span),
         });
         return;
       case "string.slice": {
-        const value = this.stringValue(frame, instruction.args[1], instruction.span);
+        const value = this.stringValue(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        );
         const chars = [...value];
-        const start = this.indexArg(frame, instruction.args[2], instruction.span);
+        const start = this.indexArg(
+          frame,
+          instruction.args[2],
+          instruction.span,
+        );
         const end = this.indexArg(frame, instruction.args[3], instruction.span);
         if (start < 0 || end < start || end > chars.length) {
-          this.trap("string_bounds", "string slice out of bounds", instruction.span);
+          this.trap(
+            "string_bounds",
+            "string slice out of bounds",
+            instruction.span,
+          );
         }
-        this.writeDst(frame, instruction, { kind: "string", value: chars.slice(start, end).join("") });
+        this.writeDst(frame, instruction, {
+          kind: "string",
+          value: chars.slice(start, end).join(""),
+        });
         return;
       }
       case "math.abs":
-        this.writeDst(frame, instruction, this.scalarAbs(this.resolve(frame, instruction.args[1], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.scalarAbs(
+            this.resolve(frame, instruction.args[1], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "math.min":
-        this.writeDst(frame, instruction, this.scalarMinMax(frame, instruction, "min"));
+        this.writeDst(
+          frame,
+          instruction,
+          this.scalarMinMax(frame, instruction, "min"),
+        );
         return;
       case "math.max":
-        this.writeDst(frame, instruction, this.scalarMinMax(frame, instruction, "max"));
+        this.writeDst(
+          frame,
+          instruction,
+          this.scalarMinMax(frame, instruction, "max"),
+        );
         return;
       case "math.clamp":
         this.writeDst(frame, instruction, this.scalarClamp(frame, instruction));
         return;
       case "vec.len":
-        this.writeDst(frame, instruction, this.i64(BigInt(this.vectorArg(frame, instruction.args[1], instruction.span).items.length)));
+        this.writeDst(
+          frame,
+          instruction,
+          this.i64(
+            BigInt(
+              this.vectorArg(frame, instruction.args[1], instruction.span).items
+                .length,
+            ),
+          ),
+        );
         return;
       case "vec.get": {
         this.writeDst(
           frame,
           instruction,
-          this.vectorGetOption(frame, instruction, instruction.args[1], instruction.args[2])
+          this.vectorGetOption(
+            frame,
+            instruction,
+            instruction.args[1],
+            instruction.args[2],
+          ),
         );
         return;
       }
       case "vec.push":
-        this.vectorArg(frame, instruction.args[1], instruction.span).items.push(cloneValue(this.resolve(frame, instruction.args[2], instruction.span)));
+        this.vectorArg(frame, instruction.args[1], instruction.span).items.push(
+          cloneValue(
+            this.resolve(frame, instruction.args[2], instruction.span),
+          ),
+        );
         return;
       case "regex.compile":
-        this.writeDst(frame, instruction, this.compileRegex(this.stringValue(frame, instruction.args[1], instruction.span), instruction.span));
+        this.writeDst(
+          frame,
+          instruction,
+          this.compileRegex(
+            this.stringValue(frame, instruction.args[1], instruction.span),
+            instruction.span,
+          ),
+        );
         return;
       case "regex.is_match":
-        this.writeDst(frame, instruction, { kind: "bool", value: this.regexArg(frame, instruction.args[1], instruction.span).regex.test(this.stringValue(frame, instruction.args[2], instruction.span)) });
+        this.writeDst(frame, instruction, {
+          kind: "bool",
+          value: this.regexArg(
+            frame,
+            instruction.args[1],
+            instruction.span,
+          ).regex.test(
+            this.stringValue(frame, instruction.args[2], instruction.span),
+          ),
+        });
         return;
       case "regex.find": {
-        const regex = this.regexArg(frame, instruction.args[1], instruction.span).regex;
-        this.writeDst(frame, instruction, { kind: "string", value: regex.exec(this.stringValue(frame, instruction.args[2], instruction.span))?.[0] ?? "" });
+        const regex = this.regexArg(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        ).regex;
+        this.writeDst(frame, instruction, {
+          kind: "string",
+          value:
+            regex.exec(
+              this.stringValue(frame, instruction.args[2], instruction.span),
+            )?.[0] ?? "",
+        });
         return;
       }
       case "regex.replace": {
-        const regex = this.regexArg(frame, instruction.args[1], instruction.span).regex;
-        const input = this.stringValue(frame, instruction.args[2], instruction.span);
-        const replacement = this.stringValue(frame, instruction.args[3], instruction.span);
-        this.writeDst(frame, instruction, { kind: "string", value: input.replace(regex, replacement) });
+        const regex = this.regexArg(
+          frame,
+          instruction.args[1],
+          instruction.span,
+        ).regex;
+        const input = this.stringValue(
+          frame,
+          instruction.args[2],
+          instruction.span,
+        );
+        const replacement = this.stringValue(
+          frame,
+          instruction.args[3],
+          instruction.span,
+        );
+        this.writeDst(frame, instruction, {
+          kind: "string",
+          value: input.replace(regex, replacement),
+        });
         return;
       }
       default:
-        this.unsupportedStdlib({ id: profile.id, module: profile.module, name: profile.name }, profile, instruction.span);
+        this.unsupportedStdlib(
+          { id: profile.id, module: profile.module, name: profile.name },
+          profile,
+          instruction.span,
+        );
     }
   }
 
   private renderStdlibArgs(frame: Frame, instruction: Instruction): string {
-    return instruction.args.slice(1).map((arg) => renderStdout(this.resolve(frame, arg, instruction.span))).join(" ");
+    return instruction.args
+      .slice(1)
+      .map((arg) => renderStdout(this.resolve(frame, arg, instruction.span)))
+      .join(" ");
   }
 
   private scalarAbs(value: VmValue, span: string | null): VmValue {
@@ -1255,16 +2292,38 @@ class Interpreter {
     this.trap("invalid_local", "math.abs requires numeric operand", span);
   }
 
-  private scalarMinMax(frame: Frame, instruction: Instruction, mode: "min" | "max"): VmValue {
+  private scalarMinMax(
+    frame: Frame,
+    instruction: Instruction,
+    mode: "min" | "max",
+  ): VmValue {
     const left = this.resolve(frame, instruction.args[1], instruction.span);
     const right = this.resolve(frame, instruction.args[2], instruction.span);
     if (left.kind === "i64" && right.kind === "i64") {
-      return this.i64(mode === "min" ? (left.value <= right.value ? left.value : right.value) : (left.value >= right.value ? left.value : right.value));
+      return this.i64(
+        mode === "min"
+          ? left.value <= right.value
+            ? left.value
+            : right.value
+          : left.value >= right.value
+            ? left.value
+            : right.value,
+      );
     }
     if (left.kind === "f64" && right.kind === "f64") {
-      return { kind: "f64", value: mode === "min" ? Math.min(left.value, right.value) : Math.max(left.value, right.value) };
+      return {
+        kind: "f64",
+        value:
+          mode === "min"
+            ? Math.min(left.value, right.value)
+            : Math.max(left.value, right.value),
+      };
     }
-    this.trap("invalid_local", `math.${mode} requires matching numeric operands`, instruction.span);
+    this.trap(
+      "invalid_local",
+      `math.${mode} requires matching numeric operands`,
+      instruction.span,
+    );
   }
 
   private scalarClamp(frame: Frame, instruction: Instruction): VmValue {
@@ -1273,26 +2332,51 @@ class Interpreter {
     const high = this.resolve(frame, instruction.args[3], instruction.span);
     if (value.kind === "i64" && low.kind === "i64" && high.kind === "i64") {
       if (low.value > high.value) {
-        this.trap("invalid_local", "math.clamp lower bound exceeds upper bound", instruction.span);
+        this.trap(
+          "invalid_local",
+          "math.clamp lower bound exceeds upper bound",
+          instruction.span,
+        );
       }
-      return this.i64(value.value < low.value ? low.value : value.value > high.value ? high.value : value.value);
+      return this.i64(
+        value.value < low.value
+          ? low.value
+          : value.value > high.value
+            ? high.value
+            : value.value,
+      );
     }
     if (value.kind === "f64" && low.kind === "f64" && high.kind === "f64") {
       if (low.value > high.value) {
-        this.trap("invalid_local", "math.clamp lower bound exceeds upper bound", instruction.span);
+        this.trap(
+          "invalid_local",
+          "math.clamp lower bound exceeds upper bound",
+          instruction.span,
+        );
       }
-      return { kind: "f64", value: Math.min(Math.max(value.value, low.value), high.value) };
+      return {
+        kind: "f64",
+        value: Math.min(Math.max(value.value, low.value), high.value),
+      };
     }
-    this.trap("invalid_local", "math.clamp requires matching numeric operands", instruction.span);
+    this.trap(
+      "invalid_local",
+      "math.clamp requires matching numeric operands",
+      instruction.span,
+    );
   }
 
   private unsupportedStdlib(
     symbol: { id: string; module: string; name: string },
     profile: StdlibProfileEntry | undefined,
-    spanRef: string | null
+    spanRef: string | null,
   ): never {
     const diagnostic = unsupportedDiagnosticFor(symbol, profile);
-    this.unsupported(`${diagnostic.kind}: ${diagnostic.symbol}`, spanRef, diagnostic);
+    this.unsupported(
+      `${diagnostic.kind}: ${diagnostic.symbol}`,
+      spanRef,
+      diagnostic,
+    );
   }
 
   private compare(frame: Frame, instruction: Instruction): boolean {
@@ -1312,27 +2396,42 @@ class Interpreter {
         }
         return canonicalComparable(left) !== canonicalComparable(right);
       case "cmp.lt":
-        return compareScalar(this.scalarComparable(left, instruction.span), this.scalarComparable(right, instruction.span), "<", (message) =>
-          this.trap("invalid_local", message, instruction.span)
+        return compareScalar(
+          this.scalarComparable(left, instruction.span),
+          this.scalarComparable(right, instruction.span),
+          "<",
+          (message) => this.trap("invalid_local", message, instruction.span),
         );
       case "cmp.le":
-        return compareScalar(this.scalarComparable(left, instruction.span), this.scalarComparable(right, instruction.span), "<=", (message) =>
-          this.trap("invalid_local", message, instruction.span)
+        return compareScalar(
+          this.scalarComparable(left, instruction.span),
+          this.scalarComparable(right, instruction.span),
+          "<=",
+          (message) => this.trap("invalid_local", message, instruction.span),
         );
       case "cmp.gt":
-        return compareScalar(this.scalarComparable(left, instruction.span), this.scalarComparable(right, instruction.span), ">", (message) =>
-          this.trap("invalid_local", message, instruction.span)
+        return compareScalar(
+          this.scalarComparable(left, instruction.span),
+          this.scalarComparable(right, instruction.span),
+          ">",
+          (message) => this.trap("invalid_local", message, instruction.span),
         );
       case "cmp.ge":
-        return compareScalar(this.scalarComparable(left, instruction.span), this.scalarComparable(right, instruction.span), ">=", (message) =>
-          this.trap("invalid_local", message, instruction.span)
+        return compareScalar(
+          this.scalarComparable(left, instruction.span),
+          this.scalarComparable(right, instruction.span),
+          ">=",
+          (message) => this.trap("invalid_local", message, instruction.span),
         );
       default:
         return false;
     }
   }
 
-  private scalarComparable(value: VmValue, span: string | null): ScalarComparable {
+  private scalarComparable(
+    value: VmValue,
+    span: string | null,
+  ): ScalarComparable {
     if (value.kind === "i64") {
       return { kind: "i64", value: value.value };
     }
@@ -1348,15 +2447,25 @@ class Interpreter {
   private recordGet(frame: Frame, instruction: Instruction): VmValue {
     const record = this.resolve(frame, instruction.args[0], instruction.span);
     if (record.kind !== "record") {
-      this.trap("invalid_record_field", "invalid record value", instruction.span);
+      this.trap(
+        "invalid_record_field",
+        "invalid record value",
+        instruction.span,
+      );
     }
     const field = instruction.args[1]?.value;
     const index =
       typeof field === "number"
         ? field
-        : this.records.get(record.typeId)?.fields.find((layout) => layout.name === field)?.index ?? -1;
+        : (this.records
+            .get(record.typeId)
+            ?.fields.find((layout) => layout.name === field)?.index ?? -1);
     if (index < 0 || index >= record.fields.length) {
-      this.trap("invalid_record_field", "invalid record field", instruction.span);
+      this.trap(
+        "invalid_record_field",
+        "invalid record field",
+        instruction.span,
+      );
     }
     return cloneValue(record.fields[index]!);
   }
@@ -1385,19 +2494,32 @@ class Interpreter {
   private optionResultLayoutForDst(
     frame: Frame,
     instruction: Instruction,
-    expectedName: "Option" | "Result"
+    expectedName: "Option" | "Result",
   ): { id: string; someOkTag: number; noneErrTag: number } {
     const local = instruction.dst
       ? frame.fn.locals.find((candidate) => candidate.id === instruction.dst)
       : undefined;
     const layout = local ? this.enums.get(local.type) : undefined;
     if (!layout || layout.name !== expectedName) {
-      this.trap("invalid_enum_tag", `${instruction.op} requires a ${expectedName} destination`, instruction.span);
+      this.trap(
+        "invalid_enum_tag",
+        `${instruction.op} requires a ${expectedName} destination`,
+        instruction.span,
+      );
     }
-    const someOk = layout.variants.find((variant) => variant.name === (expectedName === "Option" ? "Some" : "Ok"));
-    const noneErr = layout.variants.find((variant) => variant.name === (expectedName === "Option" ? "None" : "Err"));
+    const someOk = layout.variants.find(
+      (variant) => variant.name === (expectedName === "Option" ? "Some" : "Ok"),
+    );
+    const noneErr = layout.variants.find(
+      (variant) =>
+        variant.name === (expectedName === "Option" ? "None" : "Err"),
+    );
     if (!someOk || !noneErr) {
-      this.trap("invalid_enum_tag", `${expectedName} layout is missing required variants`, instruction.span);
+      this.trap(
+        "invalid_enum_tag",
+        `${expectedName} layout is missing required variants`,
+        instruction.span,
+      );
     }
     return { id: layout.id, someOkTag: someOk.tag, noneErrTag: noneErr.tag };
   }
@@ -1406,7 +2528,7 @@ class Interpreter {
     frame: Frame,
     instruction: Instruction,
     vectorOperand: Operand | undefined,
-    indexOperand: Operand | undefined
+    indexOperand: Operand | undefined,
   ): VmValue {
     const vector = this.vectorArg(frame, vectorOperand, instruction.span);
     const index = this.indexArg(frame, indexOperand, instruction.span);
@@ -1416,14 +2538,14 @@ class Interpreter {
         kind: "enum",
         typeId: option.id,
         tag: option.noneErrTag,
-        payload: []
+        payload: [],
       };
     }
     return {
       kind: "enum",
       typeId: option.id,
       tag: option.someOkTag,
-      payload: [cloneValue(vector.items[index]!)]
+      payload: [cloneValue(vector.items[index]!)],
     };
   }
 
@@ -1435,20 +2557,35 @@ class Interpreter {
     }
     const state = this.messageName(instruction.args[1], instruction.span);
     if (!layout.states.includes(state)) {
-      this.trap("invalid_call", `machine ${layout.name} has no state ${state}`, instruction.span);
+      this.trap(
+        "invalid_call",
+        `machine ${layout.name} has no state ${state}`,
+        instruction.span,
+      );
     }
-    return { kind: "record", typeId: layoutId, fields: [{ kind: "string", value: state }] };
+    return {
+      kind: "record",
+      typeId: layoutId,
+      fields: [{ kind: "string", value: state }],
+    };
   }
 
   private machineState(frame: Frame, instruction: Instruction): VmValue {
     const machine = this.resolve(frame, instruction.args[0], instruction.span);
-    return { kind: "string", value: this.machineCurrentState(machine, instruction.span) };
+    return {
+      kind: "string",
+      value: this.machineCurrentState(machine, instruction.span),
+    };
   }
 
   private machineStep(frame: Frame, instruction: Instruction): VmValue {
     const machine = this.resolve(frame, instruction.args[0], instruction.span);
     if (machine.kind !== "record") {
-      this.trap("invalid_local", "machine.step requires a machine value", instruction.span);
+      this.trap(
+        "invalid_local",
+        "machine.step requires a machine value",
+        instruction.span,
+      );
     }
     const current = this.machineCurrentState(machine, instruction.span);
     const event = this.messageName(instruction.args[1], instruction.span);
@@ -1456,17 +2593,31 @@ class Interpreter {
     if (!layout) {
       this.trap("invalid_call", "machine layout not found", instruction.span);
     }
-    const transition = layout.transitions.find((candidate) => candidate.from === current && candidate.event === event);
+    const transition = layout.transitions.find(
+      (candidate) => candidate.from === current && candidate.event === event,
+    );
     if (!transition) {
-      this.trap("invalid_call", `machine ${layout.name} has no transition for ${event} in state ${current}`, instruction.span);
+      this.trap(
+        "invalid_call",
+        `machine ${layout.name} has no transition for ${event} in state ${current}`,
+        instruction.span,
+      );
     }
-    this.trace.snapshot("machine.step", {
-      machine: layout.id,
-      event,
-      from: current,
-      to: transition.to
-    }, this.trace.span(instruction.span));
-    return { kind: "record", typeId: machine.typeId, fields: [{ kind: "string", value: transition.to }] };
+    this.trace.snapshot(
+      "machine.step",
+      {
+        machine: layout.id,
+        event,
+        from: current,
+        to: transition.to,
+      },
+      this.trace.span(instruction.span),
+    );
+    return {
+      kind: "record",
+      typeId: machine.typeId,
+      fields: [{ kind: "string", value: transition.to }],
+    };
   }
 
   private machineCurrentState(machine: VmValue, span: string | null): string {
@@ -1476,7 +2627,12 @@ class Interpreter {
     return machine.fields[0].value;
   }
 
-  private checkedDiv(frame: Frame, left: Operand | undefined, right: Operand | undefined, span: string | null): bigint {
+  private checkedDiv(
+    frame: Frame,
+    left: Operand | undefined,
+    right: Operand | undefined,
+    span: string | null,
+  ): bigint {
     const lhs = this.i64Arg(frame, left, span);
     const rhs = this.i64Arg(frame, right, span);
     if (rhs === 0n) {
@@ -1488,7 +2644,12 @@ class Interpreter {
     return lhs / rhs;
   }
 
-  private checkedRem(frame: Frame, left: Operand | undefined, right: Operand | undefined, span: string | null): bigint {
+  private checkedRem(
+    frame: Frame,
+    left: Operand | undefined,
+    right: Operand | undefined,
+    span: string | null,
+  ): bigint {
     const lhs = this.i64Arg(frame, left, span);
     const rhs = this.i64Arg(frame, right, span);
     if (rhs === 0n) {
@@ -1505,7 +2666,11 @@ class Interpreter {
     }
   }
 
-  private resolve(frame: Frame, operand: Operand | undefined, span: string | null): VmValue {
+  private resolve(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): VmValue {
     if (!operand) {
       this.trap("invalid_local", "missing operand", span);
     }
@@ -1520,7 +2685,11 @@ class Interpreter {
     }
   }
 
-  private readLocal(frame: Frame, localId: string, span: string | null): VmValue {
+  private readLocal(
+    frame: Frame,
+    localId: string,
+    span: string | null,
+  ): VmValue {
     const value = frame.locals.get(localId);
     if (!value) {
       this.trap("invalid_local", `invalid local ${localId}`, span);
@@ -1528,7 +2697,11 @@ class Interpreter {
     return value;
   }
 
-  private writeDst(frame: Frame, instruction: Instruction, value: VmValue): void {
+  private writeDst(
+    frame: Frame,
+    instruction: Instruction,
+    value: VmValue,
+  ): void {
     if (instruction.dst !== null) {
       frame.locals.set(instruction.dst, value);
     }
@@ -1559,36 +2732,62 @@ class Interpreter {
 
   private numericCast(frame: Frame, instruction: Instruction): VmValue {
     const value = this.resolve(frame, instruction.args[0], instruction.span);
-    const from = this.numericCastType(this.stringOperand(instruction.args[1], instruction.span), instruction.span);
-    const to = this.numericCastType(this.stringOperand(instruction.args[2], instruction.span), instruction.span);
+    const from = this.numericCastType(
+      this.stringOperand(instruction.args[1], instruction.span),
+      instruction.span,
+    );
+    const to = this.numericCastType(
+      this.stringOperand(instruction.args[2], instruction.span),
+      instruction.span,
+    );
 
     let integerValue: bigint | null = null;
     let floatValue: number | null = null;
     if (from.kind === "integer") {
       if (value.kind !== "i64") {
-        this.trap("invalid_local", "numeric.cast integer source is not an integer", instruction.span);
+        this.trap(
+          "invalid_local",
+          "numeric.cast integer source is not an integer",
+          instruction.span,
+        );
       }
       integerValue = this.normalizeInteger(value.value, from);
     } else if (from.kind === "float") {
       if (value.kind !== "f64") {
-        this.trap("invalid_local", "numeric.cast float source is not a float", instruction.span);
+        this.trap(
+          "invalid_local",
+          "numeric.cast float source is not a float",
+          instruction.span,
+        );
       }
       floatValue = from.bits === 32 ? Math.fround(value.value) : value.value;
     } else if (from.kind === "bool") {
       if (value.kind !== "bool") {
-        this.trap("invalid_local", "numeric.cast bool source is not a bool", instruction.span);
+        this.trap(
+          "invalid_local",
+          "numeric.cast bool source is not a bool",
+          instruction.span,
+        );
       }
       integerValue = value.value ? 1n : 0n;
     } else {
       if (value.kind !== "string" || [...value.value].length !== 1) {
-        this.trap("invalid_local", "numeric.cast char source is not one Unicode scalar", instruction.span);
+        this.trap(
+          "invalid_local",
+          "numeric.cast char source is not one Unicode scalar",
+          instruction.span,
+        );
       }
       integerValue = BigInt(value.value.codePointAt(0)!);
     }
 
     if (to.kind === "bool") {
       if (integerValue === null || from.kind !== "integer") {
-        this.trap("invalid_local", "numeric.cast to bool requires an integer source", instruction.span);
+        this.trap(
+          "invalid_local",
+          "numeric.cast to bool requires an integer source",
+          instruction.span,
+        );
       }
       return { kind: "bool", value: integerValue !== 0n };
     }
@@ -1599,16 +2798,28 @@ class Interpreter {
       if (floatValue !== null) {
         return this.i64(this.saturatingFloatToInteger(floatValue, to));
       }
-      this.trap("invalid_local", "numeric.cast has no numeric source value", instruction.span);
+      this.trap(
+        "invalid_local",
+        "numeric.cast has no numeric source value",
+        instruction.span,
+      );
     }
     if (to.kind === "float") {
       const number = integerValue !== null ? Number(integerValue) : floatValue;
       if (number === null) {
-        this.trap("invalid_local", "numeric.cast has no numeric source value", instruction.span);
+        this.trap(
+          "invalid_local",
+          "numeric.cast has no numeric source value",
+          instruction.span,
+        );
       }
       return this.f64(to.bits === 32 ? Math.fround(number) : number);
     }
-    this.trap("invalid_local", "numeric.cast cannot target char", instruction.span);
+    this.trap(
+      "invalid_local",
+      "numeric.cast cannot target char",
+      instruction.span,
+    );
   }
 
   private numericCastType(name: string, span: string | null): NumericCastType {
@@ -1643,12 +2854,18 @@ class Interpreter {
       case "char":
         return { kind: "char" };
       default:
-        this.trap("invalid_local", `numeric.cast has unknown type ${name}`, span);
+        this.trap(
+          "invalid_local",
+          `numeric.cast has unknown type ${name}`,
+          span,
+        );
     }
   }
 
   private normalizeInteger(value: bigint, ty: IntegerCastType): bigint {
-    return ty.signed ? BigInt.asIntN(ty.bits, value) : BigInt.asUintN(ty.bits, value);
+    return ty.signed
+      ? BigInt.asIntN(ty.bits, value)
+      : BigInt.asUintN(ty.bits, value);
   }
 
   private saturatingFloatToInteger(value: number, ty: IntegerCastType): bigint {
@@ -1668,7 +2885,11 @@ class Interpreter {
     return BigInt(Math.trunc(value));
   }
 
-  private capacityArg(frame: Frame, operand: Operand | undefined, span: string | null): number {
+  private capacityArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): number {
     if (!operand) {
       return 1;
     }
@@ -1678,14 +2899,21 @@ class Interpreter {
     return this.indexArg(frame, operand, span);
   }
 
-  private durationArg(frame: Frame, operand: Operand | undefined, span: string | null): number {
+  private durationArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): number {
     if (typeof operand?.value === "number" && Number.isInteger(operand.value)) {
       return operand.value;
     }
     return this.indexArg(frame, operand, span);
   }
 
-  private functionOperand(operand: Operand | undefined, span: string | null): string {
+  private functionOperand(
+    operand: Operand | undefined,
+    span: string | null,
+  ): string {
     const value = this.stringOperand(operand, span);
     if (!value.startsWith("fn:")) {
       this.trap("invalid_call", "expected function operand", span);
@@ -1700,14 +2928,21 @@ class Interpreter {
     return operand.value;
   }
 
-  private stringOperand(operand: Operand | undefined, span: string | null): string {
+  private stringOperand(
+    operand: Operand | undefined,
+    span: string | null,
+  ): string {
     if (typeof operand?.value !== "string") {
       this.trap("invalid_local", "expected string operand", span);
     }
     return operand.value;
   }
 
-  private stringValue(frame: Frame, operand: Operand | undefined, span: string | null): string {
+  private stringValue(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): string {
     const value = this.resolve(frame, operand, span);
     if (value.kind === "string") {
       return value.value;
@@ -1715,7 +2950,11 @@ class Interpreter {
     return renderStdout(value);
   }
 
-  private i64Arg(frame: Frame, operand: Operand | undefined, span: string | null): bigint {
+  private i64Arg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): bigint {
     const value = this.resolve(frame, operand, span);
     if (value.kind !== "i64") {
       this.trap("invalid_local", "expected i64 operand", span);
@@ -1723,7 +2962,11 @@ class Interpreter {
     return value.value;
   }
 
-  private f64Arg(frame: Frame, operand: Operand | undefined, span: string | null): number {
+  private f64Arg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): number {
     const value = this.resolve(frame, operand, span);
     if (value.kind !== "f64") {
       this.trap("invalid_local", "expected f64 operand", span);
@@ -1731,19 +2974,34 @@ class Interpreter {
     return value.value;
   }
 
-  private f32Arg(frame: Frame, operand: Operand | undefined, span: string | null): number {
+  private f32Arg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): number {
     return Math.fround(this.f64Arg(frame, operand, span));
   }
 
-  private indexArg(frame: Frame, operand: Operand | undefined, span: string | null): number {
+  private indexArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): number {
     const value = this.i64Arg(frame, operand, span);
-    if (value < BigInt(Number.MIN_SAFE_INTEGER) || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    if (
+      value < BigInt(Number.MIN_SAFE_INTEGER) ||
+      value > BigInt(Number.MAX_SAFE_INTEGER)
+    ) {
       this.trap("invalid_local", "index is outside sandbox safe range", span);
     }
     return Number(value);
   }
 
-  private vectorArg(frame: Frame, operand: Operand | undefined, span: string | null): Extract<VmValue, { kind: "vector" }> {
+  private vectorArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): Extract<VmValue, { kind: "vector" }> {
     const value = this.resolve(frame, operand, span);
     if (value.kind !== "vector") {
       this.trap("invalid_local", "expected vector operand", span);
@@ -1751,7 +3009,11 @@ class Interpreter {
     return value;
   }
 
-  private channelArg(frame: Frame, operand: Operand | undefined, span: string | null): ChannelCell {
+  private channelArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): ChannelCell {
     const value = this.resolve(frame, operand, span);
     if (value.kind !== "channel") {
       this.trap("invalid_local", "expected channel operand", span);
@@ -1763,7 +3025,11 @@ class Interpreter {
     return channel;
   }
 
-  private taskArg(frame: Frame, operand: Operand | undefined, span: string | null): TaskCell {
+  private taskArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): TaskCell {
     const value = this.resolve(frame, operand, span);
     if (value.kind !== "task") {
       this.trap("invalid_local", "expected task operand", span);
@@ -1775,43 +3041,75 @@ class Interpreter {
     return task;
   }
 
-  private streamChannelArg(frame: Frame, operand: Operand | undefined, span: string | null): ChannelCell {
+  private streamChannelArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): ChannelCell {
     const value = this.resolve(frame, operand, span);
-    if (value.kind !== "stream" && value.kind !== "sink" && value.kind !== "duplex") {
+    if (
+      value.kind !== "stream" &&
+      value.kind !== "sink" &&
+      value.kind !== "duplex"
+    ) {
       this.trap("invalid_local", "expected stream operand", span);
     }
     const channel = this.channels.get(value.channelId);
     if (!channel) {
-      this.trap("invalid_call", `stream channel ${value.channelId} not found`, span);
+      this.trap(
+        "invalid_call",
+        `stream channel ${value.channelId} not found`,
+        span,
+      );
     }
     return channel;
   }
 
-  private streamReadableArg(frame: Frame, operand: Operand | undefined, span: string | null): ChannelCell {
+  private streamReadableArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): ChannelCell {
     const value = this.resolve(frame, operand, span);
     if (value.kind !== "stream" && value.kind !== "duplex") {
       this.trap("invalid_local", "expected readable stream operand", span);
     }
     const channel = this.channels.get(value.channelId);
     if (!channel) {
-      this.trap("invalid_call", `stream channel ${value.channelId} not found`, span);
+      this.trap(
+        "invalid_call",
+        `stream channel ${value.channelId} not found`,
+        span,
+      );
     }
     return channel;
   }
 
-  private streamWritableArg(frame: Frame, operand: Operand | undefined, span: string | null): ChannelCell {
+  private streamWritableArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): ChannelCell {
     const value = this.resolve(frame, operand, span);
     if (value.kind !== "sink" && value.kind !== "duplex") {
       this.trap("invalid_local", "expected writable stream operand", span);
     }
     const channel = this.channels.get(value.channelId);
     if (!channel) {
-      this.trap("invalid_call", `stream channel ${value.channelId} not found`, span);
+      this.trap(
+        "invalid_call",
+        `stream channel ${value.channelId} not found`,
+        span,
+      );
     }
     return channel;
   }
 
-  private regexArg(frame: Frame, operand: Operand | undefined, span: string | null): Extract<VmValue, { kind: "regex" }> {
+  private regexArg(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): Extract<VmValue, { kind: "regex" }> {
     const value = this.resolve(frame, operand, span);
     if (value.kind !== "regex") {
       this.trap("invalid_local", "expected regex operand", span);
@@ -1823,7 +3121,10 @@ class Interpreter {
     if (typeof operand?.value === "number" && Number.isInteger(operand.value)) {
       return BigInt(operand.value);
     }
-    if (typeof operand?.value === "string" && /^-?[0-9]+$/.test(operand.value)) {
+    if (
+      typeof operand?.value === "string" &&
+      /^-?[0-9]+$/.test(operand.value)
+    ) {
       return BigInt(operand.value);
     }
     this.trap("invalid_local", "expected i64 literal operand", span);
@@ -1848,7 +3149,11 @@ class Interpreter {
     return this.i64(value);
   }
 
-  private shiftCount(frame: Frame, operand: Operand | undefined, span: string | null): bigint {
+  private shiftCount(
+    frame: Frame,
+    operand: Operand | undefined,
+    span: string | null,
+  ): bigint {
     const value = this.i64Arg(frame, operand, span);
     if (value < 0n || value >= 64n) {
       this.trap("shift_out_of_range", "shift out of range", span);
@@ -1856,37 +3161,60 @@ class Interpreter {
     return value;
   }
 
-  private trapKind(operand: Operand | undefined, span: string | null): TrapKind {
+  private trapKind(
+    operand: Operand | undefined,
+    span: string | null,
+  ): TrapKind {
     const value = this.stringOperand(operand, span);
     return value as TrapKind;
   }
 
-  private messageName(operand: Operand | undefined, span: string | null): string {
+  private messageName(
+    operand: Operand | undefined,
+    span: string | null,
+  ): string {
     const value = this.stringOperand(operand, span);
     return value.startsWith("sym:") ? value.slice("sym:".length) : value;
   }
 
-  private actorPair(frame: Frame, instruction: Instruction): [VmValue, VmValue] {
+  private actorPair(
+    frame: Frame,
+    instruction: Instruction,
+  ): [VmValue, VmValue] {
     if (instruction.args.length === 1) {
       const active = this.scheduler.activeActor;
       if (!active) {
-        this.trap("invalid_call", `${instruction.op} with one actor operand requires an active actor`, instruction.span);
+        this.trap(
+          "invalid_call",
+          `${instruction.op} with one actor operand requires an active actor`,
+          instruction.span,
+        );
       }
-      return [{ kind: "actor", id: active }, this.resolve(frame, instruction.args[0], instruction.span)];
+      return [
+        { kind: "actor", id: active },
+        this.resolve(frame, instruction.args[0], instruction.span),
+      ];
     }
     return [
       this.resolve(frame, instruction.args[0], instruction.span),
-      this.resolve(frame, instruction.args[1], instruction.span)
+      this.resolve(frame, instruction.args[1], instruction.span),
     ];
   }
 
   private assertSupervisorOpAllowed(instruction: Instruction): void {
     if (this.scheduler.activeLifecycleHook !== null) {
-      this.trap("invalid_call", `M6_SUPERVISOR_HOOK_DENIED: ${instruction.op} cannot run from ${this.scheduler.activeLifecycleHook}`, instruction.span);
+      this.trap(
+        "invalid_call",
+        `M6_SUPERVISOR_HOOK_DENIED: ${instruction.op} cannot run from ${this.scheduler.activeLifecycleHook}`,
+        instruction.span,
+      );
     }
   }
 
-  private withSchedulerError<T>(instruction: Instruction, callback: () => T): T {
+  private withSchedulerError<T>(
+    instruction: Instruction,
+    callback: () => T,
+  ): T {
     try {
       return callback();
     } catch (error) {
@@ -1897,20 +3225,37 @@ class Interpreter {
     }
   }
 
-  private raiseSchedulerError(error: SchedulerRuntimeError, spanRef: string | null): never {
+  private raiseSchedulerError(
+    error: SchedulerRuntimeError,
+    spanRef: string | null,
+  ): never {
     if (error.kind === "unsupported") {
       this.unsupported(error.message, spanRef);
     }
     this.trap(error.trapKind, error.message, spanRef);
   }
 
-  private trap(trapKind: TrapKind, message: string, spanRef: string | null): never {
+  private trap(
+    trapKind: TrapKind,
+    message: string,
+    spanRef: string | null,
+  ): never {
     const status: RuntimeStatus = trapKind === "panic" ? "panic" : "trap";
     this.fail(status, trapKind, message, spanRef);
   }
 
-  private unsupported(message: string, spanRef: string | null, unsupported?: UnsupportedStdlibDiagnostic): never {
-    const failure = runtimeFailure("unsupported", message, "unsupported_instruction", this.trace.span(spanRef), unsupported);
+  private unsupported(
+    message: string,
+    spanRef: string | null,
+    unsupported?: UnsupportedStdlibDiagnostic,
+  ): never {
+    const failure = runtimeFailure(
+      "unsupported",
+      message,
+      "unsupported_instruction",
+      this.trace.span(spanRef),
+      unsupported,
+    );
     // When executing inside an actor turn, route through ActorTurnCrash so that
     // the supervisor can catch and restart the actor, rather than halting the whole VM.
     if (this.scheduler.activeActor !== null) {
@@ -1920,9 +3265,19 @@ class Interpreter {
     throw new VmHalt("runtime_failure");
   }
 
-  private fail(status: RuntimeStatus, trapKind: TrapKind, message: string, spanRef: string | null): never {
+  private fail(
+    status: RuntimeStatus,
+    trapKind: TrapKind,
+    message: string,
+    spanRef: string | null,
+  ): never {
     const kind = status === "panic" ? "panic" : "trap";
-    const failure = runtimeFailure(kind, message, trapKind, this.trace.span(spanRef));
+    const failure = runtimeFailure(
+      kind,
+      message,
+      trapKind,
+      this.trace.span(spanRef),
+    );
     if (this.scheduler.activeActor !== null) {
       throw new ActorTurnCrash(failure);
     }
@@ -1936,11 +3291,20 @@ function fixtureIdFromPackage(bytecode: SandboxBytecodePackage): string {
 }
 
 function hasMetadataFlag(instruction: Instruction, key: string): boolean {
-  return typeof instruction.metadata === "object" && instruction.metadata !== null && !Array.isArray(instruction.metadata) && instruction.metadata[key] === true;
+  return (
+    typeof instruction.metadata === "object" &&
+    instruction.metadata !== null &&
+    !Array.isArray(instruction.metadata) &&
+    instruction.metadata[key] === true
+  );
 }
 
-function metadataRecord(value: JsonValue | undefined): Record<string, JsonValue> {
-  return typeof value === "object" && value !== null && !Array.isArray(value) ? value : {};
+function metadataRecord(
+  value: JsonValue | undefined,
+): Record<string, JsonValue> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value
+    : {};
 }
 
 function toTraceValue(value: VmValue): JsonValue {
@@ -1951,7 +3315,10 @@ function selectTieIndex(seed: number, counter: number, length: number): number {
   if (length <= 0) {
     throw new RangeError("length must be positive");
   }
-  let state = BigInt.asUintN(64, BigInt(seed) ^ (BigInt(counter) * 0x9e3779b97f4a7c15n));
+  let state = BigInt.asUintN(
+    64,
+    BigInt(seed) ^ (BigInt(counter) * 0x9e3779b97f4a7c15n),
+  );
   state = BigInt.asUintN(64, (state ^ (state >> 30n)) * 0xbf58476d1ce4e5b9n);
   state = BigInt.asUintN(64, (state ^ (state >> 27n)) * 0x94d049bb133111ebn);
   state = state ^ (state >> 31n);
@@ -2016,7 +3383,11 @@ function renderComparable(value: VmValue): JsonValue {
     case "record":
       return { type: value.typeId, fields: value.fields.map(renderComparable) };
     case "enum":
-      return { type: value.typeId, tag: value.tag, payload: value.payload.map(renderComparable) };
+      return {
+        type: value.typeId,
+        tag: value.tag,
+        payload: value.payload.map(renderComparable),
+      };
     case "vector":
       return value.items.map(renderComparable);
     case "function":
@@ -2024,9 +3395,16 @@ function renderComparable(value: VmValue): JsonValue {
   }
 }
 
-function compareScalar(left: ScalarComparable, right: ScalarComparable, op: "<" | "<=" | ">" | ">=", trapMixed: (message: string) => never): boolean {
+function compareScalar(
+  left: ScalarComparable,
+  right: ScalarComparable,
+  op: "<" | "<=" | ">" | ">=",
+  trapMixed: (message: string) => never,
+): boolean {
   if (left.kind !== right.kind) {
-    trapMixed(`mixed scalar comparison requires matching operand types (${left.kind} vs ${right.kind})`);
+    trapMixed(
+      `mixed scalar comparison requires matching operand types (${left.kind} vs ${right.kind})`,
+    );
   }
   if (left.kind === "string" && right.kind === "string") {
     switch (op) {
@@ -2067,39 +3445,77 @@ function compareScalar(left: ScalarComparable, right: ScalarComparable, op: "<" 
 }
 
 function actorLayout(value: unknown): ActorLayout {
-  if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    typeof value.name !== "string"
+  ) {
     throw new Error("invalid actor layout");
   }
   const stateFields = Array.isArray(value.state_fields)
     ? value.state_fields.map((field, index) => {
-        if (!isRecord(field) || typeof field.name !== "string" || typeof field.type !== "string") {
+        if (
+          !isRecord(field) ||
+          typeof field.name !== "string" ||
+          typeof field.type !== "string"
+        ) {
           throw new Error("invalid actor state field layout");
         }
-        return { name: field.name, type: field.type, index: typeof field.index === "number" ? field.index : index };
+        return {
+          name: field.name,
+          type: field.type,
+          index: typeof field.index === "number" ? field.index : index,
+        };
       })
     : [];
   const handlers = Array.isArray(value.handlers)
     ? value.handlers.map((handler) => {
-        if (!isRecord(handler) || typeof handler.name !== "string" || typeof handler.function !== "string") {
+        if (
+          !isRecord(handler) ||
+          typeof handler.name !== "string" ||
+          typeof handler.function !== "string"
+        ) {
           throw new Error("invalid actor handler layout");
         }
         return { name: handler.name, function: handler.function };
       })
     : [];
-  const maxMailbox = typeof value.max_mailbox === "number" ? value.max_mailbox : undefined;
-  const maxHeap = typeof value.max_heap === "number" ? value.max_heap : undefined;
-  return { id: value.id, name: value.name, state_fields: stateFields, handlers, max_mailbox: maxMailbox, max_heap: maxHeap };
+  const maxMailbox =
+    typeof value.max_mailbox === "number" ? value.max_mailbox : undefined;
+  const maxHeap =
+    typeof value.max_heap === "number" ? value.max_heap : undefined;
+  return {
+    id: value.id,
+    name: value.name,
+    state_fields: stateFields,
+    handlers,
+    max_mailbox: maxMailbox,
+    max_heap: maxHeap,
+  };
 }
 
 function machineLayout(value: unknown): MachineLayout {
-  if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    typeof value.name !== "string"
+  ) {
     throw new Error("invalid machine layout");
   }
-  const states = Array.isArray(value.states) ? value.states.filter((state): state is string => typeof state === "string") : [];
-  const events = Array.isArray(value.events) ? value.events.filter((event): event is string => typeof event === "string") : [];
+  const states = Array.isArray(value.states)
+    ? value.states.filter((state): state is string => typeof state === "string")
+    : [];
+  const events = Array.isArray(value.events)
+    ? value.events.filter((event): event is string => typeof event === "string")
+    : [];
   const transitions = Array.isArray(value.transitions)
     ? value.transitions.map((raw) => {
-        if (!isRecord(raw) || typeof raw.event !== "string" || typeof raw.from !== "string" || typeof raw.to !== "string") {
+        if (
+          !isRecord(raw) ||
+          typeof raw.event !== "string" ||
+          typeof raw.from !== "string" ||
+          typeof raw.to !== "string"
+        ) {
           throw new Error("invalid machine transition");
         }
         return { event: raw.event, from: raw.from, to: raw.to };
@@ -2109,10 +3525,16 @@ function machineLayout(value: unknown): MachineLayout {
 }
 
 function supervisorLayout(value: unknown): SupervisorLayout {
-  if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    typeof value.name !== "string"
+  ) {
     throw new Error("invalid supervisor layout");
   }
-  const strategy = supervisorStrategy(typeof value.strategy === "string" ? value.strategy : "one_for_one");
+  const strategy = supervisorStrategy(
+    typeof value.strategy === "string" ? value.strategy : "one_for_one",
+  );
   const restartIntensity =
     typeof value.restart_intensity === "number"
       ? value.restart_intensity
@@ -2134,7 +3556,12 @@ function supervisorLayout(value: unknown): SupervisorLayout {
       : [];
   const children = rawChildren.map((raw, index) => {
     if (typeof raw === "string") {
-      return { id: `child:${index}`, restart: "permanent" as const, actorLayoutId: raw, initialState: [] };
+      return {
+        id: `child:${index}`,
+        restart: "permanent" as const,
+        actorLayoutId: raw,
+        initialState: [],
+      };
     }
     if (!isRecord(raw)) {
       throw new Error("invalid supervisor child spec");
@@ -2158,9 +3585,11 @@ function supervisorLayout(value: unknown): SupervisorLayout {
         : [];
     return {
       id: typeof raw.id === "string" ? raw.id : `child:${index}`,
-      restart: childRestartClass(typeof raw.restart === "string" ? raw.restart : "permanent"),
+      restart: childRestartClass(
+        typeof raw.restart === "string" ? raw.restart : "permanent",
+      ),
       actorLayoutId,
-      initialState: args.map(valueFromLiteral)
+      initialState: args.map(valueFromLiteral),
     };
   });
   return {
@@ -2169,7 +3598,7 @@ function supervisorLayout(value: unknown): SupervisorLayout {
     strategy,
     restartIntensity: layoutNonNegativeInt(restartIntensity),
     restartWindowMs: layoutNonNegativeInt(restartWindowMs),
-    children
+    children,
   };
 }
 

--- a/hew-sandbox-vm/src/interpreter/run-program.ts
+++ b/hew-sandbox-vm/src/interpreter/run-program.ts
@@ -1,13 +1,15 @@
 import { runBytecode } from "./interpreter.js";
-import type { Instruction, JsonValue, Operand, SandboxBytecodePackage, SandboxTrace, TrapKind } from "./types.js";
+import type {
+  Instruction,
+  JsonValue,
+  SandboxBytecodePackage,
+  SandboxTrace,
+  TrapKind,
+} from "./types.js";
 
 const SANDBOX_PROFILE = "sandbox-vm-export";
-const STDIN_READ_LINE_HELPER = "fn:__hew_sandbox_stdin_read_line";
-const STDIN_READ_LINE_SYMBOL = "sym:core.stdin.read_line";
 const PROCESS_EXIT_SYMBOL = "sym:core.exit";
 const PROCESS_EXIT_CAPABILITY = "core.exit";
-const LINE_FEED = 0x0a;
-const CARRIAGE_RETURN = 0x0d;
 
 export interface Diagnostic {
   severity: string;
@@ -28,7 +30,10 @@ interface CompileOutput {
   bytecode: SandboxBytecodePackage | null;
 }
 
-type SandboxCompiler = (source: string, profile?: string) => string | CompileOutput;
+type SandboxCompiler = (
+  source: string,
+  profile?: string,
+) => string | CompileOutput;
 
 declare global {
   var __hewSandboxCompileToSandboxBytecode: SandboxCompiler | undefined;
@@ -37,49 +42,61 @@ declare global {
 
 export function runProgram(source: string, stdin: string): RunProgramResult {
   const compileOutput = compileSource(source);
-  if (hasErrorDiagnostics(compileOutput.diagnostics) || compileOutput.bytecode === null) {
+  if (
+    hasErrorDiagnostics(compileOutput.diagnostics) ||
+    compileOutput.bytecode === null
+  ) {
     return {
       stdout: "",
       exit_code: SandboxExitCode.CompileError,
-      diagnostics: compileOutput.diagnostics
+      diagnostics: compileOutput.diagnostics,
     };
   }
 
-  const bytecode = withPageStdin(compileOutput.bytecode, stdin);
+  // stdin travels as a replay input and is read line by line at run time by
+  // the `io.stdin.read_line` shim, so a loop sees successive lines.
+  const bytecode = withPageExit(compileOutput.bytecode);
   const trace = runBytecode(bytecode, {
     fixtureId: "page-run",
-    traceId: "trace:page-run"
+    traceId: "trace:page-run",
+    replay: { inputs: [{ kind: "stdin", data: stdin }] },
   });
 
   return {
     stdout: trace.final_state.stdout.join(""),
     exit_code: exitCodeForTrace(trace),
-    diagnostics: [...compileOutput.diagnostics, ...runtimeDiagnostics(trace)]
+    diagnostics: [...compileOutput.diagnostics, ...runtimeDiagnostics(trace)],
   };
 }
 
 function compileSource(source: string): CompileOutput {
-  const compiler = globalThis.__hewSandboxCompileToSandboxBytecode ?? globalThis.compileToSandboxBytecode;
+  const compiler =
+    globalThis.__hewSandboxCompileToSandboxBytecode ??
+    globalThis.compileToSandboxBytecode;
   if (!compiler) {
-    throw new Error("compile_to_sandbox_bytecode WASM bridge is not initialized");
+    throw new Error(
+      "compile_to_sandbox_bytecode WASM bridge is not initialized",
+    );
   }
   const output = compiler(source, SANDBOX_PROFILE);
-  const parsed = typeof output === "string" ? (JSON.parse(output) as unknown) : output;
+  const parsed =
+    typeof output === "string" ? (JSON.parse(output) as unknown) : output;
   if (!isCompileOutput(parsed)) {
     throw new Error("compile_to_sandbox_bytecode returned an invalid payload");
   }
   return parsed;
 }
 
-function withPageStdin(bytecode: SandboxBytecodePackage, stdin: string): SandboxBytecodePackage {
-  const input = new PageStdinBuffer(stdin);
+function withPageExit(
+  bytecode: SandboxBytecodePackage,
+): SandboxBytecodePackage {
   const patched = {
     ...bytecode,
     capabilities: ensureCapability(bytecode.capabilities, {
       id: PROCESS_EXIT_CAPABILITY,
       disposition: "allowed",
       reason: "main return value maps to the sandbox process exit code",
-      required_by: [PROCESS_EXIT_SYMBOL]
+      required_by: [PROCESS_EXIT_SYMBOL],
     }),
     stdlib_symbols: ensureStdlibSymbol(bytecode.stdlib_symbols, {
       id: PROCESS_EXIT_SYMBOL,
@@ -88,7 +105,7 @@ function withPageStdin(bytecode: SandboxBytecodePackage, stdin: string): Sandbox
       params: ["type:i64"],
       result: "type:never",
       capability: PROCESS_EXIT_CAPABILITY,
-      admission: "allowed"
+      admission: "allowed",
     }),
     functions: bytecode.functions.map((fn) => ({
       ...fn,
@@ -96,60 +113,32 @@ function withPageStdin(bytecode: SandboxBytecodePackage, stdin: string): Sandbox
       blocks: fn.blocks.map((block) => ({
         ...block,
         params: [...block.params],
-        instructions: block.instructions.map((instruction) => {
-          if (fn.id !== STDIN_READ_LINE_HELPER && isStdinReadInstruction(instruction)) {
-            return {
-              ...instruction,
-              op: "const.string",
-              args: [{ kind: "literal", value: input.readLine() } satisfies Operand]
-            };
-          }
-          return {
-            ...instruction,
-            args: instruction.args.map((arg) => ({ ...arg }))
-          };
-        }),
+        instructions: block.instructions.map((instruction) => ({
+          ...instruction,
+          args: instruction.args.map((arg) => ({ ...arg })),
+        })),
         terminator: {
           ...block.terminator,
           args: block.terminator.args.map((arg) => ({ ...arg })),
-          ...(block.terminator.condition ? { condition: { ...block.terminator.condition } } : {})
-        }
-      }))
-    }))
+          ...(block.terminator.condition
+            ? { condition: { ...block.terminator.condition } }
+            : {}),
+        },
+      })),
+    })),
   };
   return withMainReturnExit(patched);
 }
 
-class PageStdinBuffer {
-  private readonly bytes: Uint8Array;
-  private offset = 0;
-
-  constructor(stdin: string) {
-    this.bytes = new TextEncoder().encode(stdin);
-  }
-
-  readLine(): string {
-    if (this.offset >= this.bytes.length) {
-      return "";
-    }
-    const start = this.offset;
-    while (this.offset < this.bytes.length && this.bytes[this.offset] !== LINE_FEED) {
-      this.offset += 1;
-    }
-    let end = this.offset;
-    if (this.offset < this.bytes.length && this.bytes[this.offset] === LINE_FEED) {
-      this.offset += 1;
-    }
-    if (end > start && this.bytes[end - 1] === CARRIAGE_RETURN) {
-      end -= 1;
-    }
-    return new TextDecoder().decode(this.bytes.slice(start, end));
-  }
-}
-
-function withMainReturnExit(bytecode: SandboxBytecodePackage): SandboxBytecodePackage {
-  const entryModule = bytecode.module_graph.modules.find((module) => module.id === bytecode.module_graph.entry);
-  const mainId = entryModule?.functions.find((id) => bytecode.functions.find((fn) => fn.id === id)?.name === "main");
+function withMainReturnExit(
+  bytecode: SandboxBytecodePackage,
+): SandboxBytecodePackage {
+  const entryModule = bytecode.module_graph.modules.find(
+    (module) => module.id === bytecode.module_graph.entry,
+  );
+  const mainId = entryModule?.functions.find(
+    (id) => bytecode.functions.find((fn) => fn.id === id)?.name === "main",
+  );
   if (!mainId) {
     return bytecode;
   }
@@ -163,7 +152,12 @@ function withMainReturnExit(bytecode: SandboxBytecodePackage): SandboxBytecodePa
         ...fn,
         blocks: fn.blocks.map((block, index) => {
           const lastInstruction = block.instructions.at(-1);
-          if (index !== fn.blocks.length - 1 || block.terminator.op !== "trap" || block.terminator.trap_kind !== "internal_error" || !lastInstruction?.dst) {
+          if (
+            index !== fn.blocks.length - 1 ||
+            block.terminator.op !== "trap" ||
+            block.terminator.trap_kind !== "internal_error" ||
+            !lastInstruction?.dst
+          ) {
             return block;
           }
           return {
@@ -175,32 +169,46 @@ function withMainReturnExit(bytecode: SandboxBytecodePackage): SandboxBytecodePa
                 dst: null,
                 args: [
                   { kind: "symbol", value: PROCESS_EXIT_SYMBOL },
-                  { kind: "local", value: lastInstruction.dst }
+                  { kind: "local", value: lastInstruction.dst },
                 ],
-                span: block.terminator.span
-              } satisfies Instruction
-            ]
+                span: block.terminator.span,
+              } satisfies Instruction,
+            ],
           };
-        })
+        }),
       };
-    })
+    }),
   };
 }
 
 function ensureCapability(
   capabilities: SandboxBytecodePackage["capabilities"],
-  capability: SandboxBytecodePackage["capabilities"][number]
+  capability: SandboxBytecodePackage["capabilities"][number],
 ): SandboxBytecodePackage["capabilities"] {
   return capabilities.some((item) => item.id === capability.id)
-    ? capabilities.map((item) => ({ ...item, required_by: [...item.required_by] }))
-    : [...capabilities.map((item) => ({ ...item, required_by: [...item.required_by] })), capability];
+    ? capabilities.map((item) => ({
+        ...item,
+        required_by: [...item.required_by],
+      }))
+    : [
+        ...capabilities.map((item) => ({
+          ...item,
+          required_by: [...item.required_by],
+        })),
+        capability,
+      ];
 }
 
 function ensureStdlibSymbol(
   symbols: SandboxBytecodePackage["stdlib_symbols"],
-  symbol: SandboxBytecodePackage["stdlib_symbols"][number]
+  symbol: SandboxBytecodePackage["stdlib_symbols"][number],
 ): SandboxBytecodePackage["stdlib_symbols"] {
-  return symbols.some((item) => item.id === symbol.id) ? symbols.map((item) => ({ ...item, params: [...item.params] })) : [...symbols.map((item) => ({ ...item, params: [...item.params] })), symbol];
+  return symbols.some((item) => item.id === symbol.id)
+    ? symbols.map((item) => ({ ...item, params: [...item.params] }))
+    : [
+        ...symbols.map((item) => ({ ...item, params: [...item.params] })),
+        symbol,
+      ];
 }
 
 enum SandboxExitCode {
@@ -214,7 +222,7 @@ enum SandboxExitCode {
   IndexOutOfBounds = 205,
   ActorSendFailed = 206,
   MachineDispatchUnreachable = 207,
-  ExhaustivenessFallthrough = 208
+  ExhaustivenessFallthrough = 208,
 }
 
 const TRAP_EXIT_CODES: Readonly<Record<TrapKind, SandboxExitCode>> = {
@@ -233,7 +241,7 @@ const TRAP_EXIT_CODES: Readonly<Record<TrapKind, SandboxExitCode>> = {
   budget_exhausted: SandboxExitCode.HeapExceeded,
   panic: SandboxExitCode.Panic,
   unsupported_instruction: SandboxExitCode.InternalError,
-  internal_error: SandboxExitCode.InternalError
+  internal_error: SandboxExitCode.InternalError,
 };
 
 function exitCodeForTrace(trace: SandboxTrace): number {
@@ -251,7 +259,7 @@ function runtimeDiagnostics(trace: SandboxTrace): Diagnostic[] {
     message: failure.message,
     kind: failure.trap_kind ?? failure.kind,
     ...(failure.span ? { span: failure.span as unknown as JsonValue } : {}),
-    ...(failure.trap_kind ? { trap_kind: failure.trap_kind } : {})
+    ...(failure.trap_kind ? { trap_kind: failure.trap_kind } : {}),
   }));
 }
 
@@ -259,25 +267,18 @@ function hasErrorDiagnostics(diagnostics: readonly Diagnostic[]): boolean {
   return diagnostics.some((diagnostic) => diagnostic.severity === "error");
 }
 
-function symbolOperandValue(operand: { kind: string; value: JsonValue } | undefined): string | null {
-  return operand?.kind === "symbol" && typeof operand.value === "string" ? operand.value : null;
-}
-
-function functionOperandValue(operand: { kind: string; value: JsonValue } | undefined): string | null {
-  return operand?.kind === "function" && typeof operand.value === "string" ? operand.value : null;
-}
-
-function isStdinReadInstruction(instruction: Instruction): boolean {
-  return (
-    (instruction.op === "call.stdlib" && symbolOperandValue(instruction.args[0]) === STDIN_READ_LINE_SYMBOL) ||
-    (instruction.op === "call.direct" && functionOperandValue(instruction.args[0]) === STDIN_READ_LINE_HELPER)
-  );
-}
-
 function isCompileOutput(value: unknown): value is CompileOutput {
-  if (typeof value !== "object" || value === null || !("diagnostics" in value) || !("bytecode" in value)) {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("diagnostics" in value) ||
+    !("bytecode" in value)
+  ) {
     return false;
   }
   const output = value as { diagnostics: unknown; bytecode: unknown };
-  return Array.isArray(output.diagnostics) && (output.bytecode === null || typeof output.bytecode === "object");
+  return (
+    Array.isArray(output.diagnostics) &&
+    (output.bytecode === null || typeof output.bytecode === "object")
+  );
 }

--- a/hew-sandbox-vm/src/interpreter/stdlib-profile.ts
+++ b/hew-sandbox-vm/src/interpreter/stdlib-profile.ts
@@ -15,6 +15,7 @@ export type StdlibShimHandler =
   | "io.stderr.print"
   | "io.stderr.println"
   | "io.log"
+  | "io.stdin.read_line"
   | "process.exit"
   | "time.now"
   | "time.sleep"
@@ -55,95 +56,468 @@ export interface UnsupportedStdlibDiagnostic {
 export const SANDBOX_STDLIB_PROFILE_VERSION = "hew.sandbox.stdlib-profile.m7";
 
 export const SANDBOX_STDLIB_PROFILE: readonly StdlibProfileEntry[] = [
-  shim("sym:core.stdout.print", "core.stdout", "print", "io.stdout.print", "page stdout buffer", ["sym:builtin.print", "sym:std.io.stdout.print"]),
-  shim("sym:core.stdout.println", "core.stdout", "println", "io.stdout.println", "page stdout buffer", ["sym:builtin.println", "sym:std.io.stdout.println"]),
-  shim("sym:core.stderr.print", "core.stderr", "print", "io.stderr.print", "page stderr buffer", ["sym:std.io.stderr.print"]),
-  shim("sym:core.stderr.println", "core.stderr", "println", "io.stderr.println", "page stderr buffer", ["sym:std.io.stderr.println"]),
+  shim(
+    "sym:core.stdout.print",
+    "core.stdout",
+    "print",
+    "io.stdout.print",
+    "page stdout buffer",
+    ["sym:builtin.print", "sym:std.io.stdout.print"],
+  ),
+  shim(
+    "sym:core.stdout.println",
+    "core.stdout",
+    "println",
+    "io.stdout.println",
+    "page stdout buffer",
+    ["sym:builtin.println", "sym:std.io.stdout.println"],
+  ),
+  shim(
+    "sym:core.stderr.print",
+    "core.stderr",
+    "print",
+    "io.stderr.print",
+    "page stderr buffer",
+    ["sym:std.io.stderr.print"],
+  ),
+  shim(
+    "sym:core.stdin.read_line",
+    "core.stdin",
+    "read_line",
+    "io.stdin.read_line",
+    "page stdin replay input, consumed one line per call",
+    ["sym:builtin.read_line", "sym:std.io.read_line"],
+  ),
+  shim(
+    "sym:core.stderr.println",
+    "core.stderr",
+    "println",
+    "io.stderr.println",
+    "page stderr buffer",
+    ["sym:std.io.stderr.println"],
+  ),
   shim("sym:std.misc.log", "std.misc", "log", "io.log", "page log sink"),
-  shim("sym:core.exit", "core", "exit", "process.exit", "sandbox termination record", ["sym:builtin.exit"]),
-  shim("sym:std.time.now", "std.time", "now", "time.now", "virtual clock current time", ["sym:time.now"]),
-  shim("sym:std.time.sleep", "std.time", "sleep", "time.sleep", "virtual clock sleep", ["sym:time.sleep", "sym:builtin.sleep"]),
-  shim("sym:std.time.deadline", "std.time", "deadline", "time.deadline", "virtual clock deadline calculation", ["sym:time.deadline"]),
-  shim("sym:std.fmt.to_string", "std.fmt", "to_string", "fmt.to_string", "canonical sandbox value rendering", ["sym:std.fmt.debug"]),
-  shim("sym:std.string.len", "std.string", "len", "string.len", "Unicode code-point string length"),
-  shim("sym:std.string.concat", "std.string", "concat", "string.concat", "pure string concatenation"),
-  shim("sym:std.string.slice", "std.string", "slice", "string.slice", "Unicode code-point string slicing"),
-  shim("sym:std.math.abs", "std.math", "abs", "math.abs", "deterministic integer/float absolute value"),
-  shim("sym:std.math.min", "std.math", "min", "math.min", "deterministic scalar minimum"),
-  shim("sym:std.math.max", "std.math", "max", "math.max", "deterministic scalar maximum"),
-  shim("sym:std.math.clamp", "std.math", "clamp", "math.clamp", "deterministic scalar clamp"),
+  shim(
+    "sym:core.exit",
+    "core",
+    "exit",
+    "process.exit",
+    "sandbox termination record",
+    ["sym:builtin.exit"],
+  ),
+  shim(
+    "sym:std.time.now",
+    "std.time",
+    "now",
+    "time.now",
+    "virtual clock current time",
+    ["sym:time.now"],
+  ),
+  shim(
+    "sym:std.time.sleep",
+    "std.time",
+    "sleep",
+    "time.sleep",
+    "virtual clock sleep",
+    ["sym:time.sleep", "sym:builtin.sleep"],
+  ),
+  shim(
+    "sym:std.time.deadline",
+    "std.time",
+    "deadline",
+    "time.deadline",
+    "virtual clock deadline calculation",
+    ["sym:time.deadline"],
+  ),
+  shim(
+    "sym:std.fmt.to_string",
+    "std.fmt",
+    "to_string",
+    "fmt.to_string",
+    "canonical sandbox value rendering",
+    ["sym:std.fmt.debug"],
+  ),
+  shim(
+    "sym:std.string.len",
+    "std.string",
+    "len",
+    "string.len",
+    "Unicode code-point string length",
+  ),
+  shim(
+    "sym:std.string.concat",
+    "std.string",
+    "concat",
+    "string.concat",
+    "pure string concatenation",
+  ),
+  shim(
+    "sym:std.string.slice",
+    "std.string",
+    "slice",
+    "string.slice",
+    "Unicode code-point string slicing",
+  ),
+  shim(
+    "sym:std.math.abs",
+    "std.math",
+    "abs",
+    "math.abs",
+    "deterministic integer/float absolute value",
+  ),
+  shim(
+    "sym:std.math.min",
+    "std.math",
+    "min",
+    "math.min",
+    "deterministic scalar minimum",
+  ),
+  shim(
+    "sym:std.math.max",
+    "std.math",
+    "max",
+    "math.max",
+    "deterministic scalar maximum",
+  ),
+  shim(
+    "sym:std.math.clamp",
+    "std.math",
+    "clamp",
+    "math.clamp",
+    "deterministic scalar clamp",
+  ),
   shim("sym:std.vec.len", "std.vec", "len", "vec.len", "VM vector length"),
-  shim("sym:std.vec.get", "std.vec", "get", "vec.get", "VM vector bounds-checked lookup"),
+  shim(
+    "sym:std.vec.get",
+    "std.vec",
+    "get",
+    "vec.get",
+    "VM vector bounds-checked lookup",
+  ),
   shim("sym:std.vec.push", "std.vec", "push", "vec.push", "VM vector append"),
-  shim("sym:std.text.regex.compile", "std.text.regex", "compile", "regex.compile", "curated deterministic JavaScript RegExp subset"),
-  shim("sym:std.text.regex.is_match", "std.text.regex", "is_match", "regex.is_match", "curated deterministic JavaScript RegExp subset"),
-  shim("sym:std.text.regex.find", "std.text.regex", "find", "regex.find", "curated deterministic JavaScript RegExp subset"),
-  shim("sym:std.text.regex.replace", "std.text.regex", "replace", "regex.replace", "curated deterministic JavaScript RegExp subset"),
+  shim(
+    "sym:std.text.regex.compile",
+    "std.text.regex",
+    "compile",
+    "regex.compile",
+    "curated deterministic JavaScript RegExp subset",
+  ),
+  shim(
+    "sym:std.text.regex.is_match",
+    "std.text.regex",
+    "is_match",
+    "regex.is_match",
+    "curated deterministic JavaScript RegExp subset",
+  ),
+  shim(
+    "sym:std.text.regex.find",
+    "std.text.regex",
+    "find",
+    "regex.find",
+    "curated deterministic JavaScript RegExp subset",
+  ),
+  shim(
+    "sym:std.text.regex.replace",
+    "std.text.regex",
+    "replace",
+    "regex.replace",
+    "curated deterministic JavaScript RegExp subset",
+  ),
 
-  unsupported("sym:std.option", "std.option", "*", "unsupported_m7_deferred_to_post_v05", "Option helper lowering is not emitted as a sandbox stdlib call in M7"),
-  unsupported("sym:std.result", "std.result", "*", "unsupported_m7_deferred_to_post_v05", "Result helper lowering is not emitted as a sandbox stdlib call in M7"),
-  unsupported("sym:std.iter", "std.iter", "*", "unsupported_m7_deferred_to_post_v05", "Iterator helper lowering is deferred until post-v0.5"),
-  unsupported("sym:std.sort", "std.sort", "*", "unsupported_m7_deferred_to_post_v05", "Sort helper lowering is deferred until post-v0.5"),
-  unsupported("sym:std.collections.hashset", "std.collections.hashset", "*", "unsupported_m7_deferred_to_post_v05", "Visible deterministic hashset iteration is deferred until post-v0.5"),
-  unsupported("sym:std.deque", "std.deque", "*", "unsupported_m7_deferred_to_post_v05", "Deque helper lowering is deferred until post-v0.5"),
-  unsupported("sym:std.encoding.csv", "std.encoding.csv", "*", "unsupported_m7_deferred_to_post_v05", "CSV encoding shim is deferred until post-v0.5"),
-  unsupported("sym:std.encoding.yaml", "std.encoding.yaml", "*", "unsupported_m7_deferred_to_post_v05", "YAML encoding shim is deferred until post-v0.5"),
-  unsupported("sym:std.encoding.toml", "std.encoding.toml", "*", "unsupported_m7_deferred_to_post_v05", "TOML encoding shim is deferred until post-v0.5"),
-  unsupported("sym:std.encoding.xml", "std.encoding.xml", "*", "unsupported_m7_deferred_to_post_v05", "XML encoding shim is deferred until post-v0.5"),
-  unsupported("sym:std.encoding.markdown", "std.encoding.markdown", "*", "unsupported_m7_deferred_to_post_v05", "Markdown rendering requires a sanitizer boundary and is deferred"),
-  unsupported("sym:std.encoding.msgpack", "std.encoding.msgpack", "*", "unsupported_m7_deferred_to_post_v05", "MessagePack encoding shim is deferred until post-v0.5"),
-  unsupported("sym:std.encoding.protobuf", "std.encoding.protobuf", "*", "unsupported_m7_deferred_to_post_v05", "Protobuf encoding shim is deferred until post-v0.5"),
-  unsupported("sym:std.encoding.compress", "std.encoding.compress", "*", "unsupported_m7_deferred_to_post_v05", "Compression shims are deferred until post-v0.5"),
-  unsupported("sym:std.crypto.random_bytes", "std.crypto", "random_bytes", "unsupported_m7_deferred_to_post_v05", "Seeded non-cryptographic random bytes need an explicit lesson capability"),
-  unsupported("sym:std.crypto.password", "std.crypto.password", "*", "unsupported_m7_deferred_to_post_v05", "Password and JWT helpers are entropy/time-sensitive and deferred"),
-  unsupported("sym:std.bench", "std.bench", "*", "unsupported_m7_deferred_to_post_v05", "Real-time benchmarking does not apply to the virtual-clock sandbox"),
-  unsupported("sym:std.net.websocket", "std.net.websocket", "*", "unsupported_m7_deferred_to_post_v05", "WebSocket host capability is deferred beyond M7"),
+  unsupported(
+    "sym:std.option",
+    "std.option",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Option helper lowering is not emitted as a sandbox stdlib call in M7",
+  ),
+  unsupported(
+    "sym:std.result",
+    "std.result",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Result helper lowering is not emitted as a sandbox stdlib call in M7",
+  ),
+  unsupported(
+    "sym:std.iter",
+    "std.iter",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Iterator helper lowering is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.sort",
+    "std.sort",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Sort helper lowering is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.collections.hashset",
+    "std.collections.hashset",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Visible deterministic hashset iteration is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.deque",
+    "std.deque",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Deque helper lowering is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.encoding.csv",
+    "std.encoding.csv",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "CSV encoding shim is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.encoding.yaml",
+    "std.encoding.yaml",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "YAML encoding shim is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.encoding.toml",
+    "std.encoding.toml",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "TOML encoding shim is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.encoding.xml",
+    "std.encoding.xml",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "XML encoding shim is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.encoding.markdown",
+    "std.encoding.markdown",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Markdown rendering requires a sanitizer boundary and is deferred",
+  ),
+  unsupported(
+    "sym:std.encoding.msgpack",
+    "std.encoding.msgpack",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "MessagePack encoding shim is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.encoding.protobuf",
+    "std.encoding.protobuf",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Protobuf encoding shim is deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.encoding.compress",
+    "std.encoding.compress",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Compression shims are deferred until post-v0.5",
+  ),
+  unsupported(
+    "sym:std.crypto.random_bytes",
+    "std.crypto",
+    "random_bytes",
+    "unsupported_m7_deferred_to_post_v05",
+    "Seeded non-cryptographic random bytes need an explicit lesson capability",
+  ),
+  unsupported(
+    "sym:std.crypto.password",
+    "std.crypto.password",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Password and JWT helpers are entropy/time-sensitive and deferred",
+  ),
+  unsupported(
+    "sym:std.bench",
+    "std.bench",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "Real-time benchmarking does not apply to the virtual-clock sandbox",
+  ),
+  unsupported(
+    "sym:std.net.websocket",
+    "std.net.websocket",
+    "*",
+    "unsupported_m7_deferred_to_post_v05",
+    "WebSocket host capability is deferred beyond M7",
+  ),
 
-  unsupported("sym:std.fs", "std.fs", "*", "unsupported_native_only", "Real filesystem access is unavailable in the browser sandbox"),
-  unsupported("sym:std.io.file", "std.io.file", "*", "unsupported_native_only", "File-backed I/O is unavailable in the browser sandbox"),
-  unsupported("sym:std.os", "std.os", "*", "unsupported_native_only", "Host OS args, env, and system data are unavailable in the sandbox"),
-  unsupported("sym:std.process", "std.process", "*", "unsupported_native_only", "Process spawning is unavailable in the sandbox"),
-  unsupported("sym:std.net.tcp", "std.net.tcp", "*", "unsupported_native_only", "TCP sockets are unavailable in the deterministic browser sandbox"),
-  unsupported("sym:std.net.http", "std.net.http", "*", "unsupported_native_only", "HTTP server sockets are unavailable in the deterministic browser sandbox"),
-  unsupported("sym:std.net.http_client", "std.net.http_client", "*", "unsupported_native_only", "Browser fetch is not exposed to Hew semantics in the deterministic sandbox"),
-  unsupported("sym:std.net.dns", "std.net.dns", "*", "unsupported_native_only", "External DNS is nondeterministic and unavailable in the sandbox"),
-  unsupported("sym:std.net.tls", "std.net.tls", "*", "unsupported_native_only", "TLS networking is native-only"),
-  unsupported("sym:std.net.quic", "std.net.quic", "*", "unsupported_native_only", "QUIC networking is native-only"),
-  unsupported("sym:std.net.smtp", "std.net.smtp", "*", "unsupported_native_only", "SMTP networking is native-only"),
-  unsupported("sym:stream.file", "stream.file", "*", "unsupported_native_only", "File-backed streams are unavailable in the browser sandbox"),
-  unsupported("sym:stream.net", "stream.net", "*", "unsupported_native_only", "Network-backed streams are unavailable in the deterministic sandbox"),
+  unsupported(
+    "sym:std.fs",
+    "std.fs",
+    "*",
+    "unsupported_native_only",
+    "Real filesystem access is unavailable in the browser sandbox",
+  ),
+  unsupported(
+    "sym:std.io.file",
+    "std.io.file",
+    "*",
+    "unsupported_native_only",
+    "File-backed I/O is unavailable in the browser sandbox",
+  ),
+  unsupported(
+    "sym:std.os",
+    "std.os",
+    "*",
+    "unsupported_native_only",
+    "Host OS args, env, and system data are unavailable in the sandbox",
+  ),
+  unsupported(
+    "sym:std.process",
+    "std.process",
+    "*",
+    "unsupported_native_only",
+    "Process spawning is unavailable in the sandbox",
+  ),
+  unsupported(
+    "sym:std.net.tcp",
+    "std.net.tcp",
+    "*",
+    "unsupported_native_only",
+    "TCP sockets are unavailable in the deterministic browser sandbox",
+  ),
+  unsupported(
+    "sym:std.net.http",
+    "std.net.http",
+    "*",
+    "unsupported_native_only",
+    "HTTP server sockets are unavailable in the deterministic browser sandbox",
+  ),
+  unsupported(
+    "sym:std.net.http_client",
+    "std.net.http_client",
+    "*",
+    "unsupported_native_only",
+    "Browser fetch is not exposed to Hew semantics in the deterministic sandbox",
+  ),
+  unsupported(
+    "sym:std.net.dns",
+    "std.net.dns",
+    "*",
+    "unsupported_native_only",
+    "External DNS is nondeterministic and unavailable in the sandbox",
+  ),
+  unsupported(
+    "sym:std.net.tls",
+    "std.net.tls",
+    "*",
+    "unsupported_native_only",
+    "TLS networking is native-only",
+  ),
+  unsupported(
+    "sym:std.net.quic",
+    "std.net.quic",
+    "*",
+    "unsupported_native_only",
+    "QUIC networking is native-only",
+  ),
+  unsupported(
+    "sym:std.net.smtp",
+    "std.net.smtp",
+    "*",
+    "unsupported_native_only",
+    "SMTP networking is native-only",
+  ),
+  unsupported(
+    "sym:stream.file",
+    "stream.file",
+    "*",
+    "unsupported_native_only",
+    "File-backed streams are unavailable in the browser sandbox",
+  ),
+  unsupported(
+    "sym:stream.net",
+    "stream.net",
+    "*",
+    "unsupported_native_only",
+    "Network-backed streams are unavailable in the deterministic sandbox",
+  ),
 
-  unsupported("sym:std.path.host", "std.path", "metadata", "unsupported_out_of_scope", "Host-dependent path metadata is outside the sandbox profile"),
-  unsupported("sym:std.net.url", "std.net.url", "*", "unsupported_out_of_scope", "URL helpers are not exported by the M7 sandbox VM profile"),
-  unsupported("sym:std.net.mime", "std.net.mime", "*", "unsupported_out_of_scope", "MIME helpers are not exported by the M7 sandbox VM profile"),
-  unsupported("sym:std.net.ipnet", "std.net.ipnet", "*", "unsupported_out_of_scope", "IP network helpers are not exported by the M7 sandbox VM profile"),
-  unsupported("sym:std.testing", "std.testing", "*", "unsupported_out_of_scope", "Testing helpers are compile-time/lesson tooling and are outside runtime VM shims")
+  unsupported(
+    "sym:std.path.host",
+    "std.path",
+    "metadata",
+    "unsupported_out_of_scope",
+    "Host-dependent path metadata is outside the sandbox profile",
+  ),
+  unsupported(
+    "sym:std.net.url",
+    "std.net.url",
+    "*",
+    "unsupported_out_of_scope",
+    "URL helpers are not exported by the M7 sandbox VM profile",
+  ),
+  unsupported(
+    "sym:std.net.mime",
+    "std.net.mime",
+    "*",
+    "unsupported_out_of_scope",
+    "MIME helpers are not exported by the M7 sandbox VM profile",
+  ),
+  unsupported(
+    "sym:std.net.ipnet",
+    "std.net.ipnet",
+    "*",
+    "unsupported_out_of_scope",
+    "IP network helpers are not exported by the M7 sandbox VM profile",
+  ),
+  unsupported(
+    "sym:std.testing",
+    "std.testing",
+    "*",
+    "unsupported_out_of_scope",
+    "Testing helpers are compile-time/lesson tooling and are outside runtime VM shims",
+  ),
 ] as const;
 
 export function stdlibProfileEntries(): readonly StdlibProfileEntry[] {
   return SANDBOX_STDLIB_PROFILE;
 }
 
-export function lookupStdlibProfile(symbol: { id: string; module: string; name: string }): StdlibProfileEntry | undefined {
-  return PROFILE_BY_ID.get(symbol.id) ?? PROFILE_BY_MODULE_NAME.get(`${symbol.module}.${symbol.name}`) ?? PROFILE_BY_MODULE_NAME.get(`${symbol.module}.*`);
+export function lookupStdlibProfile(symbol: {
+  id: string;
+  module: string;
+  name: string;
+}): StdlibProfileEntry | undefined {
+  return (
+    PROFILE_BY_ID.get(symbol.id) ??
+    PROFILE_BY_MODULE_NAME.get(`${symbol.module}.${symbol.name}`) ??
+    PROFILE_BY_MODULE_NAME.get(`${symbol.module}.*`)
+  );
 }
 
 export function unsupportedDiagnosticFor(
   symbol: { id: string; module: string; name: string },
-  entry: StdlibProfileEntry | undefined
+  entry: StdlibProfileEntry | undefined,
 ): UnsupportedStdlibDiagnostic {
-  const status = entry?.status === "shim" || entry === undefined ? classifyUnknownStatus(symbol.module) : entry.status;
+  const status =
+    entry?.status === "shim" || entry === undefined
+      ? classifyUnknownStatus(symbol.module)
+      : entry.status;
   return {
     kind: unsupportedKind(status),
     symbol: `${symbol.module}.${symbol.name}`,
     status,
-    reason: entry?.status === "shim" || entry === undefined ? unknownReason(status, symbol.module) : entry.reason
+    reason:
+      entry?.status === "shim" || entry === undefined
+        ? unknownReason(status, symbol.module)
+        : entry.reason,
   };
 }
 
 export function validateStdlibProfile(
   profile: readonly StdlibProfileEntry[],
-  implementedHandlers: ReadonlySet<StdlibShimHandler>
+  implementedHandlers: ReadonlySet<StdlibShimHandler>,
 ): void {
   const seenIds = new Set<string>();
   const failures: string[] = [];
@@ -156,10 +530,14 @@ export function validateStdlibProfile(
       if (!entry.handler) {
         failures.push(`${entry.id}: shim entry missing handler`);
       } else if (!implementedHandlers.has(entry.handler)) {
-        failures.push(`${entry.id}: shim handler ${entry.handler} is not implemented`);
+        failures.push(
+          `${entry.id}: shim handler ${entry.handler} is not implemented`,
+        );
       }
     } else if (entry.handler) {
-      failures.push(`${entry.id}: unsupported entry must not declare a handler`);
+      failures.push(
+        `${entry.id}: unsupported entry must not declare a handler`,
+      );
     }
   }
   if (failures.length > 0) {
@@ -191,7 +569,7 @@ function shim(
   name: string,
   handler: StdlibShimHandler,
   reason: string,
-  aliases: string[] = []
+  aliases: string[] = [],
 ): StdlibProfileEntry {
   return { id, module, name, status: "shim", reason, handler, aliases };
 }
@@ -201,12 +579,14 @@ function unsupported(
   module: string,
   name: string,
   status: Exclude<StdlibCapabilityStatus, "shim">,
-  reason: string
+  reason: string,
 ): StdlibProfileEntry {
   return { id, module, name, status, reason };
 }
 
-function unsupportedKind(status: Exclude<StdlibCapabilityStatus, "shim">): UnsupportedKind {
+function unsupportedKind(
+  status: Exclude<StdlibCapabilityStatus, "shim">,
+): UnsupportedKind {
   switch (status) {
     case "unsupported_m7_deferred_to_post_v05":
       return "Unsupported::M7_DEFERRED";
@@ -217,7 +597,9 @@ function unsupportedKind(status: Exclude<StdlibCapabilityStatus, "shim">): Unsup
   }
 }
 
-function classifyUnknownStatus(moduleName: string): Exclude<StdlibCapabilityStatus, "shim"> {
+function classifyUnknownStatus(
+  moduleName: string,
+): Exclude<StdlibCapabilityStatus, "shim"> {
   if (
     moduleName.startsWith("std.fs") ||
     moduleName.startsWith("std.os") ||
@@ -229,13 +611,20 @@ function classifyUnknownStatus(moduleName: string): Exclude<StdlibCapabilityStat
   ) {
     return "unsupported_native_only";
   }
-  if (moduleName.startsWith("std.encoding") || moduleName.startsWith("std.crypto") || moduleName.startsWith("std.bench")) {
+  if (
+    moduleName.startsWith("std.encoding") ||
+    moduleName.startsWith("std.crypto") ||
+    moduleName.startsWith("std.bench")
+  ) {
     return "unsupported_m7_deferred_to_post_v05";
   }
   return "unsupported_out_of_scope";
 }
 
-function unknownReason(status: Exclude<StdlibCapabilityStatus, "shim">, moduleName: string): string {
+function unknownReason(
+  status: Exclude<StdlibCapabilityStatus, "shim">,
+  moduleName: string,
+): string {
   switch (status) {
     case "unsupported_native_only":
       return `${moduleName} requires host/native capabilities that are unavailable in the deterministic browser sandbox`;

--- a/hew-sandbox-vm/test/run-program.test.mjs
+++ b/hew-sandbox-vm/test/run-program.test.mjs
@@ -88,6 +88,51 @@ fn main() {
   assert.deepEqual(result.diagnostics, []);
 });
 
+test("runProgram hands a read_line loop successive stdin lines and then empty at end of input", () => {
+  const result = runProgram(
+    `
+import std.io;
+
+fn main() {
+    for i in 0..5 {
+        let line = io.read_line();
+        if line == "" { return; }
+        println(line);
+    }
+}
+`,
+    "one\ntwo\r\nthree\n"
+  );
+
+  assert.equal(result.stdout, "one\ntwo\nthree\n");
+  assert.equal(result.exit_code, 0);
+  assert.deepEqual(result.diagnostics, []);
+});
+
+test("runProgram records each consumed stdin line as a replay.input event without duplicating the record", () => {
+  const compiled = globalThis.__hewSandboxCompileToSandboxBytecode(
+    `
+import std.io;
+
+fn main() {
+    let a = io.read_line();
+    let b = io.read_line();
+    println(a);
+    println(b);
+}
+`,
+    "sandbox-vm-export"
+  );
+  const bytecode = typeof compiled === "string" ? JSON.parse(compiled).bytecode : compiled.bytecode;
+  const trace = runBytecode(bytecode, { replay: { inputs: [{ kind: "stdin", data: "x\ny\n" }] } });
+  assert.deepEqual(trace.replay.inputs, [{ kind: "stdin", data: "x\ny\n" }]);
+  assert.deepEqual(
+    trace.events.filter((event) => event.type === "replay.input").map((event) => event.replay_input),
+    [{ kind: "stdin", data: "x" }, { kind: "stdin", data: "y" }]
+  );
+  assert.deepEqual(trace.final_state.stdout, ["x\n", "y\n"]);
+});
+
 test("runProgram parse errors return diagnostics and do not execute cached bytecode", () => {
   const result = runProgram("fn main( {\n    println(\"nope\");\n}\n", "");
 


### PR DESCRIPTION
## Problem

`hew-sandbox-vm`'s `runProgram` patched every `read_line` call site into a `const.string` while preparing the bytecode. The page stdin buffer was consumed once per *call site*, not per call, so any program reading inside a loop got the first line on every iteration and never reached end of input. The only existing test read two lines in straight-line code, which is the one shape that worked.

Found while moving HEWBOT's per-tick levels onto the sandbox: a `for` loop over `io.read_line()` printed the same command sixty times.

## Fix

- stdin is passed to `runBytecode` as a `stdin` replay input (the path `specs/conformance-v0.md` reserves for external input).
- A new `io.stdin.read_line` shim (`sym:core.stdin.read_line`, aliases `sym:builtin.read_line` / `sym:std.io.read_line`) reads one line per call at run time. Line splitting is unchanged (LF, optional CR, `""` at end).
- Each consumed line is recorded as a `replay.input` trace event without duplicating the replay record.
- `run-program.ts` no longer rewrites instructions; the exit-code patch stays.

## Tests

- New: a `for` loop reads successive lines and stops at `""`; consumed lines appear as `replay.input` events and the replay record is not duplicated.
- Existing byte-clean two-line test unchanged and passing.
- `npm --prefix hew-sandbox-vm test`: 84 passed.

https://claude.ai/code/session_018aat5ZxJy1MhmBcDkxpKiz