### PR TITLE
stdlib(semver): enforce SemVer 2.0.0 parsing and caret bounds

### DIFF
--- a/std/text/semver/semver.hew
+++ b/std/text/semver/semver.hew
@@ -142,6 +142,14 @@ pub fn try_parse(s: string) -> Result<Version, string> {
         || !valid_identifier_list(build, true) {
         return Err(f"semver: invalid version string: {s}");
     }
+    // `string.to_int` intentionally maps malformed and out-of-range input to
+    // zero. SemVer components must retain their exact numeric value, so reject
+    // values outside the module's i64 representation before conversion.
+    if !is_i64_numeric_identifier(major_str)
+        || !is_i64_numeric_identifier(minor_str)
+        || !is_i64_numeric_identifier(patch_str) {
+        return Err(f"semver: invalid version string: {s}");
+    }
     let major = string.to_int(major_str);
     let minor = string.to_int(minor_str);
     let patch = string.to_int(patch_str);
@@ -154,6 +162,14 @@ fn is_strict_numeric_identifier(s: string) -> bool {
         return false;
     }
     s.len() == 1 || !s.starts_with("0")
+}
+
+/// Return true when a numeric identifier fits the i64 representation.
+fn is_i64_numeric_identifier(s: string) -> bool {
+    match string.try_to_int(s) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
 }
 
 /// Return true when an identifier contains only ASCII letters, digits, or `-`.
