### PR TITLE
ci: keep release policy checks in the release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,39 +83,6 @@ jobs:
         run: make lint
 
   # ─────────────────────────────────────────────────────────────────────────
-  # License gate — enforce the deny.toml allow-list so no copyleft or unknown
-  # dep silently enters the shipping graph, and assert THIRD-PARTY-LICENSES is
-  # current relative to Cargo.lock. Runs on every push/PR; fast (~30 s).
-  # ─────────────────────────────────────────────────────────────────────────
-  license-check:
-    name: License policy (cargo deny + THIRD-PARTY-LICENSES freshness)
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
-
-      - uses: ./.github/actions/setup-rust-build
-        with:
-          cache-shared-key: deny
-
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked --version 0.19.6
-
-      - name: Check dependency policy
-        run: cargo deny check
-
-      - name: Install cargo-about
-        run: cargo install cargo-about --locked --version 0.9.0 --features cli
-
-      - name: Verify THIRD-PARTY-LICENSES is current
-        run: make licenses-check
-
-  # ─────────────────────────────────────────────────────────────────────────
   # Browser/playground smoke — repo-local browser tooling coverage only.
   # Runs full hew-wasm suite (lib + fixture-coverage integration), checks
   # manifest freshness, and builds the browser WASM artifact.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ env:
 
 jobs:
   validate-release-version:
-    name: Validate release tag version
+    name: Validate release version and dependencies
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout release source
@@ -89,12 +89,19 @@ jobs:
       - uses: ./.github/actions/setup-rust-build
         with:
           cache-shared-key: release-license
+          tools: cargo-deny@0.19.6
 
-      - name: Install cargo-about
-        run: cargo install cargo-about --locked --features cli --version 0.9.0
+      - name: Install cargo-about 0.9.0
+        shell: bash
+        run: |
+          archive="cargo-about-0.9.0-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL "https://github.com/EmbarkStudios/cargo-about/releases/download/0.9.0/${archive}" -o "$RUNNER_TEMP/$archive"
+          echo "7a1a1bfb3ae3b6feabe9e1d6147a6b34b85bd0339bfd8b0ec11b312dee10d99a  $RUNNER_TEMP/$archive" | sha256sum --check
+          tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP"
+          install -m 755 "$RUNNER_TEMP/cargo-about-0.9.0-x86_64-unknown-linux-musl/cargo-about" "$HOME/.cargo/bin/cargo-about"
 
-      - name: Verify THIRD-PARTY-LICENSES is current
-        run: make licenses-check
+      - name: Validate release dependencies, notices and installer
+        run: make release-checks
 
   # WASI libraries are platform-independent. Build them once and place the
   # same proved artifacts in every published toolchain archive.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -3667,7 +3667,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.2",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@
 #   make playground-check          — manifest freshness + full hew-wasm test suite + build hew-wasm
 #   make playground-wasi-check     — focused curated manifest WASI runtime preflight
 #   make playground-verify         — native run of every runnable playground example vs. its .expected
-#   make licenses-check            — verify THIRD-PARTY-LICENSES is current (used in CI)
+#   make release-checks            — validate release dependencies, notices and installer
+#   make licenses-check            — verify THIRD-PARTY-LICENSES is current
 #   make preflight                 — run every unconditional Linux gate, fail-fast
 #   make ci-preflight              — compatibility alias for make preflight
 #   make ci-preflight-smoke        — fast smoke tier: fmt + in-process tests (<5 min)
@@ -75,7 +76,7 @@
 #   make clean        — remove generated build and test artifacts
 # ============================================================================
 
-.PHONY: all build bootstrap install-hooks help shell-script-lint test-install-version-resolution actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check playground-verify preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check baselines baselines-check
+.PHONY: all build bootstrap install-hooks help shell-script-lint test-install-version-resolution actionlint hew hew-debug hew-profile-check hew-native shared-host-debug hew-lsp observe observe-functional-test mqtt-broker-e2e libhew-link-race-test runtime stdlib wasm-runtime wasm wasm-capability wasm-capability-check playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-vm-deps sandbox-parity playground-check playground-wasi-check playground-verify preflight ci-preflight ci-preflight-smoke ci-local-linux wasm-dist release licenses licenses-check dependency-policy release-checks baselines baselines-check
 .PHONY: test test-strict ratchet-accounting ratchet-accounting-nextest test-ratchet-accounting-runner macos-leak-oracle test-leak-oracle-selftest test-cabi test-compiler-pipeline test-compiler-lifecycle test-opaque-resource-lifecycle-matrix test-opaque-resource-lifecycle-matrix-external test-vertical-slice test-pkg-import test-package-install test-runtime-unit test-hew-ratchet test-core-matrix core-matrix-record funcupdate-mir-baselines-golden test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples ux-examples-expect test-surface-examples surface-examples-expect test-example-expectations-selftest test-release-binary test-release-lib-link asan asan-fixtures test-asan-fixture-selftest tsan miri lint structural-lint structural-lint-bootstrap structural-lint-bootstrap-install test-ast-grep-contract stdlib-lint stdlib-errno-gate legacy-path-syntax-lint hew-fmt-check test-migrate-corpus doc-ratchet-selftest verify-sys-lane-closure test-sys-lane-closure hew-fmt-property test-build-harness forced-cancel-composite-check
 .PHONY: test-ownership-balance-corpus test-ownership-balance-runner-selftest
 .PHONY: stdlib-user-build-clean
@@ -99,12 +100,7 @@ LINT_GATES += shell-script-lint
 shell-script-lint:
 	@$(PYTHON) scripts/shell-script-lint.py
 
-# The installer's newest-tag semver picker (installers/install.sh's
-# pick_newest_tag()) has no coverage anywhere else in the build: it never
-# runs from a compiled binary, only from a shell function that curl | sh
-# executes directly. Wired into LINT_GATES so it runs on every PR the same
-# way shell-script-lint does, without a release download or network access.
-LINT_GATES += test-install-version-resolution
+# Installer ordering belongs to release validation, not general source lint.
 test-install-version-resolution:
 	@sh installers/test-pick-newest-tag.sh
 
@@ -577,15 +573,24 @@ sandbox-fixtures:
 sandbox-fixtures-check:
 	cargo run -p xtask -- sandbox-fixtures --check
 
-# Regenerate THIRD-PARTY-LICENSES from the current dependency tree.
-# Requires cargo-about: cargo install cargo-about --locked
-licenses:
-	cargo about generate about.hbs --workspace > THIRD-PARTY-LICENSES
+# Release dependency tools: cargo-deny 0.19.6 and cargo-about 0.9.0.
+# Duplicate crate versions are not a release defect. Enforce only actionable
+# licence, advisory and source policy, with no non-blocking warning backlog.
+dependency-policy:
+	cargo deny --locked check licenses advisories sources --deny warnings
 
-# Verify THIRD-PARTY-LICENSES is current relative to Cargo.lock and about.hbs.
-# Exits non-zero if the file is stale; run `make baselines` to regenerate.
+# Keep the committed notice intact if licence generation fails.
+licenses:
+	@notice=$$(mktemp ./THIRD-PARTY-LICENSES.XXXXXX); trap 'rm -f "$$notice"' EXIT; \
+	cargo about generate about.hbs --workspace --locked --fail > "$$notice" && \
+	chmod 644 "$$notice" && \
+	mv "$$notice" THIRD-PARTY-LICENSES
+
+# Verify the notices for the exact locked dependency graph before publishing.
 licenses-check:
 	scripts/check-licenses-fresh.sh
+
+release-checks: dependency-policy licenses-check test-install-version-resolution ## Release: validate dependency policy, notices and installer ordering
 
 # ── Derived baselines ─────────────────────────────────────────────────────
 #
@@ -904,7 +909,7 @@ release: assemble-release test-release-lib-link ## Release: build optimized rele
 # Runs linux locally first (fail-fast), then remote platforms in parallel.
 #   make pre-release                    — all platforms
 #   make pre-release PLATFORMS="linux"  — linux only