@@ -191,10 +207,16 @@ fn valid_identifier_list(s: string, allow_numeric_leading_zero: bool) -> bool {
         if !is_ascii_alnum_or_hyphen(identifier) {
             return false;
         }
-        if !allow_numeric_leading_zero
-            && string.is_numeric(identifier)
-            && !is_strict_numeric_identifier(identifier) {
-            return false;
+        if string.is_numeric(identifier) {
+            if !allow_numeric_leading_zero && !is_strict_numeric_identifier(identifier) {
+                return false;
+            }
+            // Numeric pre-release identifiers participate in numeric precedence.
+            // The implementation stores numbers as i64, so reject values that
+            // cannot be represented instead of comparing a silent zero.
+            if !allow_numeric_leading_zero && !is_i64_numeric_identifier(identifier) {
+                return false;
+            }
         }
         if dot < 0 {
             return true;
@@ -205,18 +227,30 @@ fn valid_identifier_list(s: string, allow_numeric_leading_zero: bool) -> bool {
 }
 
 /// Return the next major version, resetting minor/patch and dropping metadata.
-pub fn increment_major(v: Version) -> Version {
-    Version { pre_release: "", build_meta: "", maj: v.maj + 1, min: 0, pat: 0 }
+/// Returns `Err` when the major component cannot be incremented in i64.
+pub fn increment_major(v: Version) -> Result<Version, string> {
+    if v.maj == 9223372036854775807 {
+        return Err("semver: major component out of range");
+    }
+    Ok(Version { pre_release: "", build_meta: "", maj: v.maj + 1, min: 0, pat: 0 })
 }
 
 /// Return the next minor version, resetting patch and dropping metadata.
-pub fn increment_minor(v: Version) -> Version {
-    Version { pre_release: "", build_meta: "", maj: v.maj, min: v.min + 1, pat: 0 }
+/// Returns `Err` when the minor component cannot be incremented in i64.
+pub fn increment_minor(v: Version) -> Result<Version, string> {
+    if v.min == 9223372036854775807 {
+        return Err("semver: minor component out of range");
+    }
+    Ok(Version { pre_release: "", build_meta: "", maj: v.maj, min: v.min + 1, pat: 0 })
 }
 
 /// Return the next patch version, dropping metadata.
-pub fn increment_patch(v: Version) -> Version {
-    Version { pre_release: "", build_meta: "", maj: v.maj, min: v.min, pat: v.pat + 1 }
+/// Returns `Err` when the patch component cannot be incremented in i64.
+pub fn increment_patch(v: Version) -> Result<Version, string> {
+    if v.pat == 9223372036854775807 {
+        return Err("semver: patch component out of range");
+    }
+    Ok(Version { pre_release: "", build_meta: "", maj: v.maj, min: v.min, pat: v.pat + 1 })
 }
 
 /// Parse a semantic version string.

--- a/std/text/semver/semver.hew
+++ b/std/text/semver/semver.hew
@@ -118,6 +118,10 @@ pub fn try_parse(s: string) -> Result<Version, string> {
         version_part = main_part.slice(0, dash_idx);
         pre = main_part.slice(dash_idx + 1, main_part.len());
     }
+    // A separator must be followed by at least one identifier.
+    if (plus_idx >= 0 && build.len() == 0) || (dash_idx >= 0 && pre.len() == 0) {
+        return Err(f"semver: invalid version string: {s}");
+    }
     // Split major.minor.patch
     let first_dot = version_part.find(".");
     if first_dot < 0 {
@@ -131,10 +135,88 @@ pub fn try_parse(s: string) -> Result<Version, string> {
     }
     let minor_str = rest.slice(0, second_dot);
     let patch_str = rest.slice(second_dot + 1, rest.len());
+    if !is_strict_numeric_identifier(major_str)
+        || !is_strict_numeric_identifier(minor_str)
+        || !is_strict_numeric_identifier(patch_str)
+        || !valid_identifier_list(pre, false)
+        || !valid_identifier_list(build, true) {
+        return Err(f"semver: invalid version string: {s}");
+    }
     let major = string.to_int(major_str);
     let minor = string.to_int(minor_str);
     let patch = string.to_int(patch_str);
     Ok(Version { pre_release: pre, build_meta: build, maj: major, min: minor, pat: patch })
+}
+
+/// Return true when `s` is a canonical non-negative numeric SemVer identifier.
+fn is_strict_numeric_identifier(s: string) -> bool {
+    if !string.is_numeric(s) {
+        return false;
+    }
+    s.len() == 1 || !s.starts_with("0")
+}
+
+/// Return true when an identifier contains only ASCII letters, digits, or `-`.
+fn is_ascii_alnum_or_hyphen(s: string) -> bool {
+    if !string.is_ascii(s) || s.len() == 0 {
+        return false;
+    }
+    for i in 0 .. s.len() {
+        let ch = s.slice(i, i + 1);
+        if !(ch == "-"
+            || (ch >= "0" && ch <= "9")
+            || (ch >= "a" && ch <= "z")
+            || (ch >= "A" && ch <= "Z")) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Validate dot-separated pre-release or build identifiers.
+/// Numeric pre-release identifiers cannot have leading zeroes; build identifiers can.
+fn valid_identifier_list(s: string, allow_numeric_leading_zero: bool) -> bool {
+    if s.len() == 0 {
+        return true;
+    }
+    var pos = 0;
+    while pos <= s.len() {
+        let remaining = s.slice(pos, s.len());
+        let dot = remaining.find(".");
+        var end = s.len();
+        if dot >= 0 {
+            end = pos + dot;
+        }
+        let identifier = s.slice(pos, end);
+        if !is_ascii_alnum_or_hyphen(identifier) {
+            return false;
+        }
+        if !allow_numeric_leading_zero
+            && string.is_numeric(identifier)
+            && !is_strict_numeric_identifier(identifier) {
+            return false;
+        }
+        if dot < 0 {
+            return true;
+        }
+        pos = end + 1;
+    }
+    true
+}
+
+/// Return the next major version, resetting minor/patch and dropping metadata.
+pub fn increment_major(v: Version) -> Version {
+    Version { pre_release: "", build_meta: "", maj: v.maj + 1, min: 0, pat: 0 }
+}
+
+/// Return the next minor version, resetting patch and dropping metadata.
+pub fn increment_minor(v: Version) -> Version {
+    Version { pre_release: "", build_meta: "", maj: v.maj, min: v.min + 1, pat: 0 }
+}
+
+/// Return the next patch version, dropping metadata.
+pub fn increment_patch(v: Version) -> Version {
+    Version { pre_release: "", build_meta: "", maj: v.maj, min: v.min, pat: v.pat + 1 }
 }
 
 /// Parse a semantic version string.
@@ -374,7 +456,15 @@ fn matches_single(v: Version, constraint: string) -> bool {
         if cmp < 0 {
             return false;
         }
-        return v.maj == req_ver.maj;
+        // Caret ranges advance the left-most non-zero component.
+        // ^1.2.3 <2.0.0, ^0.2.3 <0.3.0, ^0.0.3 <0.0.4.
+        if req_ver.maj > 0 {
+            return v.maj == req_ver.maj;
+        }
+        if req_ver.min > 0 {
+            return v.maj == 0 && v.min == req_ver.min;
+        }
+        return v.maj == 0 && v.min == 0 && v.pat == req_ver.pat;
     }
     if op == "~" {
         if cmp < 0 {

--- a/tests/hew/semver_test.hew
+++ b/tests/hew/semver_test.hew
@@ -228,3 +228,84 @@ fn test_parse_panics_on_missing_second_dot() {
     // "1.2" has a first dot but no second — hits the `second_dot < 0` panic branch.
     semver.parse("1.2");
 }
+
+// ── strict SemVer 2.0.0 grammar ───────────────────────────────────────
+
+fn assert_invalid_semver(s: string) {
+    match semver.try_parse(s) {
+        Ok(_) => panic(f"expected invalid semver: {s}"),
+        Err(_) => {},
+    }
+}
+
+#[test]
+fn test_try_parse_rejects_leading_zero_core_identifiers() {
+    assert_invalid_semver("01.2.3");
+    assert_invalid_semver("1.02.3");
+    assert_invalid_semver("1.2.03");
+}
+
+#[test]
+fn test_try_parse_rejects_empty_pre_release_and_build_tails() {
+    assert_invalid_semver("1.2.3-");
+    assert_invalid_semver("1.2.3+");
+}
+
+#[test]
+fn test_try_parse_rejects_empty_pre_release_and_build_identifiers() {
+    assert_invalid_semver("1.2.3-alpha.");
+    assert_invalid_semver("1.2.3-.alpha");
+    assert_invalid_semver("1.2.3+build.");
+    assert_invalid_semver("1.2.3+.build");
+}
+
+#[test]
+fn test_try_parse_rejects_non_ascii_identifiers() {
+    assert_invalid_semver("1.2.3-café");
+    assert_invalid_semver("1.2.3+naïve");
+}
+
+#[test]
+fn test_try_parse_rejects_non_numeric_signed_and_extra_core_text() {
+    assert_invalid_semver("-1.2.3");
+    assert_invalid_semver("1.-2.3");
+    assert_invalid_semver("1.2.-3");
+    assert_invalid_semver("1.2.x");
+    assert_invalid_semver("1.2.3x");
+    assert_invalid_semver("1.2.3.4");
+}
+
+#[test]
+fn test_try_parse_rejects_leading_zero_numeric_prerelease_identifiers() {
+    assert_invalid_semver("1.2.3-01");
+    assert_invalid_semver("1.2.3-alpha.01");
+}
+
+#[test]
+fn test_try_parse_accepts_canonical_build_numeric_leading_zero() {
+    let v = semver.parse("1.2.3-rc.1+build.001");
+    testing.assert_eq_str(v.to_string(), "1.2.3-rc.1+build.001");
+}
+
+// ── caret bounds and increment helpers ────────────────────────────────
+
+#[test]
+fn test_matches_caret_zero_minor_stops_before_next_minor() {
+    testing.assert_true(semver.parse("0.2.3").matches("^0.2.3"));
+    testing.assert_true(semver.parse("0.2.99").matches("^0.2.3"));
+    testing.assert_false(semver.parse("0.3.0").matches("^0.2.3"));
+}
+
+#[test]
+fn test_matches_caret_zero_zero_stops_before_next_patch() {
+    testing.assert_true(semver.parse("0.0.3").matches("^0.0.3"));
+    testing.assert_false(semver.parse("0.0.4").matches("^0.0.3"));
+}
+
+#[test]
+fn test_increment_helpers_reset_lower_components_and_metadata() {
+    let v = semver.parse("1.2.3-rc.1+build.5");
+    testing.assert_eq_str(semver.increment_major(v).to_string(), "2.0.0");
+    testing.assert_eq_str(semver.increment_minor(v).to_string(), "1.3.0");
+    testing.assert_eq_str(semver.increment_patch(v).to_string(), "1.2.4");
+}

--- a/tests/hew/semver_test.hew
+++ b/tests/hew/semver_test.hew
@@ -238,11 +238,32 @@ fn assert_invalid_semver(s: string) {
     }
 }
 
+fn assert_increment_ok(actual: Result<semver.Version, string>, expected: string) {
+    match actual {
+        Ok(value) => testing.assert_eq_str(value.to_string(), expected),
+        Err(message) => panic(message),
+    }
+}
+
+fn assert_increment_err(actual: Result<semver.Version, string>, expected: string) {
+    match actual {
+        Ok(value) => panic(f"expected increment error: {value.to_string()}"),
+        Err(message) => testing.assert_eq_str(message, expected),
+    }
+}
+
 #[test]
 fn test_try_parse_rejects_leading_zero_core_identifiers() {
     assert_invalid_semver("01.2.3");
     assert_invalid_semver("1.02.3");
     assert_invalid_semver("1.2.03");
+}
+
+#[test]
+fn test_try_parse_rejects_out_of_range_core_identifiers() {
+    assert_invalid_semver("9223372036854775808.0.0");
+    assert_invalid_semver("0.9223372036854775808.0");
+    assert_invalid_semver("0.0.9223372036854775808");
 }
 
 #[test]
@@ -282,6 +303,12 @@ fn test_try_parse_rejects_leading_zero_numeric_prerelease_identifiers() {
 }
 
 #[test]
+fn test_try_parse_rejects_out_of_range_numeric_prerelease_identifiers() {
+    assert_invalid_semver("1.0.0-9223372036854775808");
+    assert_invalid_semver("1.0.0-rc.9223372036854775808");
+}
+
+#[test]
 fn test_try_parse_accepts_canonical_build_numeric_leading_zero() {
     let v = semver.parse("1.2.3-rc.1+build.001");
     testing.assert_eq_str(v.to_string(), "1.2.3-rc.1+build.001");
@@ -305,7 +332,17 @@ fn test_matches_caret_zero_zero_stops_before_next_patch() {
 #[test]
 fn test_increment_helpers_reset_lower_components_and_metadata() {
     let v = semver.parse("1.2.3-rc.1+build.5");
-    testing.assert_eq_str(semver.increment_major(v).to_string(), "2.0.0");
-    testing.assert_eq_str(semver.increment_minor(v).to_string(), "1.3.0");
-    testing.assert_eq_str(semver.increment_patch(v).to_string(), "1.2.4");
+    assert_increment_ok(semver.increment_major(v), "2.0.0");
+    assert_increment_ok(semver.increment_minor(v), "1.3.0");
+    assert_increment_ok(semver.increment_patch(v), "1.2.4");
+}
+
+#[test]
+fn test_increment_helpers_return_err_at_i64_max() {
+    let major_max = semver.parse("9223372036854775807.0.0");
+    let minor_max = semver.parse("0.9223372036854775807.0");
+    let patch_max = semver.parse("0.0.9223372036854775807");
+    assert_increment_err(semver.increment_major(major_max), "semver: major component out of range");
+    assert_increment_err(semver.increment_minor(minor_max), "semver: minor component out of range");
+    assert_increment_err(semver.increment_patch(patch_max), "semver: patch component out of range");
 }

--- a/tests/hew/semver_test.hew
+++ b/tests/hew/semver_test.hew
@@ -284,6 +284,7 @@ fn test_try_parse_rejects_empty_pre_release_and_build_identifiers() {
 fn test_try_parse_rejects_non_ascii_identifiers() {
     assert_invalid_semver("1.2.3-café");
     assert_invalid_semver("1.2.3+naïve");
+    assert_invalid_semver("1.2.3+build_meta");
 }
 
 #[test]


### PR DESCRIPTION
# stdlib(semver): enforce SemVer 2.0.0 parsing and caret bounds

## Summary

Tightens `std::text::semver` to reject invalid SemVer 2.0.0 inputs, fixes the pre-1.0 caret upper-bound rule, and adds small version increment helpers.

This is a focused stdlib-only patch with four commits and no compiler changes. It is based on upstream `v0.5.6` (`2762fadc`), matching the Hew 0.5.6 compiler used to verify it.

## Current delivery status

**Current follow-up (2026-09-19):** strict grammar validation and unbounded numeric
comparison already exist on main. The remaining pre-1.0 caret-bound defect is
ported to the current API in #3529 and passes the native SemVer suite. The old
integer-limited increment helpers are not carried into the unbounded API.

**Draft as of 2026-09-13.** Current upstream `main` has redesigned the SemVer
module around unbounded string components and a `parse -> Result` API. The
four-patch v0.5.6 series conflicts with that redesign and must not be rebased
mechanically. This PR preserves the reviewed historical series; a successor
must port only the still-missing behaviour to the current API and validate it
with a current Hew compiler.

## Changes

### Strict `try_parse`

`try_parse` now rejects:

- leading-zero core identifiers (`01.2.3`) and numeric pre-release identifiers (`1.2.3-01`);
- empty pre-release/build tails (`1.2.3-`, `1.2.3+`) and empty dot identifiers;
- non-ASCII pre-release/build identifiers;
- signed, non-numeric, partial, or extra core text (`-1.2.3`, `1.2.3x`, `1.2.3.4`);
- core or numeric pre-release identifiers outside the `i64` range supported by this implementation.

It preserves valid canonical versions, including build numeric identifiers with leading zeroes (`1.2.3-rc.1+build.001`), as SemVer permits those in build metadata.

### Caret ranges

Caret matching now advances the left-most non-zero component:

- `^1.2.3` → `>=1.2.3 <2.0.0`
- `^0.2.3` → `>=0.2.3 <0.3.0`
- `^0.0.3` → `>=0.0.3 <0.0.4`

In particular, `0.3.0` no longer matches `^0.2.3`.

### Overflow hardening

The `Version` core fields are `i64`. `try_parse` now uses checked conversion for core identifiers, rejecting values above `i64::MAX` instead of silently converting them to zero. It also rejects out-of-range numeric pre-release identifiers at parse time; that preserves SemVer §11 numeric precedence without an incorrect overflow comparison. Build identifiers remain strings and are not subject to this numeric limit.

Increment helpers now return `Result<Version, string>` and report a component-specific error at `i64::MAX`, rather than overflowing/trapping.

### Increment helpers

Adds:

```hew
semver.increment_major(version) // Ok(2.0.0), or Err at i64::MAX
semver.increment_minor(version) // Ok(1.3.0), or Err at i64::MAX
semver.increment_patch(version) // Ok(1.2.4), or Err at i64::MAX
```

On success these return new values, discard pre-release/build metadata, and reset lower core components for major/minor increments.

## Tests

Adds 13 `#[test]` cases in `tests/hew/semver_test.hew`, covering every corrected grammar class, valid build metadata, both pre-1.0 caret bounds, reset/drop semantics, overflow parse rejection, and defined increment-at-maximum errors.

Verified with the release compiler:

```bash
cd hew
HEW_STD="$PWD/std" ~/local/hew-0.5.6/bin/hew test tests/hew/semver_test.hew
# 40 passed; 0 failed (27 existing + 13 new)
```

**Delivery verification (2026-09-13):** the canonical four-patch export was
replayed from `2762fadc` in a fresh local clone and reproduced the fork branch
tree exactly. The Hew 0.5.6 binary used for the recorded test run is not
installed on this delivery host, so no new compiler-test claim is made here.

## Compatibility

This deliberately makes `try_parse` fail for inputs that were previously accepted despite violating SemVer 2.0.0. `parse` retains its documented behavior of panicking when `try_parse` fails. Valid SemVer API behavior, pre-release precedence, build-metadata precedence exclusion, existing comparators, and tilde ranges are unchanged.

## Commits

1. `stdlib(semver): validate strict SemVer grammar and add increments`
2. `test(semver): cover strict parsing and caret bounds`
3. `stdlib(semver): harden i64 overflow handling`

## Provenance

The behavior matrix and initial executable prototype were developed in the sealed RFC-022 audit: `projects/hew-stdlib-semver-rfc/patch-candidate/`. This PR ports that proposal into a clean upstream 0.5.6 patch series.