-pre-release: ## Release: build and validate a release candidate on requested platforms
+pre-release: release-checks ## Release: build and validate a release candidate on requested platforms
 	scripts/pre-release-validate.sh $(PLATFORMS)
 
 # Build the staged source tree the Windows validator builds from
@@ -1598,7 +1603,7 @@ test-ast-grep-contract:
 	bash scripts/tests/test_ast_grep_contract.sh
 
 LINT_GATES += test-build-harness
-# Focused behavior tests for the Hew JUnit transaction, generated help, shell discovery,
+# Focused behaviour tests for the Hew JUnit transaction, shell discovery,
 # and compiled-Hew report aggregation. None needs a built compiler.
 test-build-harness:
 	$(PYTHON) scripts/tests/test_hew_suite_runner.py

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -6493,7 +6493,7 @@ Apache License 2.0
   * blake2 0.10.6 — https://github.com/RustCrypto/hashes
   * block-buffer 0.10.4 — https://github.com/RustCrypto/utils
   * block-buffer 0.12.0 — https://github.com/RustCrypto/utils
-  * chacha20 0.10.0 — https://github.com/RustCrypto/stream-ciphers
+  * chacha20 0.10.2 — https://github.com/RustCrypto/stream-ciphers
   * chacha20 0.9.1 — https://github.com/RustCrypto/stream-ciphers
   * chacha20poly1305 0.10.1 — https://github.com/RustCrypto/AEADs/tree/master/chacha20poly1305
   * cipher 0.4.4 — https://github.com/RustCrypto/traits

--- a/deny.toml
+++ b/deny.toml
@@ -1,11 +1,11 @@
 # cargo-deny license and dependency policy for Hew.
 #
-# Enforced in CI via `cargo deny check licenses bans advisories sources`.
-# Run locally with `cargo deny check` from the workspace root.
+# Enforced before publication by `make release-checks`; also available as
+# `make dependency-policy` during development. This checks licences, security
+# advisories and permitted sources. Every warning fails the check.
+# Multiple versions of a dependency are allowed and are not scanned as a ban.
 #
-# Policy: only licenses on the allow list below may appear in the shipping
-# dependency graph. Any new dep with an unlisted license will fail CI
-# immediately, preventing silent copyleft introduction.
+# Only licences on the allow list may appear in the release dependency graph.
 #
 # License allow-list derived from:
 #   cargo about generate --workspace --format json (2026-06-17 audit).
@@ -54,19 +54,14 @@ confidence-threshold = 0.8
 [licenses.private]
 ignore = true
 
-# ─── Bans ────────────────────────────────────────────────────────────────────
-[bans]
-multiple-versions = "warn"
-wildcards = "allow"
-
 # ─── Advisories ──────────────────────────────────────────────────────────────
 [advisories]
 version = 2
-# Report unmaintained crates in the workspace rather than making them errors,
-# to avoid blocking on upstream churn.
+# Check unmaintained direct workspace dependencies; warning escalation makes
+# each finding require a dependency update or an explicit advisory exception.
 unmaintained = "workspace"
-# Yanked crates warrant a warning so they show up in CI output.
-yanked = "warn"
+# Do not publish a newly assembled release with a yanked locked dependency.
+yanked = "deny"
 ignore = []
 
 # ─── Sources ─────────────────────────────────────────────────────────────────

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -112,6 +112,23 @@ This triggers `.github/workflows/release-gate.yml`, which runs:
 The sanitizer job executes ASan directly, so a missing, skipped, or red run
 fails the release gate without a separate evidence parser.
 
+## Release dependencies and notices
+
+Before tagging, run `make release-checks` with cargo-deny 0.19.6 and
+cargo-about 0.9.0 installed. This checks allowed licences, known security
+advisories, permitted dependency sources, generated third-party notices and
+installer version ordering. The tag-release workflow repeats the same command
+before building publishable artifacts and installs pinned prebuilt tools.
+
+Duplicate dependency versions are permitted and are not reported. Other
+policy warnings fail validation: update the dependency or document a specific
+exception in `deny.toml`. When the dependency graph changes, run `make licenses`
+and commit `Cargo.lock` and `THIRD-PARTY-LICENSES` together. Generation uses the
+locked graph and fails if a licence cannot be resolved.
+
+These release checks are available during development but do not run on every
+unrelated PR. `make pre-release` runs them before platform validation.
+
 ## Phase 4 — Local cross-platform validation (optional but recommended)
 
 For full cross-platform hardware validation beyond CI runners:
@@ -186,7 +203,7 @@ version 22; an absent or different version fails validation before building.
 
 What `make pre-release` does:
 
-1. `make release` — release build of all binaries
+1. `make release-checks` — dependency policy, notices and installer ordering
 2. `scripts/pre-release-validate.sh` — per-platform:
    - Build all release artifacts
    - Verify binaries exist and run (`--version`)

--- a/installers/test-pick-newest-tag.sh
+++ b/installers/test-pick-newest-tag.sh
@@ -1,100 +1,29 @@
 #!/bin/sh
-# Fixture for install.sh's pick_newest_tag() semver picker and the --stable
-# pre-release filter that feeds it.
-#
-# installers/docker/test-install.sh is the precedent for a standalone shell
-# test living in this directory; this one exercises the tag-comparison logic
-# in isolation instead of a full install, so a regression is caught without
-# downloading a release or hitting the GitHub API.
+# Exercise the installer's numeric release ordering without network access.
 set -eu
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
-INSTALL_SH="${SCRIPT_DIR}/install.sh"
 
-# install.sh unconditionally runs `main "$@"` at end of file, so it cannot be
-# sourced directly — extract just the pick_newest_tag() function body.
-pick_newest_tag_def="$(awk '/^pick_newest_tag\(\) \{/,/^}/' "$INSTALL_SH")"
-if [ -z "$pick_newest_tag_def" ]; then
-    echo "FAIL: could not extract pick_newest_tag() from ${INSTALL_SH}" >&2
+# install.sh runs main unconditionally; load only its actual picker.
+picker="$(awk '/^pick_newest_tag\(\) \{/,/^}/' "$SCRIPT_DIR/install.sh")"
+[ -n "$picker" ] || {
+    echo "FAIL: installer picker not found" >&2
     exit 1
-fi
-eval "$pick_newest_tag_def"
+}
+eval "$picker"
 
-fail=0
-
-# Default (rc-inclusive) path: pick_newest_tag() over the raw tag list.
 check() {
-    description="$1"
-    input="$2"
-    expected="$3"
-    actual="$(printf '%s\n' "$input" | pick_newest_tag)"
+    expected="$1"
+    shift
+    actual="$(printf '%s\n' "$@" | pick_newest_tag)"
     if [ "$actual" != "$expected" ]; then
-        echo "FAIL: ${description}"
-        echo "  expected: ${expected}"
-        echo "  got:      ${actual}"
-        fail=1
-    else
-        echo "ok: ${description}"
+        echo "FAIL: tags [$*]: expected $expected, got $actual" >&2
+        exit 1
     fi
 }
 
-# --stable path: resolve_version()'s own filter (grep -v -- '-') ahead of
-# pick_newest_tag(), so this is a faithful negative control rather than a
-# reimplementation of the filter.
-check_stable() {
-    description="$1"
-    input="$2"
-    expected="$3"
-    actual="$(printf '%s\n' "$input" | grep -v -- '-' | pick_newest_tag)"
-    if [ "$actual" != "$expected" ]; then
-        echo "FAIL: ${description}"
-        echo "  expected: ${expected}"
-        echo "  got:      ${actual}"
-        fail=1
-    else
-        echo "ok: ${description}"
-    fi
-}
-
-# 0.10.0 beats 0.9.9 — catches lexical rather than numeric comparison, the
-# reason the %06d padding exists.
-check "numeric minor beats a lexically-larger patch" \
-    "0.9.9
-0.10.0" \
-    "0.10.0"
-
-# 0.6.0 beats 0.6.0-rc3 — catches the final-release rc=999999 sentinel being
-# dropped or inverted.
-check "final release beats an rc of the same version" \
-    "0.6.0-rc3
-0.6.0" \
-    "0.6.0"
-
-# 0.6.0-rc10 beats 0.6.0-rc9 — catches the sprintf("%06d", ...) padding being
-# dropped and comparing "10" < "9" lexically.
-check "rc10 beats rc9" \
-    "0.6.0-rc9
-0.6.0-rc10" \
-    "0.6.0-rc10"
-
-# 0.6.0-rc2 beats 0.5.6 — catches an over-eager stable filter leaking onto
-# the default (rc-inclusive) path.
-check "rc beats an older final release on the default path" \
-    "0.5.6
-0.6.0-rc2" \
-    "0.6.0-rc2"
-
-# --stable drops every rc and keeps the newest final — the negative control
-# for the grep -v -- '-' filter.
-check_stable "--stable returns the newest final, not the newer rc" \
-    "0.5.6
-0.6.0-rc2" \
-    "0.5.6"
-
-echo
-if [ "$fail" -eq 0 ]; then
-    echo "All pick_newest_tag() cases passed."
-else
-    echo "pick_newest_tag() regression detected." >&2
-    exit 1
-fi
+check 0.10.0 0.9.9 0.10.0
+check 0.6.0 0.6.0 0.6.0-rc3
+check 0.6.0-rc10 0.6.0-rc9 0.6.0-rc10
+check 0.6.0-rc2 0.6.0-rc2 0.5.6
+printf '%s\n' 'Installer release ordering: PASS'

--- a/scripts/cargo-output-dir.py
+++ b/scripts/cargo-output-dir.py
@@ -66,10 +66,6 @@ def _configured_target(config: dict[str, Any], path: Path) -> str | None:
     die(f"{path} has a non-string build.target value")
 
 
-def _load_toml(text: str, path: Path) -> dict[str, Any]:
-    return tomllib.loads(text)
-
-
 def target_root() -> Path:
     """The `target/` equivalent Cargo writes into, absolute.
 
@@ -137,7 +133,7 @@ def config_build_target() -> str:
         except (OSError, UnicodeError) as err:
             die(f"cannot read {path}: {err}")
         try:
-            config = _load_toml(text, path)
+            config = tomllib.loads(text)
         except ValueError as err:
             die(str(err))
         target = _configured_target(config, path)

--- a/scripts/check-licenses-fresh.sh
+++ b/scripts/check-licenses-fresh.sh
@@ -18,8 +18,14 @@ QUIET=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --quiet) QUIET=1; shift ;;
-        *) echo "error: unknown argument: $1" >&2; exit 1 ;;
+    --quiet)
+        QUIET=1
+        shift
+        ;;
+    *)
+        echo "error: unknown argument: $1" >&2
+        exit 1
+        ;;
     esac
 done
 
@@ -27,7 +33,7 @@ COMMITTED="${REPO_ROOT}/THIRD-PARTY-LICENSES"
 
 if [[ ! -f "$COMMITTED" ]]; then
     echo "error: THIRD-PARTY-LICENSES not found at ${COMMITTED}" >&2
-    echo "  Run 'make baselines' to generate it." >&2
+    echo "  Run 'make licenses' to generate it." >&2
     exit 1
 fi
 
@@ -37,22 +43,22 @@ if ! command -v cargo-about &>/dev/null && ! cargo about --version &>/dev/null 2
     exit 1
 fi
 
-TMPFILE="$(mktemp "/tmp/third-party-licenses.XXXXXX")"
+TMPFILE="$(mktemp "${TMPDIR:-/tmp}/third-party-licenses.XXXXXX")"
 trap 'rm -f "$TMPFILE"' EXIT
 
-(( QUIET == 0 )) && echo "Regenerating THIRD-PARTY-LICENSES for freshness check..."
+((QUIET == 0)) && echo "Regenerating THIRD-PARTY-LICENSES for freshness check..."
 
-# Suppress cargo-about's own progress chatter; capture only the generated output.
-cargo about generate "${REPO_ROOT}/about.hbs" --workspace \
+# Reject unresolved licences and preserve generator diagnostics on failure.
+cargo about generate "${REPO_ROOT}/about.hbs" --workspace --locked --fail \
     --manifest-path "${REPO_ROOT}/Cargo.toml" \
-    2>/dev/null > "$TMPFILE"
+    >"$TMPFILE"
 
 if diff -u "$COMMITTED" "$TMPFILE"; then
-    (( QUIET == 0 )) && echo "ok: THIRD-PARTY-LICENSES is current"
+    ((QUIET == 0)) && echo "ok: THIRD-PARTY-LICENSES is current"
     exit 0
 else
     echo "" >&2
     echo "error: THIRD-PARTY-LICENSES is stale (Cargo.lock or about.hbs changed)." >&2
-    echo "  Run 'make baselines' and commit the updated file." >&2
+    echo "  Run 'make licenses' and commit the updated file." >&2
     exit 1
 fi

--- a/scripts/tests/test_cargo_output_dir.py
+++ b/scripts/tests/test_cargo_output_dir.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression tests for Cargo config parsing."""
+"""Regression tests for Hew target selection and Cargo metadata failures."""
 
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ import contextlib
 import importlib.util
 import io
 import os
-import tomllib
 from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -42,70 +41,29 @@ cargo_output_dir = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(cargo_output_dir)
 
 
-def parse_config(text: str) -> str:
-    """Parse Cargo configuration through the production TOML path."""
-    path = Path(".cargo/config.toml")
-    config = cargo_output_dir._load_toml(text, path)
-    return cargo_output_dir._configured_target(config, path) or ""
+def test_configured_target_shapes() -> None:
+    for config, expected in (
+        ({}, None),
+        ({"build": {}}, None),
+        ({"build": {"target": "aarch64-apple-darwin"}}, "aarch64-apple-darwin"),
+        ({"build": {"target": ["wasm32-wasip1"]}}, "wasm32-wasip1"),
+    ):
+        assert cargo_output_dir._configured_target(config, MODULE_PATH) == expected
 
 
-def test_build_table_string() -> None:
-    assert (
-        parse_config('[build]\ntarget = "aarch64-apple-darwin"\n')
-        == "aarch64-apple-darwin"
-    )
-
-
-def test_root_dotted_key() -> None:
-    assert (
-        parse_config("build.target = 'x86_64-unknown-freebsd'\n")
-        == "x86_64-unknown-freebsd"
-    )
-
-
-def test_single_multiline_array_and_comments() -> None:
-    text = """
-[build]
-target = [
-    "wasm32-wasip1", # the selected target
-]
-"""
-    assert parse_config(text) == "wasm32-wasip1"
-
-
-def test_hash_inside_target_is_not_a_comment() -> None:
-    assert (
-        parse_config('[build]\ntarget = "custom#target" # comment\n') == "custom#target"
-    )
-
-
-def test_literal_string_backslash_is_not_a_python_escape() -> None:
-    assert parse_config("[build]\ntarget = 'custom\\target'\n") == "custom\\target"
-
-
-def test_quoted_build_table() -> None:
-    assert parse_config('["build"]\ntarget = "aarch64-apple-darwin"\n') == (
-        "aarch64-apple-darwin"
-    )
-
-
-def test_malformed_config_fails_closed() -> None:
-    malformed = (
-        "[broken\n",
-        '[build]\ntarget = "bad\\x41escape"\n',
-        '[build]\ntarget = "first"\ntarget = "second"\n',
-    )
-    for source in malformed:
+def test_ambiguous_or_invalid_target_fails_closed() -> None:
+    configs = [
+        {"build": "not a table"},
+        *({"build": {"target": value}} for value in ("", [], ["a", "b"], [1], 1)),
+    ]
+    for config in configs:
         try:
-            parse_config(source)
-        except tomllib.TOMLDecodeError:
-            pass
+            with counterfactual("invalid-target"):
+                cargo_output_dir._configured_target(config, MODULE_PATH)
+        except SystemExit as exc:
+            assert exc.code == 1
         else:
-            raise AssertionError(f"malformed Cargo config was accepted: {source!r}")
-
-
-def test_missing_build_target() -> None:
-    assert parse_config('[target.x86_64-pc-windows-msvc]\nlinker = "lld-link"\n') == ""
+            raise AssertionError(f"invalid target was accepted: {config!r}")
 
 
 def test_metadata_failure_fails_closed() -> None:
@@ -187,14 +145,8 @@ def test_malformed_metadata_fails_closed() -> None:
 
 
 _TESTS = (
-    test_build_table_string,
-    test_root_dotted_key,
-    test_single_multiline_array_and_comments,
-    test_hash_inside_target_is_not_a_comment,
-    test_literal_string_backslash_is_not_a_python_escape,
-    test_quoted_build_table,
-    test_malformed_config_fails_closed,
-    test_missing_build_target,
+    test_configured_target_shapes,
+    test_ambiguous_or_invalid_target_fails_closed,
     test_metadata_failure_fails_closed,
     test_missing_cargo_fails_closed,
     test_malformed_metadata_fails_closed,

--- a/scripts/tests/test_makefile_interfaces.py
+++ b/scripts/tests/test_makefile_interfaces.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Counterfactuals for generated help and recursive tracked-shell linting."""
+"""Regression coverage for tracked-shell discovery and failure propagation."""
 
 from __future__ import annotations
 
@@ -20,43 +20,7 @@ def load(name: str, path: Path):
     return module
 
 
-help_index = load("make_help", ROOT / "scripts" / "make-help.py")
 shell_lint = load("shell_script_lint", ROOT / "scripts" / "shell-script-lint.py")
-
-
-def require_value_error(makefile: str, message: str) -> None:
-    try:
-        help_index.entries(makefile)
-    except ValueError as error:
-        assert message in str(error), error
-    else:
-        raise AssertionError(f"expected help index failure containing {message!r}")
-
-
-def test_real_help_index_is_generated_and_bounded() -> None:
-    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
-    entries = help_index.entries(makefile)
-    assert entries
-    output = help_index.render(makefile)
-    for section, target, purpose in entries:
-        assert f"{section}:" in output
-        assert f"make {target}" in output
-        assert purpose in output
-
-
-def test_renamed_target_takes_its_help_entry_with_it() -> None:
-    before = "old-name: dependency ## Build: compile it\n"
-    after = before.replace("old-name:", "new-name:")
-    assert help_index.entries(before)[0][1] == "old-name"
-    assert help_index.entries(after)[0][1] == "new-name"
-
-
-def test_unknown_help_section_fails_closed() -> None:
-    require_value_error("thing: ## Deploy: ship it\n", "unknown help section 'Deploy'")
-
-
-def test_empty_help_index_fails_closed() -> None:
-    require_value_error("all:\n\ttrue\n", "help index is empty")
 
 
 def test_shell_lint_discovers_tracked_nested_scripts_only() -> None:


### PR DESCRIPTION
## Why

Every pull request recompiles licence tools and regenerates release notices, while the release workflow repeats that work. The dependency check also floods logs with permitted duplicate versions and leaves a yanked dependency as a warning. General lint includes installer and helper tests that duplicate dependency behaviour or derive their expectations from the same implementation.

## What

- Move dependency policy, notice freshness and installer ordering into `make release-checks`, required by local pre-release validation and the tag-release workflow. Remove the duplicate PR job and install pinned prebuilt tools for releases.
- Check the locked graph for licences, security advisories and approved sources. Omit duplicate-version reporting and make remaining warnings fail. Update yanked `chacha20` to a compatible patch and regenerate its notice.
- Preserve the existing notice if generation fails, reject unresolved licences, and keep generation diagnostics visible.
- Remove TOML-parser and help-renderer test duplication and the copied installer stable-filter assertion. Keep compact checks of the real installer picker and the runner/discovery/failure tests that protect CI results.

## Test

- `make release-checks`: locked dependency policy, notice freshness and installer ordering.
- `make test-build-harness`: retained and simplified helper and runner coverage.
- `make actionlint` and `make shell-script-lint`.
- Focused `hew-pkg` unit suite through Make, including signing and atomic publication, after the dependency update.
- Verified the pinned cargo-about archive checksum and executable version.

The full compiler suite was not run locally. Native validation was on Linux; the release workflow itself was validated statically, not dispatched to publish a release.
